### PR TITLE
docs: codify PR flow and release-please conventions for agents and contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,22 +18,43 @@
 - If another agent owns a file, do not overwrite their changes. Adjust around them or coordinate a handoff.
 - Keep changes narrow. Split docs, bootstrap, migration, and feature work into separate branches unless they are inseparable.
 
+## Branch Protection And PR Flow
+- `main` is protected by the repository ruleset `main-protect`. Direct pushes to `main` are blocked even for repository admins.
+- Every change ships through a pull request. The required status check is the CI `Test` job.
+- Admin bypass mode is `pull_request`: the admin can self-merge a PR without approvals, but the PR itself is mandatory.
+- Default merge method is **squash**. The PR title becomes the squash commit subject and is what release-please parses, so write it as a Conventional Commit. Follow [docs/pr-guideline.md](docs/pr-guideline.md) for full conventions.
+- `make install` cannot run before the PR is merged into `main`. The full team-lead loop is: push branch → open PR → wait for CI → merge → `git pull --ff-only` → `make install`.
+
 ## Standard Dev Flow
 - Make targets are the contract for local validation. Keep them stable and predictable.
-- Run work in this order before review:
+- Run work in this order before opening a PR:
   1. `make fmt`
   2. `make fix`
   3. `make test`
   4. `make test-integration`
   5. `make test-e2e`
-- `make install` is the deploy step (build + atomic replace of `$(go env GOPATH)/bin/projmux` + `projmux tmux apply`). Do not run it during routine validation; reserve it for after review when promoting a build.
+- Then push and open the PR:
+  6. `git push -u origin <branch>`
+  7. `gh pr create --title ... --body ...` (Conventional Commit title; see [docs/pr-guideline.md](docs/pr-guideline.md)).
+  8. Wait for the `Test` check to turn green (`gh pr checks <num> --watch`). Use `--auto` on `gh pr merge` if you want it queued.
+  9. `gh pr merge <num> --squash --delete-branch`.
+- Promote the build only after merge:
+  10. `git -C <repo> pull --ff-only`
+  11. `make install` — atomic replace of `$(go env GOPATH)/bin/projmux` plus `projmux tmux apply`. **Never run it before step 10**; pre-merge state has not cleared CI yet and may not match what `main` will hold.
+  12. `wt cleanup --apply` to retire the merged worktree.
 - If a target is missing for the area you are changing, add it or leave the repository in a state where the gap is explicit in docs and review notes.
-- If behavior changes, update the maintained test list in [docs/agent-workflow.md](/home/es5h/source/repos/projmux/docs/agent-workflow.md) in the same branch.
+- If behavior changes, update the maintained test list in [docs/agent-workflow.md](docs/agent-workflow.md) in the same branch.
 - Do not skip `fmt` or `fix` because tests passed. Formatting, automatic fixes, and test execution are separate gates.
 
+## Release Flow
+- `release-please-action` watches `main`, accumulates Conventional Commit subjects, and opens or refreshes a "chore(main): release X.Y.Z" PR. That PR contains the version bump (`internal/version/version.go` + `.release-please-manifest.json`), `CHANGELOG.md` updates, and the release notes.
+- Merging the release PR pushes the `vX.Y.Z` tag and creates the GitHub Release with auto-generated notes.
+- `.github/workflows/release.yml` triggers on the tag push, builds the linux/darwin × amd64/arm64 matrix, and uploads tarballs to the release that already exists (`gh release upload --clobber`). Do not add hardcoded notes back to that workflow — release-please owns the notes.
+- Non-Conventional commit subjects on `main` are silently skipped by release-please. Keep PR titles strict; squash merge ensures the PR title is the only subject that lands.
+
 ## Configuration And Environment
-- `PROJDIR` (preferred) and `RP` (legacy) supply the sessionizer repo root. `~/.config/projmux/projdir` memoizes whichever value was last seen.
-- `PROJMUX_MANAGED_ROOTS` / `TMUX_SESSIONIZER_ROOTS` provide colon-separated search-root lists. They take priority over the saved file and the default heuristics.
+- `PROJDIR` is the canonical project-root env. Memoized to `~/.config/projmux/projdir` after first use. The legacy `RP` alias is still honored at runtime; do not feature it in user-facing docs.
+- `PROJMUX_MANAGED_ROOTS` is the colon-separated search-root override (priority: env > saved file > defaults). Legacy alias `TMUX_SESSIONIZER_ROOTS` is still honored at runtime.
 - `~/.config/projmux/workdirs` stores the cumulative workdirs list managed via the Settings UX. It is read only when no env list is set.
 - `tmux set-option -g @projmux_projdir <path>` is a declarative source for `PROJDIR` that the switch command reads through `tmuxProjdirOption`.
 

--- a/docs/pr-guideline.md
+++ b/docs/pr-guideline.md
@@ -1,0 +1,106 @@
+# PR Guideline
+
+Audience: every contributor — humans and agents alike. Agents working in this
+repo (`claude` / `codex` panes, the team-lead session, etc.) MUST follow these
+rules; the conventions here are what `release-please` parses for the next
+release notes, so a sloppy PR title silently breaks the changelog.
+
+For the surrounding workflow (worktree, validation gates, post-merge install)
+see [AGENTS.md](../AGENTS.md). This document covers only the PR itself.
+
+## PR title — Conventional Commits
+
+Default merge method is **squash**, so the PR title becomes the only commit
+subject that lands on `main`. Format:
+
+```
+<type>(<optional scope>): <imperative summary>
+```
+
+Examples:
+
+```
+feat(ai): add codex split picker keybinding
+fix(ai): prepend agent bin dir to PATH so node-managed CLIs find node
+docs(readme): drop Releases and Configuration sections
+chore: bump release-please manifest to 0.3.0
+refactor(picker): collapse duplicate fzf bootstrap code
+```
+
+Rules:
+
+- Subject is in the imperative ("add", "fix", "drop"), no trailing period.
+- Keep the title under ~70 characters when possible. Long detail goes in the
+  body.
+- The scope is optional but recommended for non-trivial diffs (`ai`, `picker`,
+  `tmux`, `readme`, `ci`, etc.).
+- A `!` after the type or scope marks a breaking change:
+  `feat(ai)!: rename PROJMUX_NOTIFY_HOOK to PROJMUX_NOTIFY_BIN`.
+- Or include a `BREAKING CHANGE: <description>` footer in the body. Either form
+  bumps the major version on the next release-please run.
+
+### Allowed types
+
+| type | use for | release impact |
+| --- | --- | --- |
+| `feat` | user-visible new behavior or capability | minor bump |
+| `fix` | bug fix that ships to users | patch bump |
+| `perf` | measurable runtime/memory improvement | patch bump |
+| `refactor` | code restructure with no user-visible change | none |
+| `docs` | docs-only change | none |
+| `test` | adding or restructuring tests | none |
+| `build` | build system, Makefile, dependencies | none |
+| `ci` | CI workflow / GitHub Actions | none |
+| `chore` | release plumbing, tooling, repo housekeeping | none |
+| `style` | formatting only, no logic change | none |
+
+If the change includes both a feat and a fix, split it into two PRs. release-please
+classifies the whole PR by its title type, not by content.
+
+## PR body
+
+Use this template:
+
+```markdown
+## Summary
+- 1–3 bullets describing what changed and why.
+
+## Test plan
+- [ ] make fmt-check
+- [ ] make test
+- [ ] manual verification step (if relevant)
+```
+
+Notes:
+
+- **Why** matters more than **what**. Diff already shows the what.
+- Reference issues with `Closes #<n>` so they auto-close on merge.
+- Mention follow-ups explicitly when scope was deliberately deferred.
+
+## Branch protection in effect
+
+`main` is governed by ruleset `main-protect`:
+
+- Direct push to `main` is blocked. Even repository admin must use a PR.
+- Required status check: the CI `Test` job. The PR cannot merge until it is
+  green.
+- Admin bypass is `pull_request` mode — admin can self-merge without
+  approvals, but the PR itself is mandatory.
+- Linear history is enforced. The merge methods exposed are
+  `merge` / `squash` / `rebase`; **default is squash** and that is what the
+  team-lead session uses unless the change explicitly needs preserved history.
+- Force pushes and branch deletions on `main` are blocked.
+
+`gh pr merge <num> --squash --delete-branch` is the canonical merge command.
+Use `--auto` if you want the merge queued automatically once CI passes.
+
+## Release-please coupling
+
+Every PR title that lands on `main` is parsed by `release-please-action`.
+A `feat:` or `fix:` PR adds an entry to the next release notes; `chore:` /
+`docs:` / `refactor:` etc. do not. To force a release of accumulated non-user
+changes, open a `chore` PR titled `chore: release X.Y.Z` (or wait for any
+real change). The `internal/version/version.go` constant carries the
+`x-release-please-version` marker so release-please bumps it automatically.
+
+Do not hand-author CHANGELOG.md or version bumps. release-please owns both.


### PR DESCRIPTION
## Summary
- AGENTS.md gains a 'Branch Protection And PR Flow' section, an explicit post-merge install rule, and a 'Release Flow' section that names release-please as the owner of CHANGELOG / version bumps / release notes.
- Standard Dev Flow now ends at PR-create → CI green → squash merge → 'pull --ff-only' → 'make install' → 'wt cleanup', so agents do not race ahead of CI when promoting a build.
- Configuration And Environment trimmed to match the README env-vars cleanup (legacy 'RP' / 'TMUX_SESSIONIZER_ROOTS' kept as runtime-only behavior).
- New docs/pr-guideline.md: Conventional Commits PR title format, type → release-please-impact table, body template, branch-protection summary, release-please coupling note. AGENTS.md cross-links to it.

## Test plan
- [x] make fmt-check
- [x] make test (full suite passes locally)
- [ ] CI 'Test' check passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)