### PR TITLE
ci: enable manual dispatch on release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add 'workflow_dispatch: {}' trigger to '.github/workflows/release-please.yml'.
- Lets the release-please workflow be re-run on demand from the Actions UI or via 'gh workflow run release-please.yml', alongside the existing push-to-main trigger.

## Test plan
- [x] make fmt-check
- [x] make test
- [ ] CI 'Test' check passes on this PR.
- [ ] After merge: the release-please workflow run for this commit succeeds (workflow PR-creation permission was enabled in repo settings) and opens the first 'chore(main): release X.Y.Z' Release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)