### PR TITLE
feat(ai): add 'topic' subcommand for pane topic control

### DIFF
--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -83,6 +83,8 @@ func (c *aiCommand) Run(args []string, stdout, stderr io.Writer) error {
 		return c.runNotify(args[1:], stderr)
 	case "watch-title":
 		return c.runWatchTitle(args[1:], stderr)
+	case "topic":
+		return c.runTopic(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
 		printAIUsage(stdout)
 		return nil
@@ -329,6 +331,118 @@ func (c *aiCommand) runWatchTitle(args []string, stderr io.Writer) error {
 		}
 		c.sleepFor(interval)
 	}
+}
+
+func (c *aiCommand) runTopic(args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		printAIUsage(stderr)
+		return errors.New("ai topic requires a subcommand")
+	}
+	switch args[0] {
+	case "set":
+		rest, paneID, err := parseAITopicArgs(args[1:])
+		if err != nil {
+			printAIUsage(stderr)
+			return err
+		}
+		if len(rest) == 0 {
+			printAIUsage(stderr)
+			return errors.New("ai topic set requires <text>")
+		}
+		if len(rest) > 1 {
+			printAIUsage(stderr)
+			return errors.New("ai topic set accepts a single <text> argument")
+		}
+		text := strings.TrimSpace(rest[0])
+		if text == "" {
+			printAIUsage(stderr)
+			return errors.New("ai topic set requires non-empty <text>")
+		}
+		paneID, err = c.resolveTopicPaneID(paneID)
+		if err != nil {
+			fmt.Fprintln(stderr, err.Error())
+			return err
+		}
+		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneTopicOption, text)
+		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneTopicManualOption, "on")
+		return nil
+	case "clear":
+		rest, paneID, err := parseAITopicArgs(args[1:])
+		if err != nil {
+			printAIUsage(stderr)
+			return err
+		}
+		if len(rest) > 0 {
+			printAIUsage(stderr)
+			return errors.New("ai topic clear takes no positional arguments")
+		}
+		paneID, err = c.resolveTopicPaneID(paneID)
+		if err != nil {
+			fmt.Fprintln(stderr, err.Error())
+			return err
+		}
+		_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, aiPaneTopicOption)
+		_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, aiPaneTopicManualOption)
+		return nil
+	case "get":
+		rest, paneID, err := parseAITopicArgs(args[1:])
+		if err != nil {
+			printAIUsage(stderr)
+			return err
+		}
+		if len(rest) > 0 {
+			printAIUsage(stderr)
+			return errors.New("ai topic get takes no positional arguments")
+		}
+		paneID, err = c.resolveTopicPaneID(paneID)
+		if err != nil {
+			fmt.Fprintln(stderr, err.Error())
+			return err
+		}
+		fmt.Fprintln(stdout, c.readTmuxPaneOption(paneID, aiPaneTopicOption))
+		return nil
+	case "help", "--help", "-h":
+		printAIUsage(stdout)
+		return nil
+	default:
+		printAIUsage(stderr)
+		return fmt.Errorf("unknown ai topic subcommand: %s", args[0])
+	}
+}
+
+func parseAITopicArgs(args []string) ([]string, string, error) {
+	rest := make([]string, 0, len(args))
+	paneID := ""
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--pane":
+			if i+1 >= len(args) {
+				return nil, "", errors.New("--pane requires a value")
+			}
+			paneID = strings.TrimSpace(args[i+1])
+			i++
+		default:
+			if value, ok := strings.CutPrefix(args[i], "--pane="); ok {
+				paneID = strings.TrimSpace(value)
+				continue
+			}
+			rest = append(rest, args[i])
+		}
+	}
+	return rest, paneID, nil
+}
+
+func (c *aiCommand) resolveTopicPaneID(explicit string) (string, error) {
+	if explicit = strings.TrimSpace(explicit); explicit != "" {
+		return explicit, nil
+	}
+	if envPane := strings.TrimSpace(c.env("TMUX_PANE")); envPane != "" {
+		return envPane, nil
+	}
+	if pane := c.readTrimmed("tmux", "display-message", "-p", "#{pane_id}"); pane != "" {
+		return pane, nil
+	}
+	return "", errors.New("ai topic requires a tmux pane (set --pane or run inside tmux)")
 }
 
 func (c *aiCommand) runSplit(args []string, stderr io.Writer) error {
@@ -1898,4 +2012,7 @@ func printAIUsage(w io.Writer) {
 	fmt.Fprintln(w, "  projmux ai status set <thinking|waiting|idle> [pane]")
 	fmt.Fprintln(w, "  projmux ai notify [notify|reset] [pane]")
 	fmt.Fprintln(w, "  projmux ai watch-title [pane]")
+	fmt.Fprintln(w, "  projmux ai topic set <text> [--pane <id>]")
+	fmt.Fprintln(w, "  projmux ai topic clear [--pane <id>]")
+	fmt.Fprintln(w, "  projmux ai topic get [--pane <id>]")
 }

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -1429,3 +1429,158 @@ func paneGeometryIDs(panes []aiPaneGeometry) []string {
 	}
 	return ids
 }
+
+func TestAITopicSetWritesPaneOptionAndManualFlag(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+
+	if err := cmd.Run([]string{"topic", "set", "fix login bug", "--pane", "%3"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run topic set error = %v", err)
+	}
+
+	want := []recordedAICommand{
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%3", "@projmux_ai_topic", "fix login bug"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%3", "@projmux_ai_topic_manual", "on"}},
+	}
+	if !reflect.DeepEqual(cmdRecorder(cmd).commands, want) {
+		t.Fatalf("commands = %#v, want %#v", cmdRecorder(cmd).commands, want)
+	}
+}
+
+func TestAITopicSetUsesEnvPaneWhenFlagOmitted(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.lookupEnv = func(name string) string {
+		switch name {
+		case "TMUX_PANE":
+			return "%7"
+		case "HOME":
+			return home
+		default:
+			return ""
+		}
+	}
+
+	if err := cmd.Run([]string{"topic", "set", "review PR"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run topic set error = %v", err)
+	}
+
+	want := []recordedAICommand{
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", "@projmux_ai_topic", "review PR"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", "@projmux_ai_topic_manual", "on"}},
+	}
+	if !reflect.DeepEqual(cmdRecorder(cmd).commands, want) {
+		t.Fatalf("commands = %#v, want %#v", cmdRecorder(cmd).commands, want)
+	}
+}
+
+func TestAITopicClearUnsetsBothPaneOptions(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+
+	if err := cmd.Run([]string{"topic", "clear", "--pane", "%4"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run topic clear error = %v", err)
+	}
+
+	want := []recordedAICommand{
+		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%4", "@projmux_ai_topic"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%4", "@projmux_ai_topic_manual"}},
+	}
+	if !reflect.DeepEqual(cmdRecorder(cmd).commands, want) {
+		t.Fatalf("commands = %#v, want %#v", cmdRecorder(cmd).commands, want)
+	}
+}
+
+func TestAITopicGetPrintsPaneOptionValue(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%5", "#{@projmux_ai_topic}"}) {
+			return []byte("ship the feature\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	stdout := &bytes.Buffer{}
+	if err := cmd.Run([]string{"topic", "get", "--pane", "%5"}, stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run topic get error = %v", err)
+	}
+
+	if got, want := stdout.String(), "ship the feature\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestAITopicGetEmitsBlankLineWhenUnset(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+
+	stdout := &bytes.Buffer{}
+	if err := cmd.Run([]string{"topic", "get", "--pane", "%6"}, stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run topic get error = %v", err)
+	}
+	if got, want := stdout.String(), "\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestAITopicSetRequiresText(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+
+	stderr := &bytes.Buffer{}
+	if err := cmd.Run([]string{"topic", "set", "--pane", "%2"}, &bytes.Buffer{}, stderr); err == nil {
+		t.Fatalf("Run topic set without text expected error, got nil")
+	}
+	if len(cmdRecorder(cmd).commands) != 0 {
+		t.Fatalf("expected no tmux commands, got %#v", cmdRecorder(cmd).commands)
+	}
+}
+
+func TestAITopicUnknownActionReturnsError(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+
+	stderr := &bytes.Buffer{}
+	err := cmd.Run([]string{"topic", "foo"}, &bytes.Buffer{}, stderr)
+	if err == nil {
+		t.Fatalf("Run topic foo expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown ai topic subcommand") {
+		t.Fatalf("error = %v, want contains \"unknown ai topic subcommand\"", err)
+	}
+	if len(cmdRecorder(cmd).commands) != 0 {
+		t.Fatalf("expected no tmux commands, got %#v", cmdRecorder(cmd).commands)
+	}
+}
+
+func TestAITopicHelpListedInUsage(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	printAIUsage(stdout)
+	for _, want := range []string{
+		"projmux ai topic set <text> [--pane <id>]",
+		"projmux ai topic clear [--pane <id>]",
+		"projmux ai topic get [--pane <id>]",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("usage = %q, want contains %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestAITopicErrorsWhenNoPaneAvailable(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.lookupEnv = func(string) string { return "" }
+	cmd.readCommand = func(context.Context, string, ...string) ([]byte, error) {
+		return nil, errors.New("not in tmux")
+	}
+
+	stderr := &bytes.Buffer{}
+	if err := cmd.Run([]string{"topic", "set", "anything"}, &bytes.Buffer{}, stderr); err == nil {
+		t.Fatalf("Run topic set without pane expected error, got nil")
+	}
+	if len(cmdRecorder(cmd).commands) != 0 {
+		t.Fatalf("expected no tmux set-option commands, got %#v", cmdRecorder(cmd).commands)
+	}
+}


### PR DESCRIPTION
## Summary
- 새 서브커맨드 `projmux ai topic {set|clear|get}` 추가 — tmux pane option `@projmux_ai_topic` 와 `@projmux_ai_topic_manual` 을 직접 제어
- `topic set <text>` 은 토픽을 저장하고 manual 플래그를 `on` 으로 설정해 자동 추론(`bestAITopic`)이 덮어쓰지 않도록 고정
- `topic clear` 는 두 옵션 모두 unset 하여 자동 추론 모드로 복귀
- `topic get` 은 현재 `@projmux_ai_topic` 값을 stdout 한 줄로 출력 (없으면 빈 줄)
- `--pane <id>` 미지정 시 `$TMUX_PANE` → `tmux display-message -p '#{pane_id}'` 순으로 폴백, 둘 다 없으면 stderr 에러 + exit 1
- `printAIUsage` 에 새 명령 3줄 추가

## Test plan
- [x] `go build ./...` — 통과
- [x] `go vet ./...` — 깨끗
- [x] `go test ./...` — 모든 패키지 PASS (기존 테스트 무회귀)
- [x] 신규 테스트 9건 (`internal/app/ai_test.go`):
  - `TestAITopicSetWritesPaneOptionAndManualFlag`
  - `TestAITopicSetUsesEnvPaneWhenFlagOmitted`
  - `TestAITopicClearUnsetsBothPaneOptions`
  - `TestAITopicGetPrintsPaneOptionValue`
  - `TestAITopicGetEmitsBlankLineWhenUnset`
  - `TestAITopicSetRequiresText`
  - `TestAITopicUnknownActionReturnsError`
  - `TestAITopicHelpListedInUsage`
  - `TestAITopicErrorsWhenNoPaneAvailable`

Generated with Claude Code