### PR TITLE
chore!: transfer ownership to crevissepartners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           name="projmux_${version}_${GOOS}_${GOARCH}"
           mkdir -p "dist/${name}"
           go build -trimpath \
-            -ldflags "-s -w -X github.com/es5h/projmux/internal/version.current=${version}" \
+            -ldflags "-s -w -X github.com/crevissepartners/projmux/internal/version.current=${version}" \
             -o "dist/${name}/projmux" ./cmd/projmux
           cp README.md README-ko.md LICENSE "dist/${name}/"
           tar -C dist -czf "dist/${name}.tar.gz" "${name}"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 es5h
+Copyright (c) 2026 Crevisse Partners
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README-ko.md
+++ b/README-ko.md
@@ -70,7 +70,7 @@ projmux shell
 ## 설치
 
 ```sh
-go install github.com/es5h/projmux/cmd/projmux@latest
+go install github.com/crevissepartners/projmux/cmd/projmux@latest
 ```
 
 binary 는 `$(go env GOBIN)` (설정된 경우) 또는 `$(go env GOPATH)/bin`
@@ -103,7 +103,7 @@ export PROJDIR="$HOME/source/repos"
 ### 소스에서 빌드
 
 ```sh
-git clone https://github.com/es5h/projmux.git
+git clone https://github.com/crevissepartners/projmux.git
 cd projmux
 make install
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Desktop notifications: Linux uses `notify-send`; WSL routes Windows toasts via
 ## Install
 
 ```sh
-go install github.com/es5h/projmux/cmd/projmux@latest
+go install github.com/crevissepartners/projmux/cmd/projmux@latest
 ```
 
 This drops the binary in `$(go env GOBIN)` (when set) or `$(go env GOPATH)/bin`
@@ -105,7 +105,7 @@ the same root even without the env var.
 ### From source
 
 ```sh
-git clone https://github.com/es5h/projmux.git
+git clone https://github.com/crevissepartners/projmux.git
 cd projmux
 make install
 ```

--- a/cmd/projmux/main.go
+++ b/cmd/projmux/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/es5h/projmux/internal/app"
+	"github.com/crevissepartners/projmux/internal/app"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/es5h/projmux
+module github.com/crevissepartners/projmux
 
 go 1.24.2

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -17,7 +17,7 @@ import (
 	"time"
 	"unicode/utf16"
 
-	intfzf "github.com/es5h/projmux/internal/ui/fzf"
+	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 )
 
 const (

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -16,7 +16,7 @@ import (
 	"time"
 	"unicode/utf16"
 
-	intfzf "github.com/es5h/projmux/internal/ui/fzf"
+	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 )
 
 func TestAISettingsGetAndSetMode(t *testing.T) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/es5h/projmux/internal/version"
+	"github.com/crevissepartners/projmux/internal/version"
 )
 
 // Run is the current CLI bootstrap. Feature commands will grow from here.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	coresessions "github.com/es5h/projmux/internal/core/sessions"
+	coresessions "github.com/crevissepartners/projmux/internal/core/sessions"
 )
 
 func TestAppRunCurrentEnsuresAndOpensDerivedSession(t *testing.T) {

--- a/internal/app/attach.go
+++ b/internal/app/attach.go
@@ -10,9 +10,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/es5h/projmux/internal/core/lifecycle"
-	coresessions "github.com/es5h/projmux/internal/core/sessions"
-	inttmux "github.com/es5h/projmux/internal/integrations/tmux"
+	"github.com/crevissepartners/projmux/internal/core/lifecycle"
+	coresessions "github.com/crevissepartners/projmux/internal/core/sessions"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
 type attachInventoryResolver interface {

--- a/internal/app/attach_test.go
+++ b/internal/app/attach_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/es5h/projmux/internal/core/lifecycle"
+	"github.com/crevissepartners/projmux/internal/core/lifecycle"
 )
 
 func TestAppRunAttachAutoReusesEphemeralSession(t *testing.T) {

--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	inttmux "github.com/es5h/projmux/internal/integrations/tmux"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
 const (

--- a/internal/app/current.go
+++ b/internal/app/current.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"path/filepath"
 
-	coresessions "github.com/es5h/projmux/internal/core/sessions"
-	inttmux "github.com/es5h/projmux/internal/integrations/tmux"
+	coresessions "github.com/crevissepartners/projmux/internal/core/sessions"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
 type sessionIdentityResolver interface {

--- a/internal/app/kill.go
+++ b/internal/app/kill.go
@@ -10,11 +10,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/es5h/projmux/internal/config"
-	"github.com/es5h/projmux/internal/core/lifecycle"
-	coresessions "github.com/es5h/projmux/internal/core/sessions"
-	"github.com/es5h/projmux/internal/core/tags"
-	inttmux "github.com/es5h/projmux/internal/integrations/tmux"
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/core/lifecycle"
+	coresessions "github.com/crevissepartners/projmux/internal/core/sessions"
+	"github.com/crevissepartners/projmux/internal/core/tags"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
 type killCurrentSessionResolver interface {

--- a/internal/app/kill_test.go
+++ b/internal/app/kill_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/es5h/projmux/internal/core/lifecycle"
+	"github.com/crevissepartners/projmux/internal/core/lifecycle"
 )
 
 func TestAppRunKillTaggedExecutesOrchestrator(t *testing.T) {

--- a/internal/app/pin.go
+++ b/internal/app/pin.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/es5h/projmux/internal/config"
-	"github.com/es5h/projmux/internal/core/pins"
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/core/pins"
 )
 
 type pinStore interface {

--- a/internal/app/pin_test.go
+++ b/internal/app/pin_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/es5h/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/config"
 )
 
 func TestAppRunPinList(t *testing.T) {

--- a/internal/app/preview.go
+++ b/internal/app/preview.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/es5h/projmux/internal/config"
-	corepreview "github.com/es5h/projmux/internal/core/preview"
-	inttmux "github.com/es5h/projmux/internal/integrations/tmux"
+	"github.com/crevissepartners/projmux/internal/config"
+	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
 type previewStore interface {

--- a/internal/app/preview_test.go
+++ b/internal/app/preview_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	corepreview "github.com/es5h/projmux/internal/core/preview"
-	inttmux "github.com/es5h/projmux/internal/integrations/tmux"
+	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
 func TestAppRunPreviewCyclePane(t *testing.T) {

--- a/internal/app/prune.go
+++ b/internal/app/prune.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/es5h/projmux/internal/core/lifecycle"
-	inttmux "github.com/es5h/projmux/internal/integrations/tmux"
+	"github.com/crevissepartners/projmux/internal/core/lifecycle"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
 type pruneInventoryResolver interface {

--- a/internal/app/prune_test.go
+++ b/internal/app/prune_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/es5h/projmux/internal/core/lifecycle"
+	"github.com/crevissepartners/projmux/internal/core/lifecycle"
 )
 
 func TestAppRunPruneEphemeralKillsTargetsBeyondKeep(t *testing.T) {

--- a/internal/app/session_popup.go
+++ b/internal/app/session_popup.go
@@ -8,10 +8,10 @@ import (
 	"io"
 	"strings"
 
-	"github.com/es5h/projmux/internal/config"
-	corepreview "github.com/es5h/projmux/internal/core/preview"
-	inttmux "github.com/es5h/projmux/internal/integrations/tmux"
-	intrender "github.com/es5h/projmux/internal/ui/render"
+	"github.com/crevissepartners/projmux/internal/config"
+	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+	intrender "github.com/crevissepartners/projmux/internal/ui/render"
 )
 
 type sessionPopupStore interface {

--- a/internal/app/session_popup_test.go
+++ b/internal/app/session_popup_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	corepreview "github.com/es5h/projmux/internal/core/preview"
+	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
 )
 
 func TestAppRunSessionPopupPreview(t *testing.T) {

--- a/internal/app/sessions.go
+++ b/internal/app/sessions.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"strings"
 
-	corepreview "github.com/es5h/projmux/internal/core/preview"
-	inttmux "github.com/es5h/projmux/internal/integrations/tmux"
-	intfzf "github.com/es5h/projmux/internal/ui/fzf"
-	intrender "github.com/es5h/projmux/internal/ui/render"
+	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
+	intrender "github.com/crevissepartners/projmux/internal/ui/render"
 )
 
 const sessionsKillExpectKey = "ctrl-x"

--- a/internal/app/sessions_test.go
+++ b/internal/app/sessions_test.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"testing"
 
-	corepreview "github.com/es5h/projmux/internal/core/preview"
-	inttmux "github.com/es5h/projmux/internal/integrations/tmux"
-	intfzf "github.com/es5h/projmux/internal/ui/fzf"
+	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 )
 
 func TestAppRunSessionsDefaultsToPopupAndOpensSelectedSession(t *testing.T) {

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	intfzf "github.com/es5h/projmux/internal/ui/fzf"
-	intrender "github.com/es5h/projmux/internal/ui/render"
-	"github.com/es5h/projmux/internal/version"
+	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
+	intrender "github.com/crevissepartners/projmux/internal/ui/render"
+	"github.com/crevissepartners/projmux/internal/version"
 )
 
 // osStat is a package-level indirection so tests can stub filesystem checks.
@@ -672,8 +672,8 @@ func (c *settingsCommand) aiEntries() []intfzf.Entry {
 func settingsAboutEntries() []intfzf.Entry {
 	rows := []struct{ name, value string }{
 		{"Version", "projmux " + version.String()},
-		{"Source", "https://github.com/es5h/projmux"},
-		{"Update", "go install github.com/es5h/projmux/cmd/projmux@latest"},
+		{"Source", "https://github.com/crevissepartners/projmux"},
+		{"Update", "go install github.com/crevissepartners/projmux/cmd/projmux@latest"},
 		{"App", "sidebar, sessions, projects, AI picker, settings"},
 		{"Tmux actions", "new window, rename window/pane, previous/next window"},
 		{"Key model", "terminal sends CSI-u keys; tmux runs projmux actions"},

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/es5h/projmux/internal/core/candidates"
-	intfzf "github.com/es5h/projmux/internal/ui/fzf"
+	"github.com/crevissepartners/projmux/internal/core/candidates"
+	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 )
 
 func TestSettingsHubSetsAIDefaultMode(t *testing.T) {
@@ -158,8 +158,8 @@ func TestSettingsHubShowsAboutSection(t *testing.T) {
 	}
 	for _, want := range []string{
 		"projmux 0.2.1",
-		"https://github.com/es5h/projmux",
-		"go install github.com/es5h/projmux/cmd/projmux@latest",
+		"https://github.com/crevissepartners/projmux",
+		"go install github.com/crevissepartners/projmux/cmd/projmux@latest",
 		"sidebar, sessions, projects",
 		"new window, rename window/pane",
 		"terminal sends CSI-u keys",

--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -13,14 +13,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/es5h/projmux/internal/config"
-	"github.com/es5h/projmux/internal/core/candidates"
-	"github.com/es5h/projmux/internal/core/pins"
-	corepreview "github.com/es5h/projmux/internal/core/preview"
-	coretags "github.com/es5h/projmux/internal/core/tags"
-	inttmux "github.com/es5h/projmux/internal/integrations/tmux"
-	intfzf "github.com/es5h/projmux/internal/ui/fzf"
-	intrender "github.com/es5h/projmux/internal/ui/render"
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/core/candidates"
+	"github.com/crevissepartners/projmux/internal/core/pins"
+	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
+	coretags "github.com/crevissepartners/projmux/internal/core/tags"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
+	intrender "github.com/crevissepartners/projmux/internal/ui/render"
 )
 
 const (

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/es5h/projmux/internal/config"
-	"github.com/es5h/projmux/internal/core/candidates"
-	corepreview "github.com/es5h/projmux/internal/core/preview"
-	intfzf "github.com/es5h/projmux/internal/ui/fzf"
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/core/candidates"
+	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
+	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 )
 
 func TestAppRunSwitchDefaultsToPopupAndOpensSelectedSession(t *testing.T) {

--- a/internal/app/tag.go
+++ b/internal/app/tag.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/es5h/projmux/internal/config"
-	coretags "github.com/es5h/projmux/internal/core/tags"
+	"github.com/crevissepartners/projmux/internal/config"
+	coretags "github.com/crevissepartners/projmux/internal/core/tags"
 )
 
 type tagStore interface {

--- a/internal/app/tag_test.go
+++ b/internal/app/tag_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/es5h/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/config"
 )
 
 func TestAppRunTagList(t *testing.T) {

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -11,7 +11,7 @@ import (
 	"slices"
 	"strings"
 
-	inttmux "github.com/es5h/projmux/internal/integrations/tmux"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
 type tmuxPopupClient interface {

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	inttmux "github.com/es5h/projmux/internal/integrations/tmux"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
 func TestAppRunTmuxPopupPreviewUsesDefaultOptions(t *testing.T) {

--- a/internal/app/upgrade.go
+++ b/internal/app/upgrade.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/es5h/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/config"
 )
 
 // upgradeCommand wraps `go install` to refresh the active projmux binary.
@@ -60,7 +60,7 @@ type upgradeOptions struct {
 
 const (
 	defaultUpgradeRef    = "latest"
-	defaultUpgradeModule = "github.com/es5h/projmux/cmd/projmux"
+	defaultUpgradeModule = "github.com/crevissepartners/projmux/cmd/projmux"
 )
 
 // Run executes the projmux upgrade self-update flow.

--- a/internal/app/upgrade_test.go
+++ b/internal/app/upgrade_test.go
@@ -71,7 +71,7 @@ func TestUpgradeRunDryRunPrintsExpectedCommands(t *testing.T) {
 
 	out := stdout.String()
 	wantSubstrings := []string{
-		"would run: GOBIN=/home/user/.local/bin/.projmux-upgrade-XXXXXX go install github.com/es5h/projmux/cmd/projmux@latest",
+		"would run: GOBIN=/home/user/.local/bin/.projmux-upgrade-XXXXXX go install github.com/crevissepartners/projmux/cmd/projmux@latest",
 		"would replace: /home/user/.local/bin/projmux (atomic via temp file)",
 		"would run: /home/user/.local/bin/projmux tmux apply",
 	}
@@ -251,7 +251,7 @@ func TestUpgradeRunHappyPathInvokesGoInstallAndApply(t *testing.T) {
 		t.Fatalf("commands = %d, want 2 (go install + apply)\nrecorded=%v", len(stub.commands), stub.commands)
 	}
 
-	wantInstall := []string{"/usr/local/bin/go", "install", "github.com/es5h/projmux/cmd/projmux@v1.2.3"}
+	wantInstall := []string{"/usr/local/bin/go", "install", "github.com/crevissepartners/projmux/cmd/projmux@v1.2.3"}
 	if !equalSlices(stub.commands[0].args, wantInstall) {
 		t.Fatalf("install command = %v, want %v", stub.commands[0].args, wantInstall)
 	}
@@ -280,7 +280,7 @@ func TestUpgradeRunHappyPathInvokesGoInstallAndApply(t *testing.T) {
 
 	out := stdout.String()
 	for _, want := range []string{
-		">> fetching github.com/es5h/projmux/cmd/projmux@v1.2.3 via go install",
+		">> fetching github.com/crevissepartners/projmux/cmd/projmux@v1.2.3 via go install",
 		">> installed: /home/user/.local/bin/.projmux-upgrade-stub/projmux",
 		">> atomically replaced " + target,
 		">> applying live config...",

--- a/internal/core/pins/store.go
+++ b/internal/core/pins/store.go
@@ -5,8 +5,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/es5h/projmux/internal/config"
-	"github.com/es5h/projmux/internal/state"
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/state"
 )
 
 var ErrInvalidPin = errors.New("invalid pin path")

--- a/internal/core/pins/store_test.go
+++ b/internal/core/pins/store_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/es5h/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/config"
 )
 
 func TestNewDefaultStoreUsesConfigPinFile(t *testing.T) {

--- a/internal/core/preview/store.go
+++ b/internal/core/preview/store.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/es5h/projmux/internal/config"
-	"github.com/es5h/projmux/internal/state"
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/state"
 )
 
 var ErrInvalidSessionName = errors.New("invalid session name")

--- a/internal/core/preview/store_test.go
+++ b/internal/core/preview/store_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/es5h/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/config"
 )
 
 func TestNewDefaultStoreUsesStatePreviewFile(t *testing.T) {

--- a/internal/core/tags/store.go
+++ b/internal/core/tags/store.go
@@ -5,8 +5,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/es5h/projmux/internal/config"
-	"github.com/es5h/projmux/internal/state"
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/state"
 )
 
 var ErrInvalidTag = errors.New("invalid tag")

--- a/internal/integrations/tmux/client.go
+++ b/internal/integrations/tmux/client.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/es5h/projmux/internal/core/lifecycle"
+	"github.com/crevissepartners/projmux/internal/core/lifecycle"
 )
 
 var (

--- a/internal/ui/render/popup.go
+++ b/internal/ui/render/popup.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/es5h/projmux/internal/core/preview"
+	"github.com/crevissepartners/projmux/internal/core/preview"
 )
 
 // RenderPopupPreview renders a concise textual popup preview from the derived

--- a/internal/ui/render/popup_test.go
+++ b/internal/ui/render/popup_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/es5h/projmux/internal/core/preview"
+	"github.com/crevissepartners/projmux/internal/core/preview"
 )
 
 func TestRenderPopupPreviewWithSelectedWindowAndPane(t *testing.T) {

--- a/internal/ui/render/switch.go
+++ b/internal/ui/render/switch.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/es5h/projmux/internal/ui/picker"
+	"github.com/crevissepartners/projmux/internal/ui/picker"
 )
 
 const (

--- a/internal/ui/render/switch_preview.go
+++ b/internal/ui/render/switch_preview.go
@@ -5,7 +5,7 @@ import (
 	"slices"
 	"strings"
 
-	corepreview "github.com/es5h/projmux/internal/core/preview"
+	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
 )
 
 // RenderSwitchPreview renders sidebar/popup preview context for a switch

--- a/internal/ui/render/switch_preview_test.go
+++ b/internal/ui/render/switch_preview_test.go
@@ -3,7 +3,7 @@ package render
 import (
 	"testing"
 
-	corepreview "github.com/es5h/projmux/internal/core/preview"
+	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
 )
 
 func TestRenderSwitchPreviewForExistingSession(t *testing.T) {


### PR DESCRIPTION
## Summary
- Repo ownership moved from `es5h` to `crevissepartners`. This PR reflects the rename across the codebase so the module/imports/build/install URLs all match the new home.
- Go module path: `github.com/es5h/projmux` → `github.com/crevissepartners/projmux` (`go.mod` + every internal import + `release.yml` ldflag + `defaultUpgradeModule` in `internal/app/upgrade.go`).
- User-visible strings: README install/clone URLs (EN + KO), Settings UI Source/Update rows, LICENSE copyright holder.

## Out of scope (intentional)
- `internal/core/sessions/identity_test.go` `/home/es5h` paths and the `"es5h"` mock literal in `internal/app/ai_test.go` are Unix-username test fixtures, unrelated to the GitHub org. Left untouched so the suite keeps passing on the dev machine.

## Test plan
- [x] `make fmt`
- [x] `make fix`
- [x] `make test` — 14/14 packages pass
- [x] `make test-integration` — no suites yet
- [x] `make test-e2e` — no suites yet

## Notes
- Marked as a breaking change (`!`) because the Go module path moved; any downstream importer or anyone following the published install/clone URL needs to update.
- `git remote origin` already repointed to `https://github.com/crevissepartners/projmux.git`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)