### PR TITLE
chore: keep breaking changes at minor bumps while pre-1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,8 @@
   "release-type": "go",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "packages": {
     ".": {
       "extra-files": [


### PR DESCRIPTION
## Summary
- Add `bump-minor-pre-major: true` and `bump-patch-for-minor-pre-major: true` to `release-please-config.json`.
- This keeps breaking changes at a minor bump (e.g. 0.2.x → 0.3.0) and feat/fix at a patch bump while we are still on 0.x. Without it, release-please escalates the first `chore!`/`feat!` straight to 1.0.0 — which is what just happened on PR #4 and is not what we want yet.

## Why now
- PR #6 (`chore!: transfer ownership to crevissepartners`) made release-please open #4 as a 1.0.0 release. We want that release cut as 0.3.0 instead.
- After this lands, the next release-please run on `main` should refresh PR #4 to target 0.3.0.

## Test plan
- [ ] Merge → wait for `Release Please` workflow to fire on `main`.
- [ ] Confirm PR #4 retitles to `chore(main): release 0.3.0` and the manifest/version diff updates accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)