### PR TITLE
test(settings): track current version instead of hardcoding

### DIFF
--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/core/candidates"
 	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
+	"github.com/crevissepartners/projmux/internal/version"
 )
 
 func TestSettingsHubSetsAIDefaultMode(t *testing.T) {
@@ -157,7 +158,7 @@ func TestSettingsHubShowsAboutSection(t *testing.T) {
 		t.Fatalf("settings about entries = %#v, want back entry", aboutOptions.Entries)
 	}
 	for _, want := range []string{
-		"projmux 0.2.1",
+		"projmux " + version.String(),
 		"https://github.com/crevissepartners/projmux",
 		"go install github.com/crevissepartners/projmux/cmd/projmux@latest",
 		"sidebar, sessions, projects",


### PR DESCRIPTION
## Summary
- `TestSettingsHubShowsAboutSection` hardcoded the literal `"projmux 0.2.1"` in the About-section label assertion.
- Every release-please version bump turned that test red — it just blocked PR #4 (release 0.3.0) from passing CI.
- Replace the literal with `"projmux " + version.String()` so the assertion tracks whatever release-please writes.

## Test plan
- [x] `make fmt-check`
- [x] `make test` — `TestSettingsHubShowsAboutSection` passes locally
- [ ] CI green on this PR
- [ ] After merge, release-please refreshes PR #4 with this fix included → CI passes there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)