### PR TITLE
ci(release-please): use PAT so generated PRs and tags trigger workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,5 +17,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- GitHub silently suppresses workflow runs that would be triggered by actions performed via the default `GITHUB_TOKEN` (anti-recursion safeguard).
- That blocked us twice this release: PR #4 had no `Test` check (so was unmergeable) and the v0.3.0 tag did not fire `release.yml`, so no binary artifacts were attached to the GitHub release.
- Wire `release-please-action@v4` to a fine-grained PAT stored as `RELEASE_PLEASE_TOKEN`. PR/tag creation will then look like a real user action and downstream workflows fire normally.

## Required setup (already done)
- Repo secret `RELEASE_PLEASE_TOKEN` set to a fine-grained PAT scoped to `crevissepartners/projmux` with `Contents: R/W`, `Pull requests: R/W`, `Metadata: R`.

## Test plan
- [x] `git diff` shows only the single `token:` line added under `with:`
- [ ] After merge, next `Release Please` workflow run uses the PAT, opens its PR, and CI runs on that PR automatically — no empty-commit / close-reopen workaround needed
- [ ] When that release PR merges, the v* tag push triggers `release.yml` and binary artifacts attach to the release

## Out of scope (next)
- Backfill v0.3.0 binary artifacts (since release.yml never ran for it). Will handle separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)