### PR TITLE
feat(hooks): add post-create hook for tmux sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,9 @@
 - If behavior changes, update the maintained test list in [docs/agent-workflow.md](docs/agent-workflow.md) in the same branch.
 - Do not skip `fmt` or `fix` because tests passed. Formatting, automatic fixes, and test execution are separate gates.
 
+## Hook Contract Stability
+- The post-create hook contract (path `~/.config/projmux/hooks/post-create`, `PROJMUX_*` env vars, 5s timeout) is part of the public API. Adding, removing, or renaming any `PROJMUX_*` env var, or moving the hook path, requires at minimum a minor version bump.
+
 ## Release Flow
 - `release-please-action` watches `main`, accumulates Conventional Commit subjects, and opens or refreshes a "chore(main): release X.Y.Z" PR. That PR contains the version bump (`internal/version/version.go` + `.release-please-manifest.json`), `CHANGELOG.md` updates, and the release notes.
 - Merging the release PR pushes the `vX.Y.Z` tag and creates the GitHub Release with auto-generated notes.

--- a/README-ko.md
+++ b/README-ko.md
@@ -176,6 +176,15 @@ Project...`는 이 filesystem root를 depth 3까지 스캔하므로 `~`나 `~rp`
 `#`로 시작하는 줄은 주석으로 무시됩니다. env가 설정되어 있을 때는 무시되며
 env가 비었을 때만 사용됩니다.
 
+## Hooks
+
+projmux는 새 tmux 세션을 만들 때마다 선택적 사용자 스크립트
+`~/.config/projmux/hooks/post-create`를 실행합니다. `tmux set-environment`로
+세션별 환경 변수를 주입하거나(예: 프로젝트 경로별 `GH_TOKEN` 선택) 다른
+부수 효과를 걸 때 활용하세요. 파일이 없거나 실행 비트가 빠져 있으면 조용히
+건너뛰며, hook 실패는 세션 생성을 막지 않습니다. 환경 변수 계약, 예시,
+문제 해결은 [Hooks](docs/hooks.md)를 참고하세요.
+
 ## 환경 변수
 
 | 변수 | 용도 |
@@ -208,6 +217,7 @@ make verify
 
 - [Architecture](docs/architecture.md)
 - [CLI Shape](docs/cli.md)
+- [Hooks](docs/hooks.md)
 - [Migration Plan](docs/migration-plan.md)
 - [Repo Layout](docs/repo-layout.md)
 - [터미널 키 설정](docs/keybindings.md)

--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ filesystem scan. Use it for paths you do not want crawled, e.g. WSL mounts
 The saved file lives at `~/.config/projmux/workdirs` (one absolute path per
 line, `#` comments allowed). It is consulted only when the env vars are unset.
 
+## Hooks
+
+projmux runs an optional user script at `~/.config/projmux/hooks/post-create`
+whenever it creates a new tmux session. Use it to inject per-session env via
+`tmux set-environment` (e.g. picking a `GH_TOKEN` based on the project path).
+Missing or non-executable hooks are skipped silently; failures never block
+session creation. See [Hooks](docs/hooks.md) for the env contract, examples,
+and troubleshooting.
+
 ## Environment Variables
 
 | Variable | Purpose |
@@ -212,6 +221,7 @@ More documentation:
 
 - [Architecture](docs/architecture.md)
 - [CLI Shape](docs/cli.md)
+- [Hooks](docs/hooks.md)
 - [Migration Plan](docs/migration-plan.md)
 - [Repo Layout](docs/repo-layout.md)
 - [Terminal Keybindings](docs/keybindings.md)

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,87 @@
+# Hooks
+
+projmux runs an optional user script when it creates a new tmux session. The
+hook is the project-agnostic seam for things projmux itself stays out of:
+injecting per-session env via `tmux set-environment`, picking a `GH_TOKEN` for
+the repo, exporting a Kubernetes context, kicking off a background sync, etc.
+projmux never ships behavior specific to any of those — that lives in the
+hook.
+
+## Where it lives
+
+```
+${XDG_CONFIG_HOME:-$HOME/.config}/projmux/hooks/post-create
+```
+
+The file must exist, be a regular file or symlink (not a directory), and have
+the owner-execute bit set. Anything else is silently skipped — no warning,
+no log. There is no enable flag.
+
+```sh
+mkdir -p ~/.config/projmux/hooks
+chmod +x ~/.config/projmux/hooks/post-create
+```
+
+## When it runs
+
+After projmux creates a brand-new tmux session via `EnsureSession` (the
+persistent path used by `current` and `switch`) or `CreateEphemeralSession`
+(used by `attach`). It does **not** run when projmux attaches to an existing
+session.
+
+The hook's exit code is ignored — session creation always succeeds.
+Hook stdout and stderr are forwarded to projmux's stderr line-by-line,
+prefixed with `[post-create] `. The hook is killed after 5 seconds.
+
+## Environment
+
+The hook inherits projmux's environment, plus:
+
+| Variable | Always set | Description |
+| --- | --- | --- |
+| `PROJMUX_SESSION` | yes | tmux session name |
+| `PROJMUX_CWD` | yes | absolute working directory of the new session |
+| `PROJMUX_SESSION_KIND` | yes | `persistent` or `ephemeral` |
+| `PROJMUX_VERSION` | yes | projmux version string |
+| `PROJMUX_SOCKET` | only if projmux used `tmux -L <socket>` | tmux socket name |
+
+## Examples
+
+### Stub
+
+```bash
+#!/usr/bin/env bash
+echo "session=$PROJMUX_SESSION cwd=$PROJMUX_CWD kind=$PROJMUX_SESSION_KIND"
+```
+
+### Per-session GH_TOKEN by repo
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$PROJMUX_CWD" in
+  "$HOME"/source/repos/personal/*)  token=$GH_TOKEN_PERSONAL ;;
+  "$HOME"/source/repos/work/*)      token=$GH_TOKEN_WORK ;;
+  *) exit 0 ;;
+esac
+
+tmux set-environment -t "$PROJMUX_SESSION" GH_TOKEN "$token"
+```
+
+`set-environment` only seeds the session env that newly-spawned panes inherit;
+it does not retroactively change the current shell. Open new panes via tmux
+(`Ctrl-b c`, `Ctrl-b "`, etc.) to pick up the value.
+
+## Troubleshooting
+
+- **Nothing happens.** Check the execute bit (`ls -l ~/.config/projmux/hooks/post-create`).
+  A missing bit makes projmux skip silently by design.
+- **`projmux: post-create hook: ... timed out after 5s`.** Long-running work
+  belongs in a backgrounded child (`(slow-thing &) >/dev/null 2>&1`). The hook
+  itself must return within 5s or projmux kills it.
+- **`projmux: post-create hook: hook ... exited with status N`.** The script
+  returned non-zero. projmux logs it once and moves on; the session is still
+  created.
+- **Lines appear with `[post-create] ` prefix.** Expected — that is how the
+  hook's stdout/stderr is multiplexed into projmux's stderr stream.

--- a/internal/app/attach.go
+++ b/internal/app/attach.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/core/lifecycle"
 	coresessions "github.com/crevissepartners/projmux/internal/core/sessions"
-	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
 type attachInventoryResolver interface {
@@ -39,7 +38,7 @@ type attachCommand struct {
 }
 
 func newAttachCommand() *attachCommand {
-	client := inttmux.NewClient(inttmux.ExecRunner{})
+	client := defaultTmuxClient()
 	return &attachCommand{
 		inventory:  client,
 		sessions:   client,

--- a/internal/app/current.go
+++ b/internal/app/current.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 
 	coresessions "github.com/crevissepartners/projmux/internal/core/sessions"
-	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
 type sessionIdentityResolver interface {
@@ -39,7 +38,7 @@ type currentPlan struct {
 }
 
 func newCurrentCommand() *currentCommand {
-	client := inttmux.NewClient(inttmux.ExecRunner{})
+	client := defaultTmuxClient()
 	identity, err := newDefaultCurrentIdentityResolver()
 
 	return &currentCommand{

--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -137,7 +137,7 @@ type switchPlan struct {
 }
 
 func newSwitchCommand() *switchCommand {
-	client := inttmux.NewClient(inttmux.ExecRunner{})
+	client := defaultTmuxClient()
 	identity, err := newDefaultCurrentIdentityResolver()
 	paths, pathsErr := config.DefaultPathsFromEnv()
 

--- a/internal/app/tmux_client.go
+++ b/internal/app/tmux_client.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"os"
+
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/integrations/hooks"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+	"github.com/crevissepartners/projmux/internal/version"
+)
+
+// defaultTmuxClient builds the production tmux client wired with the optional
+// post-create hook runner. Hook discovery uses the standard XDG-derived
+// projmux config dir; if that resolution fails we silently fall back to a
+// hookless client so session creation is never blocked by config errors.
+func defaultTmuxClient() *inttmux.Client {
+	opts := []inttmux.ClientOption{}
+	if hookPath := defaultPostCreateHookPath(); hookPath != "" {
+		opts = append(opts, inttmux.WithPostCreateRunner(&hooks.PostCreateRunner{
+			HookPath: hookPath,
+			Logger:   os.Stderr,
+			Timeout:  hooks.DefaultPostCreateTimeout,
+			Version:  version.String(),
+		}))
+	}
+	return inttmux.NewClient(inttmux.ExecRunner{}, opts...)
+}
+
+func defaultPostCreateHookPath() string {
+	paths, err := config.DefaultPathsFromEnv()
+	if err != nil {
+		return ""
+	}
+	return paths.PostCreateHookPath()
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,11 +10,13 @@ import (
 )
 
 const (
-	AppName              = "projmux"
-	PinsFileName         = "pins"
-	TagsFileName         = "tags"
-	PreviewStateFileName = "preview-state"
-	ProjdirFileName      = "projdir"
+	AppName                = "projmux"
+	PinsFileName           = "pins"
+	TagsFileName           = "tags"
+	PreviewStateFileName   = "preview-state"
+	ProjdirFileName        = "projdir"
+	HooksDirName           = "hooks"
+	PostCreateHookFileName = "post-create"
 )
 
 var ErrHomeDirRequired = errors.New("home directory is required when XDG homes are unset")
@@ -59,6 +61,12 @@ func (p Paths) PreviewStateFile() string {
 // ProjdirFile returns the default file used for the persisted PROJDIR value.
 func (p Paths) ProjdirFile() string {
 	return filepath.Join(p.ConfigDir, ProjdirFileName)
+}
+
+// PostCreateHookPath returns the default location for the optional
+// post-create hook script.
+func (p Paths) PostCreateHookPath() string {
+	return filepath.Join(p.ConfigDir, HooksDirName, PostCreateHookFileName)
 }
 
 // ProjdirFile returns the path to the persisted PROJDIR file rooted at the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -102,6 +102,19 @@ func TestPathsProjdirFile(t *testing.T) {
 	}
 }
 
+func TestPathsPostCreateHookPath(t *testing.T) {
+	t.Parallel()
+
+	paths := Paths{ConfigDir: "/tmp/config/projmux"}
+	want := filepath.Join(paths.ConfigDir, HooksDirName, PostCreateHookFileName)
+	if got := paths.PostCreateHookPath(); got != want {
+		t.Fatalf("PostCreateHookPath() = %q, want %q", got, want)
+	}
+	if want != filepath.Join("/tmp/config/projmux", "hooks", "post-create") {
+		t.Fatalf("PostCreateHookPath layout drifted: want %q", want)
+	}
+}
+
 func TestProjdirFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integrations/hooks/hooks.go
+++ b/internal/integrations/hooks/hooks.go
@@ -1,0 +1,174 @@
+// Package hooks runs optional user-supplied hook scripts at projmux
+// lifecycle points (e.g. tmux session creation).
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultPostCreateTimeout is the maximum wall-clock time the post-create hook
+// is allowed to run before it gets killed.
+const DefaultPostCreateTimeout = 5 * time.Second
+
+const postCreatePrefix = "[post-create] "
+
+// PostCreateContext describes the tmux session that was just created and is
+// passed to the hook script as PROJMUX_* environment variables.
+type PostCreateContext struct {
+	SessionName string
+	CWD         string
+	Kind        string
+	Socket      string
+	// Version is optional. When empty the runner's Version is used.
+	Version string
+}
+
+// PostCreateRunner runs the optional post-create hook script at HookPath.
+// A nil receiver, an empty HookPath, or a missing/non-executable file all
+// degrade to a silent no-op so the caller can always invoke Run unconditionally.
+type PostCreateRunner struct {
+	HookPath string
+	Logger   io.Writer
+	Timeout  time.Duration
+	Version  string
+}
+
+// Run executes the post-create hook for c if one is configured. Hook failures
+// (missing file, non-executable, non-zero exit, exec error, timeout) are
+// recorded as a single warning line on Logger and never returned.
+func (r *PostCreateRunner) Run(ctx context.Context, c PostCreateContext) {
+	if r == nil || strings.TrimSpace(r.HookPath) == "" {
+		return
+	}
+
+	info, err := os.Stat(r.HookPath)
+	if err != nil {
+		return
+	}
+	if info.IsDir() {
+		return
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		return
+	}
+
+	timeout := r.Timeout
+	if timeout <= 0 {
+		timeout = DefaultPostCreateTimeout
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, r.HookPath)
+	cmd.Stdin = nil
+	cmd.Dir = c.CWD
+	cmd.Env = buildHookEnv(c, r.Version)
+	// Force-close inherited pipes 250ms after SIGKILL so a child that
+	// inherited stdout/stderr (e.g. a backgrounded sleep) cannot keep us
+	// blocked in cmd.Wait.
+	cmd.WaitDelay = 250 * time.Millisecond
+
+	logger := r.Logger
+	prefixed := newLinePrefixer(logger, postCreatePrefix)
+	cmd.Stdout = prefixed
+	cmd.Stderr = prefixed
+
+	err = cmd.Run()
+	prefixed.Flush()
+
+	if runCtx.Err() == context.DeadlineExceeded {
+		warnf(logger, "hook %q timed out after %s", r.HookPath, timeout)
+		return
+	}
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			warnf(logger, "hook %q exited with status %d", r.HookPath, exitErr.ExitCode())
+			return
+		}
+		warnf(logger, "hook %q: %v", r.HookPath, err)
+	}
+}
+
+func buildHookEnv(c PostCreateContext, fallbackVersion string) []string {
+	env := append([]string{}, os.Environ()...)
+	version := c.Version
+	if version == "" {
+		version = fallbackVersion
+	}
+	env = append(env,
+		"PROJMUX_SESSION="+c.SessionName,
+		"PROJMUX_CWD="+c.CWD,
+		"PROJMUX_SESSION_KIND="+c.Kind,
+		"PROJMUX_VERSION="+version,
+	)
+	if strings.TrimSpace(c.Socket) != "" {
+		env = append(env, "PROJMUX_SOCKET="+c.Socket)
+	}
+	return env
+}
+
+// linePrefixer wraps a destination writer and rewrites bytes into newline
+// terminated lines prefixed with prefix. It is safe for concurrent writes from
+// child stdout and stderr because exec.Cmd serializes through its lock when
+// the same writer is assigned to both — but we still guard with a mutex so
+// future callers can share a logger without surprises.
+type linePrefixer struct {
+	mu     sync.Mutex
+	dst    io.Writer
+	prefix string
+	buf    bytes.Buffer
+}
+
+func newLinePrefixer(dst io.Writer, prefix string) *linePrefixer {
+	return &linePrefixer{dst: dst, prefix: prefix}
+}
+
+func (p *linePrefixer) Write(b []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.dst == nil {
+		return len(b), nil
+	}
+	n := len(b)
+	for len(b) > 0 {
+		idx := bytes.IndexByte(b, '\n')
+		if idx < 0 {
+			p.buf.Write(b)
+			break
+		}
+		p.buf.Write(b[:idx])
+		_, _ = io.WriteString(p.dst, p.prefix+p.buf.String()+"\n")
+		p.buf.Reset()
+		b = b[idx+1:]
+	}
+	return n, nil
+}
+
+// Flush writes any buffered partial line (no trailing newline) to dst.
+func (p *linePrefixer) Flush() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.dst == nil || p.buf.Len() == 0 {
+		return
+	}
+	_, _ = io.WriteString(p.dst, p.prefix+p.buf.String()+"\n")
+	p.buf.Reset()
+}
+
+func warnf(w io.Writer, format string, args ...interface{}) {
+	if w == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "projmux: post-create hook: "+format+"\n", args...)
+}

--- a/internal/integrations/hooks/hooks_test.go
+++ b/internal/integrations/hooks/hooks_test.go
@@ -1,0 +1,217 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPostCreateRunnerEmptyHookPathIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	var logger bytes.Buffer
+	runner := &PostCreateRunner{Logger: &logger}
+	runner.Run(context.Background(), PostCreateContext{SessionName: "workspace"})
+
+	if logger.Len() != 0 {
+		t.Fatalf("logger output = %q, want empty", logger.String())
+	}
+}
+
+func TestPostCreateRunnerNilReceiverIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	var runner *PostCreateRunner
+	runner.Run(context.Background(), PostCreateContext{SessionName: "workspace"})
+}
+
+func TestPostCreateRunnerMissingHookIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	var logger bytes.Buffer
+	runner := &PostCreateRunner{
+		HookPath: filepath.Join(t.TempDir(), "missing"),
+		Logger:   &logger,
+	}
+	runner.Run(context.Background(), PostCreateContext{SessionName: "workspace"})
+
+	if logger.Len() != 0 {
+		t.Fatalf("logger output = %q, want empty", logger.String())
+	}
+}
+
+func TestPostCreateRunnerNonExecutableHookIsNoOp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash fixtures require POSIX")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hook")
+	if err := os.WriteFile(path, []byte("#!/usr/bin/env bash\nexit 0\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var logger bytes.Buffer
+	runner := &PostCreateRunner{HookPath: path, Logger: &logger}
+	runner.Run(context.Background(), PostCreateContext{SessionName: "workspace"})
+
+	if logger.Len() != 0 {
+		t.Fatalf("logger output = %q, want empty (non-executable should be silent)", logger.String())
+	}
+}
+
+func TestPostCreateRunnerDirectoryAtHookPathIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	var logger bytes.Buffer
+	runner := &PostCreateRunner{HookPath: dir, Logger: &logger}
+	runner.Run(context.Background(), PostCreateContext{SessionName: "workspace"})
+
+	if logger.Len() != 0 {
+		t.Fatalf("logger output = %q, want empty", logger.String())
+	}
+}
+
+func TestPostCreateRunnerHappyPathInjectsEnvAndPrefixesOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash fixtures require POSIX")
+	}
+	t.Parallel()
+
+	hookPath := absFixture(t, "echo-env.sh")
+	cwd := t.TempDir()
+	var logger bytes.Buffer
+	runner := &PostCreateRunner{HookPath: hookPath, Logger: &logger}
+	runner.Run(context.Background(), PostCreateContext{
+		SessionName: "workspace",
+		CWD:         cwd,
+		Kind:        "persistent",
+		Socket:      "projmux",
+		Version:     "0.0.0-test",
+	})
+
+	got := logger.String()
+	want := []string{
+		"[post-create] session=workspace",
+		"[post-create] cwd=" + cwd,
+		"[post-create] kind=persistent",
+		"[post-create] socket=projmux",
+		"[post-create] version=0.0.0-test",
+		"[post-create] stderr-line",
+	}
+	for _, line := range want {
+		if !strings.Contains(got, line) {
+			t.Fatalf("logger output missing %q\nfull output:\n%s", line, got)
+		}
+	}
+	if strings.Contains(got, "projmux: post-create hook:") {
+		t.Fatalf("happy path should not emit warning: %q", got)
+	}
+}
+
+func TestPostCreateRunnerOmitsSocketWhenEmpty(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash fixtures require POSIX")
+	}
+	t.Parallel()
+
+	hookPath := absFixture(t, "echo-env.sh")
+	var logger bytes.Buffer
+	runner := &PostCreateRunner{HookPath: hookPath, Logger: &logger}
+	runner.Run(context.Background(), PostCreateContext{
+		SessionName: "workspace",
+		CWD:         t.TempDir(),
+		Kind:        "ephemeral",
+		Version:     "0.0.0-test",
+	})
+
+	got := logger.String()
+	if !strings.Contains(got, "[post-create] socket=unset") {
+		t.Fatalf("expected socket env to be unset, got:\n%s", got)
+	}
+}
+
+func TestPostCreateRunnerNonZeroExitWritesWarning(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash fixtures require POSIX")
+	}
+	t.Parallel()
+
+	hookPath := absFixture(t, "fail.sh")
+	var logger bytes.Buffer
+	runner := &PostCreateRunner{HookPath: hookPath, Logger: &logger}
+	runner.Run(context.Background(), PostCreateContext{
+		SessionName: "workspace",
+		CWD:         t.TempDir(),
+		Kind:        "persistent",
+		Version:     "0.0.0-test",
+	})
+
+	got := logger.String()
+	if !strings.Contains(got, "projmux: post-create hook:") {
+		t.Fatalf("expected warning line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "exited with status 7") {
+		t.Fatalf("expected exit status 7 in warning, got:\n%s", got)
+	}
+}
+
+func TestPostCreateRunnerTimeoutKillsHookAndWarns(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash fixtures require POSIX")
+	}
+	t.Parallel()
+
+	hookPath := absFixture(t, "slow.sh")
+	var logger bytes.Buffer
+	runner := &PostCreateRunner{
+		HookPath: hookPath,
+		Logger:   &logger,
+		Timeout:  200 * time.Millisecond,
+	}
+
+	start := time.Now()
+	runner.Run(context.Background(), PostCreateContext{
+		SessionName: "workspace",
+		CWD:         t.TempDir(),
+		Kind:        "persistent",
+		Version:     "0.0.0-test",
+	})
+	elapsed := time.Since(start)
+
+	if elapsed > 3*time.Second {
+		t.Fatalf("timeout did not fire in time: elapsed=%s", elapsed)
+	}
+	got := logger.String()
+	if !strings.Contains(got, "timed out") {
+		t.Fatalf("expected timeout warning, got:\n%s", got)
+	}
+}
+
+func absFixture(t *testing.T, name string) string {
+	t.Helper()
+	abs, err := filepath.Abs(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		t.Fatalf("stat fixture %s: %v", abs, err)
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		// Repo restore did not preserve the execute bit; restore it for this run
+		// so we still exercise the happy path locally. CI checks that the bit is
+		// committed via git update-index --chmod=+x.
+		if err := os.Chmod(abs, 0o755); err != nil {
+			t.Fatalf("chmod fixture %s: %v", abs, err)
+		}
+	}
+	return abs
+}

--- a/internal/integrations/hooks/testdata/echo-env.sh
+++ b/internal/integrations/hooks/testdata/echo-env.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+echo "session=${PROJMUX_SESSION}"
+echo "cwd=${PROJMUX_CWD}"
+echo "kind=${PROJMUX_SESSION_KIND}"
+echo "socket=${PROJMUX_SOCKET-unset}"
+echo "version=${PROJMUX_VERSION}"
+echo "stderr-line" >&2
+exit 0

--- a/internal/integrations/hooks/testdata/fail.sh
+++ b/internal/integrations/hooks/testdata/fail.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "boom" >&2
+exit 7

--- a/internal/integrations/hooks/testdata/slow.sh
+++ b/internal/integrations/hooks/testdata/slow.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+sleep 10
+exit 0

--- a/internal/integrations/tmux/client.go
+++ b/internal/integrations/tmux/client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/crevissepartners/projmux/internal/core/lifecycle"
+	"github.com/crevissepartners/projmux/internal/integrations/hooks"
 )
 
 var (
@@ -60,10 +61,43 @@ func (ExecRunner) Run(ctx context.Context, name string, args ...string) ([]byte,
 	return output, nil
 }
 
+// postCreateRunner is the subset of *hooks.PostCreateRunner that the tmux
+// client invokes after creating a new session. The interface keeps the
+// dependency narrow and lets tests stub it without spinning up real exec.
+type postCreateRunner interface {
+	Run(ctx context.Context, c hooks.PostCreateContext)
+}
+
 // Client exposes typed tmux queries used by CLI commands.
 type Client struct {
-	runner    commandRunner
-	lookupEnv func(string) string
+	runner     commandRunner
+	lookupEnv  func(string) string
+	postCreate postCreateRunner
+	socket     string
+}
+
+// ClientOption configures optional Client behavior.
+type ClientOption func(*Client)
+
+// WithPostCreateRunner attaches a hook runner that fires after a tmux
+// session is newly created. Pass nil to disable.
+func WithPostCreateRunner(r *hooks.PostCreateRunner) ClientOption {
+	return func(c *Client) {
+		if r == nil {
+			c.postCreate = nil
+			return
+		}
+		c.postCreate = r
+	}
+}
+
+// WithSocketName records the tmux -L socket name (if any) the caller is using
+// so it can be propagated to hook scripts via PROJMUX_SOCKET. The Client
+// itself does not currently shell out with -L; this is metadata only.
+func WithSocketName(socket string) ClientOption {
+	return func(c *Client) {
+		c.socket = strings.TrimSpace(socket)
+	}
 }
 
 // Window describes a tmux window inventory row for a session.
@@ -129,16 +163,28 @@ type RecentSessionSummary struct {
 	Activity    int64
 }
 
-// NewClient builds a tmux client over the provided runner.
-func NewClient(runner commandRunner) *Client {
-	return newClientWithEnv(runner, os.Getenv)
+// NewClient builds a tmux client over the provided runner with optional
+// configuration.
+func NewClient(runner commandRunner, opts ...ClientOption) *Client {
+	c := &Client{
+		runner:    runner,
+		lookupEnv: os.Getenv,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
-func newClientWithEnv(runner commandRunner, lookupEnv func(string) string) *Client {
-	return &Client{
+func newClientWithEnv(runner commandRunner, lookupEnv func(string) string, opts ...ClientOption) *Client {
+	c := &Client{
 		runner:    runner,
 		lookupEnv: lookupEnv,
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // CurrentPanePath returns the current tmux pane path for the active client.
@@ -344,6 +390,7 @@ func (c *Client) EnsureSession(ctx context.Context, sessionName, cwd string) err
 		return fmt.Errorf("create tmux session %q: %w", sessionName, err)
 	}
 
+	c.runPostCreate(ctx, sessionName, cwd, "persistent")
 	return nil
 }
 
@@ -361,10 +408,25 @@ func (c *Client) CreateEphemeralSession(ctx context.Context, sessionName, cwd st
 		return fmt.Errorf("create tmux ephemeral session %q: %w", sessionName, err)
 	}
 	if _, err := c.runner.Run(ctx, "tmux", "set-option", "-t", sessionName, "-q", "@projmux_ephemeral", "1"); err != nil {
-		return nil
+		// set-option failure is intentionally swallowed; the session is still
+		// usable. The post-create hook still runs so the session gets the same
+		// lifecycle treatment as one whose marker stuck.
 	}
+	c.runPostCreate(ctx, sessionName, cwd, "ephemeral")
 
 	return nil
+}
+
+func (c *Client) runPostCreate(ctx context.Context, sessionName, cwd, kind string) {
+	if c.postCreate == nil {
+		return
+	}
+	c.postCreate.Run(ctx, hooks.PostCreateContext{
+		SessionName: sessionName,
+		CWD:         cwd,
+		Kind:        kind,
+		Socket:      c.socket,
+	})
 }
 
 // SessionExists reports whether the named tmux session already exists.

--- a/internal/integrations/tmux/client_test.go
+++ b/internal/integrations/tmux/client_test.go
@@ -7,7 +7,10 @@ import (
 	"os/exec"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/crevissepartners/projmux/internal/integrations/hooks"
 )
 
 func TestClientCurrentPanePathTrimsOutput(t *testing.T) {
@@ -1403,6 +1406,149 @@ func TestBuildSwitchSidebarFocusCommandQuotesBinaryPath(t *testing.T) {
 	}
 }
 
+func TestClientEnsureSessionInvokesPostCreateRunnerOnNewSession(t *testing.T) {
+	t.Parallel()
+
+	runner := &scriptedRunner{
+		t: t,
+		steps: []scriptedStep{
+			{err: exitError(t, 1)},
+			{},
+		},
+	}
+	hook := &fakePostCreateRunner{}
+	client := NewClient(runner, withPostCreateRunnerInterface(hook), WithSocketName("projmux"))
+
+	if err := client.EnsureSession(context.Background(), "workspace", "/tmp/projmux"); err != nil {
+		t.Fatalf("EnsureSession returned error: %v", err)
+	}
+
+	if got := len(hook.calls); got != 1 {
+		t.Fatalf("post-create calls = %d, want 1", got)
+	}
+	want := hooks.PostCreateContext{
+		SessionName: "workspace",
+		CWD:         "/tmp/projmux",
+		Kind:        "persistent",
+		Socket:      "projmux",
+	}
+	if got := hook.calls[0]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("post-create call = %#v, want %#v", got, want)
+	}
+}
+
+func TestClientEnsureSessionSkipsPostCreateWhenSessionExists(t *testing.T) {
+	t.Parallel()
+
+	runner := &scriptedRunner{
+		t:     t,
+		steps: []scriptedStep{{}},
+	}
+	hook := &fakePostCreateRunner{}
+	client := NewClient(runner, withPostCreateRunnerInterface(hook))
+
+	if err := client.EnsureSession(context.Background(), "workspace", "/tmp/projmux"); err != nil {
+		t.Fatalf("EnsureSession returned error: %v", err)
+	}
+
+	if len(hook.calls) != 0 {
+		t.Fatalf("post-create calls = %#v, want none", hook.calls)
+	}
+}
+
+func TestClientEnsureSessionSkipsPostCreateWhenNewSessionFails(t *testing.T) {
+	t.Parallel()
+
+	runner := &scriptedRunner{
+		t: t,
+		steps: []scriptedStep{
+			{err: exitError(t, 1)},
+			{err: errors.New("new-session failed")},
+		},
+	}
+	hook := &fakePostCreateRunner{}
+	client := NewClient(runner, withPostCreateRunnerInterface(hook))
+
+	if err := client.EnsureSession(context.Background(), "workspace", "/tmp/projmux"); err == nil {
+		t.Fatal("expected error")
+	}
+	if len(hook.calls) != 0 {
+		t.Fatalf("post-create calls = %#v, want none", hook.calls)
+	}
+}
+
+func TestClientCreateEphemeralSessionInvokesPostCreateRunner(t *testing.T) {
+	t.Parallel()
+
+	runner := &scriptedRunner{
+		t:     t,
+		steps: []scriptedStep{{}, {}},
+	}
+	hook := &fakePostCreateRunner{}
+	client := NewClient(runner, withPostCreateRunnerInterface(hook), WithSocketName("projmux"))
+
+	if err := client.CreateEphemeralSession(context.Background(), "scratch", "/tmp/projmux"); err != nil {
+		t.Fatalf("CreateEphemeralSession returned error: %v", err)
+	}
+
+	if got := len(hook.calls); got != 1 {
+		t.Fatalf("post-create calls = %d, want 1", got)
+	}
+	want := hooks.PostCreateContext{
+		SessionName: "scratch",
+		CWD:         "/tmp/projmux",
+		Kind:        "ephemeral",
+		Socket:      "projmux",
+	}
+	if got := hook.calls[0]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("post-create call = %#v, want %#v", got, want)
+	}
+}
+
+func TestClientCreateEphemeralSessionRunsHookEvenWhenMarkerFails(t *testing.T) {
+	t.Parallel()
+
+	runner := &scriptedRunner{
+		t: t,
+		steps: []scriptedStep{
+			{},
+			{err: errors.New("set-option failed")},
+		},
+	}
+	hook := &fakePostCreateRunner{}
+	client := NewClient(runner, withPostCreateRunnerInterface(hook))
+
+	if err := client.CreateEphemeralSession(context.Background(), "scratch", "/tmp/projmux"); err != nil {
+		t.Fatalf("CreateEphemeralSession returned error: %v", err)
+	}
+	if len(hook.calls) != 1 {
+		t.Fatalf("post-create calls = %d, want 1", len(hook.calls))
+	}
+	if hook.calls[0].Kind != "ephemeral" {
+		t.Fatalf("post-create kind = %q, want ephemeral", hook.calls[0].Kind)
+	}
+}
+
+func TestClientCreateEphemeralSessionSkipsPostCreateWhenNewSessionFails(t *testing.T) {
+	t.Parallel()
+
+	runner := &scriptedRunner{
+		t: t,
+		steps: []scriptedStep{
+			{err: errors.New("new-session failed")},
+		},
+	}
+	hook := &fakePostCreateRunner{}
+	client := NewClient(runner, withPostCreateRunnerInterface(hook))
+
+	if err := client.CreateEphemeralSession(context.Background(), "scratch", "/tmp/projmux"); err == nil {
+		t.Fatal("expected error")
+	}
+	if len(hook.calls) != 0 {
+		t.Fatalf("post-create calls = %#v, want none", hook.calls)
+	}
+}
+
 func TestClientEnsureSessionRequiresCWD(t *testing.T) {
 	t.Parallel()
 
@@ -1448,6 +1594,25 @@ func (r *scriptedRunner) Run(ctx context.Context, name string, args ...string) (
 	step := r.steps[0]
 	r.steps = r.steps[1:]
 	return step.output, step.err
+}
+
+type fakePostCreateRunner struct {
+	mu    sync.Mutex
+	calls []hooks.PostCreateContext
+}
+
+func (f *fakePostCreateRunner) Run(_ context.Context, c hooks.PostCreateContext) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, c)
+}
+
+// withPostCreateRunnerInterface wires a test stub through the same field that
+// WithPostCreateRunner targets without depending on a real *hooks.PostCreateRunner.
+func withPostCreateRunnerInterface(r postCreateRunner) ClientOption {
+	return func(c *Client) {
+		c.postCreate = r
+	}
 }
 
 func exitError(t *testing.T, code int) error {


### PR DESCRIPTION
## Summary
- Add `${ConfigDir}/hooks/post-create` user-script hook that runs after projmux creates a new tmux session (persistent or ephemeral). Missing / non-executable / dir / nil-runner all degrade to silent no-op.
- Hook gets `PROJMUX_SESSION`, `PROJMUX_CWD`, `PROJMUX_SESSION_KIND` (`persistent`|`ephemeral`), `PROJMUX_VERSION`, and `PROJMUX_SOCKET` (only when projmux uses `-L`). Stdin closed; stdout/stderr forwarded to projmux stderr with `[post-create] ` prefix; 5s timeout; exit code ignored.
- Generic by design — projmux stays out of GitHub/secret-tool/keyring concerns. Use case (per-repo `GH_TOKEN` injection) lives in the hook script, documented in `docs/hooks.md`.

## Where
- New package `internal/integrations/hooks` (`PostCreateRunner`, `PostCreateContext`, line-prefixer, fixtures).
- `internal/config`: `HooksDirName`, `PostCreateHookFileName`, `Paths.PostCreateHookPath()`.
- `internal/integrations/tmux/client.go`: variadic `ClientOption`, `WithPostCreateRunner`, `WithSocketName`. Hook fires only on **newly created** session in `EnsureSession`; in `CreateEphemeralSession` it fires after the (still swallowed) `@projmux_ephemeral` marker step.
- `internal/app/tmux_client.go`: production wiring; the three call sites that construct a client (`attach`, `current`, `switch`) now go through it.
- Docs: `docs/hooks.md`, README/README-ko Hooks section, AGENTS.md hook contract stability line.

## Notes for reviewer
- `cmd.WaitDelay = 250ms` is intentional: a backgrounded `sleep` inheriting pipes from bash would otherwise keep `Wait` blocked even after `CommandContext` SIGKILLs the script.
- `CreateEphemeralSession` previously did `return nil` on a failed `set-option` — silent success. Behavior preserved (still silent), but the function now continues to the hook call so ephemeral sessions get the same lifecycle treatment as persistent ones.
- `WithSocketName` is plumbed but unused in the bootstrap (no caller sets `-L` today). It exists so a future `-L projmux` mode can light up `PROJMUX_SOCKET` without another API change.

## Test plan
- [x] `make fmt-check`
- [x] `make test` (incl. new `internal/integrations/hooks` and the new `internal/integrations/tmux` cases)
- [x] `go test -race ./internal/integrations/hooks/... ./internal/integrations/tmux/...`
- [x] `go vet ./...`
- [ ] CI green
- [ ] Manual: drop a `~/.config/projmux/hooks/post-create` that runs `tmux set-environment` and `tmux show-environment -t <session> GH_TOKEN` confirms inject

## Out of scope
- `pre-create` / `post-attach` / multiple-hook / remote-hook variants. Per spec § 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)