### PR TITLE
feat!: rename PROJDIR env to PROJMUX_PROJDIR and support multi-path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,10 +56,10 @@
 - Non-Conventional commit subjects on `main` are silently skipped by release-please. Keep PR titles strict; squash merge ensures the PR title is the only subject that lands.
 
 ## Configuration And Environment
-- `PROJDIR` is the canonical project-root env. Memoized to `~/.config/projmux/projdir` after first use. The legacy `RP` alias is still honored at runtime; do not feature it in user-facing docs.
+- `PROJMUX_PROJDIR` is the canonical project-root env. It accepts an OS-native PATH-style multi-value (`filepath.SplitList`): the first non-empty entry is the primary repo root (memoized to `~/.config/projmux/projdir`), and any additional entries are prepended to managed roots. The legacy `PROJDIR`/`RP` env vars are no longer honored.
 - `PROJMUX_MANAGED_ROOTS` is the colon-separated search-root override (priority: env > saved file > defaults). Legacy alias `TMUX_SESSIONIZER_ROOTS` is still honored at runtime.
 - `~/.config/projmux/workdirs` stores the cumulative workdirs list managed via the Settings UX. It is read only when no env list is set.
-- `tmux set-option -g @projmux_projdir <path>` is a declarative source for `PROJDIR` that the switch command reads through `tmuxProjdirOption`.
+- `tmux set-option -g @projmux_projdir <path>` is a declarative source for `PROJMUX_PROJDIR` that the switch command reads through `tmuxProjdirOption`.
 
 ## Review Expectations
 - Reviews should be small enough to reason about quickly.

--- a/README-ko.md
+++ b/README-ko.md
@@ -86,19 +86,40 @@ export PATH="$(go env GOPATH)/bin:$PATH"
 projmux version
 ```
 
-### 선택: `PROJDIR`
+### 선택: `PROJMUX_PROJDIR`
 
-`PROJDIR` 은 projmux 가 picker/탐색에서 기본으로 사용할 프로젝트 루트입니다.
-설정하지 않으면 projmux 가 내장된 source-root 탐색(`~/source`, `~/work`,
-`~/projects`, `~/src`, `~/code`, `~/source/repos`) 으로 자동 fallback 합니다.
+`PROJMUX_PROJDIR` 은 projmux 가 picker/탐색에서 기본으로 사용할 프로젝트
+루트입니다. 설정하지 않으면 projmux 가 내장된 source-root 탐색(`~/source`,
+`~/work`, `~/projects`, `~/src`, `~/code`, `~/source/repos`) 으로 자동
+fallback 합니다.
 
 ```sh
-export PROJDIR="$HOME/source/repos"
+export PROJMUX_PROJDIR="$HOME/source/repos"
 ```
 
 `~/.zshrc` (또는 사용 중인 shell rc 파일) 에 한 줄 추가하면 됩니다. 첫 실행
 이후에는 `~/.config/projmux/projdir` 에 memoize 되므로, 이후 env 가 없어도 같은
 루트가 유지됩니다.
+
+`PROJMUX_PROJDIR` 은 OS-native PATH 형식의 multi-path 도 받습니다 (Linux/macOS
+는 `:`, Windows 는 `;`). 첫 번째 비어있지 않은 항목이 primary 프로젝트 루트가
+되고, 이후 항목은 `PROJMUX_MANAGED_ROOTS` 처럼 managed roots 검색 목록 앞에
+prepend 됩니다. saved 파일에는 primary 만 memoize 됩니다.
+
+```sh
+# Linux/macOS — primary repo + 보조 검색 root
+export PROJMUX_PROJDIR="$HOME/source/repos:/srv/work/repos"
+```
+
+#### 최초 설치 시 projdir 지정
+
+```sh
+PROJMUX_PROJDIR=/your/path go install github.com/crevissepartners/projmux/cmd/projmux@latest
+PROJMUX_PROJDIR=/your/path projmux tmux apply
+```
+
+env 가 살아있는 첫 실행이 `~/.config/projmux/projdir` 에 값을 기록하므로,
+이후 새 shell 에서 env 없이도 같은 루트가 유지됩니다.
 
 ### 소스에서 빌드
 
@@ -140,8 +161,19 @@ projmux upgrade --no-apply                       # 'projmux tmux apply' 생략
 projmux upgrade --dry-run                        # 실행 없이 단계만 출력
 ```
 
-upgrade 는 호출 shell 의 `PROJDIR`/`RP` 를 읽어 `~/.config/projmux/projdir` 에
-memoize 하므로, 새 binary 도 같은 프로젝트 루트 컨텍스트를 유지합니다.
+upgrade 는 호출 shell 의 `PROJMUX_PROJDIR` 을 읽어 primary (첫 번째) 경로를
+`~/.config/projmux/projdir` 에 memoize 하므로, 새 binary 도 같은 프로젝트 루트
+컨텍스트를 유지합니다.
+
+업그레이드와 동시에 새 프로젝트 루트로 전환하고 싶다면 env 와 함께 호출하세요:
+
+```sh
+PROJMUX_PROJDIR=/new/path projmux upgrade
+
+# multi-path 도 동일하게 동작합니다. saved 파일에는 primary 만 기록됩니다.
+PROJMUX_PROJDIR="/main/repos:/secondary/repos" projmux upgrade   # Linux/macOS
+# Windows: PROJMUX_PROJDIR="C:\main\repos;C:\secondary\repos"
+```
 
 ## 사용법
 
@@ -189,7 +221,7 @@ projmux는 새 tmux 세션을 만들 때마다 선택적 사용자 스크립트
 
 | 변수 | 용도 |
 | --- | --- |
-| `PROJDIR` | 현재 shell 의 기본 프로젝트 루트. 첫 사용 후 `~/.config/projmux/projdir` 에 memoize 됨. |
+| `PROJMUX_PROJDIR` | 현재 shell 의 기본 프로젝트 루트. OS-native PATH 형식 multi-value 지원: 첫 항목이 primary repo root (saved 파일에 memoize), 이후 항목은 managed-roots 검색 목록 앞에 prepend. |
 | `PROJMUX_MANAGED_ROOTS` | 콜론 구분 검색 root 목록. saved/default 보다 우선. |
 | `PROJMUX_NOTIFY_HOOK` | AI desktop notification 을 내장 sender 대신 받는 외부 실행 파일. |
 

--- a/README.md
+++ b/README.md
@@ -87,20 +87,43 @@ Verify:
 projmux version
 ```
 
-### Optional: `PROJDIR`
+### Optional: `PROJMUX_PROJDIR`
 
-`PROJDIR` is the default project root projmux uses for picker and discovery.
-It is optional — when unset, projmux falls back to its built-in source-root
-discovery (`~/source`, `~/work`, `~/projects`, `~/src`, `~/code`,
+`PROJMUX_PROJDIR` is the default project root projmux uses for picker and
+discovery. It is optional — when unset, projmux falls back to its built-in
+source-root discovery (`~/source`, `~/work`, `~/projects`, `~/src`, `~/code`,
 `~/source/repos`).
 
 ```sh
-export PROJDIR="$HOME/source/repos"
+export PROJMUX_PROJDIR="$HOME/source/repos"
 ```
 
 Add the line to `~/.zshrc` (or your shell's rc file). The resolved value is
 memoized to `~/.config/projmux/projdir` after first use, so later shells keep
 the same root even without the env var.
+
+`PROJMUX_PROJDIR` accepts an OS-native PATH-style multi-value (`:` on
+Linux/macOS, `;` on Windows). The first non-empty entry is the primary
+project root; any additional entries are prepended to the managed-roots
+search list, so they participate in discovery just like
+`PROJMUX_MANAGED_ROOTS`. Only the primary path is memoized to
+`~/.config/projmux/projdir`.
+
+```sh
+# Linux/macOS — primary repo + secondary search root
+export PROJMUX_PROJDIR="$HOME/source/repos:/srv/work/repos"
+```
+
+#### Set the project root at install time
+
+```sh
+PROJMUX_PROJDIR=/your/path go install github.com/crevissepartners/projmux/cmd/projmux@latest
+PROJMUX_PROJDIR=/your/path projmux tmux apply
+```
+
+The first invocation that sees the env var writes
+`~/.config/projmux/projdir`, so later shells without the env var still
+resolve the same root.
 
 ### From source
 
@@ -144,9 +167,20 @@ projmux upgrade --no-apply                       # skip 'projmux tmux apply'
 projmux upgrade --dry-run                        # print the steps only
 ```
 
-The upgrade reads `PROJDIR`/`RP` from the calling shell and memoizes the
-resolved value to `~/.config/projmux/projdir`, so the new binary keeps the
-same project root context as the one it replaces.
+The upgrade reads `PROJMUX_PROJDIR` from the calling shell and memoizes the
+primary (first) path to `~/.config/projmux/projdir`, so the new binary keeps
+the same project root context as the one it replaces.
+
+Pass a new project root inline to atomically switch the binary and the saved
+projdir in one step:
+
+```sh
+PROJMUX_PROJDIR=/new/path projmux upgrade
+
+# Multi-path also works; only the primary entry is persisted to the saved file.
+PROJMUX_PROJDIR="/main/repos:/secondary/repos" projmux upgrade   # Linux/macOS
+# Windows: PROJMUX_PROJDIR="C:\main\repos;C:\secondary\repos"
+```
 
 ## Usage
 
@@ -194,7 +228,7 @@ and troubleshooting.
 
 | Variable | Purpose |
 | --- | --- |
-| `PROJDIR` | Default project root for the current shell. Memoized to `~/.config/projmux/projdir` after first use. |
+| `PROJMUX_PROJDIR` | Default project root for the current shell. Accepts an OS-native PATH-style multi-value: the first entry is the primary repo root (memoized to `~/.config/projmux/projdir`), and any additional entries are prepended to the managed-roots search list. |
 | `PROJMUX_MANAGED_ROOTS` | Colon-separated list of search roots. Overrides the saved/default list. |
 | `PROJMUX_NOTIFY_HOOK` | External executable that receives AI desktop notifications instead of the built-in sender. |
 

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -524,7 +524,7 @@ func (c *settingsCommand) projectPickerEntries() []intfzf.Entry {
 	return entries
 }
 
-// projectRootEntry renders the resolved PROJDIR path with its source label.
+// projectRootEntry renders the resolved PROJMUX_PROJDIR path with its source label.
 // The row is read-only (settingsNoopValue) and never triggers memoization.
 func (c *settingsCommand) projectRootEntry() intfzf.Entry {
 	if c.switcher == nil {
@@ -548,9 +548,10 @@ func (c *settingsCommand) projectRootEntry() intfzf.Entry {
 
 func (c *settingsCommand) projectRootHintEntry() intfzf.Entry {
 	// Keep the entire hint in one dim run so search substrings such as
-	// "Override via PROJDIR env" stay contiguous in the rendered label.
+	// "Override via PROJMUX_PROJDIR env" stay contiguous in the rendered
+	// label.
 	return intfzf.Entry{
-		Label: "  " + settingsColorDim + "Override via PROJDIR env, set -g @projmux_projdir, or ~/.config/projmux/projdir" + settingsColorReset,
+		Label: "  " + settingsColorDim + "Override via PROJMUX_PROJDIR env (multi-path with `:` on Linux/`;` on Windows), set -g @projmux_projdir, or ~/.config/projmux/projdir" + settingsColorReset,
 		Value: settingsNoopValue,
 	}
 }

--- a/internal/app/settings_render.go
+++ b/internal/app/settings_render.go
@@ -91,7 +91,7 @@ func settingsLabelDim(name, description string) string {
 //
 //	·  Name (muted, padded)  Value (bold)  (source) (dim)
 //
-// Used for things like "Project Root  /home/...  (PROJDIR env)" where the
+// Used for things like "Project Root  /home/...  (PROJMUX_PROJDIR env)" where the
 // name is a static label, the value is the resolved data, and the source
 // annotation explains where the value came from.
 func settingsLabelInfo(name, value, source string) string {

--- a/internal/app/settings_render_test.go
+++ b/internal/app/settings_render_test.go
@@ -56,7 +56,7 @@ func TestSettingsLabelDimWrapsRowInDimColor(t *testing.T) {
 func TestSettingsLabelInfoEmitsValueAndSource(t *testing.T) {
 	t.Parallel()
 
-	label := settingsLabelInfo("Project Root", "/home/me/code", "PROJDIR env")
+	label := settingsLabelInfo("Project Root", "/home/me/code", "PROJMUX_PROJDIR env")
 
 	if !strings.Contains(label, "Project Root") {
 		t.Fatalf("label = %q, want name", label)
@@ -64,7 +64,7 @@ func TestSettingsLabelInfoEmitsValueAndSource(t *testing.T) {
 	if !strings.Contains(label, settingsColorActive+"/home/me/code"+settingsColorReset) {
 		t.Fatalf("label = %q, want bold value run", label)
 	}
-	if !strings.Contains(label, "(PROJDIR env)") {
+	if !strings.Contains(label, "(PROJMUX_PROJDIR env)") {
 		t.Fatalf("label = %q, want parenthesized source", label)
 	}
 }

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -694,7 +694,7 @@ func testSettingsSwitchCommandWithHome(t *testing.T, home string, store *stubSwi
 		homeDir:    func() (string, error) { return home, nil },
 		workingDir: func() (string, error) { return filepath.Join(home, "source", "repos", "app"), nil },
 		lookupEnv: func(name string) string {
-			if name == repoRootEnvVar {
+			if name == projdirEnvVar {
 				return filepath.Join(home, "source", "repos")
 			}
 			return ""
@@ -715,13 +715,10 @@ func TestCurrentProjdirInfoSourcePriority(t *testing.T) {
 		wantSource string
 	}{
 		{
-			name: "PROJDIR env wins",
+			name: "PROJMUX_PROJDIR env wins",
 			lookup: func(name string) string {
-				switch name {
-				case projdirEnvVar:
+				if name == projdirEnvVar {
 					return "/from/projdir"
-				case repoRootEnvVar:
-					return "/from/rp"
 				}
 				return ""
 			},
@@ -731,30 +728,25 @@ func TestCurrentProjdirInfoSourcePriority(t *testing.T) {
 			wantSource: projdirSourcePROJDIRenv,
 		},
 		{
-			name: "tmux option used when PROJDIR empty",
+			name: "PROJMUX_PROJDIR multi-path uses first entry as primary",
 			lookup: func(name string) string {
-				if name == repoRootEnvVar {
-					return "/from/rp"
-				}
-				return ""
-			},
-			tmuxOption: func() string { return "/from/tmux" },
-			load:       func(string) (string, error) { return "/from/saved", nil },
-			wantValue:  "/from/tmux",
-			wantSource: projdirSourceTmuxOption,
-		},
-		{
-			name: "RP env used when PROJDIR and tmux empty",
-			lookup: func(name string) string {
-				if name == repoRootEnvVar {
-					return "/from/rp"
+				if name == projdirEnvVar {
+					return "/from/projdir" + string(os.PathListSeparator) + "/extra/one"
 				}
 				return ""
 			},
 			tmuxOption: emptyTmuxOption,
 			load:       func(string) (string, error) { return "/from/saved", nil },
-			wantValue:  "/from/rp",
-			wantSource: projdirSourceRPEnv,
+			wantValue:  "/from/projdir",
+			wantSource: projdirSourcePROJDIRenv,
+		},
+		{
+			name:       "tmux option used when PROJMUX_PROJDIR empty",
+			lookup:     func(string) string { return "" },
+			tmuxOption: func() string { return "/from/tmux" },
+			load:       func(string) (string, error) { return "/from/saved", nil },
+			wantValue:  "/from/tmux",
+			wantSource: projdirSourceTmuxOption,
 		},
 		{
 			name:       "saved file used when env unset",
@@ -836,7 +828,7 @@ func TestProjectPickerEntriesIncludesProjdirRow(t *testing.T) {
 	if !hasEntryLabelContaining(entries, "("+projdirSourcePROJDIRenv+")") {
 		t.Fatalf("project picker entries = %#v, want source label", entries)
 	}
-	if !hasEntryLabelContaining(entries, "Override via PROJDIR env") {
+	if !hasEntryLabelContaining(entries, "Override via PROJMUX_PROJDIR env") {
 		t.Fatalf("project picker entries = %#v, want override hint row", entries)
 	}
 }

--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -33,8 +33,7 @@ const (
 	switchContextSessionEnv  = "TMUX_SESSIONIZER_CONTEXT_SESSION"
 	managedRootsEnvVar       = "PROJMUX_MANAGED_ROOTS"
 	legacyManagedRootsEnvVar = "TMUX_SESSIONIZER_ROOTS"
-	repoRootEnvVar           = "RP"
-	projdirEnvVar            = "PROJDIR"
+	projdirEnvVar            = "PROJMUX_PROJDIR"
 )
 
 var switchPinHiddenWhitelist = []string{
@@ -541,10 +540,11 @@ func (c *switchCommand) candidateInputs(currentPath string) (candidates.Inputs, 
 	}
 
 	repoRoot := c.switchRepoRoot(homeDir)
+	extraRoots := extraProjdirRoots(c.lookupEnv)
 	return candidates.Inputs{
 		HomeDir:      homeDir,
 		RepoRoot:     repoRoot,
-		ManagedRoots: switchManagedRoots(homeDir, repoRoot, c.lookupEnv, c.loadWorkdirs),
+		ManagedRoots: switchManagedRoots(homeDir, repoRoot, extraRoots, c.lookupEnv, c.loadWorkdirs),
 		Pins:         pins,
 		CurrentPath:  currentPath,
 	}, nil
@@ -893,9 +893,8 @@ func (c *switchCommand) originSession() string {
 // projdirSource labels the origin of a resolved repo root for display in
 // settings. Strings are stable identifiers (also used by tests).
 const (
-	projdirSourcePROJDIRenv = "PROJDIR env"
+	projdirSourcePROJDIRenv = "PROJMUX_PROJDIR env"
 	projdirSourceTmuxOption = "@projmux_projdir tmux"
-	projdirSourceRPEnv      = "RP env"
 	projdirSourceSaved      = "saved"
 	projdirSourceDefault    = "default"
 	projdirSourceUnresolved = ""
@@ -914,7 +913,7 @@ func switchRepoRoot(
 ) string {
 	value, source := resolveProjdir(homeDir, lookup, tmuxOption, load)
 	switch source {
-	case projdirSourcePROJDIRenv, projdirSourceRPEnv:
+	case projdirSourcePROJDIRenv:
 		memoizeProjdir(homeDir, value, load, save)
 	}
 	return value
@@ -932,8 +931,13 @@ func resolveProjdir(
 	load func(string) (string, error),
 ) (string, string) {
 	if raw := envValue(lookup, projdirEnvVar); strings.TrimSpace(raw) != "" {
-		if repoRoot := cleanOptionalPath(raw); repoRoot != "" {
-			return repoRoot, projdirSourcePROJDIRenv
+		// PROJMUX_PROJDIR is a PATH-style multi-value: the first
+		// non-empty entry is the primary repo root; extra entries are
+		// fed to managed roots elsewhere via extraProjdirRoots.
+		for _, entry := range filepath.SplitList(raw) {
+			if repoRoot := cleanOptionalPath(entry); repoRoot != "" {
+				return repoRoot, projdirSourcePROJDIRenv
+			}
 		}
 	}
 
@@ -942,12 +946,6 @@ func resolveProjdir(
 			if repoRoot := cleanOptionalPath(raw); repoRoot != "" {
 				return repoRoot, projdirSourceTmuxOption
 			}
-		}
-	}
-
-	if raw := envValue(lookup, repoRootEnvVar); strings.TrimSpace(raw) != "" {
-		if repoRoot := cleanOptionalPath(raw); repoRoot != "" {
-			return repoRoot, projdirSourceRPEnv
 		}
 	}
 
@@ -979,17 +977,56 @@ func (c *switchCommand) currentProjdirInfo() (string, string, error) {
 }
 
 // preferredProjdirEnv returns the effective env value for the repo root and
-// the variable name that supplied it ($PROJDIR takes precedence over $RP).
-// An empty source string means neither variable was set.
+// the variable name that supplied it. The value may be a PATH-style
+// multi-value; callers that persist a single canonical path should pass it
+// through firstProjdirPath first. An empty source string means the variable
+// was not set.
 func preferredProjdirEnv(lookup func(string) string) (string, string) {
-	for _, name := range []string{projdirEnvVar, repoRootEnvVar} {
-		raw := envValue(lookup, name)
-		if strings.TrimSpace(raw) == "" {
+	raw := envValue(lookup, projdirEnvVar)
+	if strings.TrimSpace(raw) == "" {
+		return "", ""
+	}
+	return raw, projdirEnvVar
+}
+
+// firstProjdirPath returns the first non-empty entry of a PATH-style
+// PROJMUX_PROJDIR value. It returns an empty string when raw contains no
+// usable path. The entry is not cleaned; callers that want the canonical
+// path should run cleanOptionalPath afterwards.
+func firstProjdirPath(raw string) string {
+	for _, entry := range filepath.SplitList(raw) {
+		if strings.TrimSpace(entry) != "" {
+			return entry
+		}
+	}
+	return ""
+}
+
+// extraProjdirRoots returns the additional roots that follow the primary
+// entry in a PATH-style PROJMUX_PROJDIR value. The primary (first
+// non-empty) entry is excluded because it is already surfaced via
+// switchRepoRoot. Each remaining entry is cleaned and empty entries are
+// dropped. Order is preserved.
+func extraProjdirRoots(lookup func(string) string) []string {
+	raw := envValue(lookup, projdirEnvVar)
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	entries := filepath.SplitList(raw)
+	primaryFound := false
+	extras := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		cleaned := cleanOptionalPath(entry)
+		if cleaned == "" {
 			continue
 		}
-		return raw, name
+		if !primaryFound {
+			primaryFound = true
+			continue
+		}
+		extras = append(extras, cleaned)
 	}
-	return "", ""
+	return extras
 }
 
 // tmuxProjdirOption returns the tmux user-option @projmux_projdir value when
@@ -1031,51 +1068,61 @@ func memoizeProjdir(
 	_ = save(homeDir, value)
 }
 
-func switchManagedRoots(homeDir, repoRoot string, lookup func(string) string, loadWorkdirs func(string) ([]string, error)) []string {
+func switchManagedRoots(homeDir, repoRoot string, extraProjdirRoots []string, lookup func(string) string, loadWorkdirs func(string) ([]string, error)) []string {
 	roots := make([]string, 0)
 	seen := make(map[string]struct{})
+
+	appendRoot := func(root string) {
+		root = cleanOptionalPath(root)
+		if root == "" {
+			return
+		}
+		if _, ok := seen[root]; ok {
+			return
+		}
+		seen[root] = struct{}{}
+		roots = append(roots, root)
+	}
+
+	// Extra PROJMUX_PROJDIR roots (everything past the primary entry)
+	// are prepended so they take priority over env- or saved-managed
+	// roots and the default fallback list. Like PROJMUX_MANAGED_ROOTS,
+	// any explicit env-driven entry suppresses the saved-workdirs and
+	// default fallback below.
+	managedFromEnv := false
+	for _, root := range extraProjdirRoots {
+		if cleanOptionalPath(root) == "" {
+			continue
+		}
+		managedFromEnv = true
+		appendRoot(root)
+	}
 
 	for _, value := range []string{
 		envValue(lookup, managedRootsEnvVar),
 		envValue(lookup, legacyManagedRootsEnvVar),
 	} {
 		for _, root := range filepath.SplitList(value) {
-			root = cleanOptionalPath(root)
-			if root == "" {
+			if cleanOptionalPath(root) == "" {
 				continue
 			}
-			if _, ok := seen[root]; ok {
-				continue
-			}
-			seen[root] = struct{}{}
-			roots = append(roots, root)
+			managedFromEnv = true
+			appendRoot(root)
 		}
 	}
 
-	if len(roots) == 0 && loadWorkdirs != nil {
+	if !managedFromEnv && loadWorkdirs != nil {
 		saved, err := loadWorkdirs(homeDir)
 		if err == nil {
 			for _, root := range saved {
-				root = cleanOptionalPath(root)
-				if root == "" {
-					continue
-				}
-				if _, ok := seen[root]; ok {
-					continue
-				}
-				seen[root] = struct{}{}
-				roots = append(roots, root)
+				appendRoot(root)
 			}
 		}
 	}
 
 	if len(roots) == 0 {
 		for _, root := range defaultManagedRoots(homeDir, repoRoot) {
-			if _, ok := seen[root]; ok {
-				continue
-			}
-			seen[root] = struct{}{}
-			roots = append(roots, root)
+			appendRoot(root)
 		}
 	}
 

--- a/internal/app/switch_repo_root_test.go
+++ b/internal/app/switch_repo_root_test.go
@@ -2,7 +2,9 @@ package app
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -12,14 +14,10 @@ func TestSwitchRepoRootPrefersProjdirEnv(t *testing.T) {
 	t.Parallel()
 
 	lookup := func(name string) string {
-		switch name {
-		case projdirEnvVar:
+		if name == projdirEnvVar {
 			return "/from/projdir"
-		case repoRootEnvVar:
-			return "/from/rp"
-		default:
-			return ""
 		}
+		return ""
 	}
 	tmuxOption := func() string { return "/from/tmux" }
 	load := func(string) (string, error) { return "/from/saved", nil }
@@ -38,12 +36,7 @@ func TestSwitchRepoRootPrefersProjdirEnv(t *testing.T) {
 func TestSwitchRepoRootUsesTmuxOptionWhenProjdirEmpty(t *testing.T) {
 	t.Parallel()
 
-	lookup := func(name string) string {
-		if name == repoRootEnvVar {
-			return "/from/rp"
-		}
-		return ""
-	}
+	lookup := func(string) string { return "" }
 	tmuxOption := func() string { return "/from/tmux" }
 	load := func(string) (string, error) { return "/from/saved", nil }
 	save := func(string, string) error {
@@ -71,32 +64,6 @@ func TestSwitchRepoRootTmuxOptionPreferredOverSavedFile(t *testing.T) {
 	got := switchRepoRoot("/home/tester", lookup, tmuxOption, load, save)
 	if got != "/from/tmux" {
 		t.Fatalf("switchRepoRoot() = %q, want %q", got, "/from/tmux")
-	}
-}
-
-func TestSwitchRepoRootFallsBackToRPEnvWhenProjdirAndTmuxEmpty(t *testing.T) {
-	t.Parallel()
-
-	lookup := func(name string) string {
-		switch name {
-		case projdirEnvVar:
-			return ""
-		case repoRootEnvVar:
-			return "/from/rp"
-		default:
-			return ""
-		}
-	}
-	load := func(string) (string, error) { return "/from/saved", nil }
-	var savedValue string
-	save := func(_, value string) error { savedValue = value; return nil }
-
-	got := switchRepoRoot("/home/tester", lookup, emptyTmuxOption, load, save)
-	if got != "/from/rp" {
-		t.Fatalf("switchRepoRoot() = %q, want %q", got, "/from/rp")
-	}
-	if savedValue != "/from/rp" {
-		t.Fatalf("savedValue = %q, want %q", savedValue, "/from/rp")
 	}
 }
 
@@ -208,5 +175,113 @@ func TestSwitchRepoRootTmuxOptionDoesNotMemoize(t *testing.T) {
 	}
 	if saveCalls != 0 {
 		t.Fatalf("save calls = %d, want 0 (tmux option must not memoize)", saveCalls)
+	}
+}
+
+func TestSwitchRepoRootMultiPathReturnsFirstEntry(t *testing.T) {
+	t.Parallel()
+
+	multi := strings.Join([]string{"/main/repo", "/extra/one", "/extra/two"}, string(os.PathListSeparator))
+	lookup := func(name string) string {
+		if name == projdirEnvVar {
+			return multi
+		}
+		return ""
+	}
+	load := func(string) (string, error) { return "", nil }
+	var savedValue string
+	save := func(_, value string) error { savedValue = value; return nil }
+
+	got := switchRepoRoot("/home/tester", lookup, emptyTmuxOption, load, save)
+	if got != "/main/repo" {
+		t.Fatalf("switchRepoRoot() = %q, want %q", got, "/main/repo")
+	}
+	if savedValue != "/main/repo" {
+		t.Fatalf("savedValue = %q, want only primary path", savedValue)
+	}
+}
+
+func TestSwitchRepoRootMultiPathSkipsEmptyLeadingEntries(t *testing.T) {
+	t.Parallel()
+
+	// Leading empty entries (e.g. PROJMUX_PROJDIR=":/main/repo") must
+	// be skipped so the primary path is the first non-empty value.
+	multi := strings.Join([]string{"", "/main/repo"}, string(os.PathListSeparator))
+	lookup := func(name string) string {
+		if name == projdirEnvVar {
+			return multi
+		}
+		return ""
+	}
+	got := switchRepoRoot("/home/tester", lookup, emptyTmuxOption, func(string) (string, error) { return "", nil }, func(string, string) error { return nil })
+	if got != "/main/repo" {
+		t.Fatalf("switchRepoRoot() = %q, want %q", got, "/main/repo")
+	}
+}
+
+func TestExtraProjdirRootsReturnsTrailingPaths(t *testing.T) {
+	t.Parallel()
+
+	multi := strings.Join([]string{"/main/repo", "/extra/one", "", "/extra/two"}, string(os.PathListSeparator))
+	lookup := func(name string) string {
+		if name == projdirEnvVar {
+			return multi
+		}
+		return ""
+	}
+
+	got := extraProjdirRoots(lookup)
+	want := []string{"/extra/one", "/extra/two"}
+	if len(got) != len(want) {
+		t.Fatalf("extraProjdirRoots() = %#v, want %#v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("extraProjdirRoots()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestExtraProjdirRootsEmptyWhenSinglePath(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(name string) string {
+		if name == projdirEnvVar {
+			return "/main/repo"
+		}
+		return ""
+	}
+	if got := extraProjdirRoots(lookup); len(got) != 0 {
+		t.Fatalf("extraProjdirRoots() = %#v, want empty for single path", got)
+	}
+}
+
+func TestExtraProjdirRootsEmptyWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	lookup := func(string) string { return "" }
+	if got := extraProjdirRoots(lookup); len(got) != 0 {
+		t.Fatalf("extraProjdirRoots() = %#v, want empty when env unset", got)
+	}
+}
+
+func TestFirstProjdirPathReturnsFirstNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	multi := strings.Join([]string{"", "/first", "/second"}, string(os.PathListSeparator))
+	if got := firstProjdirPath(multi); got != "/first" {
+		t.Fatalf("firstProjdirPath() = %q, want %q", got, "/first")
+	}
+}
+
+func TestFirstProjdirPathEmptyForBlankInput(t *testing.T) {
+	t.Parallel()
+
+	if got := firstProjdirPath(""); got != "" {
+		t.Fatalf("firstProjdirPath(\"\") = %q, want empty", got)
+	}
+	blank := strings.Repeat(string(os.PathListSeparator), 3)
+	if got := firstProjdirPath(blank); got != "" {
+		t.Fatalf("firstProjdirPath(only-separators) = %q, want empty", got)
 	}
 }

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -54,7 +54,7 @@ func TestAppRunSwitchDefaultsToPopupAndOpensSelectedSession(t *testing.T) {
 			workingDir: func() (string, error) { return "/rp/repo-a/nested", nil },
 			lookupEnv: func(name string) string {
 				switch name {
-				case repoRootEnvVar:
+				case projdirEnvVar:
 					return "/rp"
 				case managedRootsEnvVar:
 					return "/managed/a:/managed/b"
@@ -378,8 +378,7 @@ func TestNewSwitchCommandUsesEnvAndDefaultPinStore(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", configHome)
 	t.Setenv("XDG_STATE_HOME", stateHome)
 	t.Setenv("TMUX", "")
-	t.Setenv(projdirEnvVar, "")
-	t.Setenv(repoRootEnvVar, fixture.path("rp"))
+	t.Setenv(projdirEnvVar, fixture.path("rp"))
 	t.Setenv(managedRootsEnvVar, fixture.path("managed"))
 
 	paths, err := config.DefaultPathsFromEnv()
@@ -478,7 +477,6 @@ func TestNewSwitchCommandInfersRepoRootFromHomeSourceRepos(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", fixture.path("xdg-state"))
 	t.Setenv("TMUX", "")
 	t.Setenv(projdirEnvVar, "")
-	t.Setenv(repoRootEnvVar, "")
 	t.Chdir(fixture.path("home/source/repos/app/nested"))
 
 	cmd := newSwitchCommand()
@@ -758,7 +756,6 @@ func TestSwitchCommandUsesDefaultManagedRootsWhenEnvUnset(t *testing.T) {
 func TestSwitchCommandUsesSavedWorkdirsWhenEnvUnset(t *testing.T) {
 	t.Setenv("TMUX", "")
 	t.Setenv(projdirEnvVar, "")
-	t.Setenv(repoRootEnvVar, "")
 
 	var gotInputs candidates.Inputs
 	cmd := &switchCommand{
@@ -797,7 +794,6 @@ func TestSwitchCommandUsesSavedWorkdirsWhenEnvUnset(t *testing.T) {
 func TestSwitchCommandManagedRootsEnvBeatsSavedWorkdirs(t *testing.T) {
 	t.Setenv("TMUX", "")
 	t.Setenv(projdirEnvVar, "")
-	t.Setenv(repoRootEnvVar, "")
 
 	var gotInputs candidates.Inputs
 	cmd := &switchCommand{
@@ -833,6 +829,119 @@ func TestSwitchCommandManagedRootsEnvBeatsSavedWorkdirs(t *testing.T) {
 		"/env/two",
 	}; !equalStrings(got, want) {
 		t.Fatalf("inputs.ManagedRoots = %q, want %q", got, want)
+	}
+}
+
+func TestSwitchCommandMultiPathProjdirSplitsPrimaryAndExtras(t *testing.T) {
+	t.Setenv("TMUX", "")
+
+	multi := strings.Join([]string{"/main/repo", "/extra/one", "/extra/two"}, string(os.PathListSeparator))
+	t.Setenv(projdirEnvVar, multi)
+
+	var gotInputs candidates.Inputs
+	cmd := &switchCommand{
+		discover: func(inputs candidates.Inputs) ([]string, error) {
+			gotInputs = inputs
+			return []string{"/tmp/app"}, nil
+		},
+		pinStore:   func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
+		runner:     switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil }),
+		sessions:   &capturingSwitchSessionExecutor{},
+		identity:   stubSwitchIdentityResolver{name: "tmp-app"},
+		validate:   func(string) error { return nil },
+		homeDir:    func() (string, error) { return "/home/tester", nil },
+		workingDir: func() (string, error) { return "/tmp", nil },
+		lookupEnv:  os.Getenv,
+		loadWorkdirs: func(string) ([]string, error) {
+			t.Fatalf("loadWorkdirs should not be consulted when PROJMUX_PROJDIR provides extras")
+			return nil, nil
+		},
+	}
+
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if got, want := gotInputs.RepoRoot, "/main/repo"; got != want {
+		t.Fatalf("inputs.RepoRoot = %q, want %q", got, want)
+	}
+	if got, want := gotInputs.ManagedRoots, []string{
+		"/extra/one",
+		"/extra/two",
+	}; !equalStrings(got, want) {
+		t.Fatalf("inputs.ManagedRoots = %q, want %q", got, want)
+	}
+}
+
+func TestSwitchCommandMultiPathProjdirCombinesWithManagedRootsEnv(t *testing.T) {
+	t.Setenv("TMUX", "")
+
+	multi := strings.Join([]string{"/main/repo", "/extra/one"}, string(os.PathListSeparator))
+	t.Setenv(projdirEnvVar, multi)
+	t.Setenv(managedRootsEnvVar, strings.Join([]string{"/extra/one", "/managed/two"}, string(os.PathListSeparator)))
+
+	var gotInputs candidates.Inputs
+	cmd := &switchCommand{
+		discover: func(inputs candidates.Inputs) ([]string, error) {
+			gotInputs = inputs
+			return []string{"/tmp/app"}, nil
+		},
+		pinStore:   func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
+		runner:     switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil }),
+		sessions:   &capturingSwitchSessionExecutor{},
+		identity:   stubSwitchIdentityResolver{name: "tmp-app"},
+		validate:   func(string) error { return nil },
+		homeDir:    func() (string, error) { return "/home/tester", nil },
+		workingDir: func() (string, error) { return "/tmp", nil },
+		lookupEnv:  os.Getenv,
+	}
+
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// extras prepend; PROJMUX_MANAGED_ROOTS follows, dedupe drops the
+	// repeated /extra/one.
+	if got, want := gotInputs.ManagedRoots, []string{
+		"/extra/one",
+		"/managed/two",
+	}; !equalStrings(got, want) {
+		t.Fatalf("inputs.ManagedRoots = %q, want %q", got, want)
+	}
+}
+
+func TestSwitchCommandSinglePathProjdirRetainsSavedWorkdirs(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv(projdirEnvVar, "/main/repo")
+
+	var gotInputs candidates.Inputs
+	cmd := &switchCommand{
+		discover: func(inputs candidates.Inputs) ([]string, error) {
+			gotInputs = inputs
+			return []string{"/tmp/app"}, nil
+		},
+		pinStore:   func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
+		runner:     switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil }),
+		sessions:   &capturingSwitchSessionExecutor{},
+		identity:   stubSwitchIdentityResolver{name: "tmp-app"},
+		validate:   func(string) error { return nil },
+		homeDir:    func() (string, error) { return "/home/tester", nil },
+		workingDir: func() (string, error) { return "/tmp", nil },
+		lookupEnv:  os.Getenv,
+		loadWorkdirs: func(string) ([]string, error) {
+			return []string{"/srv/projects"}, nil
+		},
+	}
+
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if got, want := gotInputs.RepoRoot, "/main/repo"; got != want {
+		t.Fatalf("inputs.RepoRoot = %q, want %q", got, want)
+	}
+	if got, want := gotInputs.ManagedRoots, []string{"/srv/projects"}; !equalStrings(got, want) {
+		t.Fatalf("inputs.ManagedRoots = %q, want %q (single-path PROJMUX_PROJDIR must not suppress saved workdirs)", got, want)
 	}
 }
 
@@ -873,7 +982,7 @@ func TestSwitchCommandPreviewRendersExistingSessionContext(t *testing.T) {
 		homeDir:      func() (string, error) { return fixture.path("home"), nil },
 		workingDir:   func() (string, error) { return fixture.path("home/source/repos/repo-a/subdir"), nil },
 		lookupEnv: func(name string) string {
-			if name == repoRootEnvVar {
+			if name == projdirEnvVar {
 				return fixture.path("home/source/repos")
 			}
 			return ""
@@ -934,7 +1043,7 @@ func TestSwitchCommandPreviewRendersNewSessionContextWithoutInventory(t *testing
 		homeDir:      func() (string, error) { return fixture.path("home"), nil },
 		workingDir:   func() (string, error) { return fixture.path("home/source/repos/repo-a/subdir"), nil },
 		lookupEnv: func(name string) string {
-			if name == repoRootEnvVar {
+			if name == projdirEnvVar {
 				return fixture.path("home/source/repos")
 			}
 			return ""
@@ -973,7 +1082,7 @@ func TestSwitchCommandPreviewRendersSettingsSentinel(t *testing.T) {
 		},
 		homeDir: func() (string, error) { return "/home/tester", nil },
 		lookupEnv: func(name string) string {
-			if name == repoRootEnvVar {
+			if name == projdirEnvVar {
 				return "/home/tester/source/repos"
 			}
 			return ""
@@ -1017,7 +1126,7 @@ func TestSwitchCommandSettingsMenuOffersAddCurrentPin(t *testing.T) {
 		validate:   func(string) error { return nil },
 		identity:   stubSwitchIdentityResolver{name: "new-app"},
 		lookupEnv: func(name string) string {
-			if name == repoRootEnvVar {
+			if name == projdirEnvVar {
 				return "/home/tester/source/repos"
 			}
 			return ""
@@ -1055,7 +1164,7 @@ func TestSwitchCommandSettingsMenuSkipsAddWhenCurrentTargetAlreadyPinned(t *test
 		validate:   func(string) error { return nil },
 		identity:   stubSwitchIdentityResolver{name: "app"},
 		lookupEnv: func(name string) string {
-			if name == repoRootEnvVar {
+			if name == projdirEnvVar {
 				return "/home/tester/source/repos"
 			}
 			return ""
@@ -1108,7 +1217,7 @@ func TestSwitchCommandCycleWindowUpdatesStoredPreviewSelection(t *testing.T) {
 		validate:     validateDirectory,
 		homeDir:      func() (string, error) { return fixture.path("home"), nil },
 		lookupEnv: func(name string) string {
-			if name == repoRootEnvVar {
+			if name == projdirEnvVar {
 				return fixture.path("home/source/repos")
 			}
 			return ""
@@ -1150,7 +1259,7 @@ func TestSwitchCommandCyclePaneNoOpsForNewSessionCandidates(t *testing.T) {
 		validate:     validateDirectory,
 		homeDir:      func() (string, error) { return fixture.path("home"), nil },
 		lookupEnv: func(name string) string {
-			if name == repoRootEnvVar {
+			if name == projdirEnvVar {
 				return fixture.path("home/source/repos")
 			}
 			return ""
@@ -1426,7 +1535,7 @@ func TestSwitchCommandSettingsMenuAddCurrentPin(t *testing.T) {
 		homeDir:    func() (string, error) { return "/home/tester", nil },
 		workingDir: func() (string, error) { return "/home/tester/source/repos/new-app/subdir", nil },
 		lookupEnv: func(name string) string {
-			if name == repoRootEnvVar {
+			if name == projdirEnvVar {
 				return "/home/tester/source/repos"
 			}
 			return ""
@@ -1491,7 +1600,7 @@ func TestSwitchCommandSettingsMenuInteractiveAddPin(t *testing.T) {
 		homeDir:    func() (string, error) { return "/home/tester", nil },
 		workingDir: func() (string, error) { return "/home/tester/source/repos/new-app/subdir", nil },
 		lookupEnv: func(name string) string {
-			if name == repoRootEnvVar {
+			if name == projdirEnvVar {
 				return "/home/tester/source/repos"
 			}
 			return ""

--- a/internal/app/upgrade.go
+++ b/internal/app/upgrade.go
@@ -129,7 +129,13 @@ func (c *upgradeCommand) runDryRun(opts upgradeOptions, stdout io.Writer) error 
 func (c *upgradeCommand) runUpgrade(opts upgradeOptions, stdout, stderr io.Writer) error {
 	if home, err := os.UserHomeDir(); err == nil {
 		if raw, _ := preferredProjdirEnv(os.Getenv); raw != "" {
-			memoizeProjdir(home, raw, config.LoadProjdir, config.SaveProjdir)
+			// PROJMUX_PROJDIR is a PATH-style multi-value; only the
+			// primary (first non-empty) entry is persisted to the
+			// saved projdir file so the saved value remains a
+			// single canonical path.
+			if primary := firstProjdirPath(raw); primary != "" {
+				memoizeProjdir(home, primary, config.LoadProjdir, config.SaveProjdir)
+			}
 		}
 	}
 	if c.lookPath == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,7 +58,8 @@ func (p Paths) PreviewStateFile() string {
 	return filepath.Join(p.StateDir, PreviewStateFileName)
 }
 
-// ProjdirFile returns the default file used for the persisted PROJDIR value.
+// ProjdirFile returns the default file used for the persisted
+// PROJMUX_PROJDIR value (the primary project root path).
 func (p Paths) ProjdirFile() string {
 	return filepath.Join(p.ConfigDir, ProjdirFileName)
 }
@@ -69,7 +70,7 @@ func (p Paths) PostCreateHookPath() string {
 	return filepath.Join(p.ConfigDir, HooksDirName, PostCreateHookFileName)
 }
 
-// ProjdirFile returns the path to the persisted PROJDIR file rooted at the
+// ProjdirFile returns the path to the persisted projdir file rooted at the
 // supplied home directory. An empty homeDir yields an empty string.
 func ProjdirFile(homeDir string) string {
 	if homeDir == "" {
@@ -78,7 +79,7 @@ func ProjdirFile(homeDir string) string {
 	return filepath.Join(homeDir, ".config", AppName, ProjdirFileName)
 }
 
-// LoadProjdir returns the trimmed first line of the persisted PROJDIR file
+// LoadProjdir returns the trimmed first line of the persisted projdir file
 // rooted at homeDir. A missing file or empty content yields ("", nil).
 func LoadProjdir(homeDir string) (string, error) {
 	path := ProjdirFile(homeDir)
@@ -108,7 +109,7 @@ func LoadProjdir(homeDir string) (string, error) {
 	return "", nil
 }
 
-// SaveProjdir persists value to the PROJDIR file rooted at homeDir using an
+// SaveProjdir persists value to the projdir file rooted at homeDir using an
 // atomic rename. An empty value removes the file. The parent directory is
 // created with 0o755 if missing.
 func SaveProjdir(homeDir, value string) error {


### PR DESCRIPTION
## Summary
- `PROJDIR` / `RP` env vars 제거. 새 이름 `PROJMUX_PROJDIR` 로 통일 (tmux user-option `@projmux_projdir` 와 일관). **breaking change, 하위호환 없음**.
- `PROJMUX_PROJDIR` 가 OS-native PATH 형식 multi-path 지원: 첫 번째 = primary repo root, 나머지 = managed roots 에 prepend (dedupe).
- saved 파일 (`~/.config/projmux/projdir`) 에는 첫 번째(primary) path 만 memoize.
- README.md / README-ko.md 에 install 시·upgrade 시 `PROJMUX_PROJDIR` 설정 / 변경하는 방법 섹션 추가.

## Migration

| 기존 | 새로 |
|---|---|
| `export PROJDIR=/path` | `export PROJMUX_PROJDIR=/path` |
| `export RP=/path` | `export PROJMUX_PROJDIR=/path` |
| `PROJDIR=/p projmux upgrade` | `PROJMUX_PROJDIR=/p projmux upgrade` |
| (없음) | `PROJMUX_PROJDIR="/main:/extra" projmux` — primary `/main`, managed roots 에 `/extra` prepend |

## Test plan
- [x] `make fmt-check`
- [x] `make test`
- [ ] CI `Test` 잡 통과 후 squash merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)