### PR TITLE
feat(init): add projmux init to auto-merge keybindings (Ghostty first)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -18,6 +18,7 @@ type App struct {
 	attention    *attentionCommand
 	attach       *attachCommand
 	current      *currentCommand
+	initCmd      *initCommand
 	kill         *killCommand
 	pin          *pinCommand
 	preview      *previewCommand
@@ -42,6 +43,7 @@ func New() *App {
 		attention:    newAttentionCommand(),
 		attach:       newAttachCommand(),
 		current:      newCurrentCommand(),
+		initCmd:      newInitCommand(),
 		kill:         newKillCommand(),
 		pin:          newPinCommand(),
 		preview:      newPreviewCommand(),
@@ -74,6 +76,8 @@ func (a *App) Run(args []string, stdout, stderr io.Writer) error {
 		return a.attach.Run(args[1:], stdout, stderr)
 	case "current":
 		return a.current.Run(args[1:], stdout, stderr)
+	case "init":
+		return a.initCmd.Run(args[1:], stdout, stderr)
 	case "kill":
 		return a.kill.Run(args[1:], stdout, stderr)
 	case "pin":
@@ -120,6 +124,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  attention Manage tmux pane attention badges")
 	fmt.Fprintln(w, "  attach    Open tmux lifecycle entry helpers")
 	fmt.Fprintln(w, "  current   Resolve the active tmux pane path")
+	fmt.Fprintln(w, "  init      Merge projmux keybindings into a terminal config")
 	fmt.Fprintln(w, "  kill      Terminate tagged tmux sessions")
 	fmt.Fprintln(w, "  pin       Manage pinned project directories")
 	fmt.Fprintln(w, "  preview   Manage persisted tmux preview selection")

--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -1,0 +1,230 @@
+package app
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// initCommand auto-merges projmux keybindings into a terminal emulator's
+// config file. The framework dispatches by terminal name and delegates the
+// actual merge to a TerminalAdapter implementation.
+type initCommand struct {
+	registry *terminalRegistry
+	getenv   func(string) string
+	readFile func(string) ([]byte, error)
+	stat     func(string) (os.FileInfo, error)
+}
+
+func newInitCommand() *initCommand {
+	return &initCommand{
+		registry: defaultTerminalRegistry,
+		getenv:   os.Getenv,
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+	}
+}
+
+// Run implements the `projmux init [terminal]` flow. The default mode is a
+// dry-run that prints the planned changes; --apply commits them with a
+// timestamped backup. The terminal name may appear before or after flags,
+// e.g. `projmux init ghostty --apply` or `projmux init --apply ghostty`.
+func (c *initCommand) Run(args []string, stdout, stderr io.Writer) error {
+	terminalName, flagArgs := splitInitArgs(args)
+
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	apply := fs.Bool("apply", false, "write the merged config (default: dry-run preview)")
+	dryRun := fs.Bool("dry-run", false, "force dry-run preview even when no other flag is set")
+	configOverride := fs.String("config", "", "override the terminal config path (mostly for tests)")
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	if *apply && *dryRun {
+		return errors.New("init: --apply and --dry-run are mutually exclusive")
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("init: unexpected positional argument %q", fs.Arg(0))
+	}
+
+	registry := c.registry
+	if registry == nil {
+		registry = defaultTerminalRegistry
+	}
+
+	var (
+		adapter TerminalAdapter
+		ok      bool
+	)
+	if terminalName != "" {
+		name := strings.ToLower(strings.TrimSpace(terminalName))
+		adapter, ok = registry.lookup(name)
+		if !ok {
+			return fmt.Errorf("init: unknown terminal %q (known: %s)", name, strings.Join(registry.names(), ", "))
+		}
+	} else {
+		adapter, ok = registry.detect(c.env())
+		if !ok {
+			return fmt.Errorf("init: could not auto-detect terminal; pass one explicitly (known: %s)", strings.Join(registry.names(), ", "))
+		}
+	}
+
+	configPath := strings.TrimSpace(*configOverride)
+	if configPath == "" {
+		path, err := adapter.ConfigPath(c.env())
+		if err != nil {
+			return fmt.Errorf("init: resolve %s config path: %w", adapter.Name(), err)
+		}
+		configPath = path
+	}
+
+	current, exists, err := c.loadConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("init: read %s: %w", configPath, err)
+	}
+
+	plan, err := adapter.PlanMerge(current, exists)
+	if err != nil {
+		return fmt.Errorf("init: plan %s merge: %w", adapter.Name(), err)
+	}
+	plan.ConfigPath = configPath
+
+	if !*apply {
+		return c.printPlan(adapter.Name(), plan, stdout)
+	}
+
+	if err := adapter.ApplyMerge(plan); err != nil {
+		return fmt.Errorf("init: apply %s merge: %w", adapter.Name(), err)
+	}
+
+	return c.printApplyResult(adapter.Name(), plan, stdout)
+}
+
+func (c *initCommand) env() func(string) string {
+	if c.getenv != nil {
+		return c.getenv
+	}
+	return os.Getenv
+}
+
+// loadConfig reads the terminal config and reports whether it already exists.
+// A missing file is not an error; the merge will create it.
+func (c *initCommand) loadConfig(path string) (string, bool, error) {
+	statFn := c.stat
+	if statFn == nil {
+		statFn = os.Stat
+	}
+	if _, err := statFn(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	readFn := c.readFile
+	if readFn == nil {
+		readFn = os.ReadFile
+	}
+	data, err := readFn(path)
+	if err != nil {
+		return "", true, err
+	}
+	return string(data), true, nil
+}
+
+func (c *initCommand) printPlan(terminal string, plan MergePlan, stdout io.Writer) error {
+	if _, err := fmt.Fprintf(stdout, "projmux init %s (dry-run)\n", terminal); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(stdout, "config: %s\n", plan.ConfigPath); err != nil {
+		return err
+	}
+	if plan.CreateNew {
+		if _, err := fmt.Fprintln(stdout, "note:   config file does not exist; would be created"); err != nil {
+			return err
+		}
+	}
+	for _, ch := range plan.Changes {
+		switch ch.Kind {
+		case "add":
+			if _, err := fmt.Fprintf(stdout, "  +  %s = %s\n", ch.Trigger, ch.Action); err != nil {
+				return err
+			}
+		case "noop":
+			if _, err := fmt.Fprintf(stdout, "  =  %s = %s (already set)\n", ch.Trigger, ch.Action); err != nil {
+				return err
+			}
+		case "skip-conflict":
+			if _, err := fmt.Fprintf(stdout, "  !  %s already mapped to %s; skipping (want %s)\n", ch.Trigger, ch.Existing, ch.Action); err != nil {
+				return err
+			}
+		}
+	}
+	if !plan.HasEffect() {
+		_, err := fmt.Fprintln(stdout, "no changes; already configured")
+		return err
+	}
+	_, err := fmt.Fprintln(stdout, "run with --apply to write changes (a timestamped backup will be created)")
+	return err
+}
+
+func (c *initCommand) printApplyResult(terminal string, plan MergePlan, stdout io.Writer) error {
+	if _, err := fmt.Fprintf(stdout, "projmux init %s --apply\n", terminal); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(stdout, "config: %s\n", plan.ConfigPath); err != nil {
+		return err
+	}
+	added := 0
+	skipped := 0
+	for _, ch := range plan.Changes {
+		switch ch.Kind {
+		case "add":
+			added++
+		case "skip-conflict":
+			skipped++
+			if _, err := fmt.Fprintf(stdout, "warning: %s already mapped to %s; skipped (want %s)\n", ch.Trigger, ch.Existing, ch.Action); err != nil {
+				return err
+			}
+		}
+	}
+	if !plan.HasEffect() {
+		_, err := fmt.Fprintln(stdout, "no changes; already configured")
+		return err
+	}
+	if _, err := fmt.Fprintf(stdout, "wrote %d new keybindings (%d skipped due to user conflict)\n", added, skipped); err != nil {
+		return err
+	}
+	if !plan.CreateNew {
+		_, err := fmt.Fprintln(stdout, "previous config saved as <path>.bak.<timestamp>")
+		return err
+	}
+	_, err := fmt.Fprintln(stdout, "created new config")
+	return err
+}
+
+// splitInitArgs separates the (optional) terminal name from the remaining
+// flag-style arguments. The terminal name is the first non-flag token, no
+// matter where it appears in the slice. Subsequent non-flag tokens are left
+// in flagArgs so the flag parser can complain about them.
+func splitInitArgs(args []string) (terminal string, flagArgs []string) {
+	flagArgs = make([]string, 0, len(args))
+	consumed := false
+	for _, a := range args {
+		if !consumed && a != "" && !strings.HasPrefix(a, "-") {
+			terminal = a
+			consumed = true
+			continue
+		}
+		flagArgs = append(flagArgs, a)
+	}
+	return terminal, flagArgs
+}
+
+// init registers the Ghostty adapter with the package-level registry. Future
+// terminals add a sibling file with their own init() block.
+func init() {
+	RegisterTerminalAdapter(NewGhosttyAdapter())
+}

--- a/internal/app/init_ghostty.go
+++ b/internal/app/init_ghostty.go
@@ -1,0 +1,308 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ghosttyBinding is one keybind = trigger=action pair the projmux init
+// command guarantees in the user's Ghostty config. The list is the single
+// source of truth in code; docs/keybindings.md mirrors it for users.
+type ghosttyBinding struct {
+	Trigger string
+	Action  string
+}
+
+// ghosttyDesiredBindings mirrors the "Ghostty" section of docs/keybindings.md.
+// Update both when adjusting CSI-u routing.
+var ghosttyDesiredBindings = []ghosttyBinding{
+	{Trigger: "alt+1", Action: "csi:9005u"},
+	{Trigger: "alt+2", Action: "csi:9003u"},
+	{Trigger: "alt+3", Action: "csi:9004u"},
+	{Trigger: "alt+4", Action: "csi:9006u"},
+	{Trigger: "alt+5", Action: "csi:9007u"},
+	{Trigger: "ctrl+shift+r", Action: "csi:9001u"},
+	{Trigger: "ctrl+shift+l", Action: "csi:9002u"},
+	{Trigger: "ctrl+shift+n", Action: "csi:9008u"},
+	{Trigger: "ctrl+m", Action: "csi:9011u"},
+	{Trigger: "ctrl+shift+m", Action: "csi:9012u"},
+	{Trigger: "alt+shift+left", Action: "csi:9009u"},
+	{Trigger: "alt+shift+right", Action: "csi:9010u"},
+}
+
+// ghosttyManagedHeader marks the projmux-managed block in the Ghostty config.
+const (
+	ghosttyManagedHeader = "# >>> projmux managed keybindings (do not edit between markers)"
+	ghosttyManagedFooter = "# <<< projmux managed keybindings"
+)
+
+// GhosttyAdapter implements TerminalAdapter for the Ghostty terminal.
+type GhosttyAdapter struct {
+	// now allows tests to pin the timestamp used for backup file names.
+	now func() time.Time
+	// userHomeDir defaults to os.UserHomeDir for path resolution.
+	userHomeDir func() (string, error)
+	// writeFile defaults to os.WriteFile (used for backups + the new config).
+	writeFile func(name string, data []byte, perm os.FileMode) error
+	// mkdirAll defaults to os.MkdirAll for the parent config dir.
+	mkdirAll func(path string, perm os.FileMode) error
+}
+
+// NewGhosttyAdapter constructs a Ghostty adapter wired to real filesystem
+// helpers. Tests can override the internal hooks afterwards.
+func NewGhosttyAdapter() *GhosttyAdapter {
+	return &GhosttyAdapter{
+		now:         time.Now,
+		userHomeDir: os.UserHomeDir,
+		writeFile:   os.WriteFile,
+		mkdirAll:    os.MkdirAll,
+	}
+}
+
+// Name implements TerminalAdapter.
+func (g *GhosttyAdapter) Name() string { return "ghostty" }
+
+// Detect implements TerminalAdapter. Ghostty exposes itself via either
+// TERM_PROGRAM=ghostty (current builds) or GHOSTTY_RESOURCES_DIR (older
+// + linux/macos installs). Either signal is sufficient.
+func (g *GhosttyAdapter) Detect(env func(string) string) bool {
+	if env == nil {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(env("TERM_PROGRAM")), "ghostty") {
+		return true
+	}
+	if strings.TrimSpace(env("GHOSTTY_RESOURCES_DIR")) != "" {
+		return true
+	}
+	return false
+}
+
+// ConfigPath implements TerminalAdapter. Ghostty looks at
+// `$XDG_CONFIG_HOME/ghostty/config` first, falling back to
+// `$HOME/.config/ghostty/config`.
+func (g *GhosttyAdapter) ConfigPath(env func(string) string) (string, error) {
+	if env == nil {
+		env = os.Getenv
+	}
+	if xdg := strings.TrimSpace(env("XDG_CONFIG_HOME")); xdg != "" {
+		return filepath.Join(xdg, "ghostty", "config"), nil
+	}
+	homeFn := g.userHomeDir
+	if homeFn == nil {
+		homeFn = os.UserHomeDir
+	}
+	home, err := homeFn()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory for ghostty config: %w", err)
+	}
+	if home == "" {
+		return "", fmt.Errorf("resolve home directory for ghostty config: empty home")
+	}
+	return filepath.Join(home, ".config", "ghostty", "config"), nil
+}
+
+// PlanMerge implements TerminalAdapter. The merge is idempotent: bindings
+// already pointing at the desired action are no-ops, missing bindings are
+// appended in a managed block, and triggers already mapped to a different
+// action are left untouched (skip with a warning entry).
+func (g *GhosttyAdapter) PlanMerge(currentConfig string, fileExists bool) (MergePlan, error) {
+	plan := MergePlan{Original: currentConfig, CreateNew: !fileExists}
+
+	// Parse triggers already present anywhere in the file (including in any
+	// previous projmux managed block). The merge re-emits the managed block
+	// from scratch, so we drop existing block lines from the user-side map.
+	stripped, userBindings := splitGhosttyConfig(currentConfig)
+
+	var (
+		toAppend []ghosttyBinding
+		changes  []MergeChange
+	)
+	for _, want := range ghosttyDesiredBindings {
+		existing, ok := userBindings[want.Trigger]
+		switch {
+		case !ok:
+			toAppend = append(toAppend, want)
+			changes = append(changes, MergeChange{
+				Trigger: want.Trigger,
+				Action:  want.Action,
+				Kind:    "add",
+			})
+		case existing == want.Action:
+			changes = append(changes, MergeChange{
+				Trigger:  want.Trigger,
+				Action:   want.Action,
+				Existing: existing,
+				Kind:     "noop",
+			})
+		default:
+			changes = append(changes, MergeChange{
+				Trigger:  want.Trigger,
+				Action:   want.Action,
+				Existing: existing,
+				Kind:     "skip-conflict",
+				Reason:   "user mapped to " + existing,
+			})
+		}
+	}
+
+	plan.Changes = changes
+
+	if len(toAppend) == 0 {
+		// Nothing to add. Updated == Original keeps HasEffect false.
+		plan.Updated = currentConfig
+		return plan, nil
+	}
+
+	plan.Updated = renderGhosttyConfig(stripped, toAppend)
+	return plan, nil
+}
+
+// ApplyMerge implements TerminalAdapter. It backs up the existing config to
+// `<config>.bak.<YYYYMMDD-HHMMSS>` (when the file exists) and writes the
+// plan's Updated contents to ConfigPath. The caller is expected to have
+// populated plan.ConfigPath via the init dispatcher.
+func (g *GhosttyAdapter) ApplyMerge(plan MergePlan) error {
+	if plan.ConfigPath == "" {
+		return fmt.Errorf("apply ghostty merge: plan has no ConfigPath")
+	}
+	if !plan.HasEffect() {
+		return nil
+	}
+
+	dir := filepath.Dir(plan.ConfigPath)
+	mkdir := g.mkdirAll
+	if mkdir == nil {
+		mkdir = os.MkdirAll
+	}
+	if err := mkdir(dir, 0o755); err != nil {
+		return fmt.Errorf("create ghostty config dir %s: %w", dir, err)
+	}
+
+	write := g.writeFile
+	if write == nil {
+		write = os.WriteFile
+	}
+
+	if !plan.CreateNew {
+		nowFn := g.now
+		if nowFn == nil {
+			nowFn = time.Now
+		}
+		stamp := nowFn().Format("20060102-150405")
+		backup := plan.ConfigPath + ".bak." + stamp
+		if err := write(backup, []byte(plan.Original), 0o644); err != nil {
+			return fmt.Errorf("write ghostty config backup %s: %w", backup, err)
+		}
+	}
+
+	if err := write(plan.ConfigPath, []byte(plan.Updated), 0o644); err != nil {
+		return fmt.Errorf("write ghostty config %s: %w", plan.ConfigPath, err)
+	}
+	return nil
+}
+
+// splitGhosttyConfig parses the supplied config text and returns:
+//   - stripped: the original text with any prior projmux-managed block removed
+//   - bindings: trigger -> action map of every keybind line in the file,
+//     including ones inside a previously-emitted managed block. Conflict
+//     detection therefore sees the user's true intent (mappings outside the
+//     block override anything we previously appended), and re-runs treat
+//     already-managed bindings as noop instead of fresh adds.
+//
+// The output text drops the managed block so the next render can append a
+// fresh one; the file content remains stable when the bindings already
+// match.
+func splitGhosttyConfig(raw string) (string, map[string]string) {
+	bindings := map[string]string{}
+	if raw == "" {
+		return "", bindings
+	}
+	lines := strings.Split(raw, "\n")
+	out := make([]string, 0, len(lines))
+	inManaged := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !inManaged && trimmed == ghosttyManagedHeader {
+			inManaged = true
+			// Capture managed-block bindings into the map so the merge
+			// recognises them as noop; do not echo them into stripped.
+			continue
+		}
+		if inManaged {
+			if trimmed == ghosttyManagedFooter {
+				inManaged = false
+				continue
+			}
+			if trigger, action, ok := parseGhosttyKeybind(line); ok {
+				if _, set := bindings[trigger]; !set {
+					// User-owned mappings outside the block win; only
+					// adopt managed-block entries when no user override
+					// already appeared above the block.
+					bindings[trigger] = action
+				}
+			}
+			continue
+		}
+		out = append(out, line)
+		trigger, action, ok := parseGhosttyKeybind(line)
+		if !ok {
+			continue
+		}
+		// Last write wins: matches Ghostty's own behavior where the final
+		// keybind line for a trigger overrides earlier ones.
+		bindings[trigger] = action
+	}
+	stripped := strings.Join(out, "\n")
+	return stripped, bindings
+}
+
+// parseGhosttyKeybind extracts (trigger, action) from a `keybind = X=Y` line.
+// Comments (`#`) and non-keybind lines return ok=false.
+func parseGhosttyKeybind(line string) (string, string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		return "", "", false
+	}
+	if !strings.HasPrefix(trimmed, "keybind") {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(trimmed, "keybind")
+	rest = strings.TrimLeft(rest, " \t")
+	if !strings.HasPrefix(rest, "=") {
+		return "", "", false
+	}
+	rest = strings.TrimLeft(rest[1:], " \t")
+	eq := strings.Index(rest, "=")
+	if eq <= 0 {
+		return "", "", false
+	}
+	trigger := strings.TrimSpace(rest[:eq])
+	action := strings.TrimSpace(rest[eq+1:])
+	if trigger == "" || action == "" {
+		return "", "", false
+	}
+	return trigger, action, true
+}
+
+// renderGhosttyConfig appends a managed projmux block containing the supplied
+// bindings to stripped. It guarantees a single blank line separator between
+// existing user content and the managed block, and a trailing newline.
+func renderGhosttyConfig(stripped string, additions []ghosttyBinding) string {
+	var b strings.Builder
+	if stripped != "" {
+		b.WriteString(strings.TrimRight(stripped, "\n"))
+		b.WriteString("\n\n")
+	}
+	b.WriteString(ghosttyManagedHeader)
+	b.WriteString("\n")
+	for _, kb := range additions {
+		fmt.Fprintf(&b, "keybind = %s=%s\n", kb.Trigger, kb.Action)
+	}
+	b.WriteString(ghosttyManagedFooter)
+	b.WriteString("\n")
+	return b.String()
+}

--- a/internal/app/init_ghostty_test.go
+++ b/internal/app/init_ghostty_test.go
@@ -1,0 +1,405 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newGhosttyTestAdapter(t *testing.T) *GhosttyAdapter {
+	t.Helper()
+	a := NewGhosttyAdapter()
+	a.now = func() time.Time { return time.Date(2026, 4, 30, 1, 32, 15, 0, time.UTC) }
+	return a
+}
+
+func TestGhosttyAdapterDetect(t *testing.T) {
+	t.Parallel()
+
+	a := NewGhosttyAdapter()
+
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{name: "term program ghostty", env: map[string]string{"TERM_PROGRAM": "ghostty"}, want: true},
+		{name: "term program uppercase", env: map[string]string{"TERM_PROGRAM": "GHOSTTY"}, want: true},
+		{name: "resources dir", env: map[string]string{"GHOSTTY_RESOURCES_DIR": "/opt/ghostty"}, want: true},
+		{name: "neither", env: map[string]string{"TERM_PROGRAM": "iTerm.app"}, want: false},
+		{name: "empty env", env: map[string]string{}, want: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			env := func(k string) string { return tc.env[k] }
+			if got := a.Detect(env); got != tc.want {
+				t.Fatalf("Detect(%v) = %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGhosttyAdapterDetectNilEnv(t *testing.T) {
+	t.Parallel()
+	a := NewGhosttyAdapter()
+	if a.Detect(nil) {
+		t.Fatalf("Detect(nil) = true, want false")
+	}
+}
+
+func TestGhosttyAdapterConfigPathPrefersXDG(t *testing.T) {
+	t.Parallel()
+
+	a := NewGhosttyAdapter()
+	env := func(k string) string {
+		if k == "XDG_CONFIG_HOME" {
+			return "/xdg"
+		}
+		return ""
+	}
+	got, err := a.ConfigPath(env)
+	if err != nil {
+		t.Fatalf("ConfigPath() error = %v", err)
+	}
+	if want := filepath.Join("/xdg", "ghostty", "config"); got != want {
+		t.Fatalf("ConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestGhosttyAdapterConfigPathFallsBackToHome(t *testing.T) {
+	t.Parallel()
+
+	a := NewGhosttyAdapter()
+	a.userHomeDir = func() (string, error) { return "/home/u", nil }
+	got, err := a.ConfigPath(func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("ConfigPath() error = %v", err)
+	}
+	if want := filepath.Join("/home/u", ".config", "ghostty", "config"); got != want {
+		t.Fatalf("ConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestGhosttyPlanMergeEmptyConfigAddsAllBindings(t *testing.T) {
+	t.Parallel()
+
+	a := newGhosttyTestAdapter(t)
+	plan, err := a.PlanMerge("", false)
+	if err != nil {
+		t.Fatalf("PlanMerge empty error = %v", err)
+	}
+	if !plan.HasEffect() {
+		t.Fatalf("expected effect on empty config")
+	}
+	if !plan.CreateNew {
+		t.Fatalf("CreateNew = false, want true for missing file")
+	}
+	addCount := 0
+	for _, ch := range plan.Changes {
+		if ch.Kind == "add" {
+			addCount++
+		}
+	}
+	if addCount != len(ghosttyDesiredBindings) {
+		t.Fatalf("add count = %d, want %d", addCount, len(ghosttyDesiredBindings))
+	}
+	for _, kb := range ghosttyDesiredBindings {
+		needle := "keybind = " + kb.Trigger + "=" + kb.Action
+		if !strings.Contains(plan.Updated, needle) {
+			t.Fatalf("Updated missing %q\n--\n%s", needle, plan.Updated)
+		}
+	}
+	if !strings.Contains(plan.Updated, ghosttyManagedHeader) {
+		t.Fatalf("Updated missing managed header")
+	}
+}
+
+func TestGhosttyPlanMergeIdempotent(t *testing.T) {
+	t.Parallel()
+
+	a := newGhosttyTestAdapter(t)
+	first, err := a.PlanMerge("", false)
+	if err != nil {
+		t.Fatalf("PlanMerge first error = %v", err)
+	}
+	second, err := a.PlanMerge(first.Updated, true)
+	if err != nil {
+		t.Fatalf("PlanMerge second error = %v", err)
+	}
+	if second.HasEffect() {
+		t.Fatalf("second merge unexpectedly changed config\nbefore:\n%s\nafter:\n%s", first.Updated, second.Updated)
+	}
+	for _, ch := range second.Changes {
+		if ch.Kind != "noop" {
+			t.Fatalf("expected all noop on second merge, got %+v", ch)
+		}
+	}
+}
+
+func TestGhosttyPlanMergePartialAddsMissingBindings(t *testing.T) {
+	t.Parallel()
+
+	a := newGhosttyTestAdapter(t)
+	// Pre-seed with the first two desired bindings, written by the user.
+	current := "# user config\n" +
+		"keybind = alt+1=csi:9005u\n" +
+		"keybind = alt+2=csi:9003u\n"
+	plan, err := a.PlanMerge(current, true)
+	if err != nil {
+		t.Fatalf("PlanMerge error = %v", err)
+	}
+	if !plan.HasEffect() {
+		t.Fatalf("expected effect when bindings missing")
+	}
+
+	expectAdd := len(ghosttyDesiredBindings) - 2
+	addCount := 0
+	noopCount := 0
+	for _, ch := range plan.Changes {
+		switch ch.Kind {
+		case "add":
+			addCount++
+		case "noop":
+			noopCount++
+		}
+	}
+	if addCount != expectAdd {
+		t.Fatalf("add count = %d, want %d", addCount, expectAdd)
+	}
+	if noopCount != 2 {
+		t.Fatalf("noop count = %d, want 2", noopCount)
+	}
+	if !strings.Contains(plan.Updated, "# user config") {
+		t.Fatalf("Updated lost user content:\n%s", plan.Updated)
+	}
+	// Pre-existing user bindings still present.
+	if !strings.Contains(plan.Updated, "keybind = alt+1=csi:9005u") {
+		t.Fatalf("Updated dropped user-owned alt+1 binding")
+	}
+}
+
+func TestGhosttyPlanMergeConflictSkipsAndWarns(t *testing.T) {
+	t.Parallel()
+
+	a := newGhosttyTestAdapter(t)
+	current := "keybind = alt+1=new_window\n"
+	plan, err := a.PlanMerge(current, true)
+	if err != nil {
+		t.Fatalf("PlanMerge error = %v", err)
+	}
+	var conflict *MergeChange
+	for i := range plan.Changes {
+		if plan.Changes[i].Trigger == "alt+1" {
+			conflict = &plan.Changes[i]
+			break
+		}
+	}
+	if conflict == nil {
+		t.Fatalf("missing alt+1 change in plan")
+	}
+	if conflict.Kind != "skip-conflict" {
+		t.Fatalf("alt+1 kind = %q, want skip-conflict", conflict.Kind)
+	}
+	if conflict.Existing != "new_window" {
+		t.Fatalf("alt+1 existing = %q, want new_window", conflict.Existing)
+	}
+	// Conflict trigger must NOT appear in the appended block.
+	if strings.Contains(plan.Updated, "keybind = alt+1=csi:9005u") {
+		t.Fatalf("Updated unexpectedly overrode user mapping:\n%s", plan.Updated)
+	}
+	// Original user mapping still present.
+	if !strings.Contains(plan.Updated, "keybind = alt+1=new_window") {
+		t.Fatalf("Updated dropped user's alt+1 mapping:\n%s", plan.Updated)
+	}
+}
+
+func TestGhosttyApplyMergeWritesBackupAndConfig(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfg := filepath.Join(tmp, "ghostty", "config")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	original := "# original user config\n"
+	if err := os.WriteFile(cfg, []byte(original), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	a := newGhosttyTestAdapter(t)
+	plan, err := a.PlanMerge(original, true)
+	if err != nil {
+		t.Fatalf("PlanMerge: %v", err)
+	}
+	plan.ConfigPath = cfg
+	if err := a.ApplyMerge(plan); err != nil {
+		t.Fatalf("ApplyMerge: %v", err)
+	}
+
+	got, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatalf("read written config: %v", err)
+	}
+	if string(got) != plan.Updated {
+		t.Fatalf("written config != plan.Updated\ngot:\n%s\nwant:\n%s", got, plan.Updated)
+	}
+
+	backup := cfg + ".bak.20260430-013215"
+	bak, err := os.ReadFile(backup)
+	if err != nil {
+		t.Fatalf("read backup %s: %v", backup, err)
+	}
+	if string(bak) != original {
+		t.Fatalf("backup contents = %q, want %q", bak, original)
+	}
+}
+
+func TestGhosttyApplyMergeCreatesNewConfigWithoutBackup(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfg := filepath.Join(tmp, "ghostty", "config")
+
+	a := newGhosttyTestAdapter(t)
+	plan, err := a.PlanMerge("", false)
+	if err != nil {
+		t.Fatalf("PlanMerge: %v", err)
+	}
+	plan.ConfigPath = cfg
+
+	if err := a.ApplyMerge(plan); err != nil {
+		t.Fatalf("ApplyMerge: %v", err)
+	}
+
+	if _, err := os.Stat(cfg); err != nil {
+		t.Fatalf("written config missing: %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(cfg))
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.Contains(entry.Name(), ".bak.") {
+			t.Fatalf("unexpected backup created on first run: %s", entry.Name())
+		}
+	}
+}
+
+func TestGhosttyApplyMergeNoEffectIsNoop(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfg := filepath.Join(tmp, "config")
+	a := newGhosttyTestAdapter(t)
+
+	plan := MergePlan{
+		ConfigPath: cfg,
+		Original:   "x",
+		Updated:    "x",
+	}
+	if err := a.ApplyMerge(plan); err != nil {
+		t.Fatalf("ApplyMerge no-op error = %v", err)
+	}
+	if _, err := os.Stat(cfg); !os.IsNotExist(err) {
+		t.Fatalf("expected no file written, stat err = %v", err)
+	}
+}
+
+func TestGhosttyApplyMergeRequiresConfigPath(t *testing.T) {
+	t.Parallel()
+
+	a := newGhosttyTestAdapter(t)
+	plan := MergePlan{Original: "a", Updated: "b"}
+	err := a.ApplyMerge(plan)
+	if err == nil || !strings.Contains(err.Error(), "ConfigPath") {
+		t.Fatalf("ApplyMerge without ConfigPath error = %v", err)
+	}
+}
+
+func TestParseGhosttyKeybind(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		line        string
+		wantTrigger string
+		wantAction  string
+		wantOk      bool
+	}{
+		{line: "keybind = alt+1=csi:9005u", wantTrigger: "alt+1", wantAction: "csi:9005u", wantOk: true},
+		{line: "  keybind=alt+2=csi:9003u  ", wantTrigger: "alt+2", wantAction: "csi:9003u", wantOk: true},
+		{line: "# keybind = alt+1=csi:9005u", wantOk: false},
+		{line: "", wantOk: false},
+		{line: "keybind = onlytrigger", wantOk: false},
+		{line: "font-size = 14", wantOk: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.line, func(t *testing.T) {
+			t.Parallel()
+			gotTrigger, gotAction, gotOk := parseGhosttyKeybind(tc.line)
+			if gotOk != tc.wantOk {
+				t.Fatalf("parse(%q) ok = %v, want %v", tc.line, gotOk, tc.wantOk)
+			}
+			if !tc.wantOk {
+				return
+			}
+			if gotTrigger != tc.wantTrigger || gotAction != tc.wantAction {
+				t.Fatalf("parse(%q) = (%q, %q), want (%q, %q)", tc.line, gotTrigger, gotAction, tc.wantTrigger, tc.wantAction)
+			}
+		})
+	}
+}
+
+func TestSplitGhosttyConfigStripsManagedBlock(t *testing.T) {
+	t.Parallel()
+
+	raw := "# user\n" +
+		"keybind = ctrl+a=csi:9999u\n" +
+		ghosttyManagedHeader + "\n" +
+		"keybind = alt+1=csi:9005u\n" +
+		ghosttyManagedFooter + "\n" +
+		"font-size = 14\n"
+
+	stripped, bindings := splitGhosttyConfig(raw)
+	if strings.Contains(stripped, ghosttyManagedHeader) {
+		t.Fatalf("stripped still contains managed header:\n%s", stripped)
+	}
+	if strings.Contains(stripped, "alt+1=csi:9005u") {
+		t.Fatalf("stripped still contains managed binding:\n%s", stripped)
+	}
+	if got, ok := bindings["ctrl+a"]; !ok || got != "csi:9999u" {
+		t.Fatalf("user binding ctrl+a = (%q,%v), want csi:9999u true", got, ok)
+	}
+	// Managed-block bindings are kept in the map so the merge can recognise
+	// them as noop on a second run. They are still excluded from stripped
+	// (verified above).
+	if got, ok := bindings["alt+1"]; !ok || got != "csi:9005u" {
+		t.Fatalf("alt+1 binding from managed block = (%q,%v), want csi:9005u", got, ok)
+	}
+	if !strings.Contains(stripped, "font-size = 14") {
+		t.Fatalf("stripped lost trailing user content:\n%s", stripped)
+	}
+}
+
+func TestSplitGhosttyConfigUserOverrideTrumpsManagedBlock(t *testing.T) {
+	t.Parallel()
+
+	// User declared alt+1=new_window before our managed block. The managed
+	// block contains alt+1=csi:9005u. The user's intent must win so the
+	// merge classifies alt+1 as skip-conflict instead of noop.
+	raw := "keybind = alt+1=new_window\n" +
+		ghosttyManagedHeader + "\n" +
+		"keybind = alt+1=csi:9005u\n" +
+		ghosttyManagedFooter + "\n"
+
+	_, bindings := splitGhosttyConfig(raw)
+	if got := bindings["alt+1"]; got != "new_window" {
+		t.Fatalf("alt+1 = %q, want new_window (user override should win)", got)
+	}
+}

--- a/internal/app/init_terminal.go
+++ b/internal/app/init_terminal.go
@@ -1,0 +1,138 @@
+package app
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// MergeChange describes a single binding-level diff produced by a
+// TerminalAdapter while planning a merge into the user's terminal config.
+type MergeChange struct {
+	// Trigger is the canonical key combo (e.g. "alt+1").
+	Trigger string
+	// Action is the canonical action string (e.g. "csi:9005u").
+	Action string
+	// Existing is the user's current action mapped to Trigger, if any.
+	Existing string
+	// Kind is one of "add", "update", "skip-conflict", "noop".
+	Kind string
+	// Reason is a short human-readable note (used for skip-conflict).
+	Reason string
+}
+
+// MergePlan is the output of TerminalAdapter.PlanMerge. It contains the
+// pre-image, the post-image, and a list of per-binding changes that callers
+// can render as a preview/diff before applying.
+type MergePlan struct {
+	// ConfigPath is the absolute config file path the plan targets.
+	ConfigPath string
+	// Original is the verbatim file contents read from disk (empty if missing).
+	Original string
+	// Updated is the file contents that ApplyMerge would write.
+	Updated string
+	// Changes is the per-binding decision list, ordered by trigger.
+	Changes []MergeChange
+	// CreateNew is true when the config file does not exist yet.
+	CreateNew bool
+}
+
+// HasEffect reports whether applying this plan would change anything on disk.
+func (p MergePlan) HasEffect() bool {
+	return p.Original != p.Updated
+}
+
+// TerminalAdapter is the per-terminal contract for `projmux init`.
+//
+// Implementations register themselves in the package-level registry via
+// RegisterTerminalAdapter so the init command can dispatch by name and
+// auto-detect the active terminal.
+type TerminalAdapter interface {
+	// Name returns the terminal's canonical CLI name, e.g. "ghostty".
+	Name() string
+	// Detect reports whether the running shell appears to be inside this
+	// terminal. env is an indirection over os.Getenv so tests can drive it.
+	Detect(env func(string) string) bool
+	// ConfigPath resolves the absolute config file path for this terminal.
+	ConfigPath(env func(string) string) (string, error)
+	// PlanMerge returns the diff of merging projmux bindings into the
+	// supplied current config. fileExists is true when the config file
+	// already exists on disk; an empty string with fileExists=false means
+	// the file should be created.
+	PlanMerge(currentConfig string, fileExists bool) (MergePlan, error)
+	// ApplyMerge writes the plan's Updated contents to disk, creating a
+	// timestamped backup of the previous file when one exists.
+	ApplyMerge(plan MergePlan) error
+}
+
+// terminalRegistry is the global registry of TerminalAdapter implementations.
+type terminalRegistry struct {
+	mu       sync.RWMutex
+	adapters map[string]TerminalAdapter
+}
+
+var defaultTerminalRegistry = &terminalRegistry{adapters: map[string]TerminalAdapter{}}
+
+// RegisterTerminalAdapter adds a TerminalAdapter to the default registry.
+// It panics on duplicate names so registration bugs surface at init time.
+func RegisterTerminalAdapter(a TerminalAdapter) {
+	defaultTerminalRegistry.register(a)
+}
+
+func (r *terminalRegistry) register(a TerminalAdapter) {
+	if a == nil {
+		panic("RegisterTerminalAdapter: nil adapter")
+	}
+	name := a.Name()
+	if name == "" {
+		panic("RegisterTerminalAdapter: empty Name()")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.adapters[name]; exists {
+		panic(fmt.Sprintf("RegisterTerminalAdapter: %q already registered", name))
+	}
+	r.adapters[name] = a
+}
+
+// lookup returns the adapter registered under name, or false.
+func (r *terminalRegistry) lookup(name string) (TerminalAdapter, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	a, ok := r.adapters[name]
+	return a, ok
+}
+
+// names returns the registered adapter names sorted alphabetically.
+func (r *terminalRegistry) names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, 0, len(r.adapters))
+	for name := range r.adapters {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// detect walks the registry and returns the first adapter whose Detect
+// reports a match. If no adapter matches, the second return is false.
+func (r *terminalRegistry) detect(env func(string) string) (TerminalAdapter, bool) {
+	for _, name := range r.names() {
+		a, _ := r.lookup(name)
+		if a == nil {
+			continue
+		}
+		if a.Detect(env) {
+			return a, true
+		}
+	}
+	return nil, false
+}
+
+// reset clears the registry. Test helper.
+func (r *terminalRegistry) reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.adapters = map[string]TerminalAdapter{}
+}

--- a/internal/app/init_test.go
+++ b/internal/app/init_test.go
@@ -1,0 +1,284 @@
+package app
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeAdapter is a minimal TerminalAdapter used by registry/dispatch tests.
+type fakeAdapter struct {
+	name        string
+	detect      bool
+	detectCalls int
+	planFn      func(current string, exists bool) (MergePlan, error)
+	applied     *MergePlan
+	configPath  string
+}
+
+func (f *fakeAdapter) Name() string { return f.name }
+
+func (f *fakeAdapter) Detect(env func(string) string) bool {
+	f.detectCalls++
+	return f.detect
+}
+
+func (f *fakeAdapter) ConfigPath(env func(string) string) (string, error) {
+	if f.configPath == "" {
+		return "/tmp/" + f.name + "/config", nil
+	}
+	return f.configPath, nil
+}
+
+func (f *fakeAdapter) PlanMerge(current string, exists bool) (MergePlan, error) {
+	if f.planFn != nil {
+		return f.planFn(current, exists)
+	}
+	return MergePlan{Original: current, Updated: current + "added\n", CreateNew: !exists,
+		Changes: []MergeChange{{Trigger: "alt+1", Action: "csi:9005u", Kind: "add"}}}, nil
+}
+
+func (f *fakeAdapter) ApplyMerge(plan MergePlan) error {
+	cp := plan
+	f.applied = &cp
+	return nil
+}
+
+func newTestRegistry() *terminalRegistry {
+	return &terminalRegistry{adapters: map[string]TerminalAdapter{}}
+}
+
+func TestTerminalRegistryRegisterAndLookup(t *testing.T) {
+	t.Parallel()
+
+	reg := newTestRegistry()
+	a := &fakeAdapter{name: "alpha"}
+	reg.register(a)
+
+	got, ok := reg.lookup("alpha")
+	if !ok || got != a {
+		t.Fatalf("lookup(alpha) = (%v, %v), want adapter %v", got, ok, a)
+	}
+	if _, ok := reg.lookup("missing"); ok {
+		t.Fatalf("lookup(missing) ok = true, want false")
+	}
+
+	names := reg.names()
+	if len(names) != 1 || names[0] != "alpha" {
+		t.Fatalf("names() = %v, want [alpha]", names)
+	}
+}
+
+func TestTerminalRegistryRegisterDuplicatePanics(t *testing.T) {
+	t.Parallel()
+
+	reg := newTestRegistry()
+	reg.register(&fakeAdapter{name: "alpha"})
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic on duplicate register")
+		}
+	}()
+	reg.register(&fakeAdapter{name: "alpha"})
+}
+
+func TestTerminalRegistryRegisterEmptyNamePanics(t *testing.T) {
+	t.Parallel()
+
+	reg := newTestRegistry()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic on empty name")
+		}
+	}()
+	reg.register(&fakeAdapter{name: ""})
+}
+
+func TestTerminalRegistryDetectReturnsFirstMatch(t *testing.T) {
+	t.Parallel()
+
+	reg := newTestRegistry()
+	reg.register(&fakeAdapter{name: "alpha"})
+	beta := &fakeAdapter{name: "beta", detect: true}
+	reg.register(beta)
+	reg.register(&fakeAdapter{name: "gamma", detect: true})
+
+	got, ok := reg.detect(func(string) string { return "" })
+	if !ok || got.Name() != "beta" {
+		t.Fatalf("detect() = (%v, %v); want beta adapter", got, ok)
+	}
+}
+
+func TestTerminalRegistryDetectNoMatch(t *testing.T) {
+	t.Parallel()
+
+	reg := newTestRegistry()
+	reg.register(&fakeAdapter{name: "alpha"})
+
+	if got, ok := reg.detect(func(string) string { return "" }); ok {
+		t.Fatalf("detect() ok = true (got %v); want false", got)
+	}
+}
+
+func TestRegisterTerminalAdapterRegistersGhosttyByDefault(t *testing.T) {
+	t.Parallel()
+
+	got, ok := defaultTerminalRegistry.lookup("ghostty")
+	if !ok {
+		t.Fatalf("default registry missing ghostty adapter")
+	}
+	if got.Name() != "ghostty" {
+		t.Fatalf("default ghostty adapter name = %q, want ghostty", got.Name())
+	}
+}
+
+func TestInitCommandUnknownTerminalReturnsError(t *testing.T) {
+	t.Parallel()
+
+	reg := newTestRegistry()
+	reg.register(&fakeAdapter{name: "alpha"})
+
+	cmd := &initCommand{registry: reg, getenv: func(string) string { return "" }}
+	var stdout, stderr bytes.Buffer
+	err := cmd.Run([]string{"unknown"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "unknown terminal") {
+		t.Fatalf("Run(unknown) error = %v, want unknown terminal", err)
+	}
+}
+
+func TestInitCommandAutoDetectFailsWithoutMatch(t *testing.T) {
+	t.Parallel()
+
+	reg := newTestRegistry()
+	reg.register(&fakeAdapter{name: "alpha"})
+
+	cmd := &initCommand{registry: reg, getenv: func(string) string { return "" }}
+	var stdout, stderr bytes.Buffer
+	err := cmd.Run(nil, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "auto-detect") {
+		t.Fatalf("Run() error = %v, want auto-detect failure", err)
+	}
+}
+
+func TestInitCommandDryRunPrintsPlanAndDoesNotApply(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfg := filepath.Join(tmp, "config")
+	if err := os.WriteFile(cfg, []byte("# user config\n"), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	adapter := &fakeAdapter{
+		name:       "alpha",
+		detect:     true,
+		configPath: cfg,
+	}
+	reg := newTestRegistry()
+	reg.register(adapter)
+
+	cmd := &initCommand{
+		registry: reg,
+		getenv:   func(string) string { return "" },
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+	}
+	var stdout, stderr bytes.Buffer
+	if err := cmd.Run([]string{"alpha"}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run() error = %v (stderr=%s)", err, stderr.String())
+	}
+	if adapter.applied != nil {
+		t.Fatalf("dry-run unexpectedly applied: %+v", adapter.applied)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "dry-run") {
+		t.Fatalf("dry-run output missing 'dry-run' marker: %q", out)
+	}
+	if !strings.Contains(out, "--apply") {
+		t.Fatalf("dry-run output missing apply hint: %q", out)
+	}
+	if !strings.Contains(out, "alt+1") {
+		t.Fatalf("dry-run output missing change preview: %q", out)
+	}
+}
+
+func TestInitCommandApplyInvokesAdapter(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfg := filepath.Join(tmp, "config")
+
+	adapter := &fakeAdapter{name: "alpha", configPath: cfg}
+	reg := newTestRegistry()
+	reg.register(adapter)
+
+	cmd := &initCommand{
+		registry: reg,
+		getenv:   func(string) string { return "" },
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+	}
+	var stdout, stderr bytes.Buffer
+	if err := cmd.Run([]string{"alpha", "--apply"}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run(--apply) error = %v (stderr=%s)", err, stderr.String())
+	}
+	if adapter.applied == nil {
+		t.Fatalf("--apply did not call ApplyMerge")
+	}
+	if adapter.applied.ConfigPath != cfg {
+		t.Fatalf("ApplyMerge plan.ConfigPath = %q, want %q", adapter.applied.ConfigPath, cfg)
+	}
+	if !strings.Contains(stdout.String(), "wrote") {
+		t.Fatalf("apply stdout = %q, want 'wrote' summary", stdout.String())
+	}
+}
+
+func TestInitCommandRejectsApplyAndDryRunTogether(t *testing.T) {
+	t.Parallel()
+
+	cmd := &initCommand{
+		registry: newTestRegistry(),
+		getenv:   func(string) string { return "" },
+	}
+	var stdout, stderr bytes.Buffer
+	err := cmd.Run([]string{"--apply", "--dry-run"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("Run(--apply --dry-run) error = %v, want mutual exclusion", err)
+	}
+}
+
+func TestInitCommandLoadConfigMissingFile(t *testing.T) {
+	t.Parallel()
+
+	cmd := &initCommand{
+		readFile: os.ReadFile,
+		stat: func(name string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist
+		},
+	}
+	current, exists, err := cmd.loadConfig("/nope")
+	if err != nil {
+		t.Fatalf("loadConfig missing error = %v", err)
+	}
+	if exists {
+		t.Fatalf("loadConfig missing exists = true, want false")
+	}
+	if current != "" {
+		t.Fatalf("loadConfig missing current = %q, want empty", current)
+	}
+}
+
+func TestInitCommandLoadConfigPropagatesUnexpectedStatError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	cmd := &initCommand{
+		stat: func(name string) (os.FileInfo, error) { return nil, sentinel },
+	}
+	if _, _, err := cmd.loadConfig("/whatever"); !errors.Is(err, sentinel) {
+		t.Fatalf("loadConfig stat error = %v, want sentinel", err)
+	}
+}


### PR DESCRIPTION
## Summary
- 새 서브커맨드 `projmux init [terminal]` — 터미널별 config 에 projmux CSI-u 키바인딩을 자동 머지
- `TerminalAdapter` 인터페이스 + 레지스트리 도입 (후속 PR 에서 Kitty/Alacritty/WezTerm/iTerm2/WindowsTerminal 등 어댑터만 추가하면 됨)
- 첫 어댑터: **Ghostty**
  - 감지: `TERM_PROGRAM=ghostty` / `GHOSTTY_RESOURCES_DIR`
  - config 위치: `$XDG_CONFIG_HOME/ghostty/config` 또는 `~/.config/ghostty/config`
  - dry-run 기본, `--apply` 시 timestamped backup + idempotent merge
  - managed 블록 마커 (`# >>> projmux managed keybindings ... # <<<`) 로 두 번째 실행 시 noop
  - 사용자가 같은 trigger 를 블록 외부에서 다른 액션에 매핑한 경우 → 경고 + skip (사용자 의도 우선)
- Flag/positional 순서 자유 (`init ghostty --apply` 와 `init --apply ghostty` 둘 다 OK)

## Test plan
- [x] \`go test ./...\` 전 패키지 PASS, \`go vet\` clean
- [x] \`make fmt-check\` 통과
- [ ] CI Test 잡 통과 후 squash merge

## 후속 PR 에서 추가 예정
- Windows Terminal 어댑터 (WSL 포함)
- Kitty / Alacritty / WezTerm / iTerm2

🤖 Generated with [Claude Code](https://claude.com/claude-code)