### PR TITLE
feat(init): add Windows Terminal adapter (WSL + native)

### DIFF
--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -223,8 +223,10 @@ func splitInitArgs(args []string) (terminal string, flagArgs []string) {
 	return terminal, flagArgs
 }
 
-// init registers the Ghostty adapter with the package-level registry. Future
-// terminals add a sibling file with their own init() block.
+// init registers the bundled terminal adapters with the package-level
+// registry. Future terminals add a sibling file with their own init() block,
+// or extend this list when registration order matters.
 func init() {
 	RegisterTerminalAdapter(NewGhosttyAdapter())
+	RegisterTerminalAdapter(NewWindowsTerminalAdapter())
 }

--- a/internal/app/init_windows_terminal.go
+++ b/internal/app/init_windows_terminal.go
@@ -1,0 +1,643 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// wtBinding mirrors one Windows Terminal action+keybinding pair the projmux
+// init command guarantees in the user's settings.json. Each entry corresponds
+// to one of the 12 projmux app shortcuts; the table is the single source of
+// truth in code (docs/keybindings.md mirrors it for users).
+type wtBinding struct {
+	// ID is the stable settings.json identifier (prefixed with User.projmux).
+	// Same value is used in both the actions[] entry and the keybindings[]
+	// entry so the two halves stay in sync across re-runs.
+	ID string
+	// Keys is the canonical key combo (e.g. "alt+1").
+	Keys string
+	// Input is the literal byte sequence sendInput should write to the
+	// pseudo-terminal. Stored as the actual rune sequence (with real escape
+	// chars), not the JSON-source `` form.
+	Input string
+}
+
+// wtIDPrefix marks a settings.json entry as projmux-managed. Anything starting
+// with this string in `id` is owned by the merge; anything else is the user's.
+const wtIDPrefix = "User.projmux"
+
+// wtDesiredBindings is the canonical list inlined from docs/keybindings.md.
+// Update both sites together when CSI-u routing changes.
+var wtDesiredBindings = []wtBinding{
+	{ID: "User.projmuxSidebar", Keys: "alt+1", Input: "\x1b1"},
+	{ID: "User.projmuxSessions", Keys: "alt+2", Input: "\x1b2"},
+	{ID: "User.projmuxSwitch", Keys: "alt+3", Input: "\x1b3"},
+	{ID: "User.projmuxAIPicker", Keys: "alt+4", Input: "\x1b4"},
+	{ID: "User.projmuxSettings", Keys: "alt+5", Input: "\x1b5"},
+	{ID: "User.projmuxAISplitRight", Keys: "ctrl+shift+r", Input: "\x02r"},
+	{ID: "User.projmuxAISplitDown", Keys: "ctrl+shift+l", Input: "\x02l"},
+	{ID: "User.projmuxNewWindow", Keys: "ctrl+n", Input: "\x0e"},
+	{ID: "User.projmuxPrevWindow", Keys: "alt+shift+left", Input: "\x1b[1;4D"},
+	{ID: "User.projmuxNextWindow", Keys: "alt+shift+right", Input: "\x1b[1;4C"},
+	{ID: "User.projmuxRenameWindow", Keys: "ctrl+m", Input: "\x1b[9011u"},
+	{ID: "User.projmuxRenamePane", Keys: "ctrl+shift+m", Input: "\x1b[9012u"},
+}
+
+// WindowsTerminalAdapter implements TerminalAdapter for Windows Terminal,
+// covering both native Windows installs and WSL where the host shell is WT.
+type WindowsTerminalAdapter struct {
+	// now allows tests to pin the timestamp used for backup file names.
+	now func() time.Time
+	// userHomeDir defaults to os.UserHomeDir for the WSL fallback path.
+	userHomeDir func() (string, error)
+	// stat is used to choose between candidate config paths (Store vs
+	// unpackaged) and defaults to os.Stat.
+	stat func(string) (os.FileInfo, error)
+	// writeFile defaults to os.WriteFile.
+	writeFile func(name string, data []byte, perm os.FileMode) error
+	// mkdirAll defaults to os.MkdirAll for the parent config dir.
+	mkdirAll func(path string, perm os.FileMode) error
+	// runCmdExe is the WSL interop hook; given args (e.g. ["cmd.exe", "/c",
+	// "echo %LOCALAPPDATA%"]) it returns the captured stdout. Tests can swap
+	// this for a fake to drive the path resolution logic.
+	runCmdExe func(args []string) (string, error)
+}
+
+// NewWindowsTerminalAdapter constructs a WT adapter wired to real OS helpers.
+// Tests can override the internal hooks afterwards.
+func NewWindowsTerminalAdapter() *WindowsTerminalAdapter {
+	return &WindowsTerminalAdapter{
+		now:         time.Now,
+		userHomeDir: os.UserHomeDir,
+		stat:        os.Stat,
+		writeFile:   os.WriteFile,
+		mkdirAll:    os.MkdirAll,
+		runCmdExe:   defaultRunCmdExe,
+	}
+}
+
+// Name implements TerminalAdapter.
+func (w *WindowsTerminalAdapter) Name() string { return "windows-terminal" }
+
+// Detect implements TerminalAdapter. WT is identified via:
+//   - WT_SESSION (set by Windows Terminal in spawned children, both native
+//     and via WSL interop)
+//   - TERM_PROGRAM=WindowsTerminal (preview builds and newer stables)
+//   - WSL_DISTRO_NAME / WSL_INTEROP (we're in WSL — projmux assumes WT is the
+//     host since that's the most common setup; users on a different host can
+//     override by passing the terminal name explicitly)
+func (w *WindowsTerminalAdapter) Detect(env func(string) string) bool {
+	if env == nil {
+		return false
+	}
+	if strings.TrimSpace(env("WT_SESSION")) != "" {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(env("TERM_PROGRAM")), "WindowsTerminal") {
+		return true
+	}
+	if strings.TrimSpace(env("WSL_DISTRO_NAME")) != "" {
+		return true
+	}
+	if strings.TrimSpace(env("WSL_INTEROP")) != "" {
+		return true
+	}
+	return false
+}
+
+// isWSL reports whether we appear to be running inside WSL based on the
+// environment. WSL governs how ConfigPath resolves the Windows-side
+// %LOCALAPPDATA% path.
+func isWSL(env func(string) string) bool {
+	if env == nil {
+		return false
+	}
+	if strings.TrimSpace(env("WSL_DISTRO_NAME")) != "" {
+		return true
+	}
+	if strings.TrimSpace(env("WSL_INTEROP")) != "" {
+		return true
+	}
+	return false
+}
+
+// ConfigPath implements TerminalAdapter. Two branches:
+//
+//	WSL:    resolve Windows-side %LOCALAPPDATA% via cmd.exe interop, then
+//	        translate C:\... into /mnt/c/... ; on interop failure fall back
+//	        to /mnt/c/Users/<linux-user>/AppData/Local heuristic.
+//	native: probe Store-install path, then unpackaged path; if neither exists
+//	        return the Store path so the caller knows where to create one.
+//
+// In both branches, when both candidates exist the Store path wins because
+// that's the modern install location.
+func (w *WindowsTerminalAdapter) ConfigPath(env func(string) string) (string, error) {
+	if env == nil {
+		env = os.Getenv
+	}
+	if isWSL(env) {
+		return w.wslConfigPath(env)
+	}
+	return w.nativeConfigPath(env)
+}
+
+// nativeConfigPath returns the first existing Windows Terminal settings.json
+// among the well-known candidates, defaulting to the Store path.
+func (w *WindowsTerminalAdapter) nativeConfigPath(env func(string) string) (string, error) {
+	localAppData := strings.TrimSpace(env("LOCALAPPDATA"))
+	if localAppData == "" {
+		// Best-effort recovery: %USERPROFILE%\AppData\Local.
+		userProfile := strings.TrimSpace(env("USERPROFILE"))
+		if userProfile == "" {
+			return "", fmt.Errorf("resolve windows-terminal config: LOCALAPPDATA unset")
+		}
+		localAppData = filepath.Join(userProfile, "AppData", "Local")
+	}
+	candidates := wtNativeCandidates(localAppData)
+	return w.firstExistingOrDefault(candidates), nil
+}
+
+// wtNativeCandidates returns the {Store, unpackaged} settings.json candidates
+// rooted at the supplied %LOCALAPPDATA% (or its WSL-translated equivalent).
+func wtNativeCandidates(localAppData string) []string {
+	return []string{
+		filepath.Join(localAppData, "Packages", "Microsoft.WindowsTerminal_8wekyb3d8bbcwe", "LocalState", "settings.json"),
+		filepath.Join(localAppData, "Microsoft", "Windows Terminal", "settings.json"),
+	}
+}
+
+// firstExistingOrDefault stats each candidate and returns the first that
+// exists, falling back to candidates[0] when none do (so a fresh install
+// still has a sensible default target).
+func (w *WindowsTerminalAdapter) firstExistingOrDefault(candidates []string) string {
+	statFn := w.stat
+	if statFn == nil {
+		statFn = os.Stat
+	}
+	for _, c := range candidates {
+		if _, err := statFn(c); err == nil {
+			return c
+		}
+	}
+	return candidates[0]
+}
+
+// wslConfigPath resolves the Windows Terminal settings.json from inside WSL.
+// Preferred path is via cmd.exe interop (gives us the exact %LOCALAPPDATA%
+// even when the Windows username differs from the Linux username); on failure
+// we fall back to the /mnt/c/Users/<linux-user> heuristic and let the user
+// re-run with --config if their Windows username differs.
+func (w *WindowsTerminalAdapter) wslConfigPath(env func(string) string) (string, error) {
+	runner := w.runCmdExe
+	if runner == nil {
+		runner = defaultRunCmdExe
+	}
+	out, err := runner([]string{"cmd.exe", "/c", "echo %LOCALAPPDATA%"})
+	if err == nil {
+		winPath := strings.TrimSpace(out)
+		// cmd.exe occasionally appends \r before the LF we already trimmed.
+		winPath = strings.TrimRight(winPath, "\r")
+		if winPath != "" && !strings.Contains(winPath, "%") {
+			mnt, convErr := winPathToMnt(winPath)
+			if convErr == nil {
+				return w.firstExistingOrDefault(wtNativeCandidates(mnt)), nil
+			}
+		}
+	}
+	// Fallback: /mnt/c/Users/<linux-user>/AppData/Local
+	homeFn := w.userHomeDir
+	if homeFn == nil {
+		homeFn = os.UserHomeDir
+	}
+	home, herr := homeFn()
+	if herr != nil || home == "" {
+		return "", fmt.Errorf("resolve windows-terminal config: cmd.exe interop failed (%v) and could not derive home dir (%v)", err, herr)
+	}
+	user := filepath.Base(home)
+	mnt := filepath.Join("/mnt/c/Users", user, "AppData", "Local")
+	return w.firstExistingOrDefault(wtNativeCandidates(mnt)), nil
+}
+
+// winPathToMnt converts a Windows path like `C:\Users\foo\AppData\Local` into
+// its WSL-mounted equivalent `/mnt/c/Users/foo/AppData/Local`. Drive letters
+// are lowercased; backslashes become forward slashes.
+func winPathToMnt(winPath string) (string, error) {
+	if len(winPath) < 2 || winPath[1] != ':' {
+		return "", fmt.Errorf("not a drive-rooted windows path: %q", winPath)
+	}
+	drive := unicode.ToLower(rune(winPath[0]))
+	rest := strings.ReplaceAll(winPath[2:], "\\", "/")
+	rest = strings.TrimPrefix(rest, "/")
+	return "/mnt/" + string(drive) + "/" + rest, nil
+}
+
+// defaultRunCmdExe is the production WSL interop hook: it shells out to
+// cmd.exe and returns its stdout. Tests replace this with an in-memory fake.
+func defaultRunCmdExe(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("runCmdExe: no command")
+	}
+	cmd := exec.Command(args[0], args[1:]...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%s: %w (stderr=%q)", args[0], err, stderr.String())
+	}
+	return stdout.String(), nil
+}
+
+// PlanMerge implements TerminalAdapter. It parses the JSONC settings,
+// merges the projmux actions[] / keybindings[] entries idempotently, and
+// returns a re-serialised settings document plus the per-binding change
+// list. Conflicts on `keys` (the user has the same key bound to a non-
+// projmux id) are reported as skip-conflict and left untouched.
+func (w *WindowsTerminalAdapter) PlanMerge(currentConfig string, fileExists bool) (MergePlan, error) {
+	plan := MergePlan{Original: currentConfig, CreateNew: !fileExists}
+
+	root, err := parseSettings(currentConfig, fileExists)
+	if err != nil {
+		return MergePlan{}, fmt.Errorf("parse windows-terminal settings.json: %w", err)
+	}
+
+	actions := asObjectArray(root["actions"])
+	keybindings := asObjectArray(root["keybindings"])
+
+	// Build lookup maps by id (managed entries) and by keys (so conflict
+	// detection sees the user's true intent).
+	actionByID := map[string]map[string]any{}
+	for _, a := range actions {
+		if id, ok := a["id"].(string); ok {
+			actionByID[id] = a
+		}
+	}
+	keybindingByID := map[string]map[string]any{}
+	keybindingByKeys := map[string]map[string]any{}
+	for _, kb := range keybindings {
+		if id, ok := kb["id"].(string); ok {
+			keybindingByID[id] = kb
+		}
+		if keys, ok := kb["keys"].(string); ok && keys != "" {
+			keybindingByKeys[strings.ToLower(keys)] = kb
+		}
+	}
+
+	var changes []MergeChange
+	dirty := false
+
+	for _, want := range wtDesiredBindings {
+		// 1) Conflict check: a non-projmux binding already owns these keys.
+		if existingKB, ok := keybindingByKeys[strings.ToLower(want.Keys)]; ok {
+			existingID, _ := existingKB["id"].(string)
+			if !strings.HasPrefix(existingID, wtIDPrefix) {
+				existingLabel := existingID
+				if existingLabel == "" {
+					existingLabel = "<unknown action>"
+				}
+				changes = append(changes, MergeChange{
+					Trigger:  want.Keys,
+					Action:   want.ID,
+					Existing: existingLabel,
+					Kind:     "skip-conflict",
+					Reason:   "user mapped keys to " + existingLabel,
+				})
+				continue
+			}
+		}
+
+		desiredAction := newProjmuxAction(want)
+		desiredKB := newProjmuxKeybinding(want)
+
+		// 2) Action entry: add or update if id not present / drifted.
+		actionChanged := false
+		if existingAction, ok := actionByID[want.ID]; ok {
+			if !sameProjmuxAction(existingAction, desiredAction) {
+				// Drift: replace in-place to keep object ordering stable.
+				for k := range existingAction {
+					delete(existingAction, k)
+				}
+				for k, v := range desiredAction {
+					existingAction[k] = v
+				}
+				actionChanged = true
+				dirty = true
+			}
+		} else {
+			actions = append(actions, desiredAction)
+			actionByID[want.ID] = desiredAction
+			actionChanged = true
+			dirty = true
+		}
+
+		// 3) Keybinding entry: same drift check on the {id, keys} pair.
+		kbChanged := false
+		if existingKB, ok := keybindingByID[want.ID]; ok {
+			if !sameProjmuxKeybinding(existingKB, desiredKB) {
+				for k := range existingKB {
+					delete(existingKB, k)
+				}
+				for k, v := range desiredKB {
+					existingKB[k] = v
+				}
+				kbChanged = true
+				dirty = true
+			}
+		} else {
+			keybindings = append(keybindings, desiredKB)
+			keybindingByID[want.ID] = desiredKB
+			keybindingByKeys[strings.ToLower(want.Keys)] = desiredKB
+			kbChanged = true
+			dirty = true
+		}
+
+		switch {
+		case !actionChanged && !kbChanged:
+			changes = append(changes, MergeChange{
+				Trigger: want.Keys,
+				Action:  want.ID,
+				Kind:    "noop",
+			})
+		default:
+			changes = append(changes, MergeChange{
+				Trigger: want.Keys,
+				Action:  want.ID,
+				Kind:    "add",
+			})
+		}
+	}
+
+	// Stable sort changes by trigger so output is deterministic regardless
+	// of map iteration order quirks above (the desired list is already in a
+	// fixed order, but defence-in-depth keeps tests stable across refactors).
+	sort.SliceStable(changes, func(i, j int) bool {
+		return changes[i].Trigger < changes[j].Trigger
+	})
+
+	plan.Changes = changes
+
+	if !dirty {
+		plan.Updated = currentConfig
+		return plan, nil
+	}
+
+	root["actions"] = actions
+	root["keybindings"] = keybindings
+
+	encoded, err := encodeSettings(root)
+	if err != nil {
+		return MergePlan{}, fmt.Errorf("encode windows-terminal settings.json: %w", err)
+	}
+	plan.Updated = encoded
+	return plan, nil
+}
+
+// newProjmuxAction builds the canonical actions[] entry for a binding.
+func newProjmuxAction(b wtBinding) map[string]any {
+	return map[string]any{
+		"command": map[string]any{
+			"action": "sendInput",
+			"input":  b.Input,
+		},
+		"id": b.ID,
+	}
+}
+
+// newProjmuxKeybinding builds the canonical keybindings[] entry for a binding.
+func newProjmuxKeybinding(b wtBinding) map[string]any {
+	return map[string]any{
+		"id":   b.ID,
+		"keys": b.Keys,
+	}
+}
+
+// sameProjmuxAction reports whether two action objects describe the same
+// {id, command.action, command.input} triple. Other user-added fields are
+// ignored; the merge owns the canonical fields only.
+func sameProjmuxAction(have, want map[string]any) bool {
+	if have["id"] != want["id"] {
+		return false
+	}
+	hc, _ := have["command"].(map[string]any)
+	wc, _ := want["command"].(map[string]any)
+	if hc == nil || wc == nil {
+		return false
+	}
+	return hc["action"] == wc["action"] && hc["input"] == wc["input"]
+}
+
+// sameProjmuxKeybinding compares the canonical {id, keys} pair.
+func sameProjmuxKeybinding(have, want map[string]any) bool {
+	return have["id"] == want["id"] && have["keys"] == want["keys"]
+}
+
+// asObjectArray normalises an `any` value (the result of unmarshalling a JSON
+// array into `any`) into a slice of map[string]any. Non-array or non-object
+// elements are dropped — Windows Terminal would ignore them anyway, so this
+// keeps the merge tolerant of malformed user content.
+func asObjectArray(v any) []map[string]any {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(arr))
+	for _, e := range arr {
+		if m, ok := e.(map[string]any); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// parseSettings reads the JSONC settings document into a generic object map.
+// Comments and trailing commas are stripped before passing to encoding/json
+// so we can stay on the standard library. An empty / missing file produces
+// an empty map so the merge can populate it from scratch.
+func parseSettings(raw string, fileExists bool) (map[string]any, error) {
+	if !fileExists || strings.TrimSpace(raw) == "" {
+		return map[string]any{}, nil
+	}
+	cleaned := stripJSONC(raw)
+	dec := json.NewDecoder(strings.NewReader(cleaned))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+	root, ok := v.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("settings.json root must be an object, got %T", v)
+	}
+	return root, nil
+}
+
+// encodeSettings serialises the merged document back to disk. We re-emit as
+// standard JSON with two-space indent (matching Windows Terminal's default
+// formatting). User comments cannot survive a strip-then-reparse round-trip,
+// so the dispatcher creates a timestamped backup before write.
+func encodeSettings(root map[string]any) (string, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "    ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(root); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// stripJSONC removes // line comments, /* block comments */, and trailing
+// commas before object/array closers, leaving a string that encoding/json
+// can parse. Comments inside string literals are preserved because the
+// scanner tracks the in-string state.
+//
+// The implementation walks the string byte-by-byte. We avoid pulling in a
+// third-party JSONC parser to keep the module dependency-free; the cost is
+// that user comments are not round-tripped (the apply step keeps a backup
+// to compensate).
+func stripJSONC(raw string) string {
+	var out bytes.Buffer
+	out.Grow(len(raw))
+
+	inString := false
+	escape := false
+	i := 0
+	for i < len(raw) {
+		c := raw[i]
+		if inString {
+			out.WriteByte(c)
+			if escape {
+				escape = false
+			} else if c == '\\' {
+				escape = true
+			} else if c == '"' {
+				inString = false
+			}
+			i++
+			continue
+		}
+		// Line comment
+		if c == '/' && i+1 < len(raw) && raw[i+1] == '/' {
+			i += 2
+			for i < len(raw) && raw[i] != '\n' {
+				i++
+			}
+			continue
+		}
+		// Block comment
+		if c == '/' && i+1 < len(raw) && raw[i+1] == '*' {
+			i += 2
+			for i+1 < len(raw) && !(raw[i] == '*' && raw[i+1] == '/') {
+				i++
+			}
+			if i+1 < len(raw) {
+				i += 2
+			} else {
+				i = len(raw)
+			}
+			continue
+		}
+		if c == '"' {
+			inString = true
+			out.WriteByte(c)
+			i++
+			continue
+		}
+		out.WriteByte(c)
+		i++
+	}
+	return stripTrailingCommas(out.String())
+}
+
+// stripTrailingCommas removes commas that immediately precede a `}` or `]`
+// (modulo whitespace). It assumes JSONC comments have already been stripped
+// and tracks the in-string state to leave string contents alone.
+func stripTrailingCommas(s string) string {
+	out := make([]byte, 0, len(s))
+	inString := false
+	escape := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inString {
+			out = append(out, c)
+			if escape {
+				escape = false
+			} else if c == '\\' {
+				escape = true
+			} else if c == '"' {
+				inString = false
+			}
+			continue
+		}
+		if c == '"' {
+			inString = true
+			out = append(out, c)
+			continue
+		}
+		if c == ',' {
+			j := i + 1
+			for j < len(s) && (s[j] == ' ' || s[j] == '\t' || s[j] == '\n' || s[j] == '\r') {
+				j++
+			}
+			if j < len(s) && (s[j] == '}' || s[j] == ']') {
+				// Skip the comma; preserve following whitespace.
+				continue
+			}
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+// ApplyMerge implements TerminalAdapter. It backs up the prior settings.json
+// to <path>.bak.<YYYYMMDD-HHMMSS> when one existed and writes the merged
+// document atomically (via the standard write-then-rename of os.WriteFile is
+// good enough on the host filesystems we target; drvfs (/mnt/c) writes use
+// the same path and surface umask-related EACCES errors with the original
+// message intact).
+func (w *WindowsTerminalAdapter) ApplyMerge(plan MergePlan) error {
+	if plan.ConfigPath == "" {
+		return fmt.Errorf("apply windows-terminal merge: plan has no ConfigPath")
+	}
+	if !plan.HasEffect() {
+		return nil
+	}
+
+	dir := filepath.Dir(plan.ConfigPath)
+	mkdir := w.mkdirAll
+	if mkdir == nil {
+		mkdir = os.MkdirAll
+	}
+	if err := mkdir(dir, 0o755); err != nil {
+		return fmt.Errorf("create windows-terminal config dir %s: %w", dir, err)
+	}
+
+	write := w.writeFile
+	if write == nil {
+		write = os.WriteFile
+	}
+
+	if !plan.CreateNew {
+		nowFn := w.now
+		if nowFn == nil {
+			nowFn = time.Now
+		}
+		stamp := nowFn().Format("20060102-150405")
+		backup := plan.ConfigPath + ".bak." + stamp
+		if err := write(backup, []byte(plan.Original), 0o644); err != nil {
+			return fmt.Errorf("write windows-terminal settings backup %s: %w", backup, err)
+		}
+	}
+
+	if err := write(plan.ConfigPath, []byte(plan.Updated), 0o644); err != nil {
+		return fmt.Errorf("write windows-terminal settings %s: %w", plan.ConfigPath, err)
+	}
+	return nil
+}

--- a/internal/app/init_windows_terminal_test.go
+++ b/internal/app/init_windows_terminal_test.go
@@ -1,0 +1,686 @@
+package app
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newWTTestAdapter returns a WindowsTerminalAdapter with deterministic
+// timestamps and no implicit cmd.exe interop, suitable for unit tests.
+func newWTTestAdapter(t *testing.T) *WindowsTerminalAdapter {
+	t.Helper()
+	a := NewWindowsTerminalAdapter()
+	a.now = func() time.Time { return time.Date(2026, 4, 30, 1, 32, 15, 0, time.UTC) }
+	a.runCmdExe = func([]string) (string, error) { return "", errors.New("interop disabled in test") }
+	return a
+}
+
+// envFn returns a getenv-style closure backed by the supplied map.
+func envFn(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+// presetSidebarOnly builds a settings.json that already contains a single
+// projmux-managed entry (User.projmuxSidebar) with the canonical ESC+1 input
+// bytes encoded as the JSON escape sequence  — that's how Windows Terminal
+// stores them on disk and how json.Unmarshal will decode them back into Go's
+// "\x1b1" runtime representation.
+func presetSidebarOnly() string {
+	// Build the JSON escape `BACKSLASH u 0 0 1 b` byte-by-byte so the source
+	// file itself never embeds a literal ESC character.
+	jsonEsc := string([]byte{0x5c, 0x75, 0x30, 0x30, 0x31, 0x62})
+	body := "{\n" +
+		"  \"actions\": [\n" +
+		"    { \"command\": { \"action\": \"sendInput\", \"input\": \"" + jsonEsc + "1\" }, \"id\": \"User.projmuxSidebar\" }\n" +
+		"  ],\n" +
+		"  \"keybindings\": [\n" +
+		"    { \"id\": \"User.projmuxSidebar\", \"keys\": \"alt+1\" }\n" +
+		"  ]\n" +
+		"}\n"
+	return body
+}
+
+func TestWTAdapterRegisteredAlongsideGhostty(t *testing.T) {
+	t.Parallel()
+
+	wt, ok := defaultTerminalRegistry.lookup("windows-terminal")
+	if !ok {
+		t.Fatalf("default registry missing windows-terminal adapter")
+	}
+	if wt.Name() != "windows-terminal" {
+		t.Fatalf("name = %q, want windows-terminal", wt.Name())
+	}
+	if _, ok := defaultTerminalRegistry.lookup("ghostty"); !ok {
+		t.Fatalf("default registry missing ghostty adapter (regression in PR-B)")
+	}
+}
+
+func TestWTAdapterDetect(t *testing.T) {
+	t.Parallel()
+
+	a := NewWindowsTerminalAdapter()
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{name: "wt session only", env: map[string]string{"WT_SESSION": "abc-123"}, want: true},
+		{name: "term program windows terminal", env: map[string]string{"TERM_PROGRAM": "WindowsTerminal"}, want: true},
+		{name: "term program case insensitive", env: map[string]string{"TERM_PROGRAM": "windowsterminal"}, want: true},
+		{name: "wsl distro alone", env: map[string]string{"WSL_DISTRO_NAME": "Ubuntu"}, want: true},
+		{name: "wsl interop alone", env: map[string]string{"WSL_INTEROP": "/run/WSL/1_interop"}, want: true},
+		{name: "wsl + wt session", env: map[string]string{"WSL_DISTRO_NAME": "Ubuntu", "WT_SESSION": "x"}, want: true},
+		{name: "neither", env: map[string]string{"TERM_PROGRAM": "iTerm.app"}, want: false},
+		{name: "empty", env: map[string]string{}, want: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := a.Detect(envFn(tc.env)); got != tc.want {
+				t.Fatalf("Detect(%v) = %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWTAdapterDetectNilEnv(t *testing.T) {
+	t.Parallel()
+	a := NewWindowsTerminalAdapter()
+	if a.Detect(nil) {
+		t.Fatalf("Detect(nil) = true, want false")
+	}
+}
+
+func TestIsWSL(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		env  map[string]string
+		want bool
+	}{
+		{env: map[string]string{"WSL_DISTRO_NAME": "Ubuntu"}, want: true},
+		{env: map[string]string{"WSL_INTEROP": "/run/WSL/1_interop"}, want: true},
+		{env: map[string]string{"WT_SESSION": "x"}, want: false},
+		{env: map[string]string{}, want: false},
+	}
+	for _, tc := range cases {
+		if got := isWSL(envFn(tc.env)); got != tc.want {
+			t.Fatalf("isWSL(%v) = %v, want %v", tc.env, got, tc.want)
+		}
+	}
+	if isWSL(nil) {
+		t.Fatalf("isWSL(nil) = true")
+	}
+}
+
+func TestWTConfigPathNativePrefersStorePathWhenItExists(t *testing.T) {
+	t.Parallel()
+
+	a := newWTTestAdapter(t)
+	storeWant := filepath.Join("C:\\AppData\\Local", "Packages", "Microsoft.WindowsTerminal_8wekyb3d8bbcwe", "LocalState", "settings.json")
+	a.stat = func(p string) (os.FileInfo, error) {
+		if p == storeWant {
+			return fakeFileInfo{name: "settings.json"}, nil
+		}
+		return nil, os.ErrNotExist
+	}
+	got, err := a.ConfigPath(envFn(map[string]string{"LOCALAPPDATA": "C:\\AppData\\Local"}))
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	if got != storeWant {
+		t.Fatalf("ConfigPath = %q, want %q", got, storeWant)
+	}
+}
+
+func TestWTConfigPathNativeFallsBackToUnpackagedWhenStoreMissing(t *testing.T) {
+	t.Parallel()
+
+	a := newWTTestAdapter(t)
+	unpackagedWant := filepath.Join("C:\\AppData\\Local", "Microsoft", "Windows Terminal", "settings.json")
+	a.stat = func(p string) (os.FileInfo, error) {
+		if p == unpackagedWant {
+			return fakeFileInfo{name: "settings.json"}, nil
+		}
+		return nil, os.ErrNotExist
+	}
+	got, err := a.ConfigPath(envFn(map[string]string{"LOCALAPPDATA": "C:\\AppData\\Local"}))
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	if got != unpackagedWant {
+		t.Fatalf("ConfigPath = %q, want %q", got, unpackagedWant)
+	}
+}
+
+func TestWTConfigPathNativeDefaultsToStoreWhenNothingExists(t *testing.T) {
+	t.Parallel()
+
+	a := newWTTestAdapter(t)
+	a.stat = func(p string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+	got, err := a.ConfigPath(envFn(map[string]string{"LOCALAPPDATA": "C:\\Users\\me\\AppData\\Local"}))
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	if !strings.Contains(got, "Microsoft.WindowsTerminal_8wekyb3d8bbcwe") {
+		t.Fatalf("ConfigPath fallback = %q, want Store path", got)
+	}
+}
+
+func TestWTConfigPathNativeMissingLocalAppData(t *testing.T) {
+	t.Parallel()
+
+	a := newWTTestAdapter(t)
+	a.stat = func(p string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+	_, err := a.ConfigPath(envFn(map[string]string{}))
+	if err == nil {
+		t.Fatalf("ConfigPath() with no LOCALAPPDATA/USERPROFILE returned nil error")
+	}
+}
+
+func TestWTConfigPathNativeFallsBackToUserProfile(t *testing.T) {
+	t.Parallel()
+
+	a := newWTTestAdapter(t)
+	a.stat = func(p string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+	got, err := a.ConfigPath(envFn(map[string]string{"USERPROFILE": "C:\\Users\\me"}))
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	wantPrefix := filepath.Join("C:\\Users\\me", "AppData", "Local")
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("ConfigPath = %q, want prefix %q", got, wantPrefix)
+	}
+}
+
+func TestWTConfigPathWSLUsesCmdExeInterop(t *testing.T) {
+	t.Parallel()
+
+	a := newWTTestAdapter(t)
+	wantBase := "/mnt/c/Users/foo/AppData/Local"
+	a.runCmdExe = func(args []string) (string, error) {
+		if len(args) < 3 || args[0] != "cmd.exe" {
+			t.Fatalf("unexpected runCmdExe args: %v", args)
+		}
+		return "C:\\Users\\foo\\AppData\\Local\r\n", nil
+	}
+	a.stat = func(p string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+
+	got, err := a.ConfigPath(envFn(map[string]string{
+		"WSL_DISTRO_NAME": "Ubuntu",
+		"WSL_INTEROP":     "/run/WSL/1_interop",
+	}))
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	if !strings.HasPrefix(got, wantBase) {
+		t.Fatalf("ConfigPath = %q, want prefix %q", got, wantBase)
+	}
+	if !strings.Contains(got, "Microsoft.WindowsTerminal_8wekyb3d8bbcwe") {
+		t.Fatalf("ConfigPath = %q, expected default Store path under WSL mount", got)
+	}
+}
+
+func TestWTConfigPathWSLFallbackOnInteropFailure(t *testing.T) {
+	t.Parallel()
+
+	a := newWTTestAdapter(t)
+	a.runCmdExe = func([]string) (string, error) { return "", errors.New("cmd.exe not found") }
+	a.userHomeDir = func() (string, error) { return "/home/linuxuser", nil }
+	a.stat = func(p string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+
+	got, err := a.ConfigPath(envFn(map[string]string{"WSL_DISTRO_NAME": "Ubuntu"}))
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	wantBase := "/mnt/c/Users/linuxuser/AppData/Local"
+	if !strings.HasPrefix(got, wantBase) {
+		t.Fatalf("ConfigPath fallback = %q, want prefix %q", got, wantBase)
+	}
+}
+
+func TestWTConfigPathWSLFallbackBubblesHomeError(t *testing.T) {
+	t.Parallel()
+
+	a := newWTTestAdapter(t)
+	a.runCmdExe = func([]string) (string, error) { return "", errors.New("cmd.exe not found") }
+	a.userHomeDir = func() (string, error) { return "", errors.New("no home") }
+	a.stat = func(p string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+
+	_, err := a.ConfigPath(envFn(map[string]string{"WSL_DISTRO_NAME": "Ubuntu"}))
+	if err == nil {
+		t.Fatalf("ConfigPath WSL with no home/interop returned nil error")
+	}
+}
+
+func TestWinPathToMnt(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{in: "C:\\Users\\foo\\AppData\\Local", want: "/mnt/c/Users/foo/AppData/Local"},
+		{in: "D:\\Tools", want: "/mnt/d/Tools"},
+		{in: "C:", want: "/mnt/c/"},
+		{in: "no-drive", wantErr: true},
+		{in: "", wantErr: true},
+	}
+	for _, tc := range cases {
+		got, err := winPathToMnt(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("winPathToMnt(%q) err = nil, want error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("winPathToMnt(%q) err = %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("winPathToMnt(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestStripJSONCRemovesCommentsAndTrailingCommas(t *testing.T) {
+	t.Parallel()
+
+	raw := "{\n" +
+		"  // top-level comment\n" +
+		"  \"name\": \"wt\", /* inline */\n" +
+		"  \"list\": [\n" +
+		"    1,\n" +
+		"    2, // trailing comment\n" +
+		"    3,\n" +
+		"  ],\n" +
+		"  \"nested\": {\n" +
+		"    \"key\": \"value with // not a comment\",\n" +
+		"    \"other\": \"string with /* still not comment */\"\n" +
+		"  }\n" +
+		"}"
+	cleaned := stripJSONC(raw)
+	if strings.Contains(cleaned, "// top-level") {
+		t.Fatalf("stripJSONC left a // comment behind:\n%s", cleaned)
+	}
+	if strings.Contains(cleaned, "/* inline") {
+		t.Fatalf("stripJSONC left a /* */ comment behind:\n%s", cleaned)
+	}
+	// Strings must still contain their literal // and /* tokens.
+	if !strings.Contains(cleaned, "value with // not a comment") {
+		t.Fatalf("stripJSONC removed an in-string //:\n%s", cleaned)
+	}
+	if !strings.Contains(cleaned, "string with /* still not comment */") {
+		t.Fatalf("stripJSONC removed an in-string /* */:\n%s", cleaned)
+	}
+	// The result must be valid JSON (trailing commas have been stripped).
+	var v any
+	if err := json.Unmarshal([]byte(cleaned), &v); err != nil {
+		t.Fatalf("stripJSONC output is not valid JSON: %v\n%s", err, cleaned)
+	}
+}
+
+func TestParseSettingsHandlesJSONCAndMissing(t *testing.T) {
+	t.Parallel()
+
+	root, err := parseSettings("", false)
+	if err != nil {
+		t.Fatalf("parseSettings empty: %v", err)
+	}
+	if len(root) != 0 {
+		t.Fatalf("parseSettings empty = %v, want empty map", root)
+	}
+
+	jsonc := "{\n" +
+		"  // user comment\n" +
+		"  \"actions\": [],\n" +
+		"  \"keybindings\": [\n" +
+		"    { \"id\": \"User.foo\", \"keys\": \"ctrl+x\" }, // trailing comma below\n" +
+		"  ]\n" +
+		"}"
+	root, err = parseSettings(jsonc, true)
+	if err != nil {
+		t.Fatalf("parseSettings jsonc: %v", err)
+	}
+	if _, ok := root["keybindings"].([]any); !ok {
+		t.Fatalf("keybindings not parsed as array: %T", root["keybindings"])
+	}
+}
+
+func TestWTPlanMergeEmptyAddsAllBindings(t *testing.T) {
+	t.Parallel()
+
+	a := newWTTestAdapter(t)
+	plan, err := a.PlanMerge("", false)
+	if err != nil {
+		t.Fatalf("PlanMerge: %v", err)
+	}
+	if !plan.HasEffect() {
+		t.Fatalf("expected effect on empty config")
+	}
+	if !plan.CreateNew {
+		t.Fatalf("CreateNew = false, want true")
+	}
+	addCount := 0
+	for _, ch := range plan.Changes {
+		if ch.Kind == "add" {
+			addCount++
+		}
+	}
+	if addCount != len(wtDesiredBindings) {
+		t.Fatalf("add count = %d, want %d", addCount, len(wtDesiredBindings))
+	}
+	// Verify the merged JSON parses and has the expected entries.
+	root := mustJSON(t, plan.Updated)
+	actions := asObjectArray(root["actions"])
+	if len(actions) != len(wtDesiredBindings) {
+		t.Fatalf("actions len = %d, want %d", len(actions), len(wtDesiredBindings))
+	}
+	keybindings := asObjectArray(root["keybindings"])
+	if len(keybindings) != len(wtDesiredBindings) {
+		t.Fatalf("keybindings len = %d, want %d", len(keybindings), len(wtDesiredBindings))
+	}
+	// Spot-check one binding round-trips with the expected escape bytes.
+	var foundSidebar bool
+	for _, action := range actions {
+		if action["id"] == "User.projmuxSidebar" {
+			cmd := action["command"].(map[string]any)
+			if cmd["input"] != "\x1b1" {
+				t.Fatalf("Sidebar input = %q, want ESC+1", cmd["input"])
+			}
+			foundSidebar = true
+		}
+	}
+	if !foundSidebar {
+		t.Fatalf("Sidebar action not found in merged settings")
+	}
+}
+
+func TestWTPlanMergeIdempotent(t *testing.T) {
+	t.Parallel()
+
+	a := newWTTestAdapter(t)
+	first, err := a.PlanMerge("", false)
+	if err != nil {
+		t.Fatalf("PlanMerge first: %v", err)
+	}
+	second, err := a.PlanMerge(first.Updated, true)
+	if err != nil {
+		t.Fatalf("PlanMerge second: %v", err)
+	}
+	if second.HasEffect() {
+		t.Fatalf("second merge unexpectedly changed config\nbefore:\n%s\nafter:\n%s", first.Updated, second.Updated)
+	}
+	for _, ch := range second.Changes {
+		if ch.Kind != "noop" {
+			t.Fatalf("second pass change not noop: %+v", ch)
+		}
+	}
+}
+
+func TestWTPlanMergePartialFillsGaps(t *testing.T) {
+	t.Parallel()
+
+	a := newWTTestAdapter(t)
+	plan, err := a.PlanMerge(presetSidebarOnly(), true)
+	if err != nil {
+		t.Fatalf("PlanMerge: %v", err)
+	}
+	if !plan.HasEffect() {
+		t.Fatalf("expected merge to add missing entries")
+	}
+	addCount, noopCount := 0, 0
+	for _, ch := range plan.Changes {
+		switch ch.Kind {
+		case "add":
+			addCount++
+		case "noop":
+			noopCount++
+		}
+	}
+	if addCount != len(wtDesiredBindings)-1 {
+		t.Fatalf("add count = %d, want %d", addCount, len(wtDesiredBindings)-1)
+	}
+	if noopCount != 1 {
+		t.Fatalf("noop count = %d, want 1", noopCount)
+	}
+}
+
+func TestWTPlanMergeKeysConflictSkipsAndWarns(t *testing.T) {
+	t.Parallel()
+
+	// User has `alt+1` mapped to a non-projmux action. The merge must not
+	// overwrite it.
+	preset := "{\n" +
+		"  \"actions\": [\n" +
+		"    { \"command\": { \"action\": \"newTab\" }, \"id\": \"User.userNewTab\" }\n" +
+		"  ],\n" +
+		"  \"keybindings\": [\n" +
+		"    { \"id\": \"User.userNewTab\", \"keys\": \"alt+1\" }\n" +
+		"  ]\n" +
+		"}\n"
+	a := newWTTestAdapter(t)
+	plan, err := a.PlanMerge(preset, true)
+	if err != nil {
+		t.Fatalf("PlanMerge: %v", err)
+	}
+
+	var conflict *MergeChange
+	for i := range plan.Changes {
+		if plan.Changes[i].Trigger == "alt+1" {
+			conflict = &plan.Changes[i]
+			break
+		}
+	}
+	if conflict == nil {
+		t.Fatalf("no alt+1 change in plan")
+	}
+	if conflict.Kind != "skip-conflict" {
+		t.Fatalf("alt+1 kind = %q, want skip-conflict", conflict.Kind)
+	}
+	if conflict.Existing != "User.userNewTab" {
+		t.Fatalf("alt+1 existing = %q, want User.userNewTab", conflict.Existing)
+	}
+
+	// Verify Updated still has the user's mapping intact and no projmux
+	// keybinding pointing at alt+1 was added.
+	root := mustJSON(t, plan.Updated)
+	keybindings := asObjectArray(root["keybindings"])
+	for _, kb := range keybindings {
+		if kb["keys"] == "alt+1" && kb["id"] != "User.userNewTab" {
+			t.Fatalf("alt+1 remapped despite conflict: %+v", kb)
+		}
+	}
+}
+
+func TestWTPlanMergeUpdatesDriftedManagedEntry(t *testing.T) {
+	t.Parallel()
+
+	// Old projmux entry with stale input bytes — the merge must replace it.
+	preset := "{\n" +
+		"  \"actions\": [\n" +
+		"    { \"command\": { \"action\": \"sendInput\", \"input\": \"STALE\" }, \"id\": \"User.projmuxSidebar\" }\n" +
+		"  ],\n" +
+		"  \"keybindings\": [\n" +
+		"    { \"id\": \"User.projmuxSidebar\", \"keys\": \"alt+1\" }\n" +
+		"  ]\n" +
+		"}\n"
+	a := newWTTestAdapter(t)
+	plan, err := a.PlanMerge(preset, true)
+	if err != nil {
+		t.Fatalf("PlanMerge: %v", err)
+	}
+	if !plan.HasEffect() {
+		t.Fatalf("expected drift to trigger update")
+	}
+	root := mustJSON(t, plan.Updated)
+	for _, action := range asObjectArray(root["actions"]) {
+		if action["id"] == "User.projmuxSidebar" {
+			cmd := action["command"].(map[string]any)
+			if cmd["input"] != "\x1b1" {
+				t.Fatalf("Sidebar input = %q, want ESC+1 after update", cmd["input"])
+			}
+		}
+	}
+}
+
+func TestWTPlanMergePreservesUnrelatedUserContent(t *testing.T) {
+	t.Parallel()
+
+	preset := "{\n" +
+		"  \"schemes\": [{ \"name\": \"Solarized\" }],\n" +
+		"  \"profiles\": { \"defaults\": { \"fontFace\": \"Cascadia\" } },\n" +
+		"  \"actions\": [\n" +
+		"    { \"command\": { \"action\": \"newTab\" }, \"id\": \"User.userNewTab\" }\n" +
+		"  ],\n" +
+		"  \"keybindings\": [\n" +
+		"    { \"id\": \"User.userNewTab\", \"keys\": \"ctrl+t\" }\n" +
+		"  ]\n" +
+		"}\n"
+	a := newWTTestAdapter(t)
+	plan, err := a.PlanMerge(preset, true)
+	if err != nil {
+		t.Fatalf("PlanMerge: %v", err)
+	}
+	root := mustJSON(t, plan.Updated)
+	if _, ok := root["schemes"]; !ok {
+		t.Fatalf("schemes dropped from merged settings")
+	}
+	if _, ok := root["profiles"]; !ok {
+		t.Fatalf("profiles dropped from merged settings")
+	}
+	// User's keybinding survives.
+	var foundUserKB bool
+	for _, kb := range asObjectArray(root["keybindings"]) {
+		if kb["id"] == "User.userNewTab" && kb["keys"] == "ctrl+t" {
+			foundUserKB = true
+		}
+	}
+	if !foundUserKB {
+		t.Fatalf("user's ctrl+t -> User.userNewTab keybinding lost")
+	}
+}
+
+func TestWTApplyMergeWritesBackupAndSettings(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfg := filepath.Join(tmp, "settings.json")
+	original := "{ \"actions\": [], \"keybindings\": [] }\n"
+	if err := os.WriteFile(cfg, []byte(original), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	a := newWTTestAdapter(t)
+	plan, err := a.PlanMerge(original, true)
+	if err != nil {
+		t.Fatalf("PlanMerge: %v", err)
+	}
+	plan.ConfigPath = cfg
+	if err := a.ApplyMerge(plan); err != nil {
+		t.Fatalf("ApplyMerge: %v", err)
+	}
+
+	got, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatalf("read written: %v", err)
+	}
+	if string(got) != plan.Updated {
+		t.Fatalf("written settings != plan.Updated")
+	}
+
+	backup := cfg + ".bak.20260430-013215"
+	bak, err := os.ReadFile(backup)
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(bak) != original {
+		t.Fatalf("backup contents = %q, want %q", bak, original)
+	}
+}
+
+func TestWTApplyMergeCreatesNewWithoutBackup(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfg := filepath.Join(tmp, "wt", "settings.json")
+	a := newWTTestAdapter(t)
+	plan, err := a.PlanMerge("", false)
+	if err != nil {
+		t.Fatalf("PlanMerge: %v", err)
+	}
+	plan.ConfigPath = cfg
+	if err := a.ApplyMerge(plan); err != nil {
+		t.Fatalf("ApplyMerge: %v", err)
+	}
+	if _, err := os.Stat(cfg); err != nil {
+		t.Fatalf("settings missing: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Dir(cfg))
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".bak.") {
+			t.Fatalf("unexpected backup created: %s", e.Name())
+		}
+	}
+}
+
+func TestWTApplyMergeNoEffectIsNoop(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfg := filepath.Join(tmp, "settings.json")
+	a := newWTTestAdapter(t)
+	plan := MergePlan{ConfigPath: cfg, Original: "x", Updated: "x"}
+	if err := a.ApplyMerge(plan); err != nil {
+		t.Fatalf("ApplyMerge no-op: %v", err)
+	}
+	if _, err := os.Stat(cfg); !os.IsNotExist(err) {
+		t.Fatalf("expected no file written, stat err = %v", err)
+	}
+}
+
+func TestWTApplyMergeRequiresConfigPath(t *testing.T) {
+	t.Parallel()
+
+	a := newWTTestAdapter(t)
+	plan := MergePlan{Original: "a", Updated: "b"}
+	err := a.ApplyMerge(plan)
+	if err == nil || !strings.Contains(err.Error(), "ConfigPath") {
+		t.Fatalf("ApplyMerge without ConfigPath: err = %v", err)
+	}
+}
+
+// mustJSON parses s as JSON and returns the root object, failing the test on
+// parse errors. Used to sanity-check the merge output.
+func mustJSON(t *testing.T, s string) map[string]any {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		t.Fatalf("merge output is not valid JSON: %v\n%s", err, s)
+	}
+	root, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("merge output is not a JSON object: %T", v)
+	}
+	return root
+}
+
+// fakeFileInfo is a stub os.FileInfo implementation for stat hooks in tests.
+type fakeFileInfo struct {
+	name string
+}
+
+func (f fakeFileInfo) Name() string       { return f.name }
+func (f fakeFileInfo) Size() int64        { return 0 }
+func (f fakeFileInfo) Mode() os.FileMode  { return 0o644 }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return false }
+func (f fakeFileInfo) Sys() any           { return nil }


### PR DESCRIPTION
## Summary
- 두 번째 TerminalAdapter — Windows Terminal (native + WSL 환경 둘 다)
- Detection: `WT_SESSION` / `TERM_PROGRAM=WindowsTerminal` / `WSL_INTEROP` (WSL 안에서)
- Path resolution:
  - WSL: `cmd.exe /c echo %LOCALAPPDATA%` interop → `/mnt/c/...` 변환
  - interop 실패 시 `/mnt/c/Users/<user>/AppData/Local/...` heuristic
  - native: `%LOCALAPPDATA%\\Packages\\Microsoft.WindowsTerminal_*` (Store) / `Microsoft\\Windows Terminal` (unpackaged) 후보 중 stat 우선
- JSONC merge: stdlib only 자체 stripper (`//`, `/* */`, trailing comma, in-string 추적). 사용자 주석은 round-trip 시 유실 — timestamped backup 으로 보전
- Idempotency: `id: User.projmux*` prefix 매칭 + drift 시 in-place replace (stable order)
- 충돌 (사용자가 같은 keys 를 비-projmux id 에 매핑): skip + warning (Ghostty 와 동일 정책)
- 외부 의존성 0개 추가

## Test plan
- [x] \`make fmt-check\`
- [x] \`make test\` (어댑터 hooks 로 격리, t.TempDir() 안에서만 fs 작업)
- [ ] CI Test 잡 통과 후 squash merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)