### PR TITLE
feat(init): handle Ghostty config/config.ghostty paths and symlinks safely

### DIFF
--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -17,6 +18,11 @@ type initCommand struct {
 	getenv   func(string) string
 	readFile func(string) ([]byte, error)
 	stat     func(string) (os.FileInfo, error)
+	// lstat is used for symlink detection; defaults to os.Lstat. Tests can
+	// override it to drive the symlink branch without touching the real fs.
+	lstat func(string) (os.FileInfo, error)
+	// getwd resolves relative --config paths against the caller's cwd.
+	getwd func() (string, error)
 }
 
 func newInitCommand() *initCommand {
@@ -25,6 +31,8 @@ func newInitCommand() *initCommand {
 		getenv:   os.Getenv,
 		readFile: os.ReadFile,
 		stat:     os.Stat,
+		lstat:    os.Lstat,
+		getwd:    os.Getwd,
 	}
 }
 
@@ -39,7 +47,8 @@ func (c *initCommand) Run(args []string, stdout, stderr io.Writer) error {
 	fs.SetOutput(stderr)
 	apply := fs.Bool("apply", false, "write the merged config (default: dry-run preview)")
 	dryRun := fs.Bool("dry-run", false, "force dry-run preview even when no other flag is set")
-	configOverride := fs.String("config", "", "override the terminal config path (mostly for tests)")
+	configOverride := fs.String("config", "", "explicit config file path (overrides auto-detected candidates)")
+	allowSymlink := fs.Bool("allow-symlink", false, "merge into a symlinked config target (default: refuse to mutate symlink targets such as dotfiles repos)")
 	if err := fs.Parse(flagArgs); err != nil {
 		return err
 	}
@@ -72,13 +81,13 @@ func (c *initCommand) Run(args []string, stdout, stderr io.Writer) error {
 		}
 	}
 
-	configPath := strings.TrimSpace(*configOverride)
-	if configPath == "" {
-		path, err := adapter.ConfigPath(c.env())
-		if err != nil {
-			return fmt.Errorf("init: resolve %s config path: %w", adapter.Name(), err)
-		}
-		configPath = path
+	configPath, err := c.resolveConfigPath(adapter, strings.TrimSpace(*configOverride))
+	if err != nil {
+		return err
+	}
+
+	if err := c.guardSymlink(configPath, *allowSymlink); err != nil {
+		return err
 	}
 
 	current, exists, err := c.loadConfig(configPath)
@@ -108,6 +117,111 @@ func (c *initCommand) env() func(string) string {
 		return c.getenv
 	}
 	return os.Getenv
+}
+
+// resolveConfigPath chooses the config file the merge should target.
+//
+// When the caller passes an explicit --config override, that path is used
+// verbatim (with relative paths resolved against the cwd). Otherwise the
+// adapter is asked for its candidate list (or single ConfigPath, for
+// adapters that have not opted into the multi-candidate interface):
+//
+//   - exactly one candidate exists  -> pick it
+//   - both candidates exist         -> ambiguous, require --config <path>
+//   - none exist                    -> pick the first (canonical default)
+//
+// Adapters that only register a single ConfigPath fall through to the same
+// logic with a one-element candidate list.
+func (c *initCommand) resolveConfigPath(adapter TerminalAdapter, override string) (string, error) {
+	if override != "" {
+		return c.absConfigPath(override)
+	}
+
+	candidates, err := c.candidatesFor(adapter)
+	if err != nil {
+		return "", fmt.Errorf("init: resolve %s config path: %w", adapter.Name(), err)
+	}
+	if len(candidates) == 0 {
+		return "", fmt.Errorf("init: %s has no config path candidates", adapter.Name())
+	}
+
+	statFn := c.stat
+	if statFn == nil {
+		statFn = os.Stat
+	}
+	var existing []string
+	for _, cand := range candidates {
+		if _, statErr := statFn(cand); statErr == nil {
+			existing = append(existing, cand)
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return "", fmt.Errorf("init: stat %s: %w", cand, statErr)
+		}
+	}
+	switch len(existing) {
+	case 0:
+		return candidates[0], nil
+	case 1:
+		return existing[0], nil
+	default:
+		return "", fmt.Errorf("init: multiple %s config files found (%s); pass --config <path> to disambiguate", adapter.Name(), strings.Join(existing, ", "))
+	}
+}
+
+// candidatesFor returns the adapter's well-known config path candidates,
+// falling back to a single-element list for adapters that have not opted
+// into ConfigPathCandidatesResolver.
+func (c *initCommand) candidatesFor(adapter TerminalAdapter) ([]string, error) {
+	if multi, ok := adapter.(ConfigPathCandidatesResolver); ok {
+		return multi.ConfigPathCandidates(c.env())
+	}
+	path, err := adapter.ConfigPath(c.env())
+	if err != nil {
+		return nil, err
+	}
+	return []string{path}, nil
+}
+
+// absConfigPath turns a (possibly relative) --config override into an
+// absolute path so downstream stat/symlink checks behave consistently.
+func (c *initCommand) absConfigPath(p string) (string, error) {
+	if filepath.IsAbs(p) {
+		return p, nil
+	}
+	getwd := c.getwd
+	if getwd == nil {
+		getwd = os.Getwd
+	}
+	cwd, err := getwd()
+	if err != nil {
+		return "", fmt.Errorf("init: resolve --config %q: %w", p, err)
+	}
+	return filepath.Join(cwd, p), nil
+}
+
+// guardSymlink refuses to merge into a symlinked target unless the caller
+// explicitly opts in via --allow-symlink. The default refusal exists because
+// dotfiles users commonly symlink terminal configs into a tracked repo, and
+// silently editing through the symlink would mutate that repo without their
+// knowledge.
+func (c *initCommand) guardSymlink(path string, allow bool) error {
+	lstatFn := c.lstat
+	if lstatFn == nil {
+		lstatFn = os.Lstat
+	}
+	info, err := lstatFn(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("init: lstat %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return nil
+	}
+	if allow {
+		return nil
+	}
+	return fmt.Errorf("init: %s is a symlink; merging would mutate the symlink target (e.g. a dotfiles repo). Pass --config <path> to point at a different file, or --allow-symlink to proceed anyway", path)
 }
 
 // loadConfig reads the terminal config and reports whether it already exists.

--- a/internal/app/init_ghostty.go
+++ b/internal/app/init_ghostty.go
@@ -81,28 +81,58 @@ func (g *GhosttyAdapter) Detect(env func(string) string) bool {
 	return false
 }
 
-// ConfigPath implements TerminalAdapter. Ghostty looks at
-// `$XDG_CONFIG_HOME/ghostty/config` first, falling back to
-// `$HOME/.config/ghostty/config`.
+// ConfigPath implements TerminalAdapter. It returns the canonical default
+// path (`config`); callers wanting both well-known XDG candidates should use
+// ConfigPathCandidates instead. Resolution order:
+//   - `$XDG_CONFIG_HOME/ghostty/config`
+//   - `$HOME/.config/ghostty/config`
 func (g *GhosttyAdapter) ConfigPath(env func(string) string) (string, error) {
+	candidates, err := g.ConfigPathCandidates(env)
+	if err != nil {
+		return "", err
+	}
+	if len(candidates) == 0 {
+		return "", fmt.Errorf("resolve ghostty config path: no candidates")
+	}
+	return candidates[0], nil
+}
+
+// ConfigPathCandidates returns both well-known Ghostty config paths in the
+// order Ghostty itself loads them. The init dispatcher uses this list to pick
+// the file that already exists, surface ambiguity when both exist, and create
+// the canonical `config` path when neither does.
+//
+// Order:
+//  1. `<config-dir>/ghostty/config`         (canonical default)
+//  2. `<config-dir>/ghostty/config.ghostty` (common dotfiles convention)
+//
+// `<config-dir>` honours `$XDG_CONFIG_HOME` first, falling back to
+// `$HOME/.config`.
+func (g *GhosttyAdapter) ConfigPathCandidates(env func(string) string) ([]string, error) {
 	if env == nil {
 		env = os.Getenv
 	}
+	var base string
 	if xdg := strings.TrimSpace(env("XDG_CONFIG_HOME")); xdg != "" {
-		return filepath.Join(xdg, "ghostty", "config"), nil
+		base = filepath.Join(xdg, "ghostty")
+	} else {
+		homeFn := g.userHomeDir
+		if homeFn == nil {
+			homeFn = os.UserHomeDir
+		}
+		home, err := homeFn()
+		if err != nil {
+			return nil, fmt.Errorf("resolve home directory for ghostty config: %w", err)
+		}
+		if home == "" {
+			return nil, fmt.Errorf("resolve home directory for ghostty config: empty home")
+		}
+		base = filepath.Join(home, ".config", "ghostty")
 	}
-	homeFn := g.userHomeDir
-	if homeFn == nil {
-		homeFn = os.UserHomeDir
-	}
-	home, err := homeFn()
-	if err != nil {
-		return "", fmt.Errorf("resolve home directory for ghostty config: %w", err)
-	}
-	if home == "" {
-		return "", fmt.Errorf("resolve home directory for ghostty config: empty home")
-	}
-	return filepath.Join(home, ".config", "ghostty", "config"), nil
+	return []string{
+		filepath.Join(base, "config"),
+		filepath.Join(base, "config.ghostty"),
+	}, nil
 }
 
 // PlanMerge implements TerminalAdapter. The merge is idempotent: bindings

--- a/internal/app/init_ghostty_test.go
+++ b/internal/app/init_ghostty_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -401,5 +402,367 @@ func TestSplitGhosttyConfigUserOverrideTrumpsManagedBlock(t *testing.T) {
 	_, bindings := splitGhosttyConfig(raw)
 	if got := bindings["alt+1"]; got != "new_window" {
 		t.Fatalf("alt+1 = %q, want new_window (user override should win)", got)
+	}
+}
+
+func TestGhosttyAdapterConfigPathCandidatesXDG(t *testing.T) {
+	t.Parallel()
+
+	a := NewGhosttyAdapter()
+	env := func(k string) string {
+		if k == "XDG_CONFIG_HOME" {
+			return "/xdg"
+		}
+		return ""
+	}
+	got, err := a.ConfigPathCandidates(env)
+	if err != nil {
+		t.Fatalf("ConfigPathCandidates() error = %v", err)
+	}
+	want := []string{
+		filepath.Join("/xdg", "ghostty", "config"),
+		filepath.Join("/xdg", "ghostty", "config.ghostty"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ConfigPathCandidates() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ConfigPathCandidates()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestGhosttyAdapterConfigPathCandidatesHomeFallback(t *testing.T) {
+	t.Parallel()
+
+	a := NewGhosttyAdapter()
+	a.userHomeDir = func() (string, error) { return "/home/u", nil }
+	got, err := a.ConfigPathCandidates(func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("ConfigPathCandidates() error = %v", err)
+	}
+	want := []string{
+		filepath.Join("/home/u", ".config", "ghostty", "config"),
+		filepath.Join("/home/u", ".config", "ghostty", "config.ghostty"),
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidates[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// newGhosttyTestInitCommand returns an init command wired to operate inside a
+// per-test temp dir as if it were $XDG_CONFIG_HOME. The Ghostty adapter is
+// the sole registered terminal so the test exercises the production code
+// path including ConfigPathCandidates.
+func newGhosttyTestInitCommand(t *testing.T, xdg string) *initCommand {
+	t.Helper()
+	reg := newTestRegistry()
+	reg.register(NewGhosttyAdapter())
+	return &initCommand{
+		registry: reg,
+		getenv: func(k string) string {
+			if k == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		},
+		readFile: os.ReadFile,
+		stat:     os.Stat,
+		lstat:    os.Lstat,
+		getwd:    os.Getwd,
+	}
+}
+
+func TestGhosttyInitNoCandidatesCreatesConfig(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cmd := newGhosttyTestInitCommand(t, tmp)
+	var stdout, stderr bytes.Buffer
+	if err := cmd.Run([]string{"ghostty", "--apply"}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run() error = %v (stderr=%s)", err, stderr.String())
+	}
+	cfg := filepath.Join(tmp, "ghostty", "config")
+	if _, err := os.Stat(cfg); err != nil {
+		t.Fatalf("expected canonical config to be created at %s: %v", cfg, err)
+	}
+	other := filepath.Join(tmp, "ghostty", "config.ghostty")
+	if _, err := os.Stat(other); !os.IsNotExist(err) {
+		t.Fatalf("config.ghostty should not be created when neither candidate exists, stat err=%v", err)
+	}
+}
+
+func TestGhosttyInitOnlyConfigExistsMergesIntoIt(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfgDir := filepath.Join(tmp, "ghostty")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfg := filepath.Join(cfgDir, "config")
+	if err := os.WriteFile(cfg, []byte("# user\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	cmd := newGhosttyTestInitCommand(t, tmp)
+	var stdout, stderr bytes.Buffer
+	if err := cmd.Run([]string{"ghostty", "--apply"}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run() error = %v (stderr=%s)", err, stderr.String())
+	}
+	got, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(got), ghosttyManagedHeader) {
+		t.Fatalf("merge did not write managed block:\n%s", got)
+	}
+	if _, err := os.Stat(filepath.Join(cfgDir, "config.ghostty")); !os.IsNotExist(err) {
+		t.Fatalf("config.ghostty should not be created when only config exists, stat err=%v", err)
+	}
+}
+
+func TestGhosttyInitOnlyConfigGhosttyExistsMergesIntoIt(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfgDir := filepath.Join(tmp, "ghostty")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	target := filepath.Join(cfgDir, "config.ghostty")
+	if err := os.WriteFile(target, []byte("# dotfiles\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	cmd := newGhosttyTestInitCommand(t, tmp)
+	var stdout, stderr bytes.Buffer
+	if err := cmd.Run([]string{"ghostty", "--apply"}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run() error = %v (stderr=%s)", err, stderr.String())
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read config.ghostty: %v", err)
+	}
+	if !strings.Contains(string(got), ghosttyManagedHeader) {
+		t.Fatalf("merge did not write managed block into config.ghostty:\n%s", got)
+	}
+	// The other candidate must NOT be created — that would split the user's
+	// dotfiles between two files.
+	if _, err := os.Stat(filepath.Join(cfgDir, "config")); !os.IsNotExist(err) {
+		t.Fatalf("canonical config should not be created when config.ghostty exists, stat err=%v", err)
+	}
+	if !strings.Contains(stdout.String(), "config.ghostty") {
+		t.Fatalf("output should reference config.ghostty path, got:\n%s", stdout.String())
+	}
+}
+
+func TestGhosttyInitBothCandidatesExistRequiresExplicitConfig(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfgDir := filepath.Join(tmp, "ghostty")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, name := range []string{"config", "config.ghostty"} {
+		if err := os.WriteFile(filepath.Join(cfgDir, name), []byte("# "+name+"\n"), 0o644); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	cmd := newGhosttyTestInitCommand(t, tmp)
+	var stdout, stderr bytes.Buffer
+	err := cmd.Run([]string{"ghostty", "--apply"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatalf("expected ambiguity error when both candidates exist")
+	}
+	if !strings.Contains(err.Error(), "--config") {
+		t.Fatalf("error message should mention --config, got: %v", err)
+	}
+	// Neither file should have been mutated.
+	for _, name := range []string{"config", "config.ghostty"} {
+		got, readErr := os.ReadFile(filepath.Join(cfgDir, name))
+		if readErr != nil {
+			t.Fatalf("read %s: %v", name, readErr)
+		}
+		if strings.Contains(string(got), ghosttyManagedHeader) {
+			t.Fatalf("%s mutated despite ambiguity:\n%s", name, got)
+		}
+	}
+}
+
+func TestGhosttyInitBothCandidatesExistResolvedByConfigOverride(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfgDir := filepath.Join(tmp, "ghostty")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, name := range []string{"config", "config.ghostty"} {
+		if err := os.WriteFile(filepath.Join(cfgDir, name), []byte("# "+name+"\n"), 0o644); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	target := filepath.Join(cfgDir, "config.ghostty")
+	cmd := newGhosttyTestInitCommand(t, tmp)
+	var stdout, stderr bytes.Buffer
+	if err := cmd.Run([]string{"ghostty", "--apply", "--config", target}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run() with --config error = %v (stderr=%s)", err, stderr.String())
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if !strings.Contains(string(got), ghosttyManagedHeader) {
+		t.Fatalf("--config override did not merge into chosen file:\n%s", got)
+	}
+	// The other candidate must remain pristine.
+	other, err := os.ReadFile(filepath.Join(cfgDir, "config"))
+	if err != nil {
+		t.Fatalf("read other: %v", err)
+	}
+	if strings.Contains(string(other), ghosttyManagedHeader) {
+		t.Fatalf("non-targeted candidate should not be mutated:\n%s", other)
+	}
+}
+
+func TestGhosttyInitSymlinkRefusedByDefault(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfgDir := filepath.Join(tmp, "ghostty")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Pretend the user keeps their real config in a dotfiles directory and
+	// has symlinked ~/.config/ghostty/config.ghostty to it.
+	dotfiles := filepath.Join(tmp, "dotfiles")
+	if err := os.MkdirAll(dotfiles, 0o755); err != nil {
+		t.Fatalf("mkdir dotfiles: %v", err)
+	}
+	source := filepath.Join(dotfiles, "ghostty.conf")
+	original := "# tracked in dotfiles repo\n"
+	if err := os.WriteFile(source, []byte(original), 0o644); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+	link := filepath.Join(cfgDir, "config.ghostty")
+	if err := os.Symlink(source, link); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	cmd := newGhosttyTestInitCommand(t, tmp)
+	var stdout, stderr bytes.Buffer
+	err := cmd.Run([]string{"ghostty", "--apply"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatalf("expected symlink refusal")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("error should mention symlink, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--allow-symlink") {
+		t.Fatalf("error should mention --allow-symlink, got: %v", err)
+	}
+	got, readErr := os.ReadFile(source)
+	if readErr != nil {
+		t.Fatalf("read source: %v", readErr)
+	}
+	if string(got) != original {
+		t.Fatalf("source mutated despite refusal:\n%s", got)
+	}
+}
+
+func TestGhosttyInitSymlinkProceedsWithAllowFlag(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfgDir := filepath.Join(tmp, "ghostty")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	dotfiles := filepath.Join(tmp, "dotfiles")
+	if err := os.MkdirAll(dotfiles, 0o755); err != nil {
+		t.Fatalf("mkdir dotfiles: %v", err)
+	}
+	source := filepath.Join(dotfiles, "ghostty.conf")
+	if err := os.WriteFile(source, []byte("# tracked\n"), 0o644); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+	link := filepath.Join(cfgDir, "config.ghostty")
+	if err := os.Symlink(source, link); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	cmd := newGhosttyTestInitCommand(t, tmp)
+	var stdout, stderr bytes.Buffer
+	if err := cmd.Run([]string{"ghostty", "--apply", "--allow-symlink"}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run() with --allow-symlink error = %v (stderr=%s)", err, stderr.String())
+	}
+	// Writing through the symlink must update the real source file.
+	got, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if !strings.Contains(string(got), ghosttyManagedHeader) {
+		t.Fatalf("merge did not write through symlink:\n%s", got)
+	}
+}
+
+func TestGhosttyInitConfigOverrideToSymlinkStillRefused(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "real.conf")
+	if err := os.WriteFile(source, []byte("# real\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	link := filepath.Join(tmp, "linked.conf")
+	if err := os.Symlink(source, link); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	// Use a separate xdg dir with no candidates so override is the only
+	// path being considered.
+	xdg := filepath.Join(tmp, "xdg")
+	if err := os.MkdirAll(xdg, 0o755); err != nil {
+		t.Fatalf("mkdir xdg: %v", err)
+	}
+	cmd := newGhosttyTestInitCommand(t, xdg)
+	var stdout, stderr bytes.Buffer
+	err := cmd.Run([]string{"ghostty", "--apply", "--config", link}, &stdout, &stderr)
+	if err == nil {
+		t.Fatalf("expected --config override to a symlink to be refused")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("error should mention symlink, got: %v", err)
+	}
+}
+
+func TestGhosttyInitConfigOverrideAcceptsRelativePath(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "custom.conf")
+	if err := os.WriteFile(target, []byte("# custom\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	cmd := newGhosttyTestInitCommand(t, tmp)
+	cmd.getwd = func() (string, error) { return tmp, nil }
+	var stdout, stderr bytes.Buffer
+	if err := cmd.Run([]string{"ghostty", "--apply", "--config", "custom.conf"}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run() with relative --config error = %v (stderr=%s)", err, stderr.String())
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if !strings.Contains(string(got), ghosttyManagedHeader) {
+		t.Fatalf("relative --config did not merge into target:\n%s", got)
 	}
 }

--- a/internal/app/init_terminal.go
+++ b/internal/app/init_terminal.go
@@ -65,6 +65,20 @@ type TerminalAdapter interface {
 	ApplyMerge(plan MergePlan) error
 }
 
+// ConfigPathCandidatesResolver is an optional interface for terminal adapters
+// whose configuration may live at one of several well-known paths (e.g.
+// Ghostty looks at both `config` and `config.ghostty`). The init command uses
+// the candidate list to pick the existing file, surface ambiguity when more
+// than one exists, and fall back to the first entry when none exists. Adapters
+// that map cleanly to a single path can ignore this interface; the init
+// dispatcher falls back to TerminalAdapter.ConfigPath in that case.
+type ConfigPathCandidatesResolver interface {
+	// ConfigPathCandidates returns the ordered list of well-known config
+	// file paths, most-canonical first (used as the "default" when none of
+	// the candidates exist on disk).
+	ConfigPathCandidates(env func(string) string) ([]string, error)
+}
+
 // terminalRegistry is the global registry of TerminalAdapter implementations.
 type terminalRegistry struct {
 	mu       sync.RWMutex


### PR DESCRIPTION
## Summary
- Ghostty 의 두 자동-로드 후보 모두 인식: \`\$XDG_CONFIG_HOME/ghostty/{config, config.ghostty}\`
- 판정 매트릭스: 둘 다 부재 → 표준 \`config\` 새로 생성 / 하나만 → 그 파일에 머지 / 둘 다 → \`--config <path>\` 명시 요구
- Symlink guard: 대상 파일이 symlink 면 default 거절 (dotfiles repo mutation 방지). \`--allow-symlink\` 으로 opt-in
- 새 flag (init 레벨, 모든 어댑터 공통):
  - \`--config <path>\` — 자동 감지 무시하고 명시 path 사용 (relative 도 허용)
  - \`--allow-symlink\` — symlink target 머지 허용
- 인터페이스: 옵셔널 \`ConfigPathCandidatesResolver\` 추가 — \`MergePlan\`/\`TerminalAdapter\` 시그니처 불변, Windows Terminal 어댑터 무영향

## Why now
PR #14 (Ghostty 첫 어댑터) 가 \`config\` 만 보고 있었음. dotfiles 사용자는 \`config.ghostty\` 만 두는 케이스가 흔하고, 그 파일이 symlink 인 경우도 흔해 자동 머지가 dotfiles repo 를 변경할 위험이 있었다.

## Test plan
- [x] \`make fmt-check\` clean / \`make test\` 전 패키지 통과
- [x] 케이스: 매트릭스 4종, symlink 거절/허용, \`--config\` override + symlink/relative
- [ ] CI Test 잡 통과 후 squash merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)