### PR TITLE
docs(keybindings): restructure for progressive disclosure of setup/init/CSI-u

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -144,8 +144,11 @@ projmux shell
 projmux가 이 tmux 서버, 생성된 설정, status bar, popup binding을 직접 소유합니다.
 하단 좌측 뱃지에는 현재 프로젝트 이름이, 우측에는 경로/kube/git/시간이 표시됩니다.
 
-터미널 에뮬레이터에서 키 전달을 명시해야 한다면
-[터미널 키 설정](docs/keybindings.md)을 참고하세요.
+키가 동작하지 않으면 `projmux setup` 으로 터미널이 어떤 시퀀스를 swallow 하는지
+진단한 뒤, `projmux init [terminal] --apply` (terminal 생략 시 자동 감지) 로
+필요한 CSI-u 바인딩을 터미널 설정에 머지하세요. 여러 머신을 dotfiles 로
+관리하는 경우에는 `--allow-symlink` 또는 `--config <path>` 로 의도를 명시합니다.
+전체 흐름과 수동 CSI-u fallback 은 [터미널 키 설정](docs/keybindings.md) 참고.
 
 ## 업그레이드
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,12 @@ projmux owns this tmux server, its generated config, status bar, and popup
 bindings. The left status badge shows the current project name; the right side
 shows path, kube segment, git segment, and clock.
 
-If your terminal emulator needs explicit key forwarding, see
+If a key does not fire, run `projmux setup` to see which sequences your
+terminal swallows, then `projmux init [terminal] --apply` (auto-detects when
+no terminal is given) to merge the right CSI-u bindings into your terminal
+config. Dotfiles users on multi-machine setups should pass
+`--allow-symlink` or `--config <path>` to make their intent explicit. Full
+flow and the manual CSI-u fallback are in
 [Terminal Keybindings](docs/keybindings.md).
 
 ## Upgrading

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -4,18 +4,42 @@ projmux is keyboard-driven. `projmux shell` writes a tmux config that owns
 every binding listed here, so the keys are live the moment the app starts —
 no extra setup in most terminals.
 
-If your terminal emulator swallows `Alt-1`, `Ctrl-M`, or other shortcuts before
-tmux sees them, jump to [If your terminal eats shortcuts](#if-your-terminal-eats-shortcuts).
+The recommended path when a key does not fire:
 
-> 한국어 요약: `projmux shell` 만 실행하면 아래 키가 바로 동작합니다. 터미널이
-> `Alt-1` 같은 조합을 먼저 가로채는 경우 [If your terminal eats shortcuts](#if-your-terminal-eats-shortcuts)
-> 의 Ghostty / Windows Terminal 설정을 참고해 CSI-u 시퀀스를 tmux 로 흘려보내면
-> 됩니다.
+1. Press the key inside `projmux shell` and see what works on your terminal
+   out of the box ([Quick start](#quick-start-no-setup)).
+2. If something is swallowed, run [`projmux setup`](#diagnose-projmux-setup) —
+   it tells you exactly which sequences reach the process and which the
+   terminal is eating.
+3. For terminals projmux knows how to configure, run
+   [`projmux init [terminal]`](#auto-config-projmux-init) to merge the right
+   bindings into your terminal config (dry-run by default, `--apply` writes a
+   timestamped backup).
+4. If your terminal is not in the init list (or you prefer to edit configs by
+   hand), use the [Manual fallback / advanced (CSI-u)](#manual-fallback--advanced-csi-u)
+   section.
+
+> 한국어 요약: 대부분의 터미널은 `projmux shell` 만으로 아래 키가 바로 동작합니다.
+> 동작하지 않으면 `projmux setup` 으로 어떤 키가 막혔는지 진단하고,
+> `projmux init [terminal]` 으로 자동 설정하세요. 자동 설정이 없는 터미널은
+> 마지막 [Manual fallback / advanced (CSI-u)](#manual-fallback--advanced-csi-u)
+> 섹션의 매핑표를 참고해 직접 설정하면 됩니다.
 
 The tmux **prefix** is the upstream default `Ctrl-b`. Inside the running
 session, `Ctrl-b ?` lists every binding live.
 
-## Pickers
+## Quick start (no setup)
+
+These shortcuts are bound by projmux's generated tmux config. On terminals
+that pass `Alt-*` and `Ctrl-*` chords through to the running process
+unchanged (e.g. Linux gnome-terminal, foot, most stock Linux terminals),
+they work the moment you launch `projmux shell` — no terminal config
+required.
+
+If a key does nothing, jump to
+[Diagnose: `projmux setup`](#diagnose-projmux-setup) instead of guessing.
+
+### Pickers
 
 These open the projmux popups and the sidebar. No prefix needed.
 
@@ -36,7 +60,7 @@ The same surfaces are also available from the prefix table:
 | `Prefix f` | Project switcher popup |
 | `Prefix g` | Jump to the current pane's project session |
 
-## Windows, panes, AI splits
+### Windows, panes, AI splits
 
 | Shortcut | Action |
 | --- | --- |
@@ -51,17 +75,7 @@ The same surfaces are also available from the prefix table:
 When a pane closes, projmux re-spreads remaining panes so the surviving split
 does not stretch lopsided.
 
-### Conditional rename keys
-
-These two only fire if your terminal forwards CSI-u sequences (see
-[CSI-u Map](#csi-u-map)). Without that wiring, plain `Ctrl-M` is just `Enter`.
-
-| Shortcut | Action |
-| --- | --- |
-| `Ctrl-M` | Rename the current window (terminal must send `User10`) |
-| `Ctrl-Shift-M` | Rename the current AI pane label / topic (terminal must send `User11`) |
-
-## Inside the pickers
+### Inside the pickers
 
 | Surface | Shortcut | Action |
 | --- | --- | --- |
@@ -71,12 +85,159 @@ These two only fire if your terminal forwards CSI-u sequences (see
 | Project switcher | `Ctrl-X` | Kill the focused existing session and reopen the picker |
 | Project switcher | `Alt-P` | Pin or unpin the focused directory |
 
-## If your terminal eats shortcuts
+### Conditional rename keys
 
-Some terminals consume `Alt-1`, `Ctrl-M`, or `Ctrl-Shift-M` for their own
-actions. The fix is to map those keystrokes to a CSI-u sequence the terminal
-sends to tmux unchanged. projmux binds CSI-u escapes to tmux's `User0`–`User11`
-keys, so once the terminal forwards the sequence the action fires.
+These two only fire if your terminal forwards CSI-u sequences for `Ctrl-M`
+and `Ctrl-Shift-M`. Without that wiring, plain `Ctrl-M` is just `Enter` and
+`Ctrl-Shift-M` typically does nothing. `projmux init` configures this for
+the terminals it supports; otherwise see
+[Manual fallback / advanced (CSI-u)](#manual-fallback--advanced-csi-u).
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl-M` | Rename the current window (terminal must send `User10`) |
+| `Ctrl-Shift-M` | Rename the current AI pane label / topic (terminal must send `User11`) |
+
+## Diagnose: `projmux setup`
+
+Run `projmux setup` *outside* tmux (in your raw terminal window) to find out
+which projmux keys actually reach the process. The command auto-detects your
+terminal, then asks you to press each shortcut in turn and classifies the
+result:
+
+| Status | Meaning |
+| --- | --- |
+| `OK plain` | The terminal forwarded the bare escape (e.g. `\x1b1` for `Alt-1`); tmux's plain bind handles it. |
+| `OK csi-u` | The terminal already forwards a `ESC [ NNNNu` sequence routed to a tmux `User*` key. You are fully wired. |
+| `MISS timeout` | No bytes arrived — the terminal swallowed the key for its own action. |
+| `MISS unknown` | Something arrived, but it does not match either expected sequence — the terminal bound this combo to a different action. |
+
+The summary at the end lists the failing keys and a remediation hint
+tailored to the detected terminal (Ghostty, WezTerm, kitty, iTerm2,
+Alacritty, Windows Terminal, foot, VS Code, …). When projmux ships an init
+adapter for the terminal, the hint ends with the exact command to run, e.g.
+`projmux init ghostty`.
+
+Useful flags:
+
+```sh
+projmux setup                       # interactive probe (default)
+projmux setup --timeout 10s         # wait longer per key
+projmux setup --non-interactive     # just print the expected key map and exit
+```
+
+`--non-interactive` is handy when you only want to see, on this machine and
+shell, which `plain` and `csi-u` byte sequences projmux is listening for —
+useful for hand-rolling a config in a terminal projmux does not yet know
+about.
+
+> 한국어 요약: `projmux setup` 을 tmux *밖에서* 실행하면, 진단 대상 키를 차례로
+> 누르며 어떤 키가 plain/CSI-u 로 도달하는지, 어떤 키가 swallow 되는지 표로
+> 알려줍니다. 끝에서 터미널별 다음 단계를 제안합니다.
+
+## Auto-config: `projmux init`
+
+`projmux init` merges the projmux CSI-u keybindings into a terminal
+emulator's config file. Default mode is **dry-run** — nothing is written
+until you pass `--apply`. Applying the merge always creates a timestamped
+backup of the previous file.
+
+```sh
+projmux init                              # auto-detect + dry-run preview
+projmux init ghostty                      # explicit terminal, dry-run preview
+projmux init ghostty --apply              # write changes (with .bak.<ts> backup)
+projmux init --config /path/to/file       # bypass auto-detected paths
+projmux init --allow-symlink              # opt in to merging through a symlink
+projmux init --dry-run                    # force dry-run even with no other flag
+```
+
+The merge is idempotent: bindings already pointing at the desired action are
+no-ops, missing bindings are appended in a managed block, and triggers
+already mapped to a *different* action are left untouched and reported as
+`skip-conflict` warnings — projmux never silently overwrites your custom
+mappings. Re-running `projmux init --apply` after editing the file refreshes
+just the projmux-owned region.
+
+### Supported terminals
+
+#### Ghostty
+
+- Detection: `TERM_PROGRAM=ghostty` or `GHOSTTY_RESOURCES_DIR` set.
+- Config candidates (resolved in this order):
+  1. `<config-dir>/ghostty/config` — canonical default
+  2. `<config-dir>/ghostty/config.ghostty` — common dotfiles convention
+
+  `<config-dir>` honours `$XDG_CONFIG_HOME` first, then `$HOME/.config`.
+  When both candidates exist, init refuses to guess and asks for
+  `--config <path>` to disambiguate.
+- Idempotency marker: bindings live inside a managed block delimited by
+
+  ```text
+  # >>> projmux managed keybindings (do not edit between markers)
+  ...
+  # <<< projmux managed keybindings
+  ```
+
+  Edit anything *outside* those markers freely; init re-renders the inside
+  on every `--apply`.
+- Symlink guard: if the resolved config path is a symlink (typical when
+  dotfiles users symlink the terminal config into a tracked repo), init
+  refuses by default to avoid silently mutating the symlink target. Pass
+  `--allow-symlink` to opt in, or `--config <path>` to point at a
+  non-symlinked file.
+
+#### Windows Terminal (including WSL)
+
+- Detection: `WT_SESSION` set (native Windows), or `WSL_DISTRO_NAME` /
+  `WSL_INTEROP` set (running from inside WSL where the host terminal is
+  Windows Terminal).
+- Config resolution:
+  - Native Windows: `%LOCALAPPDATA%\Packages\Microsoft.WindowsTerminal_*\LocalState\settings.json`.
+  - WSL: resolves `%LOCALAPPDATA%` through `cmd.exe /c echo %LOCALAPPDATA%`
+    interop, then translates `C:\Users\...` into `/mnt/c/Users/...` so the
+    Linux side can read/write the file directly.
+- Merge model: settings.json is JSONC (allows `//` and `/* */` comments,
+  trailing commas). Init parses, locates `actions[]` and `keybindings[]`,
+  and merges entries identified by the `User.projmux*` ID prefix. Anything
+  outside that prefix is preserved verbatim, including comments and
+  formatting where reasonable.
+- Conflicts: a key already mapped to a non-projmux action is skipped with a
+  warning, same as Ghostty.
+
+### Reading dry-run output
+
+Each line of the dry-run plan prefixes the action with one of:
+
+| Prefix | Meaning |
+| --- | --- |
+| `+` | New binding will be added. |
+| `=` | Binding already matches; no change. |
+| `!` | Trigger is already mapped to a *different* action; will be skipped. Resolve manually before applying. |
+
+The trailing `note:` lines flag whether the config file does not yet exist
+(it will be created), and the final line tells you whether you still need
+`--apply` or whether the file is already up to date.
+
+> 한국어 요약: `projmux init` 은 dry-run 이 기본이고 `--apply` 시 timestamped
+> 백업 후 머지합니다. Ghostty 는 managed 블록 마커로 idempotent, 두 표준
+> path 모두 인식하며 symlink 는 default 거절. Windows Terminal 은 WSL interop
+> 으로 `/mnt/c/...` 경로까지 알아서 풀고, JSONC 형식의 `settings.json` 에
+> `User.projmux*` prefix 로 머지합니다. 사용자가 같은 키를 다른 액션에 매핑한
+> 경우 skip + warning.
+
+## Manual fallback / advanced (CSI-u)
+
+Use this section when:
+
+- your terminal is not yet supported by `projmux init`, or
+- you prefer to manage the config by hand, or
+- `projmux setup` shows specific keys still being swallowed and you want to
+  redirect just those.
+
+The fix is to map the swallowed keystroke to a CSI-u sequence the terminal
+forwards to tmux unchanged. projmux binds CSI-u escapes to tmux's
+`User0`–`User11` keys, so once the terminal forwards the sequence the
+action fires.
 
 ### CSI-u Map
 
@@ -95,11 +256,13 @@ keys, so once the terminal forwards the sequence the action fires.
 | `ESC [ 9011 u` | `User10` | Rename the current tmux window |
 | `ESC [ 9012 u` | `User11` | Rename the current tmux pane label |
 
-### Ghostty
+### Ghostty (manual)
 
-Add key bindings to your Ghostty config. Ghostty keybinds use
-`keybind = trigger=action`; the `csi:` action sends a CSI sequence without the
-leading `ESC [` bytes.
+`projmux init ghostty` is the maintained path. The block below is what the
+managed region in `~/.config/ghostty/config` ends up looking like — useful
+if you want to author it by hand or vet what init produces. Ghostty
+keybinds use `keybind = trigger=action`; the `csi:` action sends a CSI
+sequence without the leading `ESC [` bytes.
 
 ```text
 keybind = alt+1=csi:9005u
@@ -120,12 +283,13 @@ keybind = alt+shift+right=csi:9010u
 
 Reload Ghostty or restart the terminal after changing the config.
 
-### Windows Terminal
+### Windows Terminal (manual)
 
-Add `sendInput` actions to `settings.json` and bind them from `keybindings`.
-Windows Terminal works well with plain tmux escape sequences for the default
-`Alt` shortcuts, while the split actions can send tmux prefix sequences
-directly. Escape bytes should be written as `\u001b`.
+`projmux init windows-terminal` (which also covers WSL) is the maintained
+path. Use the snippet below to author `settings.json` by hand. Add
+`sendInput` actions and bind them from `keybindings`. Windows Terminal
+works well with plain tmux escape sequences for the default `Alt`
+shortcuts, while the split actions can send tmux prefix sequences directly. Escape bytes should be written as `\u001b`.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- 키바인딩 docs 흐름을 **점진 disclosure** 로 재구성: `0-config 시도 → projmux setup (진단) → projmux init (자동 보정) → CSI-u 수동 fallback`
- 기존 표·코드블록 (Pickers, Windows panes, CSI-u Map, Ghostty/Windows Terminal 수동 config) 100% 보존 — 순서·헤더 레벨만 변경
- 신설 섹션: `## Diagnose: projmux setup` / `## Auto-config: projmux init`
- 기존 "If your terminal eats shortcuts" → `## Manual fallback / advanced (CSI-u)` 로 rename, 후미로 이동
- README / README-ko Quick Start: setup/init 진입점 추가, dotfiles 머신 시 `--allow-symlink` / `--config <path>` 안내

## Why
PR #13 (setup), #14/#15/#16 (init Ghostty/WT/path safety) 4개의 명령들에 대한 통합 안내 부재. 80–90% 사용자가 setup·init 두 명령으로 끝나고, 막힌 사용자만 CSI-u 표를 본다.

## Test plan
- [x] \`make fmt-check\` clean
- [x] docs only — 코드 회귀 영향 없음
- [x] escape sequence (\`\\u001b\` 10개) 보존, raw ESC 0개 확인
- [ ] CI Test 잡 통과 후 squash merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)