### PR TITLE
fix(switch): wire sidebar focus binding to switch sessions on navigation

### DIFF
--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -1398,6 +1398,11 @@ func (c *switchCommand) switchPickerSurface(plan switchPlan) (string, []string, 
 
 	bindings := pickerCloseBindings()
 	if plan.UI == switchUISidebar {
+		sidebarFocus, err := inttmux.BuildSwitchSidebarFocusCommand(binaryPath)
+		if err != nil {
+			return "", nil, fmt.Errorf("build switch sidebar-focus command: %w", err)
+		}
+		bindings = append(bindings, "focus:execute-silent("+sidebarFocus+")")
 		if pos := switchSidebarInitialPos(plan); pos > 0 {
 			bindings = append(bindings, fmt.Sprintf("start:pos(%d)", pos))
 		}

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -199,6 +199,7 @@ func TestSwitchCommandSupportsSidebarUI(t *testing.T) {
 		"alt-1:abort",
 		"alt-2:abort",
 		"alt-3:abort",
+		"focus:execute-silent(exec '/tmp/projmux' 'switch' 'sidebar-focus' {2})",
 	}; !equalStrings(got, want) {
 		t.Fatalf("runner bindings = %q, want %q", got, want)
 	}
@@ -292,6 +293,7 @@ func TestSwitchCommandSidebarUsesContextSessionForInitialPosition(t *testing.T) 
 		"alt-1:abort",
 		"alt-2:abort",
 		"alt-3:abort",
+		"focus:execute-silent(exec '/tmp/projmux' 'switch' 'sidebar-focus' {2})",
 		"start:pos(1)",
 	}; !equalStrings(got, want) {
 		t.Fatalf("runner bindings = %q, want %q", got, want)
@@ -445,6 +447,7 @@ func TestNewSwitchCommandUsesEnvAndDefaultPinStore(t *testing.T) {
 		"alt-1:abort",
 		"alt-2:abort",
 		"alt-3:abort",
+		"focus:execute-silent(exec '/tmp/projmux' 'switch' 'sidebar-focus' {2})",
 		"start:pos(4)",
 	}; !equalStrings(got, want) {
 		t.Fatalf("runner bindings = %q, want %q", got, want)


### PR DESCRIPTION
## Summary
- 사이드바에서 위/아래로 항목을 이동해도 세션 스위치가 일어나지 않던 회귀 수정. `switchPickerSurface`가 `switchUISidebar` 분기에서 어떤 `focus:` 액션도 추가하지 않은 채 일찍 return해서, 이미 구현되어 있던 `BuildSwitchSidebarFocusCommand` / `runSidebarFocus` 경로가 fzf로부터 호출되지 못했음.
- 사이드바 분기에 `focus:execute-silent(<switch sidebar-focus {2}>)` 바인딩을 추가해, 행을 옮길 때마다 fzf가 `projmux switch sidebar-focus`를 호출하고 해당 경로의 기존 tmux 세션으로 `OpenSession`하도록 함.

## Test plan
- [x] `go test ./internal/app/... ./internal/integrations/tmux/...`
- [x] `go build ./...`
- [ ] tmux 세션에서 사이드바 띄우고 j/k(↑/↓)로 이동하며 세션이 즉시 전환되는지 수동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)