### PR TITLE
feat(focus): unified focus dispatch core (projmux focus)

### DIFF
--- a/cmd/projmux/main.go
+++ b/cmd/projmux/main.go
@@ -1,18 +1,36 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/crevissepartners/projmux/internal/app"
 )
 
+// exitCoder lets specific commands request a non-default exit code while
+// still flowing through the app.Run error channel. The command is expected to
+// have already written any user-facing diagnostic, so main suppresses the
+// default stderr print for these.
+type exitCoder interface {
+	error
+	ExitCode() int
+}
+
 func main() {
-	if err := app.Run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		if app.IsUsageError(err) {
-			os.Exit(2)
-		}
-		os.Exit(1)
+	err := app.Run(os.Args[1:], os.Stdout, os.Stderr)
+	if err == nil {
+		return
 	}
+
+	var coded exitCoder
+	if errors.As(err, &coded) {
+		os.Exit(coded.ExitCode())
+	}
+
+	fmt.Fprintln(os.Stderr, err)
+	if app.IsUsageError(err) {
+		os.Exit(2)
+	}
+	os.Exit(1)
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -43,6 +43,7 @@ type App struct {
 	attach       *attachCommand
 	current      *currentCommand
 	doctor       *doctorCommand
+	focus        *focusCommand
 	initCmd      *initCommand
 	kill         *killCommand
 	notify       *notifyCommand
@@ -71,6 +72,7 @@ func New() *App {
 		attach:       newAttachCommand(),
 		current:      newCurrentCommand(),
 		doctor:       newDoctorCommand(),
+		focus:        newFocusCommand(),
 		initCmd:      newInitCommand(),
 		kill:         newKillCommand(),
 		notify:       newNotifyCommand(),
@@ -108,6 +110,8 @@ func (a *App) Run(args []string, stdout, stderr io.Writer) error {
 		return a.current.Run(args[1:], stdout, stderr)
 	case "doctor":
 		return a.doctor.Run(args[1:], stdout, stderr)
+	case "focus":
+		return a.focus.Run(args[1:], stdout, stderr)
 	case "init":
 		return a.initCmd.Run(args[1:], stdout, stderr)
 	case "kill":
@@ -161,6 +165,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  attach    Open tmux lifecycle entry helpers")
 	fmt.Fprintln(w, "  current   Resolve the active tmux pane path")
 	fmt.Fprintln(w, "  doctor    Diagnose runtime dependencies and suggest installs")
+	fmt.Fprintln(w, "  focus     Switch the active client to a session/window/pane target")
 	fmt.Fprintln(w, "  init      Merge projmux keybindings into a terminal config")
 	fmt.Fprintln(w, "  kill      Terminate tagged tmux sessions")
 	fmt.Fprintln(w, "  notify    Persist status-bar notifications (push/list/ack)")

--- a/internal/app/focus.go
+++ b/internal/app/focus.go
@@ -1,0 +1,494 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+
+	corefocus "github.com/crevissepartners/projmux/internal/core/focus"
+)
+
+// focusExitNotResolved is the exit code emitted when no session matches the
+// requested target and no reasonable fallback is available. It is documented
+// in the spec so callers (status bar, notification dispatch) can branch on it.
+const focusExitNotResolved = 2
+
+// focusCommandRunner abstracts shelling out so tests can stub tmux.
+type focusCommandRunner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// focusNotifier delivers a desktop-side "session ready" message when the
+// focus request cannot be honored on the current display (for example, the
+// requested socket has no attached client at all).
+type focusNotifier interface {
+	Notify(notification aiNotification) error
+}
+
+type focusCommand struct {
+	runner       focusCommandRunner
+	lookupEnv    func(string) string
+	stdout       io.Writer
+	stderr       io.Writer
+	notifierOnce func(stderr io.Writer) focusNotifier
+}
+
+type focusOptions struct {
+	Target string
+	Socket string
+	Source string
+	Kind   string
+	JSON   bool
+}
+
+type focusResult struct {
+	OK       bool   `json:"ok"`
+	Fallback string `json:"fallback,omitempty"`
+	Target   string `json:"target,omitempty"`
+	Socket   string `json:"socket,omitempty"`
+	Note     string `json:"note,omitempty"`
+}
+
+func newFocusCommand() *focusCommand {
+	return &focusCommand{
+		runner:    focusExecRunner{},
+		lookupEnv: os.Getenv,
+		notifierOnce: func(stderr io.Writer) focusNotifier {
+			// Reuse the existing notifier chain (WSL toast, notify-send, hook).
+			ai := newAICommand()
+			return ai.notificationNotifier()
+		},
+	}
+}
+
+// Run is the dispatcher entry point.
+func (c *focusCommand) Run(args []string, stdout, stderr io.Writer) error {
+	c.stdout = stdout
+	c.stderr = stderr
+
+	opts, err := parseFocusArgs(args, stderr)
+	if err != nil {
+		return err
+	}
+
+	target, err := corefocus.Parse(opts.Target)
+	if err != nil {
+		return err
+	}
+
+	socket := c.resolveSocket(opts.Socket)
+	c.logTelemetry(opts, target, socket)
+
+	res, err := c.execute(context.Background(), target, socket)
+	res.Target = target.Raw
+	res.Socket = socket
+
+	if opts.JSON {
+		if writeErr := writeFocusJSON(stdout, res); writeErr != nil {
+			return writeErr
+		}
+	}
+
+	if err != nil {
+		// On non-JSON output paths we emit a short diagnostic to stderr; the
+		// JSON path already conveys the failure via ok:false.
+		if !opts.JSON {
+			fmt.Fprintln(stderr, err.Error())
+		}
+		var notResolved *focusUnresolvedError
+		if errors.As(err, &notResolved) {
+			return focusExitError{code: focusExitNotResolved, err: err}
+		}
+		return err
+	}
+	return nil
+}
+
+func parseFocusArgs(args []string, stderr io.Writer) (focusOptions, error) {
+	fs := flag.NewFlagSet("focus", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	opts := focusOptions{}
+	fs.StringVar(&opts.Target, "target", "", "Focus target SESSION[:WINDOW[.PANE]] (required)")
+	fs.StringVar(&opts.Socket, "socket", "", "tmux socket path (overrides $TMUX)")
+	fs.StringVar(&opts.Source, "source", "", "Telemetry label: ai|status-bar|external|os-notification")
+	fs.StringVar(&opts.Kind, "kind", "", "Telemetry label: reply-ready|busy-cleared|segment-click|custom")
+	fs.BoolVar(&opts.JSON, "json", false, "Emit a single-line JSON result")
+
+	if err := fs.Parse(args); err != nil {
+		return focusOptions{}, err
+	}
+	if fs.NArg() != 0 {
+		return focusOptions{}, fmt.Errorf("focus does not accept positional arguments")
+	}
+	if strings.TrimSpace(opts.Target) == "" {
+		return focusOptions{}, fmt.Errorf("--target is required")
+	}
+	return opts, nil
+}
+
+func (c *focusCommand) execute(ctx context.Context, target corefocus.Target, socket string) (focusResult, error) {
+	inventory, err := c.listSessionInventory(ctx, socket)
+	if err != nil {
+		return focusResult{}, err
+	}
+
+	resolution, ok := corefocus.Resolve(target.Session, inventory)
+	if !ok {
+		return focusResult{},
+			&focusUnresolvedError{session: target.Session, socket: socket}
+	}
+
+	clients, err := c.listClients(ctx, socket)
+	if err != nil {
+		return focusResult{}, err
+	}
+
+	// Decide whether any client on this socket can be redirected. If the
+	// resolved session is itself attached we still use switch-client on a
+	// client already viewing that session; otherwise pick any client and
+	// redirect it. We do not force-detach other clients — multi-client
+	// users may legitimately keep parallel views; a future config flag can
+	// promote this to a "force focus" behavior.
+	if len(clients) == 0 {
+		if err := c.notifySessionReady(resolution.Name); err != nil {
+			fmt.Fprintf(c.stderr, "focus: notify failed: %v\n", err)
+		}
+		return focusResult{
+			OK:       true,
+			Fallback: combineFallback(resolution.Fallback, "notify-only"),
+			Note:     "no tmux client attached on socket; notification emitted",
+		}, nil
+	}
+
+	clientName := pickFocusClient(clients, resolution.Name)
+	if err := c.switchClient(ctx, socket, clientName, resolution.Name); err != nil {
+		return focusResult{}, err
+	}
+
+	if target.HasWindow() {
+		windowTarget := fmt.Sprintf("%s:%s", resolution.Name, target.WindowSelector())
+		if err := c.selectWindow(ctx, socket, windowTarget); err != nil {
+			// Window selection failure is recoverable when only an index was
+			// provided (split layout could have changed). With an explicit
+			// id we surface the error.
+			if target.WindowID != "" {
+				return focusResult{}, err
+			}
+			fmt.Fprintf(c.stderr, "focus: select-window %s failed: %v (stopping at session level)\n", windowTarget, err)
+			return focusResult{
+				OK:       true,
+				Fallback: combineFallback(resolution.Fallback, "session-only"),
+			}, nil
+		}
+
+		if target.HasPane() {
+			paneTarget := fmt.Sprintf("%s.%s", windowTarget, target.PaneSelector())
+			if err := c.selectPane(ctx, socket, paneTarget); err != nil {
+				if target.PaneID != "" {
+					return focusResult{}, err
+				}
+				fmt.Fprintf(c.stderr, "focus: select-pane %s failed: %v (stopping at window level)\n", paneTarget, err)
+				return focusResult{
+					OK:       true,
+					Fallback: combineFallback(resolution.Fallback, "window-only"),
+				}, nil
+			}
+		}
+	}
+
+	return focusResult{
+		OK:       true,
+		Fallback: resolution.Fallback,
+	}, nil
+}
+
+func (c *focusCommand) resolveSocket(explicit string) string {
+	if v := strings.TrimSpace(explicit); v != "" {
+		return v
+	}
+	tmuxEnv := strings.TrimSpace(c.lookupEnv("TMUX"))
+	if tmuxEnv == "" {
+		return ""
+	}
+	// $TMUX has the form "<socket>,<pid>,<session-id>"; we need only the path.
+	first, _, _ := strings.Cut(tmuxEnv, ",")
+	return strings.TrimSpace(first)
+}
+
+func (c *focusCommand) tmuxArgs(socket string, args ...string) []string {
+	if socket == "" {
+		return args
+	}
+	out := make([]string, 0, len(args)+2)
+	out = append(out, "-S", socket)
+	return append(out, args...)
+}
+
+func (c *focusCommand) listSessionInventory(ctx context.Context, socket string) ([]corefocus.Candidate, error) {
+	args := c.tmuxArgs(socket, "list-sessions", "-F", "#{session_activity}\t#{session_name}\t#{session_attached}")
+	out, err := c.runner.Run(ctx, "tmux", args...)
+	if err != nil {
+		if isNoServerLikeError(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("focus: list-sessions: %w", err)
+	}
+	return parseFocusInventory(out)
+}
+
+func (c *focusCommand) listClients(ctx context.Context, socket string) ([]focusClient, error) {
+	args := c.tmuxArgs(socket, "list-clients", "-F", "#{client_name}\t#{client_session}")
+	out, err := c.runner.Run(ctx, "tmux", args...)
+	if err != nil {
+		if isNoServerLikeError(err) {
+			return nil, nil
+		}
+		// list-clients exits non-zero when there is no server. Treat any error
+		// not matching the no-server signature as fatal so the caller knows
+		// the focus failed for a non-fallback reason.
+		return nil, fmt.Errorf("focus: list-clients: %w", err)
+	}
+	return parseFocusClients(out), nil
+}
+
+func (c *focusCommand) switchClient(ctx context.Context, socket, clientName, sessionName string) error {
+	tail := []string{"switch-client"}
+	if clientName != "" {
+		tail = append(tail, "-c", clientName)
+	}
+	tail = append(tail, "-t", sessionName)
+	if _, err := c.runner.Run(ctx, "tmux", c.tmuxArgs(socket, tail...)...); err != nil {
+		return fmt.Errorf("focus: switch-client to %q: %w", sessionName, err)
+	}
+	return nil
+}
+
+func (c *focusCommand) selectWindow(ctx context.Context, socket, target string) error {
+	if _, err := c.runner.Run(ctx, "tmux", c.tmuxArgs(socket, "select-window", "-t", target)...); err != nil {
+		return fmt.Errorf("focus: select-window %q: %w", target, err)
+	}
+	return nil
+}
+
+func (c *focusCommand) selectPane(ctx context.Context, socket, target string) error {
+	if _, err := c.runner.Run(ctx, "tmux", c.tmuxArgs(socket, "select-pane", "-t", target)...); err != nil {
+		return fmt.Errorf("focus: select-pane %q: %w", target, err)
+	}
+	return nil
+}
+
+func (c *focusCommand) notifySessionReady(sessionName string) error {
+	if c.notifierOnce == nil {
+		return errors.New("focus notifier is not configured")
+	}
+	notifier := c.notifierOnce(c.stderr)
+	if notifier == nil {
+		return errors.New("focus notifier is not available")
+	}
+	return notifier.Notify(aiNotification{
+		Summary: "session ready: " + sessionName,
+		Body:    "Click to switch to " + sessionName + ".",
+		Urgency: "normal",
+		AppName: "projmux",
+		Tag:     "projmux.focus." + sessionName,
+		Group:   "projmux.focus",
+	})
+}
+
+func (c *focusCommand) logTelemetry(opts focusOptions, target corefocus.Target, socket string) {
+	if c.stderr == nil {
+		return
+	}
+	if strings.TrimSpace(c.lookupEnv("PROJMUX_FOCUS_DEBUG")) == "" {
+		return
+	}
+	fmt.Fprintf(c.stderr,
+		"focus: target=%s session=%s window=%s pane=%s socket=%s source=%s kind=%s\n",
+		target.Raw, target.Session, target.WindowSelector(), target.PaneSelector(),
+		socket, opts.Source, opts.Kind,
+	)
+}
+
+func writeFocusJSON(stdout io.Writer, res focusResult) error {
+	payload, err := json.Marshal(res)
+	if err != nil {
+		return fmt.Errorf("focus: marshal result: %w", err)
+	}
+	if _, err := stdout.Write(append(payload, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+func combineFallback(parts ...string) string {
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	if len(out) == 0 {
+		return ""
+	}
+	return strings.Join(out, "+")
+}
+
+type focusClient struct {
+	Name    string
+	Session string
+}
+
+// pickFocusClient prefers a client already viewing the resolved session so
+// the focus is immediate and visible; otherwise it picks the lexicographically
+// first client to give a stable choice across runs.
+func pickFocusClient(clients []focusClient, sessionName string) string {
+	if len(clients) == 0 {
+		return ""
+	}
+	names := make([]focusClient, 0, len(clients))
+	names = append(names, clients...)
+	sort.Slice(names, func(i, j int) bool { return names[i].Name < names[j].Name })
+	for _, c := range names {
+		if c.Session == sessionName {
+			return c.Name
+		}
+	}
+	return names[0].Name
+}
+
+type focusUnresolvedError struct {
+	session string
+	socket  string
+}
+
+func (e *focusUnresolvedError) Error() string {
+	if e.socket == "" {
+		return fmt.Sprintf("focus: session %q not found and no fallback matched", e.session)
+	}
+	return fmt.Sprintf("focus: session %q not found on socket %q and no fallback matched", e.session, e.socket)
+}
+
+// focusExitError carries a desired process exit code up to main(). The CLI
+// entrypoint maps this to os.Exit; tests inspect the wrapped error directly.
+type focusExitError struct {
+	code int
+	err  error
+}
+
+func (e focusExitError) Error() string { return e.err.Error() }
+func (e focusExitError) Unwrap() error { return e.err }
+func (e focusExitError) ExitCode() int { return e.code }
+
+type focusExecRunner struct{}
+
+func (focusExecRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(out))
+		if trimmed != "" {
+			return out, fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, trimmed)
+		}
+		return out, fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+	}
+	return out, nil
+}
+
+func isNoServerLikeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "no server running on") ||
+		strings.Contains(msg, "failed to connect to server") ||
+		(strings.Contains(msg, "error connecting to ") && strings.Contains(msg, "(No such file or directory)"))
+}
+
+func parseFocusInventory(out []byte) ([]corefocus.Candidate, error) {
+	type row struct {
+		activity int64
+		name     string
+		attached bool
+		order    int
+	}
+
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	lines := strings.Split(trimmed, "\n")
+	rows := make([]row, 0, len(lines))
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, "\t", 3)
+		if len(fields) != 3 {
+			return nil, fmt.Errorf("focus: parse list-sessions row %q", line)
+		}
+		activity, err := strconv.ParseInt(strings.TrimSpace(fields[0]), 10, 64)
+		if err != nil {
+			activity = 0
+		}
+		attachedCount, err := strconv.Atoi(strings.TrimSpace(fields[2]))
+		if err != nil {
+			attachedCount = 0
+		}
+		name := strings.TrimSpace(fields[1])
+		if name == "" {
+			continue
+		}
+		rows = append(rows, row{activity: activity, name: name, attached: attachedCount > 0, order: i})
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].activity == rows[j].activity {
+			return rows[i].order < rows[j].order
+		}
+		return rows[i].activity > rows[j].activity
+	})
+
+	out2 := make([]corefocus.Candidate, 0, len(rows))
+	for _, r := range rows {
+		out2 = append(out2, corefocus.Candidate{Name: r.name, Attached: r.attached})
+	}
+	return out2, nil
+}
+
+func parseFocusClients(out []byte) []focusClient {
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return nil
+	}
+	lines := strings.Split(trimmed, "\n")
+	clients := make([]focusClient, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, "\t", 2)
+		name := strings.TrimSpace(fields[0])
+		session := ""
+		if len(fields) == 2 {
+			session = strings.TrimSpace(fields[1])
+		}
+		if name == "" {
+			continue
+		}
+		clients = append(clients, focusClient{Name: name, Session: session})
+	}
+	return clients
+}

--- a/internal/app/focus_test.go
+++ b/internal/app/focus_test.go
@@ -1,0 +1,298 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+type focusFakeCall struct {
+	name string
+	args []string
+}
+
+type focusFakeRunner struct {
+	calls   []focusFakeCall
+	respond func(args []string) ([]byte, error)
+}
+
+func (f *focusFakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, focusFakeCall{name: name, args: append([]string(nil), args...)})
+	if f.respond == nil {
+		return nil, nil
+	}
+	return f.respond(args)
+}
+
+type focusFakeNotifier struct {
+	notifications []aiNotification
+	err           error
+}
+
+func (n *focusFakeNotifier) Notify(notification aiNotification) error {
+	n.notifications = append(n.notifications, notification)
+	return n.err
+}
+
+func newFocusTestCommand(runner *focusFakeRunner, env map[string]string, notifier *focusFakeNotifier) *focusCommand {
+	c := &focusCommand{
+		runner: runner,
+		lookupEnv: func(name string) string {
+			if env == nil {
+				return ""
+			}
+			return env[name]
+		},
+	}
+	if notifier != nil {
+		c.notifierOnce = func(_ io.Writer) focusNotifier { return notifier }
+	}
+	return c
+}
+
+func TestFocus_SwitchesAttachedSession(t *testing.T) {
+	t.Parallel()
+
+	listSessions := []byte("100\tworkspace\t1\n")
+	listClients := []byte("/dev/pts/0\tworkspace\n")
+
+	runner := &focusFakeRunner{
+		respond: func(args []string) ([]byte, error) {
+			switch {
+			case containsArg(args, "list-sessions"):
+				return listSessions, nil
+			case containsArg(args, "list-clients"):
+				return listClients, nil
+			}
+			return nil, nil
+		},
+	}
+
+	cmd := newFocusTestCommand(runner, nil, nil)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := cmd.Run([]string{"--target", "workspace:1.0", "--json"}, stdout, stderr); err != nil {
+		t.Fatalf("Run returned error: %v (stderr=%s)", err, stderr.String())
+	}
+
+	var res focusResult
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &res); err != nil {
+		t.Fatalf("decode JSON: %v (raw=%q)", err, stdout.String())
+	}
+	if !res.OK || res.Fallback != "" {
+		t.Fatalf("result = %#v, want ok=true fallback=\"\"", res)
+	}
+
+	for _, sub := range []string{"list-sessions", "list-clients", "switch-client", "select-window", "select-pane"} {
+		if !sawSubcommand(runner.calls, sub) {
+			t.Errorf("expected tmux call with %q, got %#v", sub, runner.calls)
+		}
+	}
+}
+
+func TestFocus_FallbackPrefixMatch(t *testing.T) {
+	t.Parallel()
+
+	listSessions := []byte("100\tfoo-main\t1\n50\tfoo-feat\t0\n")
+	listClients := []byte("/dev/pts/0\tfoo-main\n")
+
+	runner := &focusFakeRunner{
+		respond: func(args []string) ([]byte, error) {
+			switch {
+			case containsArg(args, "list-sessions"):
+				return listSessions, nil
+			case containsArg(args, "list-clients"):
+				return listClients, nil
+			}
+			return nil, nil
+		},
+	}
+
+	cmd := newFocusTestCommand(runner, nil, nil)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := cmd.Run([]string{"--target", "foo-feat-baz", "--json"}, stdout, stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	var res focusResult
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &res); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if !res.OK || res.Fallback != "prefix-match" {
+		t.Fatalf("result = %#v, want ok=true fallback=prefix-match", res)
+	}
+}
+
+func TestFocus_NoClientNotifyOnly(t *testing.T) {
+	t.Parallel()
+
+	listSessions := []byte("100\tworkspace\t0\n")
+
+	runner := &focusFakeRunner{
+		respond: func(args []string) ([]byte, error) {
+			switch {
+			case containsArg(args, "list-sessions"):
+				return listSessions, nil
+			case containsArg(args, "list-clients"):
+				return []byte(""), nil
+			}
+			return nil, nil
+		},
+	}
+	notifier := &focusFakeNotifier{}
+	cmd := newFocusTestCommand(runner, nil, notifier)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := cmd.Run([]string{"--target", "workspace:1.0", "--json"}, stdout, stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	var res focusResult
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &res); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if !res.OK || res.Fallback != "notify-only" {
+		t.Fatalf("result = %#v, want notify-only fallback", res)
+	}
+	if len(notifier.notifications) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(notifier.notifications))
+	}
+	if !strings.Contains(notifier.notifications[0].Summary, "session ready") {
+		t.Fatalf("notification summary = %q, want session ready prefix", notifier.notifications[0].Summary)
+	}
+	if sawSubcommand(runner.calls, "switch-client") {
+		t.Fatalf("did not expect switch-client when no clients attached, calls=%#v", runner.calls)
+	}
+}
+
+func TestFocus_UnresolvedSessionExitCode(t *testing.T) {
+	t.Parallel()
+
+	runner := &focusFakeRunner{
+		respond: func(args []string) ([]byte, error) {
+			switch {
+			case containsArg(args, "list-sessions"):
+				return []byte("100\tunrelated\t0\n"), nil
+			case containsArg(args, "list-clients"):
+				return []byte(""), nil
+			}
+			return nil, nil
+		},
+	}
+	cmd := newFocusTestCommand(runner, nil, nil)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	err := cmd.Run([]string{"--target", "needle:1", "--json"}, stdout, stderr)
+	if err == nil {
+		t.Fatalf("expected error for unresolved session, got nil")
+	}
+	var coded focusExitError
+	if !errors.As(err, &coded) {
+		t.Fatalf("error %v does not unwrap to focusExitError", err)
+	}
+	if coded.ExitCode() != focusExitNotResolved {
+		t.Fatalf("exit code = %d, want %d", coded.ExitCode(), focusExitNotResolved)
+	}
+	var res focusResult
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &res); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if res.OK {
+		t.Fatalf("result = %#v, want ok=false", res)
+	}
+}
+
+func TestFocus_SocketArgPropagates(t *testing.T) {
+	t.Parallel()
+
+	runner := &focusFakeRunner{
+		respond: func(args []string) ([]byte, error) {
+			switch {
+			case containsArg(args, "list-sessions"):
+				return []byte("100\twork\t1\n"), nil
+			case containsArg(args, "list-clients"):
+				return []byte("/dev/pts/0\twork\n"), nil
+			}
+			return nil, nil
+		},
+	}
+	cmd := newFocusTestCommand(runner, nil, nil)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := cmd.Run([]string{"--target", "work", "--socket", "/tmp/projmux.sock", "--json"}, stdout, stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	for _, c := range runner.calls {
+		if len(c.args) < 2 || c.args[0] != "-S" || c.args[1] != "/tmp/projmux.sock" {
+			t.Fatalf("expected every tmux call to start with -S /tmp/projmux.sock, got %#v", c.args)
+		}
+	}
+}
+
+func TestFocus_SocketInferredFromTMUXEnv(t *testing.T) {
+	t.Parallel()
+
+	cmd := newFocusTestCommand(&focusFakeRunner{}, map[string]string{"TMUX": "/tmp/derived.sock,1234,1"}, nil)
+	got := cmd.resolveSocket("")
+	if got != "/tmp/derived.sock" {
+		t.Fatalf("resolveSocket = %q, want /tmp/derived.sock", got)
+	}
+}
+
+func TestFocus_RequiresTarget(t *testing.T) {
+	t.Parallel()
+
+	cmd := newFocusTestCommand(&focusFakeRunner{}, nil, nil)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := cmd.Run([]string{}, stdout, stderr); err == nil {
+		t.Fatalf("expected error when --target missing, got nil")
+	}
+}
+
+func TestFocus_AppDispatcherRoutesFocus(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	// Use a benign argument set that should fail target parsing fast (so the
+	// command is reachable through the dispatcher without shelling out).
+	err := app.Run([]string{"focus", "--target", ""}, stdout, stderr)
+	if err == nil {
+		t.Fatalf("expected dispatcher to surface focus parse error, got nil")
+	}
+}
+
+func containsArg(args []string, needle string) bool {
+	for _, a := range args {
+		if a == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func sawSubcommand(calls []focusFakeCall, sub string) bool {
+	for _, c := range calls {
+		for _, a := range c.args {
+			if a == sub {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+var _ focusCommandRunner = (*focusFakeRunner)(nil)
+var _ focusNotifier = (*focusFakeNotifier)(nil)

--- a/internal/core/focus/parse.go
+++ b/internal/core/focus/parse.go
@@ -1,0 +1,175 @@
+// Package focus parses click-to-focus targets and resolves them against tmux.
+//
+// Targets describe a coordinate inside a tmux server in the form
+//
+//	SESSION[:WINDOW[.PANE]]
+//
+// where WINDOW is either a numeric index or a tmux window id (`@N`) and PANE
+// is either a numeric index or a tmux pane id (`%N`). When both an index and
+// an id are usable for the same coordinate the id wins; the index is kept
+// only as a fallback for tmux releases that drop ids on layout changes.
+package focus
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ErrEmptyTarget is returned when the input target string is blank.
+var ErrEmptyTarget = errors.New("focus target is required")
+
+// Target is a parsed focus coordinate.
+type Target struct {
+	// Raw preserves the original spec for logging.
+	Raw string
+
+	// Session is the tmux session name; always populated.
+	Session string
+
+	// WindowIndex is the numeric window index (zero if unset).
+	WindowIndex int
+	// HasWindowIndex reports whether WindowIndex was supplied.
+	HasWindowIndex bool
+	// WindowID is the tmux window id (`@N`) when supplied.
+	WindowID string
+
+	// PaneIndex is the numeric pane index (zero if unset).
+	PaneIndex int
+	// HasPaneIndex reports whether PaneIndex was supplied.
+	HasPaneIndex bool
+	// PaneID is the tmux pane id (`%N`) when supplied.
+	PaneID string
+}
+
+// HasWindow reports whether a window-level coordinate was supplied.
+func (t Target) HasWindow() bool {
+	return t.HasWindowIndex || t.WindowID != ""
+}
+
+// HasPane reports whether a pane-level coordinate was supplied.
+func (t Target) HasPane() bool {
+	return t.HasPaneIndex || t.PaneID != ""
+}
+
+// WindowSelector returns the tmux selector portion for the window, preferring
+// the id form when present.
+func (t Target) WindowSelector() string {
+	if t.WindowID != "" {
+		return t.WindowID
+	}
+	if t.HasWindowIndex {
+		return strconv.Itoa(t.WindowIndex)
+	}
+	return ""
+}
+
+// PaneSelector returns the tmux selector portion for the pane, preferring the
+// id form when present.
+func (t Target) PaneSelector() string {
+	if t.PaneID != "" {
+		return t.PaneID
+	}
+	if t.HasPaneIndex {
+		return strconv.Itoa(t.PaneIndex)
+	}
+	return ""
+}
+
+// Parse interprets a target spec of the form SESSION[:WINDOW[.PANE]].
+//
+// Window may be a positive integer index or a tmux window id like @7.
+// Pane may be a non-negative integer index or a tmux pane id like %12.
+// Pane id (%N) takes precedence over pane index when both forms are usable
+// for the same coordinate; the same precedence applies at the window level.
+func Parse(spec string) (Target, error) {
+	trimmed := strings.TrimSpace(spec)
+	if trimmed == "" {
+		return Target{}, ErrEmptyTarget
+	}
+
+	target := Target{Raw: trimmed}
+
+	sessionPart, rest, hasRest := strings.Cut(trimmed, ":")
+	sessionPart = strings.TrimSpace(sessionPart)
+	if sessionPart == "" {
+		return Target{}, fmt.Errorf("focus target %q: session name is required", trimmed)
+	}
+	target.Session = sessionPart
+	if !hasRest {
+		return target, nil
+	}
+
+	windowPart, panePart, hasPane := strings.Cut(rest, ".")
+	windowPart = strings.TrimSpace(windowPart)
+	if windowPart == "" {
+		return Target{}, fmt.Errorf("focus target %q: window selector is required after ':'", trimmed)
+	}
+	if err := assignWindow(&target, windowPart); err != nil {
+		return Target{}, fmt.Errorf("focus target %q: %w", trimmed, err)
+	}
+	if !hasPane {
+		return target, nil
+	}
+
+	panePart = strings.TrimSpace(panePart)
+	if panePart == "" {
+		return Target{}, fmt.Errorf("focus target %q: pane selector is required after '.'", trimmed)
+	}
+	if err := assignPane(&target, panePart); err != nil {
+		return Target{}, fmt.Errorf("focus target %q: %w", trimmed, err)
+	}
+
+	return target, nil
+}
+
+func assignWindow(target *Target, raw string) error {
+	if strings.HasPrefix(raw, "@") {
+		body := strings.TrimPrefix(raw, "@")
+		if body == "" {
+			return errors.New("window id '@' must be followed by digits")
+		}
+		if _, err := strconv.Atoi(body); err != nil {
+			return fmt.Errorf("window id %q is not numeric", raw)
+		}
+		target.WindowID = raw
+		return nil
+	}
+
+	idx, err := strconv.Atoi(raw)
+	if err != nil {
+		return fmt.Errorf("window selector %q must be an index or @id", raw)
+	}
+	if idx < 0 {
+		return fmt.Errorf("window index %d must be non-negative", idx)
+	}
+	target.WindowIndex = idx
+	target.HasWindowIndex = true
+	return nil
+}
+
+func assignPane(target *Target, raw string) error {
+	if strings.HasPrefix(raw, "%") {
+		body := strings.TrimPrefix(raw, "%")
+		if body == "" {
+			return errors.New("pane id '%' must be followed by digits")
+		}
+		if _, err := strconv.Atoi(body); err != nil {
+			return fmt.Errorf("pane id %q is not numeric", raw)
+		}
+		target.PaneID = raw
+		return nil
+	}
+
+	idx, err := strconv.Atoi(raw)
+	if err != nil {
+		return fmt.Errorf("pane selector %q must be an index or %%id", raw)
+	}
+	if idx < 0 {
+		return fmt.Errorf("pane index %d must be non-negative", idx)
+	}
+	target.PaneIndex = idx
+	target.HasPaneIndex = true
+	return nil
+}

--- a/internal/core/focus/parse_test.go
+++ b/internal/core/focus/parse_test.go
@@ -151,12 +151,12 @@ func TestTarget_Selectors(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name      string
-		target    Target
-		wantHasW  bool
-		wantHasP  bool
-		wantWSel  string
-		wantPSel  string
+		name     string
+		target   Target
+		wantHasW bool
+		wantHasP bool
+		wantWSel string
+		wantPSel string
 	}{
 		{
 			name:     "session only",

--- a/internal/core/focus/parse_test.go
+++ b/internal/core/focus/parse_test.go
@@ -1,0 +1,226 @@
+package focus
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParse_Forms(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		spec string
+		want Target
+	}{
+		{
+			name: "session only",
+			spec: "sess",
+			want: Target{Raw: "sess", Session: "sess"},
+		},
+		{
+			name: "session and window index",
+			spec: "sess:1",
+			want: Target{
+				Raw:            "sess:1",
+				Session:        "sess",
+				WindowIndex:    1,
+				HasWindowIndex: true,
+			},
+		},
+		{
+			name: "session window pane indices",
+			spec: "sess:1.0",
+			want: Target{
+				Raw:            "sess:1.0",
+				Session:        "sess",
+				WindowIndex:    1,
+				HasWindowIndex: true,
+				PaneIndex:      0,
+				HasPaneIndex:   true,
+			},
+		},
+		{
+			name: "session window id",
+			spec: "sess:@7",
+			want: Target{
+				Raw:      "sess:@7",
+				Session:  "sess",
+				WindowID: "@7",
+			},
+		},
+		{
+			name: "session window index pane id",
+			spec: "sess:1.%12",
+			want: Target{
+				Raw:            "sess:1.%12",
+				Session:        "sess",
+				WindowIndex:    1,
+				HasWindowIndex: true,
+				PaneID:         "%12",
+			},
+		},
+		{
+			name: "session window id and pane id",
+			spec: "sess:@4.%9",
+			want: Target{
+				Raw:      "sess:@4.%9",
+				Session:  "sess",
+				WindowID: "@4",
+				PaneID:   "%9",
+			},
+		},
+		{
+			name: "leading and trailing whitespace",
+			spec: "  sess:2.1  ",
+			want: Target{
+				Raw:            "sess:2.1",
+				Session:        "sess",
+				WindowIndex:    2,
+				HasWindowIndex: true,
+				PaneIndex:      1,
+				HasPaneIndex:   true,
+			},
+		},
+		{
+			name: "session with dashes",
+			spec: "team-projmux:0",
+			want: Target{
+				Raw:            "team-projmux:0",
+				Session:        "team-projmux",
+				WindowIndex:    0,
+				HasWindowIndex: true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Parse(tc.spec)
+			if err != nil {
+				t.Fatalf("Parse(%q) returned error: %v", tc.spec, err)
+			}
+			if got != tc.want {
+				t.Fatalf("Parse(%q) = %#v, want %#v", tc.spec, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParse_Errors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		spec string
+	}{
+		{name: "empty", spec: ""},
+		{name: "whitespace", spec: "   "},
+		{name: "missing session", spec: ":1"},
+		{name: "missing window after colon", spec: "sess:"},
+		{name: "missing pane after dot", spec: "sess:1."},
+		{name: "negative window index", spec: "sess:-1"},
+		{name: "negative pane index", spec: "sess:1.-2"},
+		{name: "non-numeric window", spec: "sess:abc"},
+		{name: "non-numeric pane", spec: "sess:1.abc"},
+		{name: "bare at", spec: "sess:@"},
+		{name: "bare percent", spec: "sess:1.%"},
+		{name: "non-numeric window id", spec: "sess:@a"},
+		{name: "non-numeric pane id", spec: "sess:1.%a"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := Parse(tc.spec); err == nil {
+				t.Fatalf("Parse(%q) returned nil error, want error", tc.spec)
+			}
+		})
+	}
+}
+
+func TestParse_EmptyReturnsSentinel(t *testing.T) {
+	t.Parallel()
+	if _, err := Parse(""); !errors.Is(err, ErrEmptyTarget) {
+		t.Fatalf("Parse(\"\") error = %v, want ErrEmptyTarget", err)
+	}
+}
+
+func TestTarget_Selectors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		target    Target
+		wantHasW  bool
+		wantHasP  bool
+		wantWSel  string
+		wantPSel  string
+	}{
+		{
+			name:     "session only",
+			target:   Target{Session: "sess"},
+			wantHasW: false,
+			wantHasP: false,
+		},
+		{
+			name: "window id wins over index",
+			target: Target{
+				Session:        "sess",
+				WindowIndex:    1,
+				HasWindowIndex: true,
+				WindowID:       "@7",
+			},
+			wantHasW: true,
+			wantWSel: "@7",
+		},
+		{
+			name: "pane id wins over index",
+			target: Target{
+				Session:        "sess",
+				WindowIndex:    1,
+				HasWindowIndex: true,
+				PaneIndex:      2,
+				HasPaneIndex:   true,
+				PaneID:         "%9",
+			},
+			wantHasW: true,
+			wantHasP: true,
+			wantWSel: "1",
+			wantPSel: "%9",
+		},
+		{
+			name: "indices only",
+			target: Target{
+				Session:        "sess",
+				WindowIndex:    3,
+				HasWindowIndex: true,
+				PaneIndex:      0,
+				HasPaneIndex:   true,
+			},
+			wantHasW: true,
+			wantHasP: true,
+			wantWSel: "3",
+			wantPSel: "0",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.target.HasWindow(); got != tc.wantHasW {
+				t.Fatalf("HasWindow = %v, want %v", got, tc.wantHasW)
+			}
+			if got := tc.target.HasPane(); got != tc.wantHasP {
+				t.Fatalf("HasPane = %v, want %v", got, tc.wantHasP)
+			}
+			if got := tc.target.WindowSelector(); got != tc.wantWSel {
+				t.Fatalf("WindowSelector = %q, want %q", got, tc.wantWSel)
+			}
+			if got := tc.target.PaneSelector(); got != tc.wantPSel {
+				t.Fatalf("PaneSelector = %q, want %q", got, tc.wantPSel)
+			}
+		})
+	}
+}

--- a/internal/core/focus/resolve.go
+++ b/internal/core/focus/resolve.go
@@ -1,0 +1,104 @@
+package focus
+
+import "strings"
+
+// Candidate represents one tmux session known to the server, ordered by
+// most-recent activity first by the caller.
+type Candidate struct {
+	Name     string
+	Attached bool
+}
+
+// Resolution describes the outcome of matching a requested target session
+// against the live session inventory.
+type Resolution struct {
+	// Name is the session to act on (may differ from request when Fallback != "").
+	Name string
+	// Attached is true if Name is already attached on the server.
+	Attached bool
+	// Fallback is empty on an exact match, otherwise a short label describing
+	// how Name was chosen (e.g. "prefix-match").
+	Fallback string
+}
+
+// Resolve picks the session to focus given the requested name and the current
+// inventory. Inventory must already be ordered most-recent-first.
+//
+// When the requested session is missing the resolver looks for the most
+// recent session whose name shares a leading token (split on '-' or '_')
+// with the request. If no such session exists, ok is false.
+func Resolve(requested string, inventory []Candidate) (Resolution, bool) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return Resolution{}, false
+	}
+
+	for _, candidate := range inventory {
+		if candidate.Name == requested {
+			return Resolution{
+				Name:     candidate.Name,
+				Attached: candidate.Attached,
+			}, true
+		}
+	}
+
+	wantTokens := tokens(requested)
+	if len(wantTokens) == 0 {
+		return Resolution{}, false
+	}
+
+	bestIdx := -1
+	bestShared := 0
+	for i, candidate := range inventory {
+		shared := sharedPrefixTokens(wantTokens, tokens(candidate.Name))
+		if shared == 0 {
+			continue
+		}
+		// Inventory is most-recent-first, so first hit at the maximum shared
+		// length wins. Equal-length later candidates are older and lose.
+		if shared > bestShared {
+			bestShared = shared
+			bestIdx = i
+		}
+	}
+	if bestIdx < 0 {
+		return Resolution{}, false
+	}
+
+	chosen := inventory[bestIdx]
+	return Resolution{
+		Name:     chosen.Name,
+		Attached: chosen.Attached,
+		Fallback: "prefix-match",
+	}, true
+}
+
+func tokens(name string) []string {
+	if name == "" {
+		return nil
+	}
+	parts := strings.FieldsFunc(name, func(r rune) bool {
+		return r == '-' || r == '_'
+	})
+	out := parts[:0]
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func sharedPrefixTokens(a, b []string) int {
+	limit := len(a)
+	if len(b) < limit {
+		limit = len(b)
+	}
+	for i := 0; i < limit; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return limit
+}

--- a/internal/core/focus/resolve_test.go
+++ b/internal/core/focus/resolve_test.go
@@ -1,0 +1,94 @@
+package focus
+
+import "testing"
+
+func TestResolve_ExactMatch(t *testing.T) {
+	t.Parallel()
+
+	inv := []Candidate{
+		{Name: "foo-main", Attached: true},
+		{Name: "foo-feat", Attached: false},
+	}
+
+	res, ok := Resolve("foo-main", inv)
+	if !ok {
+		t.Fatalf("Resolve returned ok=false, want true")
+	}
+	if res.Name != "foo-main" || res.Fallback != "" || !res.Attached {
+		t.Fatalf("Resolve = %#v, want exact attached match", res)
+	}
+}
+
+func TestResolve_PrefixFallbackPicksMostRecent(t *testing.T) {
+	t.Parallel()
+
+	// Inventory is most-recent-first by contract.
+	inv := []Candidate{
+		{Name: "foo-feat-bar"},
+		{Name: "foo-main"},
+		{Name: "unrelated"},
+	}
+
+	res, ok := Resolve("foo-feat-baz", inv)
+	if !ok {
+		t.Fatalf("Resolve returned ok=false, want true")
+	}
+	if res.Name != "foo-feat-bar" {
+		t.Fatalf("Resolve.Name = %q, want %q", res.Name, "foo-feat-bar")
+	}
+	if res.Fallback != "prefix-match" {
+		t.Fatalf("Resolve.Fallback = %q, want prefix-match", res.Fallback)
+	}
+}
+
+func TestResolve_PrefersLongerSharedPrefixOverRecency(t *testing.T) {
+	t.Parallel()
+
+	inv := []Candidate{
+		{Name: "foo-other"},     // shares 1 token (foo)
+		{Name: "foo-feat-zzz"},  // shares 2 tokens (foo, feat)
+	}
+
+	res, ok := Resolve("foo-feat-baz", inv)
+	if !ok {
+		t.Fatalf("Resolve returned ok=false, want true")
+	}
+	if res.Name != "foo-feat-zzz" {
+		t.Fatalf("Resolve.Name = %q, want %q", res.Name, "foo-feat-zzz")
+	}
+}
+
+func TestResolve_NoMatch(t *testing.T) {
+	t.Parallel()
+
+	inv := []Candidate{
+		{Name: "alpha"},
+		{Name: "beta"},
+	}
+	if _, ok := Resolve("gamma", inv); ok {
+		t.Fatal("Resolve returned ok=true for unrelated request, want false")
+	}
+}
+
+func TestResolve_EmptyRequest(t *testing.T) {
+	t.Parallel()
+
+	if _, ok := Resolve("", []Candidate{{Name: "x"}}); ok {
+		t.Fatal("Resolve returned ok=true for empty request, want false")
+	}
+}
+
+func TestResolve_UnderscoreToken(t *testing.T) {
+	t.Parallel()
+
+	inv := []Candidate{
+		{Name: "team_lead_qa"},
+	}
+	res, ok := Resolve("team_lead_dev", inv)
+	if !ok {
+		t.Fatalf("Resolve returned ok=false, want true")
+	}
+	if res.Name != "team_lead_qa" || res.Fallback != "prefix-match" {
+		t.Fatalf("Resolve = %#v, want team_lead_qa prefix-match", res)
+	}
+}

--- a/internal/core/focus/resolve_test.go
+++ b/internal/core/focus/resolve_test.go
@@ -45,8 +45,8 @@ func TestResolve_PrefersLongerSharedPrefixOverRecency(t *testing.T) {
 	t.Parallel()
 
 	inv := []Candidate{
-		{Name: "foo-other"},     // shares 1 token (foo)
-		{Name: "foo-feat-zzz"},  // shares 2 tokens (foo, feat)
+		{Name: "foo-other"},    // shares 1 token (foo)
+		{Name: "foo-feat-zzz"}, // shares 2 tokens (foo, feat)
 	}
 
 	res, ok := Resolve("foo-feat-baz", inv)


### PR DESCRIPTION
## Summary
- New top-level subcommand `projmux focus --target SESSION[:WINDOW[.PANE]] [--socket ...] [--source ...] [--kind ...] [--json]`.
- Unified dispatch core for all click-to-focus paths (status-bar segments, attention badges, OS notifications). Keeps every entry point routed through one CLI surface.
- Socket-aware (uses `tmux -S` per call), id-over-index pane targeting, attached/detached awareness, prefix-token fallback when target session vanishes.

## Design notes
- `internal/core/focus` holds parser + resolver (no tmux deps); `internal/app/focus.go` does the tmux dispatch via a focus-local runner that prepends `-S <socket>`. This keeps the slice self-contained — promoting `-S` into `internal/integrations/tmux/client.go` is left as a follow-up so other commands can also become socket-aware.
- Fallback contract: if no client is attached on the target socket, focus emits a desktop notification ("session ready: …") and returns `{ok:true, fallback:"notify-only"}`. Window/pane resolution failures degrade to session-only with `+`-joined `fallback` tokens (e.g. `prefix-match+window-only`).
- Multi-client policy: never force-detach. `pickFocusClient` prefers a client already on the resolved session, else lexicographically-first. Comment marks the future "force focus" config-flag extension point.
- Exit-code 2 for unresolved targets via a typed `exitCoder` interface in `cmd/projmux/main.go`; `main` suppresses the default stderr print for those (the command already wrote its own diagnostic).

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (focus parser, resolver, dispatcher with fakes — all green)
- [x] Manual: `./projmux focus --target some-session:1.0 --json` against missing socket emits well-formed JSON + exits 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)