### PR TITLE
feat(usage): codex/claude usage tracker (5h + weekly)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -60,6 +60,7 @@ type App struct {
 	tag          *tagCommand
 	tmux         *tmuxCommand
 	upgrade      *upgradeCommand
+	usage        *usageCommand
 }
 
 // New builds the default application graph.
@@ -89,6 +90,7 @@ func New() *App {
 		tag:          newTagCommand(),
 		tmux:         newTmuxCommand(),
 		upgrade:      newUpgradeCommand(),
+		usage:        newUsageCommand(),
 	}
 }
 
@@ -144,6 +146,8 @@ func (a *App) Run(args []string, stdout, stderr io.Writer) error {
 		return a.tmux.Run(args[1:], stdout, stderr)
 	case "upgrade":
 		return a.upgrade.Run(args[1:], stdout, stderr)
+	case "usage":
+		return a.usage.Run(args[1:], stdout, stderr)
 	case "version", "--version", "-version":
 		_, err := fmt.Fprintf(stdout, "projmux %s\n", version.String())
 		return err
@@ -182,6 +186,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  tag       Manage tagged tmux sessions")
 	fmt.Fprintln(w, "  tmux      Open tmux popup entry helpers")
 	fmt.Fprintln(w, "  upgrade   Self-update projmux via go install")
+	fmt.Fprintln(w, "  usage     Report AI token usage across 5h and weekly windows")
 	fmt.Fprintln(w, "  help      Show bootstrap help")
 	fmt.Fprintln(w, "  version   Print the current version")
 }

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -21,6 +21,7 @@ type statusCommand struct {
 	homeDir     func() (string, error)
 	readCommand func(ctx context.Context, name string, args ...string) ([]byte, error)
 	now         func() time.Time
+	usage       *usageCommand
 }
 
 func newStatusCommand() *statusCommand {
@@ -29,6 +30,7 @@ func newStatusCommand() *statusCommand {
 		homeDir:     os.UserHomeDir,
 		readCommand: readExternalCommand,
 		now:         time.Now,
+		usage:       newUsageCommand(),
 	}
 }
 
@@ -43,6 +45,11 @@ func (c *statusCommand) Run(args []string, stdout, stderr io.Writer) error {
 		return c.runGit(args[1:], stdout, stderr)
 	case "kube":
 		return c.runKube(args[1:], stdout, stderr)
+	case "usage":
+		if c.usage == nil {
+			c.usage = newUsageCommand()
+		}
+		return c.usage.runStatus(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
 		printStatusUsage(stdout)
 		return nil
@@ -276,4 +283,5 @@ func printStatusUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  projmux status git [path]")
 	fmt.Fprintln(w, "  projmux status kube [session]")
+	fmt.Fprintln(w, "  projmux status usage [--max-width N]")
 }

--- a/internal/app/usage.go
+++ b/internal/app/usage.go
@@ -1,0 +1,315 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/core/usage"
+	claudeadapter "github.com/crevissepartners/projmux/internal/core/usage/adapters/claude"
+	codexadapter "github.com/crevissepartners/projmux/internal/core/usage/adapters/codex"
+)
+
+// usageCommand exposes the `projmux usage` and `projmux status usage`
+// surfaces. Both share a single Manager so collect-once-render-twice stays
+// cheap.
+type usageCommand struct {
+	managerFn func() (*usage.Manager, error)
+	now       func() time.Time
+	lookupEnv func(string) string
+}
+
+func newUsageCommand() *usageCommand {
+	c := &usageCommand{
+		now:       time.Now,
+		lookupEnv: os.Getenv,
+	}
+	c.managerFn = c.defaultManager
+	return c
+}
+
+// Run implements `projmux usage [...]`.
+func (c *usageCommand) Run(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("usage", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	model := fs.String("model", "all", "filter by model: codex | claude | all")
+	window := fs.String("window", "all", "filter by window: 5h | weekly | all")
+	asJSON := fs.Bool("json", false, "emit a JSON array instead of the tab-aligned table")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		printUsageHelp(stderr)
+		return fmt.Errorf("usage does not accept positional arguments")
+	}
+
+	mgr, err := c.managerFn()
+	if err != nil {
+		return err
+	}
+	snaps, collectErr := mgr.Collect(context.Background())
+	// collectErr is informational — adapters that fail still keep the rest
+	// of the rendering pipeline working. We surface a single warning to
+	// stderr so the user knows partial data was used.
+	if collectErr != nil {
+		fmt.Fprintf(stderr, "usage: warning: %v\n", collectErr)
+	}
+
+	filtered := filterSnapshots(snaps, *model, *window)
+	filtered = usage.SortedSnapshots(filtered)
+
+	if *asJSON {
+		return writeUsageJSON(stdout, filtered)
+	}
+	return writeUsageTable(stdout, filtered)
+}
+
+// runStatus implements the `projmux status usage` subcommand. It reads from
+// the persisted cache (no adapter walk) so it is safe to call from the
+// tmux status interval.
+func (c *usageCommand) runStatus(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("status usage", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	maxWidth := fs.Int("max-width", 0, "truncate output to N runes (0 = no truncation)")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("status usage does not accept positional arguments")
+	}
+
+	mgr, err := c.managerFn()
+	if err != nil {
+		// Status segment must never fail loudly — silently emit nothing.
+		return nil
+	}
+	snaps, err := mgr.LoadAll()
+	if err != nil {
+		return nil
+	}
+
+	out := formatStatusUsage(snaps, *maxWidth)
+	if out == "" {
+		return nil
+	}
+	_, err = fmt.Fprint(stdout, out)
+	return err
+}
+
+func (c *usageCommand) defaultManager() (*usage.Manager, error) {
+	paths, err := config.DefaultPathsFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("usage: resolve config paths: %w", err)
+	}
+	registry := usage.NewRegistry()
+	if err := registry.Register(claudeadapter.New()); err != nil {
+		return nil, fmt.Errorf("usage: register claude adapter: %w", err)
+	}
+	if err := registry.Register(codexadapter.New()); err != nil {
+		return nil, fmt.Errorf("usage: register codex adapter: %w", err)
+	}
+	limits, err := usage.LoadLimits(c.env(usage.LimitsEnvVar))
+	if err != nil {
+		return nil, err
+	}
+	store := usage.NewStore(filepath.Join(paths.StateDir, "usage"))
+	return usage.NewManager(registry, store, limits, c.now), nil
+}
+
+func (c *usageCommand) env(name string) string {
+	if c.lookupEnv == nil {
+		return ""
+	}
+	return c.lookupEnv(name)
+}
+
+// filterSnapshots applies the --model and --window filters. "all" passes
+// every value through.
+func filterSnapshots(snaps []usage.Snapshot, model, window string) []usage.Snapshot {
+	model = strings.ToLower(strings.TrimSpace(model))
+	window = strings.ToLower(strings.TrimSpace(window))
+	if model == "" {
+		model = "all"
+	}
+	if window == "" {
+		window = "all"
+	}
+	out := snaps[:0:0]
+	for _, s := range snaps {
+		if model != "all" && !strings.EqualFold(s.Model, model) {
+			continue
+		}
+		if window != "all" && string(s.Window) != window {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func writeUsageJSON(w io.Writer, snaps []usage.Snapshot) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if snaps == nil {
+		return enc.Encode([]usage.Snapshot{})
+	}
+	return enc.Encode(snaps)
+}
+
+func writeUsageTable(w io.Writer, snaps []usage.Snapshot) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "MODEL\tWINDOW\tTOKENS\tPCT\tRESETS_AT"); err != nil {
+		return err
+	}
+	for _, s := range snaps {
+		pct := "-"
+		if s.Limit > 0 {
+			pct = fmt.Sprintf("%.0f%%", s.Pct)
+		}
+		resets := "-"
+		if !s.ResetsAt.IsZero() {
+			resets = s.ResetsAt.Local().Format(time.RFC3339)
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\n", s.Model, s.Window, s.Tokens, pct, resets); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+// formatStatusUsage produces the one-line tmux status segment described in
+// the spec: `c:42% w:18% | x:71% w:55%`.
+//
+//   - claude => c:, codex => x:.
+//   - First number is the 5h window, second is the weekly window.
+//   - A model with no snapshots (or no limits to compute pct) is omitted.
+//   - When maxWidth > 0 and the rendered output exceeds that rune count,
+//     trailing groups are dropped first and, if still too long, the last
+//     group is truncated and ellipsised.
+func formatStatusUsage(snaps []usage.Snapshot, maxWidth int) string {
+	groups := buildStatusGroups(snaps)
+	if len(groups) == 0 {
+		return ""
+	}
+	full := strings.Join(groups, " | ")
+	if maxWidth <= 0 || runeLen(full) <= maxWidth {
+		return full
+	}
+	// Drop trailing groups until it fits.
+	for len(groups) > 1 {
+		groups = groups[:len(groups)-1]
+		candidate := strings.Join(groups, " | ")
+		if runeLen(candidate) <= maxWidth {
+			return candidate
+		}
+	}
+	// Last resort: truncate the single remaining group.
+	only := groups[0]
+	if runeLen(only) <= maxWidth {
+		return only
+	}
+	if maxWidth <= 1 {
+		return string([]rune(only)[:maxWidth])
+	}
+	rs := []rune(only)
+	return string(rs[:maxWidth-1]) + "…"
+}
+
+// statusGroup builds the per-model substring like "c:42% w:18%". Returns ""
+// when the model has no usable snapshots.
+func statusGroup(prefix string, fiveH, weekly *usage.Snapshot) string {
+	parts := make([]string, 0, 2)
+	if fiveH != nil && fiveH.Limit > 0 {
+		parts = append(parts, fmt.Sprintf("%s:%.0f%%", prefix, fiveH.Pct))
+	}
+	if weekly != nil && weekly.Limit > 0 {
+		parts = append(parts, fmt.Sprintf("w:%.0f%%", weekly.Pct))
+	}
+	return strings.Join(parts, " ")
+}
+
+// statusPrefix maps known model names to their single-letter status prefix.
+// Unknown models get the first letter of their name as a graceful fallback.
+func statusPrefix(model string) string {
+	switch strings.ToLower(model) {
+	case "claude":
+		return "c"
+	case "codex":
+		return "x"
+	default:
+		if model == "" {
+			return "?"
+		}
+		return strings.ToLower(model[:1])
+	}
+}
+
+// buildStatusGroups groups snapshots by model in the canonical claude-then-
+// codex order and renders each group.
+func buildStatusGroups(snaps []usage.Snapshot) []string {
+	byModel := make(map[string]map[usage.Window]*usage.Snapshot)
+	order := make([]string, 0, 2)
+	for i := range snaps {
+		s := snaps[i]
+		row, ok := byModel[s.Model]
+		if !ok {
+			row = make(map[usage.Window]*usage.Snapshot, 2)
+			byModel[s.Model] = row
+			order = append(order, s.Model)
+		}
+		row[s.Window] = &s
+	}
+	// Stable canonical order: claude first, codex second, anything else after
+	// in first-seen order.
+	canonical := []string{"claude", "codex"}
+	priority := map[string]int{}
+	for i, m := range canonical {
+		priority[m] = i
+	}
+	sortedModels := make([]string, 0, len(order))
+	for _, m := range canonical {
+		if _, ok := byModel[m]; ok {
+			sortedModels = append(sortedModels, m)
+		}
+	}
+	for _, m := range order {
+		if _, listed := priority[m]; listed {
+			continue
+		}
+		sortedModels = append(sortedModels, m)
+	}
+	groups := make([]string, 0, len(sortedModels))
+	for _, m := range sortedModels {
+		row := byModel[m]
+		group := statusGroup(statusPrefix(m), row[usage.Window5h], row[usage.WindowWeekly])
+		if group != "" {
+			groups = append(groups, group)
+		}
+	}
+	return groups
+}
+
+func runeLen(s string) int {
+	return len([]rune(s))
+}
+
+func printUsageHelp(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  projmux usage [--model codex|claude|all] [--window 5h|weekly|all] [--json]")
+	fmt.Fprintln(w, "  projmux status usage [--max-width N]")
+}

--- a/internal/app/usage_test.go
+++ b/internal/app/usage_test.go
@@ -1,0 +1,218 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/usage"
+)
+
+func TestFormatStatusUsageRendersBothModels(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	snaps := []usage.Snapshot{
+		{Model: "claude", Window: usage.Window5h, Tokens: 420, Limit: 1000, Pct: 42.0, UpdatedAt: now},
+		{Model: "claude", Window: usage.WindowWeekly, Tokens: 180, Limit: 1000, Pct: 18.0, UpdatedAt: now},
+		{Model: "codex", Window: usage.Window5h, Tokens: 710, Limit: 1000, Pct: 71.0, UpdatedAt: now},
+		{Model: "codex", Window: usage.WindowWeekly, Tokens: 550, Limit: 1000, Pct: 55.0, UpdatedAt: now},
+	}
+	got := formatStatusUsage(snaps, 0)
+	want := "c:42% w:18% | x:71% w:55%"
+	if got != want {
+		t.Fatalf("formatStatusUsage = %q, want %q", got, want)
+	}
+}
+
+func TestFormatStatusUsageOmitsModelsWithNoLimit(t *testing.T) {
+	t.Parallel()
+
+	snaps := []usage.Snapshot{
+		{Model: "claude", Window: usage.Window5h, Tokens: 1, Limit: 0, Pct: 0},
+		{Model: "claude", Window: usage.WindowWeekly, Tokens: 1, Limit: 0, Pct: 0},
+		{Model: "codex", Window: usage.Window5h, Tokens: 100, Limit: 200, Pct: 50},
+		{Model: "codex", Window: usage.WindowWeekly, Tokens: 50, Limit: 200, Pct: 25},
+	}
+	got := formatStatusUsage(snaps, 0)
+	want := "x:50% w:25%"
+	if got != want {
+		t.Fatalf("formatStatusUsage = %q, want %q", got, want)
+	}
+}
+
+func TestFormatStatusUsageAllEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := formatStatusUsage(nil, 0); got != "" {
+		t.Fatalf("formatStatusUsage(nil) = %q, want empty", got)
+	}
+	snaps := []usage.Snapshot{
+		{Model: "claude", Window: usage.Window5h, Limit: 0},
+	}
+	if got := formatStatusUsage(snaps, 0); got != "" {
+		t.Fatalf("formatStatusUsage(no limits) = %q, want empty", got)
+	}
+}
+
+func TestFormatStatusUsageWidthDropsTrailingGroups(t *testing.T) {
+	t.Parallel()
+
+	snaps := []usage.Snapshot{
+		{Model: "claude", Window: usage.Window5h, Limit: 1000, Pct: 42},
+		{Model: "claude", Window: usage.WindowWeekly, Limit: 1000, Pct: 18},
+		{Model: "codex", Window: usage.Window5h, Limit: 1000, Pct: 71},
+		{Model: "codex", Window: usage.WindowWeekly, Limit: 1000, Pct: 55},
+	}
+	full := formatStatusUsage(snaps, 0)
+	if !strings.Contains(full, "|") {
+		t.Fatalf("full = %q, want contains separator", full)
+	}
+	// Width that fits only the first group ("c:42% w:18%" = 11 runes).
+	got := formatStatusUsage(snaps, 11)
+	if got != "c:42% w:18%" {
+		t.Fatalf("width=11 got %q, want %q", got, "c:42% w:18%")
+	}
+}
+
+func TestFormatStatusUsageWidthTruncatesSingleGroupWithEllipsis(t *testing.T) {
+	t.Parallel()
+
+	snaps := []usage.Snapshot{
+		{Model: "claude", Window: usage.Window5h, Limit: 1000, Pct: 42},
+		{Model: "claude", Window: usage.WindowWeekly, Limit: 1000, Pct: 18},
+	}
+	got := formatStatusUsage(snaps, 5)
+	rs := []rune(got)
+	if len(rs) != 5 {
+		t.Fatalf("len(got runes) = %d, want 5; got=%q", len(rs), got)
+	}
+	if rs[len(rs)-1] != '…' {
+		t.Fatalf("trailing rune = %q, want ellipsis", rs[len(rs)-1])
+	}
+}
+
+func TestFilterSnapshotsByModelAndWindow(t *testing.T) {
+	t.Parallel()
+
+	snaps := []usage.Snapshot{
+		{Model: "claude", Window: usage.Window5h},
+		{Model: "claude", Window: usage.WindowWeekly},
+		{Model: "codex", Window: usage.Window5h},
+		{Model: "codex", Window: usage.WindowWeekly},
+	}
+	got := filterSnapshots(snaps, "claude", "all")
+	if len(got) != 2 {
+		t.Fatalf("model=claude got %d, want 2", len(got))
+	}
+	got = filterSnapshots(snaps, "all", "5h")
+	if len(got) != 2 {
+		t.Fatalf("window=5h got %d, want 2", len(got))
+	}
+	got = filterSnapshots(snaps, "codex", "weekly")
+	if len(got) != 1 || got[0].Model != "codex" || got[0].Window != usage.WindowWeekly {
+		t.Fatalf("codex+weekly got %+v, want one codex weekly", got)
+	}
+}
+
+type stubAdapter struct {
+	name   string
+	events []usage.TokenEvent
+	err    error
+}
+
+func (s *stubAdapter) Name() string { return s.name }
+func (s *stubAdapter) Collect(ctx context.Context) ([]usage.TokenEvent, error) {
+	return s.events, s.err
+}
+
+func newStubManager(t *testing.T, snaps []usage.Snapshot) (*usage.Manager, error) {
+	t.Helper()
+	dir := t.TempDir()
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	registry := usage.NewRegistry()
+	for _, s := range snaps {
+		_ = registry.Replace(&stubAdapter{
+			name:   s.Model,
+			events: []usage.TokenEvent{{At: now.Add(-time.Hour), Tokens: s.Tokens}},
+		})
+	}
+	limits := usage.Limits{
+		"claude": {usage.Window5h: 1000, usage.WindowWeekly: 5000},
+		"codex":  {usage.Window5h: 1000, usage.WindowWeekly: 5000},
+	}
+	store := usage.NewStore(dir)
+	return usage.NewManager(registry, store, limits, func() time.Time { return now }), nil
+}
+
+func TestUsageRunJSONEmptyCacheReturnsArray(t *testing.T) {
+	t.Parallel()
+
+	c := newUsageCommand()
+	c.managerFn = func() (*usage.Manager, error) {
+		dir := t.TempDir()
+		registry := usage.NewRegistry()
+		_ = registry.Register(&stubAdapter{name: "claude"})
+		store := usage.NewStore(dir)
+		return usage.NewManager(registry, store, usage.DefaultLimits, func() time.Time {
+			return time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+		}), nil
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := c.Run([]string{"--json"}, stdout, stderr); err != nil {
+		t.Fatalf("Run: %v err=%s", err, stderr.String())
+	}
+	if !strings.HasPrefix(strings.TrimSpace(stdout.String()), "[") {
+		t.Fatalf("stdout = %q, want JSON array", stdout.String())
+	}
+}
+
+func TestUsageStatusEmitsFormattedSegment(t *testing.T) {
+	t.Parallel()
+
+	c := newUsageCommand()
+	mgr, err := newStubManager(t, []usage.Snapshot{
+		{Model: "claude", Tokens: 300},
+		{Model: "codex", Tokens: 700},
+	})
+	if err != nil {
+		t.Fatalf("newStubManager: %v", err)
+	}
+	// Prime the cache via Collect so LoadAll has data.
+	if _, err := mgr.Collect(context.Background()); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	c.managerFn = func() (*usage.Manager, error) { return mgr, nil }
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := c.runStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "c:") || !strings.Contains(out, "x:") {
+		t.Fatalf("status output = %q, want both prefixes", out)
+	}
+}
+
+func TestUsageStatusManagerErrorIsSilent(t *testing.T) {
+	t.Parallel()
+
+	c := newUsageCommand()
+	c.managerFn = func() (*usage.Manager, error) {
+		return nil, errors.New("boom")
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := c.runStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("runStatus must swallow error, got %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}

--- a/internal/core/usage/adapters/claude/claude.go
+++ b/internal/core/usage/adapters/claude/claude.go
@@ -1,0 +1,207 @@
+// Package claude implements a best-effort v0 usage Adapter for Claude Code.
+//
+// Source of truth: Claude Code persists per-session JSONL transcripts under
+// ~/.claude/projects/<flat-cwd>/<sessionID>.jsonl. Each assistant message
+// emits a `usage` block with input/cache/output token counters. This
+// adapter scans those files and emits a TokenEvent per assistant message
+// using the message's top-level `timestamp`.
+//
+// Caveats:
+//
+//   - The same logical assistant turn often shows up multiple times across
+//     adjacent records (the transcript records partial states). We dedupe
+//     on `requestId`, falling back to `message.id` if requestId is missing.
+//   - "Tokens" here = input + output + cache_creation_input. cache_read is
+//     deliberately excluded so the rolling sum reflects the user's billable
+//     consumption rather than re-served context.
+//   - We only inspect files modified within the last weekly retention
+//     window so cold-start cost stays bounded.
+//
+// TODO(usage): when Claude Code exposes a stable `claude usage` command or
+// HTTP endpoint with authoritative limits and consumption, prefer that over
+// JSONL scraping. Until then this adapter is intentionally tolerant of
+// schema drift: any malformed record is skipped silently.
+package claude
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/usage"
+)
+
+// Name is the adapter's registered identifier. Aligns with the model-key
+// used in the limits table.
+const Name = "claude"
+
+// scanWindow caps how far back the adapter walks transcripts. Anything
+// older than this is skipped entirely; the cache layer handles longer-term
+// retention so the adapter can stay cheap on every Collect.
+const scanWindow = 8 * 24 * time.Hour
+
+// Adapter is the Claude implementation of usage.Adapter.
+type Adapter struct {
+	homeDir func() (string, error)
+	now     func() time.Time
+	// rootOverride lets tests point at a fixture tree without juggling HOME.
+	rootOverride string
+}
+
+// New returns an Adapter that reads from $HOME/.claude/projects.
+func New() *Adapter {
+	return &Adapter{homeDir: os.UserHomeDir, now: time.Now}
+}
+
+// NewWithRoot is intended for tests: it reads JSONL transcripts from the
+// supplied directory tree instead of $HOME/.claude/projects.
+func NewWithRoot(root string) *Adapter {
+	return &Adapter{homeDir: os.UserHomeDir, now: time.Now, rootOverride: root}
+}
+
+// Name implements usage.Adapter.
+func (a *Adapter) Name() string { return Name }
+
+// Collect walks the transcript tree and emits TokenEvents. Best-effort: if
+// the directory doesn't exist or any single file fails to parse we skip it
+// silently rather than error out — the status segment must keep working
+// with partial data.
+func (a *Adapter) Collect(ctx context.Context) ([]usage.TokenEvent, error) {
+	root, err := a.resolveRoot()
+	if err != nil {
+		return nil, nil // best-effort: no home dir => no events.
+	}
+	if _, err := os.Stat(root); err != nil {
+		return nil, nil
+	}
+
+	now := a.now().UTC()
+	cutoff := now.Add(-scanWindow)
+
+	var events []usage.TokenEvent
+	seen := make(map[string]struct{})
+
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// A single unreadable subdir mustn't take down the whole walk.
+			if errors.Is(err, fs.ErrPermission) {
+				return nil
+			}
+			return nil
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".jsonl") {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return nil
+		}
+		if info.ModTime().Before(cutoff) {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		fileEvents := scanTranscript(path, cutoff, seen)
+		events = append(events, fileEvents...)
+		return nil
+	})
+	if walkErr != nil && !errors.Is(walkErr, ctx.Err()) {
+		return nil, nil
+	}
+	return events, nil
+}
+
+func (a *Adapter) resolveRoot() (string, error) {
+	if a.rootOverride != "" {
+		return a.rootOverride, nil
+	}
+	home, err := a.homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", "projects"), nil
+}
+
+// transcriptRecord is the subset of the Claude Code JSONL schema we care
+// about. Unknown fields are intentionally ignored so future schema bumps
+// don't break the adapter.
+type transcriptRecord struct {
+	Type      string    `json:"type"`
+	Timestamp time.Time `json:"timestamp"`
+	RequestID string    `json:"requestId"`
+	Message   *struct {
+		ID    string `json:"id"`
+		Usage *struct {
+			InputTokens              int64 `json:"input_tokens"`
+			OutputTokens             int64 `json:"output_tokens"`
+			CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+// scanTranscript reads a single JSONL file and returns the deduped events
+// that fall inside the cutoff window. seen is shared across files so we
+// dedupe across the entire collect call.
+func scanTranscript(path string, cutoff time.Time, seen map[string]struct{}) []usage.TokenEvent {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	// Claude transcripts contain very long single-line records (full
+	// assistant messages with attachments). Bump the buffer so we don't
+	// truncate them mid-line.
+	const maxLine = 16 * 1024 * 1024
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLine)
+
+	var out []usage.TokenEvent
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var rec transcriptRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			continue
+		}
+		if rec.Type != "assistant" {
+			continue
+		}
+		if rec.Message == nil || rec.Message.Usage == nil {
+			continue
+		}
+		if rec.Timestamp.Before(cutoff) {
+			continue
+		}
+		key := rec.RequestID
+		if key == "" {
+			key = rec.Message.ID
+		}
+		if key == "" {
+			// No stable identity; conservatively skip to avoid double-counting.
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		u := rec.Message.Usage
+		// Cache reads are excluded — see package doc.
+		tokens := u.InputTokens + u.OutputTokens + u.CacheCreationInputTokens
+		if tokens <= 0 {
+			continue
+		}
+		out = append(out, usage.TokenEvent{At: rec.Timestamp.UTC(), Tokens: tokens})
+	}
+	return out
+}

--- a/internal/core/usage/adapters/claude/claude_test.go
+++ b/internal/core/usage/adapters/claude/claude_test.go
@@ -1,0 +1,91 @@
+package claude
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAdapterCollectFromTranscriptFixture(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	projDir := filepath.Join(dir, "-home-test-repo")
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	jsonl := `{"type":"user","timestamp":"2026-05-06T11:00:00Z"}` + "\n" +
+		`{"type":"assistant","timestamp":"2026-05-06T11:01:00Z","requestId":"req-A","message":{"id":"m1","usage":{"input_tokens":10,"output_tokens":20,"cache_creation_input_tokens":5,"cache_read_input_tokens":1000}}}` + "\n" +
+		`{"type":"assistant","timestamp":"2026-05-06T11:02:00Z","requestId":"req-A","message":{"id":"m1","usage":{"input_tokens":10,"output_tokens":20}}}` + "\n" +
+		`{"type":"assistant","timestamp":"2026-05-06T11:03:00Z","requestId":"req-B","message":{"id":"m2","usage":{"input_tokens":7,"output_tokens":3}}}` + "\n"
+	file := filepath.Join(projDir, "session.jsonl")
+	if err := os.WriteFile(file, []byte(jsonl), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	a := NewWithRoot(dir)
+	a.now = func() time.Time { return time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC) }
+
+	events, err := a.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2 (deduped on requestId)", len(events))
+	}
+	// First: 10+20+5 = 35.
+	if events[0].Tokens != 35 {
+		t.Fatalf("event[0].Tokens = %d, want 35", events[0].Tokens)
+	}
+	// Second: 7+3 = 10.
+	if events[1].Tokens != 10 {
+		t.Fatalf("event[1].Tokens = %d, want 10", events[1].Tokens)
+	}
+}
+
+func TestAdapterCollectMissingRootIsBestEffort(t *testing.T) {
+	t.Parallel()
+
+	a := NewWithRoot(filepath.Join(t.TempDir(), "does-not-exist"))
+	a.now = func() time.Time { return time.Now() }
+
+	events, err := a.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if events != nil {
+		t.Fatalf("events = %v, want nil", events)
+	}
+}
+
+func TestAdapterCollectSkipsOldFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	projDir := filepath.Join(dir, "old-project")
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	file := filepath.Join(projDir, "ancient.jsonl")
+	body := `{"type":"assistant","timestamp":"2025-01-01T00:00:00Z","requestId":"old","message":{"id":"x","usage":{"input_tokens":1,"output_tokens":1}}}` + "\n"
+	if err := os.WriteFile(file, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	old := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(file, old, old); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	a := NewWithRoot(dir)
+	a.now = func() time.Time { return time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC) }
+
+	events, err := a.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("got %d events, want 0 (file mtime predates window)", len(events))
+	}
+}

--- a/internal/core/usage/adapters/codex/codex.go
+++ b/internal/core/usage/adapters/codex/codex.go
@@ -1,0 +1,191 @@
+// Package codex implements a best-effort v0 usage Adapter for the Codex CLI.
+//
+// Source of truth: the Codex CLI persists per-session "rollout" JSONL files
+// under ~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-*.jsonl. These contain
+// `event_msg` records of `type: "token_count"` whose payload reports the
+// last assistant turn's usage:
+//
+//	{
+//	  "timestamp": "2026-04-08T08:14:25.958Z",
+//	  "type": "event_msg",
+//	  "payload": {
+//	    "type": "token_count",
+//	    "info": {
+//	      "last_token_usage": {"total_tokens": 14476, ...},
+//	      "total_token_usage": {"total_tokens": 82491, ...},
+//	      ...
+//	    },
+//	    "rate_limits": {...}
+//	  }
+//	}
+//
+// We emit one TokenEvent per `last_token_usage.total_tokens`, since
+// `total_token_usage` is a running session sum that would double-count if we
+// summed it.
+//
+// Caveats:
+//
+//   - Codex's `rate_limits.primary/secondary` payload also exposes the
+//     official 5h/weekly used_percent. A future PR should prefer that
+//     directly because it sidesteps any local-counting drift; for now we
+//     only consume `last_token_usage` so the adapter has a single shape.
+//   - Old session directories outside the weekly retention window are
+//     skipped to keep cold-start cheap.
+//
+// TODO(usage): switch to `rate_limits.primary.used_percent` for the 5h
+// window once we plumb a "report percent directly" hook through the
+// aggregator.
+package codex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/usage"
+)
+
+// Name is the adapter's registered identifier.
+const Name = "codex"
+
+// scanWindow caps how far back the adapter walks rollout transcripts.
+const scanWindow = 8 * 24 * time.Hour
+
+// Adapter is the Codex implementation of usage.Adapter.
+type Adapter struct {
+	homeDir      func() (string, error)
+	now          func() time.Time
+	rootOverride string
+}
+
+// New returns an Adapter that reads from $HOME/.codex/sessions.
+func New() *Adapter {
+	return &Adapter{homeDir: os.UserHomeDir, now: time.Now}
+}
+
+// NewWithRoot is intended for tests.
+func NewWithRoot(root string) *Adapter {
+	return &Adapter{homeDir: os.UserHomeDir, now: time.Now, rootOverride: root}
+}
+
+// Name implements usage.Adapter.
+func (a *Adapter) Name() string { return Name }
+
+// Collect walks the rollout tree and emits one TokenEvent per token_count
+// record. Best-effort: missing tree => nil events, malformed lines skipped
+// silently.
+func (a *Adapter) Collect(ctx context.Context) ([]usage.TokenEvent, error) {
+	root, err := a.resolveRoot()
+	if err != nil {
+		return nil, nil
+	}
+	if _, err := os.Stat(root); err != nil {
+		return nil, nil
+	}
+
+	now := a.now().UTC()
+	cutoff := now.Add(-scanWindow)
+
+	var events []usage.TokenEvent
+
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrPermission) {
+				return nil
+			}
+			return nil
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".jsonl") {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return nil
+		}
+		if info.ModTime().Before(cutoff) {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		events = append(events, scanRollout(path, cutoff)...)
+		return nil
+	})
+	if walkErr != nil && !errors.Is(walkErr, ctx.Err()) {
+		return nil, nil
+	}
+	return events, nil
+}
+
+func (a *Adapter) resolveRoot() (string, error) {
+	if a.rootOverride != "" {
+		return a.rootOverride, nil
+	}
+	home, err := a.homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".codex", "sessions"), nil
+}
+
+// rolloutRecord captures the bits of the codex rollout schema we need.
+type rolloutRecord struct {
+	Timestamp time.Time `json:"timestamp"`
+	Type      string    `json:"type"`
+	Payload   *struct {
+		Type string `json:"type"`
+		Info *struct {
+			LastTokenUsage *struct {
+				TotalTokens int64 `json:"total_tokens"`
+			} `json:"last_token_usage"`
+		} `json:"info"`
+	} `json:"payload"`
+}
+
+func scanRollout(path string, cutoff time.Time) []usage.TokenEvent {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	const maxLine = 16 * 1024 * 1024
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLine)
+
+	var out []usage.TokenEvent
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var rec rolloutRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			continue
+		}
+		if rec.Type != "event_msg" || rec.Payload == nil {
+			continue
+		}
+		if rec.Payload.Type != "token_count" {
+			continue
+		}
+		if rec.Payload.Info == nil || rec.Payload.Info.LastTokenUsage == nil {
+			continue
+		}
+		if rec.Timestamp.Before(cutoff) {
+			continue
+		}
+		tokens := rec.Payload.Info.LastTokenUsage.TotalTokens
+		if tokens <= 0 {
+			continue
+		}
+		out = append(out, usage.TokenEvent{At: rec.Timestamp.UTC(), Tokens: tokens})
+	}
+	return out
+}

--- a/internal/core/usage/adapters/codex/codex_test.go
+++ b/internal/core/usage/adapters/codex/codex_test.go
@@ -1,0 +1,80 @@
+package codex
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAdapterCollectFromRolloutFixture(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dayDir := filepath.Join(dir, "2026", "05", "06")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	body := `{"timestamp":"2026-05-06T11:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":1000}}}}` + "\n" +
+		`{"timestamp":"2026-05-06T11:01:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":2500}}}}` + "\n" +
+		// Non-token_count event is ignored.
+		`{"timestamp":"2026-05-06T11:02:00Z","type":"event_msg","payload":{"type":"agent_message"}}` + "\n"
+	file := filepath.Join(dayDir, "rollout-2026-05-06T11-00-00-test.jsonl")
+	if err := os.WriteFile(file, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	a := NewWithRoot(dir)
+	a.now = func() time.Time { return time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC) }
+
+	events, err := a.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2", len(events))
+	}
+	if events[0].Tokens != 1000 || events[1].Tokens != 2500 {
+		t.Fatalf("events = %+v, want tokens [1000, 2500]", events)
+	}
+}
+
+func TestAdapterCollectMissingRootIsBestEffort(t *testing.T) {
+	t.Parallel()
+
+	a := NewWithRoot(filepath.Join(t.TempDir(), "missing"))
+	events, err := a.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if events != nil {
+		t.Fatalf("events = %v, want nil", events)
+	}
+}
+
+func TestAdapterCollectIgnoresUnknownPayload(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dayDir := filepath.Join(dir, "2026", "05", "06")
+	_ = os.MkdirAll(dayDir, 0o755)
+	body := `{"timestamp":"2026-05-06T11:00:00Z","type":"event_msg","payload":{"type":"token_count","info":null}}` + "\n" +
+		`not-json` + "\n" +
+		`{"timestamp":"2026-05-06T11:01:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":0}}}}` + "\n"
+	file := filepath.Join(dayDir, "rollout-empty.jsonl")
+	if err := os.WriteFile(file, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	a := NewWithRoot(dir)
+	a.now = func() time.Time { return time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC) }
+
+	events, err := a.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("got %d events, want 0", len(events))
+	}
+}

--- a/internal/core/usage/aggregate.go
+++ b/internal/core/usage/aggregate.go
@@ -1,0 +1,137 @@
+package usage
+
+import (
+	"sort"
+	"time"
+)
+
+// Aggregate computes Snapshots for a single model across the canonical
+// windows. The caller supplies the persisted bucket slice (from Store.Append
+// or Store.Load), the current wall clock, and the resolved Limits row for
+// the model. The returned snapshots are ordered as AllWindows().
+//
+// Rollover policy:
+//
+//   - Window5h: rolling. ResetsAt is the timestamp at which the EARLIEST
+//     event currently inside the window will fall out, i.e. earliest + 5h.
+//     If the window has no events, ResetsAt is now + 5h. Documented per
+//     spec.
+//   - WindowWeekly: calendar-aligned. ResetsAt is the next Monday 00:00 in
+//     the local timezone. This matches the reset cadence Anthropic and
+//     OpenAI publicly document at the time of writing.
+func Aggregate(model string, buckets []Bucket, limits ModelLimits, now time.Time) []Snapshot {
+	out := make([]Snapshot, 0, len(AllWindows()))
+	for _, w := range AllWindows() {
+		out = append(out, snapshotFor(model, w, buckets, limits, now))
+	}
+	return out
+}
+
+// snapshotFor returns the snapshot for one (model, window) pair.
+func snapshotFor(model string, w Window, buckets []Bucket, limits ModelLimits, now time.Time) Snapshot {
+	cutoff := windowStart(w, now)
+	tokens, earliest := sumWithin(buckets, cutoff, now)
+	limit := limits.For(w)
+	pct := 0.0
+	if limit > 0 {
+		pct = float64(tokens) / float64(limit) * 100.0
+	}
+	return Snapshot{
+		Model:     model,
+		Window:    w,
+		Tokens:    tokens,
+		Limit:     limit,
+		Pct:       pct,
+		ResetsAt:  NextResetAt(w, earliest, now),
+		UpdatedAt: now,
+	}
+}
+
+// windowStart returns the inclusive lower bound for events that should be
+// counted in this window relative to now.
+func windowStart(w Window, now time.Time) time.Time {
+	switch w {
+	case Window5h:
+		return now.Add(-w.Duration())
+	case WindowWeekly:
+		// For aggregation purposes we still compute a 7-day rolling sum.
+		// The Monday-rollover policy only affects ResetsAt below; consumed
+		// tokens accrue across the rolling 168-hour window so callers can
+		// see usage trends near the boundary instead of a cliff.
+		return now.Add(-w.Duration())
+	default:
+		return now
+	}
+}
+
+// sumWithin returns (tokens, earliest) for the buckets between [cutoff, now].
+// earliest is the zero time when the window has no events.
+func sumWithin(buckets []Bucket, cutoff, now time.Time) (int64, time.Time) {
+	cutoff = cutoff.UTC()
+	end := now.UTC()
+	var tokens int64
+	var earliest time.Time
+	for _, b := range buckets {
+		m := b.Minute.UTC()
+		if m.Before(cutoff) {
+			continue
+		}
+		if m.After(end) {
+			continue
+		}
+		tokens += b.Tokens
+		if earliest.IsZero() || m.Before(earliest) {
+			earliest = m
+		}
+	}
+	return tokens, earliest
+}
+
+// NextResetAt computes the next rollover for the window. earliest is the
+// earliest in-window event minute (zero if none). Documented in Aggregate.
+func NextResetAt(w Window, earliest, now time.Time) time.Time {
+	switch w {
+	case Window5h:
+		if earliest.IsZero() {
+			return now.Add(w.Duration())
+		}
+		return earliest.Add(w.Duration())
+	case WindowWeekly:
+		return nextMondayMidnight(now)
+	default:
+		return time.Time{}
+	}
+}
+
+// nextMondayMidnight returns the next Monday 00:00 in now's local timezone.
+// If now is exactly Monday 00:00, the result is one week later.
+func nextMondayMidnight(now time.Time) time.Time {
+	loc := now.Location()
+	if loc == nil {
+		loc = time.UTC
+	}
+	year, month, day := now.Date()
+	startOfToday := time.Date(year, month, day, 0, 0, 0, 0, loc)
+	weekday := int(startOfToday.Weekday()) // Sunday = 0 ... Saturday = 6.
+	// Days until next Monday. weekday=Mon(1) -> 7 days (next Monday, not now).
+	daysUntil := (8 - weekday) % 7
+	if daysUntil == 0 {
+		daysUntil = 7
+	}
+	return startOfToday.AddDate(0, 0, daysUntil)
+}
+
+// SortedSnapshots returns snapshots ordered by (model, window). Convenience
+// for CLI rendering that wants stable output.
+func SortedSnapshots(snaps []Snapshot) []Snapshot {
+	out := make([]Snapshot, len(snaps))
+	copy(out, snaps)
+	windowOrder := map[Window]int{Window5h: 0, WindowWeekly: 1}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Model != out[j].Model {
+			return out[i].Model < out[j].Model
+		}
+		return windowOrder[out[i].Window] < windowOrder[out[j].Window]
+	})
+	return out
+}

--- a/internal/core/usage/aggregate_test.go
+++ b/internal/core/usage/aggregate_test.go
@@ -1,0 +1,158 @@
+package usage
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestAggregate5hWindowSumsAndComputesPct(t *testing.T) {
+	t.Parallel()
+
+	now := mustTime(t, "2026-05-06T12:00:00Z")
+	buckets := []Bucket{
+		{Minute: mustTime(t, "2026-05-06T08:00:00Z"), Tokens: 100}, // 4h ago — in.
+		{Minute: mustTime(t, "2026-05-06T11:30:00Z"), Tokens: 50},  // 30m ago — in.
+		{Minute: mustTime(t, "2026-05-06T05:00:00Z"), Tokens: 25},  // 7h ago — out.
+	}
+	limits := ModelLimits{Window5h: 1000, WindowWeekly: 5000}
+
+	snaps := Aggregate("claude", buckets, limits, now)
+	if len(snaps) != 2 {
+		t.Fatalf("len(snaps) = %d, want 2", len(snaps))
+	}
+	five := snaps[0]
+	if five.Window != Window5h {
+		t.Fatalf("snaps[0].Window = %q, want %q", five.Window, Window5h)
+	}
+	if five.Tokens != 150 {
+		t.Fatalf("5h tokens = %d, want 150", five.Tokens)
+	}
+	if five.Limit != 1000 {
+		t.Fatalf("5h limit = %d, want 1000", five.Limit)
+	}
+	if five.Pct < 14.99 || five.Pct > 15.01 {
+		t.Fatalf("5h pct = %v, want ~15", five.Pct)
+	}
+	want := mustTime(t, "2026-05-06T08:00:00Z").Add(5 * time.Hour)
+	if !five.ResetsAt.Equal(want) {
+		t.Fatalf("5h ResetsAt = %v, want earliest+5h = %v", five.ResetsAt, want)
+	}
+}
+
+func TestAggregate5hEmptyResetsAtIsNowPlus5h(t *testing.T) {
+	t.Parallel()
+
+	now := mustTime(t, "2026-05-06T12:00:00Z")
+	snaps := Aggregate("claude", nil, ModelLimits{}, now)
+	if len(snaps) != 2 {
+		t.Fatalf("len(snaps) = %d, want 2", len(snaps))
+	}
+	if snaps[0].Tokens != 0 {
+		t.Fatalf("tokens = %d, want 0", snaps[0].Tokens)
+	}
+	if snaps[0].Pct != 0 {
+		t.Fatalf("pct = %v, want 0 (limit unknown)", snaps[0].Pct)
+	}
+	want := now.Add(5 * time.Hour)
+	if !snaps[0].ResetsAt.Equal(want) {
+		t.Fatalf("ResetsAt = %v, want %v", snaps[0].ResetsAt, want)
+	}
+}
+
+func TestAggregateWeeklyResetsAtNextMondayMidnight(t *testing.T) {
+	t.Parallel()
+
+	loc, err := time.LoadLocation("Asia/Seoul")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+	// 2026-05-06 is a Wednesday in Asia/Seoul. Next Monday = 2026-05-11 00:00.
+	now := time.Date(2026, 5, 6, 15, 30, 0, 0, loc)
+	snaps := Aggregate("claude", nil, ModelLimits{}, now)
+	weekly := snaps[1]
+	if weekly.Window != WindowWeekly {
+		t.Fatalf("snaps[1].Window = %q, want %q", weekly.Window, WindowWeekly)
+	}
+	got := weekly.ResetsAt.In(loc)
+	want := time.Date(2026, 5, 11, 0, 0, 0, 0, loc)
+	if !got.Equal(want) {
+		t.Fatalf("weekly ResetsAt = %v, want %v", got, want)
+	}
+}
+
+func TestNextMondayMidnightOnMondayRollsForwardOneWeek(t *testing.T) {
+	t.Parallel()
+
+	loc := time.UTC
+	monday := time.Date(2026, 5, 4, 0, 0, 0, 0, loc) // Monday 00:00.
+	got := nextMondayMidnight(monday)
+	want := time.Date(2026, 5, 11, 0, 0, 0, 0, loc)
+	if !got.Equal(want) {
+		t.Fatalf("nextMondayMidnight(Mon 00:00) = %v, want %v", got, want)
+	}
+
+	// Sunday 23:59 should land on the next day's midnight (Monday).
+	sunday := time.Date(2026, 5, 10, 23, 59, 0, 0, loc)
+	got = nextMondayMidnight(sunday)
+	want = time.Date(2026, 5, 11, 0, 0, 0, 0, loc)
+	if !got.Equal(want) {
+		t.Fatalf("nextMondayMidnight(Sun 23:59) = %v, want %v", got, want)
+	}
+}
+
+func TestSumWithinIgnoresOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	now := mustTime(t, "2026-05-06T12:00:00Z")
+	cutoff := now.Add(-time.Hour)
+	buckets := []Bucket{
+		{Minute: mustTime(t, "2026-05-06T13:00:00Z"), Tokens: 99}, // future — drop.
+		{Minute: mustTime(t, "2026-05-06T11:30:00Z"), Tokens: 5},  // in.
+	}
+	tokens, earliest := sumWithin(buckets, cutoff, now)
+	if tokens != 5 {
+		t.Fatalf("tokens = %d, want 5", tokens)
+	}
+	if !earliest.Equal(mustTime(t, "2026-05-06T11:30:00Z")) {
+		t.Fatalf("earliest = %v, want 11:30", earliest)
+	}
+}
+
+func TestLoadLimitsAppliesOverrideOnTopOfDefaults(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := dir + "/limits.json"
+	body := `{"claude": {"5h": 12345}, "newmodel": {"weekly": 999}}`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	limits, err := LoadLimits(path)
+	if err != nil {
+		t.Fatalf("LoadLimits: %v", err)
+	}
+	if limits.For("claude").For(Window5h) != 12345 {
+		t.Fatalf("claude 5h = %d, want 12345 (override)", limits.For("claude").For(Window5h))
+	}
+	// Unmodified field falls through to default.
+	if limits.For("claude").For(WindowWeekly) != DefaultLimits["claude"][WindowWeekly] {
+		t.Fatalf("claude weekly = %d, want default", limits.For("claude").For(WindowWeekly))
+	}
+	if limits.For("newmodel").For(WindowWeekly) != 999 {
+		t.Fatalf("newmodel weekly = %d, want 999", limits.For("newmodel").For(WindowWeekly))
+	}
+}
+
+func TestLoadLimitsMissingFileReturnsDefaults(t *testing.T) {
+	t.Parallel()
+
+	limits, err := LoadLimits("/does/not/exist.json")
+	if err != nil {
+		t.Fatalf("LoadLimits missing path error = %v", err)
+	}
+	if limits.For("claude").For(Window5h) != DefaultLimits["claude"][Window5h] {
+		t.Fatalf("default 5h not preserved")
+	}
+}
+

--- a/internal/core/usage/aggregate_test.go
+++ b/internal/core/usage/aggregate_test.go
@@ -155,4 +155,3 @@ func TestLoadLimitsMissingFileReturnsDefaults(t *testing.T) {
 		t.Fatalf("default 5h not preserved")
 	}
 }
-

--- a/internal/core/usage/limits.go
+++ b/internal/core/usage/limits.go
@@ -1,0 +1,104 @@
+package usage
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// LimitsEnvVar is the environment variable that, when set, points to a JSON
+// file overriding the hardcoded model limits. The JSON layout mirrors
+// LimitsFile below, e.g.:
+//
+//	{
+//	  "claude": {"5h": 1000000, "weekly": 20000000},
+//	  "codex":  {"5h": 500000,  "weekly": 10000000}
+//	}
+const LimitsEnvVar = "PROJMUX_USAGE_LIMITS_PATH"
+
+// Default limits — placeholders until the real numbers are pulled from each
+// vendor's API.
+//
+// TODO(usage): pull real limits from the Anthropic / OpenAI APIs (or, for
+// Claude Code, surface them via `claude usage` once that lands). The values
+// below are deliberately round numbers chosen as conservative ballpark caps
+// so a 0%-or-100% status segment doesn't render as missing data.
+var DefaultLimits = Limits{
+	"claude": {Window5h: 1_000_000, WindowWeekly: 20_000_000},
+	"codex":  {Window5h: 500_000, WindowWeekly: 10_000_000},
+}
+
+// ModelLimits is a per-window limit row for a single model.
+type ModelLimits map[Window]int64
+
+// For returns the limit for the given window, or 0 when unknown.
+func (m ModelLimits) For(w Window) int64 {
+	if m == nil {
+		return 0
+	}
+	return m[w]
+}
+
+// Limits is the model-keyed limit table the aggregator consumes.
+type Limits map[string]ModelLimits
+
+// For returns the ModelLimits row for the model name, or nil.
+func (l Limits) For(model string) ModelLimits {
+	if l == nil {
+		return nil
+	}
+	return l[strings.ToLower(model)]
+}
+
+// LoadLimits returns the effective limits, applying the override file at
+// path on top of the defaults. An empty path or a missing file returns the
+// defaults verbatim with no error so the env var stays optional.
+func LoadLimits(path string) (Limits, error) {
+	merged := cloneLimits(DefaultLimits)
+	if strings.TrimSpace(path) == "" {
+		return merged, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return merged, nil
+		}
+		return nil, fmt.Errorf("usage: read limits %s: %w", path, err)
+	}
+	override := Limits{}
+	if err := json.Unmarshal(data, &override); err != nil {
+		return nil, fmt.Errorf("usage: parse limits %s: %w", path, err)
+	}
+	for model, row := range override {
+		key := strings.ToLower(strings.TrimSpace(model))
+		if key == "" {
+			continue
+		}
+		dst, ok := merged[key]
+		if !ok || dst == nil {
+			dst = ModelLimits{}
+		}
+		for w, v := range row {
+			if v < 0 {
+				continue
+			}
+			dst[w] = v
+		}
+		merged[key] = dst
+	}
+	return merged, nil
+}
+
+func cloneLimits(in Limits) Limits {
+	out := make(Limits, len(in))
+	for model, row := range in {
+		copyRow := make(ModelLimits, len(row))
+		for w, v := range row {
+			copyRow[w] = v
+		}
+		out[model] = copyRow
+	}
+	return out
+}

--- a/internal/core/usage/manager.go
+++ b/internal/core/usage/manager.go
@@ -1,0 +1,88 @@
+package usage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Manager wires a Registry, a Store, and a Limits table into the standard
+// "collect, persist, aggregate" flow consumed by the CLI.
+type Manager struct {
+	registry *Registry
+	store    *Store
+	limits   Limits
+	now      func() time.Time
+}
+
+// NewManager constructs a Manager. now defaults to time.Now when nil.
+func NewManager(registry *Registry, store *Store, limits Limits, now func() time.Time) *Manager {
+	if now == nil {
+		now = time.Now
+	}
+	return &Manager{registry: registry, store: store, limits: limits, now: now}
+}
+
+// Collect runs every registered adapter, appends the resulting events into
+// the per-model cache, aggregates the canonical windows, and returns a flat
+// list of Snapshots. Adapter errors are surfaced as a joined error but
+// non-fatal — successful adapters' snapshots are still returned.
+func (m *Manager) Collect(ctx context.Context) ([]Snapshot, error) {
+	if m == nil {
+		return nil, errors.New("usage: nil manager")
+	}
+	if m.registry == nil {
+		return nil, errors.New("usage: nil registry")
+	}
+	if m.store == nil {
+		return nil, errors.New("usage: nil store")
+	}
+
+	now := m.now().UTC()
+	var allSnaps []Snapshot
+	var errs []error
+	for _, adapter := range m.registry.All() {
+		events, err := adapter.Collect(ctx)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", adapter.Name(), err))
+		}
+		buckets, storeErr := m.store.Append(adapter.Name(), events, now)
+		if storeErr != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", adapter.Name(), storeErr))
+			continue
+		}
+		modelLimits := m.limits.For(adapter.Name())
+		allSnaps = append(allSnaps, Aggregate(adapter.Name(), buckets, modelLimits, now)...)
+	}
+	if len(errs) > 0 {
+		return allSnaps, errors.Join(errs...)
+	}
+	return allSnaps, nil
+}
+
+// LoadAll re-aggregates the persisted cache without invoking adapters. Useful
+// for the status-bar segment which wants to be cheap and read-only on the
+// hot path.
+func (m *Manager) LoadAll() ([]Snapshot, error) {
+	if m == nil {
+		return nil, errors.New("usage: nil manager")
+	}
+	if m.registry == nil {
+		return nil, errors.New("usage: nil registry")
+	}
+	if m.store == nil {
+		return nil, errors.New("usage: nil store")
+	}
+	now := m.now().UTC()
+	var allSnaps []Snapshot
+	for _, adapter := range m.registry.All() {
+		buckets, err := m.store.Load(adapter.Name())
+		if err != nil {
+			return nil, err
+		}
+		modelLimits := m.limits.For(adapter.Name())
+		allSnaps = append(allSnaps, Aggregate(adapter.Name(), buckets, modelLimits, now)...)
+	}
+	return allSnaps, nil
+}

--- a/internal/core/usage/registry.go
+++ b/internal/core/usage/registry.go
@@ -1,0 +1,105 @@
+package usage
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Adapter is the pluggable contract for an AI-usage data source.
+//
+// Adapters return raw TokenEvents. They MUST NOT perform aggregation — the
+// Store and Aggregator handle bucketing and window math centrally so a future
+// PR can swap in real data sources without touching CLI code.
+//
+// Best-effort v0 contract: when data is not yet reachable (logs missing,
+// schema unknown, etc), implementations should return nil events and a nil
+// error so the pipeline degrades to "no data" rather than failing loudly.
+type Adapter interface {
+	Name() string
+	Collect(ctx context.Context) ([]TokenEvent, error)
+}
+
+// Registry stores adapters keyed by Name(). It is safe for concurrent use.
+type Registry struct {
+	mu       sync.RWMutex
+	adapters map[string]Adapter
+}
+
+// NewRegistry returns an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{adapters: make(map[string]Adapter)}
+}
+
+// Register adds an adapter to the registry. Re-registering the same name
+// returns an error; callers that want to override should call Replace.
+func (r *Registry) Register(a Adapter) error {
+	if a == nil {
+		return fmt.Errorf("usage: register nil adapter")
+	}
+	name := a.Name()
+	if name == "" {
+		return fmt.Errorf("usage: register adapter with empty name")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.adapters[name]; exists {
+		return fmt.Errorf("usage: adapter %q already registered", name)
+	}
+	r.adapters[name] = a
+	return nil
+}
+
+// Replace registers an adapter, overwriting any prior adapter with the same
+// name. Mostly useful in tests.
+func (r *Registry) Replace(a Adapter) error {
+	if a == nil {
+		return fmt.Errorf("usage: replace with nil adapter")
+	}
+	name := a.Name()
+	if name == "" {
+		return fmt.Errorf("usage: replace adapter with empty name")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.adapters[name] = a
+	return nil
+}
+
+// Lookup returns the adapter registered under name. The bool is false when
+// no adapter has been registered.
+func (r *Registry) Lookup(name string) (Adapter, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	a, ok := r.adapters[name]
+	return a, ok
+}
+
+// Names returns the registered adapter names in lexicographic order.
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.adapters))
+	for n := range r.adapters {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// All returns every registered adapter, ordered by Name().
+func (r *Registry) All() []Adapter {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.adapters))
+	for n := range r.adapters {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	out := make([]Adapter, 0, len(names))
+	for _, n := range names {
+		out = append(out, r.adapters[n])
+	}
+	return out
+}

--- a/internal/core/usage/registry_test.go
+++ b/internal/core/usage/registry_test.go
@@ -1,0 +1,108 @@
+package usage
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+type fakeAdapter struct {
+	name   string
+	events []TokenEvent
+	err    error
+}
+
+func (f *fakeAdapter) Name() string { return f.name }
+func (f *fakeAdapter) Collect(ctx context.Context) ([]TokenEvent, error) {
+	return f.events, f.err
+}
+
+func TestRegistryRegisterAndLookup(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	c := &fakeAdapter{name: "claude"}
+	x := &fakeAdapter{name: "codex"}
+
+	if err := r.Register(c); err != nil {
+		t.Fatalf("Register(claude) error = %v", err)
+	}
+	if err := r.Register(x); err != nil {
+		t.Fatalf("Register(codex) error = %v", err)
+	}
+
+	got, ok := r.Lookup("claude")
+	if !ok {
+		t.Fatalf("Lookup(claude) ok=false, want true")
+	}
+	if got.Name() != "claude" {
+		t.Fatalf("Lookup(claude).Name() = %q, want claude", got.Name())
+	}
+
+	if _, ok := r.Lookup("missing"); ok {
+		t.Fatalf("Lookup(missing) ok=true, want false")
+	}
+
+	if got, want := r.Names(), []string{"claude", "codex"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Names() = %v, want %v", got, want)
+	}
+}
+
+func TestRegistryRegisterDuplicateRejected(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	if err := r.Register(&fakeAdapter{name: "claude"}); err != nil {
+		t.Fatalf("first Register error = %v", err)
+	}
+	if err := r.Register(&fakeAdapter{name: "claude"}); err == nil {
+		t.Fatalf("duplicate Register error = nil, want non-nil")
+	}
+}
+
+func TestRegistryReplaceOverridesExisting(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	original := &fakeAdapter{name: "claude"}
+	replacement := &fakeAdapter{name: "claude"}
+
+	if err := r.Register(original); err != nil {
+		t.Fatalf("Register error = %v", err)
+	}
+	if err := r.Replace(replacement); err != nil {
+		t.Fatalf("Replace error = %v", err)
+	}
+	got, _ := r.Lookup("claude")
+	if got != replacement {
+		t.Fatalf("Lookup after Replace = %v, want %v", got, replacement)
+	}
+}
+
+func TestRegistryRejectsEmptyName(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	if err := r.Register(&fakeAdapter{name: ""}); err == nil {
+		t.Fatalf("Register(empty name) error = nil, want non-nil")
+	}
+	if err := r.Register(nil); err == nil {
+		t.Fatalf("Register(nil) error = nil, want non-nil")
+	}
+}
+
+func TestRegistryAllReturnsSorted(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	_ = r.Register(&fakeAdapter{name: "codex"})
+	_ = r.Register(&fakeAdapter{name: "claude"})
+
+	all := r.All()
+	if len(all) != 2 {
+		t.Fatalf("All() len = %d, want 2", len(all))
+	}
+	if all[0].Name() != "claude" || all[1].Name() != "codex" {
+		t.Fatalf("All() order = %s,%s; want claude,codex", all[0].Name(), all[1].Name())
+	}
+}

--- a/internal/core/usage/store.go
+++ b/internal/core/usage/store.go
@@ -1,0 +1,214 @@
+package usage
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// retentionDuration controls how far back the rolling cache is preserved.
+// 8 days covers the weekly window with a safety margin so a clock skew or a
+// missed collection cycle near the boundary does not silently drop data.
+const retentionDuration = 8 * 24 * time.Hour
+
+// bucketLayout records bucket-key formatting. Buckets are 1-minute wide and
+// keyed by RFC3339 minute timestamps so the persisted file stays
+// human-inspectable.
+const bucketLayout = "2006-01-02T15:04Z07:00"
+
+// cacheFile is the on-disk schema for a single model's bucket cache. The
+// schema is intentionally tiny so future PRs can extend it without breaking
+// older clients.
+type cacheFile struct {
+	Version int           `json:"version"`
+	Model   string        `json:"model"`
+	Buckets []cacheBucket `json:"buckets"`
+}
+
+type cacheBucket struct {
+	// Minute is the bucket's UTC minute boundary (truncated).
+	Minute time.Time `json:"minute"`
+	// Tokens is the sum of TokenEvent.Tokens that fell into this bucket.
+	Tokens int64 `json:"tokens"`
+}
+
+// Store persists per-minute token totals for a single model under
+// <baseDir>/<model>.json.
+type Store struct {
+	baseDir string
+}
+
+// NewStore returns a Store rooted at baseDir. Callers typically pass
+// filepath.Join(paths.StateDir, "usage").
+func NewStore(baseDir string) *Store {
+	return &Store{baseDir: baseDir}
+}
+
+// FilePath returns the on-disk JSON path used for a specific model. Exposed
+// so callers can plumb it through diagnostics.
+func (s *Store) FilePath(model string) string {
+	return filepath.Join(s.baseDir, sanitizeModel(model)+".json")
+}
+
+// Load reads the cache for a given model. A missing file reads as an empty
+// cache (no error) so first-run callers see []Bucket{}.
+func (s *Store) Load(model string) ([]Bucket, error) {
+	path := s.FilePath(model)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("usage: read cache %s: %w", path, err)
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var f cacheFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("usage: parse cache %s: %w", path, err)
+	}
+	out := make([]Bucket, 0, len(f.Buckets))
+	for _, b := range f.Buckets {
+		out = append(out, Bucket{Minute: b.Minute.UTC(), Tokens: b.Tokens})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Minute.Before(out[j].Minute) })
+	return out, nil
+}
+
+// Append merges new TokenEvents into the existing buckets, trims entries
+// older than the retention window relative to now, and writes the cache
+// atomically. Returns the merged bucket slice the caller can pass straight
+// to the aggregator without re-reading disk.
+func (s *Store) Append(model string, events []TokenEvent, now time.Time) ([]Bucket, error) {
+	existing, err := s.Load(model)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := mergeEvents(existing, events)
+	merged = trim(merged, now.Add(-retentionDuration))
+
+	if err := s.write(model, merged); err != nil {
+		return nil, err
+	}
+	return merged, nil
+}
+
+// write persists the merged bucket slice atomically.
+func (s *Store) write(model string, buckets []Bucket) error {
+	if err := os.MkdirAll(s.baseDir, 0o755); err != nil {
+		return fmt.Errorf("usage: create cache dir %s: %w", s.baseDir, err)
+	}
+	payload := cacheFile{
+		Version: 1,
+		Model:   model,
+		Buckets: make([]cacheBucket, 0, len(buckets)),
+	}
+	for _, b := range buckets {
+		payload.Buckets = append(payload.Buckets, cacheBucket{
+			Minute: b.Minute.UTC(),
+			Tokens: b.Tokens,
+		})
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("usage: encode cache: %w", err)
+	}
+	path := s.FilePath(model)
+	tmp, err := os.CreateTemp(s.baseDir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("usage: create temp cache: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("usage: write temp cache: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("usage: close temp cache: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		return fmt.Errorf("usage: chmod temp cache: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("usage: rename temp cache: %w", err)
+	}
+	cleanup = false
+	return nil
+}
+
+// Bucket is the in-memory representation of a 1-minute aggregation bucket.
+type Bucket struct {
+	Minute time.Time
+	Tokens int64
+}
+
+// mergeEvents folds a slice of raw events into the existing bucket list,
+// returning a new sorted slice keyed by 1-minute bucket boundaries.
+func mergeEvents(existing []Bucket, events []TokenEvent) []Bucket {
+	if len(events) == 0 {
+		return append([]Bucket(nil), existing...)
+	}
+	index := make(map[time.Time]int64, len(existing)+len(events))
+	for _, b := range existing {
+		index[b.Minute.UTC().Truncate(time.Minute)] += b.Tokens
+	}
+	for _, e := range events {
+		key := e.At.UTC().Truncate(time.Minute)
+		index[key] += e.Tokens
+	}
+	out := make([]Bucket, 0, len(index))
+	for minute, tokens := range index {
+		out = append(out, Bucket{Minute: minute, Tokens: tokens})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Minute.Before(out[j].Minute) })
+	return out
+}
+
+// trim drops buckets whose minute is strictly before the cutoff.
+func trim(buckets []Bucket, cutoff time.Time) []Bucket {
+	cutoff = cutoff.UTC().Truncate(time.Minute)
+	out := buckets[:0]
+	for _, b := range buckets {
+		if b.Minute.Before(cutoff) {
+			continue
+		}
+		out = append(out, b)
+	}
+	// Avoid handing the caller a slice that aliases the input's backing array
+	// in surprising ways: copy when the trimmed length differs.
+	trimmed := make([]Bucket, len(out))
+	copy(trimmed, out)
+	return trimmed
+}
+
+// sanitizeModel keeps cache file names safe for arbitrary model strings.
+func sanitizeModel(name string) string {
+	if name == "" {
+		return "_"
+	}
+	out := make([]rune, 0, len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '-', r == '_':
+			out = append(out, r)
+		default:
+			out = append(out, '_')
+		}
+	}
+	return string(out)
+}

--- a/internal/core/usage/store_test.go
+++ b/internal/core/usage/store_test.go
@@ -1,0 +1,117 @@
+package usage
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func mustTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("parse %q: %v", value, err)
+	}
+	return parsed.UTC()
+}
+
+func TestStoreLoadMissingReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore(t.TempDir())
+	got, err := s.Load("claude")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Load() = %v, want nil", got)
+	}
+}
+
+func TestStoreAppendAggregatesBucketsByMinute(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore(t.TempDir())
+	now := mustTime(t, "2026-05-06T12:30:00Z")
+	events := []TokenEvent{
+		{At: mustTime(t, "2026-05-06T12:00:10Z"), Tokens: 100},
+		{At: mustTime(t, "2026-05-06T12:00:55Z"), Tokens: 200},
+		{At: mustTime(t, "2026-05-06T12:05:00Z"), Tokens: 50},
+	}
+	merged, err := s.Append("claude", events, now)
+	if err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+	if len(merged) != 2 {
+		t.Fatalf("len(merged) = %d, want 2", len(merged))
+	}
+	if merged[0].Minute != mustTime(t, "2026-05-06T12:00:00Z") || merged[0].Tokens != 300 {
+		t.Fatalf("bucket[0] = %+v, want minute=12:00 tokens=300", merged[0])
+	}
+	if merged[1].Minute != mustTime(t, "2026-05-06T12:05:00Z") || merged[1].Tokens != 50 {
+		t.Fatalf("bucket[1] = %+v, want minute=12:05 tokens=50", merged[1])
+	}
+}
+
+func TestStoreAppendPersistsAndReloads(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := NewStore(dir)
+	now := mustTime(t, "2026-05-06T12:30:00Z")
+
+	if _, err := s.Append("codex", []TokenEvent{{At: mustTime(t, "2026-05-06T12:00:10Z"), Tokens: 7}}, now); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+	if _, err := s.Append("codex", []TokenEvent{{At: mustTime(t, "2026-05-06T12:00:50Z"), Tokens: 3}}, now); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+
+	reloaded, err := s.Load("codex")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(reloaded) != 1 {
+		t.Fatalf("len(reloaded) = %d, want 1", len(reloaded))
+	}
+	if reloaded[0].Tokens != 10 {
+		t.Fatalf("tokens = %d, want 10 (merged 7+3)", reloaded[0].Tokens)
+	}
+	// Sanity: file lives where FilePath says.
+	if got := s.FilePath("codex"); filepath.Dir(got) != dir {
+		t.Fatalf("FilePath dir = %q, want %q", filepath.Dir(got), dir)
+	}
+}
+
+func TestStoreAppendTrimsBeyondRetention(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore(t.TempDir())
+	now := mustTime(t, "2026-05-10T00:00:00Z")
+	events := []TokenEvent{
+		{At: mustTime(t, "2026-05-01T00:00:00Z"), Tokens: 1}, // 9 days ago — drop.
+		{At: mustTime(t, "2026-05-04T00:00:00Z"), Tokens: 2}, // 6 days ago — keep.
+		{At: mustTime(t, "2026-05-09T00:00:00Z"), Tokens: 4}, // 1 day ago — keep.
+	}
+	merged, err := s.Append("claude", events, now)
+	if err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+	if len(merged) != 2 {
+		t.Fatalf("len(merged) = %d, want 2 (after trim)", len(merged))
+	}
+	if merged[0].Tokens != 2 || merged[1].Tokens != 4 {
+		t.Fatalf("merged = %+v, want [{tokens:2}, {tokens:4}]", merged)
+	}
+}
+
+func TestStoreFilePathSanitizesModel(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore("/tmp/usage")
+	got := s.FilePath("claude/dangerous..name")
+	want := "/tmp/usage/claude_dangerous__name.json"
+	if got != want {
+		t.Fatalf("FilePath = %q, want %q", got, want)
+	}
+}

--- a/internal/core/usage/usage.go
+++ b/internal/core/usage/usage.go
@@ -1,0 +1,67 @@
+// Package usage models AI token usage tracking for projmux.
+//
+// The package exposes:
+//
+//   - Adapter / TokenEvent: a pluggable interface for collecting raw token
+//     events from external sources (CLI logs, API endpoints, etc).
+//   - Registry: a process-level registry of named adapters.
+//   - Store: a per-model 1-minute-bucketed cache persisted under
+//     <StateDir>/usage/<model>.json. Entries older than the weekly retention
+//     window are trimmed on append.
+//   - Aggregator: window math (5h rolling, weekly Mon 00:00 local rollover).
+//   - Limits: hardcoded placeholder limits with optional JSON override loaded
+//     from PROJMUX_USAGE_LIMITS_PATH.
+//
+// All adapters today are best-effort v0 stubs — if the data is not reachable
+// they return zero events (not an error) so the rest of the pipeline (and the
+// status-bar segment) degrades gracefully. See the per-adapter package
+// comment for the TODO that marks the real-data follow-up.
+package usage
+
+import "time"
+
+// Window enumerates the rolling windows the aggregator understands.
+type Window string
+
+const (
+	Window5h     Window = "5h"
+	WindowWeekly Window = "weekly"
+)
+
+// AllWindows returns the canonical ordered window list used by the CLI.
+func AllWindows() []Window {
+	return []Window{Window5h, WindowWeekly}
+}
+
+// Duration is the rolling window length used when aggregating events. The
+// weekly window's "duration" is approximate — actual rollover follows the
+// Monday-00:00-local boundary in NextResetAt.
+func (w Window) Duration() time.Duration {
+	switch w {
+	case Window5h:
+		return 5 * time.Hour
+	case WindowWeekly:
+		return 7 * 24 * time.Hour
+	default:
+		return 0
+	}
+}
+
+// TokenEvent is a single point-in-time count of consumed tokens reported by
+// an adapter. Adapters emit raw events; aggregation is the Store's job.
+type TokenEvent struct {
+	At     time.Time
+	Tokens int64
+}
+
+// Snapshot is the aggregated, CLI-facing view of usage for one (model,
+// window) pair.
+type Snapshot struct {
+	Model     string    `json:"model"`
+	Window    Window    `json:"window"`
+	Tokens    int64     `json:"tokens"`
+	Limit     int64     `json:"limit"`
+	Pct       float64   `json:"pct"`
+	ResetsAt  time.Time `json:"resets_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}


### PR DESCRIPTION
## Summary
- New `projmux usage [--model codex|claude|all] [--window 5h|weekly|all] [--json]` and `projmux status usage` subcommand for status-bar embedding.
- Pluggable adapter registry; **real data sources wired** (not stubbed):
  - **Claude**: scans `~/.claude/projects/<flat-cwd>/<sessionID>.jsonl`, dedupes by `requestId`, counts billable tokens (input + output + cache_creation; cache reads excluded).
  - **Codex**: walks `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`, emits per `event_msg/token_count` using `info.last_token_usage.total_tokens`.
- Rolling 1-minute bucketed cache at `<StateDir>/usage/<model>.json`, 8-day trim.

## Design notes
- **Rollover policy**: 5h is rolling (resets_at = earliest_event + 5h); weekly is calendar-aligned to next Monday 00:00 local but aggregation uses rolling 168h sum so usage doesn't cliff at boundary.
- **Limit defaults** (placeholders, flagged with `TODO(usage): pull real limits from API`):
  - claude 5h=1M / weekly=20M
  - codex 5h=500k / weekly=10M
  - Override via `PROJMUX_USAGE_LIMITS_PATH` JSON
- Both adapters cap walks to mtime > now-8d and silently skip malformed lines so transient errors never break the status segment.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (registry, store, aggregator, both adapters, CLI formatter — all pass)
- [x] Sanity: `projmux usage --json` returns 4 well-formed entries (claude+codex × 5h+weekly); on dev box reads real local data.
- [x] `projmux status usage --max-width 12` correctly truncates trailing group.

## Follow-ups (not in this PR)
- Wire `#(projmux status usage --max-width 24)` into tmux status-right template (lead's wiring slice).
- Add tmux `#[fg=...]` color escapes once thresholds (yellow >70%, red >90%) are agreed.
- Replace placeholder limits with real API lookup once authoritative numbers are exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)