### PR TITLE
feat(statusbar): three-line clickable status bar

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,31 @@ Ephemeral runtime state:
 - popup marker files
 - current tagged selection set
 
+## Three-line clickable status bar
+
+projmux configures tmux with `status 3`. Line 0 is the existing
+session/window/path/git/kube/clock row, line 1 is the AI usage bar, and line 2
+is the notification bar. Each clickable segment is wrapped in a tmux
+user-defined range (`#[range=user|<id>]...#[norange]`) and dispatched through
+`projmux statusbar click <range-id>`. A single `bind -n MouseDown1Status`
+covers all three lines because tmux fires `MouseDown1Status` from any line of a
+multi-line status bar with `#{mouse_status_range}` resolving to whichever
+range the cursor was over.
+
+| Range id | Line | Click action                              | Keybinding   |
+|----------|------|-------------------------------------------|--------------|
+| session  | 0    | display session name (TODO: picker)       | prefix+s s   |
+| pwd      | 0    | display pane_current_path                 | prefix+s p   |
+| kube     | 0    | (TODO: kube filter picker)                | prefix+s k   |
+| git      | 0    | (TODO: git filter picker)                 | prefix+s g   |
+| usage    | 1    | popup `projmux usage`                     | prefix+s u   |
+| notify   | 2    | focus origin pane of newest notification  | prefix+s n   |
+
+The keyboard chord uses `bind-key s switch-client -T projmux-status` so the
+prefix-then-`s`-then-letter shortcut routes through the same dispatcher as
+the mouse click. Empty `#{mouse_status_range}` (clicks on whitespace) is a
+no-op so the binding never flashes a spurious error.
+
 ## Non-goals
 
 - replacing tmux

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -52,6 +52,14 @@ the `projmux.TmuxCodex` AppUserModelID automatically on first use.
 ### Tmux status bar
 - `projmux status git [path]`
 - `projmux status kube [session]`
+- `projmux status usage [--max-width N]`
+- `projmux status notify [--max-width N]`
+- `projmux statusbar click <range-id> [--socket <s>] [--mouse-x N] [--mouse-y N]`
+
+`projmux statusbar click` is the click/keyboard dispatcher for the three-line
+status bar. Range ids are `session pwd kube git usage notify`. See
+[architecture.md](architecture.md#three-line-clickable-status-bar) for the
+full mapping.
 
 ### Tmux-facing helper entrypoints
 - `projmux tmux popup-toggle <mode>`

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -56,6 +56,7 @@ type App struct {
 	setup        *setupCommand
 	shell        *shellCommand
 	status       *statusCommand
+	statusbar    *statusbarCommand
 	switcher     *switchCommand
 	tag          *tagCommand
 	tmux         *tmuxCommand
@@ -86,6 +87,7 @@ func New() *App {
 		setup:        newSetupCommand(),
 		shell:        newShellCommand(),
 		status:       newStatusCommand(),
+		statusbar:    newStatusbarCommand(),
 		switcher:     switcher,
 		tag:          newTagCommand(),
 		tmux:         newTmuxCommand(),
@@ -138,6 +140,8 @@ func (a *App) Run(args []string, stdout, stderr io.Writer) error {
 		return a.shell.Run(args[1:], stdout, stderr)
 	case "status":
 		return a.status.Run(args[1:], stdout, stderr)
+	case "statusbar":
+		return a.statusbar.Run(args[1:], stdout, stderr)
 	case "switch":
 		return a.switcher.Run(args[1:], stdout, stderr)
 	case "tag":
@@ -182,6 +186,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  setup     Probe terminal key delivery for projmux bindings")
 	fmt.Fprintln(w, "  shell     Open the isolated projmux tmux app")
 	fmt.Fprintln(w, "  status    Render tmux status bar segments")
+	fmt.Fprintln(w, "  statusbar Dispatch projmux status bar clicks and shortcuts")
 	fmt.Fprintln(w, "  switch    Pick and open a project tmux session")
 	fmt.Fprintln(w, "  tag       Manage tagged tmux sessions")
 	fmt.Fprintln(w, "  tmux      Open tmux popup entry helpers")

--- a/internal/app/shell_test.go
+++ b/internal/app/shell_test.go
@@ -58,7 +58,7 @@ func TestShellWritesAppConfigAndRunsIsolatedTmux(t *testing.T) {
 		"bind-key -n User10 command-prompt",
 		"bind-key -n User11 command-prompt",
 		"set -g status-left-length 20",
-		"set -g status-left \"#[bold,fg=colour231,bg=colour90] #{s|^[^-]*-||:session_name} #[default]\"",
+		"set -g status-left \"#[range=user|session]#[bold,fg=colour231,bg=colour90] #{s|^[^-]*-||:session_name} #[default]#[norange]\"",
 		"#[bold,fg=colour231,bg=colour90] #{s|^[^-]*-||:session_name} #[default]",
 		"'/tmp/proj mux/bin/projmux' tmux popup-toggle --client #{client_tty} sessionizer-sidebar",
 	} {

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -3,12 +3,16 @@ package app
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/core/notify"
 )
 
 const (
@@ -17,21 +21,34 @@ const (
 )
 
 type statusCommand struct {
-	lookupEnv   func(string) string
-	homeDir     func() (string, error)
-	readCommand func(ctx context.Context, name string, args ...string) ([]byte, error)
-	now         func() time.Time
-	usage       *usageCommand
+	lookupEnv     func(string) string
+	homeDir       func() (string, error)
+	readCommand   func(ctx context.Context, name string, args ...string) ([]byte, error)
+	now           func() time.Time
+	usage         *usageCommand
+	notifyStoreFn func() (notifyStore, error)
 }
 
 func newStatusCommand() *statusCommand {
 	return &statusCommand{
-		lookupEnv:   os.Getenv,
-		homeDir:     os.UserHomeDir,
-		readCommand: readExternalCommand,
-		now:         time.Now,
-		usage:       newUsageCommand(),
+		lookupEnv:     os.Getenv,
+		homeDir:       os.UserHomeDir,
+		readCommand:   readExternalCommand,
+		now:           time.Now,
+		usage:         newUsageCommand(),
+		notifyStoreFn: defaultStatusNotifyStore,
 	}
+}
+
+// defaultStatusNotifyStore resolves the canonical notify queue used by the
+// status bar segment. Failures here become silent emptiness — the status
+// segment must never fail loudly during the tmux refresh interval.
+func defaultStatusNotifyStore() (notifyStore, error) {
+	paths, err := config.DefaultPathsFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("resolve default config paths: %w", err)
+	}
+	return notify.NewDefaultStore(paths), nil
 }
 
 func (c *statusCommand) Run(args []string, stdout, stderr io.Writer) error {
@@ -50,6 +67,8 @@ func (c *statusCommand) Run(args []string, stdout, stderr io.Writer) error {
 			c.usage = newUsageCommand()
 		}
 		return c.usage.runStatus(args[1:], stdout, stderr)
+	case "notify":
+		return c.runNotify(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
 		printStatusUsage(stdout)
 		return nil
@@ -284,4 +303,121 @@ func printStatusUsage(w io.Writer) {
 	fmt.Fprintln(w, "  projmux status git [path]")
 	fmt.Fprintln(w, "  projmux status kube [session]")
 	fmt.Fprintln(w, "  projmux status usage [--max-width N]")
+	fmt.Fprintln(w, "  projmux status notify [--max-width N]")
+}
+
+// defaultStatusNotifyMaxWidth bounds the rendered notification segment so it
+// cannot blow out the status line on narrow terminals.
+const defaultStatusNotifyMaxWidth = 200
+
+// runNotify renders the newest entry in the notify queue as a tmux status
+// segment. The segment is intentionally silent on failure — the tmux status
+// interval polls this command and must never produce a stack trace.
+func (c *statusCommand) runNotify(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("status notify", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	maxWidth := fs.Int("max-width", defaultStatusNotifyMaxWidth, "truncate the inner text to N runes (0 = no truncation)")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("status notify does not accept positional arguments")
+	}
+
+	store, err := c.notifyStore()
+	if err != nil {
+		// Status segments must never fail loudly.
+		return nil
+	}
+	entries, err := store.List()
+	if err != nil {
+		return nil
+	}
+	out := formatStatusNotify(entries, *maxWidth)
+	if out == "" {
+		return nil
+	}
+	_, err = fmt.Fprint(stdout, out)
+	return err
+}
+
+func (c *statusCommand) notifyStore() (notifyStore, error) {
+	if c.notifyStoreFn == nil {
+		return nil, errors.New("status notify store factory is not configured")
+	}
+	return c.notifyStoreFn()
+}
+
+// formatStatusNotify renders the newest entry of the queue as a single tmux
+// status segment. The output is plain ASCII (no emoji) and ends with a tmux
+// `#[default]` reset so adjacent segments are not stained by colors.
+//
+// Layout: `[X] <text> · <session> +<N>` where X is one of I/W/!.
+func formatStatusNotify(entries []notify.Notification, maxWidth int) string {
+	if len(entries) == 0 {
+		return ""
+	}
+	head := entries[0]
+	extras := len(entries) - 1
+	prefix := "[" + severityLetter(head.Severity) + "] "
+	suffix := " " + middotSeparator() + " " + head.Session
+	plus := ""
+	if extras > 0 {
+		plus = fmt.Sprintf(" +%d", extras)
+	}
+
+	overhead := runeLen(prefix) + runeLen(suffix) + runeLen(plus)
+	text := strings.TrimSpace(head.Text)
+	if maxWidth > 0 {
+		room := maxWidth - overhead
+		if room < 1 {
+			room = 1
+		}
+		if runeLen(text) > room {
+			rs := []rune(text)
+			if room <= 1 {
+				text = string(rs[:room])
+			} else {
+				text = string(rs[:room-1]) + "."
+			}
+		}
+	}
+
+	color := severityColor(head.Severity)
+	return color + prefix + text + suffix + plus + "#[default]"
+}
+
+// severityLetter maps notify severities to a single-character status letter.
+// Anything unknown falls back to `I` so we never emit garbage.
+func severityLetter(severity string) string {
+	switch severity {
+	case notify.SeverityWarn:
+		return "W"
+	case notify.SeverityCritical:
+		return "!"
+	default:
+		return "I"
+	}
+}
+
+// severityColor maps notify severities to the tmux color prefix. Info is the
+// default style (no color override) — tmux ignores empty `#[]` so we omit it.
+func severityColor(severity string) string {
+	switch severity {
+	case notify.SeverityWarn:
+		return "#[fg=yellow]"
+	case notify.SeverityCritical:
+		return "#[fg=red,bold]"
+	default:
+		return ""
+	}
+}
+
+// middotSeparator returns the ASCII separator used between the message body
+// and the session name. The spec requires plain ASCII so we use `-`.
+func middotSeparator() string {
+	return "-"
 }

--- a/internal/app/status_notify_test.go
+++ b/internal/app/status_notify_test.go
@@ -1,0 +1,179 @@
+package app
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/notify"
+)
+
+func newStatusNotifyCommand(store notifyStore) *statusCommand {
+	cmd := testStatusCommand("/tmp")
+	cmd.notifyStoreFn = func() (notifyStore, error) { return store, nil }
+	return cmd
+}
+
+func TestStatusNotifyEmptyQueueIsEmptyOutput(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStatusNotifyCommand(&stubNotifyStore{})
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"notify"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+}
+
+func TestStatusNotifyInfoEntryOmitsColorPrefix(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{ID: "a", Text: "hello", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+	}}
+	cmd := newStatusNotifyCommand(store)
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"notify"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got := stdout.String()
+	if !strings.HasPrefix(got, "[I] hello") {
+		t.Fatalf("stdout = %q, want prefix '[I] hello'", got)
+	}
+	if !strings.HasSuffix(got, "#[default]") {
+		t.Fatalf("stdout = %q, want suffix '#[default]'", got)
+	}
+	if strings.HasPrefix(got, "#[fg=") {
+		t.Fatalf("info severity should not emit a color prefix; got %q", got)
+	}
+	if !strings.Contains(got, "main") {
+		t.Fatalf("stdout = %q, want session 'main'", got)
+	}
+}
+
+func TestStatusNotifyWarnEntryEmitsYellow(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{ID: "a", Text: "warn-me", Severity: notify.SeverityWarn, Source: notify.SourceAI, Session: "ops"},
+	}}
+	cmd := newStatusNotifyCommand(store)
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"notify"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got := stdout.String()
+	if !strings.HasPrefix(got, "#[fg=yellow][W] warn-me") {
+		t.Fatalf("stdout = %q, want yellow warn prefix", got)
+	}
+}
+
+func TestStatusNotifyCriticalEntryEmitsRedBold(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{ID: "a", Text: "boom", Severity: notify.SeverityCritical, Source: notify.SourceAI, Session: "prod"},
+	}}
+	cmd := newStatusNotifyCommand(store)
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"notify"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got := stdout.String()
+	if !strings.HasPrefix(got, "#[fg=red,bold][!] boom") {
+		t.Fatalf("stdout = %q, want red,bold critical prefix", got)
+	}
+}
+
+func TestStatusNotifyMultipleEntriesAppendsCount(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{ID: "a", Text: "newest", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+		{ID: "b", Text: "older1", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+		{ID: "c", Text: "older2", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+	}}
+	cmd := newStatusNotifyCommand(store)
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"notify"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "+2") {
+		t.Fatalf("stdout = %q, want suffix '+2'", got)
+	}
+	if !strings.Contains(got, "[I] newest") {
+		t.Fatalf("stdout = %q, want '[I] newest'", got)
+	}
+}
+
+func TestStatusNotifyMaxWidthTruncatesInnerTextOnly(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{
+			ID:       "a",
+			Text:     "this text is intentionally pretty long",
+			Severity: notify.SeverityInfo,
+			Source:   notify.SourceAI,
+			Session:  "main",
+		},
+		{ID: "b", Text: "x", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+	}}
+	cmd := newStatusNotifyCommand(store)
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"notify", "--max-width", "30"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got := stdout.String()
+	// Strip the trailing reset directive and compute the visible-ish length.
+	visible := strings.TrimSuffix(got, "#[default]")
+	if len([]rune(visible)) > 30 {
+		t.Fatalf("rendered length = %d, want <= 30 (got %q)", len([]rune(visible)), got)
+	}
+	if !strings.HasPrefix(got, "[I] ") {
+		t.Fatalf("stdout = %q, want severity prefix kept", got)
+	}
+	if !strings.Contains(got, "+1") {
+		t.Fatalf("stdout = %q, want '+N' suffix kept", got)
+	}
+	if !strings.Contains(got, "main") {
+		t.Fatalf("stdout = %q, want session suffix kept", got)
+	}
+}
+
+func TestStatusNotifyMissingStoreFactoryReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	cmd := testStatusCommand("/tmp")
+	cmd.notifyStoreFn = nil
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"notify"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestStatusNotifyStableTimestampOrdering(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{ID: "newer", Text: "newer", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main", CreatedAt: now},
+		{ID: "older", Text: "older", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main", CreatedAt: now.Add(-time.Minute)},
+	}}
+	cmd := newStatusNotifyCommand(store)
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"notify"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "[I] newer") {
+		t.Fatalf("stdout = %q, want newest entry first", got)
+	}
+}

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -1,0 +1,299 @@
+// Package app: statusbar dispatches click and keyboard activations from the
+// projmux tmux status bar to per-segment handlers. The status bar wraps each
+// segment in a tmux user-defined range (e.g. `#[range=user|notify]...`); the
+// mouse binding `bind -n MouseDown1Status run-shell '<bin> statusbar click
+// "#{mouse_status_range}"'` invokes us with the matching range id, and the
+// `prefix s {u,n,g,k,p,s}` shortcuts call us with hard-coded ids.
+package app
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/core/notify"
+)
+
+// statusbarRangeID identifies one clickable segment in the projmux status bar.
+type statusbarRangeID string
+
+const (
+	statusbarRangeSession statusbarRangeID = "session"
+	statusbarRangePwd     statusbarRangeID = "pwd"
+	statusbarRangeKube    statusbarRangeID = "kube"
+	statusbarRangeGit     statusbarRangeID = "git"
+	statusbarRangeUsage   statusbarRangeID = "usage"
+	statusbarRangeNotify  statusbarRangeID = "notify"
+)
+
+// statusbarRunner abstracts the tmux/projmux invocations the click handlers
+// emit. Tests substitute a recording fake so they can assert on every shelled
+// command without spawning real subprocesses.
+type statusbarRunner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// statusbarCommand is the dispatch entry point invoked by tmux for both mouse
+// clicks and keyboard shortcuts. The intentionally tiny surface keeps the
+// dispatcher cheap to call from a tmux status interval.
+type statusbarCommand struct {
+	runner        statusbarRunner
+	executable    func() (string, error)
+	notifyStoreFn func() (notifyStore, error)
+}
+
+// newStatusbarCommand builds the production wiring: real tmux + projmux exec
+// runner, real binary resolution, and the on-disk notify queue.
+func newStatusbarCommand() *statusbarCommand {
+	return &statusbarCommand{
+		runner:        statusbarExecRunner{},
+		executable:    os.Executable,
+		notifyStoreFn: defaultStatusbarNotifyStore,
+	}
+}
+
+func defaultStatusbarNotifyStore() (notifyStore, error) {
+	paths, err := config.DefaultPathsFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("resolve default config paths: %w", err)
+	}
+	return notify.NewDefaultStore(paths), nil
+}
+
+// Run is the CLI entry: `projmux statusbar <subcommand> ...`.
+func (c *statusbarCommand) Run(args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		printStatusbarUsage(stderr)
+		return usageError("statusbar requires a subcommand")
+	}
+	switch args[0] {
+	case "click":
+		return c.runClick(args[1:], stdout, stderr)
+	case "help", "--help", "-h":
+		printStatusbarUsage(stdout)
+		return nil
+	default:
+		printStatusbarUsage(stderr)
+		return usageError(fmt.Sprintf("unknown statusbar subcommand: %s", args[0]))
+	}
+}
+
+// statusbarClickOptions captures the parsed argv. mouseX/mouseY are reserved
+// for future telemetry — see runClick.
+type statusbarClickOptions struct {
+	RangeID statusbarRangeID
+	Socket  string
+	MouseX  int
+	MouseY  int
+}
+
+func (c *statusbarCommand) runClick(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("statusbar click", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	socket := fs.String("socket", "", "tmux socket path (overrides $TMUX)")
+	mouseX := fs.Int("mouse-x", -1, "tmux #{mouse_x} (reserved for telemetry)")
+	mouseY := fs.Int("mouse-y", -1, "tmux #{mouse_y} (reserved for telemetry)")
+	if err := fs.Parse(args); err != nil {
+		return usageError(fmt.Sprintf("parse statusbar click flags: %v", err))
+	}
+	if fs.NArg() != 1 {
+		printStatusbarUsage(stderr)
+		return usageError("statusbar click requires exactly 1 <range-id> argument")
+	}
+
+	raw := strings.TrimSpace(fs.Arg(0))
+	if raw == "" {
+		// tmux emits an empty `#{mouse_status_range}` when the user clicks on
+		// status bar whitespace outside any user-defined range. Treat that as
+		// a no-op rather than an error so the bind does not flash a message.
+		return nil
+	}
+
+	opts := statusbarClickOptions{
+		RangeID: statusbarRangeID(raw),
+		Socket:  strings.TrimSpace(*socket),
+		MouseX:  *mouseX,
+		MouseY:  *mouseY,
+	}
+	// MouseX/MouseY are intentionally unused today. The fields are wired
+	// through so we can plumb click telemetry without changing the bind.
+	_ = opts.MouseX
+	_ = opts.MouseY
+
+	handler, ok := c.dispatchTable()[opts.RangeID]
+	if !ok {
+		printStatusbarUsage(stderr)
+		return usageError(fmt.Sprintf("unknown statusbar range id: %s", raw))
+	}
+	return handler(opts, stdout, stderr)
+}
+
+// dispatchTable maps each known range id to its click handler. A method on the
+// receiver returns it so handlers can capture `c` without leaking package
+// state across goroutines.
+func (c *statusbarCommand) dispatchTable() map[statusbarRangeID]func(statusbarClickOptions, io.Writer, io.Writer) error {
+	return map[statusbarRangeID]func(statusbarClickOptions, io.Writer, io.Writer) error{
+		statusbarRangeSession: c.handleSession,
+		statusbarRangePwd:     c.handlePwd,
+		statusbarRangeKube:    c.handleKube,
+		statusbarRangeGit:     c.handleGit,
+		statusbarRangeUsage:   c.handleUsage,
+		statusbarRangeNotify:  c.handleNotify,
+	}
+}
+
+// handleSession surfaces the active session name for now. TODO: open a session
+// picker (see `projmux switch --ui=popup`) so the click maps to a meaningful
+// navigation action. For now we keep parity with the other "todo" segments.
+func (c *statusbarCommand) handleSession(_ statusbarClickOptions, _, stderr io.Writer) error {
+	// TODO: replace with a session picker popup once the picker UI hardens.
+	return c.runTmux(stderr, "display-message", "session: #{session_name}")
+}
+
+// handlePwd shows the current pane's path. This mirrors what tmux already
+// stores in #{pane_current_path} but surfaces it in a place users can copy.
+func (c *statusbarCommand) handlePwd(_ statusbarClickOptions, _, stderr io.Writer) error {
+	return c.runTmux(stderr, "display-message", "#{pane_current_path}")
+}
+
+// handleKube is a placeholder for the "switch to a session whose kube context
+// matches a filter" action. TODO: wire to `projmux switch --filter=kube`.
+func (c *statusbarCommand) handleKube(_ statusbarClickOptions, _, stderr io.Writer) error {
+	// TODO: wire to `projmux switch --filter=kube` once the switcher exposes
+	// filter flags.
+	return c.runTmux(stderr, "display-message", "kube clicker - TODO: wire to switch --filter=kube")
+}
+
+// handleGit is a placeholder for the "switch to a dirty git session" action.
+// TODO: wire to `projmux switch --filter=git-dirty`.
+func (c *statusbarCommand) handleGit(_ statusbarClickOptions, _, stderr io.Writer) error {
+	// TODO: wire to `projmux switch --filter=git-dirty` once the switcher
+	// exposes filter flags.
+	return c.runTmux(stderr, "display-message", "git clicker - TODO: wire to switch --filter=git-dirty")
+}
+
+// handleUsage opens the full `projmux usage` table inside a popup so users can
+// see per-window detail without leaving tmux. Falls back to display-message if
+// the popup itself fails (defensive — tmux 3.4+ supports popups everywhere).
+func (c *statusbarCommand) handleUsage(_ statusbarClickOptions, _, stderr io.Writer) error {
+	binaryPath, err := c.resolveBinary()
+	if err != nil {
+		return c.runTmux(stderr, "display-message", "statusbar usage: cannot resolve projmux binary")
+	}
+	popupShell := tmuxShellQuote(binaryPath) + " usage; read -n1 -s"
+	if err := c.runTmuxNoFallback(stderr, "display-popup", "-E", "-h", "60%", "-w", "80%", popupShell); err == nil {
+		return nil
+	}
+	// Fallback path: inline the rendered table into a one-shot message.
+	out, runErr := c.runner.Run(context.Background(), binaryPath, "usage")
+	if runErr != nil {
+		return c.runTmux(stderr, "display-message", "statusbar usage: invocation failed")
+	}
+	return c.runTmux(stderr, "display-message", strings.TrimSpace(string(out)))
+}
+
+// handleNotify focuses the origin pane of the newest queued notification. If
+// the queue is empty we surface that fact in tmux rather than silently doing
+// nothing — that gives the keyboard shortcut a useful interactive ack.
+func (c *statusbarCommand) handleNotify(opts statusbarClickOptions, _, stderr io.Writer) error {
+	if c.notifyStoreFn == nil {
+		return c.runTmux(stderr, "display-message", "no notifications")
+	}
+	store, err := c.notifyStoreFn()
+	if err != nil {
+		return c.runTmux(stderr, "display-message", "no notifications")
+	}
+	entries, err := store.List()
+	if err != nil || len(entries) == 0 {
+		return c.runTmux(stderr, "display-message", "no notifications")
+	}
+
+	head := entries[0]
+	target := notify.FormatTarget(notify.Target{
+		Session: head.Session,
+		Window:  head.Window,
+		Pane:    head.Pane,
+	})
+	if strings.TrimSpace(target) == "" {
+		return c.runTmux(stderr, "display-message", "notification has no routable target")
+	}
+
+	binaryPath, err := c.resolveBinary()
+	if err != nil {
+		return fmt.Errorf("statusbar notify: resolve projmux binary: %w", err)
+	}
+
+	socket := opts.Socket
+	if socket == "" {
+		socket = strings.TrimSpace(head.Socket)
+	}
+
+	args := []string{"focus", "--target", target, "--source", "status-bar", "--kind", "segment-click"}
+	if socket != "" {
+		args = append(args, "--socket", socket)
+	}
+	if _, err := c.runner.Run(context.Background(), binaryPath, args...); err != nil {
+		return fmt.Errorf("statusbar notify: focus invocation failed: %w", err)
+	}
+	return nil
+}
+
+func (c *statusbarCommand) resolveBinary() (string, error) {
+	if c.executable == nil {
+		return "", errors.New("statusbar binary resolver is not configured")
+	}
+	binaryPath, err := c.executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve statusbar projmux binary: %w", err)
+	}
+	if strings.TrimSpace(binaryPath) == "" {
+		return "", errors.New("statusbar projmux binary path is empty")
+	}
+	return binaryPath, nil
+}
+
+// runTmux invokes tmux with the supplied args and swallows any error after
+// reporting it on stderr. We do not fail the whole click handler if tmux
+// declines (e.g. no client attached) — the click is best-effort UX.
+func (c *statusbarCommand) runTmux(stderr io.Writer, args ...string) error {
+	if err := c.runTmuxNoFallback(stderr, args...); err != nil {
+		fmt.Fprintf(stderr, "statusbar: tmux %s: %v\n", strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+func (c *statusbarCommand) runTmuxNoFallback(_ io.Writer, args ...string) error {
+	if c.runner == nil {
+		return errors.New("statusbar runner is not configured")
+	}
+	_, err := c.runner.Run(context.Background(), "tmux", args...)
+	return err
+}
+
+func printStatusbarUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  projmux statusbar click <range-id> [--socket <s>] [--mouse-x N] [--mouse-y N]")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Range ids: session pwd kube git usage notify")
+}
+
+type statusbarExecRunner struct{}
+
+func (statusbarExecRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(out))
+		if trimmed != "" {
+			return out, fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, trimmed)
+		}
+		return out, fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+	}
+	return out, nil
+}

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -1,0 +1,393 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/notify"
+)
+
+// statusbarFakeRunner records every call so tests can assert on exec args
+// without spawning real processes.
+type statusbarFakeRunner struct {
+	calls []statusbarFakeCall
+	// respond is consulted before each call. Returning an error makes that
+	// particular invocation appear to fail; nil leaves it as a success.
+	respond func(name string, args []string) ([]byte, error)
+}
+
+type statusbarFakeCall struct {
+	name string
+	args []string
+}
+
+func (r *statusbarFakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, statusbarFakeCall{name: name, args: append([]string(nil), args...)})
+	if r.respond != nil {
+		return r.respond(name, args)
+	}
+	return nil, nil
+}
+
+func newStatusbarTestCommand(runner *statusbarFakeRunner, store notifyStore) *statusbarCommand {
+	c := &statusbarCommand{
+		runner:     runner,
+		executable: func() (string, error) { return "/usr/local/bin/projmux", nil },
+	}
+	if store != nil {
+		c.notifyStoreFn = func() (notifyStore, error) { return store, nil }
+	}
+	return c
+}
+
+func TestStatusbarDispatchTableCoversAllKnownRanges(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+	table := cmd.dispatchTable()
+
+	want := []statusbarRangeID{
+		statusbarRangeSession,
+		statusbarRangePwd,
+		statusbarRangeKube,
+		statusbarRangeGit,
+		statusbarRangeUsage,
+		statusbarRangeNotify,
+	}
+	if got := len(table); got != len(want) {
+		t.Fatalf("dispatch table size = %d, want %d", got, len(want))
+	}
+	for _, id := range want {
+		if _, ok := table[id]; !ok {
+			t.Fatalf("dispatch table missing range %q", id)
+		}
+	}
+}
+
+func TestStatusbarClickRejectsUnknownRange(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	err := cmd.Run([]string{"click", "totally-bogus"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error for unknown range id")
+	}
+	if !IsUsageError(err) {
+		t.Fatalf("expected UsageError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "unknown statusbar range id") {
+		t.Fatalf("err = %v, want substring 'unknown statusbar range id'", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("unknown range should not invoke runner, got %d calls", len(runner.calls))
+	}
+}
+
+func TestStatusbarClickEmptyRangeIsNoop(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", ""}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("empty range should not invoke runner, got %d calls", len(runner.calls))
+	}
+}
+
+func TestStatusbarClickSessionDisplaysMessage(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "session"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !sawTmuxDisplayMessage(runner.calls, "session: #{session_name}") {
+		t.Fatalf("missing display-message; calls = %#v", runner.calls)
+	}
+}
+
+func TestStatusbarClickPwdDisplaysPanePath(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "pwd"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !sawTmuxDisplayMessage(runner.calls, "#{pane_current_path}") {
+		t.Fatalf("missing display-message; calls = %#v", runner.calls)
+	}
+}
+
+func TestStatusbarClickKubeDisplaysTodoMessage(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "kube"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got, ok := lastDisplayMessage(runner.calls)
+	if !ok {
+		t.Fatalf("missing display-message; calls = %#v", runner.calls)
+	}
+	if !strings.Contains(got, "kube clicker") {
+		t.Fatalf("display-message = %q, want substring 'kube clicker'", got)
+	}
+}
+
+func TestStatusbarClickGitDisplaysTodoMessage(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "git"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got, ok := lastDisplayMessage(runner.calls)
+	if !ok {
+		t.Fatalf("missing display-message; calls = %#v", runner.calls)
+	}
+	if !strings.Contains(got, "git clicker") {
+		t.Fatalf("display-message = %q, want substring 'git clicker'", got)
+	}
+}
+
+func TestStatusbarClickUsageOpensPopup(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "usage"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !sawTmuxSubcommand(runner.calls, "display-popup") {
+		t.Fatalf("missing display-popup; calls = %#v", runner.calls)
+	}
+}
+
+func TestStatusbarClickNotifyEmptyQueueDisplaysMessage(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	store := &stubNotifyStore{listEntries: nil}
+	cmd := newStatusbarTestCommand(runner, store)
+
+	if err := cmd.Run([]string{"click", "notify"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !sawTmuxDisplayMessage(runner.calls, "no notifications") {
+		t.Fatalf("missing 'no notifications' display-message; calls = %#v", runner.calls)
+	}
+	for _, call := range runner.calls {
+		if call.name == "/usr/local/bin/projmux" {
+			t.Fatalf("notify with empty queue must not exec focus, got %#v", call)
+		}
+	}
+}
+
+func TestStatusbarClickNotifyExecsFocusForNewestEntry(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{
+			ID:        "abc",
+			Text:      "deploy ok",
+			Severity:  notify.SeverityWarn,
+			Source:    notify.SourceAI,
+			Socket:    "projmux",
+			Session:   "main",
+			Window:    "1",
+			Pane:      "0",
+			CreatedAt: now,
+			ExpiresAt: now.Add(time.Hour),
+		},
+		{
+			ID:        "older",
+			Text:      "earlier",
+			Severity:  notify.SeverityInfo,
+			Source:    notify.SourceAI,
+			Session:   "side",
+			CreatedAt: now.Add(-time.Hour),
+			ExpiresAt: now.Add(time.Hour),
+		},
+	}}
+	cmd := newStatusbarTestCommand(runner, store)
+
+	if err := cmd.Run([]string{"click", "notify"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	var focusCall *statusbarFakeCall
+	for i := range runner.calls {
+		if runner.calls[i].name == "/usr/local/bin/projmux" {
+			focusCall = &runner.calls[i]
+			break
+		}
+	}
+	if focusCall == nil {
+		t.Fatalf("expected projmux focus invocation; calls = %#v", runner.calls)
+	}
+	wantArgs := []string{
+		"focus", "--target", "main:1.0", "--source", "status-bar", "--kind", "segment-click",
+		"--socket", "projmux",
+	}
+	if !equalStringSlices(focusCall.args, wantArgs) {
+		t.Fatalf("focus args = %#v, want %#v", focusCall.args, wantArgs)
+	}
+}
+
+func TestStatusbarClickNotifyExplicitSocketOverridesEntry(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{
+			ID:      "abc",
+			Text:    "x",
+			Source:  notify.SourceAI,
+			Socket:  "embedded-socket",
+			Session: "main",
+		},
+	}}
+	cmd := newStatusbarTestCommand(runner, store)
+
+	if err := cmd.Run([]string{"click", "--socket", "explicit-socket", "notify"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	var focusCall *statusbarFakeCall
+	for i := range runner.calls {
+		if runner.calls[i].name == "/usr/local/bin/projmux" {
+			focusCall = &runner.calls[i]
+			break
+		}
+	}
+	if focusCall == nil {
+		t.Fatalf("expected projmux focus invocation; calls = %#v", runner.calls)
+	}
+	if !sliceContainsPair(focusCall.args, "--socket", "explicit-socket") {
+		t.Fatalf("focus args = %#v, want --socket explicit-socket", focusCall.args)
+	}
+	if sliceContainsPair(focusCall.args, "--socket", "embedded-socket") {
+		t.Fatalf("focus args = %#v, embedded socket leaked", focusCall.args)
+	}
+}
+
+func TestStatusbarClickNotifyStoreErrorFallsBackToMessage(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	store := &stubNotifyStore{listErr: errors.New("disk full")}
+	cmd := newStatusbarTestCommand(runner, store)
+
+	if err := cmd.Run([]string{"click", "notify"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !sawTmuxDisplayMessage(runner.calls, "no notifications") {
+		t.Fatalf("missing 'no notifications' display-message; calls = %#v", runner.calls)
+	}
+}
+
+func TestStatusbarRunRejectsMissingSubcommand(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStatusbarTestCommand(&statusbarFakeRunner{}, &stubNotifyStore{})
+	err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsUsageError(err) {
+		t.Fatalf("expected UsageError, got %T: %v", err, err)
+	}
+}
+
+func TestStatusbarRunRejectsUnknownSubcommand(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStatusbarTestCommand(&statusbarFakeRunner{}, &stubNotifyStore{})
+	err := cmd.Run([]string{"oops"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsUsageError(err) {
+		t.Fatalf("expected UsageError, got %T: %v", err, err)
+	}
+}
+
+// --- helpers -----------------------------------------------------------------
+
+func sawTmuxSubcommand(calls []statusbarFakeCall, sub string) bool {
+	for _, c := range calls {
+		if c.name != "tmux" {
+			continue
+		}
+		for _, a := range c.args {
+			if a == sub {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func sawTmuxDisplayMessage(calls []statusbarFakeCall, want string) bool {
+	for _, c := range calls {
+		if c.name != "tmux" || len(c.args) < 2 || c.args[0] != "display-message" {
+			continue
+		}
+		if c.args[1] == want {
+			return true
+		}
+	}
+	return false
+}
+
+func lastDisplayMessage(calls []statusbarFakeCall) (string, bool) {
+	for i := len(calls) - 1; i >= 0; i-- {
+		c := calls[i]
+		if c.name == "tmux" && len(c.args) >= 2 && c.args[0] == "display-message" {
+			return c.args[1], true
+		}
+	}
+	return "", false
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sliceContainsPair(values []string, key, value string) bool {
+	for i := 0; i < len(values)-1; i++ {
+		if values[i] == key && values[i+1] == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -773,8 +773,12 @@ func tmuxStandaloneConfig(binaryPath string) string {
 		"set-hook -g after-kill-pane " + tmuxConfigQuote("run-shell -b "+tmuxConfigQuote("sleep 0.05; "+bin+" tmux rebalance-panes")),
 		"set -g window-status-format " + tmuxConfigQuote("#[fg=colour245,bg=colour235] #("+bin+" attention window #{window_id})#[fg=colour245] #I #W #[default]"),
 		"set -g window-status-current-format " + tmuxConfigQuote("#[bold,fg=colour231,bg=colour238] #("+bin+" attention window #{window_id})#[fg=colour231] #I #W #[default]"),
+		"set -g status 3",
 		"set -g status-right-length 140",
-		"set -g status-right " + tmuxConfigQuote("#[fg=colour242]#{=/28/...:pane_current_path}#[fg=colour239]  #("+bin+" status kube)#("+bin+" status git)  %Y-%m-%d %H:%M #[bold,fg=colour16,bg=colour45] projmux #[default]"),
+		"set -g status-left " + tmuxConfigQuote("#[range=user|session][#S] #[norange]"),
+		"set -g status-right " + tmuxConfigQuote("#[range=user|pwd]#[fg=colour242]#{=/28/...:pane_current_path}#[norange]#[fg=colour239]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]  %Y-%m-%d %H:%M #[bold,fg=colour16,bg=colour45] projmux #[default]"),
+		"set -g status-format[1] " + tmuxConfigQuote("#[align=left range=user|usage]#("+bin+" status usage --max-width 200)#[norange]"),
+		"set -g status-format[2] " + tmuxConfigQuote("#[align=left range=user|notify]#("+bin+" status notify --max-width 200)#[norange]"),
 		"unbind-key -q -n M-1",
 		"unbind-key -q -n M-2",
 		"unbind-key -q -n M-3",
@@ -813,6 +817,7 @@ func tmuxStandaloneConfig(binaryPath string) string {
 		"bind-key l run-shell " + tmuxConfigQuote(bin+" ai split down"),
 		"bind-key R command-prompt -I \"#{window_name}\" " + tmuxConfigQuote("rename-window -- '%%'"),
 	}
+	lines = append(lines, tmuxStatusbarKeyBindings(binaryPath)...)
 	return strings.Join(lines, "\n") + "\n"
 }
 
@@ -865,9 +870,21 @@ func tmuxAppConfig(binaryPath string) string {
 	}
 	lines = append(lines, strings.Split(strings.TrimSpace(tmuxStandaloneConfig(binaryPath)), "\n")[1:]...)
 	lines = append(lines, tmuxAppKeyBindings()...)
+	// Three-line status bar:
+	//   [0] existing session/window/path/git/kube/clock row
+	//   [1] AI usage segment (codex / claude × 5h+weekly)
+	//   [2] persistent notification segment
+	// We re-assert `status 3` here because `tmuxStandaloneConfig` already
+	// sets it, but a tmux server that previously ran an older projmux build
+	// may have stuck a leftover `status-format[1]` showing pane debug info —
+	// we explicitly overwrite both extra lines so they always reflect this
+	// build's intent.
 	lines = append(lines,
-		"set -g status-left \"#[bold,fg=colour231,bg=colour90] #{s|^[^-]*-||:session_name} #[default]\"",
-		"set -g status-right "+tmuxConfigQuote("#[fg=colour242]#{=/28/...:pane_current_path}#[fg=colour239]  #("+bin+" status kube)#("+bin+" status git)  %Y-%m-%d %H:%M#[default]"),
+		"set -g status 3",
+		"set -g status-left \"#[range=user|session]#[bold,fg=colour231,bg=colour90] #{s|^[^-]*-||:session_name} #[default]#[norange]\"",
+		"set -g status-right "+tmuxConfigQuote("#[range=user|pwd]#[fg=colour242]#{=/28/...:pane_current_path}#[norange]#[fg=colour239]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]  %Y-%m-%d %H:%M#[default]"),
+		"set -g status-format[1] "+tmuxConfigQuote("#[align=left range=user|usage]#("+bin+" status usage --max-width 200)#[norange]"),
+		"set -g status-format[2] "+tmuxConfigQuote("#[align=left range=user|notify]#("+bin+" status notify --max-width 200)#[norange]"),
 	)
 	return strings.Join(lines, "\n") + "\n"
 }
@@ -898,6 +915,31 @@ func tmuxAppKeyBindings() []string {
 		"bind-key -n User8 previous-window",
 		"bind-key -n User9 next-window",
 		"bind-key M if -F \"#{mouse}\" \"set -g mouse off \\; display-message 'tmux mouse: off'\" \"set -g mouse on \\; display-message 'tmux mouse: on'\"",
+	}
+}
+
+// tmuxStatusbarKeyBindings emits the bindings that wire the projmux statusbar
+// click dispatcher to both mouse clicks and the `prefix s {letter}` chord.
+//
+// Note: `MouseDown1Status` fires for *any* line of a multi-line status bar,
+// and `#{mouse_status_range}` returns whichever user-defined range we wrapped
+// under the cursor — so a single bind covers all three lines.
+//
+// The `prefix s` chord uses tmux's `switch-client -T <table>` mechanism so
+// keyboard users get the same handlers as mouse clickers without re-defining
+// each handler twice.
+func tmuxStatusbarKeyBindings(binaryPath string) []string {
+	bin := tmuxShellQuote(binaryPath)
+	return []string{
+		"unbind-key -q -n MouseDown1Status",
+		"bind-key -n MouseDown1Status run-shell " + tmuxConfigQuote(bin+" statusbar click \"#{mouse_status_range}\""),
+		"bind-key s switch-client -T projmux-status",
+		"bind-key -T projmux-status u run-shell " + tmuxConfigQuote(bin+" statusbar click usage"),
+		"bind-key -T projmux-status n run-shell " + tmuxConfigQuote(bin+" statusbar click notify"),
+		"bind-key -T projmux-status g run-shell " + tmuxConfigQuote(bin+" statusbar click git"),
+		"bind-key -T projmux-status k run-shell " + tmuxConfigQuote(bin+" statusbar click kube"),
+		"bind-key -T projmux-status p run-shell " + tmuxConfigQuote(bin+" statusbar click pwd"),
+		"bind-key -T projmux-status s run-shell " + tmuxConfigQuote(bin+" statusbar click session"),
 	}
 }
 

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -548,7 +548,7 @@ func TestTmuxPrintAppConfigUsesIsolatedAppSettings(t *testing.T) {
 		"bind-key R command-prompt",
 		"bind-key M if -F \"#{mouse}\"",
 		"set -g status-left-length 20",
-		"set -g status-left \"#[bold,fg=colour231,bg=colour90] #{s|^[^-]*-||:session_name} #[default]\"",
+		"set -g status-left \"#[range=user|session]#[bold,fg=colour231,bg=colour90] #{s|^[^-]*-||:session_name} #[default]#[norange]\"",
 		"#[bold,fg=colour231,bg=colour90] #{s|^[^-]*-||:session_name} #[default]",
 		"'/tmp/projmux' tmux popup-toggle --client #{client_tty} sessionizer-sidebar",
 		"%Y-%m-%d %H:%M#[default]",


### PR DESCRIPTION
## Summary
- Switches tmux to `set -g status 3` and lays out three purposeful lines:
  - **Line 0** — existing session/window/pwd/kube/git/clock row, segments wrapped in `#[range=user|<id>]...#[norange]` for clickability
  - **Line 1** — AI usage (`#(projmux status usage --max-width 200)`)
  - **Line 2** — notification content (new `projmux status notify --max-width 200`)
- New `projmux statusbar click <range-id>` dispatcher (one CLI for all status-bar clicks). Handlers reuse the existing `projmux focus` core for notification clicks.
- Single `bind -n MouseDown1Status run-shell '... statusbar click "#{mouse_status_range}"'` covers all three lines.
- `prefix s {u,n,g,k,p,s}` chord exposes the same actions for mouse-independent access.

## Range IDs
| Range id | Line | Click action | Keybinding |
|---|---|---|---|
| session | 0 | display session name (TODO: picker) | prefix+s s |
| pwd | 0 | display pane_current_path | prefix+s p |
| kube | 0 | TODO: switch --filter=kube picker | prefix+s k |
| git | 0 | TODO: switch --filter=git-dirty picker | prefix+s g |
| usage | 1 | popup `projmux usage` | prefix+s u |
| notify | 2 | focus origin pane of newest notification | prefix+s n |

## Notes / open items
- Used ASCII `-` (not middot) as the notify segment inner separator to satisfy the no-emoji / plain-ASCII constraint.
- Standalone status-left assigned `[#S]` wrapped in `range=user|session`; overrides any prior empty default if a user relied on it.
- Click handlers for `kube`/`git` are TODO stubs (display-message only) until `switch --filter=...` lands.
- `--mouse-x/y` flags accepted but unused (telemetry hook documented in code).

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (656 PASS lines incl. 22 new tests in statusbar_test.go and status_notify_test.go)
- [x] `gofmt -l .` clean
- [ ] Manual: rebuild + reload tmux config, verify three lines render and clicks fire (lead session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)