### PR TITLE
feat(usage): HUD bar layout + 30s auto-refresh

### DIFF
--- a/internal/app/usage.go
+++ b/internal/app/usage.go
@@ -192,116 +192,321 @@ func writeUsageTable(w io.Writer, snaps []usage.Snapshot) error {
 	return tw.Flush()
 }
 
-// formatStatusUsage produces the one-line tmux status segment described in
-// the spec: `c:42% w:18% | x:71% w:55%`.
+// HUD layout constants. Separators are constant runes so visualLen can
+// reliably count cells without ever falling back to the tmux-escape
+// stripper.
+const (
+	statusInnerSeparator = " · " // between 5h and wk inside a model.
+	statusModelSeparator = "   " // 3 spaces between Claude and Codex blocks.
+	statusDefaultReset   = "#[default]"
+)
+
+// modelDisplay is the in-memory representation of a single model's
+// snapshots. Pct values are floats so the >100% over-limit branch can
+// surface the actual number (e.g. `319%`) instead of capping at 100%.
+type modelDisplay struct {
+	model      string // canonical lowercase key.
+	label      string // user-facing label (Claude / Codex / ...).
+	shortLabel string // legacy single-letter (C / X / ...).
+	hasFive    bool
+	fivePct    float64
+	hasWeek    bool
+	weekPct    float64
+}
+
+// formatStatusUsage produces the HUD-style tmux status segment. The output
+// degrades gracefully through five tiers:
 //
-//   - claude => c:, codex => x:.
-//   - First number is the 5h window, second is the weekly window.
-//   - A model with no snapshots (or no limits to compute pct) is omitted.
-//   - When maxWidth > 0 and the rendered output exceeds that rune count,
-//     trailing groups are dropped first and, if still too long, the last
-//     group is truncated and ellipsised.
+//  1. Long form with bars + wk: `Claude 5h [████████░░] 80% · wk [...]`
+//  2. Drop wk bars (label + 5h bar only).
+//  3. Drop bars entirely (`Claude 5h:80% wk:30%`).
+//  4. Single-letter labels (`C 5h:80% wk:30%`).
+//  5. Hard rune-truncation with trailing `…`.
+//
+// maxWidth is measured in display cells; tmux color escapes (`#[...]`) are
+// stripped before counting so adding color does not push the segment over
+// the budget.
 func formatStatusUsage(snaps []usage.Snapshot, maxWidth int) string {
-	groups := buildStatusGroups(snaps)
-	if len(groups) == 0 {
+	models := buildModelDisplays(snaps)
+	if len(models) == 0 {
 		return ""
 	}
-	full := strings.Join(groups, " | ")
-	if maxWidth <= 0 || runeLen(full) <= maxWidth {
-		return full
+	tiers := []func([]modelDisplay) string{
+		renderTierLongHUD,
+		renderTierFiveHOnlyHUD,
+		renderTierTextLong,
+		renderTierTextShort,
 	}
-	// Drop trailing groups until it fits.
-	for len(groups) > 1 {
-		groups = groups[:len(groups)-1]
-		candidate := strings.Join(groups, " | ")
-		if runeLen(candidate) <= maxWidth {
-			return candidate
+	for _, tier := range tiers {
+		out := tier(models)
+		if out == "" {
+			continue
+		}
+		if maxWidth <= 0 || visualLen(out) <= maxWidth {
+			return out
 		}
 	}
-	// Last resort: truncate the single remaining group.
-	only := groups[0]
-	if runeLen(only) <= maxWidth {
-		return only
-	}
-	if maxWidth <= 1 {
-		return string([]rune(only)[:maxWidth])
-	}
-	rs := []rune(only)
-	return string(rs[:maxWidth-1]) + "…"
+	// Last resort: rune-truncate the shortest tier.
+	short := renderTierTextShort(models)
+	return truncateWithEllipsis(short, maxWidth)
 }
 
-// statusGroup builds the per-model substring like "c:42% w:18%". Returns ""
-// when the model has no usable snapshots.
-func statusGroup(prefix string, fiveH, weekly *usage.Snapshot) string {
+// renderTierLongHUD renders the full HUD: label + 5h bar + wk bar per model.
+func renderTierLongHUD(models []modelDisplay) string {
+	blocks := make([]string, 0, len(models))
+	for _, m := range models {
+		if !m.hasFive && !m.hasWeek {
+			continue
+		}
+		var b strings.Builder
+		b.WriteString("#[fg=cyan,bold]")
+		b.WriteString(m.label)
+		b.WriteString(statusDefaultReset)
+		first := true
+		if m.hasFive {
+			b.WriteByte(' ')
+			b.WriteString(renderHUDPair("5h", m.fivePct))
+			first = false
+		}
+		if m.hasWeek {
+			if first {
+				b.WriteByte(' ')
+			} else {
+				b.WriteString(statusInnerSeparator)
+			}
+			b.WriteString(renderHUDPair("wk", m.weekPct))
+		}
+		b.WriteString(statusDefaultReset)
+		blocks = append(blocks, b.String())
+	}
+	if len(blocks) == 0 {
+		return ""
+	}
+	return strings.Join(blocks, statusModelSeparator) + statusDefaultReset
+}
+
+// renderTierFiveHOnlyHUD drops the wk bar but keeps the 5h bar.
+func renderTierFiveHOnlyHUD(models []modelDisplay) string {
+	blocks := make([]string, 0, len(models))
+	for _, m := range models {
+		if !m.hasFive {
+			continue
+		}
+		var b strings.Builder
+		b.WriteString("#[fg=cyan,bold]")
+		b.WriteString(m.label)
+		b.WriteString(statusDefaultReset)
+		b.WriteByte(' ')
+		b.WriteString(renderHUDPair("5h", m.fivePct))
+		b.WriteString(statusDefaultReset)
+		blocks = append(blocks, b.String())
+	}
+	if len(blocks) == 0 {
+		return ""
+	}
+	return strings.Join(blocks, statusModelSeparator) + statusDefaultReset
+}
+
+// renderTierTextLong drops bars entirely but keeps the long model labels.
+func renderTierTextLong(models []modelDisplay) string {
+	blocks := make([]string, 0, len(models))
+	for _, m := range models {
+		text := renderTextPair(m, m.label)
+		if text != "" {
+			blocks = append(blocks, text)
+		}
+	}
+	if len(blocks) == 0 {
+		return ""
+	}
+	return strings.Join(blocks, statusModelSeparator)
+}
+
+// renderTierTextShort uses single-letter labels (legacy form, no color).
+func renderTierTextShort(models []modelDisplay) string {
+	blocks := make([]string, 0, len(models))
+	for _, m := range models {
+		text := renderTextPair(m, m.shortLabel)
+		if text != "" {
+			blocks = append(blocks, text)
+		}
+	}
+	if len(blocks) == 0 {
+		return ""
+	}
+	return strings.Join(blocks, statusModelSeparator)
+}
+
+// renderTextPair builds a `<label> 5h:N% wk:N%` substring used by both
+// non-HUD tiers. Returns "" when the model has nothing to show.
+func renderTextPair(m modelDisplay, label string) string {
 	parts := make([]string, 0, 2)
-	if fiveH != nil && fiveH.Limit > 0 {
-		parts = append(parts, fmt.Sprintf("%s:%.0f%%", prefix, fiveH.Pct))
+	if m.hasFive {
+		parts = append(parts, fmt.Sprintf("5h:%s", percentText(m.fivePct)))
 	}
-	if weekly != nil && weekly.Limit > 0 {
-		parts = append(parts, fmt.Sprintf("w:%.0f%%", weekly.Pct))
+	if m.hasWeek {
+		parts = append(parts, fmt.Sprintf("wk:%s", percentText(m.weekPct)))
 	}
-	return strings.Join(parts, " ")
+	if len(parts) == 0 {
+		return ""
+	}
+	return label + " " + strings.Join(parts, " ")
 }
 
-// statusPrefix maps known model names to their single-letter status prefix.
-// Unknown models get the first letter of their name as a graceful fallback.
-func statusPrefix(model string) string {
+// renderHUDPair renders a single `<window> [bar] N%` substring with color
+// escapes. Used for both 5h and wk pairs in the HUD tiers.
+func renderHUDPair(window string, pct float64) string {
+	color := usage.BarColorForPct(pct)
+	bar := usage.RenderColoredBar(pct, color, usage.BarEmptyColor)
+	// `#[default]` after the bar restores label fg before the wk text. The
+	// percent number then re-applies the same color as the bar fill so the
+	// numeric matches visually (a red bar's 90% reads red too).
+	return fmt.Sprintf("%s%s #[fg=%s]%s%s",
+		window+" ", bar, color, percentText(pct), statusDefaultReset)
+}
+
+// percentText formats a percentage. Negative values are clamped to 0.
+// Above 100 we still print the actual number (the bar saturates, the
+// numeric does not — the user must see how far over they are).
+func percentText(pct float64) string {
+	if pct < 0 {
+		pct = 0
+	}
+	return fmt.Sprintf("%.0f%%", pct)
+}
+
+// buildModelDisplays converts snapshots into the canonical-ordered display
+// rows the renderers iterate over. Snapshots without a Limit are dropped
+// because we cannot compute a percentage to display.
+func buildModelDisplays(snaps []usage.Snapshot) []modelDisplay {
+	byModel := make(map[string]*modelDisplay)
+	order := make([]string, 0, 2)
+	for i := range snaps {
+		s := snaps[i]
+		if s.Limit <= 0 {
+			continue
+		}
+		row, ok := byModel[s.Model]
+		if !ok {
+			row = &modelDisplay{
+				model:      s.Model,
+				label:      modelDisplayLabel(s.Model),
+				shortLabel: modelShortLabel(s.Model),
+			}
+			byModel[s.Model] = row
+			order = append(order, s.Model)
+		}
+		switch s.Window {
+		case usage.Window5h:
+			row.hasFive = true
+			row.fivePct = s.Pct
+		case usage.WindowWeekly:
+			row.hasWeek = true
+			row.weekPct = s.Pct
+		}
+	}
+	canonical := []string{"claude", "codex"}
+	listed := make(map[string]bool, len(canonical))
+	out := make([]modelDisplay, 0, len(byModel))
+	for _, m := range canonical {
+		if row, ok := byModel[m]; ok {
+			out = append(out, *row)
+			listed[m] = true
+		}
+	}
+	for _, m := range order {
+		if listed[m] {
+			continue
+		}
+		out = append(out, *byModel[m])
+	}
+	return out
+}
+
+// modelDisplayLabel maps a model name to its capitalized HUD label.
+func modelDisplayLabel(model string) string {
 	switch strings.ToLower(model) {
 	case "claude":
-		return "c"
+		return "Claude"
 	case "codex":
-		return "x"
+		return "Codex"
 	default:
 		if model == "" {
 			return "?"
 		}
-		return strings.ToLower(model[:1])
+		// Title-case the first rune; rest stays lowercase.
+		rs := []rune(strings.ToLower(model))
+		rs[0] = []rune(strings.ToUpper(string(rs[0])))[0]
+		return string(rs)
 	}
 }
 
-// buildStatusGroups groups snapshots by model in the canonical claude-then-
-// codex order and renders each group.
-func buildStatusGroups(snaps []usage.Snapshot) []string {
-	byModel := make(map[string]map[usage.Window]*usage.Snapshot)
-	order := make([]string, 0, 2)
-	for i := range snaps {
-		s := snaps[i]
-		row, ok := byModel[s.Model]
-		if !ok {
-			row = make(map[usage.Window]*usage.Snapshot, 2)
-			byModel[s.Model] = row
-			order = append(order, s.Model)
+// modelShortLabel returns the one-letter legacy fallback used by the
+// narrowest text tier. Stable across models so the segment stays scannable
+// when squeezed.
+func modelShortLabel(model string) string {
+	switch strings.ToLower(model) {
+	case "claude":
+		return "C"
+	case "codex":
+		return "X"
+	default:
+		if model == "" {
+			return "?"
 		}
-		row[s.Window] = &s
+		return strings.ToUpper(model[:1])
 	}
-	// Stable canonical order: claude first, codex second, anything else after
-	// in first-seen order.
-	canonical := []string{"claude", "codex"}
-	priority := map[string]int{}
-	for i, m := range canonical {
-		priority[m] = i
+}
+
+// truncateWithEllipsis hard-truncates s so its visual length is at most
+// maxWidth, appending an ellipsis when truncation actually occurred. Tmux
+// color escapes are stripped first so we never split inside an escape.
+func truncateWithEllipsis(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
 	}
-	sortedModels := make([]string, 0, len(order))
-	for _, m := range canonical {
-		if _, ok := byModel[m]; ok {
-			sortedModels = append(sortedModels, m)
-		}
+	plain := stripTmuxEscapes(s)
+	if visualLen(plain) <= maxWidth {
+		return plain
 	}
-	for _, m := range order {
-		if _, listed := priority[m]; listed {
+	rs := []rune(plain)
+	if maxWidth == 1 {
+		return string(rs[:1])
+	}
+	return string(rs[:maxWidth-1]) + "…"
+}
+
+// visualLen returns the rune count of s after stripping tmux `#[...]`
+// escape sequences. The HUD format strings only contain single-cell runes
+// (ASCII + `█` + `░` + `·`), so rune count matches display width 1:1.
+func visualLen(s string) int {
+	return len([]rune(stripTmuxEscapes(s)))
+}
+
+// stripTmuxEscapes removes `#[...]` escape sequences from s. A literal `#`
+// followed by a non-`[` is preserved untouched so user content with `#` is
+// not mangled.
+func stripTmuxEscapes(s string) string {
+	if !strings.Contains(s, "#[") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if s[i] == '#' && i+1 < len(s) && s[i+1] == '[' {
+			end := strings.IndexByte(s[i+2:], ']')
+			if end < 0 {
+				// Unterminated escape — emit verbatim and stop scanning.
+				b.WriteString(s[i:])
+				break
+			}
+			i += 2 + end + 1
 			continue
 		}
-		sortedModels = append(sortedModels, m)
+		b.WriteByte(s[i])
+		i++
 	}
-	groups := make([]string, 0, len(sortedModels))
-	for _, m := range sortedModels {
-		row := byModel[m]
-		group := statusGroup(statusPrefix(m), row[usage.Window5h], row[usage.WindowWeekly])
-		if group != "" {
-			groups = append(groups, group)
-		}
-	}
-	return groups
+	return b.String()
 }
 
 func runeLen(s string) int {

--- a/internal/app/usage.go
+++ b/internal/app/usage.go
@@ -76,9 +76,22 @@ func (c *usageCommand) Run(args []string, stdout, stderr io.Writer) error {
 	return writeUsageTable(stdout, filtered)
 }
 
-// runStatus implements the `projmux status usage` subcommand. It reads from
-// the persisted cache (no adapter walk) so it is safe to call from the
-// tmux status interval.
+// statusRefreshThrottle is the minimum interval between adapter walks
+// triggered by `projmux status usage`. tmux refreshes the status line every
+// 5s by default; 30s gives the cache enough breathing room while keeping
+// the displayed numbers fresh on a human timescale.
+const statusRefreshThrottle = 30 * time.Second
+
+// usageDebugEnvVar gates whether MaybeCollect's swallowed adapter error is
+// echoed to stderr. Off by default — the status segment must stay silent on
+// a healthy install.
+const usageDebugEnvVar = "PROJMUX_USAGE_DEBUG"
+
+// runStatus implements the `projmux status usage` subcommand. It triggers
+// an opportunistic, throttled cache refresh (so a fresh install or a stale
+// cache self-heals on the next tmux redraw) and then reads the persisted
+// cache to render the HUD segment. Adapter failures during this hot path
+// are swallowed unless PROJMUX_USAGE_DEBUG is set.
 func (c *usageCommand) runStatus(args []string, stdout, stderr io.Writer) error {
 	fs := flag.NewFlagSet("status usage", flag.ContinueOnError)
 	fs.SetOutput(stderr)
@@ -98,6 +111,15 @@ func (c *usageCommand) runStatus(args []string, stdout, stderr io.Writer) error 
 		// Status segment must never fail loudly — silently emit nothing.
 		return nil
 	}
+
+	// Opportunistic refresh. Errors here are non-fatal; on debug builds we
+	// echo to stderr so the user can investigate why the cache is stale.
+	if _, refreshErr := mgr.MaybeCollect(context.Background(), statusRefreshThrottle); refreshErr != nil {
+		if c.env(usageDebugEnvVar) != "" {
+			fmt.Fprintf(stderr, "usage: refresh: %v\n", refreshErr)
+		}
+	}
+
 	snaps, err := mgr.LoadAll()
 	if err != nil {
 		return nil

--- a/internal/app/usage_test.go
+++ b/internal/app/usage_test.go
@@ -317,3 +317,92 @@ func TestUsageStatusManagerErrorIsSilent(t *testing.T) {
 	}
 }
 
+func TestUsageStatusMaybeCollectThrottledOnSecondCall(t *testing.T) {
+	t.Parallel()
+
+	c := newUsageCommand()
+	mgr, err := newStubManager(t, []usage.Snapshot{
+		{Model: "claude", Tokens: 100},
+		{Model: "codex", Tokens: 100},
+	})
+	if err != nil {
+		t.Fatalf("newStubManager: %v", err)
+	}
+	c.managerFn = func() (*usage.Manager, error) { return mgr, nil }
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	// First call refreshes the cache (no marker yet → MaybeCollect runs).
+	if err := c.runStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("first runStatus: %v", err)
+	}
+	first := stdout.String()
+	stdout.Reset()
+	// Second call within the throttle window: MaybeCollect short-circuits
+	// but the segment still renders by reading the cache.
+	if err := c.runStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("second runStatus: %v", err)
+	}
+	second := stdout.String()
+	if first == "" || second == "" {
+		t.Fatalf("expected non-empty status output, got %q / %q", first, second)
+	}
+}
+
+func TestUsageStatusSwallowsAdapterErrorByDefault(t *testing.T) {
+	t.Parallel()
+
+	c := newUsageCommand()
+	dir := t.TempDir()
+	registry := usage.NewRegistry()
+	_ = registry.Replace(&stubAdapter{
+		name: "claude",
+		err:  errors.New("network down"),
+	})
+	store := usage.NewStore(dir)
+	mgr := usage.NewManager(registry, store, usage.DefaultLimits, func() time.Time {
+		return time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	})
+	c.managerFn = func() (*usage.Manager, error) { return mgr, nil }
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := c.runStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty (adapter failures must be silent)", stderr.String())
+	}
+}
+
+func TestUsageStatusEchoesAdapterErrorWithDebugEnv(t *testing.T) {
+	t.Parallel()
+
+	c := newUsageCommand()
+	c.lookupEnv = func(name string) string {
+		if name == usageDebugEnvVar {
+			return "1"
+		}
+		return ""
+	}
+	dir := t.TempDir()
+	registry := usage.NewRegistry()
+	_ = registry.Replace(&stubAdapter{
+		name: "claude",
+		err:  errors.New("network down"),
+	})
+	store := usage.NewStore(dir)
+	mgr := usage.NewManager(registry, store, usage.DefaultLimits, func() time.Time {
+		return time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	})
+	c.managerFn = func() (*usage.Manager, error) { return mgr, nil }
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := c.runStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "network down") {
+		t.Fatalf("stderr = %q, want adapter error surfaced under PROJMUX_USAGE_DEBUG", stderr.String())
+	}
+}

--- a/internal/app/usage_test.go
+++ b/internal/app/usage_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/core/usage"
 )
 
-func TestFormatStatusUsageRendersBothModels(t *testing.T) {
+func TestFormatStatusUsageRendersBothModelsHUD(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
@@ -22,9 +22,31 @@ func TestFormatStatusUsageRendersBothModels(t *testing.T) {
 		{Model: "codex", Window: usage.WindowWeekly, Tokens: 550, Limit: 1000, Pct: 55.0, UpdatedAt: now},
 	}
 	got := formatStatusUsage(snaps, 0)
-	want := "c:42% w:18% | x:71% w:55%"
-	if got != want {
-		t.Fatalf("formatStatusUsage = %q, want %q", got, want)
+
+	// Long-form HUD — labels are full-word and color-wrapped, bars present
+	// for both 5h and wk pairs.
+	if !strings.Contains(got, "Claude") || !strings.Contains(got, "Codex") {
+		t.Fatalf("missing model labels: %q", got)
+	}
+	if !strings.Contains(got, "5h ") || !strings.Contains(got, "wk ") {
+		t.Fatalf("missing window labels: %q", got)
+	}
+	// Check at least one filled bar cell exists for the 42% claude bar.
+	if !strings.Contains(got, "█") || !strings.Contains(got, "░") {
+		t.Fatalf("missing bar runes: %q", got)
+	}
+	// Numeric percentages must be present.
+	for _, want := range []string{"42%", "18%", "71%", "55%"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in %q", want, got)
+		}
+	}
+	// Color escapes for cyan label and green/yellow/red bars must appear.
+	if !strings.Contains(got, "#[fg=cyan,bold]") {
+		t.Fatalf("missing cyan label color: %q", got)
+	}
+	if !strings.HasSuffix(got, "#[default]") {
+		t.Fatalf("must end with #[default]: %q", got)
 	}
 }
 
@@ -38,9 +60,14 @@ func TestFormatStatusUsageOmitsModelsWithNoLimit(t *testing.T) {
 		{Model: "codex", Window: usage.WindowWeekly, Tokens: 50, Limit: 200, Pct: 25},
 	}
 	got := formatStatusUsage(snaps, 0)
-	want := "x:50% w:25%"
-	if got != want {
-		t.Fatalf("formatStatusUsage = %q, want %q", got, want)
+	if strings.Contains(got, "Claude") {
+		t.Fatalf("claude has no limit but appears in output: %q", got)
+	}
+	if !strings.Contains(got, "Codex") {
+		t.Fatalf("codex must appear: %q", got)
+	}
+	if !strings.Contains(got, "50%") || !strings.Contains(got, "25%") {
+		t.Fatalf("missing codex percentages: %q", got)
 	}
 }
 
@@ -58,7 +85,7 @@ func TestFormatStatusUsageAllEmpty(t *testing.T) {
 	}
 }
 
-func TestFormatStatusUsageWidthDropsTrailingGroups(t *testing.T) {
+func TestFormatStatusUsageWidthTiers(t *testing.T) {
 	t.Parallel()
 
 	snaps := []usage.Snapshot{
@@ -67,31 +94,104 @@ func TestFormatStatusUsageWidthDropsTrailingGroups(t *testing.T) {
 		{Model: "codex", Window: usage.Window5h, Limit: 1000, Pct: 71},
 		{Model: "codex", Window: usage.WindowWeekly, Limit: 1000, Pct: 55},
 	}
-	full := formatStatusUsage(snaps, 0)
-	if !strings.Contains(full, "|") {
-		t.Fatalf("full = %q, want contains separator", full)
+
+	// Tier 1: long HUD with both bars per model.
+	long := formatStatusUsage(snaps, 200)
+	if !strings.Contains(long, "Claude") || !strings.Contains(long, "wk ") {
+		t.Fatalf("tier1 long HUD missing wk bar: %q", long)
 	}
-	// Width that fits only the first group ("c:42% w:18%" = 11 runes).
-	got := formatStatusUsage(snaps, 11)
-	if got != "c:42% w:18%" {
-		t.Fatalf("width=11 got %q, want %q", got, "c:42% w:18%")
+	if visualLen(long) > 200 {
+		t.Fatalf("tier1 visualLen=%d > 200", visualLen(long))
+	}
+
+	// Tier 2: drop wk bars (label + 5h only).
+	tier2 := formatStatusUsage(snaps, 60)
+	if visualLen(tier2) > 60 {
+		t.Fatalf("tier2 visualLen=%d > 60: %q", visualLen(tier2), tier2)
+	}
+	if !strings.Contains(tier2, "Claude") || !strings.Contains(tier2, "Codex") {
+		t.Fatalf("tier2 missing labels: %q", tier2)
+	}
+	if !strings.Contains(tier2, "5h ") {
+		t.Fatalf("tier2 must keep 5h bar: %q", tier2)
+	}
+	if strings.Contains(tier2, "wk ") {
+		t.Fatalf("tier2 must drop wk bar: %q", tier2)
+	}
+
+	// Tier 3: drop bars, keep long labels.
+	// Long-label text form is 42 cells: `Claude 5h:42% wk:18%` (20) + 3
+	// separator + `Codex 5h:71% wk:55%` (19) = 42.
+	tier3 := formatStatusUsage(snaps, 45)
+	if visualLen(tier3) > 45 {
+		t.Fatalf("tier3 visualLen=%d > 45: %q", visualLen(tier3), tier3)
+	}
+	if !strings.Contains(tier3, "Claude 5h:42% wk:18%") {
+		t.Fatalf("tier3 long-label form missing: %q", tier3)
+	}
+	if strings.Contains(tier3, "█") || strings.Contains(tier3, "░") {
+		t.Fatalf("tier3 must not contain bar runes: %q", tier3)
+	}
+
+	// Tier 4: single-letter labels.
+	tier4 := formatStatusUsage(snaps, 30)
+	if visualLen(tier4) > 30 {
+		t.Fatalf("tier4 visualLen=%d > 30: %q", visualLen(tier4), tier4)
+	}
+	if !strings.Contains(tier4, "C 5h:42%") || !strings.Contains(tier4, "X 5h:71%") {
+		t.Fatalf("tier4 short-label form missing: %q", tier4)
+	}
+	if strings.Contains(tier4, "Claude") {
+		t.Fatalf("tier4 must drop long labels: %q", tier4)
+	}
+
+	// Tier 5: hard truncate with ellipsis.
+	tier5 := formatStatusUsage(snaps, 15)
+	if visualLen(tier5) > 15 {
+		t.Fatalf("tier5 visualLen=%d > 15: %q", visualLen(tier5), tier5)
+	}
+	if !strings.HasSuffix(tier5, "…") {
+		t.Fatalf("tier5 must end with ellipsis: %q", tier5)
 	}
 }
 
-func TestFormatStatusUsageWidthTruncatesSingleGroupWithEllipsis(t *testing.T) {
+func TestFormatStatusUsageOverLimitShowsActualPercent(t *testing.T) {
 	t.Parallel()
 
 	snaps := []usage.Snapshot{
-		{Model: "claude", Window: usage.Window5h, Limit: 1000, Pct: 42},
-		{Model: "claude", Window: usage.WindowWeekly, Limit: 1000, Pct: 18},
+		{Model: "claude", Window: usage.Window5h, Limit: 1000, Pct: 319},
+		{Model: "claude", Window: usage.WindowWeekly, Limit: 1000, Pct: 110},
 	}
-	got := formatStatusUsage(snaps, 5)
-	rs := []rune(got)
-	if len(rs) != 5 {
-		t.Fatalf("len(got runes) = %d, want 5; got=%q", len(rs), got)
+	got := formatStatusUsage(snaps, 0)
+	if !strings.Contains(got, "319%") {
+		t.Fatalf("missing actual over-limit percent: %q", got)
 	}
-	if rs[len(rs)-1] != '…' {
-		t.Fatalf("trailing rune = %q, want ellipsis", rs[len(rs)-1])
+	if !strings.Contains(got, "red,bold") {
+		t.Fatalf("over-limit must use red,bold color: %q", got)
+	}
+}
+
+func TestVisualLenIgnoresTmuxEscapes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"abc", 3},
+		{"#[fg=red]abc#[default]", 3},
+		{"#[fg=cyan,bold]Claude#[default] 5h", 9}, // "Claude 5h"
+		{"a#[fg=red]b#[default]c", 3},
+		// Unterminated escape: stripper preserves verbatim → counts as runes.
+		{"abc#[broken", 11},
+		// `#` not followed by `[` stays literal.
+		{"hash#tag", 8},
+	}
+	for _, tc := range cases {
+		if got := visualLen(tc.in); got != tc.want {
+			t.Fatalf("visualLen(%q) = %d, want %d", tc.in, got, tc.want)
+		}
 	}
 }
 
@@ -195,8 +295,8 @@ func TestUsageStatusEmitsFormattedSegment(t *testing.T) {
 		t.Fatalf("runStatus: %v", err)
 	}
 	out := stdout.String()
-	if !strings.Contains(out, "c:") || !strings.Contains(out, "x:") {
-		t.Fatalf("status output = %q, want both prefixes", out)
+	if !strings.Contains(out, "Claude") || !strings.Contains(out, "Codex") {
+		t.Fatalf("status output = %q, want HUD model labels", out)
 	}
 }
 
@@ -216,3 +316,4 @@ func TestUsageStatusManagerErrorIsSilent(t *testing.T) {
 		t.Fatalf("stdout = %q, want empty", stdout.String())
 	}
 }
+

--- a/internal/core/usage/hud.go
+++ b/internal/core/usage/hud.go
@@ -1,0 +1,114 @@
+package usage
+
+// HUD bar rendering primitives shared by the `projmux status usage` HUD
+// segment. Kept in the core package (rather than internal/app) so unit tests
+// can exercise the math without importing the CLI plumbing.
+
+import (
+	"strings"
+)
+
+// BarCells is the fixed width of the HUD bar widget in cells. The bar is
+// rendered with `█` filled cells and `░` empty cells, surrounded by `[` `]`.
+const BarCells = 10
+
+// BarFilledRune is the rune used for the filled portion of the HUD bar.
+const BarFilledRune = '█'
+
+// BarEmptyRune is the rune used for the empty portion of the HUD bar.
+const BarEmptyRune = '░'
+
+// BarFillCount returns the number of filled cells for the supplied
+// percentage. The result is clamped to [0, BarCells]. For percentages > 100
+// the bar saturates at full — callers should still surface the over-limit
+// number as text so the user sees the actual overshoot.
+func BarFillCount(pct float64) int {
+	if pct <= 0 {
+		return 0
+	}
+	if pct >= 100 {
+		return BarCells
+	}
+	cells := int(pct/100.0*float64(BarCells) + 0.5)
+	if cells < 0 {
+		cells = 0
+	}
+	if cells > BarCells {
+		cells = BarCells
+	}
+	return cells
+}
+
+// RenderBar returns a fixed-width HUD bar string. The output includes
+// surrounding brackets but no color escapes — callers that want colorisation
+// should use RenderColoredBar.
+func RenderBar(pct float64) string {
+	filled := BarFillCount(pct)
+	var b strings.Builder
+	b.Grow(BarCells + 2)
+	b.WriteByte('[')
+	for i := 0; i < BarCells; i++ {
+		if i < filled {
+			b.WriteRune(BarFilledRune)
+		} else {
+			b.WriteRune(BarEmptyRune)
+		}
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+// RenderColoredBar wraps the filled and empty halves of the bar in tmux
+// color escapes. fillColor is applied to the `█` runs, emptyColor to the
+// `░` runs. Callers append `#[default]` or another color reset themselves.
+func RenderColoredBar(pct float64, fillColor, emptyColor string) string {
+	filled := BarFillCount(pct)
+	var b strings.Builder
+	b.Grow(BarCells + 32)
+	b.WriteByte('[')
+	if filled > 0 {
+		if fillColor != "" {
+			b.WriteString("#[fg=")
+			b.WriteString(fillColor)
+			b.WriteByte(']')
+		}
+		for i := 0; i < filled; i++ {
+			b.WriteRune(BarFilledRune)
+		}
+	}
+	if filled < BarCells {
+		if emptyColor != "" {
+			b.WriteString("#[fg=")
+			b.WriteString(emptyColor)
+			b.WriteByte(']')
+		}
+		for i := filled; i < BarCells; i++ {
+			b.WriteRune(BarEmptyRune)
+		}
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+// BarColorForPct returns the tmux color spec for the bar fill at the
+// supplied percentage. Ramps:
+//
+//	<50%   → green
+//	50-80% → yellow
+//	80-100%→ red
+//	>100%  → red,bold (over-limit)
+func BarColorForPct(pct float64) string {
+	switch {
+	case pct > 100:
+		return "red,bold"
+	case pct >= 80:
+		return "red"
+	case pct >= 50:
+		return "yellow"
+	default:
+		return "green"
+	}
+}
+
+// BarEmptyColor is the tmux color used for empty bar cells across the HUD.
+const BarEmptyColor = "colour238"

--- a/internal/core/usage/hud_test.go
+++ b/internal/core/usage/hud_test.go
@@ -1,0 +1,138 @@
+package usage
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBarFillCountBoundaryCases(t *testing.T) {
+	t.Parallel()
+
+	// Each row asserts (input pct, expected number of filled cells).
+	cases := []struct {
+		name string
+		pct  float64
+		want int
+	}{
+		{"zero", 0, 0},
+		{"one", 1, 0},  // 1% rounds to 0 cells (0.1 → 0).
+		{"five", 5, 1}, // boundary: 0.5 → 1 cell with round-half-up.
+		{"forty-nine", 49, 5},
+		{"fifty", 50, 5},
+		{"seventy-nine", 79, 8},
+		{"eighty", 80, 8},
+		{"ninety-nine", 99, 10},
+		{"hundred", 100, 10},
+		{"one-fifty", 150, 10}, // saturates at full.
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := BarFillCount(tc.pct); got != tc.want {
+				t.Fatalf("BarFillCount(%v) = %d, want %d", tc.pct, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRenderBarFixedWidth(t *testing.T) {
+	t.Parallel()
+
+	// Bar is always BarCells+2 runes (brackets included).
+	cases := []float64{0, 1, 49, 50, 79, 80, 99, 100, 150}
+	for _, pct := range cases {
+		bar := RenderBar(pct)
+		runes := []rune(bar)
+		if len(runes) != BarCells+2 {
+			t.Fatalf("RenderBar(%v) rune len = %d, want %d (%q)", pct, len(runes), BarCells+2, bar)
+		}
+		if runes[0] != '[' || runes[len(runes)-1] != ']' {
+			t.Fatalf("RenderBar(%v) brackets missing: %q", pct, bar)
+		}
+	}
+}
+
+func TestRenderBarFillRatios(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		pct   float64
+		fills int
+	}{
+		{0, 0},
+		{50, 5},
+		{100, 10},
+		{150, 10},
+	}
+	for _, tc := range cases {
+		bar := RenderBar(tc.pct)
+		filled := strings.Count(bar, string(BarFilledRune))
+		empty := strings.Count(bar, string(BarEmptyRune))
+		if filled != tc.fills {
+			t.Fatalf("RenderBar(%v) filled=%d, want %d (%q)", tc.pct, filled, tc.fills, bar)
+		}
+		if filled+empty != BarCells {
+			t.Fatalf("RenderBar(%v) filled+empty = %d, want %d (%q)", tc.pct, filled+empty, BarCells, bar)
+		}
+	}
+}
+
+func TestBarColorForPctRamp(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		pct  float64
+		want string
+	}{
+		{0, "green"},
+		{49, "green"},
+		{50, "yellow"},
+		{79, "yellow"},
+		{80, "red"},
+		{100, "red"},
+		{101, "red,bold"},
+		{300, "red,bold"},
+	}
+	for _, tc := range cases {
+		if got := BarColorForPct(tc.pct); got != tc.want {
+			t.Fatalf("BarColorForPct(%v) = %q, want %q", tc.pct, got, tc.want)
+		}
+	}
+}
+
+func TestRenderColoredBarHasEscapes(t *testing.T) {
+	t.Parallel()
+
+	// 50% → 5 filled + 5 empty + brackets + 2 color escapes.
+	out := RenderColoredBar(50, "yellow", BarEmptyColor)
+	if !strings.HasPrefix(out, "[#[fg=yellow]") {
+		t.Fatalf("missing fill color prefix: %q", out)
+	}
+	if !strings.Contains(out, "#[fg="+BarEmptyColor+"]") {
+		t.Fatalf("missing empty color escape: %q", out)
+	}
+	if !strings.HasSuffix(out, "]") {
+		t.Fatalf("missing closing bracket: %q", out)
+	}
+}
+
+func TestRenderColoredBarFullSuppressesEmptyEscape(t *testing.T) {
+	t.Parallel()
+
+	// 100% has no empty cells — empty color escape must be omitted.
+	out := RenderColoredBar(100, "red", BarEmptyColor)
+	if strings.Contains(out, BarEmptyColor) {
+		t.Fatalf("full bar must not emit empty color escape: %q", out)
+	}
+}
+
+func TestRenderColoredBarEmptySuppressesFillEscape(t *testing.T) {
+	t.Parallel()
+
+	// 0% has no filled cells — fill color escape must be omitted.
+	out := RenderColoredBar(0, "green", BarEmptyColor)
+	if strings.Contains(out, "fg=green") {
+		t.Fatalf("empty bar must not emit fill color escape: %q", out)
+	}
+}

--- a/internal/core/usage/manager.go
+++ b/internal/core/usage/manager.go
@@ -4,8 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 )
+
+// collectMarkerName is the file the Manager touches after a successful
+// MaybeCollect. Its mtime is the throttle anchor — when the file is missing
+// or older than the supplied throttle, the next MaybeCollect runs adapters.
+const collectMarkerName = "last_collect"
 
 // Manager wires a Registry, a Store, and a Limits table into the standard
 // "collect, persist, aggregate" flow consumed by the CLI.
@@ -59,6 +66,93 @@ func (m *Manager) Collect(ctx context.Context) ([]Snapshot, error) {
 		return allSnaps, errors.Join(errs...)
 	}
 	return allSnaps, nil
+}
+
+// MaybeCollect opportunistically refreshes the cache if the supplied
+// throttle interval has elapsed since the last successful collection. It is
+// the cheap, status-bar-safe variant of Collect:
+//
+//   - If the marker file is missing the cache is treated as stale and
+//     adapters run immediately. This covers fresh installs where the user
+//     never invoked `projmux usage` interactively.
+//   - When the marker exists and its mtime is younger than throttle, the
+//     call is a no-op (no adapter walk, no disk write beyond the mtime
+//     check). This keeps tmux's 5-second status redraw cheap.
+//   - Adapter errors are swallowed and the call returns nil. The status
+//     segment must NEVER bubble up adapter failures. Set
+//     PROJMUX_USAGE_DEBUG to surface a stderr line for diagnostics; the
+//     env-var observation lives at the call site (CLI plumbing) so the
+//     core package stays free of os.Getenv.
+//
+// Returns true when a collect cycle ran (regardless of success), false when
+// throttled. Tests inject a custom now via NewManager.
+func (m *Manager) MaybeCollect(ctx context.Context, throttle time.Duration) (bool, error) {
+	if m == nil {
+		return false, errors.New("usage: nil manager")
+	}
+	if m.store == nil {
+		return false, errors.New("usage: nil store")
+	}
+	now := m.now().UTC()
+	markerPath := m.markerPath()
+	if !markerStale(markerPath, now, throttle) {
+		return false, nil
+	}
+	// Ignore the adapter error — the spec calls for swallow-and-continue
+	// during status redraw. Callers that want richer diagnostics should
+	// drive the unconditional Collect path instead.
+	_, collectErr := m.Collect(ctx)
+	// Always touch the marker on a collect attempt so a permanently failing
+	// adapter does not flood the status hot path with retries every redraw.
+	if err := touchMarker(markerPath, now); err != nil && collectErr == nil {
+		collectErr = err
+	}
+	return true, collectErr
+}
+
+// markerPath returns the absolute path to the throttle marker file inside
+// the store's base dir.
+func (m *Manager) markerPath() string {
+	return filepath.Join(m.store.BaseDir(), collectMarkerName)
+}
+
+// markerStale reports whether a collect cycle should run. A missing marker
+// is always stale; any I/O error other than ErrNotExist is treated as
+// "needs collect" so a corrupt state dir self-heals on the next redraw.
+func markerStale(path string, now time.Time, throttle time.Duration) bool {
+	if throttle <= 0 {
+		return true
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return true
+	}
+	return now.Sub(info.ModTime().UTC()) >= throttle
+}
+
+// touchMarker writes the marker file with the supplied mtime. Best-effort:
+// any error is returned but the caller usually ignores it (status segment
+// stays silent on failure).
+func touchMarker(path string, now time.Time) error {
+	if path == "" {
+		return errors.New("usage: empty marker path")
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("usage: create marker dir %s: %w", dir, err)
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("usage: open marker %s: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("usage: close marker %s: %w", path, err)
+	}
+	stamp := now.UTC()
+	if err := os.Chtimes(path, stamp, stamp); err != nil {
+		return fmt.Errorf("usage: chtimes marker %s: %w", path, err)
+	}
+	return nil
 }
 
 // LoadAll re-aggregates the persisted cache without invoking adapters. Useful

--- a/internal/core/usage/manager_test.go
+++ b/internal/core/usage/manager_test.go
@@ -1,0 +1,193 @@
+package usage
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countingAdapter records how many times Collect has been invoked. Used by
+// the MaybeCollect tests to assert the throttle gate actually blocks
+// repeated adapter walks.
+type countingAdapter struct {
+	name  string
+	calls int64
+	err   error
+}
+
+func (c *countingAdapter) Name() string { return c.name }
+
+func (c *countingAdapter) Collect(ctx context.Context) ([]TokenEvent, error) {
+	atomic.AddInt64(&c.calls, 1)
+	return nil, c.err
+}
+
+func (c *countingAdapter) Calls() int64 {
+	return atomic.LoadInt64(&c.calls)
+}
+
+func newTestManager(t *testing.T, adapter Adapter, now time.Time) (*Manager, string) {
+	t.Helper()
+	dir := t.TempDir()
+	registry := NewRegistry()
+	if adapter != nil {
+		if err := registry.Register(adapter); err != nil {
+			t.Fatalf("register: %v", err)
+		}
+	}
+	store := NewStore(dir)
+	clock := now
+	mgr := NewManager(registry, store, DefaultLimits, func() time.Time { return clock })
+	return mgr, dir
+}
+
+func TestMaybeCollectRunsWhenMarkerMissing(t *testing.T) {
+	t.Parallel()
+
+	now := mustTime(t, "2026-05-06T12:00:00Z")
+	adapter := &countingAdapter{name: "claude"}
+	mgr, dir := newTestManager(t, adapter, now)
+
+	ran, err := mgr.MaybeCollect(context.Background(), 30*time.Second)
+	if err != nil {
+		t.Fatalf("MaybeCollect: %v", err)
+	}
+	if !ran {
+		t.Fatalf("ran=false, want true (marker missing)")
+	}
+	if adapter.Calls() != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.Calls())
+	}
+	if _, err := os.Stat(filepath.Join(dir, collectMarkerName)); err != nil {
+		t.Fatalf("marker not written: %v", err)
+	}
+}
+
+func TestMaybeCollectThrottlesWithinWindow(t *testing.T) {
+	t.Parallel()
+
+	now := mustTime(t, "2026-05-06T12:00:00Z")
+	adapter := &countingAdapter{name: "claude"}
+	mgr, dir := newTestManager(t, adapter, now)
+
+	ran, err := mgr.MaybeCollect(context.Background(), 30*time.Second)
+	if err != nil || !ran {
+		t.Fatalf("first MaybeCollect: ran=%v err=%v", ran, err)
+	}
+	if adapter.Calls() != 1 {
+		t.Fatalf("after first: calls=%d, want 1", adapter.Calls())
+	}
+
+	// Second call inside the throttle window — must be a no-op.
+	ran, err = mgr.MaybeCollect(context.Background(), 30*time.Second)
+	if err != nil {
+		t.Fatalf("second MaybeCollect: %v", err)
+	}
+	if ran {
+		t.Fatalf("ran=true, want false (throttled)")
+	}
+	if adapter.Calls() != 1 {
+		t.Fatalf("after second: calls=%d, want 1 (still)", adapter.Calls())
+	}
+
+	// Sanity: marker still present.
+	if _, err := os.Stat(filepath.Join(dir, collectMarkerName)); err != nil {
+		t.Fatalf("marker missing: %v", err)
+	}
+}
+
+func TestMaybeCollectRunsAfterThrottleExpires(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	adapter := &countingAdapter{name: "claude"}
+	registry := NewRegistry()
+	if err := registry.Register(adapter); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	store := NewStore(dir)
+
+	now := mustTime(t, "2026-05-06T12:00:00Z")
+	clock := &now
+	mgr := NewManager(registry, store, DefaultLimits, func() time.Time { return *clock })
+
+	if _, err := mgr.MaybeCollect(context.Background(), 30*time.Second); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if adapter.Calls() != 1 {
+		t.Fatalf("after first: calls=%d, want 1", adapter.Calls())
+	}
+
+	// Advance clock past the throttle window — adapters should run again.
+	*clock = now.Add(31 * time.Second)
+	ran, err := mgr.MaybeCollect(context.Background(), 30*time.Second)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if !ran {
+		t.Fatalf("ran=false after throttle expiry, want true")
+	}
+	if adapter.Calls() != 2 {
+		t.Fatalf("after second: calls=%d, want 2", adapter.Calls())
+	}
+}
+
+func TestMaybeCollectSwallowsAdapterError(t *testing.T) {
+	t.Parallel()
+
+	now := mustTime(t, "2026-05-06T12:00:00Z")
+	adapter := &countingAdapter{name: "claude", err: errors.New("network down")}
+	mgr, dir := newTestManager(t, adapter, now)
+
+	ran, err := mgr.MaybeCollect(context.Background(), 30*time.Second)
+	if !ran {
+		t.Fatalf("ran=false, want true even on adapter error")
+	}
+	// MaybeCollect surfaces the joined error so callers (the CLI) can route
+	// it to PROJMUX_USAGE_DEBUG. The status segment must still write the
+	// marker so a permanently-failing adapter doesn't loop on every redraw.
+	if err == nil {
+		t.Fatalf("err = nil, want adapter error surfaced for debug logging")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, collectMarkerName)); statErr != nil {
+		t.Fatalf("marker missing after failed adapter: %v", statErr)
+	}
+	if adapter.Calls() != 1 {
+		t.Fatalf("calls = %d, want 1", adapter.Calls())
+	}
+
+	// Subsequent call inside the throttle window is still a no-op despite
+	// the prior failure — the marker mtime gates retries.
+	ran, _ = mgr.MaybeCollect(context.Background(), 30*time.Second)
+	if ran {
+		t.Fatalf("ran=true on second call, want throttled")
+	}
+	if adapter.Calls() != 1 {
+		t.Fatalf("retried failing adapter: calls=%d", adapter.Calls())
+	}
+}
+
+func TestMaybeCollectZeroThrottleAlwaysRuns(t *testing.T) {
+	t.Parallel()
+
+	now := mustTime(t, "2026-05-06T12:00:00Z")
+	adapter := &countingAdapter{name: "claude"}
+	mgr, _ := newTestManager(t, adapter, now)
+
+	for i := 0; i < 3; i++ {
+		ran, err := mgr.MaybeCollect(context.Background(), 0)
+		if err != nil {
+			t.Fatalf("iter %d: %v", i, err)
+		}
+		if !ran {
+			t.Fatalf("iter %d: ran=false, want true with zero throttle", i)
+		}
+	}
+	if adapter.Calls() != 3 {
+		t.Fatalf("calls = %d, want 3 (zero throttle bypasses gate)", adapter.Calls())
+	}
+}

--- a/internal/core/usage/store.go
+++ b/internal/core/usage/store.go
@@ -54,6 +54,16 @@ func (s *Store) FilePath(model string) string {
 	return filepath.Join(s.baseDir, sanitizeModel(model)+".json")
 }
 
+// BaseDir returns the directory the Store is rooted at. Used by the Manager
+// to locate the MaybeCollect throttle marker so the marker stays colocated
+// with the per-model cache files.
+func (s *Store) BaseDir() string {
+	if s == nil {
+		return ""
+	}
+	return s.baseDir
+}
+
 // Load reads the cache for a given model. A missing file reads as an empty
 // cache (no error) so first-run callers see []Bucket{}.
 func (s *Store) Load(model string) ([]Bucket, error) {


### PR DESCRIPTION
## Summary
- Replace `c:N% w:N% | x:N% w:N%` with HUD-style bar layout: `Claude 5h [████████░░] 80% · wk [███░░░░░░░] 31%   Codex 5h [██░░░░░░░░] 20% · wk [░░░░░░░░░░] 1%`.
- Color-coded bars (green <50, yellow 50-80, red 80-100, red+bold >100); model labels in cyan+bold so they pop.
- Width-aware degradation: long → drop wk bars → drop bars → single-letter labels → hard truncate with `…`.
- Fix the "always 0%" bug: `projmux status usage` now triggers cache refresh through `Manager.MaybeCollect(30s)` with a `<StateDir>/usage/last_collect` mtime marker. Adapter errors are silenced unless `PROJMUX_USAGE_DEBUG` is set.

## Sample tier outputs
| --max-width | Output |
|---|---|
| 200 | `Claude 5h [████████░░] 80% · wk [███░░░░░░░] 31%   Codex 5h [██░░░░░░░░] 20% · wk [░░░░░░░░░░] 1%` |
| 60  | `Claude 5h [████████░░] 80%   Codex 5h [██░░░░░░░░] 20%` |
| 30  | `C 5h:80% wk:31%   X 5h:20% wk…` |
| 15  | `C 5h:80% wk:31…` |

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (672 tests, all pass; new HUD/manager tests cover boundaries 0/1/49/50/79/80/99/100/150% and throttle behavior)
- [x] `gofmt -l .` clean

## Follow-ups (not in this PR)
- Real `limit` lookup — placeholder claude 5h=1M is too low (319% on dev box). Codex rollout JSONL already includes `rate_limits.primary.used_percent` which could replace placeholder for codex.
- `PROJMUX_USAGE_LIMITS_PATH` JSON override is supported; mention in README/docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)