### PR TITLE
feat(statusbar): collapse to two-line layout (notify+usage split row)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,16 +88,17 @@ Ephemeral runtime state:
 - popup marker files
 - current tagged selection set
 
-## Three-line clickable status bar
+## Two-line clickable status bar
 
-projmux configures tmux with `status 3`. Line 0 is the existing
-session/window/path/git/kube/clock row, line 1 is the AI usage bar, and line 2
-is the notification bar. Each clickable segment is wrapped in a tmux
-user-defined range (`#[range=user|<id>]...#[norange]`) and dispatched through
-`projmux statusbar click <range-id>`. A single `bind -n MouseDown1Status`
-covers all three lines because tmux fires `MouseDown1Status` from any line of a
-multi-line status bar with `#{mouse_status_range}` resolving to whichever
-range the cursor was over.
+projmux configures tmux with `status 2`. Line 0 is the existing
+session/window/path/git/kube/clock row. Line 1 splits the notification bar
+(left half, capped at 80 cells) and the AI usage HUD (right half, capped at
+120 cells) using tmux `#[align=left]` / `#[align=right]`. Each clickable
+segment is wrapped in a tmux user-defined range (`#[range=user|<id>]...
+#[norange]`) and dispatched through `projmux statusbar click <range-id>`. A
+single `bind -n MouseDown1Status` covers both lines because tmux fires
+`MouseDown1Status` from any line of a multi-line status bar with
+`#{mouse_status_range}` resolving to whichever range the cursor was over.
 
 | Range id | Line | Click action                              | Keybinding   |
 |----------|------|-------------------------------------------|--------------|
@@ -106,7 +107,7 @@ range the cursor was over.
 | kube     | 0    | (TODO: kube filter picker)                | prefix+s k   |
 | git      | 0    | (TODO: git filter picker)                 | prefix+s g   |
 | usage    | 1    | popup `projmux usage`                     | prefix+s u   |
-| notify   | 2    | focus origin pane of newest notification  | prefix+s n   |
+| notify   | 1    | focus origin pane of newest notification  | prefix+s n   |
 
 The keyboard chord uses `bind-key s switch-client -T projmux-status` so the
 prefix-then-`s`-then-letter shortcut routes through the same dispatcher as

--- a/internal/app/shell_test.go
+++ b/internal/app/shell_test.go
@@ -61,6 +61,12 @@ func TestShellWritesAppConfigAndRunsIsolatedTmux(t *testing.T) {
 		"set -g status-left \"#[range=user|session]#[bold,fg=colour231,bg=colour90] #{s|^[^-]*-||:session_name} #[default]#[norange]\"",
 		"#[bold,fg=colour231,bg=colour90] #{s|^[^-]*-||:session_name} #[default]",
 		"'/tmp/proj mux/bin/projmux' tmux popup-toggle --client #{client_tty} sessionizer-sidebar",
+		"set -g status 2",
+		"range=user|notify",
+		"range=user|usage",
+		"align=left",
+		"align=right",
+		"set -gu status-format[2]",
 	} {
 		if !strings.Contains(config, want) {
 			t.Fatalf("config = %q, want substring %q", config, want)
@@ -68,6 +74,14 @@ func TestShellWritesAppConfigAndRunsIsolatedTmux(t *testing.T) {
 	}
 	if strings.Contains(config, "#[bold,fg=colour16,bg=colour45] app #[default]") {
 		t.Fatalf("config = %q, did not expect duplicate app status badge", config)
+	}
+	for _, banned := range []string{
+		"set -g status 3",
+		"set -g status-format[2] \"",
+	} {
+		if strings.Contains(config, banned) {
+			t.Fatalf("config = %q, did not expect substring %q", config, banned)
+		}
 	}
 
 	wantArgs := []string{"-L", "projmux", "-f", configPath, "new-session", "-A", "-s", "main", "-c", "/tmp/work tree"}

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -773,12 +773,19 @@ func tmuxStandaloneConfig(binaryPath string) string {
 		"set-hook -g after-kill-pane " + tmuxConfigQuote("run-shell -b "+tmuxConfigQuote("sleep 0.05; "+bin+" tmux rebalance-panes")),
 		"set -g window-status-format " + tmuxConfigQuote("#[fg=colour245,bg=colour235] #("+bin+" attention window #{window_id})#[fg=colour245] #I #W #[default]"),
 		"set -g window-status-current-format " + tmuxConfigQuote("#[bold,fg=colour231,bg=colour238] #("+bin+" attention window #{window_id})#[fg=colour231] #I #W #[default]"),
-		"set -g status 3",
+		"set -g status 2",
 		"set -g status-right-length 140",
 		"set -g status-left " + tmuxConfigQuote("#[range=user|session][#S] #[norange]"),
 		"set -g status-right " + tmuxConfigQuote("#[range=user|pwd]#[fg=colour242]#{=/28/...:pane_current_path}#[norange]#[fg=colour239]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]  %Y-%m-%d %H:%M #[bold,fg=colour16,bg=colour45] projmux #[default]"),
-		"set -g status-format[1] " + tmuxConfigQuote("#[align=left range=user|usage]#("+bin+" status usage --max-width 200)#[norange]"),
-		"set -g status-format[2] " + tmuxConfigQuote("#[align=left range=user|notify]#("+bin+" status notify --max-width 200)#[norange]"),
+		// Two-line status bar: line 0 is the existing session/window/path row;
+		// line 1 splits notify (left, capped at 80 cells) and the AI usage HUD
+		// (right, capped at 120 cells). Caps assume a 200+ col terminal — the
+		// HUD's full form is ~100 cells, so 120 leaves headroom while still
+		// fitting alongside an 80-cell notify segment.
+		"set -g status-format[1] " + tmuxConfigQuote("#[align=left range=user|notify]#("+bin+" status notify --max-width 80)#[norange]#[align=right range=user|usage]#("+bin+" status usage --max-width 120)#[norange]"),
+		// Clear any stale index-2 row a previous projmux build may have left on
+		// the running tmux server (older config used three lines).
+		"set -gu status-format[2]",
 		"unbind-key -q -n M-1",
 		"unbind-key -q -n M-2",
 		"unbind-key -q -n M-3",
@@ -870,21 +877,23 @@ func tmuxAppConfig(binaryPath string) string {
 	}
 	lines = append(lines, strings.Split(strings.TrimSpace(tmuxStandaloneConfig(binaryPath)), "\n")[1:]...)
 	lines = append(lines, tmuxAppKeyBindings()...)
-	// Three-line status bar:
+	// Two-line status bar:
 	//   [0] existing session/window/path/git/kube/clock row
-	//   [1] AI usage segment (codex / claude × 5h+weekly)
-	//   [2] persistent notification segment
-	// We re-assert `status 3` here because `tmuxStandaloneConfig` already
+	//   [1] notify (left, --max-width 80) + AI usage HUD (right, --max-width 120)
+	// We re-assert `status 2` here because `tmuxStandaloneConfig` already
 	// sets it, but a tmux server that previously ran an older projmux build
 	// may have stuck a leftover `status-format[1]` showing pane debug info —
-	// we explicitly overwrite both extra lines so they always reflect this
-	// build's intent.
+	// we explicitly overwrite the line so it always reflects this build's
+	// intent. `set -gu status-format[2]` clears any stale third row inherited
+	// from the previous three-line layout. Width caps (80/120) target typical
+	// 200+ col terminals; the HUD's full form is ~100 cells, so 120 leaves a
+	// small buffer while still fitting alongside notify.
 	lines = append(lines,
-		"set -g status 3",
+		"set -g status 2",
 		"set -g status-left \"#[range=user|session]#[bold,fg=colour231,bg=colour90] #{s|^[^-]*-||:session_name} #[default]#[norange]\"",
 		"set -g status-right "+tmuxConfigQuote("#[range=user|pwd]#[fg=colour242]#{=/28/...:pane_current_path}#[norange]#[fg=colour239]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]  %Y-%m-%d %H:%M#[default]"),
-		"set -g status-format[1] "+tmuxConfigQuote("#[align=left range=user|usage]#("+bin+" status usage --max-width 200)#[norange]"),
-		"set -g status-format[2] "+tmuxConfigQuote("#[align=left range=user|notify]#("+bin+" status notify --max-width 200)#[norange]"),
+		"set -g status-format[1] "+tmuxConfigQuote("#[align=left range=user|notify]#("+bin+" status notify --max-width 80)#[norange]#[align=right range=user|usage]#("+bin+" status usage --max-width 120)#[norange]"),
+		"set -gu status-format[2]",
 	)
 	return strings.Join(lines, "\n") + "\n"
 }
@@ -923,7 +932,7 @@ func tmuxAppKeyBindings() []string {
 //
 // Note: `MouseDown1Status` fires for *any* line of a multi-line status bar,
 // and `#{mouse_status_range}` returns whichever user-defined range we wrapped
-// under the cursor — so a single bind covers all three lines.
+// under the cursor — so a single bind covers both lines.
 //
 // The `prefix s` chord uses tmux's `switch-client -T <table>` mechanism so
 // keyboard users get the same handlers as mouse clickers without re-defining

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -417,9 +417,23 @@ func TestTmuxPrintConfigUsesStandaloneBindings(t *testing.T) {
 		"#[bold,fg=colour16,bg=colour45] projmux #[default]",
 		"'/tmp/proj mux/bin/projmux' status kube",
 		"'/tmp/proj mux/bin/projmux' status git",
+		"set -g status 2",
+		"range=user|notify",
+		"range=user|usage",
+		"align=left",
+		"align=right",
+		"set -gu status-format[2]",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("print-config output = %q, want substring %q", output, want)
+		}
+	}
+	for _, banned := range []string{
+		"set -g status 3",
+		"set -g status-format[2] \"",
+	} {
+		if strings.Contains(output, banned) {
+			t.Fatalf("print-config output = %q, did not expect substring %q", output, banned)
 		}
 	}
 }
@@ -552,6 +566,12 @@ func TestTmuxPrintAppConfigUsesIsolatedAppSettings(t *testing.T) {
 		"#[bold,fg=colour231,bg=colour90] #{s|^[^-]*-||:session_name} #[default]",
 		"'/tmp/projmux' tmux popup-toggle --client #{client_tty} sessionizer-sidebar",
 		"%Y-%m-%d %H:%M#[default]",
+		"set -g status 2",
+		"range=user|notify",
+		"range=user|usage",
+		"align=left",
+		"align=right",
+		"set -gu status-format[2]",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("print-app-config output = %q, want substring %q", output, want)
@@ -559,6 +579,14 @@ func TestTmuxPrintAppConfigUsesIsolatedAppSettings(t *testing.T) {
 	}
 	if strings.Contains(output, "#[bold,fg=colour16,bg=colour45] app #[default]") {
 		t.Fatalf("print-app-config output = %q, did not expect duplicate app status badge", output)
+	}
+	for _, banned := range []string{
+		"set -g status 3",
+		"set -g status-format[2] \"",
+	} {
+		if strings.Contains(output, banned) {
+			t.Fatalf("print-app-config output = %q, did not expect substring %q", output, banned)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
After seeing the HUD on a real terminal, the user found three lines redundant. Collapse to two:
- **Line 0** — unchanged (session/window/pwd/kube/git/clock)
- **Line 1** — split: notification on the left (`align=left`, max-width 80) + AI usage HUD on the right (`align=right`, max-width 120)

Both segments keep their `range=user|notify` / `range=user|usage` markers so click + keybinding flows are untouched.

`status-format[2]` is explicitly unset (`set -gu status-format[2]`) so a tmux server that already loaded the prior 3-line config stops rendering a stale third row after reload.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (19 packages pass)
- [x] `gofmt -l .` clean
- [x] Rendered config inspection: `set -g status 2`, single split `status-format[1]`, no remaining `status-format[2] '...'` setter, `set -gu status-format[2]` present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)