### PR TITLE
feat(notify-producer): push reply-ready into queue on attention transitions

### DIFF
--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -48,6 +48,7 @@ type aiCommand struct {
 	readCommand func(ctx context.Context, name string, args ...string) ([]byte, error)
 	now         func() time.Time
 	sleep       func(time.Duration)
+	producer    attentionNotifyProducer
 }
 
 func newAICommand() *aiCommand {
@@ -61,7 +62,43 @@ func newAICommand() *aiCommand {
 		readCommand: readExternalCommand,
 		now:         time.Now,
 		sleep:       time.Sleep,
+		producer:    newAttentionNotifyProducer(),
 	}
+}
+
+// notifyProducer returns the wired-up producer or a noop when the command
+// was constructed without one (the test fixtures build aiCommand structs
+// directly).
+func (c *aiCommand) notifyProducer() attentionNotifyProducer {
+	if c == nil || c.producer == nil {
+		return noopAttentionNotifyProducer{}
+	}
+	return c.producer
+}
+
+// notifyLookup adapts aiCommand's existing read helpers to the producer
+// lookup contract. It uses the same readTmuxPaneOption/readTrimmed surface
+// the rest of the AI flow already uses.
+func (c *aiCommand) notifyLookup() attentionNotifyLookup {
+	return aiNotifyLookup{cmd: c}
+}
+
+type aiNotifyLookup struct {
+	cmd *aiCommand
+}
+
+func (l aiNotifyLookup) PaneOption(paneID, option string) string {
+	if l.cmd == nil {
+		return ""
+	}
+	return l.cmd.readTmuxPaneOption(paneID, option)
+}
+
+func (l aiNotifyLookup) PaneFormat(paneID, format string) string {
+	if l.cmd == nil {
+		return ""
+	}
+	return l.cmd.readTrimmed("tmux", "display-message", "-p", "-t", paneID, format)
 }
 
 func (c *aiCommand) Run(args []string, stdout, stderr io.Writer) error {
@@ -131,6 +168,7 @@ func (c *aiCommand) applyAIStatus(state, paneID string) error {
 		_ = c.run("tmux", "set-option", "-p", "-t", paneID, attentionStateOption, attentionStateBusy)
 		_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionAckOption)
 		_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionFocusArmedOption)
+		c.notifyProducer().AckReplyReady(attentionNotifyInput{PaneID: paneID, Lookup: c.notifyLookup()})
 	case "waiting":
 		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneStateOption, "waiting")
 		_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionAckOption)
@@ -138,15 +176,20 @@ func (c *aiCommand) applyAIStatus(state, paneID string) error {
 			_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionStateOption)
 			_ = c.run("tmux", "set-option", "-p", "-t", paneID, attentionAckOption, "1")
 			_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionFocusArmedOption)
+			// The pane is already active so no reply badge survives — clear
+			// any stale queue entry instead of pushing a new one.
+			c.notifyProducer().AckReplyReady(attentionNotifyInput{PaneID: paneID, Lookup: c.notifyLookup()})
 		} else {
 			_ = c.run("tmux", "set-option", "-p", "-t", paneID, attentionStateOption, attentionStateReply)
 			_ = c.run("tmux", "set-option", "-p", "-t", paneID, attentionFocusArmedOption, "1")
 			_ = c.notifyAI(paneID)
+			c.notifyProducer().PushReplyReady(attentionNotifyInput{PaneID: paneID, Lookup: c.notifyLookup()})
 		}
 	case "idle", "":
 		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneStateOption, "idle")
 		_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionStateOption)
 		_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionFocusArmedOption)
+		c.notifyProducer().AckReplyReady(attentionNotifyInput{PaneID: paneID, Lookup: c.notifyLookup()})
 	default:
 		return fmt.Errorf("unknown ai status state: %s", state)
 	}

--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -20,11 +20,55 @@ const (
 )
 
 type attentionCommand struct {
-	runner tmuxRunner
+	runner   tmuxRunner
+	producer attentionNotifyProducer
 }
 
 func newAttentionCommand() *attentionCommand {
-	return &attentionCommand{runner: inttmux.ExecRunner{}}
+	return &attentionCommand{
+		runner:   inttmux.ExecRunner{},
+		producer: newAttentionNotifyProducer(),
+	}
+}
+
+// notifyProducer returns the wired-up producer or a noop when the command
+// was constructed without one (tests that focus on the existing tmux call
+// surface).
+func (c *attentionCommand) notifyProducer() attentionNotifyProducer {
+	if c == nil || c.producer == nil {
+		return noopAttentionNotifyProducer{}
+	}
+	return c.producer
+}
+
+// notifyLookup adapts attentionCommand's tmux helpers to the producer
+// lookup contract so the producer does not need its own tmux runner. The
+// helpers already short-circuit to "" on error, which is exactly the
+// fallback the producer expects.
+func (c *attentionCommand) notifyLookup() attentionNotifyLookup {
+	return attentionLookup{cmd: c}
+}
+
+type attentionLookup struct {
+	cmd *attentionCommand
+}
+
+func (l attentionLookup) PaneOption(paneID, option string) string {
+	if l.cmd == nil {
+		return ""
+	}
+	return l.cmd.paneOption(paneID, option)
+}
+
+func (l attentionLookup) PaneFormat(paneID, format string) string {
+	if l.cmd == nil || l.cmd.runner == nil {
+		return ""
+	}
+	output, err := l.cmd.run("tmux", "display-message", "-p", "-t", paneID, format)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
 }
 
 func (c *attentionCommand) Run(args []string, stdout, stderr io.Writer) error {
@@ -62,12 +106,14 @@ func (c *attentionCommand) runToggle(args []string, stderr io.Writer) error {
 		c.unsetPaneOption(paneID, attentionStateOption)
 		c.selectPaneTitle(paneID, trimAttentionPrefix(title))
 		c.displayPaneMessage(paneID, "attention: cleared")
+		c.notifyProducer().AckReplyReady(attentionNotifyInput{PaneID: paneID, Lookup: c.notifyLookup()})
 		return nil
 	}
 
 	c.setPaneOption(paneID, attentionStateOption, attentionStateReply)
 	c.selectPaneTitle(paneID, "✳ "+title)
 	c.displayPaneMessage(paneID, "attention: needs reply")
+	c.notifyProducer().PushReplyReady(attentionNotifyInput{PaneID: paneID, Lookup: c.notifyLookup()})
 	return nil
 }
 
@@ -87,6 +133,7 @@ func (c *attentionCommand) runClear(args []string, stderr io.Writer) error {
 	c.unsetPaneOption(paneID, attentionStateOption)
 	c.setPaneOption(paneID, attentionAckOption, "1")
 	c.unsetPaneOption(paneID, attentionFocusArmedOption)
+	c.notifyProducer().AckReplyReady(attentionNotifyInput{PaneID: paneID, Lookup: c.notifyLookup()})
 
 	title := c.paneTitle(paneID)
 	clean := trimAttentionPrefix(title)

--- a/internal/app/notify_producer.go
+++ b/internal/app/notify_producer.go
@@ -1,0 +1,175 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/core/notify"
+)
+
+// attentionNotifyTTL is the lifetime of a "reply ready" queue entry. Stale
+// entries should never sit on the bar forever even if the ack path fails;
+// 10 minutes is the spec value.
+const attentionNotifyTTL = 10 * time.Minute
+
+// attentionNotifyProducer pushes "reply ready" entries into the projmux
+// notify queue when an AI pane transitions to the reply state, and acks the
+// matching entry when the pane leaves that state. Implementations are
+// best-effort: every queue or runner failure is swallowed so the
+// pane-attention state machine never blocks on disk IO.
+type attentionNotifyProducer interface {
+	PushReplyReady(in attentionNotifyInput)
+	AckReplyReady(in attentionNotifyInput)
+}
+
+// attentionNotifyInput is the shared call shape for push/ack. The PaneID is
+// the only mandatory field; the producer reads everything else off tmux via
+// Lookup.
+type attentionNotifyInput struct {
+	PaneID string
+	Lookup attentionNotifyLookup
+}
+
+// attentionNotifyLookup is the minimal tmux read surface the producer needs.
+// Implementations resolve the requested pane option (e.g. via
+// `tmux display-message -p -t <pane> #{<option>}`) and return the trimmed
+// value. An empty string is returned on any error so the producer can fall
+// back to defaults.
+type attentionNotifyLookup interface {
+	PaneOption(paneID, option string) string
+	PaneFormat(paneID, format string) string
+}
+
+// noopAttentionNotifyProducer is the zero-value used when a notify store is
+// unavailable. It silently discards every event so callers can always invoke
+// it without nil checks.
+type noopAttentionNotifyProducer struct{}
+
+func (noopAttentionNotifyProducer) PushReplyReady(attentionNotifyInput) {}
+
+func (noopAttentionNotifyProducer) AckReplyReady(attentionNotifyInput) {}
+
+// storeAttentionNotifyProducer is the production implementation that writes
+// to the shared notify queue file.
+type storeAttentionNotifyProducer struct {
+	store notifyStore
+	ttl   time.Duration
+}
+
+// newAttentionNotifyProducer builds a producer that uses the default notify
+// store on disk. If the store cannot be resolved (e.g. because the user has
+// no XDG_STATE_HOME and no $HOME) the producer degrades to a noop so the
+// caller is never crippled by configuration drift.
+func newAttentionNotifyProducer() attentionNotifyProducer {
+	paths, err := config.DefaultPathsFromEnv()
+	if err != nil {
+		return noopAttentionNotifyProducer{}
+	}
+	return &storeAttentionNotifyProducer{
+		store: notify.NewDefaultStore(paths),
+		ttl:   attentionNotifyTTL,
+	}
+}
+
+// PushReplyReady writes an `ai:<session>:<pane>` entry into the queue. The
+// guard is the AI agent option: if it is empty the pane was not driven by
+// the AI flow (a user manually toggled attention on a shell pane), so we do
+// not push.
+func (p *storeAttentionNotifyProducer) PushReplyReady(in attentionNotifyInput) {
+	if p == nil || p.store == nil || in.Lookup == nil {
+		return
+	}
+	paneID := strings.TrimSpace(in.PaneID)
+	if paneID == "" {
+		return
+	}
+
+	agent := strings.TrimSpace(in.Lookup.PaneOption(paneID, aiPaneAgentOption))
+	if agent == "" {
+		return
+	}
+
+	session := strings.TrimSpace(in.Lookup.PaneFormat(paneID, "#S"))
+	if session == "" {
+		return
+	}
+	window := strings.TrimSpace(in.Lookup.PaneFormat(paneID, "#{window_id}"))
+	resolvedPane := strings.TrimSpace(in.Lookup.PaneFormat(paneID, "#{pane_id}"))
+	if resolvedPane == "" {
+		resolvedPane = paneID
+	}
+	socket := strings.TrimSpace(in.Lookup.PaneFormat(paneID, "#{socket_path}"))
+
+	topic := strings.TrimSpace(in.Lookup.PaneOption(paneID, aiPaneTopicOption))
+
+	ttl := p.ttl
+	if ttl <= 0 {
+		ttl = attentionNotifyTTL
+	}
+
+	_, _, _ = p.store.Push(notify.PushInput{
+		ID:       buildAttentionNotifyID(session, resolvedPane),
+		Text:     composeAttentionReplyText(agent, topic),
+		Severity: notify.SeverityInfo,
+		Source:   notify.SourceAI,
+		TTL:      ttl,
+		Target: notify.Target{
+			Socket:  socket,
+			Session: session,
+			Window:  window,
+			Pane:    resolvedPane,
+		},
+	})
+}
+
+// AckReplyReady removes the matching queue entry. The session and pane id
+// are read off the lookup so the composite id matches whatever was queued.
+// A missing id is treated as a no-op since acking is advisory.
+func (p *storeAttentionNotifyProducer) AckReplyReady(in attentionNotifyInput) {
+	if p == nil || p.store == nil || in.Lookup == nil {
+		return
+	}
+	paneID := strings.TrimSpace(in.PaneID)
+	if paneID == "" {
+		return
+	}
+	session := strings.TrimSpace(in.Lookup.PaneFormat(paneID, "#S"))
+	resolvedPane := strings.TrimSpace(in.Lookup.PaneFormat(paneID, "#{pane_id}"))
+	if resolvedPane == "" {
+		resolvedPane = paneID
+	}
+	if session == "" {
+		return
+	}
+	id := buildAttentionNotifyID(session, resolvedPane)
+	if err := p.store.Ack(id); err != nil && !errors.Is(err, notify.ErrNotFound) {
+		// Best-effort: keep the attention flow going.
+		return
+	}
+}
+
+// buildAttentionNotifyID renders the composite id that pairs a push with its
+// ack. Trimmed values are used so callers do not need to normalize.
+func buildAttentionNotifyID(session, paneID string) string {
+	return fmt.Sprintf("ai:%s:%s", strings.TrimSpace(session), strings.TrimSpace(paneID))
+}
+
+// composeAttentionReplyText renders the queue-row text. The agent label is
+// lower-cased to match the existing AI desktop notification convention
+// (`claude:` / `codex:`), and the optional topic is appended after a
+// middle-dot separator. The store truncates to 80 runes; we let it do that
+// rather than duplicating the rule here.
+func composeAttentionReplyText(agent, topic string) string {
+	label := strings.ToLower(strings.TrimSpace(agent))
+	if label == "" {
+		label = "agent"
+	}
+	text := label + ": reply ready"
+	if t := strings.TrimSpace(topic); t != "" {
+		text += " · " + t
+	}
+	return text
+}

--- a/internal/app/notify_producer_test.go
+++ b/internal/app/notify_producer_test.go
@@ -1,0 +1,469 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/notify"
+)
+
+// fakeAttentionLookup is a deterministic in-memory lookup for the producer
+// tests. Every read goes through a single map keyed by `paneID|key` so a
+// single fixture configures both PaneOption and PaneFormat reads.
+type fakeAttentionLookup struct {
+	values map[string]string
+}
+
+func (l fakeAttentionLookup) PaneOption(paneID, option string) string {
+	return l.values[paneID+"|"+option]
+}
+
+func (l fakeAttentionLookup) PaneFormat(paneID, format string) string {
+	return l.values[paneID+"|"+format]
+}
+
+func newFakeAttentionLookup(v map[string]string) fakeAttentionLookup {
+	return fakeAttentionLookup{values: v}
+}
+
+func TestStoreAttentionNotifyProducerPushReplyReadyHappyPath(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{}
+	producer := &storeAttentionNotifyProducer{store: store, ttl: 10 * time.Minute}
+
+	lookup := newFakeAttentionLookup(map[string]string{
+		"%9|@projmux_ai_agent": "claude",
+		"%9|@projmux_ai_topic": "",
+		"%9|#S":                "main",
+		"%9|#{window_id}":      "@4",
+		"%9|#{pane_id}":        "%9",
+		"%9|#{socket_path}":    "/tmp/tmux-1000/projmux",
+	})
+
+	producer.PushReplyReady(attentionNotifyInput{PaneID: "%9", Lookup: lookup})
+
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1", len(store.pushed))
+	}
+	got := store.pushed[0]
+	if got.ID != "ai:main:%9" {
+		t.Fatalf("ID = %q, want ai:main:%%9", got.ID)
+	}
+	if got.Text != "claude: reply ready" {
+		t.Fatalf("Text = %q, want %q", got.Text, "claude: reply ready")
+	}
+	if got.Source != notify.SourceAI {
+		t.Fatalf("Source = %q, want %q", got.Source, notify.SourceAI)
+	}
+	if got.Severity != notify.SeverityInfo {
+		t.Fatalf("Severity = %q, want %q", got.Severity, notify.SeverityInfo)
+	}
+	if got.TTL != 10*time.Minute {
+		t.Fatalf("TTL = %s, want 10m", got.TTL)
+	}
+	if got.Target.Session != "main" || got.Target.Window != "@4" || got.Target.Pane != "%9" || got.Target.Socket != "/tmp/tmux-1000/projmux" {
+		t.Fatalf("Target = %+v", got.Target)
+	}
+}
+
+func TestStoreAttentionNotifyProducerPushReplyReadyWithTopic(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{}
+	producer := &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+
+	lookup := newFakeAttentionLookup(map[string]string{
+		"%2|@projmux_ai_agent": "Codex",
+		"%2|@projmux_ai_topic": "wire-producer",
+		"%2|#S":                "feat-notify-producer-attention",
+		"%2|#{window_id}":      "@1",
+		"%2|#{pane_id}":        "%2",
+	})
+
+	producer.PushReplyReady(attentionNotifyInput{PaneID: "%2", Lookup: lookup})
+
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1", len(store.pushed))
+	}
+	got := store.pushed[0]
+	wantText := "codex: reply ready · wire-producer"
+	if got.Text != wantText {
+		t.Fatalf("Text = %q, want %q", got.Text, wantText)
+	}
+	if got.ID != "ai:feat-notify-producer-attention:%2" {
+		t.Fatalf("ID = %q", got.ID)
+	}
+}
+
+func TestStoreAttentionNotifyProducerSkipsPaneWithoutAgent(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{}
+	producer := &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+
+	lookup := newFakeAttentionLookup(map[string]string{
+		"%3|@projmux_ai_agent": "",
+		"%3|#S":                "shell",
+		"%3|#{pane_id}":        "%3",
+	})
+
+	producer.PushReplyReady(attentionNotifyInput{PaneID: "%3", Lookup: lookup})
+
+	if len(store.pushed) != 0 {
+		t.Fatalf("push count = %d, want 0 (no AI agent guard)", len(store.pushed))
+	}
+}
+
+func TestStoreAttentionNotifyProducerSkipsWhenSessionMissing(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{}
+	producer := &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+
+	lookup := newFakeAttentionLookup(map[string]string{
+		"%4|@projmux_ai_agent": "claude",
+		"%4|#S":                "",
+		"%4|#{pane_id}":        "%4",
+	})
+
+	producer.PushReplyReady(attentionNotifyInput{PaneID: "%4", Lookup: lookup})
+
+	if len(store.pushed) != 0 {
+		t.Fatalf("push count = %d, want 0 (session missing)", len(store.pushed))
+	}
+}
+
+func TestStoreAttentionNotifyProducerAckReplyReadyAcksMatchingID(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{}
+	producer := &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+
+	lookup := newFakeAttentionLookup(map[string]string{
+		"%9|#S":         "main",
+		"%9|#{pane_id}": "%9",
+	})
+
+	producer.AckReplyReady(attentionNotifyInput{PaneID: "%9", Lookup: lookup})
+
+	if store.ackedID != "ai:main:%9" {
+		t.Fatalf("ackedID = %q, want ai:main:%%9", store.ackedID)
+	}
+}
+
+func TestStoreAttentionNotifyProducerAckSwallowsErrNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{ackErr: notify.ErrNotFound}
+	producer := &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+
+	lookup := newFakeAttentionLookup(map[string]string{
+		"%9|#S":         "main",
+		"%9|#{pane_id}": "%9",
+	})
+
+	// Should not panic / propagate.
+	producer.AckReplyReady(attentionNotifyInput{PaneID: "%9", Lookup: lookup})
+
+	if !errors.Is(store.ackErr, notify.ErrNotFound) {
+		t.Fatalf("ackErr lost = %v", store.ackErr)
+	}
+}
+
+func TestStoreAttentionNotifyProducerAckSkipsBlankInput(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{}
+	producer := &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+
+	producer.AckReplyReady(attentionNotifyInput{})
+	producer.AckReplyReady(attentionNotifyInput{PaneID: "%9"}) // nil Lookup
+
+	if store.ackedID != "" {
+		t.Fatalf("ackedID = %q, want empty", store.ackedID)
+	}
+}
+
+func TestComposeAttentionReplyTextDefaultsAgent(t *testing.T) {
+	t.Parallel()
+
+	if got := composeAttentionReplyText("", ""); got != "agent: reply ready" {
+		t.Fatalf("default = %q", got)
+	}
+	if got := composeAttentionReplyText("CLAUDE", ""); got != "claude: reply ready" {
+		t.Fatalf("uppercase = %q", got)
+	}
+	if got := composeAttentionReplyText("codex", "  refactor split  "); got != "codex: reply ready · refactor split" {
+		t.Fatalf("topic trim = %q", got)
+	}
+}
+
+// TestAttentionToggleNotifiesQueueOnReply checks the integration point: a
+// runToggle that sets state to reply on an AI pane triggers a queue push
+// with the expected id and text, and the existing tmux call sequence is
+// preserved.
+func TestAttentionToggleNotifiesQueueOnReply(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingAttentionRunner{
+		outputs: map[string][]byte{
+			"tmux display-message -p -t %1 #{pane_title}":        []byte("server\n"),
+			"tmux display-message -p -t %1 #{@projmux_ai_agent}": []byte("claude\n"),
+			"tmux display-message -p -t %1 #{@projmux_ai_topic}": []byte("worker loop\n"),
+			"tmux display-message -p -t %1 #S":                   []byte("main\n"),
+			"tmux display-message -p -t %1 #{window_id}":         []byte("@5\n"),
+			"tmux display-message -p -t %1 #{pane_id}":           []byte("%1\n"),
+			"tmux display-message -p -t %1 #{socket_path}":       []byte("/tmp/tmux/default\n"),
+		},
+	}
+	store := &stubNotifyStore{}
+	cmd := &attentionCommand{
+		runner:   runner,
+		producer: &storeAttentionNotifyProducer{store: store, ttl: 10 * time.Minute},
+	}
+
+	if err := cmd.Run([]string{"toggle", "%1"}, nopWriter{}, nopWriter{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1", len(store.pushed))
+	}
+	got := store.pushed[0]
+	if got.ID != "ai:main:%1" {
+		t.Fatalf("ID = %q", got.ID)
+	}
+	wantText := "claude: reply ready · worker loop"
+	if got.Text != wantText {
+		t.Fatalf("Text = %q, want %q", got.Text, wantText)
+	}
+	if got.Source != notify.SourceAI {
+		t.Fatalf("Source = %q", got.Source)
+	}
+	if got.Target.Session != "main" || got.Target.Pane != "%1" || got.Target.Window != "@5" {
+		t.Fatalf("Target = %+v", got.Target)
+	}
+}
+
+// TestAttentionToggleAcksQueueWhenClearingReply checks that toggling away
+// from reply (the prefix branch) acks the matching queue id.
+func TestAttentionToggleAcksQueueWhenClearingReply(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingAttentionRunner{
+		outputs: map[string][]byte{
+			"tmux display-message -p -t %2 #{pane_title}": []byte("✳ worker\n"),
+			"tmux display-message -p -t %2 #S":            []byte("main\n"),
+			"tmux display-message -p -t %2 #{pane_id}":    []byte("%2\n"),
+		},
+	}
+	store := &stubNotifyStore{}
+	cmd := &attentionCommand{
+		runner:   runner,
+		producer: &storeAttentionNotifyProducer{store: store, ttl: 10 * time.Minute},
+	}
+
+	if err := cmd.Run([]string{"toggle", "%2"}, nopWriter{}, nopWriter{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if store.ackedID != "ai:main:%2" {
+		t.Fatalf("ackedID = %q, want ai:main:%%2", store.ackedID)
+	}
+}
+
+// TestAttentionClearAcksQueue checks that the explicit clear path also acks
+// the queue entry.
+func TestAttentionClearAcksQueue(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingAttentionRunner{
+		outputs: map[string][]byte{
+			"tmux display-message -p -t %3 #{@projmux_attention_state}":       []byte("reply\n"),
+			"tmux display-message -p -t %3 #{@projmux_attention_focus_armed}": []byte("1\n"),
+			"tmux display-message -p -t %3 #{pane_title}":                     []byte("✔ done\n"),
+			"tmux display-message -p -t %3 #S":                                []byte("main\n"),
+			"tmux display-message -p -t %3 #{pane_id}":                        []byte("%3\n"),
+		},
+	}
+	store := &stubNotifyStore{}
+	cmd := &attentionCommand{
+		runner:   runner,
+		producer: &storeAttentionNotifyProducer{store: store, ttl: 10 * time.Minute},
+	}
+
+	if err := cmd.Run([]string{"clear", "%3"}, nopWriter{}, nopWriter{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if store.ackedID != "ai:main:%3" {
+		t.Fatalf("ackedID = %q, want ai:main:%%3", store.ackedID)
+	}
+}
+
+// TestAttentionToggleSkipsQueueWithoutAgent guards: a manual toggle on a
+// non-AI pane (no `@projmux_ai_agent`) should not produce a queue entry.
+func TestAttentionToggleSkipsQueueWithoutAgent(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingAttentionRunner{
+		outputs: map[string][]byte{
+			"tmux display-message -p -t %1 #{pane_title}":        []byte("server\n"),
+			"tmux display-message -p -t %1 #{@projmux_ai_agent}": []byte("\n"),
+			"tmux display-message -p -t %1 #S":                   []byte("main\n"),
+			"tmux display-message -p -t %1 #{pane_id}":           []byte("%1\n"),
+		},
+	}
+	store := &stubNotifyStore{}
+	cmd := &attentionCommand{
+		runner:   runner,
+		producer: &storeAttentionNotifyProducer{store: store, ttl: 10 * time.Minute},
+	}
+
+	if err := cmd.Run([]string{"toggle", "%1"}, nopWriter{}, nopWriter{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(store.pushed) != 0 {
+		t.Fatalf("push count = %d, want 0 for non-AI pane", len(store.pushed))
+	}
+}
+
+type nopWriter struct{}
+
+func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// TestAIStatusSetWaitingPushesQueueWhenInactive verifies the AI flow's
+// integration: a transition to `waiting` on an inactive pane (the path that
+// flips attention to reply) pushes a queue entry with the right id and
+// claude-prefixed text.
+func TestAIStatusSetWaitingPushesQueueWhenInactive(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	store := &stubNotifyStore{}
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: 10 * time.Minute}
+
+	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name != "tmux" {
+			return nil, nil
+		}
+		if len(args) >= 5 && args[0] == "display-message" && args[1] == "-p" && args[2] == "-t" {
+			pane := args[3]
+			format := args[4]
+			if pane != "%30" {
+				return nil, nil
+			}
+			switch format {
+			case "#{pane_active}":
+				return []byte("0\n"), nil
+			case "#{@projmux_ai_agent}":
+				return []byte("claude\n"), nil
+			case "#{@projmux_ai_topic}":
+				return []byte("notify wiring\n"), nil
+			case "#S":
+				return []byte("main\n"), nil
+			case "#{window_id}":
+				return []byte("@7\n"), nil
+			case "#{pane_id}":
+				return []byte("%30\n"), nil
+			case "#{socket_path}":
+				return []byte("/tmp/tmux/default\n"), nil
+			}
+		}
+		return nil, nil
+	}
+
+	if err := cmd.Run([]string{"status", "set", "waiting", "%30"}, nopWriter{}, nopWriter{}); err != nil {
+		t.Fatalf("Run status set waiting error = %v", err)
+	}
+
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1", len(store.pushed))
+	}
+	got := store.pushed[0]
+	if got.ID != "ai:main:%30" {
+		t.Fatalf("ID = %q, want ai:main:%%30", got.ID)
+	}
+	wantText := "claude: reply ready · notify wiring"
+	if got.Text != wantText {
+		t.Fatalf("Text = %q, want %q", got.Text, wantText)
+	}
+	if got.Source != notify.SourceAI {
+		t.Fatalf("Source = %q", got.Source)
+	}
+	if got.Target.Session != "main" || got.Target.Window != "@7" || got.Target.Pane != "%30" {
+		t.Fatalf("Target = %+v", got.Target)
+	}
+}
+
+// TestAIStatusSetThinkingAcksQueue checks that the busy transition acks any
+// outstanding queue entry for the pane.
+func TestAIStatusSetThinkingAcksQueue(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	store := &stubNotifyStore{}
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: 10 * time.Minute}
+
+	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name != "tmux" {
+			return nil, nil
+		}
+		if len(args) >= 5 && args[0] == "display-message" && args[1] == "-p" && args[2] == "-t" {
+			switch args[4] {
+			case "#S":
+				return []byte("main\n"), nil
+			case "#{pane_id}":
+				return []byte("%30\n"), nil
+			}
+		}
+		return nil, nil
+	}
+
+	if err := cmd.Run([]string{"status", "set", "thinking", "%30"}, nopWriter{}, nopWriter{}); err != nil {
+		t.Fatalf("Run status set thinking error = %v", err)
+	}
+
+	if store.ackedID != "ai:main:%30" {
+		t.Fatalf("ackedID = %q, want ai:main:%%30", store.ackedID)
+	}
+}
+
+// TestAIStatusSetIdleAcksQueue checks the idle/empty transition path.
+func TestAIStatusSetIdleAcksQueue(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	store := &stubNotifyStore{}
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: 10 * time.Minute}
+
+	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name != "tmux" {
+			return nil, nil
+		}
+		if len(args) >= 5 && args[0] == "display-message" && args[1] == "-p" && args[2] == "-t" {
+			switch args[4] {
+			case "#S":
+				return []byte("main\n"), nil
+			case "#{pane_id}":
+				return []byte("%30\n"), nil
+			}
+		}
+		return nil, nil
+	}
+
+	if err := cmd.Run([]string{"status", "set", "idle", "%30"}, nopWriter{}, nopWriter{}); err != nil {
+		t.Fatalf("Run status set idle error = %v", err)
+	}
+
+	if store.ackedID != "ai:main:%30" {
+		t.Fatalf("ackedID = %q, want ai:main:%%30", store.ackedID)
+	}
+}


### PR DESCRIPTION
## Summary
The two-line status bar's notify segment was always blank because nothing pushed into the queue. Wire the existing attention/AI state machine into `notify.Push` / `notify.Ack` so reply-ready transitions automatically populate the bar.

## Wiring
- **Push** when transitioning to reply (with `@projmux_ai_agent` set as the guard):
  - `attentionCommand.runToggle` plain→reply branch
  - `aiCommand.applyAIStatus("waiting", ...)` inactive-pane branch (alongside the existing desktop-notification call)
- **Ack** when transitioning away from reply:
  - `attentionCommand.runToggle` reply→plain
  - `attentionCommand.runClear`
  - `aiCommand.applyAIStatus("thinking" | "idle" | active-pane "waiting")`

Composite id `ai:<session>:<pane>` is the dedupe key — same pane reaching reply twice replaces the prior entry rather than stacking. Text is `<agent>: reply ready[ · <topic>]` (topic from `@projmux_ai_topic` if present).

## Click-through
The existing `statusbar click notify` handler already reads the newest entry and dispatches `projmux focus --target ... --source status-bar --kind segment-click`. Once the queue starts populating, clicking the bar's left half routes the user to the AI pane waiting for them.

## Test plan
- [x] `go build ./...`, `gofmt -l .` clean
- [x] `go test ./...` (16 new tests + existing — all pass)
- [x] Manual: toggle attention on a pane with `@projmux_ai_agent` set → queue populates; toggle off → queue clears; toggle on a shell pane → queue stays empty (guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)