### PR TITLE
fix(usage): preserve snapshots on failure, per-adapter throttle, 429 backoff

### DIFF
--- a/internal/app/usage.go
+++ b/internal/app/usage.go
@@ -37,6 +37,12 @@ func newUsageCommand() *usageCommand {
 	return c
 }
 
+// staleAfter is the age at which a snapshot is considered stale and
+// flagged for the user. Aligned with the longest expected adapter
+// throttle (Claude, 60s) plus the worst-case backoff window (15m) so a
+// marker only appears when something is genuinely wrong.
+const staleAfter = 10 * time.Minute
+
 // Run implements `projmux usage [...]`.
 func (c *usageCommand) Run(args []string, stdout, stderr io.Writer) error {
 	fs := flag.NewFlagSet("usage", flag.ContinueOnError)
@@ -59,6 +65,11 @@ func (c *usageCommand) Run(args []string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
+	if c.env(usageDebugEnvVar) != "" {
+		mgr.SetDebug(func(format string, args ...any) {
+			fmt.Fprintf(stderr, format+"\n", args...)
+		})
+	}
 	snaps, collectErr := mgr.Collect(context.Background())
 	// collectErr is informational — adapters that fail still keep the rest
 	// of the rendering pipeline working. We surface a single warning to
@@ -71,15 +82,18 @@ func (c *usageCommand) Run(args []string, stdout, stderr io.Writer) error {
 	filtered = usage.SortedSnapshots(filtered)
 
 	if *asJSON {
-		return writeUsageJSON(stdout, filtered)
+		state, _ := mgr.LoadState()
+		return writeUsageJSON(stdout, filtered, state, c.now())
 	}
-	return writeUsageTable(stdout, filtered)
+	return writeUsageTable(stdout, filtered, c.now())
 }
 
 // statusRefreshThrottle is the minimum interval between adapter walks
 // triggered by `projmux status usage`. tmux refreshes the status line every
 // 5s by default; 30s gives the cache enough breathing room while keeping
-// the displayed numbers fresh on a human timescale.
+// the displayed numbers fresh on a human timescale. Adapters that
+// implement ThrottleHinter (e.g. Claude → 60s) override this floor on a
+// per-adapter basis inside the Manager.
 const statusRefreshThrottle = 30 * time.Second
 
 // usageDebugEnvVar gates whether MaybeCollect's swallowed adapter error is
@@ -111,6 +125,11 @@ func (c *usageCommand) runStatus(args []string, stdout, stderr io.Writer) error 
 		// Status segment must never fail loudly — silently emit nothing.
 		return nil
 	}
+	if c.env(usageDebugEnvVar) != "" {
+		mgr.SetDebug(func(format string, args ...any) {
+			fmt.Fprintf(stderr, format+"\n", args...)
+		})
+	}
 
 	// Opportunistic refresh. Errors here are non-fatal; on debug builds we
 	// echo to stderr so the user can investigate why the cache is stale.
@@ -125,7 +144,7 @@ func (c *usageCommand) runStatus(args []string, stdout, stderr io.Writer) error 
 		return nil
 	}
 
-	out := formatStatusUsage(snaps, *maxWidth)
+	out := formatStatusUsage(snaps, *maxWidth, c.now())
 	if out == "" {
 		return nil
 	}
@@ -210,18 +229,62 @@ func filterSnapshots(snaps []usage.Snapshot, model, window string) []usage.Snaps
 	return out
 }
 
-func writeUsageJSON(w io.Writer, snaps []usage.Snapshot) error {
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	if snaps == nil {
-		return enc.Encode([]usage.Snapshot{})
-	}
-	return enc.Encode(snaps)
+// jsonSnapshot is the wire shape emitted by `projmux usage --json`. It
+// extends the core Snapshot with a per-row `stale` boolean so callers
+// (e.g. dashboards, tmux modules) can flag stale data without
+// re-implementing the staleness rule.
+type jsonSnapshot struct {
+	usage.Snapshot
+	Stale bool `json:"stale"`
 }
 
-func writeUsageTable(w io.Writer, snaps []usage.Snapshot) error {
+// jsonBackoff is the wire shape for per-model backoff state surfaced
+// alongside the snapshots. Omitted when no backoff is active so the
+// healthy-case payload stays compact.
+type jsonBackoff struct {
+	Until       time.Time `json:"until"`
+	Consecutive int       `json:"consecutive"`
+}
+
+// jsonOutput is the top-level wrapper when callers ask for --json AND
+// per-model state is non-empty (backoff active). When everything is
+// healthy we emit just the snapshot array for backwards compatibility.
+type jsonOutput struct {
+	Snapshots []jsonSnapshot         `json:"snapshots"`
+	Backoff   map[string]jsonBackoff `json:"backoff,omitempty"`
+}
+
+func writeUsageJSON(w io.Writer, snaps []usage.Snapshot, state usage.State, now time.Time) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	rows := make([]jsonSnapshot, 0, len(snaps))
+	for _, s := range snaps {
+		rows = append(rows, jsonSnapshot{Snapshot: s, Stale: isStale(s, now)})
+	}
+
+	backoff := map[string]jsonBackoff{}
+	for k, v := range state.Backoff {
+		if v.Until.IsZero() {
+			continue
+		}
+		backoff[k] = jsonBackoff{Until: v.Until, Consecutive: v.Consecutive}
+	}
+
+	if len(backoff) == 0 {
+		// Healthy case: stay backwards-compatible with prior --json
+		// consumers that expected a bare array.
+		if len(rows) == 0 {
+			return enc.Encode([]jsonSnapshot{})
+		}
+		return enc.Encode(rows)
+	}
+	return enc.Encode(jsonOutput{Snapshots: rows, Backoff: backoff})
+}
+
+func writeUsageTable(w io.Writer, snaps []usage.Snapshot, now time.Time) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "MODEL\tWINDOW\tPCT\tRESETS_AT"); err != nil {
+	if _, err := fmt.Fprintln(tw, "MODEL\tWINDOW\tPCT\tRESETS_AT\tSTALE"); err != nil {
 		return err
 	}
 	for _, s := range snaps {
@@ -232,11 +295,26 @@ func writeUsageTable(w io.Writer, snaps []usage.Snapshot) error {
 		if !s.ResetsAt.IsZero() {
 			resets = s.ResetsAt.Local().Format(time.RFC3339)
 		}
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", s.Model, s.Window, pct, resets); err != nil {
+		stale := ""
+		if isStale(s, now) {
+			stale = "*"
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", s.Model, s.Window, pct, resets, stale); err != nil {
 			return err
 		}
 	}
 	return tw.Flush()
+}
+
+// isStale reports whether a snapshot's UpdatedAt is far enough in the
+// past that the user should be warned. now=zero disables the check (used
+// by callers that don't have a reliable clock — they get fresh
+// rendering, which is the safe default).
+func isStale(s usage.Snapshot, now time.Time) bool {
+	if now.IsZero() || s.UpdatedAt.IsZero() {
+		return false
+	}
+	return now.Sub(s.UpdatedAt) > staleAfter
 }
 
 // HUD layout constants. Separators are constant runes so visualLen can
@@ -246,6 +324,7 @@ const (
 	statusInnerSeparator = " · " // between 5h and wk inside a model.
 	statusModelSeparator = "   " // 3 spaces between Claude and Codex blocks.
 	statusDefaultReset   = "#[default]"
+	staleMarker          = "#[fg=colour245]~#[default]"
 )
 
 // modelDisplay is the in-memory representation of a single model's
@@ -257,8 +336,10 @@ type modelDisplay struct {
 	shortLabel string // legacy single-letter (C / X / ...).
 	hasFive    bool
 	fivePct    float64
+	fiveStale  bool
 	hasWeek    bool
 	weekPct    float64
+	weekStale  bool
 }
 
 // formatStatusUsage produces the HUD-style tmux status segment. The output
@@ -273,8 +354,11 @@ type modelDisplay struct {
 // maxWidth is measured in display cells; tmux color escapes (`#[...]`) are
 // stripped before counting so adding color does not push the segment over
 // the budget.
-func formatStatusUsage(snaps []usage.Snapshot, maxWidth int) string {
-	models := buildModelDisplays(snaps)
+//
+// `now` is the wall-clock used for staleness detection. Pass time.Time{}
+// to disable the marker (e.g. in tests that don't care).
+func formatStatusUsage(snaps []usage.Snapshot, maxWidth int, now time.Time) string {
+	models := buildModelDisplays(snaps, now)
 	if len(models) == 0 {
 		return ""
 	}
@@ -312,7 +396,7 @@ func renderTierLongHUD(models []modelDisplay) string {
 		first := true
 		if m.hasFive {
 			b.WriteByte(' ')
-			b.WriteString(renderHUDPair("5h", m.fivePct))
+			b.WriteString(renderHUDPair("5h", m.fivePct, m.fiveStale))
 			first = false
 		}
 		if m.hasWeek {
@@ -321,7 +405,7 @@ func renderTierLongHUD(models []modelDisplay) string {
 			} else {
 				b.WriteString(statusInnerSeparator)
 			}
-			b.WriteString(renderHUDPair("wk", m.weekPct))
+			b.WriteString(renderHUDPair("wk", m.weekPct, m.weekStale))
 		}
 		b.WriteString(statusDefaultReset)
 		blocks = append(blocks, b.String())
@@ -344,7 +428,7 @@ func renderTierFiveHOnlyHUD(models []modelDisplay) string {
 		b.WriteString(m.label)
 		b.WriteString(statusDefaultReset)
 		b.WriteByte(' ')
-		b.WriteString(renderHUDPair("5h", m.fivePct))
+		b.WriteString(renderHUDPair("5h", m.fivePct, m.fiveStale))
 		b.WriteString(statusDefaultReset)
 		blocks = append(blocks, b.String())
 	}
@@ -389,10 +473,10 @@ func renderTierTextShort(models []modelDisplay) string {
 func renderTextPair(m modelDisplay, label string) string {
 	parts := make([]string, 0, 2)
 	if m.hasFive {
-		parts = append(parts, fmt.Sprintf("5h:%s", percentText(m.fivePct)))
+		parts = append(parts, fmt.Sprintf("5h:%s%s", percentText(m.fivePct), staleSuffix(m.fiveStale)))
 	}
 	if m.hasWeek {
-		parts = append(parts, fmt.Sprintf("wk:%s", percentText(m.weekPct)))
+		parts = append(parts, fmt.Sprintf("wk:%s%s", percentText(m.weekPct), staleSuffix(m.weekStale)))
 	}
 	if len(parts) == 0 {
 		return ""
@@ -402,14 +486,27 @@ func renderTextPair(m modelDisplay, label string) string {
 
 // renderHUDPair renders a single `<window> [bar] N%` substring with color
 // escapes. Used for both 5h and wk pairs in the HUD tiers.
-func renderHUDPair(window string, pct float64) string {
+func renderHUDPair(window string, pct float64, stale bool) string {
 	color := usage.BarColorForPct(pct)
 	bar := usage.RenderColoredBar(pct, color, usage.BarEmptyColor)
+	suffix := ""
+	if stale {
+		suffix = staleMarker
+	}
 	// `#[default]` after the bar restores label fg before the wk text. The
 	// percent number then re-applies the same color as the bar fill so the
 	// numeric matches visually (a red bar's 90% reads red too).
-	return fmt.Sprintf("%s%s #[fg=%s]%s%s",
-		window+" ", bar, color, percentText(pct), statusDefaultReset)
+	return fmt.Sprintf("%s%s #[fg=%s]%s%s%s",
+		window+" ", bar, color, percentText(pct), statusDefaultReset, suffix)
+}
+
+// staleSuffix returns the text-tier stale marker. Plain `~` (no color
+// escapes) since the text tiers run uncolored.
+func staleSuffix(stale bool) string {
+	if !stale {
+		return ""
+	}
+	return "~"
 }
 
 // percentText formats a percentage. Negative values are clamped to 0.
@@ -429,7 +526,7 @@ func percentText(pct float64) string {
 // ResetsAt is the zero time — those are placeholders that represent "no
 // data" rather than a genuine 0% (e.g. when the upstream returned
 // `seven_day_oauth_apps: null`).
-func buildModelDisplays(snaps []usage.Snapshot) []modelDisplay {
+func buildModelDisplays(snaps []usage.Snapshot, now time.Time) []modelDisplay {
 	byModel := make(map[string]*modelDisplay)
 	order := make([]string, 0, 2)
 	for i := range snaps {
@@ -447,13 +544,16 @@ func buildModelDisplays(snaps []usage.Snapshot) []modelDisplay {
 			byModel[s.Model] = row
 			order = append(order, s.Model)
 		}
+		stale := isStale(s, now)
 		switch s.Window {
 		case usage.Window5h:
 			row.hasFive = true
 			row.fivePct = s.Pct
+			row.fiveStale = stale
 		case usage.WindowWeekly:
 			row.hasWeek = true
 			row.weekPct = s.Pct
+			row.weekStale = stale
 		}
 	}
 	canonical := []string{"claude", "codex"}

--- a/internal/app/usage_test.go
+++ b/internal/app/usage_test.go
@@ -21,7 +21,7 @@ func TestFormatStatusUsageRendersBothModelsHUD(t *testing.T) {
 		{Model: "codex", Window: usage.Window5h, Pct: 71.0, ResetsAt: now.Add(5 * time.Hour), UpdatedAt: now},
 		{Model: "codex", Window: usage.WindowWeekly, Pct: 55.0, ResetsAt: now.Add(7 * 24 * time.Hour), UpdatedAt: now},
 	}
-	got := formatStatusUsage(snaps, 0)
+	got := formatStatusUsage(snaps, 0, now)
 
 	if !strings.Contains(got, "Claude") || !strings.Contains(got, "Codex") {
 		t.Fatalf("missing model labels: %q", got)
@@ -58,7 +58,7 @@ func TestFormatStatusUsageOmitsPlaceholderRows(t *testing.T) {
 		{Model: "codex", Window: usage.Window5h, Pct: 50, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
 		{Model: "codex", Window: usage.WindowWeekly, Pct: 25, ResetsAt: now.Add(7 * 24 * time.Hour), UpdatedAt: now},
 	}
-	got := formatStatusUsage(snaps, 0)
+	got := formatStatusUsage(snaps, 0, now)
 	if strings.Contains(got, "Claude") {
 		t.Fatalf("claude has no data but appears in output: %q", got)
 	}
@@ -79,7 +79,7 @@ func TestFormatStatusUsageRendersGenuineZeroWithResetTime(t *testing.T) {
 	snaps := []usage.Snapshot{
 		{Model: "claude", Window: usage.Window5h, Pct: 0, ResetsAt: now.Add(5 * time.Hour), UpdatedAt: now},
 	}
-	got := formatStatusUsage(snaps, 0)
+	got := formatStatusUsage(snaps, 0, now)
 	if !strings.Contains(got, "Claude") {
 		t.Fatalf("genuine 0%% must still render label: %q", got)
 	}
@@ -91,13 +91,13 @@ func TestFormatStatusUsageRendersGenuineZeroWithResetTime(t *testing.T) {
 func TestFormatStatusUsageAllEmpty(t *testing.T) {
 	t.Parallel()
 
-	if got := formatStatusUsage(nil, 0); got != "" {
+	if got := formatStatusUsage(nil, 0, time.Time{}); got != "" {
 		t.Fatalf("formatStatusUsage(nil) = %q, want empty", got)
 	}
 	snaps := []usage.Snapshot{
 		{Model: "claude", Window: usage.Window5h},
 	}
-	if got := formatStatusUsage(snaps, 0); got != "" {
+	if got := formatStatusUsage(snaps, 0, time.Time{}); got != "" {
 		t.Fatalf("formatStatusUsage(no data) = %q, want empty", got)
 	}
 }
@@ -114,7 +114,7 @@ func TestFormatStatusUsageWidthTiers(t *testing.T) {
 	}
 
 	// Tier 1: long HUD with both bars per model.
-	long := formatStatusUsage(snaps, 200)
+	long := formatStatusUsage(snaps, 200, now)
 	if !strings.Contains(long, "Claude") || !strings.Contains(long, "wk ") {
 		t.Fatalf("tier1 long HUD missing wk bar: %q", long)
 	}
@@ -123,7 +123,7 @@ func TestFormatStatusUsageWidthTiers(t *testing.T) {
 	}
 
 	// Tier 2: drop wk bars (label + 5h only).
-	tier2 := formatStatusUsage(snaps, 60)
+	tier2 := formatStatusUsage(snaps, 60, now)
 	if visualLen(tier2) > 60 {
 		t.Fatalf("tier2 visualLen=%d > 60: %q", visualLen(tier2), tier2)
 	}
@@ -138,7 +138,7 @@ func TestFormatStatusUsageWidthTiers(t *testing.T) {
 	}
 
 	// Tier 3: drop bars, keep long labels.
-	tier3 := formatStatusUsage(snaps, 45)
+	tier3 := formatStatusUsage(snaps, 45, now)
 	if visualLen(tier3) > 45 {
 		t.Fatalf("tier3 visualLen=%d > 45: %q", visualLen(tier3), tier3)
 	}
@@ -150,7 +150,7 @@ func TestFormatStatusUsageWidthTiers(t *testing.T) {
 	}
 
 	// Tier 4: single-letter labels.
-	tier4 := formatStatusUsage(snaps, 30)
+	tier4 := formatStatusUsage(snaps, 30, now)
 	if visualLen(tier4) > 30 {
 		t.Fatalf("tier4 visualLen=%d > 30: %q", visualLen(tier4), tier4)
 	}
@@ -162,7 +162,7 @@ func TestFormatStatusUsageWidthTiers(t *testing.T) {
 	}
 
 	// Tier 5: hard truncate with ellipsis.
-	tier5 := formatStatusUsage(snaps, 15)
+	tier5 := formatStatusUsage(snaps, 15, now)
 	if visualLen(tier5) > 15 {
 		t.Fatalf("tier5 visualLen=%d > 15: %q", visualLen(tier5), tier5)
 	}
@@ -179,7 +179,7 @@ func TestFormatStatusUsageOverLimitShowsActualPercent(t *testing.T) {
 		{Model: "claude", Window: usage.Window5h, Pct: 319, ResetsAt: now.Add(time.Hour)},
 		{Model: "claude", Window: usage.WindowWeekly, Pct: 110, ResetsAt: now.Add(7 * 24 * time.Hour)},
 	}
-	got := formatStatusUsage(snaps, 0)
+	got := formatStatusUsage(snaps, 0, now)
 	if !strings.Contains(got, "319%") {
 		t.Fatalf("missing actual over-limit percent: %q", got)
 	}
@@ -413,6 +413,143 @@ func TestUsageStatusEchoesAdapterErrorWithDebugEnv(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "network down") {
 		t.Fatalf("stderr = %q, want adapter error surfaced under PROJMUX_USAGE_DEBUG", stderr.String())
+	}
+}
+
+func TestFormatStatusUsageMarksStaleSnapshot(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	stale := now.Add(-15 * time.Minute) // older than staleAfter (10m)
+	snaps := []usage.Snapshot{
+		{Model: "claude", Window: usage.Window5h, Pct: 18, ResetsAt: now.Add(time.Hour), UpdatedAt: stale},
+		{Model: "codex", Window: usage.Window5h, Pct: 50, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
+	}
+	got := formatStatusUsage(snaps, 0, now)
+	// Claude is stale → marker present after its 18%. Codex is fresh →
+	// no marker. Use the colored marker form for the HUD tier.
+	if !strings.Contains(got, "18%#[default]#[fg=colour245]~#[default]") {
+		t.Fatalf("missing stale marker after claude 18%%: %q", got)
+	}
+	// Codex 50% must NOT carry a marker.
+	if strings.Contains(got, "50%#[default]#[fg=colour245]~") {
+		t.Fatalf("codex marked stale but should be fresh: %q", got)
+	}
+}
+
+func TestFormatStatusUsageStaleTextTier(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	stale := now.Add(-15 * time.Minute)
+	snaps := []usage.Snapshot{
+		{Model: "claude", Window: usage.Window5h, Pct: 42, ResetsAt: now.Add(time.Hour), UpdatedAt: stale},
+		{Model: "claude", Window: usage.WindowWeekly, Pct: 18, ResetsAt: now.Add(7 * 24 * time.Hour), UpdatedAt: stale},
+		{Model: "codex", Window: usage.Window5h, Pct: 71, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
+		{Model: "codex", Window: usage.WindowWeekly, Pct: 55, ResetsAt: now.Add(7 * 24 * time.Hour), UpdatedAt: now},
+	}
+	// Width=45 lands us in the long-text tier; assert the plain `~`
+	// marker on the stale claude rows but not the fresh codex rows.
+	tier3 := formatStatusUsage(snaps, 45, now)
+	if !strings.Contains(tier3, "5h:42%~") {
+		t.Fatalf("text tier missing stale marker on claude 5h: %q", tier3)
+	}
+	if !strings.Contains(tier3, "wk:18%~") {
+		t.Fatalf("text tier missing stale marker on claude wk: %q", tier3)
+	}
+	if strings.Contains(tier3, "5h:71%~") || strings.Contains(tier3, "wk:55%~") {
+		t.Fatalf("fresh codex rows got stale marker: %q", tier3)
+	}
+}
+
+func TestUsageTableShowsStaleColumn(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	stale := now.Add(-30 * time.Minute)
+	snaps := []usage.Snapshot{
+		{Model: "claude", Window: usage.Window5h, Pct: 18, ResetsAt: now.Add(time.Hour), UpdatedAt: stale},
+		{Model: "codex", Window: usage.Window5h, Pct: 50, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
+	}
+	out := &bytes.Buffer{}
+	if err := writeUsageTable(out, snaps, now); err != nil {
+		t.Fatalf("writeUsageTable: %v", err)
+	}
+	body := out.String()
+	if !strings.Contains(body, "STALE") {
+		t.Fatalf("table header missing STALE column: %q", body)
+	}
+	// Claude row must have a `*` in the STALE column; codex row must not.
+	lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("table too short: %q", body)
+	}
+	var claudeLine, codexLine string
+	for _, l := range lines[1:] {
+		if strings.Contains(l, "claude") {
+			claudeLine = l
+		}
+		if strings.Contains(l, "codex") {
+			codexLine = l
+		}
+	}
+	if !strings.Contains(claudeLine, "*") {
+		t.Fatalf("claude row missing stale marker: %q", claudeLine)
+	}
+	if strings.Contains(codexLine, "*") {
+		t.Fatalf("codex row should be fresh, not stale-marked: %q", codexLine)
+	}
+}
+
+func TestUsageJSONIncludesStaleAndBackoff(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	snaps := []usage.Snapshot{
+		{Model: "claude", Window: usage.Window5h, Pct: 18, ResetsAt: now.Add(time.Hour), UpdatedAt: now.Add(-30 * time.Minute)},
+		{Model: "codex", Window: usage.Window5h, Pct: 50, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
+	}
+	state := usage.State{
+		Backoff: map[string]usage.BackoffState{
+			"claude": {Until: now.Add(5 * time.Minute), Consecutive: 1},
+		},
+	}
+	out := &bytes.Buffer{}
+	if err := writeUsageJSON(out, snaps, state, now); err != nil {
+		t.Fatalf("writeUsageJSON: %v", err)
+	}
+	body := out.String()
+	if !strings.Contains(body, `"stale": true`) {
+		t.Fatalf("missing stale=true for claude row: %s", body)
+	}
+	if !strings.Contains(body, `"stale": false`) {
+		t.Fatalf("missing stale=false for codex row: %s", body)
+	}
+	if !strings.Contains(body, `"backoff"`) {
+		t.Fatalf("missing backoff block: %s", body)
+	}
+	if !strings.Contains(body, `"claude"`) {
+		t.Fatalf("backoff block missing claude entry: %s", body)
+	}
+}
+
+func TestUsageJSONHealthyOmitsBackoff(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	snaps := []usage.Snapshot{
+		{Model: "codex", Window: usage.Window5h, Pct: 50, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
+	}
+	out := &bytes.Buffer{}
+	if err := writeUsageJSON(out, snaps, usage.State{}, now); err != nil {
+		t.Fatalf("writeUsageJSON: %v", err)
+	}
+	body := strings.TrimSpace(out.String())
+	if !strings.HasPrefix(body, "[") {
+		t.Fatalf("healthy --json should emit bare array: %s", body)
+	}
+	if !strings.Contains(body, `"stale": false`) {
+		t.Fatalf("missing per-row stale field: %s", body)
 	}
 }
 

--- a/internal/core/usage/adapters/claude/claude.go
+++ b/internal/core/usage/adapters/claude/claude.go
@@ -21,6 +21,13 @@
 // refresh token. On success the credentials file is rewritten preserving
 // its exact original schema; on failure we return zero snapshots and a
 // non-fatal error.
+//
+// Rate-limit handling: the OAuth usage endpoint enforces a low
+// per-credential request budget. On HTTP 429 the adapter persists an
+// exponential backoff (5m → 10m → cap 15m, doubling per consecutive
+// failure) so the next Collect short-circuits without making the
+// network call. A `Retry-After` header (seconds or HTTP-date) is
+// honoured up to the 15m cap. A non-429 success resets the streak.
 package claude
 
 import (
@@ -33,7 +40,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/crevissepartners/projmux/internal/core/usage"
@@ -61,6 +70,21 @@ const userAgent = "projmux-usage/0.2"
 // anthropicVersion is the API version header recommended by Anthropic.
 const anthropicVersion = "2023-06-01"
 
+// throttleHint is the per-adapter minimum interval between Collect
+// invocations. The OAuth usage endpoint is more sensitive to call
+// frequency than the local-file Codex source, so it gets a longer floor.
+const throttleHint = 60 * time.Second
+
+// Backoff parameters. Defaults align with the Anthropic guidance for
+// OAuth surfaces: start at 5 minutes, double per consecutive 429, cap at
+// 15 minutes. Retry-After (when present) overrides the doubling
+// progression but is still clamped to the cap so a hostile server can't
+// pin the adapter offline indefinitely.
+const (
+	backoffDefault = 5 * time.Minute
+	backoffCap     = 15 * time.Minute
+)
+
 // Adapter is the Claude implementation of usage.Adapter.
 type Adapter struct {
 	credentialsPath string
@@ -68,6 +92,14 @@ type Adapter struct {
 	refreshURL      string
 	httpClient      *http.Client
 	now             func() time.Time
+
+	// Backoff bookkeeping. Mutated under mu so concurrent Collect calls
+	// (rare — the CLI is single-threaded — but cheap to be safe) don't
+	// race on counter increments. The Manager round-trips the persisted
+	// form through snapshots.json via LoadBackoff/SaveBackoff.
+	mu             sync.Mutex
+	backoffUntil   time.Time
+	consecutive429 int
 }
 
 // New returns an Adapter that reads credentials from
@@ -103,11 +135,50 @@ func NewWithConfig(credentialsPath, usageURL, refreshURL string, client *http.Cl
 // Name implements usage.Adapter.
 func (a *Adapter) Name() string { return Name }
 
+// ThrottleHint implements usage.ThrottleHinter. Claude's OAuth usage
+// endpoint enforces a low per-credential request budget, so we ask the
+// Manager for at least 60s between calls.
+func (a *Adapter) ThrottleHint() time.Duration { return throttleHint }
+
+// LoadBackoff implements usage.BackoffStater. Called by the Manager
+// before Collect with the on-disk backoff snapshot, so a CLI restart
+// observes prior 429 progress.
+func (a *Adapter) LoadBackoff(state usage.BackoffState) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.backoffUntil = state.Until
+	a.consecutive429 = state.Consecutive
+}
+
+// SaveBackoff implements usage.BackoffStater. Called by the Manager
+// after Collect so a fresh 429 (or success) is persisted.
+func (a *Adapter) SaveBackoff() usage.BackoffState {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return usage.BackoffState{
+		Until:       a.backoffUntil,
+		Consecutive: a.consecutive429,
+	}
+}
+
 // Collect calls the OAuth usage endpoint and translates the response into
 // 5h + weekly Snapshots. Best-effort: any failure (no creds, network
 // error, 401 with no working refresh) returns nil snapshots and a
 // non-fatal error so the status segment stays silent.
+//
+// During 429-induced backoff the adapter short-circuits: it returns
+// (nil, nil) so the Manager's merge logic preserves the prior on-disk
+// rows. The caller never observes an error during backoff because
+// "we deferred the call" is not a failure — it's the desired behaviour.
 func (a *Adapter) Collect(ctx context.Context) ([]usage.Snapshot, error) {
+	now := a.now().UTC()
+	a.mu.Lock()
+	if !a.backoffUntil.IsZero() && now.Before(a.backoffUntil) {
+		a.mu.Unlock()
+		return nil, nil
+	}
+	a.mu.Unlock()
+
 	if a.credentialsPath == "" {
 		return nil, errors.New("claude: no credentials path resolved")
 	}
@@ -119,9 +190,13 @@ func (a *Adapter) Collect(ctx context.Context) ([]usage.Snapshot, error) {
 		return nil, errors.New("claude: empty access token")
 	}
 
-	body, status, err := a.fetchUsage(ctx, creds.token())
+	body, status, retryAfter, err := a.fetchUsage(ctx, creds.token())
 	if err != nil {
 		return nil, err
+	}
+	if status == http.StatusTooManyRequests {
+		a.recordBackoff(now, retryAfter)
+		return nil, fmt.Errorf("claude: usage endpoint returned status 429 (backing off)")
 	}
 	if status == http.StatusUnauthorized {
 		// Try a single refresh round-trip. If that fails, give up.
@@ -137,9 +212,13 @@ func (a *Adapter) Collect(ctx context.Context) ([]usage.Snapshot, error) {
 		// token is still in memory, so this Collect can proceed; the
 		// next invocation may have to refresh again.
 		_ = writeCredentials(a.credentialsPath, raw, newAccess, newRefresh, expiresIn, a.now())
-		body, status, err = a.fetchUsage(ctx, newAccess)
+		body, status, retryAfter, err = a.fetchUsage(ctx, newAccess)
 		if err != nil {
 			return nil, err
+		}
+		if status == http.StatusTooManyRequests {
+			a.recordBackoff(now, retryAfter)
+			return nil, fmt.Errorf("claude: usage endpoint returned status 429 (backing off)")
 		}
 	}
 	if status != http.StatusOK {
@@ -150,14 +229,51 @@ func (a *Adapter) Collect(ctx context.Context) ([]usage.Snapshot, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Reset backoff on a clean 200.
+	a.mu.Lock()
+	a.backoffUntil = time.Time{}
+	a.consecutive429 = 0
+	a.mu.Unlock()
 	return resp.toSnapshots(a.now().UTC()), nil
 }
 
-// fetchUsage performs a single GET against the usage endpoint.
-func (a *Adapter) fetchUsage(ctx context.Context, token string) ([]byte, int, error) {
+// recordBackoff applies the exponential-backoff policy. retryAfter > 0
+// (parsed from the Retry-After header) takes precedence over the
+// doubling progression; both are clamped to backoffCap.
+func (a *Adapter) recordBackoff(now time.Time, retryAfter time.Duration) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.consecutive429++
+	var dur time.Duration
+	if retryAfter > 0 {
+		dur = retryAfter
+	} else {
+		// 5m, 10m, 20m → cap 15m. n=1 → 5m, n=2 → 10m, n>=3 → 15m.
+		shift := a.consecutive429 - 1
+		if shift < 0 {
+			shift = 0
+		}
+		if shift > 30 {
+			shift = 30 // guard against overflow on absurd streaks.
+		}
+		dur = backoffDefault << shift
+	}
+	if dur > backoffCap {
+		dur = backoffCap
+	}
+	if dur < 0 {
+		dur = backoffDefault
+	}
+	a.backoffUntil = now.Add(dur)
+}
+
+// fetchUsage performs a single GET against the usage endpoint. The
+// returned retryAfter is non-zero only when the response carried a
+// parseable Retry-After header (typically alongside a 429).
+func (a *Adapter) fetchUsage(ctx context.Context, token string) ([]byte, int, time.Duration, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.usageURL, nil)
 	if err != nil {
-		return nil, 0, fmt.Errorf("claude: build request: %w", err)
+		return nil, 0, 0, fmt.Errorf("claude: build request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("User-Agent", userAgent)
@@ -165,14 +281,39 @@ func (a *Adapter) fetchUsage(ctx context.Context, token string) ([]byte, int, er
 	req.Header.Set("Accept", "application/json")
 	resp, err := a.httpClient.Do(req)
 	if err != nil {
-		return nil, 0, fmt.Errorf("claude: GET usage: %w", err)
+		return nil, 0, 0, fmt.Errorf("claude: GET usage: %w", err)
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return nil, resp.StatusCode, fmt.Errorf("claude: read body: %w", err)
+		return nil, resp.StatusCode, 0, fmt.Errorf("claude: read body: %w", err)
 	}
-	return body, resp.StatusCode, nil
+	retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"), a.now())
+	return body, resp.StatusCode, retryAfter, nil
+}
+
+// parseRetryAfter accepts both forms of the Retry-After header: integer
+// seconds, or an HTTP-date. Returns 0 when the value is missing or
+// unparseable so the caller falls back to the doubling progression.
+func parseRetryAfter(raw string, now time.Time) time.Duration {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(raw); err == nil {
+		if secs <= 0 {
+			return 0
+		}
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(raw); err == nil {
+		d := t.Sub(now)
+		if d <= 0 {
+			return 0
+		}
+		return d
+	}
+	return 0
 }
 
 // refreshToken trades a refresh token for a new access (and possibly a new

--- a/internal/core/usage/adapters/claude/claude_test.go
+++ b/internal/core/usage/adapters/claude/claude_test.go
@@ -211,6 +211,178 @@ func TestAdapterCollectMissingCredentialsFile(t *testing.T) {
 	}
 }
 
+func TestAdapter429SetsBackoffWithRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "120")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(server.Close)
+
+	dir := t.TempDir()
+	credsPath := filepath.Join(dir, ".credentials.json")
+	writeCreds(t, credsPath, "access-1", "refresh-1")
+
+	a := NewWithConfig(credsPath, server.URL+"/usage", server.URL+"/refresh", server.Client())
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	snaps, err := a.Collect(context.Background())
+	if err == nil {
+		t.Fatalf("expected error on 429, got nil")
+	}
+	if snaps != nil {
+		t.Fatalf("snaps = %+v, want nil on 429", snaps)
+	}
+	state := a.SaveBackoff()
+	want := now.Add(120 * time.Second)
+	if !state.Until.Equal(want) {
+		t.Fatalf("backoff.Until = %v, want %v (Retry-After=120)", state.Until, want)
+	}
+	if state.Consecutive != 1 {
+		t.Fatalf("backoff.Consecutive = %d, want 1", state.Consecutive)
+	}
+}
+
+func TestAdapter429NoHeaderUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(server.Close)
+
+	dir := t.TempDir()
+	credsPath := filepath.Join(dir, ".credentials.json")
+	writeCreds(t, credsPath, "access-1", "refresh-1")
+
+	a := NewWithConfig(credsPath, server.URL+"/usage", server.URL+"/refresh", server.Client())
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	if _, err := a.Collect(context.Background()); err == nil {
+		t.Fatalf("expected 429 error")
+	}
+	state := a.SaveBackoff()
+	want := now.Add(5 * time.Minute)
+	if !state.Until.Equal(want) {
+		t.Fatalf("backoff.Until = %v, want %v (default 5m)", state.Until, want)
+	}
+}
+
+func TestAdapter429ConsecutiveDoublesUpToCap(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(server.Close)
+
+	dir := t.TempDir()
+	credsPath := filepath.Join(dir, ".credentials.json")
+	writeCreds(t, credsPath, "access-1", "refresh-1")
+
+	a := NewWithConfig(credsPath, server.URL+"/usage", server.URL+"/refresh", server.Client())
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	// Synthesise consecutive 429s by clearing the backoff window
+	// between calls (otherwise the adapter short-circuits during
+	// backoff and never bumps the counter).
+	for i := 1; i <= 4; i++ {
+		a.LoadBackoff(usage.BackoffState{Until: time.Time{}, Consecutive: i - 1})
+		if _, err := a.Collect(context.Background()); err == nil {
+			t.Fatalf("iter %d: expected 429 error", i)
+		}
+	}
+	state := a.SaveBackoff()
+	// 5m → 10m → 20m capped at 15m → 40m capped at 15m. Final: 15m.
+	want := now.Add(15 * time.Minute)
+	if !state.Until.Equal(want) {
+		t.Fatalf("backoff.Until = %v, want %v (capped at 15m)", state.Until, want)
+	}
+	if state.Consecutive != 4 {
+		t.Fatalf("backoff.Consecutive = %d, want 4", state.Consecutive)
+	}
+}
+
+func TestAdapterBackoffShortCircuitsCollect(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"five_hour":{"utilization":1.0,"resets_at":"2026-05-06T17:00:00Z"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	dir := t.TempDir()
+	credsPath := filepath.Join(dir, ".credentials.json")
+	writeCreds(t, credsPath, "access-1", "refresh-1")
+
+	a := NewWithConfig(credsPath, server.URL+"/usage", server.URL+"/refresh", server.Client())
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+	a.LoadBackoff(usage.BackoffState{Until: now.Add(time.Minute), Consecutive: 1})
+
+	snaps, err := a.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect during backoff must be silent: %v", err)
+	}
+	if snaps != nil {
+		t.Fatalf("snaps = %+v, want nil during backoff", snaps)
+	}
+	if calls != 0 {
+		t.Fatalf("HTTP calls = %d, want 0 (backoff short-circuit)", calls)
+	}
+}
+
+func TestAdapter200ResetsBackoff(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"five_hour":{"utilization":3.0,"resets_at":"2026-05-06T17:00:00Z"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	dir := t.TempDir()
+	credsPath := filepath.Join(dir, ".credentials.json")
+	writeCreds(t, credsPath, "access-1", "refresh-1")
+
+	a := NewWithConfig(credsPath, server.URL+"/usage", server.URL+"/refresh", server.Client())
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+	// Pre-load a stale backoff that has expired (so Collect proceeds).
+	a.LoadBackoff(usage.BackoffState{Until: now.Add(-time.Minute), Consecutive: 3})
+
+	snaps, err := a.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("snaps len=%d, want 1", len(snaps))
+	}
+	state := a.SaveBackoff()
+	if !state.Until.IsZero() {
+		t.Fatalf("backoff.Until = %v, want zero (reset on 200)", state.Until)
+	}
+	if state.Consecutive != 0 {
+		t.Fatalf("backoff.Consecutive = %d, want 0 (reset on 200)", state.Consecutive)
+	}
+}
+
+func TestAdapterThrottleHint(t *testing.T) {
+	t.Parallel()
+
+	a := New()
+	if got := a.ThrottleHint(); got != 60*time.Second {
+		t.Fatalf("ThrottleHint = %v, want 60s", got)
+	}
+}
+
 func TestRedactTokenNeverLeaksFullSecret(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/usage/manager.go
+++ b/internal/core/usage/manager.go
@@ -7,12 +7,18 @@ import (
 	"time"
 )
 
+// DefaultThrottle is the per-adapter throttle used when an adapter does
+// not implement ThrottleHinter. Aligns with the prior global throttle
+// value so cheap, local-file adapters keep their existing cadence.
+const DefaultThrottle = 30 * time.Second
+
 // Manager wires a Registry and a Store into the standard "collect, persist,
 // load" flow consumed by the CLI.
 type Manager struct {
 	registry *Registry
 	store    *Store
 	now      func() time.Time
+	debug    func(format string, args ...any)
 }
 
 // NewManager constructs a Manager. now defaults to time.Now when nil.
@@ -23,11 +29,43 @@ func NewManager(registry *Registry, store *Store, now func() time.Time) *Manager
 	return &Manager{registry: registry, store: store, now: now}
 }
 
-// Collect runs every registered adapter, replaces the persisted snapshot
-// file with the union of their results, and returns the merged slice.
-// Adapter errors are joined and returned alongside any successful
-// snapshots — partial data still renders.
+// SetDebug installs a callback used to surface backoff/throttle decisions
+// for diagnostics. The callback is only invoked from cold paths and is
+// safe to leave nil — the Manager never logs by default.
+func (m *Manager) SetDebug(debug func(format string, args ...any)) {
+	if m == nil {
+		return
+	}
+	m.debug = debug
+}
+
+// Collect runs every registered adapter, merging fresh results with the
+// prior on-disk snapshots so an adapter that fails (e.g. 429) does NOT
+// erase its earlier rows. Per-adapter `last_collect` and `backoff` state
+// are also round-tripped through the snapshot file.
+//
+// Merge semantics, evaluated per adapter:
+//   - Adapter returns a non-empty snapshot slice → REPLACE all prior rows
+//     for that model.
+//   - Adapter errors or returns zero snapshots → PRESERVE prior rows for
+//     that model. The user keeps seeing last-known values until the next
+//     successful collect.
+//
+// Adapters that implement BackoffStater have their persisted state
+// loaded before Collect and saved after (success OR failure) so a 429
+// observed on one process survives a CLI restart.
 func (m *Manager) Collect(ctx context.Context) ([]Snapshot, error) {
+	// Throttle of 0 → unconditional: every adapter runs (subject to
+	// adapter-internal backoff). Used by `projmux usage` where the user
+	// explicitly asked for fresh data.
+	return m.collect(ctx, 0)
+}
+
+// collect is the shared implementation. perAdapterFloor is the minimum
+// time-since-last-collect required for an adapter to be invoked; a value
+// of 0 disables the floor and runs every adapter. Adapters that
+// implement ThrottleHinter raise the floor on a per-adapter basis.
+func (m *Manager) collect(ctx context.Context, perAdapterFloor time.Duration) ([]Snapshot, error) {
 	if m == nil {
 		return nil, errors.New("usage: nil manager")
 	}
@@ -42,12 +80,46 @@ func (m *Manager) Collect(ctx context.Context) ([]Snapshot, error) {
 	// Best-effort cleanup of v1 artifacts. Cheap; safe to retry.
 	m.store.CleanupLegacyArtifacts()
 
-	var allSnaps []Snapshot
+	priorState, _ := m.store.LoadState()
+	if priorState.LastCollect == nil {
+		priorState.LastCollect = map[string]time.Time{}
+	}
+	if priorState.Backoff == nil {
+		priorState.Backoff = map[string]BackoffState{}
+	}
+
+	// Bucket prior snapshots by model so per-adapter merge is O(n).
+	priorByModel := map[string][]Snapshot{}
+	for _, s := range priorState.Snapshots {
+		priorByModel[s.Model] = append(priorByModel[s.Model], s)
+	}
+
+	merged := make([]Snapshot, 0, len(priorState.Snapshots))
+	freshModels := map[string]bool{}
 	var errs []error
-	for _, adapter := range m.registry.All() {
+
+	adapters := m.registry.All()
+	for _, adapter := range adapters {
+		name := adapter.Name()
+
+		// Per-adapter throttle gate. Skip adapters whose effective
+		// interval has not elapsed; their prior rows survive via the
+		// merge step below. Floor=0 disables the gate.
+		if perAdapterFloor > 0 {
+			interval := adapterInterval(adapter, perAdapterFloor)
+			if last, ok := priorState.LastCollect[name]; ok && !last.IsZero() && now.Sub(last) < interval {
+				continue
+			}
+		}
+
+		// Install persisted backoff state before Collect so the adapter
+		// can early-return without making the network call.
+		if bs, ok := adapter.(BackoffStater); ok {
+			bs.LoadBackoff(priorState.Backoff[name])
+		}
 		snaps, err := adapter.Collect(ctx)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("%s: %w", adapter.Name(), err))
+			errs = append(errs, fmt.Errorf("%s: %w", name, err))
 		}
 		// Stamp UpdatedAt so the renderer can show "as of" without callers
 		// having to thread the clock through every adapter.
@@ -56,32 +128,56 @@ func (m *Manager) Collect(ctx context.Context) ([]Snapshot, error) {
 				snaps[i].UpdatedAt = now
 			}
 		}
-		allSnaps = append(allSnaps, snaps...)
+		// last_collect[name] advances on every adapter walk — failures
+		// and empty results included. The throttle is about not
+		// hammering the upstream; backoff (BackoffStater) handles the
+		// longer 429-induced cooldown separately. Only the merged
+		// snapshot rows distinguish success from failure.
+		priorState.LastCollect[name] = now
+		if len(snaps) > 0 {
+			// Successful collect: replace all prior rows for the models
+			// the adapter touched. We trust the adapter to emit one row
+			// per (model, window) it owns.
+			for _, s := range snaps {
+				freshModels[s.Model] = true
+			}
+			merged = append(merged, snaps...)
+		}
+		// Persist backoff regardless of success/failure: a 429 sets
+		// `until`; a clean success resets `consecutive` to 0.
+		if bs, ok := adapter.(BackoffStater); ok {
+			priorState.Backoff[name] = bs.SaveBackoff()
+		}
 	}
 
-	if err := m.store.SaveAll(allSnaps, now); err != nil {
+	// Preserve prior rows for any model the current cycle did NOT
+	// successfully refresh. This is the load-bearing fix for the 429
+	// regression: a Claude failure must not erase the Claude rows.
+	for model, rows := range priorByModel {
+		if freshModels[model] {
+			continue
+		}
+		merged = append(merged, rows...)
+	}
+
+	priorState.Snapshots = merged
+	if err := m.store.SaveState(priorState); err != nil {
 		errs = append(errs, fmt.Errorf("save snapshots: %w", err))
 	}
 	if len(errs) > 0 {
-		return allSnaps, errors.Join(errs...)
+		return merged, errors.Join(errs...)
 	}
-	return allSnaps, nil
+	return merged, nil
 }
 
 // MaybeCollect opportunistically refreshes the snapshot file if the
 // supplied throttle interval has elapsed since the last successful
-// collection. It is the cheap, status-bar-safe variant of Collect:
+// collection of any registered adapter. It runs Collect (which itself
+// gates each adapter on its own ThrottleHint) when at least one adapter
+// is due; otherwise it is a no-op.
 //
-//   - If the snapshot file is missing or its last_collect is older than
-//     throttle, adapters run immediately.
-//   - Otherwise the call is a no-op (no adapter walk, no disk write).
-//   - Adapter errors are surfaced for diagnostics (PROJMUX_USAGE_DEBUG)
-//     but the caller (CLI status segment) MUST swallow them. The marker
-//     in the file is updated regardless of success so a permanently
-//     failing adapter does not flood the status hot path.
-//
-// Returns true when a collect cycle ran (regardless of success), false
-// when throttled.
+// `throttle` is the floor used for adapters that do not implement
+// ThrottleHinter. Adapters with a hint use max(throttle, hint).
 func (m *Manager) MaybeCollect(ctx context.Context, throttle time.Duration) (bool, error) {
 	if m == nil {
 		return false, errors.New("usage: nil manager")
@@ -93,25 +189,57 @@ func (m *Manager) MaybeCollect(ctx context.Context, throttle time.Duration) (boo
 	if !m.shouldCollect(now, throttle) {
 		return false, nil
 	}
-	_, collectErr := m.Collect(ctx)
+	_, collectErr := m.collect(ctx, throttle)
 	return true, collectErr
 }
 
-// shouldCollect reports whether MaybeCollect should run adapters. A
-// missing file or unreadable last_collect is treated as stale so a
-// corrupt state dir self-heals on the next redraw.
-func (m *Manager) shouldCollect(now time.Time, throttle time.Duration) bool {
-	if throttle <= 0 {
+// shouldCollect reports whether MaybeCollect should run adapters. It
+// consults per-adapter timestamps so a slow adapter (Claude OAuth,
+// 60s) does not block a fast one (Codex, 30s). The Manager runs the
+// full adapter walk if ANY adapter is due, then Collect's own merge
+// preserves the not-yet-due adapters' prior rows.
+func (m *Manager) shouldCollect(now time.Time, defaultThrottle time.Duration) bool {
+	if defaultThrottle <= 0 {
 		return true
 	}
-	_, last, err := m.store.LoadAll()
+	state, err := m.store.LoadState()
 	if err != nil {
 		return true
 	}
-	if last.IsZero() {
+	if m.registry == nil {
 		return true
 	}
-	return now.Sub(last) >= throttle
+	for _, adapter := range m.registry.All() {
+		name := adapter.Name()
+		interval := adapterInterval(adapter, defaultThrottle)
+		// During backoff the adapter is effectively "not due" — we must
+		// not run Collect just to no-op the network call. Defer to the
+		// adapter's own Collect logic only when out of backoff.
+		if bs, ok := state.Backoff[name]; ok && !bs.Until.IsZero() && now.Before(bs.Until) {
+			if m.debug != nil {
+				m.debug("usage: %s in backoff until %s", name, bs.Until.Format(time.RFC3339))
+			}
+			continue
+		}
+		last := state.LastCollect[name]
+		if last.IsZero() || now.Sub(last) >= interval {
+			return true
+		}
+	}
+	return false
+}
+
+// adapterInterval resolves the effective throttle for an adapter:
+// max(default, ThrottleHint). The default acts as a floor so callers
+// that pass throttle=0 (always run) keep their semantics.
+func adapterInterval(a Adapter, defaultThrottle time.Duration) time.Duration {
+	interval := defaultThrottle
+	if hinter, ok := a.(ThrottleHinter); ok {
+		if hint := hinter.ThrottleHint(); hint > interval {
+			interval = hint
+		}
+	}
+	return interval
 }
 
 // LoadAll reads the persisted snapshots without invoking adapters. Useful
@@ -129,4 +257,16 @@ func (m *Manager) LoadAll() ([]Snapshot, error) {
 		return nil, err
 	}
 	return snaps, nil
+}
+
+// LoadState exposes per-adapter backoff/last_collect for callers that
+// want to render diagnostics (e.g. `projmux usage --json`).
+func (m *Manager) LoadState() (State, error) {
+	if m == nil {
+		return State{}, errors.New("usage: nil manager")
+	}
+	if m.store == nil {
+		return State{}, errors.New("usage: nil store")
+	}
+	return m.store.LoadState()
 }

--- a/internal/core/usage/manager_test.go
+++ b/internal/core/usage/manager_test.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"context"
 	"errors"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -226,4 +227,312 @@ func TestLoadAllReadsCacheWithoutAdapters(t *testing.T) {
 	if len(got) != 1 || got[0].Pct != 9 {
 		t.Fatalf("got = %+v, want one at 9%%", got)
 	}
+}
+
+// throttleHintAdapter declares a custom ThrottleHint per adapter. Used
+// to assert the Manager honours per-adapter intervals so a slow OAuth
+// adapter doesn't gate a fast local-file one.
+type throttleHintAdapter struct {
+	countingAdapter
+	hint time.Duration
+}
+
+func (a *throttleHintAdapter) ThrottleHint() time.Duration { return a.hint }
+
+// backoffAdapter wires the optional BackoffStater interface so the
+// manager round-trips Until/Consecutive through snapshots.json across
+// process restarts.
+type backoffAdapter struct {
+	countingAdapter
+	loaded BackoffState
+	saved  BackoffState
+}
+
+func (b *backoffAdapter) LoadBackoff(state BackoffState) {
+	b.loaded = state
+}
+
+func (b *backoffAdapter) SaveBackoff() BackoffState {
+	return b.saved
+}
+
+func TestCollectPreservesPriorSnapshotsOnAdapterFailure(t *testing.T) {
+	t.Parallel()
+
+	now := mustTime(t, "2026-05-06T12:00:00Z")
+	dir := t.TempDir()
+	registry := NewRegistry()
+	claudeAd := &countingAdapter{
+		name: "claude",
+		snaps: []Snapshot{
+			{Model: "claude", Window: Window5h, Pct: 18.0, ResetsAt: mustTime(t, "2026-05-06T17:00:00Z")},
+		},
+	}
+	codexAd := &countingAdapter{
+		name: "codex",
+		snaps: []Snapshot{
+			{Model: "codex", Window: Window5h, Pct: 42.0, ResetsAt: mustTime(t, "2026-05-06T17:00:00Z")},
+		},
+	}
+	if err := registry.Register(claudeAd); err != nil {
+		t.Fatalf("register claude: %v", err)
+	}
+	if err := registry.Register(codexAd); err != nil {
+		t.Fatalf("register codex: %v", err)
+	}
+	store := NewStore(dir)
+	mgr := NewManager(registry, store, func() time.Time { return now })
+
+	// First collect: both adapters succeed. Cache holds claude+codex.
+	if _, err := mgr.Collect(context.Background()); err != nil {
+		t.Fatalf("first Collect: %v", err)
+	}
+
+	// Second collect: claude fails (network), codex still succeeds. The
+	// claude rows must survive in the merged result and on disk.
+	claudeAd.snaps = nil
+	claudeAd.err = errors.New("claude: 429")
+	codexAd.snaps = []Snapshot{
+		{Model: "codex", Window: Window5h, Pct: 50.0, ResetsAt: mustTime(t, "2026-05-06T18:00:00Z")},
+	}
+
+	got, err := mgr.Collect(context.Background())
+	if err == nil {
+		t.Fatalf("Collect must surface adapter error for diagnostics")
+	}
+
+	gotByModel := map[string]Snapshot{}
+	for _, s := range got {
+		gotByModel[s.Model] = s
+	}
+	if cl, ok := gotByModel["claude"]; !ok {
+		t.Fatalf("merged result missing claude rows: %+v", got)
+	} else if cl.Pct != 18.0 {
+		t.Fatalf("claude rows should preserve prior 18%%, got %v", cl.Pct)
+	}
+	if cx, ok := gotByModel["codex"]; !ok {
+		t.Fatalf("merged result missing codex rows: %+v", got)
+	} else if cx.Pct != 50.0 {
+		t.Fatalf("codex rows should reflect fresh 50%%, got %v", cx.Pct)
+	}
+
+	// Disk must reflect the same merged set.
+	loaded, _, err := store.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(loaded) != 2 {
+		t.Fatalf("on-disk len = %d, want 2 (preserved claude + fresh codex)", len(loaded))
+	}
+}
+
+func TestCollectEmptyResultPreservesPrior(t *testing.T) {
+	t.Parallel()
+
+	now := mustTime(t, "2026-05-06T12:00:00Z")
+	dir := t.TempDir()
+	registry := NewRegistry()
+	claudeAd := &countingAdapter{
+		name: "claude",
+		snaps: []Snapshot{
+			{Model: "claude", Window: Window5h, Pct: 7.0},
+		},
+	}
+	if err := registry.Register(claudeAd); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	store := NewStore(dir)
+	mgr := NewManager(registry, store, func() time.Time { return now })
+
+	if _, err := mgr.Collect(context.Background()); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	// Adapter returns zero snapshots without an error (e.g. backoff
+	// branch). Prior rows must still survive.
+	claudeAd.snaps = nil
+	got, err := mgr.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if len(got) != 1 || got[0].Pct != 7.0 {
+		t.Fatalf("merged = %+v, want preserved 7%% snapshot", got)
+	}
+}
+
+func TestMaybeCollectPerAdapterThrottle(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	registry := NewRegistry()
+	claudeAd := &throttleHintAdapter{
+		countingAdapter: countingAdapter{name: "claude", snaps: []Snapshot{
+			{Model: "claude", Window: Window5h, Pct: 5},
+		}},
+		hint: 60 * time.Second,
+	}
+	codexAd := &countingAdapter{name: "codex", snaps: []Snapshot{
+		{Model: "codex", Window: Window5h, Pct: 10},
+	}}
+	if err := registry.Register(claudeAd); err != nil {
+		t.Fatalf("register claude: %v", err)
+	}
+	if err := registry.Register(codexAd); err != nil {
+		t.Fatalf("register codex: %v", err)
+	}
+	store := NewStore(dir)
+
+	now := mustTime(t, "2026-05-06T12:00:00Z")
+	clock := &now
+	mgr := NewManager(registry, store, func() time.Time { return *clock })
+
+	// First call: both adapters run.
+	if _, err := mgr.MaybeCollect(context.Background(), 30*time.Second); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if claudeAd.Calls() != 1 || codexAd.Calls() != 1 {
+		t.Fatalf("first call counts: claude=%d codex=%d, want 1/1", claudeAd.Calls(), codexAd.Calls())
+	}
+
+	// 45s later: codex (30s throttle) is due, claude (60s hint) is not.
+	*clock = now.Add(45 * time.Second)
+	ran, err := mgr.MaybeCollect(context.Background(), 30*time.Second)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if !ran {
+		t.Fatalf("ran=false, want true (codex due)")
+	}
+	if codexAd.Calls() != 2 {
+		t.Fatalf("codex calls = %d, want 2", codexAd.Calls())
+	}
+	if claudeAd.Calls() != 1 {
+		t.Fatalf("claude calls = %d, want 1 (still within 60s hint)", claudeAd.Calls())
+	}
+
+	// 70s past first call: claude is now due.
+	*clock = now.Add(70 * time.Second)
+	if _, err := mgr.MaybeCollect(context.Background(), 30*time.Second); err != nil {
+		t.Fatalf("third: %v", err)
+	}
+	if claudeAd.Calls() != 2 {
+		t.Fatalf("claude calls = %d, want 2 after 70s", claudeAd.Calls())
+	}
+}
+
+func TestMaybeCollectBackoffBlocksAdapter(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	registry := NewRegistry()
+	now := mustTime(t, "2026-05-06T12:00:00Z")
+	// Backoff persisted on disk: claude is in cooldown until now+5m.
+	store := NewStore(dir)
+	if err := store.SaveState(State{
+		Snapshots: []Snapshot{
+			{Model: "claude", Window: Window5h, Pct: 33, UpdatedAt: now.Add(-2 * time.Minute)},
+		},
+		LastCollect: map[string]time.Time{
+			"claude": now.Add(-2 * time.Minute),
+		},
+		Backoff: map[string]BackoffState{
+			"claude": {Until: now.Add(5 * time.Minute), Consecutive: 1},
+		},
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	claudeAd := &backoffAdapter{
+		countingAdapter: countingAdapter{name: "claude"},
+	}
+	if err := registry.Register(claudeAd); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	mgr := NewManager(registry, store, func() time.Time { return now })
+
+	ran, err := mgr.MaybeCollect(context.Background(), 30*time.Second)
+	if err != nil {
+		t.Fatalf("MaybeCollect: %v", err)
+	}
+	if ran {
+		t.Fatalf("ran=true, want false (claude in backoff, no other adapters due)")
+	}
+	if claudeAd.Calls() != 0 {
+		t.Fatalf("claude calls = %d, want 0 (backoff blocks Collect)", claudeAd.Calls())
+	}
+}
+
+func TestCollectPersistsBackoffState(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	registry := NewRegistry()
+	now := mustTime(t, "2026-05-06T12:00:00Z")
+	claudeAd := &backoffAdapter{
+		countingAdapter: countingAdapter{
+			name: "claude",
+			snaps: []Snapshot{
+				{Model: "claude", Window: Window5h, Pct: 5},
+			},
+		},
+		saved: BackoffState{Until: now.Add(10 * time.Minute), Consecutive: 2},
+	}
+	if err := registry.Register(claudeAd); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	store := NewStore(dir)
+	mgr := NewManager(registry, store, func() time.Time { return now })
+
+	if _, err := mgr.Collect(context.Background()); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	state, err := store.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	bs, ok := state.Backoff["claude"]
+	if !ok {
+		t.Fatalf("backoff state missing for claude: %+v", state.Backoff)
+	}
+	if bs.Consecutive != 2 {
+		t.Fatalf("backoff.Consecutive = %d, want 2", bs.Consecutive)
+	}
+	if !bs.Until.Equal(now.Add(10 * time.Minute).UTC()) {
+		t.Fatalf("backoff.Until = %v, want %v", bs.Until, now.Add(10*time.Minute))
+	}
+}
+
+func TestStoreMigratesLegacyLastCollectString(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Pre-write the v2 file with the legacy string-shaped last_collect.
+	legacy := `{
+		"version": 2,
+		"last_collect": "2026-05-06T09:29:52Z",
+		"snapshots": [
+			{"model":"claude","window":"5h","pct":1.5,"resets_at":"2026-05-06T17:00:00Z","updated_at":"2026-05-06T09:29:52Z"}
+		]
+	}`
+	path := dir + "/snapshots.json"
+	if err := writeFile(path, []byte(legacy)); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+	store := NewStore(dir)
+	state, err := store.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	// Snapshots round-trip even though last_collect is legacy.
+	if len(state.Snapshots) != 1 || state.Snapshots[0].Pct != 1.5 {
+		t.Fatalf("snapshots = %+v, want one at 1.5%%", state.Snapshots)
+	}
+	// Legacy string form: per-adapter map is empty. Next collect runs
+	// every adapter (the documented migration behaviour).
+	if len(state.LastCollect) != 0 {
+		t.Fatalf("LastCollect = %+v, want empty after legacy migration", state.LastCollect)
+	}
+}
+
+func writeFile(path string, data []byte) error {
+	return os.WriteFile(path, data, 0o644)
 }

--- a/internal/core/usage/registry.go
+++ b/internal/core/usage/registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"time"
 )
 
 // Adapter is the pluggable contract for an AI-usage data source.
@@ -21,6 +22,30 @@ import (
 type Adapter interface {
 	Name() string
 	Collect(ctx context.Context) ([]Snapshot, error)
+}
+
+// ThrottleHinter is an optional interface adapters may implement to
+// declare their preferred minimum interval between Collect calls. The
+// Manager honours this hint per-adapter; adapters that do not implement
+// the interface inherit the caller-supplied default (currently 30s).
+type ThrottleHinter interface {
+	ThrottleHint() time.Duration
+}
+
+// BackoffStater is an optional interface adapters may implement to
+// expose persisted exponential-backoff state. The Manager round-trips
+// the value through the on-disk snapshots file so a CLI restart does
+// not lose backoff progress. Adapters that do not implement this
+// interface have no persistent backoff bookkeeping (errors are still
+// surfaced for diagnostics).
+type BackoffStater interface {
+	// LoadBackoff installs persisted backoff state from disk. Called
+	// exactly once per Manager Collect cycle, before Collect is invoked.
+	LoadBackoff(state BackoffState)
+	// SaveBackoff returns the current in-memory backoff state for
+	// persistence. Called after Collect so a fresh 429 (or success) is
+	// reflected in the next file write.
+	SaveBackoff() BackoffState
 }
 
 // Registry stores adapters keyed by Name(). It is safe for concurrent use.

--- a/internal/core/usage/store.go
+++ b/internal/core/usage/store.go
@@ -16,13 +16,36 @@ import (
 // report the current account-wide state.
 const snapshotFileName = "snapshots.json"
 
-// snapshotFile is the on-disk schema the Store writes. Version is bumped
-// to 2 to make the schema break (v1 was per-model bucketed token counts)
-// explicit.
+// BackoffState captures per-adapter exponential-backoff bookkeeping that
+// must survive process restarts. `Until` is the absolute time at which
+// the next adapter call is permitted; `Consecutive` counts the number of
+// 429-style failures observed in a row so callers can grow the next
+// interval geometrically.
+type BackoffState struct {
+	Until       time.Time `json:"until"`
+	Consecutive int       `json:"consecutive"`
+}
+
+// snapshotFile is the on-disk schema the Store writes. Version stays at 2;
+// the shape evolved (per-adapter `last_collect` map, optional `backoff`
+// map) in a backward-compatible way. The custom UnmarshalJSON below
+// accepts both the prior single-string `last_collect` (treated as missing
+// per-adapter timestamps) and the new map form.
 type snapshotFile struct {
-	Version     int        `json:"version"`
-	LastCollect time.Time  `json:"last_collect"`
-	Snapshots   []Snapshot `json:"snapshots"`
+	Version     int                     `json:"version"`
+	LastCollect map[string]time.Time    `json:"last_collect,omitempty"`
+	Backoff     map[string]BackoffState `json:"backoff,omitempty"`
+	Snapshots   []Snapshot              `json:"snapshots"`
+}
+
+// snapshotFileWire is the loose, decode-only mirror of snapshotFile that
+// permits `last_collect` to be either a string (legacy) or a map. Encoding
+// always uses snapshotFile so we never re-emit the legacy string form.
+type snapshotFileWire struct {
+	Version     int                     `json:"version"`
+	LastCollect json.RawMessage         `json:"last_collect,omitempty"`
+	Backoff     map[string]BackoffState `json:"backoff,omitempty"`
+	Snapshots   []Snapshot              `json:"snapshots"`
 }
 
 // Store persists the most recent batch of Snapshots emitted by all
@@ -52,45 +75,111 @@ func (s *Store) BaseDir() string {
 	return s.baseDir
 }
 
+// State is the rich view the Manager and adapters need: snapshots plus
+// per-adapter throttle/backoff bookkeeping. Returned by LoadState; the
+// older LoadAll wrapper is kept for callers that only want the snapshot
+// list.
+type State struct {
+	Snapshots   []Snapshot
+	LastCollect map[string]time.Time
+	Backoff     map[string]BackoffState
+}
+
 // LoadAll reads the persisted snapshots. A missing file reads as empty
-// (no error) so first-run callers see []Snapshot{}.
+// (no error) so first-run callers see []Snapshot{}. The second return is
+// the most recent global last_collect across adapters (kept for callers
+// that only care that *something* was collected) — for per-adapter timing
+// use LoadState.
 func (s *Store) LoadAll() ([]Snapshot, time.Time, error) {
+	st, err := s.LoadState()
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	var latest time.Time
+	for _, t := range st.LastCollect {
+		if t.After(latest) {
+			latest = t
+		}
+	}
+	return st.Snapshots, latest, nil
+}
+
+// LoadState reads the persisted file and returns the full per-adapter
+// state. A missing file reads as zero-value State (no error).
+func (s *Store) LoadState() (State, error) {
 	path := s.FilePath()
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, time.Time{}, nil
+			return State{}, nil
 		}
-		return nil, time.Time{}, fmt.Errorf("usage: read snapshots %s: %w", path, err)
+		return State{}, fmt.Errorf("usage: read snapshots %s: %w", path, err)
 	}
 	if len(data) == 0 {
-		return nil, time.Time{}, nil
+		return State{}, nil
 	}
-	var f snapshotFile
-	if err := json.Unmarshal(data, &f); err != nil {
-		return nil, time.Time{}, fmt.Errorf("usage: parse snapshots %s: %w", path, err)
+	var w snapshotFileWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return State{}, fmt.Errorf("usage: parse snapshots %s: %w", path, err)
 	}
-	out := make([]Snapshot, 0, len(f.Snapshots))
-	for _, snap := range f.Snapshots {
+
+	state := State{
+		LastCollect: map[string]time.Time{},
+		Backoff:     map[string]BackoffState{},
+	}
+	if len(w.LastCollect) > 0 {
+		// Try map form first; fall back to string (legacy v2). A bare
+		// string predates the per-adapter map and is treated as missing
+		// per-adapter timestamps so the next collect runs everything.
+		var asMap map[string]time.Time
+		if err := json.Unmarshal(w.LastCollect, &asMap); err == nil {
+			for k, v := range asMap {
+				state.LastCollect[k] = v.UTC()
+			}
+		}
+		// If asMap parsing failed (string form), the map stays empty —
+		// equivalent to "no per-adapter timestamps", which is the
+		// documented migration behaviour.
+	}
+	for k, v := range w.Backoff {
+		v.Until = v.Until.UTC()
+		state.Backoff[k] = v
+	}
+	out := make([]Snapshot, 0, len(w.Snapshots))
+	for _, snap := range w.Snapshots {
 		// Defensive normalisation: ensure timestamps are UTC so the renderer
 		// gets a stable shape regardless of how the file was written.
 		snap.ResetsAt = snap.ResetsAt.UTC()
 		snap.UpdatedAt = snap.UpdatedAt.UTC()
 		out = append(out, snap)
 	}
-	return out, f.LastCollect.UTC(), nil
+	state.Snapshots = out
+	return state, nil
 }
 
 // SaveAll persists snapshots to disk, replacing whatever was there
-// before. lastCollect is recorded so MaybeCollect can throttle without a
-// separate marker file.
+// before. lastCollect is recorded under a single synthetic adapter key
+// ("_global") so legacy callers that don't know about per-adapter
+// throttling still mark forward progress. New callers should use
+// SaveState directly.
 func (s *Store) SaveAll(snaps []Snapshot, lastCollect time.Time) error {
+	state := State{
+		Snapshots: snaps,
+		LastCollect: map[string]time.Time{
+			"_global": lastCollect.UTC(),
+		},
+	}
+	return s.SaveState(state)
+}
+
+// SaveState persists the full per-adapter state to disk atomically.
+func (s *Store) SaveState(state State) error {
 	if err := os.MkdirAll(s.baseDir, 0o755); err != nil {
 		return fmt.Errorf("usage: create cache dir %s: %w", s.baseDir, err)
 	}
 	// Stable ordering: model asc, window asc within model.
-	sorted := make([]Snapshot, len(snaps))
-	copy(sorted, snaps)
+	sorted := make([]Snapshot, len(state.Snapshots))
+	copy(sorted, state.Snapshots)
 	windowOrder := map[Window]int{Window5h: 0, WindowWeekly: 1}
 	sort.SliceStable(sorted, func(i, j int) bool {
 		if sorted[i].Model != sorted[j].Model {
@@ -98,9 +187,25 @@ func (s *Store) SaveAll(snaps []Snapshot, lastCollect time.Time) error {
 		}
 		return windowOrder[sorted[i].Window] < windowOrder[sorted[j].Window]
 	})
+	last := map[string]time.Time{}
+	for k, v := range state.LastCollect {
+		last[k] = v.UTC()
+	}
+	backoff := map[string]BackoffState{}
+	for k, v := range state.Backoff {
+		// Drop zero-valued entries: they mean "no active backoff" and
+		// just clutter the on-disk file. Adapters reload an absent key
+		// as a zero BackoffState which is the desired default.
+		if v.Until.IsZero() && v.Consecutive == 0 {
+			continue
+		}
+		v.Until = v.Until.UTC()
+		backoff[k] = v
+	}
 	payload := snapshotFile{
 		Version:     2,
-		LastCollect: lastCollect.UTC(),
+		LastCollect: last,
+		Backoff:     backoff,
 		Snapshots:   sorted,
 	}
 	data, err := json.MarshalIndent(payload, "", "  ")


### PR DESCRIPTION
## Summary
After the OAuth slice landed, the user got rate-limited (HTTP 429) and Claude rows disappeared from the HUD entirely. Three structural fixes:

1. **Preserve prior snapshots on adapter failure**: `Collect` now merges fresh adapter results with prior on-disk snapshots. A failed adapter (or one returning empty) keeps its previous rows instead of being erased. The HUD keeps rendering the last known values.

2. **Per-adapter throttle**: introduce `ThrottleHinter` — Claude OAuth adapter declares 60s, Codex stays at 30s. Per-adapter `last_collect` timestamps drive the gate so Codex isn't blocked by Claude's slower cadence.

3. **429 exponential backoff (Claude)**: `BackoffStater` interface + persisted `backoff: { claude: { until, consecutive } }`. On 429 → backoff = `Retry-After` (seconds or HTTP-date) capped at 15m, defaulting to 5m. Consecutive 429s double up to cap. Any non-429 success resets the streak. During backoff the adapter short-circuits (no network call).

## UX additions
- `~` marker (dim `colour245`) appended after percentages in HUD when `updated_at` is older than 10 minutes
- `STALE` column in `projmux usage` table CLI
- `--json` includes per-row `stale` boolean and top-level `backoff` block when active (bare array preserved when healthy)
- `PROJMUX_USAGE_DEBUG=1` surfaces per-collect debug lines (e.g. "claude in backoff until ...")

## Schema migration
- `last_collect` was a single string in v2 → now a `map[string]time.Time` per adapter. Loader accepts both shapes; legacy string is treated as missing per-adapter timestamps so the next collect runs both adapters once.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` — 438 tests in `usage` + `app`; new tests cover failure-preserves-prior, per-adapter throttle (30s vs 60s), Retry-After (seconds + HTTP-date), default 5m, doubling-to-cap, success-resets-streak, short-circuit during backoff, stale HUD marker, STALE column.
- [x] Manual: dev box currently in 429 cooldown — verified Claude rows preserved, `backoff.claude.until` populated ~5m out, Codex rows refreshed, `usage --json` shape matches docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)