### PR TITLE
feat(notify): reconcile subcommand to back-fill queue from live pane state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ install: build
 	@echo ">> atomically replaced $(INSTALL_BIN)"
 	@echo ">> applying live config..."
 	@$(INSTALL_BIN) tmux apply
+	@echo ">> reconciling notify queue..."
+	@$(INSTALL_BIN) notify reconcile || true
 
 fmt:
 	@if [ -n "$(GO_FILES)" ]; then \

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -27,10 +27,11 @@ type notifyCommand struct {
 	store    notifyStore
 	storeErr error
 	now      func() time.Time
+	runner   tmuxRunner
 }
 
 func newNotifyCommand() *notifyCommand {
-	cmd := &notifyCommand{now: time.Now}
+	cmd := &notifyCommand{now: time.Now, runner: reconcileDefaultRunner()}
 	paths, err := config.DefaultPathsFromEnv()
 	if err != nil {
 		cmd.storeErr = fmt.Errorf("resolve default config paths: %w", err)
@@ -54,6 +55,8 @@ func (c *notifyCommand) Run(args []string, stdout, stderr io.Writer) error {
 		return c.runList(args[1:], stdout, stderr)
 	case "ack":
 		return c.runAck(args[1:], stdout, stderr)
+	case "reconcile":
+		return c.runReconcile(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
 		printNotifyUsage(stdout)
 		return nil
@@ -401,4 +404,5 @@ func printNotifyUsage(w io.Writer) {
 	fmt.Fprintln(w, "                        [--ttl <seconds>] [--id <s>] [--json]")
 	fmt.Fprintln(w, "  projmux notify list  [--json] [--limit N] [--severity ...] [--source ...]")
 	fmt.Fprintln(w, "  projmux notify ack   <id> [--all]")
+	fmt.Fprintln(w, "  projmux notify reconcile [--json]")
 }

--- a/internal/app/notify_reconcile.go
+++ b/internal/app/notify_reconcile.go
@@ -1,0 +1,248 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/crevissepartners/projmux/internal/core/notify"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+)
+
+// reconcileListPanesFormat is the tab/pipe-separated format used by the
+// reconcile pass. The producer key set (session, pane id, agent, topic,
+// socket) drives id construction and queue text composition; the
+// attention/ai state fields decide whether the pane should be in the queue.
+const reconcileListPanesFormat = "" +
+	"#{session_name}|" +
+	"#{window_id}|" +
+	"#{pane_id}|" +
+	"#{" + attentionStateOption + "}|" +
+	"#{" + aiPaneStateOption + "}|" +
+	"#{" + aiPaneAgentOption + "}|" +
+	"#{" + aiPaneTopicOption + "}|" +
+	"#{socket_path}"
+
+// reconcileResult is the summary returned by the reconcile pass.
+type reconcileResult struct {
+	Pushed int      `json:"pushed"`
+	Acked  int      `json:"acked"`
+	Kept   int      `json:"kept"`
+	Errors []string `json:"errors"`
+}
+
+// reconcilePane is the projection of one row from
+// `tmux list-panes -a -F <reconcileListPanesFormat>` after parsing.
+type reconcilePane struct {
+	Session        string
+	Window         string
+	Pane           string
+	AttentionState string
+	AIState        string
+	Agent          string
+	Topic          string
+	Socket         string
+}
+
+// shouldHaveQueueEntry reports whether the pane's live state means it must
+// be present in the notify queue. The producer pushes when the attention
+// state machine reports `reply` AND there is an AI agent associated with
+// the pane (manual `attention toggle` on a shell pane is intentionally
+// skipped). The reconcile pass mirrors that contract.
+func (p reconcilePane) shouldHaveQueueEntry() bool {
+	if strings.TrimSpace(p.Agent) == "" {
+		return false
+	}
+	if p.AttentionState == attentionStateReply {
+		return true
+	}
+	// The AI flow flips attention to reply on `status set waiting` but the
+	// option is set on the pane via tmux which is observed through the
+	// attention option; if the attention option is unset (e.g. via
+	// `attention clear`) we do not consider the pane reply-state.
+	return false
+}
+
+// id returns the canonical queue id used by the producer. Reusing the
+// shared helper guarantees push/ack/reconcile all agree on the key.
+func (p reconcilePane) id() string {
+	return buildAttentionNotifyID(p.Session, p.Pane)
+}
+
+// text returns the canonical queue text used by the producer. Reusing the
+// shared helper guarantees the agent/topic rendering stays in lockstep
+// with the event-driven path.
+func (p reconcilePane) text() string {
+	return composeAttentionReplyText(p.Agent, p.Topic)
+}
+
+// runReconcile walks every tmux pane on the host, compares the live state
+// against the persistent notify queue, and back-fills/clears entries so
+// the queue matches reality. Returns an error only for argument parsing
+// or store failures; tmux call failures are surfaced through the
+// `errors` field of the summary so install scripts get a single
+// non-fatal pass.
+func (c *notifyCommand) runReconcile(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("notify reconcile", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "emit json instead of human output")
+
+	if err := fs.Parse(args); err != nil {
+		return usageError(fmt.Sprintf("parse notify reconcile flags: %v", err))
+	}
+	if fs.NArg() != 0 {
+		printNotifyUsage(stderr)
+		return usageError("notify reconcile does not accept positional arguments")
+	}
+
+	store, err := c.requireStore()
+	if err != nil {
+		return err
+	}
+
+	result := reconcileResult{Errors: []string{}}
+
+	panes, listErr := c.listReconcilePanes()
+	if listErr != nil {
+		// Common case: tmux is not running. Treat as soft failure so the
+		// post-install hook does not break.
+		result.Errors = append(result.Errors, listErr.Error())
+		return writeReconcileSummary(stdout, result, *asJSON)
+	}
+
+	wantByID := make(map[string]reconcilePane, len(panes))
+	for _, p := range panes {
+		if !p.shouldHaveQueueEntry() {
+			continue
+		}
+		wantByID[p.id()] = p
+	}
+
+	existing, listQueueErr := store.List()
+	if listQueueErr != nil {
+		return fmt.Errorf("list notifications: %w", listQueueErr)
+	}
+
+	existingByID := make(map[string]notify.Notification, len(existing))
+	for _, e := range existing {
+		existingByID[e.ID] = e
+	}
+
+	// Push pass: for every pane that should be in the queue, add or refresh.
+	for id, pane := range wantByID {
+		want := pane.text()
+		if cur, ok := existingByID[id]; ok && cur.Text == want {
+			result.Kept++
+			continue
+		}
+		in := notify.PushInput{
+			ID:       id,
+			Text:     want,
+			Severity: notify.SeverityInfo,
+			Source:   notify.SourceAI,
+			TTL:      attentionNotifyTTL,
+			Target: notify.Target{
+				Socket:  pane.Socket,
+				Session: pane.Session,
+				Window:  pane.Window,
+				Pane:    pane.Pane,
+			},
+		}
+		if _, _, err := store.Push(in); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("push %s: %v", id, err))
+			continue
+		}
+		result.Pushed++
+	}
+
+	// Ack pass: for every queue entry whose key starts with `ai:`, drop it
+	// if the pane is no longer reply-state with an agent.
+	for _, e := range existing {
+		if !strings.HasPrefix(e.ID, "ai:") {
+			continue
+		}
+		if _, ok := wantByID[e.ID]; ok {
+			continue
+		}
+		if err := store.Ack(e.ID); err != nil && !errors.Is(err, notify.ErrNotFound) {
+			result.Errors = append(result.Errors, fmt.Sprintf("ack %s: %v", e.ID, err))
+			continue
+		}
+		result.Acked++
+	}
+
+	return writeReconcileSummary(stdout, result, *asJSON)
+}
+
+// listReconcilePanes shells out to `tmux list-panes -a -F ...` and parses
+// every live pane row. Empty/blank rows are skipped. A nil runner short-
+// circuits to an empty slice so unit tests that exercise unrelated paths
+// do not need to wire a fake.
+func (c *notifyCommand) listReconcilePanes() ([]reconcilePane, error) {
+	if c == nil || c.runner == nil {
+		return nil, errors.New("tmux runner is not configured")
+	}
+	output, err := c.runner.Run(context.Background(), "tmux", "list-panes", "-a", "-F", reconcileListPanesFormat)
+	if err != nil {
+		return nil, fmt.Errorf("tmux list-panes: %w", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(output), "\r\n"), "\n")
+	out := make([]reconcilePane, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Split(line, "|")
+		// The format string emits exactly 8 fields; tmux silently substitutes
+		// empty strings for unset options so a short row is malformed.
+		if len(fields) < 8 {
+			continue
+		}
+		p := reconcilePane{
+			Session:        strings.TrimSpace(fields[0]),
+			Window:         strings.TrimSpace(fields[1]),
+			Pane:           strings.TrimSpace(fields[2]),
+			AttentionState: strings.TrimSpace(fields[3]),
+			AIState:        strings.TrimSpace(fields[4]),
+			Agent:          strings.TrimSpace(fields[5]),
+			Topic:          strings.TrimSpace(fields[6]),
+			Socket:         strings.TrimSpace(fields[7]),
+		}
+		if p.Session == "" || p.Pane == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// writeReconcileSummary renders the result as either JSON or a single
+// human-readable line.
+func writeReconcileSummary(w io.Writer, r reconcileResult, asJSON bool) error {
+	if r.Errors == nil {
+		r.Errors = []string{}
+	}
+	if asJSON {
+		return writeJSON(w, r)
+	}
+	_, err := fmt.Fprintf(w, "reconcile: pushed %d, acked %d, kept %d\n", r.Pushed, r.Acked, r.Kept)
+	if err != nil {
+		return err
+	}
+	for _, e := range r.Errors {
+		if _, err := fmt.Fprintf(w, "reconcile error: %s\n", e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// reconcileDefaultRunner builds the production tmux runner for the
+// reconcile pass. Kept as a small helper so wiring stays in one place.
+func reconcileDefaultRunner() tmuxRunner {
+	return inttmux.ExecRunner{}
+}

--- a/internal/app/notify_reconcile_test.go
+++ b/internal/app/notify_reconcile_test.go
@@ -1,0 +1,460 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/notify"
+)
+
+// reconcileTmuxRunner is a fake tmux runner that returns a fixed payload
+// for `tmux list-panes -a -F <fmt>` and records every invocation. The
+// fake intentionally ignores other tmux commands so it can be reused
+// across subtests without surprising the cases that don't shell out to
+// list-panes.
+type reconcileTmuxRunner struct {
+	output []byte
+	err    error
+	calls  int
+}
+
+func (r *reconcileTmuxRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	if name == "tmux" && len(args) >= 2 && args[0] == "list-panes" && args[1] == "-a" {
+		r.calls++
+		return r.output, r.err
+	}
+	return nil, nil
+}
+
+// memNotifyStore is an in-memory notify store with the same surface as the
+// production *notify.Store. It is intentionally simpler than the disk
+// store: every Push replaces by id, every Ack removes by id, every List
+// returns a copy.
+type memNotifyStore struct {
+	entries []notify.Notification
+	pushed  []notify.PushInput
+	acks    []string
+}
+
+func (s *memNotifyStore) Push(in notify.PushInput) (notify.Notification, notify.PushResult, error) {
+	s.pushed = append(s.pushed, in)
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	entry := notify.Notification{
+		ID:        in.ID,
+		Text:      in.Text,
+		Severity:  in.Severity,
+		Source:    in.Source,
+		Socket:    in.Target.Socket,
+		Session:   in.Target.Session,
+		Window:    in.Target.Window,
+		Pane:      in.Target.Pane,
+		CreatedAt: now,
+		ExpiresAt: now.Add(in.TTL),
+	}
+	for i, e := range s.entries {
+		if e.ID == in.ID {
+			s.entries[i] = entry
+			return entry, notify.PushResult{ID: in.ID, QueueLen: len(s.entries), Replaced: true}, nil
+		}
+	}
+	s.entries = append(s.entries, entry)
+	return entry, notify.PushResult{ID: in.ID, QueueLen: len(s.entries)}, nil
+}
+
+func (s *memNotifyStore) List() ([]notify.Notification, error) {
+	out := make([]notify.Notification, len(s.entries))
+	copy(out, s.entries)
+	return out, nil
+}
+
+func (s *memNotifyStore) Ack(id string) error {
+	s.acks = append(s.acks, id)
+	for i, e := range s.entries {
+		if e.ID == id {
+			s.entries = append(s.entries[:i], s.entries[i+1:]...)
+			return nil
+		}
+	}
+	return notify.ErrNotFound
+}
+
+func (s *memNotifyStore) AckAll() (int, error) {
+	n := len(s.entries)
+	s.entries = nil
+	return n, nil
+}
+
+func newReconcileCmd(store notifyStore, runner tmuxRunner) *notifyCommand {
+	return &notifyCommand{
+		store:  store,
+		now:    func() time.Time { return time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC) },
+		runner: runner,
+	}
+}
+
+func TestNotifyReconcilePushesMissingEntryForReplyPane(t *testing.T) {
+	t.Parallel()
+
+	runner := &reconcileTmuxRunner{
+		output: []byte("main|@4|%16|reply|waiting|claude|notify wiring|/tmp/tmux-1000/projmux\n"),
+	}
+	store := &memNotifyStore{}
+	cmd := newReconcileCmd(store, runner)
+
+	var stdout, stderr bytes.Buffer
+	if err := cmd.Run([]string{"reconcile"}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, stderr.String())
+	}
+
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1", len(store.pushed))
+	}
+	in := store.pushed[0]
+	if in.ID != "ai:main:%16" {
+		t.Fatalf("ID = %q, want ai:main:%%16", in.ID)
+	}
+	if in.Text != "claude: reply ready · notify wiring" {
+		t.Fatalf("Text = %q", in.Text)
+	}
+	if in.Source != notify.SourceAI || in.Severity != notify.SeverityInfo {
+		t.Fatalf("Source/Severity = %q/%q", in.Source, in.Severity)
+	}
+	if in.TTL != attentionNotifyTTL {
+		t.Fatalf("TTL = %s, want %s", in.TTL, attentionNotifyTTL)
+	}
+	if in.Target.Session != "main" || in.Target.Window != "@4" || in.Target.Pane != "%16" {
+		t.Fatalf("Target = %+v", in.Target)
+	}
+	if in.Target.Socket != "/tmp/tmux-1000/projmux" {
+		t.Fatalf("Socket = %q", in.Target.Socket)
+	}
+	if got := stdout.String(); got != "reconcile: pushed 1, acked 0, kept 0\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestNotifyReconcileNoOpWhenQueueAndPanesAlreadyAgree(t *testing.T) {
+	t.Parallel()
+
+	runner := &reconcileTmuxRunner{output: []byte("")}
+	store := &memNotifyStore{}
+	cmd := newReconcileCmd(store, runner)
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"reconcile"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(store.pushed) != 0 || len(store.acks) != 0 {
+		t.Fatalf("expected no-op, pushed=%d acks=%d", len(store.pushed), len(store.acks))
+	}
+	if got := stdout.String(); got != "reconcile: pushed 0, acked 0, kept 0\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestNotifyReconcileAcksStaleEntryWhenPaneNoLongerReply(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	runner := &reconcileTmuxRunner{
+		// Pane %16 is still alive but no longer in reply state.
+		output: []byte("main|@4|%16||idle|claude||/tmp/tmux/default\n"),
+	}
+	store := &memNotifyStore{
+		entries: []notify.Notification{
+			{
+				ID:        "ai:main:%16",
+				Text:      "claude: reply ready",
+				Severity:  notify.SeverityInfo,
+				Source:    notify.SourceAI,
+				Session:   "main",
+				Pane:      "%16",
+				CreatedAt: now,
+				ExpiresAt: now.Add(attentionNotifyTTL),
+			},
+		},
+	}
+	cmd := newReconcileCmd(store, runner)
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"reconcile"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(store.acks) != 1 || store.acks[0] != "ai:main:%16" {
+		t.Fatalf("acks = %v", store.acks)
+	}
+	if len(store.entries) != 0 {
+		t.Fatalf("entries = %+v, want empty", store.entries)
+	}
+	if got := stdout.String(); got != "reconcile: pushed 0, acked 1, kept 0\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestNotifyReconcileAcksStaleEntryWhenPaneGone(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	// list-panes returns no panes at all (pane was killed).
+	runner := &reconcileTmuxRunner{output: []byte("")}
+	store := &memNotifyStore{
+		entries: []notify.Notification{
+			{
+				ID:        "ai:main:%99",
+				Text:      "codex: reply ready",
+				Severity:  notify.SeverityInfo,
+				Source:    notify.SourceAI,
+				Session:   "main",
+				Pane:      "%99",
+				CreatedAt: now,
+				ExpiresAt: now.Add(attentionNotifyTTL),
+			},
+		},
+	}
+	cmd := newReconcileCmd(store, runner)
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"reconcile"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(store.acks) != 1 || store.acks[0] != "ai:main:%99" {
+		t.Fatalf("acks = %v", store.acks)
+	}
+}
+
+func TestNotifyReconcileKeepsMatchingEntryWithoutDuplicatePush(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	runner := &reconcileTmuxRunner{
+		output: []byte("main|@4|%16|reply|waiting|claude|notify wiring|/tmp/tmux/default\n"),
+	}
+	store := &memNotifyStore{
+		entries: []notify.Notification{
+			{
+				ID:        "ai:main:%16",
+				Text:      "claude: reply ready · notify wiring",
+				Severity:  notify.SeverityInfo,
+				Source:    notify.SourceAI,
+				Session:   "main",
+				Pane:      "%16",
+				CreatedAt: now,
+				ExpiresAt: now.Add(attentionNotifyTTL),
+			},
+		},
+	}
+	cmd := newReconcileCmd(store, runner)
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"reconcile"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(store.pushed) != 0 {
+		t.Fatalf("push count = %d, want 0 (entry already matches)", len(store.pushed))
+	}
+	if len(store.acks) != 0 {
+		t.Fatalf("acks = %v, want none", store.acks)
+	}
+	if got := stdout.String(); got != "reconcile: pushed 0, acked 0, kept 1\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestNotifyReconcileRefreshesEntryWithStaleText(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	runner := &reconcileTmuxRunner{
+		// Topic on pane is "new topic" but queued entry still has old text.
+		output: []byte("main|@4|%16|reply||claude|new topic|\n"),
+	}
+	store := &memNotifyStore{
+		entries: []notify.Notification{
+			{
+				ID:        "ai:main:%16",
+				Text:      "claude: reply ready · old topic",
+				Severity:  notify.SeverityInfo,
+				Source:    notify.SourceAI,
+				Session:   "main",
+				Pane:      "%16",
+				CreatedAt: now,
+				ExpiresAt: now.Add(attentionNotifyTTL),
+			},
+		},
+	}
+	cmd := newReconcileCmd(store, runner)
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"reconcile"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1", len(store.pushed))
+	}
+	if got := store.pushed[0].Text; got != "claude: reply ready · new topic" {
+		t.Fatalf("Text = %q", got)
+	}
+	if got := stdout.String(); got != "reconcile: pushed 1, acked 0, kept 0\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestNotifyReconcileSkipsPaneWithoutAgent(t *testing.T) {
+	t.Parallel()
+
+	runner := &reconcileTmuxRunner{
+		// Pane is in reply state but has no AI agent (manual attention toggle
+		// on a shell pane). Producer skips it; reconcile mirrors that.
+		output: []byte("main|@4|%5|reply|||shell topic|\n"),
+	}
+	store := &memNotifyStore{}
+	cmd := newReconcileCmd(store, runner)
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"reconcile"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(store.pushed) != 0 {
+		t.Fatalf("push count = %d, want 0", len(store.pushed))
+	}
+	if got := stdout.String(); got != "reconcile: pushed 0, acked 0, kept 0\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestNotifyReconcileLeavesNonAIQueueEntriesUntouched(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	runner := &reconcileTmuxRunner{output: []byte("")}
+	store := &memNotifyStore{
+		entries: []notify.Notification{
+			{
+				ID:        "k8s:cluster:pod-foo",
+				Text:      "pod restarted",
+				Severity:  notify.SeverityWarn,
+				Source:    notify.SourceK8s,
+				Session:   "main",
+				CreatedAt: now,
+				ExpiresAt: now.Add(time.Hour),
+			},
+		},
+	}
+	cmd := newReconcileCmd(store, runner)
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"reconcile"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(store.acks) != 0 {
+		t.Fatalf("acks = %v, want none (non-AI entry must be left alone)", store.acks)
+	}
+	if got := stdout.String(); got != "reconcile: pushed 0, acked 0, kept 0\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestNotifyReconcileIdempotent(t *testing.T) {
+	t.Parallel()
+
+	runner := &reconcileTmuxRunner{
+		output: []byte("main|@4|%16|reply|waiting|claude|notify wiring|/tmp/tmux/default\n"),
+	}
+	store := &memNotifyStore{}
+	cmd := newReconcileCmd(store, runner)
+
+	var first bytes.Buffer
+	if err := cmd.Run([]string{"reconcile"}, &first, &bytes.Buffer{}); err != nil {
+		t.Fatalf("first Run error = %v", err)
+	}
+	if got := first.String(); got != "reconcile: pushed 1, acked 0, kept 0\n" {
+		t.Fatalf("first stdout = %q", got)
+	}
+
+	var second bytes.Buffer
+	if err := cmd.Run([]string{"reconcile"}, &second, &bytes.Buffer{}); err != nil {
+		t.Fatalf("second Run error = %v", err)
+	}
+	if got := second.String(); got != "reconcile: pushed 0, acked 0, kept 1\n" {
+		t.Fatalf("second stdout = %q", got)
+	}
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count after re-run = %d, want 1", len(store.pushed))
+	}
+}
+
+func TestNotifyReconcileJSONOutput(t *testing.T) {
+	t.Parallel()
+
+	runner := &reconcileTmuxRunner{
+		output: []byte("main|@4|%16|reply|waiting|claude||\n"),
+	}
+	store := &memNotifyStore{}
+	cmd := newReconcileCmd(store, runner)
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"reconcile", "--json"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	var got reconcileResult
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode json: %v (raw=%q)", err, stdout.String())
+	}
+	if got.Pushed != 1 || got.Acked != 0 || got.Kept != 0 {
+		t.Fatalf("decoded = %+v", got)
+	}
+	if len(got.Errors) != 0 {
+		t.Fatalf("Errors = %v", got.Errors)
+	}
+}
+
+func TestNotifyReconcileTmuxFailureSurfacesAsSoftError(t *testing.T) {
+	t.Parallel()
+
+	runner := &reconcileTmuxRunner{err: errFakeTmux}
+	store := &memNotifyStore{}
+	cmd := newReconcileCmd(store, runner)
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"reconcile", "--json"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	var got reconcileResult
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+	if len(got.Errors) == 0 {
+		t.Fatalf("expected error in summary, got %+v", got)
+	}
+	if !strings.Contains(got.Errors[0], "tmux list-panes") {
+		t.Fatalf("Errors[0] = %q", got.Errors[0])
+	}
+	if got.Pushed != 0 || got.Acked != 0 {
+		t.Fatalf("decoded = %+v", got)
+	}
+}
+
+func TestNotifyReconcileRejectsPositionalArgs(t *testing.T) {
+	t.Parallel()
+
+	runner := &reconcileTmuxRunner{}
+	cmd := newReconcileCmd(&memNotifyStore{}, runner)
+	err := cmd.Run([]string{"reconcile", "extra"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsUsageError(err) {
+		t.Fatalf("expected UsageError, got %T: %v", err, err)
+	}
+}
+
+// errFakeTmux is a sentinel for the reconcile soft-error path.
+var errFakeTmux = errFakeTmuxImpl{}
+
+type errFakeTmuxImpl struct{}
+
+func (errFakeTmuxImpl) Error() string { return "fake tmux failure" }


### PR DESCRIPTION
## Summary
The notify producer is event-driven — it pushes/acks only on attention/AI state transitions. Panes that were already in `attention=reply` when the producer code was deployed never get into the queue (the user observed `%16` with claude+reply but `notify list` empty).

This slice adds a reconciliation pass that walks all tmux panes and brings the queue in sync with reality.

## Behavior
- New subcommand `projmux notify reconcile`:
  - For each pane with `attention=reply` AND `@projmux_ai_agent` set: ensure queue entry `ai:<session>:<pane>` exists with current text/topic.
  - For each `ai:*` queue entry whose pane is gone or no longer reply: ack it.
- Output:
  - Default: `reconcile: pushed N, acked N, kept N`
  - `--json`: `{"pushed":N,"acked":N,"kept":N,"errors":[]}`
- Idempotent: second invocation reports `kept N, pushed 0, acked 0`.
- Auto-runs after `make install` so the queue is in sync immediately after upgrade.
- Soft errors (e.g. tmux not running) populate the `errors` array but exit 0.

## Test plan
- [x] `go build ./...`, `go test ./...` (12 new reconcile tests, all pass)
- [x] `gofmt -l .` clean
- [x] Manual: `projmux notify reconcile` on the dev box with no current reply panes correctly reports `pushed 0, acked 0, kept 0`. Unit test `TestNotifyReconcilePushesMissingEntryForReplyPane` exercises the populate path.
- [x] Idempotency: `TestNotifyReconcileIdempotent` confirms second run reports `kept`, no double push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)