### PR TITLE
fix(statusbar): ack notify entry after successful click-to-focus

### DIFF
--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -239,7 +239,17 @@ func (c *statusbarCommand) handleNotify(opts statusbarClickOptions, _, stderr io
 		args = append(args, "--socket", socket)
 	}
 	if _, err := c.runner.Run(context.Background(), binaryPath, args...); err != nil {
+		// Leave the entry in place so the user can retry the click.
 		return fmt.Errorf("statusbar notify: focus invocation failed: %w", err)
+	}
+	// Click-to-focus has no separate producer to ack the entry, so the
+	// click itself is the consume signal: a successful focus dispatch is
+	// the user telling us "I have handled this notification". We swallow
+	// the ack error because the focus already succeeded — the user has
+	// been navigated to the pane, and a stale queue entry will be cleaned
+	// up by the next reconcile pass anyway.
+	if ackErr := store.Ack(head.ID); ackErr != nil {
+		fmt.Fprintf(stderr, "statusbar notify: ack %s: %v\n", head.ID, ackErr)
 	}
 	return nil
 }

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -255,6 +255,65 @@ func TestStatusbarClickNotifyExecsFocusForNewestEntry(t *testing.T) {
 	}
 }
 
+func TestStatusbarClickNotifyAcksEntryAfterSuccessfulFocus(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{
+			ID:      "abc",
+			Text:    "deploy ok",
+			Source:  notify.SourceAI,
+			Socket:  "projmux",
+			Session: "main",
+			Window:  "1",
+			Pane:    "0",
+		},
+	}}
+	cmd := newStatusbarTestCommand(runner, store)
+
+	if err := cmd.Run([]string{"click", "notify"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if store.ackedID != "abc" {
+		t.Fatalf("store.ackedID = %q, want %q", store.ackedID, "abc")
+	}
+}
+
+func TestStatusbarClickNotifyDoesNotAckWhenFocusFails(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{
+		respond: func(name string, _ []string) ([]byte, error) {
+			if name == "/usr/local/bin/projmux" {
+				return nil, errors.New("focus boom")
+			}
+			return nil, nil
+		},
+	}
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{
+			ID:      "abc",
+			Text:    "deploy ok",
+			Source:  notify.SourceAI,
+			Socket:  "projmux",
+			Session: "main",
+			Window:  "1",
+			Pane:    "0",
+		},
+	}}
+	cmd := newStatusbarTestCommand(runner, store)
+
+	err := cmd.Run([]string{"click", "notify"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error from failed focus")
+	}
+	if store.ackedID != "" {
+		t.Fatalf("store.ackedID = %q, want empty (entry must remain on focus failure)", store.ackedID)
+	}
+}
+
 func TestStatusbarClickNotifyExplicitSocketOverridesEntry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
The notify segment click currently focuses the originating pane but does NOT ack the queue entry — manually-pushed entries (no producer to ack them) stayed visible forever. User expects click = handled.

## Behavior
- `handleNotify` now calls `store.Ack(head.ID)` after a successful focus exec.
- If focus fails, entry stays in the queue (user can retry).
- Same handler covers both mouse `MouseDown1Status` and `prefix s n` keybinding.

## Test plan
- [x] `go build ./...`, `gofmt -l .` clean
- [x] `go test ./...` (735 PASS, 0 fail; 2 new tests cover ack-on-click and skip-on-focus-failure)
- [x] Manual: success → entry removed from `notify list --json`; failure (bad target) → exit 2, entry stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)