### PR TITLE
feat(status-notify): HUD-style redesign with severity icon, agent block, age

### DIFF
--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -336,7 +336,11 @@ func (c *statusCommand) runNotify(args []string, stdout, stderr io.Writer) error
 	if err != nil {
 		return nil
 	}
-	out := formatStatusNotify(entries, *maxWidth)
+	now := time.Now()
+	if c.now != nil {
+		now = c.now()
+	}
+	out := formatStatusNotify(entries, *maxWidth, now)
 	if out == "" {
 		return nil
 	}
@@ -351,73 +355,274 @@ func (c *statusCommand) notifyStore() (notifyStore, error) {
 	return c.notifyStoreFn()
 }
 
-// formatStatusNotify renders the newest entry of the queue as a single tmux
-// status segment. The output is plain ASCII (no emoji) and ends with a tmux
-// `#[default]` reset so adjacent segments are not stained by colors.
+// HUD-style design tokens for the notify status segment. Reused dim color
+// (`colour245`) keeps the segment visually consistent with the AI usage
+// segment so the two read as one design family.
+const (
+	notifyDimColor       = "colour245"
+	notifyCountColor     = "colour244"
+	notifyAgentColorOpen = "#[fg=cyan,bold]"
+	notifySeverityInfo   = "#[fg=brightcyan]"
+	notifySeverityWarn   = "#[fg=yellow]"
+	notifySeverityCrit   = "#[fg=red,bold]"
+	notifyIcon           = "●"
+	notifyBar            = "▎"
+	notifyMidDot         = "·"
+	notifyEllipsis       = "…"
+	notifyReset          = "#[default]"
+)
+
+// known agent prefixes recognised when stripping a leading `<agent>:` from
+// the producer-rendered text. Lower-case match only. New agents can be added
+// here without touching call sites.
+var notifyKnownAgents = []string{"claude", "codex"}
+
+// formatStatusNotify renders the newest entry of the queue as a single
+// HUD-style tmux status segment. The output ends with a tmux `#[default]`
+// reset so adjacent segments are not stained by colors.
 //
-// Layout: `[X] <text> · <session> +<N>` where X is one of I/W/!.
-func formatStatusNotify(entries []notify.Notification, maxWidth int) string {
+// Long form: `●  <agent>  ▎  <text>  ·  <target>  ·  <age>   +<N>`
+//
+// The renderer degrades through five tiers as `maxWidth` shrinks:
+//
+//  1. Drop `<age>` (and its preceding `·`).
+//  2. Drop `<target>` (and its preceding `·`).
+//  3. Truncate `<text>` with a trailing `…`.
+//  4. Drop `▎ <agent>` (back to icon + text).
+//  5. Hard truncate everything (icon + count are still preserved).
+//
+// `now` is the wall-clock used to compute the relative age. Pass the zero
+// time to suppress the age field entirely.
+func formatStatusNotify(entries []notify.Notification, maxWidth int, now time.Time) string {
 	if len(entries) == 0 {
 		return ""
 	}
 	head := entries[0]
 	extras := len(entries) - 1
-	prefix := "[" + severityLetter(head.Severity) + "] "
-	suffix := " " + middotSeparator() + " " + head.Session
+
+	icon := renderNotifyIcon(head.Severity)
+	agent, text := splitAgentPrefix(head)
+	target := compactTarget(head)
+	age := ""
+	if !now.IsZero() && !head.CreatedAt.IsZero() {
+		age = formatRelativeAge(now.Sub(head.CreatedAt))
+	}
 	plus := ""
 	if extras > 0 {
-		plus = fmt.Sprintf(" +%d", extras)
+		plus = fmt.Sprintf("   #[fg=%s]+%d%s", notifyCountColor, extras, notifyReset)
 	}
 
-	overhead := runeLen(prefix) + runeLen(suffix) + runeLen(plus)
-	text := strings.TrimSpace(head.Text)
-	if maxWidth > 0 {
-		room := maxWidth - overhead
-		if room < 1 {
-			room = 1
+	tiers := []func() string{
+		// Tier 1: full long form.
+		func() string { return assembleNotify(icon, agent, text, target, age, plus) },
+		// Tier 2: drop age.
+		func() string { return assembleNotify(icon, agent, text, target, "", plus) },
+		// Tier 3: drop target (and age).
+		func() string { return assembleNotify(icon, agent, text, "", "", plus) },
+		// Tier 4: truncate text with trailing ellipsis.
+		func() string {
+			budget := tierBudget(maxWidth, icon, agent, "", "", "", plus)
+			truncated := shrinkText(text, budget)
+			return assembleNotify(icon, agent, truncated, "", "", plus)
+		},
+		// Tier 5: drop agent + bar.
+		func() string {
+			budget := tierBudget(maxWidth, icon, "", "", "", "", plus)
+			truncated := shrinkText(text, budget)
+			return assembleNotify(icon, "", truncated, "", "", plus)
+		},
+	}
+	for _, tier := range tiers {
+		out := tier()
+		if out == "" {
+			continue
 		}
-		if runeLen(text) > room {
-			rs := []rune(text)
-			if room <= 1 {
-				text = string(rs[:room])
-			} else {
-				text = string(rs[:room-1]) + "."
-			}
+		if maxWidth <= 0 || visualLen(out) <= maxWidth {
+			return out + notifyReset
 		}
 	}
 
-	color := severityColor(head.Severity)
-	return color + prefix + text + suffix + plus + "#[default]"
+	// Hard truncate. Keep the icon + plus suffix; rune-truncate everything
+	// in between. The reset directive is appended unconditionally so we
+	// never leak color into the next segment.
+	short := assembleNotify(icon, "", text, "", "", plus)
+	return truncateWithEllipsis(short, maxWidth) + notifyReset
 }
 
-// severityLetter maps notify severities to a single-character status letter.
-// Anything unknown falls back to `I` so we never emit garbage.
-func severityLetter(severity string) string {
-	switch severity {
-	case notify.SeverityWarn:
-		return "W"
-	case notify.SeverityCritical:
-		return "!"
-	default:
-		return "I"
+// assembleNotify glues the parts of the long form together. Empty parts are
+// omitted along with their preceding separator so we can reuse this for
+// every degradation tier.
+func assembleNotify(icon, agent, text, target, age, plus string) string {
+	var b strings.Builder
+	b.WriteString(icon)
+	if agent != "" {
+		b.WriteString("  ")
+		b.WriteString(notifyAgentColorOpen)
+		b.WriteString(agent)
+		b.WriteString(notifyReset)
+		b.WriteString("  ")
+		b.WriteString("#[fg=")
+		b.WriteString(notifyDimColor)
+		b.WriteString("]")
+		b.WriteString(notifyBar)
+		b.WriteString(notifyReset)
 	}
+	if text != "" {
+		b.WriteString("  ")
+		b.WriteString(text)
+	}
+	if target != "" {
+		b.WriteString("  ")
+		b.WriteString("#[fg=")
+		b.WriteString(notifyDimColor)
+		b.WriteString("]")
+		b.WriteString(notifyMidDot)
+		b.WriteString(notifyReset)
+		b.WriteString("  ")
+		b.WriteString("#[fg=")
+		b.WriteString(notifyDimColor)
+		b.WriteString("]")
+		b.WriteString(target)
+		b.WriteString(notifyReset)
+	}
+	if age != "" {
+		b.WriteString("  ")
+		b.WriteString("#[fg=")
+		b.WriteString(notifyDimColor)
+		b.WriteString("]")
+		b.WriteString(notifyMidDot)
+		b.WriteString(notifyReset)
+		b.WriteString("  ")
+		b.WriteString("#[fg=")
+		b.WriteString(notifyDimColor)
+		b.WriteString("]")
+		b.WriteString(age)
+		b.WriteString(notifyReset)
+	}
+	if plus != "" {
+		b.WriteString(plus)
+	}
+	return b.String()
 }
 
-// severityColor maps notify severities to the tmux color prefix. Info is the
-// default style (no color override) — tmux ignores empty `#[]` so we omit it.
-func severityColor(severity string) string {
+// tierBudget returns how many runes of `text` fit within maxWidth given the
+// fixed-width pieces we are committing to render at this tier. Returns the
+// full budget when maxWidth is non-positive.
+func tierBudget(maxWidth int, icon, agent, _, target, age, plus string) int {
+	if maxWidth <= 0 {
+		return 0
+	}
+	overhead := visualLen(assembleNotify(icon, agent, "", target, age, plus))
+	// `assembleNotify` already inserts the leading "  " before text, so we
+	// charge that back to the budget here.
+	textGap := 2
+	room := maxWidth - overhead - textGap
+	if room < 1 {
+		room = 1
+	}
+	return room
+}
+
+// shrinkText shrinks s so its rune length is at most maxRunes, replacing
+// the trailing rune with `…` when truncation actually occurs. A budget of
+// zero means "no shrinking".
+func shrinkText(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return s
+	}
+	rs := []rune(s)
+	if len(rs) <= maxRunes {
+		return s
+	}
+	if maxRunes == 1 {
+		return notifyEllipsis
+	}
+	return string(rs[:maxRunes-1]) + notifyEllipsis
+}
+
+// renderNotifyIcon returns the severity-tinted bullet that opens the
+// segment. Unknown severities fall through to the info color so we never
+// emit a stripped escape.
+func renderNotifyIcon(severity string) string {
+	color := notifySeverityInfo
 	switch severity {
 	case notify.SeverityWarn:
-		return "#[fg=yellow]"
+		color = notifySeverityWarn
 	case notify.SeverityCritical:
-		return "#[fg=red,bold]"
-	default:
+		color = notifySeverityCrit
+	}
+	return color + notifyIcon + notifyReset
+}
+
+// splitAgentPrefix extracts the leading `<agent>:` from the queue entry's
+// text when the source is `ai`. Returns the lower-cased agent token and the
+// remaining text (whitespace-trimmed). When no recognised prefix is found
+// the agent is empty and the original text (trimmed) is returned.
+//
+// Edge inputs (text without `:`, unknown agents, empty text) all degrade to
+// "no agent prefix" rather than panicking.
+func splitAgentPrefix(n notify.Notification) (string, string) {
+	text := strings.TrimSpace(n.Text)
+	if n.Source != notify.SourceAI {
+		return "", text
+	}
+	idx := strings.Index(text, ":")
+	if idx <= 0 {
+		return "", text
+	}
+	candidate := strings.ToLower(strings.TrimSpace(text[:idx]))
+	if !isKnownAgent(candidate) {
+		return "", text
+	}
+	rest := strings.TrimSpace(text[idx+1:])
+	if rest == "" {
+		// The text was just `claude:` — no body left, so don't strip.
+		return "", text
+	}
+	return candidate, rest
+}
+
+func isKnownAgent(name string) bool {
+	for _, a := range notifyKnownAgents {
+		if name == a {
+			return true
+		}
+	}
+	return false
+}
+
+// compactTarget renders the entry's target as `<sess>:<window>.<pane>`.
+// Empty session yields the empty string; empty window/pane segments are
+// dropped so we never emit dangling `:` or `.` separators.
+func compactTarget(n notify.Notification) string {
+	sess := strings.TrimSpace(n.Session)
+	if sess == "" {
 		return ""
 	}
+	out := sess
+	win := strings.TrimSpace(n.Window)
+	if win != "" {
+		out += ":" + win
+		pane := strings.TrimSpace(n.Pane)
+		if pane != "" {
+			out += "." + pane
+		}
+	}
+	return out
 }
 
-// middotSeparator returns the ASCII separator used between the message body
-// and the session name. The spec requires plain ASCII so we use `-`.
-func middotSeparator() string {
-	return "-"
+// formatRelativeAge renders a duration as `just now`, `<N>s` (only via the
+// "just now" branch), `<N>m`, `<N>h`, or `<N>d`. Negative durations (clock
+// skew) are clamped to "just now".
+func formatRelativeAge(d time.Duration) string {
+	if d < 60*time.Second {
+		return "just now"
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d/time.Minute))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(d/time.Hour))
+	}
+	return fmt.Sprintf("%dd", int(d/(24*time.Hour)))
 }

--- a/internal/app/status_notify_test.go
+++ b/internal/app/status_notify_test.go
@@ -28,37 +28,97 @@ func TestStatusNotifyEmptyQueueIsEmptyOutput(t *testing.T) {
 	}
 }
 
-func TestStatusNotifyInfoEntryOmitsColorPrefix(t *testing.T) {
+// External-source entry has no agent prefix and no leading agent block.
+func TestStatusNotifyExternalEntryOmitsAgentBlock(t *testing.T) {
 	t.Parallel()
 
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	store := &stubNotifyStore{listEntries: []notify.Notification{
-		{ID: "a", Text: "hello", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+		{
+			ID:        "a",
+			Text:      "hello world",
+			Severity:  notify.SeverityInfo,
+			Source:    notify.SourceExternal,
+			Session:   "main",
+			Window:    "1",
+			Pane:      "0",
+			CreatedAt: now.Add(-2 * time.Minute),
+		},
 	}}
 	cmd := newStatusNotifyCommand(store)
+	cmd.now = func() time.Time { return now }
 	var stdout bytes.Buffer
 	if err := cmd.Run([]string{"notify"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "[I] hello") {
-		t.Fatalf("stdout = %q, want prefix '[I] hello'", got)
+	if !strings.HasPrefix(got, "#[fg=brightcyan]●#[default]") {
+		t.Fatalf("stdout = %q, want brightcyan info icon prefix", got)
+	}
+	if strings.Contains(got, "▎") {
+		t.Fatalf("external entry must not include agent bar separator: %q", got)
+	}
+	if !strings.Contains(got, "hello world") {
+		t.Fatalf("stdout = %q, want body 'hello world'", got)
+	}
+	if !strings.Contains(got, "main:1.0") {
+		t.Fatalf("stdout = %q, want compact target 'main:1.0'", got)
+	}
+	if !strings.Contains(got, "2m") {
+		t.Fatalf("stdout = %q, want age '2m'", got)
 	}
 	if !strings.HasSuffix(got, "#[default]") {
-		t.Fatalf("stdout = %q, want suffix '#[default]'", got)
-	}
-	if strings.HasPrefix(got, "#[fg=") {
-		t.Fatalf("info severity should not emit a color prefix; got %q", got)
-	}
-	if !strings.Contains(got, "main") {
-		t.Fatalf("stdout = %q, want session 'main'", got)
+		t.Fatalf("stdout = %q, want trailing '#[default]'", got)
 	}
 }
 
-func TestStatusNotifyWarnEntryEmitsYellow(t *testing.T) {
+// AI-source entry whose text begins with `claude:` strips the prefix and
+// renders it as a bolded agent block followed by the thin bar separator.
+func TestStatusNotifyAIEntryStripsAgentPrefix(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{
+			ID:        "a",
+			Text:      "claude: reply ready · review",
+			Severity:  notify.SeverityInfo,
+			Source:    notify.SourceAI,
+			Session:   "s",
+			Window:    "1",
+			Pane:      "0",
+			CreatedAt: now.Add(-2 * time.Minute),
+		},
+	}}
+	cmd := newStatusNotifyCommand(store)
+	cmd.now = func() time.Time { return now }
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"notify", "--max-width", "80"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "#[fg=cyan,bold]claude#[default]") {
+		t.Fatalf("stdout = %q, want bolded cyan agent block", got)
+	}
+	if !strings.Contains(got, "▎") {
+		t.Fatalf("stdout = %q, want bar separator", got)
+	}
+	if strings.Contains(got, "claude:") {
+		t.Fatalf("stdout = %q, agent prefix should have been stripped from text", got)
+	}
+	if !strings.Contains(got, "reply ready · review") {
+		t.Fatalf("stdout = %q, want body 'reply ready · review'", got)
+	}
+	if !strings.Contains(got, "s:1.0") {
+		t.Fatalf("stdout = %q, want compact target", got)
+	}
+}
+
+func TestStatusNotifyWarnEntryEmitsYellowIcon(t *testing.T) {
 	t.Parallel()
 
 	store := &stubNotifyStore{listEntries: []notify.Notification{
-		{ID: "a", Text: "warn-me", Severity: notify.SeverityWarn, Source: notify.SourceAI, Session: "ops"},
+		{ID: "a", Text: "warn-me", Severity: notify.SeverityWarn, Source: notify.SourceExternal, Session: "ops"},
 	}}
 	cmd := newStatusNotifyCommand(store)
 	var stdout bytes.Buffer
@@ -66,16 +126,16 @@ func TestStatusNotifyWarnEntryEmitsYellow(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[fg=yellow][W] warn-me") {
-		t.Fatalf("stdout = %q, want yellow warn prefix", got)
+	if !strings.HasPrefix(got, "#[fg=yellow]●#[default]") {
+		t.Fatalf("stdout = %q, want yellow icon prefix", got)
 	}
 }
 
-func TestStatusNotifyCriticalEntryEmitsRedBold(t *testing.T) {
+func TestStatusNotifyCriticalEntryEmitsRedBoldIcon(t *testing.T) {
 	t.Parallel()
 
 	store := &stubNotifyStore{listEntries: []notify.Notification{
-		{ID: "a", Text: "boom", Severity: notify.SeverityCritical, Source: notify.SourceAI, Session: "prod"},
+		{ID: "a", Text: "boom", Severity: notify.SeverityCritical, Source: notify.SourceExternal, Session: "prod"},
 	}}
 	cmd := newStatusNotifyCommand(store)
 	var stdout bytes.Buffer
@@ -83,18 +143,18 @@ func TestStatusNotifyCriticalEntryEmitsRedBold(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[fg=red,bold][!] boom") {
-		t.Fatalf("stdout = %q, want red,bold critical prefix", got)
+	if !strings.HasPrefix(got, "#[fg=red,bold]●#[default]") {
+		t.Fatalf("stdout = %q, want red,bold icon prefix", got)
 	}
 }
 
-func TestStatusNotifyMultipleEntriesAppendsCount(t *testing.T) {
+func TestStatusNotifyMultipleEntriesAppendsPlusCount(t *testing.T) {
 	t.Parallel()
 
 	store := &stubNotifyStore{listEntries: []notify.Notification{
-		{ID: "a", Text: "newest", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
-		{ID: "b", Text: "older1", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
-		{ID: "c", Text: "older2", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+		{ID: "a", Text: "newest", Severity: notify.SeverityInfo, Source: notify.SourceExternal, Session: "main"},
+		{ID: "b", Text: "older1", Severity: notify.SeverityInfo, Source: notify.SourceExternal, Session: "main"},
+		{ID: "c", Text: "older2", Severity: notify.SeverityInfo, Source: notify.SourceExternal, Session: "main"},
 	}}
 	cmd := newStatusNotifyCommand(store)
 	var stdout bytes.Buffer
@@ -103,45 +163,32 @@ func TestStatusNotifyMultipleEntriesAppendsCount(t *testing.T) {
 	}
 	got := stdout.String()
 	if !strings.Contains(got, "+2") {
-		t.Fatalf("stdout = %q, want suffix '+2'", got)
+		t.Fatalf("stdout = %q, want '+2'", got)
 	}
-	if !strings.Contains(got, "[I] newest") {
-		t.Fatalf("stdout = %q, want '[I] newest'", got)
+	if !strings.Contains(got, "newest") {
+		t.Fatalf("stdout = %q, want headline 'newest'", got)
+	}
+	if !strings.Contains(got, "#[fg=colour244]+2#[default]") {
+		t.Fatalf("stdout = %q, want dim count escape", got)
 	}
 }
 
-func TestStatusNotifyMaxWidthTruncatesInnerTextOnly(t *testing.T) {
+func TestStatusNotifyStableTimestampOrdering(t *testing.T) {
 	t.Parallel()
 
+	now := time.Now()
 	store := &stubNotifyStore{listEntries: []notify.Notification{
-		{
-			ID:       "a",
-			Text:     "this text is intentionally pretty long",
-			Severity: notify.SeverityInfo,
-			Source:   notify.SourceAI,
-			Session:  "main",
-		},
-		{ID: "b", Text: "x", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+		{ID: "newer", Text: "newer", Severity: notify.SeverityInfo, Source: notify.SourceExternal, Session: "main", CreatedAt: now},
+		{ID: "older", Text: "older", Severity: notify.SeverityInfo, Source: notify.SourceExternal, Session: "main", CreatedAt: now.Add(-time.Minute)},
 	}}
 	cmd := newStatusNotifyCommand(store)
 	var stdout bytes.Buffer
-	if err := cmd.Run([]string{"notify", "--max-width", "30"}, &stdout, &bytes.Buffer{}); err != nil {
+	if err := cmd.Run([]string{"notify"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	// Strip the trailing reset directive and compute the visible-ish length.
-	visible := strings.TrimSuffix(got, "#[default]")
-	if len([]rune(visible)) > 30 {
-		t.Fatalf("rendered length = %d, want <= 30 (got %q)", len([]rune(visible)), got)
-	}
-	if !strings.HasPrefix(got, "[I] ") {
-		t.Fatalf("stdout = %q, want severity prefix kept", got)
-	}
-	if !strings.Contains(got, "+1") {
-		t.Fatalf("stdout = %q, want '+N' suffix kept", got)
-	}
-	if !strings.Contains(got, "main") {
-		t.Fatalf("stdout = %q, want session suffix kept", got)
+	if !strings.Contains(got, "newer") {
+		t.Fatalf("stdout = %q, want newest entry first ('newer')", got)
 	}
 }
 
@@ -159,21 +206,226 @@ func TestStatusNotifyMissingStoreFactoryReturnsEmpty(t *testing.T) {
 	}
 }
 
-func TestStatusNotifyStableTimestampOrdering(t *testing.T) {
+// fixtureAIEntry returns a canonical ai-source claude entry (2m old) used
+// by the width-tier table. Target is the spec example `s:1.0` so the long
+// form fits inside the 80-rune budget.
+func fixtureAIEntry(now time.Time) []notify.Notification {
+	return []notify.Notification{
+		{
+			ID:        "a",
+			Text:      "claude: reply ready · review",
+			Severity:  notify.SeverityInfo,
+			Source:    notify.SourceAI,
+			Session:   "s",
+			Window:    "1",
+			Pane:      "0",
+			CreatedAt: now.Add(-2 * time.Minute),
+		},
+		{
+			ID:        "b",
+			Text:      "claude: another",
+			Severity:  notify.SeverityInfo,
+			Source:    notify.SourceAI,
+			Session:   "s",
+			Window:    "1",
+			Pane:      "0",
+			CreatedAt: now.Add(-3 * time.Minute),
+		},
+	}
+}
+
+func TestStatusNotifyWidthTier1Long(t *testing.T) {
 	t.Parallel()
 
-	now := time.Now()
-	store := &stubNotifyStore{listEntries: []notify.Notification{
-		{ID: "newer", Text: "newer", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main", CreatedAt: now},
-		{ID: "older", Text: "older", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main", CreatedAt: now.Add(-time.Minute)},
-	}}
-	cmd := newStatusNotifyCommand(store)
-	var stdout bytes.Buffer
-	if err := cmd.Run([]string{"notify"}, &stdout, &bytes.Buffer{}); err != nil {
-		t.Fatalf("Run() error = %v", err)
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	out := formatStatusNotify(fixtureAIEntry(now), 80, now)
+	if visualLen(out) > 80 {
+		t.Fatalf("tier1 visualLen=%d > 80: %q", visualLen(out), out)
 	}
-	got := stdout.String()
-	if !strings.Contains(got, "[I] newer") {
-		t.Fatalf("stdout = %q, want newest entry first", got)
+	for _, want := range []string{"●", "claude", "▎", "reply ready · review", "s:1.0", "2m", "+1"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("tier1 missing %q in %q", want, out)
+		}
+	}
+}
+
+func TestStatusNotifyWidthTier2DropsAge(t *testing.T) {
+	t.Parallel()
+
+	// With the canonical fixture the long form is ~56 cells, so we pick a
+	// budget tight enough to force the tier-2 fallback (no age) but loose
+	// enough to keep the target.
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	out := formatStatusNotify(fixtureAIEntry(now), 50, now)
+	if visualLen(out) > 50 {
+		t.Fatalf("tier2 visualLen=%d > 50: %q", visualLen(out), out)
+	}
+	for _, want := range []string{"●", "claude", "▎", "reply ready · review", "s:1.0", "+1"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("tier2 missing %q in %q", want, out)
+		}
+	}
+	if strings.Contains(out, "2m") {
+		t.Fatalf("tier2 must drop age: %q", out)
+	}
+}
+
+func TestStatusNotifyWidthTier3DropsTarget(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	out := formatStatusNotify(fixtureAIEntry(now), 40, now)
+	if visualLen(out) > 40 {
+		t.Fatalf("tier3 visualLen=%d > 40: %q", visualLen(out), out)
+	}
+	for _, want := range []string{"●", "claude", "▎", "reply ready · review", "+1"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("tier3 missing %q in %q", want, out)
+		}
+	}
+	if strings.Contains(out, "s") {
+		t.Fatalf("tier3 must drop target: %q", out)
+	}
+	if strings.Contains(out, "2m") {
+		t.Fatalf("tier3 must drop age: %q", out)
+	}
+}
+
+func TestStatusNotifyWidthTier4TruncatesText(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	out := formatStatusNotify(fixtureAIEntry(now), 24, now)
+	if visualLen(out) > 24 {
+		t.Fatalf("tier4 visualLen=%d > 24: %q", visualLen(out), out)
+	}
+	if !strings.Contains(out, "claude") {
+		t.Fatalf("tier4 should still show agent: %q", out)
+	}
+	if !strings.Contains(out, "+1") {
+		t.Fatalf("tier4 should still show count: %q", out)
+	}
+	if !strings.Contains(out, "…") {
+		t.Fatalf("tier4 should truncate text with ellipsis: %q", out)
+	}
+}
+
+func TestStatusNotifyWidthTier5DropsAgent(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	out := formatStatusNotify(fixtureAIEntry(now), 15, now)
+	if visualLen(out) > 15 {
+		t.Fatalf("tier5 visualLen=%d > 15: %q", visualLen(out), out)
+	}
+	if strings.Contains(out, "claude") {
+		t.Fatalf("tier5 must drop agent block: %q", out)
+	}
+	if strings.Contains(out, "▎") {
+		t.Fatalf("tier5 must drop bar separator: %q", out)
+	}
+	if !strings.Contains(out, "●") {
+		t.Fatalf("tier5 should still show icon: %q", out)
+	}
+	if !strings.Contains(out, "+1") {
+		t.Fatalf("tier5 should still show count: %q", out)
+	}
+}
+
+func TestStatusNotifyWidthTier6HardTruncate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	out := formatStatusNotify(fixtureAIEntry(now), 8, now)
+	if visualLen(out) > 8 {
+		t.Fatalf("tier6 visualLen=%d > 8: %q", visualLen(out), out)
+	}
+	if !strings.HasSuffix(out, "#[default]") {
+		t.Fatalf("tier6 must end with #[default]: %q", out)
+	}
+}
+
+func TestStatusNotifyAgentPrefixGracefulFallback(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name      string
+		text      string
+		wantAgent string
+	}{
+		{name: "no colon", text: "reply ready", wantAgent: ""},
+		{name: "unknown agent", text: "gpt: reply ready", wantAgent: ""},
+		{name: "empty body after colon", text: "claude:", wantAgent: ""},
+		{name: "leading colon", text: ":hello", wantAgent: ""},
+		{name: "codex prefix", text: "codex: thought", wantAgent: "codex"},
+		{name: "claude prefix uppercase", text: "Claude: ready", wantAgent: "claude"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := formatStatusNotify([]notify.Notification{{
+				ID: "a", Text: tc.text, Severity: notify.SeverityInfo,
+				Source: notify.SourceAI, Session: "s", CreatedAt: now,
+			}}, 0, now)
+			if tc.wantAgent == "" {
+				if strings.Contains(out, "#[fg=cyan,bold]") {
+					t.Fatalf("expected no agent block in %q", out)
+				}
+				return
+			}
+			if !strings.Contains(out, "#[fg=cyan,bold]"+tc.wantAgent+"#[default]") {
+				t.Fatalf("expected agent block %q in %q", tc.wantAgent, out)
+			}
+		})
+	}
+}
+
+func TestFormatRelativeAgeBuckets(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		dur  time.Duration
+		want string
+	}{
+		{0, "just now"},
+		{30 * time.Second, "just now"},
+		{59 * time.Second, "just now"},
+		{60 * time.Second, "1m"},
+		{2 * time.Minute, "2m"},
+		{45 * time.Minute, "45m"},
+		{59*time.Minute + 59*time.Second, "59m"},
+		{time.Hour, "1h"},
+		{3 * time.Hour, "3h"},
+		{23*time.Hour + 59*time.Minute, "23h"},
+		{24 * time.Hour, "1d"},
+		{73 * time.Hour, "3d"},
+		{-time.Minute, "just now"},
+	}
+	for _, tc := range cases {
+		if got := formatRelativeAge(tc.dur); got != tc.want {
+			t.Fatalf("formatRelativeAge(%v) = %q, want %q", tc.dur, got, tc.want)
+		}
+	}
+}
+
+func TestStatusNotifyCompactTarget(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		n    notify.Notification
+		want string
+	}{
+		{notify.Notification{Session: "s"}, "s"},
+		{notify.Notification{Session: "s", Window: "1"}, "s:1"},
+		{notify.Notification{Session: "s", Window: "1", Pane: "0"}, "s:1.0"},
+		{notify.Notification{Session: ""}, ""},
+		{notify.Notification{Session: "  s  ", Window: " 1 ", Pane: " 0 "}, "s:1.0"},
+	}
+	for _, tc := range cases {
+		if got := compactTarget(tc.n); got != tc.want {
+			t.Fatalf("compactTarget(%+v) = %q, want %q", tc.n, got, tc.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
The notify segment was plain ASCII (`[I] test - sess`). Redesign with HUD-consistent palette to match the Claude/Codex usage bar.

## New format
```
●  <agent>  ▎  <text>  ·  <target>  ·  <age>   +<count>
```
- Severity icon `●`: brightcyan (info) / yellow (warn) / red+bold (critical)
- Agent block (extracted from `claude:`/`codex:` text prefix when source=ai): bold cyan
- `▎` divider in dim grey
- Separators `·` in dim grey
- Target compacted to `<sess>:<window>.<pane>` in dim grey
- Age `just now` / `<N>m` / `<N>h` / `<N>d` in dim grey
- `+<N>` count of additional entries in dim grey

## Width-tier degradation (in order)
1. Long form
2. Drop age (`· <age>`)
3. Drop target (`· <target>`)
4. Truncate text with `…`
5. Drop agent + bar (`<agent>  ▎`)
6. Hard truncate

## Test plan
- [x] `go build ./...`, `gofmt -l .` clean
- [x] `go test ./...` (17 new subtests cover all tiers, severities, agent extraction, age buckets)
- [x] Manual: synthetic entries at info/warn/critical render with correct icon colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)