### PR TITLE
feat(usage/hud): show Claude last-sync age, drop tilde markers

### DIFF
--- a/internal/app/usage.go
+++ b/internal/app/usage.go
@@ -389,22 +389,30 @@ const (
 	statusInnerSeparator = " · " // between 5h and wk inside a model.
 	statusModelSeparator = "   " // 3 spaces between Claude and Codex blocks.
 	statusDefaultReset   = "#[default]"
-	// staleMarker (`~`) flags snapshots older than staleAfter (10m).
-	// staleMarkerVery (`~~`) flags snapshots older than veryStaleAfter
-	// (1h) — rendered in the same dim color so the user sees a stronger
-	// nudge to manually `--force` without the segment shifting visual
-	// weight.
-	staleMarker     = "#[fg=colour245]~#[default]"
-	staleMarkerVery = "#[fg=colour245]~~#[default]"
+)
+
+// Age-indicator colour thresholds for the Claude HUD block. The age
+// indicator carries the staleness signal (it replaces the legacy `~` /
+// `~~` markers) so its colour ramps with the staleness level:
+//
+//   - age <  ageWarnAfter (1h)   → dim grey, informational
+//   - age >= ageWarnAfter (1h)   → dim yellow, attention
+//   - age >= ageAlertAfter (6h)  → bold red, alert
+const (
+	ageWarnAfter  = 1 * time.Hour
+	ageAlertAfter = 6 * time.Hour
 )
 
 // modelDisplay is the in-memory representation of a single model's
 // snapshots. Pct values are floats so the >100% over-limit branch can
 // surface the actual number (e.g. `319%`) instead of capping at 100%.
 //
-// Staleness is captured as a level so the renderer can emit `~` for
-// stale rows (>staleAfter) and `~~` for very-stale rows
-// (>veryStaleAfter): 0 = fresh, 1 = stale, 2 = very stale.
+// Staleness is surfaced via lastSync (the most recent UpdatedAt across
+// the model's rows) — the long HUD tier renders an age indicator
+// (`(3m)`, `(1h)`, `(8h)`) for adapters whose data may be throttled or
+// in backoff (currently Claude). Adapters whose data is always
+// near-current (Codex reads from the latest rollout file every call)
+// have showAge=false so the indicator is suppressed.
 type modelDisplay struct {
 	model      string // canonical lowercase key.
 	label      string // user-facing label (Claude / Codex / ...).
@@ -415,16 +423,26 @@ type modelDisplay struct {
 	hasWeek    bool
 	weekPct    float64
 	weekStale  int
+	// lastSync is max(fiveUpdatedAt, weekUpdatedAt). Used together
+	// with `now` to compute the age indicator. Zero when no row
+	// supplied an UpdatedAt timestamp.
+	lastSync time.Time
+	// showAge gates the age-indicator render path. False for
+	// adapters whose data is always near-current (Codex).
+	showAge bool
 }
 
 // formatStatusUsage produces the HUD-style tmux status segment. The output
-// degrades gracefully through five tiers:
+// degrades gracefully through six tiers:
 //
-//  1. Long form with bars + wk: `Claude 5h [████████░░] 80% · wk [...]`
-//  2. Drop wk bars (label + 5h bar only).
-//  3. Drop bars entirely (`Claude 5h:80% wk:30%`).
-//  4. Single-letter labels (`C 5h:80% wk:30%`).
-//  5. Hard rune-truncation with trailing `…`.
+//  1. Long form with age indicator + bars + wk:
+//     `Claude (3m) 5h [████████░░] 80% · wk [...]   Codex 5h [...] 20% · wk [...]`
+//  2. Drop the age indicator (the legacy `Claude 5h [bar] N% · wk [bar] N%`
+//     form, current default).
+//  3. Drop the wk bar (label + 5h bar only).
+//  4. Drop bars entirely (`Claude 5h:80% wk:30%`).
+//  5. Single-letter labels (`C 5h:80% wk:30%`).
+//  6. Hard rune-truncation with trailing `…`.
 //
 // maxWidth is measured in display cells; tmux color escapes (`#[...]`) are
 // stripped before counting so adding color does not push the segment over
@@ -437,14 +455,15 @@ func formatStatusUsage(snaps []usage.Snapshot, maxWidth int, now time.Time) stri
 	if len(models) == 0 {
 		return ""
 	}
-	tiers := []func([]modelDisplay) string{
+	tiers := []func([]modelDisplay, time.Time) string{
+		renderTierLongHUDWithAge,
 		renderTierLongHUD,
 		renderTierFiveHOnlyHUD,
 		renderTierTextLong,
 		renderTierTextShort,
 	}
 	for _, tier := range tiers {
-		out := tier(models)
+		out := tier(models, now)
 		if out == "" {
 			continue
 		}
@@ -453,12 +472,30 @@ func formatStatusUsage(snaps []usage.Snapshot, maxWidth int, now time.Time) stri
 		}
 	}
 	// Last resort: rune-truncate the shortest tier.
-	short := renderTierTextShort(models)
+	short := renderTierTextShort(models, now)
 	return truncateWithEllipsis(short, maxWidth)
 }
 
-// renderTierLongHUD renders the full HUD: label + 5h bar + wk bar per model.
-func renderTierLongHUD(models []modelDisplay) string {
+// renderTierLongHUDWithAge renders the long HUD plus a per-model
+// last-sync age indicator. Only models with showAge=true and a
+// non-empty rendered age (>= 60s old) emit the indicator — fresh data
+// keeps the segment tight.
+func renderTierLongHUDWithAge(models []modelDisplay, now time.Time) string {
+	return renderLongHUDInternal(models, now, true)
+}
+
+// renderTierLongHUD renders the full HUD without the age indicator
+// (current-default form). Used as tier 2 once the age block doesn't
+// fit the budget.
+func renderTierLongHUD(models []modelDisplay, now time.Time) string {
+	return renderLongHUDInternal(models, now, false)
+}
+
+// renderLongHUDInternal is the shared implementation of the two long
+// HUD tiers (with/without age indicator). When withAge is true and the
+// model carries showAge + an age >= 60s, the indicator is injected
+// between the label and the 5h bar.
+func renderLongHUDInternal(models []modelDisplay, now time.Time, withAge bool) string {
 	blocks := make([]string, 0, len(models))
 	for _, m := range models {
 		if !m.hasFive && !m.hasWeek {
@@ -468,10 +505,16 @@ func renderTierLongHUD(models []modelDisplay) string {
 		b.WriteString("#[fg=cyan,bold]")
 		b.WriteString(m.label)
 		b.WriteString(statusDefaultReset)
+		if withAge {
+			if ind := renderAgeIndicator(m, now); ind != "" {
+				b.WriteByte(' ')
+				b.WriteString(ind)
+			}
+		}
 		first := true
 		if m.hasFive {
 			b.WriteByte(' ')
-			b.WriteString(renderHUDPair("5h", m.fivePct, m.fiveStale))
+			b.WriteString(renderHUDPair("5h", m.fivePct))
 			first = false
 		}
 		if m.hasWeek {
@@ -480,7 +523,7 @@ func renderTierLongHUD(models []modelDisplay) string {
 			} else {
 				b.WriteString(statusInnerSeparator)
 			}
-			b.WriteString(renderHUDPair("wk", m.weekPct, m.weekStale))
+			b.WriteString(renderHUDPair("wk", m.weekPct))
 		}
 		b.WriteString(statusDefaultReset)
 		blocks = append(blocks, b.String())
@@ -492,7 +535,8 @@ func renderTierLongHUD(models []modelDisplay) string {
 }
 
 // renderTierFiveHOnlyHUD drops the wk bar but keeps the 5h bar.
-func renderTierFiveHOnlyHUD(models []modelDisplay) string {
+func renderTierFiveHOnlyHUD(models []modelDisplay, now time.Time) string {
+	_ = now
 	blocks := make([]string, 0, len(models))
 	for _, m := range models {
 		if !m.hasFive {
@@ -503,7 +547,7 @@ func renderTierFiveHOnlyHUD(models []modelDisplay) string {
 		b.WriteString(m.label)
 		b.WriteString(statusDefaultReset)
 		b.WriteByte(' ')
-		b.WriteString(renderHUDPair("5h", m.fivePct, m.fiveStale))
+		b.WriteString(renderHUDPair("5h", m.fivePct))
 		b.WriteString(statusDefaultReset)
 		blocks = append(blocks, b.String())
 	}
@@ -514,7 +558,8 @@ func renderTierFiveHOnlyHUD(models []modelDisplay) string {
 }
 
 // renderTierTextLong drops bars entirely but keeps the long model labels.
-func renderTierTextLong(models []modelDisplay) string {
+func renderTierTextLong(models []modelDisplay, now time.Time) string {
+	_ = now
 	blocks := make([]string, 0, len(models))
 	for _, m := range models {
 		text := renderTextPair(m, m.label)
@@ -529,7 +574,8 @@ func renderTierTextLong(models []modelDisplay) string {
 }
 
 // renderTierTextShort uses single-letter labels (legacy form, no color).
-func renderTierTextShort(models []modelDisplay) string {
+func renderTierTextShort(models []modelDisplay, now time.Time) string {
+	_ = now
 	blocks := make([]string, 0, len(models))
 	for _, m := range models {
 		text := renderTextPair(m, m.shortLabel)
@@ -544,14 +590,17 @@ func renderTierTextShort(models []modelDisplay) string {
 }
 
 // renderTextPair builds a `<label> 5h:N% wk:N%` substring used by both
-// non-HUD tiers. Returns "" when the model has nothing to show.
+// non-HUD tiers. Returns "" when the model has nothing to show. The
+// legacy `~` / `~~` stale markers are not emitted here — the long HUD
+// tier carries staleness via the age indicator. The non-JSON `usage`
+// table CLI still surfaces a STALE column for verbose inspection.
 func renderTextPair(m modelDisplay, label string) string {
 	parts := make([]string, 0, 2)
 	if m.hasFive {
-		parts = append(parts, fmt.Sprintf("5h:%s%s", percentText(m.fivePct), staleSuffix(m.fiveStale)))
+		parts = append(parts, fmt.Sprintf("5h:%s", percentText(m.fivePct)))
 	}
 	if m.hasWeek {
-		parts = append(parts, fmt.Sprintf("wk:%s%s", percentText(m.weekPct), staleSuffix(m.weekStale)))
+		parts = append(parts, fmt.Sprintf("wk:%s", percentText(m.weekPct)))
 	}
 	if len(parts) == 0 {
 		return ""
@@ -561,35 +610,61 @@ func renderTextPair(m modelDisplay, label string) string {
 
 // renderHUDPair renders a single `<window> [bar] N%` substring with color
 // escapes. Used for both 5h and wk pairs in the HUD tiers.
-func renderHUDPair(window string, pct float64, staleLevel int) string {
+func renderHUDPair(window string, pct float64) string {
 	color := usage.BarColorForPct(pct)
 	bar := usage.RenderColoredBar(pct, color, usage.BarEmptyColor)
-	suffix := ""
-	switch staleLevel {
-	case 1:
-		suffix = staleMarker
-	case 2:
-		suffix = staleMarkerVery
-	}
 	// `#[default]` after the bar restores label fg before the wk text. The
 	// percent number then re-applies the same color as the bar fill so the
 	// numeric matches visually (a red bar's 90% reads red too).
-	return fmt.Sprintf("%s%s #[fg=%s]%s%s%s",
-		window+" ", bar, color, percentText(pct), statusDefaultReset, suffix)
+	return fmt.Sprintf("%s%s #[fg=%s]%s%s",
+		window+" ", bar, color, percentText(pct), statusDefaultReset)
 }
 
-// staleSuffix returns the text-tier stale marker. Plain `~`/`~~` (no
-// color escapes) since the text tiers run uncolored. Levels match
-// staleLevel: 1 = stale (`~`), 2 = very stale (`~~`).
-func staleSuffix(staleLevel int) string {
-	switch staleLevel {
-	case 1:
-		return "~"
-	case 2:
-		return "~~"
-	default:
+// formatLastSyncAge formats the age payload used by the HUD's
+// last-sync indicator. Returns "" for an age below 1 minute (the
+// indicator is omitted to keep the bar tight when fresh) so callers
+// can branch on the empty string. Otherwise the unit ladders through
+// minutes, hours and days.
+func formatLastSyncAge(d time.Duration) string {
+	if d < time.Minute {
 		return ""
 	}
+	switch {
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
+// renderAgeIndicator returns the colored `(<age>)` block injected
+// between the model label and the 5h bar. Returns "" when the age is
+// fresh (<1m), the model opted out (Codex), or the now/lastSync clock
+// is missing. Colours ramp with staleness so the user can spot a
+// stagnant cache at a glance:
+//
+//   - <1h:  dim grey  (#[fg=colour245])
+//   - 1-6h: dim yellow (#[fg=yellow])
+//   - >=6h: bold red   (#[fg=red,bold])
+func renderAgeIndicator(m modelDisplay, now time.Time) string {
+	if !m.showAge || now.IsZero() || m.lastSync.IsZero() {
+		return ""
+	}
+	age := now.Sub(m.lastSync)
+	text := formatLastSyncAge(age)
+	if text == "" {
+		return ""
+	}
+	color := "colour245"
+	switch {
+	case age >= ageAlertAfter:
+		color = "red,bold"
+	case age >= ageWarnAfter:
+		color = "yellow"
+	}
+	return fmt.Sprintf("#[fg=%s](%s)%s", color, text, statusDefaultReset)
 }
 
 // percentText formats a percentage. Negative values are clamped to 0.
@@ -637,6 +712,17 @@ func buildModelDisplays(snaps []usage.Snapshot, now time.Time) []modelDisplay {
 			row.hasWeek = true
 			row.weekPct = s.Pct
 			row.weekStale = level
+		}
+		// lastSync tracks the most recent successful refresh
+		// across the model's rows; the long HUD tier renders its
+		// age relative to `now`. Codex reads from the latest
+		// rollout file every call so its age is always near "now"
+		// — uninteresting for the HUD, so showAge stays false.
+		if !s.UpdatedAt.IsZero() && s.UpdatedAt.After(row.lastSync) {
+			row.lastSync = s.UpdatedAt
+		}
+		if strings.EqualFold(s.Model, "claude") {
+			row.showAge = true
 		}
 	}
 	canonical := []string{"claude", "codex"}

--- a/internal/app/usage_test.go
+++ b/internal/app/usage_test.go
@@ -416,49 +416,51 @@ func TestUsageStatusEchoesAdapterErrorWithDebugEnv(t *testing.T) {
 	}
 }
 
-func TestFormatStatusUsageMarksStaleSnapshot(t *testing.T) {
+func TestFormatStatusUsageHUDOmitsTildeStaleMarker(t *testing.T) {
 	t.Parallel()
 
+	// Schema v3 of the HUD replaces the legacy `~` / `~~` stale
+	// markers with an explicit age indicator (see TestFormatStatusUsageAge*).
+	// The colored marker forms must never appear in the rendered output.
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
-	stale := now.Add(-15 * time.Minute) // older than staleAfter (10m)
+	stale := now.Add(-15 * time.Minute)
 	snaps := []usage.Snapshot{
 		{Model: "claude", Window: usage.Window5h, Pct: 18, ResetsAt: now.Add(time.Hour), UpdatedAt: stale},
 		{Model: "codex", Window: usage.Window5h, Pct: 50, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
 	}
 	got := formatStatusUsage(snaps, 0, now)
-	// Claude is stale → marker present after its 18%. Codex is fresh →
-	// no marker. Use the colored marker form for the HUD tier.
-	if !strings.Contains(got, "18%#[default]#[fg=colour245]~#[default]") {
-		t.Fatalf("missing stale marker after claude 18%%: %q", got)
+	if strings.Contains(got, "~") {
+		t.Fatalf("HUD must not emit `~` stale marker: %q", got)
 	}
-	// Codex 50% must NOT carry a marker.
-	if strings.Contains(got, "50%#[default]#[fg=colour245]~") {
-		t.Fatalf("codex marked stale but should be fresh: %q", got)
+	// Codex stays clean too — no age, no `~`.
+	if strings.Contains(got, "(") && strings.Contains(got, ")Codex") {
+		t.Fatalf("codex must not carry an age indicator: %q", got)
 	}
 }
 
-func TestFormatStatusUsageStaleTextTier(t *testing.T) {
+func TestFormatStatusUsageTextTiersOmitTildeMarker(t *testing.T) {
 	t.Parallel()
 
+	// Text tiers used to append `~` / `~~` to stale rows. Those
+	// markers are gone everywhere now (the long HUD tier carries the
+	// signal via the age indicator; verbose CLI inspection uses the
+	// `STALE` column in `projmux usage`'s table form).
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
 	stale := now.Add(-15 * time.Minute)
+	veryStale := now.Add(-90 * time.Minute)
 	snaps := []usage.Snapshot{
-		{Model: "claude", Window: usage.Window5h, Pct: 42, ResetsAt: now.Add(time.Hour), UpdatedAt: stale},
+		{Model: "claude", Window: usage.Window5h, Pct: 42, ResetsAt: now.Add(time.Hour), UpdatedAt: veryStale},
 		{Model: "claude", Window: usage.WindowWeekly, Pct: 18, ResetsAt: now.Add(7 * 24 * time.Hour), UpdatedAt: stale},
 		{Model: "codex", Window: usage.Window5h, Pct: 71, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
 		{Model: "codex", Window: usage.WindowWeekly, Pct: 55, ResetsAt: now.Add(7 * 24 * time.Hour), UpdatedAt: now},
 	}
-	// Width=45 lands us in the long-text tier; assert the plain `~`
-	// marker on the stale claude rows but not the fresh codex rows.
-	tier3 := formatStatusUsage(snaps, 45, now)
-	if !strings.Contains(tier3, "5h:42%~") {
-		t.Fatalf("text tier missing stale marker on claude 5h: %q", tier3)
-	}
-	if !strings.Contains(tier3, "wk:18%~") {
-		t.Fatalf("text tier missing stale marker on claude wk: %q", tier3)
-	}
-	if strings.Contains(tier3, "5h:71%~") || strings.Contains(tier3, "wk:55%~") {
-		t.Fatalf("fresh codex rows got stale marker: %q", tier3)
+	// Width=45 lands us in the long-text tier. Width=30 lands us in
+	// the short-label tier. Both must be `~`-free.
+	for _, w := range []int{45, 30} {
+		got := formatStatusUsage(snaps, w, now)
+		if strings.Contains(got, "~") {
+			t.Fatalf("text tier (width=%d) emitted `~`: %q", w, got)
+		}
 	}
 }
 
@@ -746,43 +748,156 @@ func TestFormatBackoffDurationShapes(t *testing.T) {
 	}
 }
 
-func TestFormatStatusUsageMarksVeryStaleSnapshot(t *testing.T) {
+// TestFormatStatusUsageAgeFreshOmitsIndicator covers the `now` case
+// from the spec: an age below 1 minute keeps the bar tight by
+// suppressing the `(<age>)` block entirely.
+func TestFormatStatusUsageAgeFreshOmitsIndicator(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
-	veryStale := now.Add(-90 * time.Minute) // > veryStaleAfter (1h)
 	snaps := []usage.Snapshot{
-		{Model: "claude", Window: usage.Window5h, Pct: 18, ResetsAt: now.Add(time.Hour), UpdatedAt: veryStale},
+		{Model: "claude", Window: usage.Window5h, Pct: 18, ResetsAt: now.Add(time.Hour), UpdatedAt: now.Add(-30 * time.Second)},
+		{Model: "claude", Window: usage.WindowWeekly, Pct: 9, ResetsAt: now.Add(7 * 24 * time.Hour), UpdatedAt: now.Add(-30 * time.Second)},
 	}
 	got := formatStatusUsage(snaps, 0, now)
-	// Very-stale → `~~` marker present in HUD form.
-	if !strings.Contains(got, "18%#[default]#[fg=colour245]~~#[default]") {
-		t.Fatalf("missing very-stale ~~ marker: %q", got)
+	if strings.Contains(got, "(") {
+		t.Fatalf("fresh data must not render an age indicator: %q", got)
+	}
+	// Sanity: the label and bar still render.
+	if !strings.Contains(got, "Claude") {
+		t.Fatalf("missing Claude label: %q", got)
 	}
 }
 
-func TestFormatStatusUsageVeryStaleTextTier(t *testing.T) {
+// TestFormatStatusUsageAgeMinutesGrey covers the spec's `(3m)`
+// scenario — minute-scale age renders in dim grey.
+func TestFormatStatusUsageAgeMinutesGrey(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
-	veryStale := now.Add(-90 * time.Minute)
-	stale := now.Add(-15 * time.Minute) // stale but not very-stale
 	snaps := []usage.Snapshot{
-		{Model: "claude", Window: usage.Window5h, Pct: 42, ResetsAt: now.Add(time.Hour), UpdatedAt: veryStale},
+		{Model: "claude", Window: usage.Window5h, Pct: 18, ResetsAt: now.Add(time.Hour), UpdatedAt: now.Add(-3 * time.Minute)},
+		{Model: "claude", Window: usage.WindowWeekly, Pct: 9, ResetsAt: now.Add(7 * 24 * time.Hour), UpdatedAt: now.Add(-3 * time.Minute)},
+	}
+	got := formatStatusUsage(snaps, 0, now)
+	if !strings.Contains(got, "#[fg=colour245](3m)#[default]") {
+		t.Fatalf("missing dim-grey (3m) age indicator: %q", got)
+	}
+}
+
+// TestFormatStatusUsageAgeWarnYellow covers the 1h..6h band — the
+// indicator switches to dim yellow to flag attention.
+func TestFormatStatusUsageAgeWarnYellow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	snaps := []usage.Snapshot{
+		{Model: "claude", Window: usage.Window5h, Pct: 18, ResetsAt: now.Add(time.Hour), UpdatedAt: now.Add(-90 * time.Minute)},
+		{Model: "claude", Window: usage.WindowWeekly, Pct: 9, ResetsAt: now.Add(7 * 24 * time.Hour), UpdatedAt: now.Add(-90 * time.Minute)},
+	}
+	got := formatStatusUsage(snaps, 0, now)
+	if !strings.Contains(got, "#[fg=yellow](1h)#[default]") {
+		t.Fatalf("missing dim-yellow (1h) age indicator: %q", got)
+	}
+}
+
+// TestFormatStatusUsageAgeAlertRedBold covers the >=6h band — the
+// indicator switches to bold red. The unit stays the actual hours
+// value (e.g. `8h`) so the user knows exactly how stale the cache is.
+func TestFormatStatusUsageAgeAlertRedBold(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	snaps := []usage.Snapshot{
+		{Model: "claude", Window: usage.Window5h, Pct: 18, ResetsAt: now.Add(time.Hour), UpdatedAt: now.Add(-8 * time.Hour)},
+		{Model: "claude", Window: usage.WindowWeekly, Pct: 9, ResetsAt: now.Add(7 * 24 * time.Hour), UpdatedAt: now.Add(-8 * time.Hour)},
+	}
+	got := formatStatusUsage(snaps, 0, now)
+	if !strings.Contains(got, "#[fg=red,bold](8h)#[default]") {
+		t.Fatalf("missing bold-red (8h) age indicator: %q", got)
+	}
+}
+
+// TestFormatStatusUsageCodexNoAgeIndicator confirms the Codex block
+// never carries the age indicator (its rate_limits payload is sourced
+// from the latest rollout file every call — always near-current).
+func TestFormatStatusUsageCodexNoAgeIndicator(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	// Even a deliberately ancient Codex UpdatedAt must not produce
+	// an age block.
+	snaps := []usage.Snapshot{
+		{Model: "codex", Window: usage.Window5h, Pct: 50, ResetsAt: now.Add(time.Hour), UpdatedAt: now.Add(-12 * time.Hour)},
+		{Model: "codex", Window: usage.WindowWeekly, Pct: 25, ResetsAt: now.Add(7 * 24 * time.Hour), UpdatedAt: now.Add(-12 * time.Hour)},
+	}
+	got := formatStatusUsage(snaps, 0, now)
+	if strings.Contains(got, "(") {
+		t.Fatalf("codex rendered an age indicator: %q", got)
+	}
+}
+
+// TestFormatStatusUsageAgeDropsOnTier2 verifies that when the budget
+// can't fit the long-with-age tier, the renderer falls back to the
+// (current default) long form WITHOUT the age block — rather than
+// jumping straight to the bar-less text tier. This matches the spec's
+// width-tier degradation table.
+func TestFormatStatusUsageAgeDropsOnTier2(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	stale := now.Add(-3 * time.Minute)
+	snaps := []usage.Snapshot{
+		{Model: "claude", Window: usage.Window5h, Pct: 42, ResetsAt: now.Add(time.Hour), UpdatedAt: stale},
 		{Model: "claude", Window: usage.WindowWeekly, Pct: 18, ResetsAt: now.Add(7 * 24 * time.Hour), UpdatedAt: stale},
 		{Model: "codex", Window: usage.Window5h, Pct: 71, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
 		{Model: "codex", Window: usage.WindowWeekly, Pct: 55, ResetsAt: now.Add(7 * 24 * time.Hour), UpdatedAt: now},
 	}
-	tier3 := formatStatusUsage(snaps, 45, now)
-	if !strings.Contains(tier3, "5h:42%~~") {
-		t.Fatalf("text tier missing very-stale ~~ marker on claude 5h: %q", tier3)
+	// Tier 1 (with age) renders to width 70.
+	tier1 := formatStatusUsage(snaps, 200, now)
+	if !strings.Contains(tier1, "(3m)") {
+		t.Fatalf("tier1 missing age indicator at unconstrained width: %q", tier1)
 	}
-	if !strings.Contains(tier3, "wk:18%~") {
-		t.Fatalf("text tier missing stale ~ marker on claude wk: %q", tier3)
+	tier1Width := visualLen(tier1)
+	// Pick a budget that fits tier 2 but not tier 1.
+	budget := tier1Width - 1
+	tier2 := formatStatusUsage(snaps, budget, now)
+	if strings.Contains(tier2, "(3m)") {
+		t.Fatalf("tier2 must drop age indicator: %q", tier2)
 	}
-	// Don't double-mark the merely-stale row as ~~.
-	if strings.Contains(tier3, "wk:18%~~") {
-		t.Fatalf("merely-stale row got ~~ marker: %q", tier3)
+	if !strings.Contains(tier2, "wk ") {
+		t.Fatalf("tier2 must keep the wk bar: %q", tier2)
+	}
+	if visualLen(tier2) > budget {
+		t.Fatalf("tier2 visualLen=%d > budget=%d: %q", visualLen(tier2), budget, tier2)
+	}
+}
+
+// TestFormatLastSyncAgeUnits covers the formatLastSyncAge unit
+// ladder: <1m → "" (omit), 1m..1h → minutes, 1h..24h → hours, >=24h
+// → days.
+func TestFormatLastSyncAgeUnits(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{30 * time.Second, ""},
+		{59 * time.Second, ""},
+		{60 * time.Second, "1m"},
+		{3 * time.Minute, "3m"},
+		{59 * time.Minute, "59m"},
+		{60 * time.Minute, "1h"},
+		{8 * time.Hour, "8h"},
+		{23 * time.Hour, "23h"},
+		{24 * time.Hour, "1d"},
+		{72 * time.Hour, "3d"},
+	}
+	for _, tc := range cases {
+		if got := formatLastSyncAge(tc.in); got != tc.want {
+			t.Fatalf("formatLastSyncAge(%v) = %q, want %q", tc.in, got, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Add an explicit last-sync age indicator on the Claude side of the usage HUD. With Claude's 5-minute throttle and 30m–1h backoff windows, freshness varies a lot — users want to see at a glance how stale the displayed values are.

## New format
```
Claude (3m)   5h [bar] 80% · wk [bar] 31%   Codex 5h [bar] 20% · wk [bar] 1%
```

- Age block immediately after `Claude`:
  - Fresh (< 60s): omitted entirely
  - Minutes (1m..60m): dim grey `(<N>m)`
  - 1h..6h: yellow `(<N>h)`
  - ≥ 6h: bold red `(<N>h)` (actual hours preserved, not capped at "6h+")
  - 24h+: `<N>d`
- Codex never gets an age block (always reflects the latest rollout file).
- The previous `~` / `~~` stale markers are removed (the explicit age block replaces them).
- The `STALE` column in `projmux usage` table CLI is unchanged.
- The `--json` `stale` field is unchanged.

## Width-tier degradation
Tier 1 (long with age) → Tier 2 drops the age → existing tiers unchanged.

## Test plan
- [x] `go build ./...`, `gofmt -l .` clean
- [x] `go test ./...` (738 PASS)
- [x] New tests cover: fresh-omits-indicator, minutes-grey, warn-yellow (1h+), alert-red-bold (6h+), codex-no-age, tier-2-drops-age, age-unit boundaries, and absence of `~` markers in HUD/text tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)