### PR TITLE
fix(statusbar): swallow focus exit codes — toast instead of tmux error popup

### DIFF
--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -201,6 +201,14 @@ func (c *statusbarCommand) handleUsage(_ statusbarClickOptions, _, stderr io.Wri
 // handleNotify focuses the origin pane of the newest queued notification. If
 // the queue is empty we surface that fact in tmux rather than silently doing
 // nothing — that gives the keyboard shortcut a useful interactive ack.
+//
+// This handler MUST NOT return an error to its caller (tmux's run-shell). A
+// non-zero exit from run-shell triggers a "...returned N" error popup, which
+// is hostile UX for a status-bar click. Every failure mode here resolves to
+// a tmux display-message toast and a nil return; the only place we still
+// surface errors is the binary-path resolution check, because if we cannot
+// even find the projmux executable there is nothing useful to display and
+// the failure is a packaging bug, not a runtime UX glitch.
 func (c *statusbarCommand) handleNotify(opts statusbarClickOptions, _, stderr io.Writer) error {
 	if c.notifyStoreFn == nil {
 		return c.runTmux(stderr, "display-message", "no notifications")
@@ -238,9 +246,22 @@ func (c *statusbarCommand) handleNotify(opts statusbarClickOptions, _, stderr io
 	if socket != "" {
 		args = append(args, "--socket", socket)
 	}
-	if _, err := c.runner.Run(context.Background(), binaryPath, args...); err != nil {
-		// Leave the entry in place so the user can retry the click.
-		return fmt.Errorf("statusbar notify: focus invocation failed: %w", err)
+	if _, runErr := c.runner.Run(context.Background(), binaryPath, args...); runErr != nil {
+		// The focus subprocess exits with a deterministic code 2 when the
+		// target session/window/pane cannot be resolved (see focus.go's
+		// focusExitNotResolved). Treat that as "the queue entry is junk":
+		// ack it so the next click moves on, and tell the user via a
+		// non-error toast. Any other exit code is treated as transient
+		// (network hiccup, tmux server churn, etc.) — keep the entry so
+		// the user can retry, and surface the reason as a toast instead
+		// of a tmux error popup.
+		if isFocusTargetUnresolved(runErr) {
+			if ackErr := store.Ack(head.ID); ackErr != nil {
+				fmt.Fprintf(stderr, "statusbar notify: ack %s: %v\n", head.ID, ackErr)
+			}
+			return c.runTmux(stderr, "display-message", "notify target gone, dropping entry")
+		}
+		return c.runTmux(stderr, "display-message", fmt.Sprintf("focus failed: %s", focusFailureSummary(runErr)))
 	}
 	// Click-to-focus has no separate producer to ack the entry, so the
 	// click itself is the consume signal: a successful focus dispatch is
@@ -252,6 +273,49 @@ func (c *statusbarCommand) handleNotify(opts statusbarClickOptions, _, stderr io
 		fmt.Fprintf(stderr, "statusbar notify: ack %s: %v\n", head.ID, ackErr)
 	}
 	return nil
+}
+
+// isFocusTargetUnresolved reports whether the focus subprocess error
+// represents the deterministic "target could not be resolved" exit
+// (focus.go: focusExitNotResolved == 2). We accept three signals:
+//
+//   - The wrapped error is an *exec.ExitError with ExitCode() == 2 (the
+//     normal in-process subprocess case).
+//   - The wrapped error is any other type that exposes ExitCode() == 2 —
+//     this covers test fakes and the in-process focusExitError shape.
+//   - The wrapped error is an app.UsageError. UsageErrors also exit the
+//     subprocess with code 2, and treating them as "target unresolved"
+//     keeps the click loop from getting stuck on a malformed queue entry.
+func isFocusTargetUnresolved(err error) bool {
+	if err == nil {
+		return false
+	}
+	var coded interface{ ExitCode() int }
+	if errors.As(err, &coded) && coded.ExitCode() == focusExitNotResolved {
+		return true
+	}
+	if IsUsageError(err) {
+		return true
+	}
+	return false
+}
+
+// focusFailureSummary renders a short human-readable reason for a transient
+// focus failure. We strip the wrapper prefixes the runner adds so the toast
+// stays under tmux's display-message length budget.
+func focusFailureSummary(err error) string {
+	if err == nil {
+		return "unknown"
+	}
+	msg := err.Error()
+	if idx := strings.LastIndex(msg, ": "); idx >= 0 && idx < len(msg)-2 {
+		msg = msg[idx+2:]
+	}
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return "unknown"
+	}
+	return msg
 }
 
 func (c *statusbarCommand) resolveBinary() (string, error) {

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -281,13 +281,13 @@ func TestStatusbarClickNotifyAcksEntryAfterSuccessfulFocus(t *testing.T) {
 	}
 }
 
-func TestStatusbarClickNotifyDoesNotAckWhenFocusFails(t *testing.T) {
+func TestStatusbarClickNotifyTransientFocusFailureSurfacesToastAndKeepsEntry(t *testing.T) {
 	t.Parallel()
 
 	runner := &statusbarFakeRunner{
 		respond: func(name string, _ []string) ([]byte, error) {
 			if name == "/usr/local/bin/projmux" {
-				return nil, errors.New("focus boom")
+				return nil, &fakeExitError{code: 1, msg: "focus boom"}
 			}
 			return nil, nil
 		},
@@ -305,12 +305,90 @@ func TestStatusbarClickNotifyDoesNotAckWhenFocusFails(t *testing.T) {
 	}}
 	cmd := newStatusbarTestCommand(runner, store)
 
-	err := cmd.Run([]string{"click", "notify"}, &bytes.Buffer{}, &bytes.Buffer{})
-	if err == nil {
-		t.Fatal("expected error from failed focus")
+	if err := cmd.Run([]string{"click", "notify"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v, want nil (transient failure must not surface as tmux error popup)", err)
 	}
 	if store.ackedID != "" {
-		t.Fatalf("store.ackedID = %q, want empty (entry must remain on focus failure)", store.ackedID)
+		t.Fatalf("store.ackedID = %q, want empty (transient focus failure must keep entry for retry)", store.ackedID)
+	}
+	got, ok := lastDisplayMessage(runner.calls)
+	if !ok {
+		t.Fatalf("missing display-message; calls = %#v", runner.calls)
+	}
+	if !strings.HasPrefix(got, "focus failed:") {
+		t.Fatalf("display-message = %q, want prefix 'focus failed:'", got)
+	}
+}
+
+func TestStatusbarClickNotifyTargetGoneAcksEntryAndShowsToast(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{
+		respond: func(name string, _ []string) ([]byte, error) {
+			if name == "/usr/local/bin/projmux" {
+				return nil, &fakeExitError{code: focusExitNotResolved, msg: "target unresolved"}
+			}
+			return nil, nil
+		},
+	}
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{
+			ID:      "abc",
+			Text:    "deploy ok",
+			Source:  notify.SourceAI,
+			Socket:  "projmux",
+			Session: "__nope",
+			Window:  "1",
+			Pane:    "0",
+		},
+	}}
+	cmd := newStatusbarTestCommand(runner, store)
+
+	if err := cmd.Run([]string{"click", "notify"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v, want nil (target-gone must not surface as tmux error popup)", err)
+	}
+	if store.ackedID != "abc" {
+		t.Fatalf("store.ackedID = %q, want %q (target-gone must ack to drop the junk entry)", store.ackedID, "abc")
+	}
+	if !sawTmuxDisplayMessage(runner.calls, "notify target gone, dropping entry") {
+		t.Fatalf("missing 'notify target gone' display-message; calls = %#v", runner.calls)
+	}
+}
+
+func TestStatusbarClickNotifyUsageErrorTreatedAsTargetGone(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{
+		respond: func(name string, _ []string) ([]byte, error) {
+			if name == "/usr/local/bin/projmux" {
+				// Simulate the focus subprocess exiting with a wrapped
+				// app.UsageError. main.go maps UsageError to exit code 2,
+				// which we equate with target-unresolved here.
+				return nil, &UsageError{Message: "focus --target invalid"}
+			}
+			return nil, nil
+		},
+	}
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{
+			ID:      "abc",
+			Text:    "deploy ok",
+			Source:  notify.SourceAI,
+			Session: "main",
+			Window:  "1",
+			Pane:    "0",
+		},
+	}}
+	cmd := newStatusbarTestCommand(runner, store)
+
+	if err := cmd.Run([]string{"click", "notify"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+	if store.ackedID != "abc" {
+		t.Fatalf("store.ackedID = %q, want %q (UsageError should ack like target-gone)", store.ackedID, "abc")
+	}
+	if !sawTmuxDisplayMessage(runner.calls, "notify target gone, dropping entry") {
+		t.Fatalf("missing target-gone display-message; calls = %#v", runner.calls)
 	}
 }
 
@@ -450,3 +528,15 @@ func sliceContainsPair(values []string, key, value string) bool {
 	}
 	return false
 }
+
+// fakeExitError simulates the shape of a subprocess exit error: it carries a
+// numeric exit code that the production code can extract via an
+// `interface{ ExitCode() int }` assertion, mirroring how *exec.ExitError
+// (via *os.ProcessState) exposes its exit code in real runs.
+type fakeExitError struct {
+	code int
+	msg  string
+}
+
+func (e *fakeExitError) Error() string { return e.msg }
+func (e *fakeExitError) ExitCode() int { return e.code }


### PR DESCRIPTION
## Summary
Clicking the notify segment used to propagate focus's exit code (e.g. exit 2 on unresolved target) up to tmux, which then displayed a `'... statusbar click "notify"' returned 2` error popup. Bad UX. This fix:

- `handleNotify` now always returns nil from the focus-exec branch.
- On focus exit-2 (target unresolved): show `tmux display-message "notify target gone, ..."` and ack the entry (junk).
- On other focus failures (transient): show toast describing the failure, keep the entry so user can retry.
- On focus success: ack as before.

## Test plan
- [x] `go build ./...`, `gofmt -l .` clean
- [x] `go test ./...` (737 PASS, 0 fail; new + rewritten tests cover target-gone, transient failure, UsageError-treated-as-target-gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)