### PR TITLE
feat(status-notify): render leading severity+agent as solid color badge

### DIFF
--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -355,21 +355,24 @@ func (c *statusCommand) notifyStore() (notifyStore, error) {
 	return c.notifyStoreFn()
 }
 
-// HUD-style design tokens for the notify status segment. Reused dim color
-// (`colour245`) keeps the segment visually consistent with the AI usage
-// segment so the two read as one design family.
+// HUD-style design tokens for the notify status segment. The leading
+// severity+agent block is rendered as a solid color "badge" (bg fill) so
+// the segment reads as an actual notification pill instead of dim text.
+// Reused dim color (`colour245`) keeps the metadata visually consistent
+// with the AI usage segment so the two read as one design family.
 const (
-	notifyDimColor       = "colour245"
-	notifyCountColor     = "colour244"
-	notifyAgentColorOpen = "#[fg=cyan,bold]"
-	notifySeverityInfo   = "#[fg=brightcyan]"
-	notifySeverityWarn   = "#[fg=yellow]"
-	notifySeverityCrit   = "#[fg=red,bold]"
-	notifyIcon           = "●"
-	notifyBar            = "▎"
-	notifyMidDot         = "·"
-	notifyEllipsis       = "…"
-	notifyReset          = "#[default]"
+	notifyDimColor      = "colour245"
+	notifyCountColor    = "colour244"
+	notifyBadgeInfoOpen = "#[bg=brightcyan,fg=black,bold]"
+	notifyBadgeWarnOpen = "#[bg=yellow,fg=black,bold]"
+	notifyBadgeCritOpen = "#[bg=red,fg=white,bold]"
+	notifySeverityInfo  = "#[fg=brightcyan]"
+	notifySeverityWarn  = "#[fg=yellow]"
+	notifySeverityCrit  = "#[fg=red,bold]"
+	notifyIcon          = "●"
+	notifyMidDot        = "·"
+	notifyEllipsis      = "…"
+	notifyReset         = "#[default]"
 )
 
 // known agent prefixes recognised when stripping a leading `<agent>:` from
@@ -381,15 +384,21 @@ var notifyKnownAgents = []string{"claude", "codex"}
 // HUD-style tmux status segment. The output ends with a tmux `#[default]`
 // reset so adjacent segments are not stained by colors.
 //
-// Long form: `●  <agent>  ▎  <text>  ·  <target>  ·  <age>   +<N>`
+// Long form: `[ <agent|LABEL> ] <text>  · <target> · <age>   +<N>`
 //
-// The renderer degrades through five tiers as `maxWidth` shrinks:
+// The leading block is a solid color badge (bg=severity, fg=black/white,
+// bold) padded with a single space on each side. The body text uses the
+// terminal default foreground (no dim, no bold) so it pops against the
+// dim metadata that follows it.
 //
-//  1. Drop `<age>` (and its preceding `·`).
-//  2. Drop `<target>` (and its preceding `·`).
-//  3. Truncate `<text>` with a trailing `…`.
-//  4. Drop `▎ <agent>` (back to icon + text).
-//  5. Hard truncate everything (icon + count are still preserved).
+// The renderer degrades through six tiers as `maxWidth` shrinks:
+//
+//  1. Full long form: badge + text + target + age + count.
+//  2. Drop `<age>` (and its preceding `·`).
+//  3. Drop `<target>` (and its preceding `·`).
+//  4. Truncate `<text>` with a trailing `…`.
+//  5. Drop the badge entirely; fall back to a standalone `●` severity icon.
+//  6. Hard truncate everything (icon + count are still preserved).
 //
 // `now` is the wall-clock used to compute the relative age. Pass the zero
 // time to suppress the age field entirely.
@@ -400,8 +409,9 @@ func formatStatusNotify(entries []notify.Notification, maxWidth int, now time.Ti
 	head := entries[0]
 	extras := len(entries) - 1
 
+	badge := renderNotifyBadge(head)
 	icon := renderNotifyIcon(head.Severity)
-	agent, text := splitAgentPrefix(head)
+	_, text := splitAgentPrefix(head)
 	target := compactTarget(head)
 	age := ""
 	if !now.IsZero() && !head.CreatedAt.IsZero() {
@@ -414,22 +424,26 @@ func formatStatusNotify(entries []notify.Notification, maxWidth int, now time.Ti
 
 	tiers := []func() string{
 		// Tier 1: full long form.
-		func() string { return assembleNotify(icon, agent, text, target, age, plus) },
+		func() string { return assembleNotify(badge, text, target, age, plus) },
 		// Tier 2: drop age.
-		func() string { return assembleNotify(icon, agent, text, target, "", plus) },
+		func() string { return assembleNotify(badge, text, target, "", plus) },
 		// Tier 3: drop target (and age).
-		func() string { return assembleNotify(icon, agent, text, "", "", plus) },
+		func() string { return assembleNotify(badge, text, "", "", plus) },
 		// Tier 4: truncate text with trailing ellipsis.
 		func() string {
-			budget := tierBudget(maxWidth, icon, agent, "", "", "", plus)
+			budget := tierBudget(maxWidth, badge, "", "", plus)
 			truncated := shrinkText(text, budget)
-			return assembleNotify(icon, agent, truncated, "", "", plus)
+			return assembleNotify(badge, truncated, "", "", plus)
 		},
-		// Tier 5: drop agent + bar.
+		// Tier 5: drop badge — fall back to bare severity icon + text.
 		func() string {
-			budget := tierBudget(maxWidth, icon, "", "", "", "", plus)
+			iconLead := icon + "  "
+			budget := tierBudget(maxWidth, iconLead, "", "", plus)
 			truncated := shrinkText(text, budget)
-			return assembleNotify(icon, "", truncated, "", "", plus)
+			if truncated == "" {
+				return iconLead + plus
+			}
+			return iconLead + truncated + plus
 		},
 	}
 	for _, tier := range tiers {
@@ -445,30 +459,24 @@ func formatStatusNotify(entries []notify.Notification, maxWidth int, now time.Ti
 	// Hard truncate. Keep the icon + plus suffix; rune-truncate everything
 	// in between. The reset directive is appended unconditionally so we
 	// never leak color into the next segment.
-	short := assembleNotify(icon, "", text, "", "", plus)
+	short := icon + "  " + text + plus
 	return truncateWithEllipsis(short, maxWidth) + notifyReset
 }
 
-// assembleNotify glues the parts of the long form together. Empty parts are
+// assembleNotify glues the long-form parts together. Empty parts are
 // omitted along with their preceding separator so we can reuse this for
 // every degradation tier.
-func assembleNotify(icon, agent, text, target, age, plus string) string {
+//
+// Layout: `<badge> <text>  · <target> · <age><plus>`
+//
+// The badge already carries its own bg/fg styling and trailing `#[default]`,
+// so we just concatenate it. The body text inherits the terminal default
+// foreground (deliberately not dim) so it pops next to the dim metadata.
+func assembleNotify(badge, text, target, age, plus string) string {
 	var b strings.Builder
-	b.WriteString(icon)
-	if agent != "" {
-		b.WriteString("  ")
-		b.WriteString(notifyAgentColorOpen)
-		b.WriteString(agent)
-		b.WriteString(notifyReset)
-		b.WriteString("  ")
-		b.WriteString("#[fg=")
-		b.WriteString(notifyDimColor)
-		b.WriteString("]")
-		b.WriteString(notifyBar)
-		b.WriteString(notifyReset)
-	}
+	b.WriteString(badge)
 	if text != "" {
-		b.WriteString("  ")
+		b.WriteString(" ")
 		b.WriteString(text)
 	}
 	if target != "" {
@@ -477,25 +485,17 @@ func assembleNotify(icon, agent, text, target, age, plus string) string {
 		b.WriteString(notifyDimColor)
 		b.WriteString("]")
 		b.WriteString(notifyMidDot)
-		b.WriteString(notifyReset)
-		b.WriteString("  ")
-		b.WriteString("#[fg=")
-		b.WriteString(notifyDimColor)
-		b.WriteString("]")
+		b.WriteString(" ")
 		b.WriteString(target)
 		b.WriteString(notifyReset)
 	}
 	if age != "" {
-		b.WriteString("  ")
+		b.WriteString(" ")
 		b.WriteString("#[fg=")
 		b.WriteString(notifyDimColor)
 		b.WriteString("]")
 		b.WriteString(notifyMidDot)
-		b.WriteString(notifyReset)
-		b.WriteString("  ")
-		b.WriteString("#[fg=")
-		b.WriteString(notifyDimColor)
-		b.WriteString("]")
+		b.WriteString(" ")
 		b.WriteString(age)
 		b.WriteString(notifyReset)
 	}
@@ -508,19 +508,63 @@ func assembleNotify(icon, agent, text, target, age, plus string) string {
 // tierBudget returns how many runes of `text` fit within maxWidth given the
 // fixed-width pieces we are committing to render at this tier. Returns the
 // full budget when maxWidth is non-positive.
-func tierBudget(maxWidth int, icon, agent, _, target, age, plus string) int {
+//
+// The text is rendered with a single leading space, which we charge back
+// here so callers don't need to know the assembly's gap rules.
+func tierBudget(maxWidth int, badge, target, age, plus string) int {
 	if maxWidth <= 0 {
 		return 0
 	}
-	overhead := visualLen(assembleNotify(icon, agent, "", target, age, plus))
-	// `assembleNotify` already inserts the leading "  " before text, so we
-	// charge that back to the budget here.
-	textGap := 2
+	overhead := visualLen(assembleNotify(badge, "", target, age, plus))
+	textGap := 1
 	room := maxWidth - overhead - textGap
 	if room < 1 {
 		room = 1
 	}
 	return room
+}
+
+// renderNotifyBadge builds the leading severity+agent pill. For ai-source
+// entries with a recognised `<agent>:` prefix, the badge text is the agent
+// name (e.g. ` claude `). Otherwise we fall back to a severity label
+// (` INFO ` / ` WARN ` / ` CRIT `). The badge always carries a trailing
+// `#[default]` so subsequent body text reverts to the terminal default fg
+// (no dim, no bold).
+func renderNotifyBadge(n notify.Notification) string {
+	open := notifyBadgeOpen(n.Severity)
+	label := notifyBadgeLabel(n)
+	return open + " " + label + " " + notifyReset
+}
+
+// notifyBadgeOpen maps a severity to the bg/fg/bold opening directive for
+// the badge. Unknown severities fall through to the info palette so we
+// never emit a stripped escape.
+func notifyBadgeOpen(severity string) string {
+	switch severity {
+	case notify.SeverityWarn:
+		return notifyBadgeWarnOpen
+	case notify.SeverityCritical:
+		return notifyBadgeCritOpen
+	default:
+		return notifyBadgeInfoOpen
+	}
+}
+
+// notifyBadgeLabel returns the inner text of the badge: the agent name
+// when present, otherwise the severity label (`INFO`/`WARN`/`CRIT`).
+func notifyBadgeLabel(n notify.Notification) string {
+	agent, _ := splitAgentPrefix(n)
+	if agent != "" {
+		return agent
+	}
+	switch n.Severity {
+	case notify.SeverityWarn:
+		return "WARN"
+	case notify.SeverityCritical:
+		return "CRIT"
+	default:
+		return "INFO"
+	}
 }
 
 // shrinkText shrinks s so its rune length is at most maxRunes, replacing

--- a/internal/app/status_notify_test.go
+++ b/internal/app/status_notify_test.go
@@ -28,8 +28,9 @@ func TestStatusNotifyEmptyQueueIsEmptyOutput(t *testing.T) {
 	}
 }
 
-// External-source entry has no agent prefix and no leading agent block.
-func TestStatusNotifyExternalEntryOmitsAgentBlock(t *testing.T) {
+// External-source info entry renders an ` INFO ` severity badge (no agent
+// prefix is available) and bright body text followed by dim metadata.
+func TestStatusNotifyExternalEntryRendersInfoBadge(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
@@ -52,11 +53,8 @@ func TestStatusNotifyExternalEntryOmitsAgentBlock(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[fg=brightcyan]●#[default]") {
-		t.Fatalf("stdout = %q, want brightcyan info icon prefix", got)
-	}
-	if strings.Contains(got, "▎") {
-		t.Fatalf("external entry must not include agent bar separator: %q", got)
+	if !strings.HasPrefix(got, "#[bg=brightcyan,fg=black,bold] INFO #[default]") {
+		t.Fatalf("stdout = %q, want INFO badge prefix", got)
 	}
 	if !strings.Contains(got, "hello world") {
 		t.Fatalf("stdout = %q, want body 'hello world'", got)
@@ -67,14 +65,25 @@ func TestStatusNotifyExternalEntryOmitsAgentBlock(t *testing.T) {
 	if !strings.Contains(got, "2m") {
 		t.Fatalf("stdout = %q, want age '2m'", got)
 	}
+	// Body text appears after the badge reset and BEFORE any dim escape —
+	// so the literal " hello world  " region must contain no `#[fg=colour`.
+	bodyStart := strings.Index(got, "#[default]") + len("#[default]")
+	dimStart := strings.Index(got, "#[fg=colour245]")
+	if bodyStart <= 0 || dimStart <= bodyStart {
+		t.Fatalf("stdout = %q, expected default-styled body before dim metadata", got)
+	}
+	body := got[bodyStart:dimStart]
+	if strings.Contains(body, "#[") {
+		t.Fatalf("body region %q must be unstyled (default fg)", body)
+	}
 	if !strings.HasSuffix(got, "#[default]") {
 		t.Fatalf("stdout = %q, want trailing '#[default]'", got)
 	}
 }
 
 // AI-source entry whose text begins with `claude:` strips the prefix and
-// renders it as a bolded agent block followed by the thin bar separator.
-func TestStatusNotifyAIEntryStripsAgentPrefix(t *testing.T) {
+// renders the agent name inside a brightcyan badge.
+func TestStatusNotifyAIEntryRendersAgentBadge(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
@@ -97,11 +106,8 @@ func TestStatusNotifyAIEntryStripsAgentPrefix(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.Contains(got, "#[fg=cyan,bold]claude#[default]") {
-		t.Fatalf("stdout = %q, want bolded cyan agent block", got)
-	}
-	if !strings.Contains(got, "▎") {
-		t.Fatalf("stdout = %q, want bar separator", got)
+	if !strings.HasPrefix(got, "#[bg=brightcyan,fg=black,bold] claude #[default]") {
+		t.Fatalf("stdout = %q, want claude badge prefix", got)
 	}
 	if strings.Contains(got, "claude:") {
 		t.Fatalf("stdout = %q, agent prefix should have been stripped from text", got)
@@ -112,9 +118,12 @@ func TestStatusNotifyAIEntryStripsAgentPrefix(t *testing.T) {
 	if !strings.Contains(got, "s:1.0") {
 		t.Fatalf("stdout = %q, want compact target", got)
 	}
+	if !strings.Contains(got, "#[fg=colour245]") {
+		t.Fatalf("stdout = %q, want dim metadata", got)
+	}
 }
 
-func TestStatusNotifyWarnEntryEmitsYellowIcon(t *testing.T) {
+func TestStatusNotifyWarnEntryRendersYellowBadge(t *testing.T) {
 	t.Parallel()
 
 	store := &stubNotifyStore{listEntries: []notify.Notification{
@@ -126,12 +135,12 @@ func TestStatusNotifyWarnEntryEmitsYellowIcon(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[fg=yellow]●#[default]") {
-		t.Fatalf("stdout = %q, want yellow icon prefix", got)
+	if !strings.HasPrefix(got, "#[bg=yellow,fg=black,bold] WARN #[default]") {
+		t.Fatalf("stdout = %q, want yellow WARN badge prefix", got)
 	}
 }
 
-func TestStatusNotifyCriticalEntryEmitsRedBoldIcon(t *testing.T) {
+func TestStatusNotifyCriticalEntryRendersRedBadge(t *testing.T) {
 	t.Parallel()
 
 	store := &stubNotifyStore{listEntries: []notify.Notification{
@@ -143,8 +152,27 @@ func TestStatusNotifyCriticalEntryEmitsRedBoldIcon(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[fg=red,bold]●#[default]") {
-		t.Fatalf("stdout = %q, want red,bold icon prefix", got)
+	if !strings.HasPrefix(got, "#[bg=red,fg=white,bold] CRIT #[default]") {
+		t.Fatalf("stdout = %q, want red CRIT badge prefix", got)
+	}
+}
+
+// Defensive: an entry with an unknown severity falls back to the INFO
+// badge palette so we never emit a stripped escape directive.
+func TestStatusNotifyUnknownSeverityFallsBackToInfoBadge(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{ID: "a", Text: "huh", Severity: "mystery", Source: notify.SourceExternal, Session: "s"},
+	}}
+	cmd := newStatusNotifyCommand(store)
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"notify"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got := stdout.String()
+	if !strings.HasPrefix(got, "#[bg=brightcyan,fg=black,bold] INFO #[default]") {
+		t.Fatalf("stdout = %q, want INFO fallback badge", got)
 	}
 }
 
@@ -242,7 +270,13 @@ func TestStatusNotifyWidthTier1Long(t *testing.T) {
 	if visualLen(out) > 80 {
 		t.Fatalf("tier1 visualLen=%d > 80: %q", visualLen(out), out)
 	}
-	for _, want := range []string{"●", "claude", "▎", "reply ready · review", "s:1.0", "2m", "+1"} {
+	for _, want := range []string{
+		"#[bg=brightcyan,fg=black,bold] claude #[default]",
+		"reply ready · review",
+		"s:1.0",
+		"2m",
+		"+1",
+	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("tier1 missing %q in %q", want, out)
 		}
@@ -252,15 +286,20 @@ func TestStatusNotifyWidthTier1Long(t *testing.T) {
 func TestStatusNotifyWidthTier2DropsAge(t *testing.T) {
 	t.Parallel()
 
-	// With the canonical fixture the long form is ~56 cells, so we pick a
+	// With the canonical fixture the long form is 48 cells, so we pick a
 	// budget tight enough to force the tier-2 fallback (no age) but loose
 	// enough to keep the target.
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
-	out := formatStatusNotify(fixtureAIEntry(now), 50, now)
-	if visualLen(out) > 50 {
-		t.Fatalf("tier2 visualLen=%d > 50: %q", visualLen(out), out)
+	out := formatStatusNotify(fixtureAIEntry(now), 45, now)
+	if visualLen(out) > 45 {
+		t.Fatalf("tier2 visualLen=%d > 45: %q", visualLen(out), out)
 	}
-	for _, want := range []string{"●", "claude", "▎", "reply ready · review", "s:1.0", "+1"} {
+	for _, want := range []string{
+		"#[bg=brightcyan,fg=black,bold] claude #[default]",
+		"reply ready · review",
+		"s:1.0",
+		"+1",
+	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("tier2 missing %q in %q", want, out)
 		}
@@ -278,12 +317,16 @@ func TestStatusNotifyWidthTier3DropsTarget(t *testing.T) {
 	if visualLen(out) > 40 {
 		t.Fatalf("tier3 visualLen=%d > 40: %q", visualLen(out), out)
 	}
-	for _, want := range []string{"●", "claude", "▎", "reply ready · review", "+1"} {
+	for _, want := range []string{
+		"#[bg=brightcyan,fg=black,bold] claude #[default]",
+		"reply ready · review",
+		"+1",
+	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("tier3 missing %q in %q", want, out)
 		}
 	}
-	if strings.Contains(out, "s") {
+	if strings.Contains(out, "s:1.0") {
 		t.Fatalf("tier3 must drop target: %q", out)
 	}
 	if strings.Contains(out, "2m") {
@@ -299,8 +342,8 @@ func TestStatusNotifyWidthTier4TruncatesText(t *testing.T) {
 	if visualLen(out) > 24 {
 		t.Fatalf("tier4 visualLen=%d > 24: %q", visualLen(out), out)
 	}
-	if !strings.Contains(out, "claude") {
-		t.Fatalf("tier4 should still show agent: %q", out)
+	if !strings.Contains(out, "#[bg=brightcyan,fg=black,bold] claude #[default]") {
+		t.Fatalf("tier4 should still show badge: %q", out)
 	}
 	if !strings.Contains(out, "+1") {
 		t.Fatalf("tier4 should still show count: %q", out)
@@ -310,22 +353,25 @@ func TestStatusNotifyWidthTier4TruncatesText(t *testing.T) {
 	}
 }
 
-func TestStatusNotifyWidthTier5DropsAgent(t *testing.T) {
+// Tier 5 drops the bg-filled badge. The standalone severity-tinted `●`
+// icon (no bg fill) preserves a minimal severity hint for very narrow
+// statuslines.
+func TestStatusNotifyWidthTier5DropsBadge(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
-	out := formatStatusNotify(fixtureAIEntry(now), 15, now)
-	if visualLen(out) > 15 {
-		t.Fatalf("tier5 visualLen=%d > 15: %q", visualLen(out), out)
+	out := formatStatusNotify(fixtureAIEntry(now), 14, now)
+	if visualLen(out) > 14 {
+		t.Fatalf("tier5 visualLen=%d > 14: %q", visualLen(out), out)
+	}
+	if strings.Contains(out, "bg=brightcyan") {
+		t.Fatalf("tier5 must drop the bg-filled badge: %q", out)
 	}
 	if strings.Contains(out, "claude") {
-		t.Fatalf("tier5 must drop agent block: %q", out)
+		t.Fatalf("tier5 must drop the agent label: %q", out)
 	}
-	if strings.Contains(out, "▎") {
-		t.Fatalf("tier5 must drop bar separator: %q", out)
-	}
-	if !strings.Contains(out, "●") {
-		t.Fatalf("tier5 should still show icon: %q", out)
+	if !strings.Contains(out, "#[fg=brightcyan]●#[default]") {
+		t.Fatalf("tier5 should still show the icon-only severity hint: %q", out)
 	}
 	if !strings.Contains(out, "+1") {
 		t.Fatalf("tier5 should still show count: %q", out)
@@ -352,7 +398,7 @@ func TestStatusNotifyAgentPrefixGracefulFallback(t *testing.T) {
 	cases := []struct {
 		name      string
 		text      string
-		wantAgent string
+		wantAgent string // "" means INFO label badge
 	}{
 		{name: "no colon", text: "reply ready", wantAgent: ""},
 		{name: "unknown agent", text: "gpt: reply ready", wantAgent: ""},
@@ -369,14 +415,12 @@ func TestStatusNotifyAgentPrefixGracefulFallback(t *testing.T) {
 				ID: "a", Text: tc.text, Severity: notify.SeverityInfo,
 				Source: notify.SourceAI, Session: "s", CreatedAt: now,
 			}}, 0, now)
-			if tc.wantAgent == "" {
-				if strings.Contains(out, "#[fg=cyan,bold]") {
-					t.Fatalf("expected no agent block in %q", out)
-				}
-				return
+			wantBadge := "#[bg=brightcyan,fg=black,bold] INFO #[default]"
+			if tc.wantAgent != "" {
+				wantBadge = "#[bg=brightcyan,fg=black,bold] " + tc.wantAgent + " #[default]"
 			}
-			if !strings.Contains(out, "#[fg=cyan,bold]"+tc.wantAgent+"#[default]") {
-				t.Fatalf("expected agent block %q in %q", tc.wantAgent, out)
+			if !strings.HasPrefix(out, wantBadge) {
+				t.Fatalf("expected badge %q at start of %q", wantBadge, out)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
The previous notify segment rendered everything in dim grey except the small `●` icon, which made it hard to tell at a glance whether a notification was actually being shown. Replace the leading severity+agent with a **solid colored badge (pill)** and brighten the body text.

## New look
```
[ claude ] reply ready · review  · s:1.0 · just now           # info ai (brightcyan bg)
[ WARN ]   kube context drift    · ops:1.0 · just now         # warn external (yellow bg)
[ CRIT ]   prod oncall page      · prod:1.0 · just now        # critical external (red bg)
```

- AI source with extracted agent prefix → badge says ` claude ` / ` codex `
- Non-AI sources → badge uses severity label ` INFO ` / ` WARN ` / ` CRIT `
- Body text now default fg (bright), not dim
- Metadata (`· target`, `· age`) and `+N` stay dim grey

## Width-tier degradation
1. Long form with badge
2. Drop age
3. Drop target
4. Truncate body with `…`
5. **Drop the bg-filled badge** → fall back to standalone tinted `●` icon + text + count (very narrow widths)
6. Hard truncate

## Test plan
- [x] `go build ./...`, `gofmt -l .` clean
- [x] `go test ./...` (17 status-notify tests, all pass; new `TestStatusNotifyUnknownSeverityFallsBackToInfoBadge`)
- [x] Manual: three severities render expected bg/fg colors; tier 5 fallback verified at max-width 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)