### PR TITLE
fix(statusbar): pass mouse-window so window-list click still switches tabs

### DIFF
--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -2,8 +2,13 @@
 // projmux tmux status bar to per-segment handlers. The status bar wraps each
 // segment in a tmux user-defined range (e.g. `#[range=user|notify]...`); the
 // mouse binding `bind -n MouseDown1Status run-shell '<bin> statusbar click
-// "#{mouse_status_range}"'` invokes us with the matching range id, and the
+// "#{mouse_status_range}" --mouse-window "#{mouse_window}"'` invokes us with
+// the matching range id and the window id under the cursor, and the
 // `prefix s {u,n,g,k,p,s}` shortcuts call us with hard-coded ids.
+//
+// When the click lands outside any user-defined range (e.g. on a window-list
+// entry) we fall back to `select-window -t @<mouse_window>` so we restore
+// tmux's default click-to-switch-window UX after taking over the bind.
 package app
 
 import (
@@ -87,16 +92,18 @@ func (c *statusbarCommand) Run(args []string, stdout, stderr io.Writer) error {
 // statusbarClickOptions captures the parsed argv. mouseX/mouseY are reserved
 // for future telemetry — see runClick.
 type statusbarClickOptions struct {
-	RangeID statusbarRangeID
-	Socket  string
-	MouseX  int
-	MouseY  int
+	RangeID     statusbarRangeID
+	Socket      string
+	MouseWindow string
+	MouseX      int
+	MouseY      int
 }
 
 func (c *statusbarCommand) runClick(args []string, stdout, stderr io.Writer) error {
 	fs := flag.NewFlagSet("statusbar click", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	socket := fs.String("socket", "", "tmux socket path (overrides $TMUX)")
+	mouseWindow := fs.String("mouse-window", "", "tmux #{mouse_window} for window-list click passthrough")
 	mouseX := fs.Int("mouse-x", -1, "tmux #{mouse_x} (reserved for telemetry)")
 	mouseY := fs.Int("mouse-y", -1, "tmux #{mouse_y} (reserved for telemetry)")
 	if err := fs.Parse(args); err != nil {
@@ -108,30 +115,58 @@ func (c *statusbarCommand) runClick(args []string, stdout, stderr io.Writer) err
 	}
 
 	raw := strings.TrimSpace(fs.Arg(0))
-	if raw == "" {
-		// tmux emits an empty `#{mouse_status_range}` when the user clicks on
-		// status bar whitespace outside any user-defined range. Treat that as
-		// a no-op rather than an error so the bind does not flash a message.
-		return nil
-	}
-
 	opts := statusbarClickOptions{
-		RangeID: statusbarRangeID(raw),
-		Socket:  strings.TrimSpace(*socket),
-		MouseX:  *mouseX,
-		MouseY:  *mouseY,
+		RangeID:     statusbarRangeID(raw),
+		Socket:      strings.TrimSpace(*socket),
+		MouseWindow: strings.TrimSpace(*mouseWindow),
+		MouseX:      *mouseX,
+		MouseY:      *mouseY,
 	}
 	// MouseX/MouseY are intentionally unused today. The fields are wired
 	// through so we can plumb click telemetry without changing the bind.
 	_ = opts.MouseX
 	_ = opts.MouseY
 
+	if raw == "" {
+		// tmux emits an empty `#{mouse_status_range}` when the click lands
+		// outside any user-defined range — typically on a window-list entry
+		// or status-bar whitespace. If `--mouse-window` is non-empty we
+		// fall back to tmux's default `select-window` behavior so users can
+		// still click a tab to switch to it; otherwise the click is a noop.
+		if opts.MouseWindow != "" {
+			return c.handleWindowListClick(opts, stderr)
+		}
+		return nil
+	}
+
 	handler, ok := c.dispatchTable()[opts.RangeID]
 	if !ok {
-		printStatusbarUsage(stderr)
-		return usageError(fmt.Sprintf("unknown statusbar range id: %s", raw))
+		// Unknown range id (something other than a known projmux range and
+		// not an empty range): tmux's default behavior would not have
+		// invoked us at all, so we treat it as a noop. If a window id is
+		// available we still perform the window-list passthrough so users
+		// can click on, e.g., a custom right-side range without losing the
+		// window-switch affordance.
+		if opts.MouseWindow != "" {
+			return c.handleWindowListClick(opts, stderr)
+		}
+		return nil
 	}
 	return handler(opts, stdout, stderr)
+}
+
+// handleWindowListClick restores tmux's default window-list click behavior
+// (`select-window -t =`) when the click lands on a window entry rather than a
+// projmux user-defined range. The id arrives as a numeric string from
+// `#{mouse_window}` (e.g. "3"); tmux requires the `@` prefix to interpret it
+// as a window id rather than a name. We strip any leading `@` first so we
+// never end up with `@@3`.
+func (c *statusbarCommand) handleWindowListClick(opts statusbarClickOptions, stderr io.Writer) error {
+	id := strings.TrimPrefix(strings.TrimSpace(opts.MouseWindow), "@")
+	if id == "" {
+		return nil
+	}
+	return c.runTmux(stderr, "select-window", "-t", "@"+id)
 }
 
 // dispatchTable maps each known range id to its click handler. A method on the
@@ -352,7 +387,7 @@ func (c *statusbarCommand) runTmuxNoFallback(_ io.Writer, args ...string) error 
 
 func printStatusbarUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  projmux statusbar click <range-id> [--socket <s>] [--mouse-x N] [--mouse-y N]")
+	fmt.Fprintln(w, "  projmux statusbar click <range-id> [--socket <s>] [--mouse-window <id>] [--mouse-x N] [--mouse-y N]")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Range ids: session pwd kube git usage notify")
 }

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -69,24 +69,21 @@ func TestStatusbarDispatchTableCoversAllKnownRanges(t *testing.T) {
 	}
 }
 
-func TestStatusbarClickRejectsUnknownRange(t *testing.T) {
+func TestStatusbarClickUnknownRangeWithoutMouseWindowIsNoop(t *testing.T) {
 	t.Parallel()
 
+	// Once we share `MouseDown1Status` with the window-list passthrough, an
+	// unknown range id is no longer a user error — it just means the click
+	// landed somewhere we don't manage. Returning nil keeps run-shell from
+	// flashing a tmux error popup at the user.
 	runner := &statusbarFakeRunner{}
 	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
 
-	err := cmd.Run([]string{"click", "totally-bogus"}, &bytes.Buffer{}, &bytes.Buffer{})
-	if err == nil {
-		t.Fatal("expected error for unknown range id")
-	}
-	if !IsUsageError(err) {
-		t.Fatalf("expected UsageError, got %T: %v", err, err)
-	}
-	if !strings.Contains(err.Error(), "unknown statusbar range id") {
-		t.Fatalf("err = %v, want substring 'unknown statusbar range id'", err)
+	if err := cmd.Run([]string{"click", "totally-bogus"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
 	}
 	if len(runner.calls) != 0 {
-		t.Fatalf("unknown range should not invoke runner, got %d calls", len(runner.calls))
+		t.Fatalf("unknown range without mouse-window should not invoke runner, got %d calls", len(runner.calls))
 	}
 }
 
@@ -101,6 +98,103 @@ func TestStatusbarClickEmptyRangeIsNoop(t *testing.T) {
 	}
 	if len(runner.calls) != 0 {
 		t.Fatalf("empty range should not invoke runner, got %d calls", len(runner.calls))
+	}
+}
+
+func TestStatusbarClickKnownRangeIgnoresMouseWindow(t *testing.T) {
+	t.Parallel()
+
+	// When the click lands on a projmux user-defined range, the range
+	// handler always wins. The `--mouse-window` passthrough only applies
+	// when the click landed outside any range.
+	runner := &statusbarFakeRunner{}
+	store := &stubNotifyStore{listEntries: nil}
+	cmd := newStatusbarTestCommand(runner, store)
+
+	if err := cmd.Run([]string{"click", "--mouse-window", "3", "notify"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	for _, call := range runner.calls {
+		if call.name != "tmux" || len(call.args) < 1 {
+			continue
+		}
+		if call.args[0] == "select-window" {
+			t.Fatalf("known range must not trigger select-window passthrough; calls = %#v", runner.calls)
+		}
+	}
+	if !sawTmuxDisplayMessage(runner.calls, "no notifications") {
+		t.Fatalf("notify handler did not run; calls = %#v", runner.calls)
+	}
+}
+
+func TestStatusbarClickEmptyRangeWithMouseWindowSelectsWindow(t *testing.T) {
+	t.Parallel()
+
+	// Default tmux behavior: clicking on a window-list entry switches to
+	// that window. Restored here via select-window with the `@` prefix.
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "--mouse-window", "3", ""}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !sawTmuxArgs(runner.calls, []string{"select-window", "-t", "@3"}) {
+		t.Fatalf("missing select-window -t @3; calls = %#v", runner.calls)
+	}
+}
+
+func TestStatusbarClickEmptyRangeWithPrefixedMouseWindowDoesNotDoublePrefix(t *testing.T) {
+	t.Parallel()
+
+	// `#{mouse_window}` is normally numeric (e.g. "3") but if a future
+	// tmux ever returns "@5" we must not produce "@@5".
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "--mouse-window", "@5", ""}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !sawTmuxArgs(runner.calls, []string{"select-window", "-t", "@5"}) {
+		t.Fatalf("missing select-window -t @5; calls = %#v", runner.calls)
+	}
+	for _, call := range runner.calls {
+		if call.name == "tmux" && len(call.args) >= 3 && call.args[0] == "select-window" && call.args[2] == "@@5" {
+			t.Fatalf("select-window target was double-prefixed; calls = %#v", runner.calls)
+		}
+	}
+}
+
+func TestStatusbarClickEmptyRangeWithEmptyMouseWindowIsNoop(t *testing.T) {
+	t.Parallel()
+
+	// Click on row-1 whitespace between two ranges: tmux gives us an empty
+	// `mouse_status_range` *and* an empty `mouse_window`. We must not call
+	// select-window with a bare `@`.
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "--mouse-window", "", ""}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("empty range + empty mouse-window must be a noop, got %d calls", len(runner.calls))
+	}
+}
+
+func TestStatusbarClickUnknownRangeWithMouseWindowSelectsWindow(t *testing.T) {
+	t.Parallel()
+
+	// Some custom right-hand `range=user|foo` from a third-party plugin
+	// could deliver an unfamiliar range id. We still want the click to
+	// switch to the window underneath the cursor when one is available.
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "--mouse-window", "7", "totally-bogus"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+	if !sawTmuxArgs(runner.calls, []string{"select-window", "-t", "@7"}) {
+		t.Fatalf("missing select-window -t @7; calls = %#v", runner.calls)
 	}
 }
 
@@ -481,6 +575,18 @@ func sawTmuxSubcommand(calls []statusbarFakeCall, sub string) bool {
 			if a == sub {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func sawTmuxArgs(calls []statusbarFakeCall, want []string) bool {
+	for _, c := range calls {
+		if c.name != "tmux" {
+			continue
+		}
+		if equalStringSlices(c.args, want) {
+			return true
 		}
 	}
 	return false

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -934,6 +934,12 @@ func tmuxAppKeyBindings() []string {
 // and `#{mouse_status_range}` returns whichever user-defined range we wrapped
 // under the cursor — so a single bind covers both lines.
 //
+// We also pass `--mouse-window "#{mouse_window}"` so the dispatcher can fall
+// back to tmux's default window-list behavior (`select-window -t @<id>`) when
+// the click lands on a window entry rather than one of our user-defined
+// ranges. Without this, overriding `MouseDown1Status` would silently disable
+// click-to-switch-window in the window list.
+//
 // The `prefix s` chord uses tmux's `switch-client -T <table>` mechanism so
 // keyboard users get the same handlers as mouse clickers without re-defining
 // each handler twice.
@@ -941,7 +947,7 @@ func tmuxStatusbarKeyBindings(binaryPath string) []string {
 	bin := tmuxShellQuote(binaryPath)
 	return []string{
 		"unbind-key -q -n MouseDown1Status",
-		"bind-key -n MouseDown1Status run-shell " + tmuxConfigQuote(bin+" statusbar click \"#{mouse_status_range}\""),
+		"bind-key -n MouseDown1Status run-shell " + tmuxConfigQuote(bin+" statusbar click \"#{mouse_status_range}\" --mouse-window \"#{mouse_window}\""),
 		"bind-key s switch-client -T projmux-status",
 		"bind-key -T projmux-status u run-shell " + tmuxConfigQuote(bin+" statusbar click usage"),
 		"bind-key -T projmux-status n run-shell " + tmuxConfigQuote(bin+" statusbar click notify"),


### PR DESCRIPTION
## Summary
The recent statusbar-clickable slice replaced tmux's default `bind -n MouseDown1Status select-window -t =`, breaking the standard window-list click → switch-window UX. User reported "탭클릭 피쳐는 사라졋네". This restores it.

## Behavior
- bind passes `--mouse-window "#{mouse_window}"` to projmux
- `projmux statusbar click <range-id> --mouse-window <id>`:
  - Known user range → existing handler
  - Empty range + mouse-window → exec `tmux select-window -t @<id>` (window switch restored)
  - Empty range + empty mouse-window → noop
  - Unknown range relaxed from UsageError to noop (third-party ranges should not cause hostile popups)

## Test plan
- [x] `go build ./...`, `gofmt -l .` clean
- [x] `go test ./...` (22 statusbar tests pass; new tests cover all four mouse-window scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)