### PR TITLE
fix(statusbar): parse click flags in any order around positional

### DIFF
--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -14,11 +14,11 @@ package app
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/crevissepartners/projmux/internal/config"
@@ -99,28 +99,124 @@ type statusbarClickOptions struct {
 	MouseY      int
 }
 
-func (c *statusbarCommand) runClick(args []string, stdout, stderr io.Writer) error {
-	fs := flag.NewFlagSet("statusbar click", flag.ContinueOnError)
-	fs.SetOutput(stderr)
-	socket := fs.String("socket", "", "tmux socket path (overrides $TMUX)")
-	mouseWindow := fs.String("mouse-window", "", "tmux #{mouse_window} for window-list click passthrough")
-	mouseX := fs.Int("mouse-x", -1, "tmux #{mouse_x} (reserved for telemetry)")
-	mouseY := fs.Int("mouse-y", -1, "tmux #{mouse_y} (reserved for telemetry)")
-	if err := fs.Parse(args); err != nil {
-		return usageError(fmt.Sprintf("parse statusbar click flags: %v", err))
-	}
-	if fs.NArg() != 1 {
-		printStatusbarUsage(stderr)
-		return usageError("statusbar click requires exactly 1 <range-id> argument")
+// parseStatusbarClickArgs parses the argv handed to `projmux statusbar click`
+// in an order-flexible way. The standard `flag` package stops at the first
+// non-flag token, which means that when tmux emits args in the natural
+// "<range-id> --mouse-window <id>" order the trailing flag pair is misread as
+// extra positionals and the whole click is rejected with exit 2 — re-introducing
+// the very tmux error popup we are trying to avoid. We therefore walk argv
+// ourselves: any token starting with `-` (or `--`) is treated as a flag plus
+// optional value, anything else is a positional. Up to one positional is
+// allowed; everything beyond that is a UsageError.
+//
+// Recognized flags: --socket, --mouse-window, --mouse-x, --mouse-y. Both
+// space-separated (`--flag value`) and equals (`--flag=value`) forms are
+// accepted. Unknown flags are reported as UsageError so typos don't silently
+// swallow values.
+func parseStatusbarClickArgs(args []string) (string, statusbarClickOptions, error) {
+	var (
+		opts        statusbarClickOptions
+		positionals []string
+		mouseX      = -1
+		mouseY      = -1
+	)
+	opts.MouseX = mouseX
+	opts.MouseY = mouseY
+
+	consumeValue := func(name string, i int) (string, int, error) {
+		if i+1 >= len(args) {
+			return "", i, usageError(fmt.Sprintf("flag --%s requires a value", name))
+		}
+		return args[i+1], i + 1, nil
 	}
 
-	raw := strings.TrimSpace(fs.Arg(0))
-	opts := statusbarClickOptions{
-		RangeID:     statusbarRangeID(raw),
-		Socket:      strings.TrimSpace(*socket),
-		MouseWindow: strings.TrimSpace(*mouseWindow),
-		MouseX:      *mouseX,
-		MouseY:      *mouseY,
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if !strings.HasPrefix(a, "-") || a == "-" {
+			positionals = append(positionals, a)
+			continue
+		}
+		// Strip leading dashes and split on `=` for the equals form.
+		name := strings.TrimLeft(a, "-")
+		value := ""
+		hasValue := false
+		if eq := strings.IndexByte(name, '='); eq >= 0 {
+			value = name[eq+1:]
+			name = name[:eq]
+			hasValue = true
+		}
+		switch name {
+		case "socket":
+			if !hasValue {
+				v, ni, err := consumeValue(name, i)
+				if err != nil {
+					return "", opts, err
+				}
+				value = v
+				i = ni
+			}
+			opts.Socket = strings.TrimSpace(value)
+		case "mouse-window":
+			if !hasValue {
+				v, ni, err := consumeValue(name, i)
+				if err != nil {
+					return "", opts, err
+				}
+				value = v
+				i = ni
+			}
+			opts.MouseWindow = strings.TrimSpace(value)
+		case "mouse-x":
+			if !hasValue {
+				v, ni, err := consumeValue(name, i)
+				if err != nil {
+					return "", opts, err
+				}
+				value = v
+				i = ni
+			}
+			n, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil {
+				return "", opts, usageError(fmt.Sprintf("flag --mouse-x: %v", err))
+			}
+			opts.MouseX = n
+		case "mouse-y":
+			if !hasValue {
+				v, ni, err := consumeValue(name, i)
+				if err != nil {
+					return "", opts, err
+				}
+				value = v
+				i = ni
+			}
+			n, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil {
+				return "", opts, usageError(fmt.Sprintf("flag --mouse-y: %v", err))
+			}
+			opts.MouseY = n
+		case "help", "h":
+			return "", opts, usageError("statusbar click: help requested")
+		default:
+			return "", opts, usageError(fmt.Sprintf("unknown flag --%s", name))
+		}
+	}
+
+	if len(positionals) > 1 {
+		return "", opts, usageError("statusbar click accepts at most 1 <range-id> argument")
+	}
+	raw := ""
+	if len(positionals) == 1 {
+		raw = strings.TrimSpace(positionals[0])
+	}
+	opts.RangeID = statusbarRangeID(raw)
+	return raw, opts, nil
+}
+
+func (c *statusbarCommand) runClick(args []string, stdout, stderr io.Writer) error {
+	raw, opts, err := parseStatusbarClickArgs(args)
+	if err != nil {
+		printStatusbarUsage(stderr)
+		return err
 	}
 	// MouseX/MouseY are intentionally unused today. The fields are wired
 	// through so we can plumb click telemetry without changing the bind.

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -538,6 +538,131 @@ func TestStatusbarClickNotifyStoreErrorFallsBackToMessage(t *testing.T) {
 	}
 }
 
+// TestStatusbarClickWindowRangeWithEmptyMouseWindowIsNoop is the direct
+// regression for the parser bug where stdlib `flag.Parse` stopped at the first
+// non-flag token. With args `["window", "--mouse-window", ""]` the package
+// previously produced 3 positionals and rejected the click as a UsageError,
+// which made tmux flash the run-shell error popup on every window-list click.
+func TestStatusbarClickWindowRangeWithEmptyMouseWindowIsNoop(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "window", "--mouse-window", ""}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("unknown range + empty mouse-window must be a noop, got %d calls", len(runner.calls))
+	}
+}
+
+// TestStatusbarClickPositionalThenFlagSelectsWindow verifies that the natural
+// tmux invocation order — the positional range id first, then the
+// `--mouse-window` flag — actually triggers the window-list passthrough rather
+// than failing parser checks.
+func TestStatusbarClickPositionalThenFlagSelectsWindow(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "window", "--mouse-window", "3"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !sawTmuxArgs(runner.calls, []string{"select-window", "-t", "@3"}) {
+		t.Fatalf("missing select-window -t @3; calls = %#v", runner.calls)
+	}
+}
+
+// TestStatusbarClickFlagThenPositionalSelectsWindow verifies the symmetric
+// "flags first, positional last" order also works.
+func TestStatusbarClickFlagThenPositionalSelectsWindow(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "--mouse-window", "3", "window"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !sawTmuxArgs(runner.calls, []string{"select-window", "-t", "@3"}) {
+		t.Fatalf("missing select-window -t @3; calls = %#v", runner.calls)
+	}
+}
+
+// TestStatusbarClickEqualsFormSelectsWindow verifies the `--flag=value` form
+// is accepted in addition to the `--flag value` form.
+func TestStatusbarClickEqualsFormSelectsWindow(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "--mouse-window=3", "window"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !sawTmuxArgs(runner.calls, []string{"select-window", "-t", "@3"}) {
+		t.Fatalf("missing select-window -t @3; calls = %#v", runner.calls)
+	}
+}
+
+// TestStatusbarClickEmptyPositionalAndEmptyMouseWindowIsNoop covers the
+// `click "" --mouse-window ""` shape (positional first then flag) which the
+// previous parser also mishandled when the flag value was empty.
+func TestStatusbarClickEmptyPositionalAndEmptyMouseWindowIsNoop(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "", "--mouse-window", ""}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("empty positional + empty mouse-window must be a noop, got %d calls", len(runner.calls))
+	}
+}
+
+// TestStatusbarClickNotifyWithMouseWindowIgnoresFlag checks that when a known
+// projmux range is clicked, the `--mouse-window` flag is ignored regardless of
+// argument order — the range handler always wins.
+func TestStatusbarClickNotifyWithMouseWindowIgnoresFlag(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	store := &stubNotifyStore{listEntries: nil}
+	cmd := newStatusbarTestCommand(runner, store)
+
+	if err := cmd.Run([]string{"click", "notify", "--mouse-window", "3"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	for _, call := range runner.calls {
+		if call.name == "tmux" && len(call.args) >= 1 && call.args[0] == "select-window" {
+			t.Fatalf("known range must not trigger select-window passthrough; calls = %#v", runner.calls)
+		}
+	}
+	if !sawTmuxDisplayMessage(runner.calls, "no notifications") {
+		t.Fatalf("notify handler did not run; calls = %#v", runner.calls)
+	}
+}
+
+// TestStatusbarClickRejectsMultiplePositionals ensures a stray second
+// positional still fails fast rather than getting silently dropped.
+func TestStatusbarClickRejectsMultiplePositionals(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStatusbarTestCommand(&statusbarFakeRunner{}, &stubNotifyStore{})
+
+	err := cmd.Run([]string{"click", "a", "b"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsUsageError(err) {
+		t.Fatalf("expected UsageError, got %T: %v", err, err)
+	}
+}
+
 func TestStatusbarRunRejectsMissingSubcommand(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
After PR #38 added `--mouse-window`, every window-list click failed with exit 2 because Go's standard `flag.Parse` stops at the first non-flag token. With args `["window", "--mouse-window", ""]` it read "window" as a positional and then choked on the remaining "flag-shaped" tokens — so 3 positionals failed the `exactly 1` check. tmux's run-shell surfaced the exit 2 as an error popup on every click.

## Fix
Replace `flag.Parse` with a single-pass walker that classifies each token as flag-or-positional. Accepts both `--flag value` and `--flag=value`. Allows zero or one positional. Rejects 2+ positionals as `UsageError`.

Both orders now work:
```
projmux statusbar click <range-id> --mouse-window <id>
projmux statusbar click --mouse-window <id> <range-id>
projmux statusbar click <range-id>
projmux statusbar click "" --mouse-window ""
```

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` (30+ statusbar tests; new tests cover flag-before/after-positional, equals form, empty values, known-range-ignores-flag, multi-positional rejection)
- [x] Manual: previously failing `statusbar click "window" --mouse-window ""` returns exit 0, no popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)