### PR TITLE
fix(statusbar): route window|<idx> range tokens to window-list handler

### DIFF
--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -223,12 +223,41 @@ func (c *statusbarCommand) runClick(args []string, stdout, stderr io.Writer) err
 	_ = opts.MouseX
 	_ = opts.MouseY
 
+	// tmux's built-in window-list ranges (the tabs on row 0) set
+	// `#{mouse_status_range}` to `window|<idx>` — *not* a user-defined range
+	// id and *not* empty. We must detect the `window` / `window|N` shape
+	// directly and route to the window-list handler, otherwise the click
+	// falls through unrecognized. Two important details:
+	//
+	//   1. Some tmux versions populate `#{mouse_window}` for window-list
+	//      clicks, others leave it empty and only encode the index in the
+	//      range token. Parsing the index out of `window|N` makes the
+	//      handler robust across both shapes.
+	//   2. We do this *before* the user-defined range dispatch so a hostile
+	//      user range named "window" can't shadow the built-in.
+	if isWindowListRangeToken(raw) {
+		// Prefer the `#{mouse_window}` value (a unique window id like `3`,
+		// addressed via `@3`) when populated. Some tmux versions / layouts
+		// leave it empty for built-in window-range clicks and only encode
+		// the winlink index in the range token (`window|<idx>`); in that
+		// case we fall back to the index, addressed via `:<idx>` so tmux
+		// resolves it against the current session's window list rather
+		// than as a (different) window-id lookup.
+		if opts.MouseWindow != "" {
+			return c.handleWindowListClick(opts, stderr)
+		}
+		if idx := windowIndexFromRangeToken(raw); idx != "" {
+			return c.runTmux(stderr, "select-window", "-t", ":"+idx)
+		}
+		return nil
+	}
+
 	if raw == "" {
 		// tmux emits an empty `#{mouse_status_range}` when the click lands
-		// outside any user-defined range — typically on a window-list entry
-		// or status-bar whitespace. If `--mouse-window` is non-empty we
-		// fall back to tmux's default `select-window` behavior so users can
-		// still click a tab to switch to it; otherwise the click is a noop.
+		// outside any range — typically on status-bar whitespace. If
+		// `--mouse-window` is non-empty we fall back to tmux's default
+		// `select-window` behavior so users can still click a tab to switch
+		// to it; otherwise the click is a noop.
 		if opts.MouseWindow != "" {
 			return c.handleWindowListClick(opts, stderr)
 		}
@@ -249,6 +278,28 @@ func (c *statusbarCommand) runClick(args []string, stdout, stderr io.Writer) err
 		return nil
 	}
 	return handler(opts, stdout, stderr)
+}
+
+// isWindowListRangeToken reports whether `raw` (the value of
+// `#{mouse_status_range}` for the click) refers to tmux's built-in window-list
+// range. tmux encodes these as `window|<idx>` (e.g. `window|3`) and, for the
+// edge case where no index is attached, as the bare string `window`.
+func isWindowListRangeToken(raw string) bool {
+	if raw == "window" {
+		return true
+	}
+	return strings.HasPrefix(raw, "window|")
+}
+
+// windowIndexFromRangeToken extracts the `<idx>` portion of a `window|<idx>`
+// range token. Returns "" for the bare `window` form (no index encoded) or any
+// non-window-list token.
+func windowIndexFromRangeToken(raw string) string {
+	const prefix = "window|"
+	if !strings.HasPrefix(raw, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(raw[len(prefix):])
 }
 
 // handleWindowListClick restores tmux's default window-list click behavior

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -647,6 +647,62 @@ func TestStatusbarClickNotifyWithMouseWindowIgnoresFlag(t *testing.T) {
 	}
 }
 
+// TestStatusbarClickWindowRangeTokenWithMouseWindowSelectsWindow covers the
+// real tmux shape for a window-list click: `#{mouse_status_range}` evaluates
+// to `window|<idx>` (the built-in `STYLE_RANGE_WINDOW`) rather than an empty
+// string. When `#{mouse_window}` is also populated we should use it (it's the
+// unique window id) and address with the `@<id>` syntax.
+func TestStatusbarClickWindowRangeTokenWithMouseWindowSelectsWindow(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "window|3", "--mouse-window", "5"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !sawTmuxArgs(runner.calls, []string{"select-window", "-t", "@5"}) {
+		t.Fatalf("missing select-window -t @5; calls = %#v", runner.calls)
+	}
+}
+
+// TestStatusbarClickWindowRangeTokenWithoutMouseWindowFallsBackToIndex covers
+// the tmux configurations where `#{mouse_window}` is empty for a window-range
+// click but the range token still carries the winlink index (`window|<idx>`).
+// We fall back to addressing by index (`:<idx>`) so the click still switches
+// tabs reliably — this is the regression the user reported.
+func TestStatusbarClickWindowRangeTokenWithoutMouseWindowFallsBackToIndex(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "window|3", "--mouse-window", ""}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !sawTmuxArgs(runner.calls, []string{"select-window", "-t", ":3"}) {
+		t.Fatalf("missing select-window -t :3; calls = %#v", runner.calls)
+	}
+}
+
+// TestStatusbarClickBareWindowRangeWithoutIndexIsNoop covers the (rare) case
+// where `#{mouse_status_range}` is the bare `window` token with no index
+// attached and no `mouse_window` either. We have nothing to switch to, so
+// the click must be a noop rather than a tmux error popup.
+func TestStatusbarClickBareWindowRangeWithoutIndexIsNoop(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{}
+	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
+
+	if err := cmd.Run([]string{"click", "window", "--mouse-window", ""}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("bare 'window' range with no mouse-window must be a noop, got %d calls", len(runner.calls))
+	}
+}
+
 // TestStatusbarClickRejectsMultiplePositionals ensures a stray second
 // positional still fails fast rather than getting silently dropped.
 func TestStatusbarClickRejectsMultiplePositionals(t *testing.T) {


### PR DESCRIPTION
## Summary
- Window-list clicks (row 0 tabs) were silently dropped on tmux configs where `#{mouse_status_range}` arrives as `window|<idx>` and `#{mouse_window}` is empty.
- `runClick` now detects the built-in `window` / `window|<idx>` token before user-range dispatch, and falls back to `select-window -t :<idx>` when only the range token carries the index.
- Regression tests cover the `mouse_window`-populated path, the index-only fallback (the user-reported regression), and the bare `window` noop.

## Test plan
- [x] `go test ./internal/app/...`
- [ ] Manually click a tab in the window list — verify it switches.
- [ ] Click the notify badge — verify it still focuses the notification origin.