### PR TITLE
fix(statusbar): short-circuit window-list clicks to native select-window

### DIFF
--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -940,14 +940,31 @@ func tmuxAppKeyBindings() []string {
 // ranges. Without this, overriding `MouseDown1Status` would silently disable
 // click-to-switch-window in the window list.
 //
+// IMPORTANT: empirically (tmux 3.4+ on `-L projmux`), a click on the window
+// list fires `MouseDown1Status` with `#{mouse_status_range}` set to the bare
+// string `"window"` and `#{mouse_window}` empty. The mouse-target idiom
+// `select-window -t =` only resolves through tmux's *internal* mouse context,
+// which is not preserved across a `run-shell` subprocess — so projmux's Go
+// dispatcher cannot recover the clicked window from those inputs alone. We
+// therefore short-circuit the `range == "window"` case to a native
+// `select-window -t =` inside the same tmux command-chain via `if-shell -F`,
+// and only fall through to `run-shell` for projmux-managed ranges. The Go
+// fallback (`isWindowListRangeToken`) is left in place as defense-in-depth
+// for any future tmux that does populate the index.
+//
 // The `prefix s` chord uses tmux's `switch-client -T <table>` mechanism so
 // keyboard users get the same handlers as mouse clickers without re-defining
 // each handler twice.
 func tmuxStatusbarKeyBindings(binaryPath string) []string {
 	bin := tmuxShellQuote(binaryPath)
+	clickCmd := bin + " statusbar click \"#{mouse_status_range}\" --mouse-window \"#{mouse_window}\""
+	mouseDownBind := "bind-key -n MouseDown1Status if-shell -F " +
+		tmuxConfigQuote("#{==:#{mouse_status_range},window}") + " " +
+		tmuxConfigQuote("select-window -t =") + " " +
+		tmuxConfigQuote("run-shell "+tmuxConfigQuote(clickCmd))
 	return []string{
 		"unbind-key -q -n MouseDown1Status",
-		"bind-key -n MouseDown1Status run-shell " + tmuxConfigQuote(bin+" statusbar click \"#{mouse_status_range}\" --mouse-window \"#{mouse_window}\""),
+		mouseDownBind,
 		"bind-key s switch-client -T projmux-status",
 		"bind-key -T projmux-status u run-shell " + tmuxConfigQuote(bin+" statusbar click usage"),
 		"bind-key -T projmux-status n run-shell " + tmuxConfigQuote(bin+" statusbar click notify"),

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -438,6 +438,45 @@ func TestTmuxPrintConfigUsesStandaloneBindings(t *testing.T) {
 	}
 }
 
+func TestTmuxPrintConfigShortCircuitsWindowListClicksToNativeSelectWindow(t *testing.T) {
+	t.Parallel()
+
+	// Empirically tmux 3.4+ fires `MouseDown1Status` with
+	// `#{mouse_status_range}` set to the bare string "window" and an empty
+	// `#{mouse_window}` for window-list clicks. The `select-window -t =`
+	// idiom only resolves through tmux's internal mouse context, which a
+	// `run-shell` subprocess cannot see — so the projmux dispatcher would
+	// no-op silently. The bind must short-circuit that case via
+	// `if-shell -F` to a native `select-window -t =` *before* invoking
+	// projmux. This test pins the rendered config so the regression cannot
+	// silently come back.
+	cmd := &tmuxCommand{executable: func() (string, error) { return "/tmp/proj mux/bin/projmux", nil }}
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"print-config"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		// Must short-circuit the bare "window" range to native select-window.
+		"bind-key -n MouseDown1Status if-shell -F \"#{==:#{mouse_status_range},window}\" \"select-window -t =\"",
+		// Projmux fallback path for non-window ranges still goes through run-shell.
+		`run-shell \"'/tmp/proj mux/bin/projmux' statusbar click \\"#{mouse_status_range}\\" --mouse-window \\"#{mouse_window}\\"\"`,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("print-config output = %q, want substring %q", output, want)
+		}
+	}
+	// The previous unconditional `run-shell` bind (no if-shell guard) must be gone.
+	for _, banned := range []string{
+		"bind-key -n MouseDown1Status run-shell ",
+	} {
+		if strings.Contains(output, banned) {
+			t.Fatalf("print-config output = %q, did not expect substring %q", output, banned)
+		}
+	}
+}
+
 func TestTmuxRebalancePanesSelectsMultiPaneWindows(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Empirical capture showed tmux fires `MouseDown1Status` for window-list clicks with `#{mouse_status_range}=window` (bare, no `|<idx>`) and `#{mouse_window}` empty — so the Go dispatcher had no way to resolve the clicked window. PR #40 covered the `window|<idx>` shape but not this one.
- Wrap `MouseDown1Status` in `if-shell -F "#{==:#{mouse_status_range},window}"` so window-list clicks short-circuit to native `select-window -t =` in the same tmux command-chain (where the mouse target is still available). Non-window ranges fall through to the existing `run-shell` projmux dispatcher.
- The Go-side `isWindowListRangeToken` fallback from PR #40 is intentionally left in place as defense-in-depth.

## Test plan
- [x] `go test ./internal/app/...`
- [x] New test pins both the if-shell short-circuit and the run-shell fallback in the rendered config.
- [ ] Manually click window-list tabs — verify they switch.
- [ ] Click notify badge — verify it still focuses the origin pane.