### PR TITLE
fix(statusbar): use tmux block syntax for window-click if-shell to fix syntax error

### DIFF
--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -958,10 +958,14 @@ func tmuxAppKeyBindings() []string {
 func tmuxStatusbarKeyBindings(binaryPath string) []string {
 	bin := tmuxShellQuote(binaryPath)
 	clickCmd := bin + " statusbar click \"#{mouse_status_range}\" --mouse-window \"#{mouse_window}\""
+	// Use tmux's `{...}` block syntax for the if-shell branches so the nested
+	// quotes inside `run-shell` don't need to be escaped through another layer
+	// of tmux config quoting (which the parser rejects). Block syntax requires
+	// tmux 3.0+; projmux already enforces tmux >= 3.4 via the doctor check.
 	mouseDownBind := "bind-key -n MouseDown1Status if-shell -F " +
 		tmuxConfigQuote("#{==:#{mouse_status_range},window}") + " " +
-		tmuxConfigQuote("select-window -t =") + " " +
-		tmuxConfigQuote("run-shell "+tmuxConfigQuote(clickCmd))
+		"{ select-window -t = } " +
+		"{ run-shell " + tmuxConfigQuote(clickCmd) + " }"
 	return []string{
 		"unbind-key -q -n MouseDown1Status",
 		mouseDownBind,

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -458,10 +458,14 @@ func TestTmuxPrintConfigShortCircuitsWindowListClicksToNativeSelectWindow(t *tes
 
 	output := stdout.String()
 	for _, want := range []string{
-		// Must short-circuit the bare "window" range to native select-window.
-		"bind-key -n MouseDown1Status if-shell -F \"#{==:#{mouse_status_range},window}\" \"select-window -t =\"",
-		// Projmux fallback path for non-window ranges still goes through run-shell.
-		`run-shell \"'/tmp/proj mux/bin/projmux' statusbar click \\"#{mouse_status_range}\\" --mouse-window \\"#{mouse_window}\\"\"`,
+		// Must short-circuit the bare "window" range to native select-window
+		// using tmux block syntax (avoids invalid triple-escaped quoting that
+		// breaks the tmux config parser).
+		"bind-key -n MouseDown1Status if-shell -F \"#{==:#{mouse_status_range},window}\"",
+		"{ select-window -t = }",
+		// Projmux fallback path for non-window ranges still goes through run-shell,
+		// now wrapped in a `{ ... }` block instead of an extra layer of quoting.
+		`{ run-shell "'/tmp/proj mux/bin/projmux' statusbar click \"#{mouse_status_range}\" --mouse-window \"#{mouse_window}\"" }`,
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("print-config output = %q, want substring %q", output, want)


### PR DESCRIPTION
## Summary
- PR #41 introduced `if-shell -F ...` for short-circuiting window-list clicks but used triple-escaped `\"` quoting that tmux's parser rejects (`syntax error` on `source-file`).
- Switch to tmux 3.0+ `{ ... }` block syntax for the if-shell branches — no nested quote escaping needed. Rendered:
  ```
  bind-key -n MouseDown1Status if-shell -F "#{==:#{mouse_status_range},window}" { select-window -t = } { run-shell "'.../projmux' statusbar click \"#{mouse_status_range}\" --mouse-window \"#{mouse_window}\"" }
  ```

## Test plan
- [x] `go test ./internal/app/...`
- [x] Smoke test: `tmux -f <rendered> start-server` returns rc=0 (previously failed).
- [ ] Manual click test on window list + notify badge.