### PR TITLE
ci: publish npm packages on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,19 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Check formatting
         run: make fmt-check
 
       - name: Run unit tests
         run: make test
+
+      - name: Validate npm package staging
+        run: make npm-pack
 
       - name: Run integration tests
         run: make test-integration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,3 +105,46 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "${GITHUB_REF_NAME}" dist/*.tar.gz --clobber
+
+  publish-npm:
+    name: Publish npm Packages
+    needs: publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Stage npm packages
+        run: scripts/package-npm.sh --version "${GITHUB_REF_NAME#v}" --out dist/npm
+
+      - name: Publish npm packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
+            echo "::error::NPM_TOKEN is required to publish npm packages"
+            exit 1
+          fi
+
+          npm whoami
+          for dir in \
+            dist/npm/@projmux/linux-x64 \
+            dist/npm/@projmux/linux-arm64 \
+            dist/npm/@projmux/darwin-x64 \
+            dist/npm/@projmux/darwin-arm64 \
+            dist/npm/projmux; do
+            npm publish "$dir" --access public
+          done

--- a/docs/npm-distribution.md
+++ b/docs/npm-distribution.md
@@ -53,6 +53,18 @@ Publishing the scoped platform packages requires control of the `@projmux`
 npm scope. The release automation should fail before publishing if that scope
 or `NPM_TOKEN` is unavailable.
 
+Tag releases publish npm packages from GitHub Actions after release archives
+are uploaded. The workflow runs:
+
+```bash
+scripts/package-npm.sh --version "${GITHUB_REF_NAME#v}" --out dist/npm
+```
+
+then publishes each staged package with `npm publish --access public`.
+Configure the repository secret `NPM_TOKEN` with an npm token that can publish
+both `projmux` and the `@projmux/*` platform packages. PR CI runs
+`make npm-pack` so package staging and dry-run packing fail before release.
+
 ## Non-Goals
 
 The npm installer must not install system dependencies, edit shell startup

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,12 @@
   "packages": {
     ".": {
       "extra-files": [
-        "internal/version/version.go"
+        "internal/version/version.go",
+        "package.json",
+        "npm/platform/darwin-arm64/package.json",
+        "npm/platform/darwin-x64/package.json",
+        "npm/platform/linux-arm64/package.json",
+        "npm/platform/linux-x64/package.json"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- add CI validation for npm package staging via `make npm-pack`
- add release-tag npm publish job after GitHub release artifacts are uploaded
- include npm package metadata in release-please extra files
- document npm release automation and required `NPM_TOKEN`

## Validation
- `make npm-pack`
- `make fmt`
- `make fix` (ran; reverted unrelated `go fix` churn outside this PR scope)
- `make test`
- `make test-integration`
- `make test-e2e`

## Notes
- The publish job requires repository secret `NPM_TOKEN` and control of the `@projmux` npm scope.