### PR TITLE
fix: include release installer update guidance

### DIFF
--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -205,7 +205,7 @@ func (c *updateCommand) applyCommands(source string, noApply bool) ([]updateAppl
 	case "source":
 		return nil, errors.New("update apply for source installs is not supported; update the source checkout and rebuild")
 	default:
-		return nil, errors.New("update apply requires PROJMUX_INSTALLER=npm or PROJMUX_INSTALLER=go")
+		return nil, errors.New("update apply requires PROJMUX_INSTALLER=npm, PROJMUX_INSTALLER=go, or PROJMUX_INSTALLER=github-release")
 	}
 }
 

--- a/internal/app/update_test.go
+++ b/internal/app/update_test.go
@@ -385,7 +385,7 @@ func TestUpdateApplyRejectsUnsupportedInstallers(t *testing.T) {
 		installer string
 		want      string
 	}{
-		{name: "unknown", installer: "", want: "requires PROJMUX_INSTALLER"},
+		{name: "unknown", installer: "", want: "PROJMUX_INSTALLER=github-release"},
 		{name: "source", installer: "source", want: "not supported"},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary
- include github-release in the update apply missing-installer guidance
- tighten the unit assertion for the guidance text

## Validation
- go test ./internal/app
- make fmt
- make fix
- make test
- make test-integration
- make test-e2e
- make npm-pack