### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,9 @@ jobs:
     name: Publish npm Packages
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -124,22 +127,14 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Stage npm packages
         run: scripts/package-npm.sh --version "${GITHUB_REF_NAME#v}" --out dist/npm
 
       - name: Publish npm packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
-            echo "::error::NPM_TOKEN is required to publish npm packages"
-            exit 1
-          fi
-
-          npm whoami
           for dir in \
             dist/npm/@projmux/linux-x64 \
             dist/npm/@projmux/linux-arm64 \

--- a/docs/npm-distribution.md
+++ b/docs/npm-distribution.md
@@ -50,8 +50,19 @@ projmux
 ```
 
 Publishing the scoped platform packages requires control of the `@projmux`
-npm scope. The release automation should fail before publishing if that scope
-or `NPM_TOKEN` is unavailable.
+npm scope. Configure npm Trusted Publishing for every package before merging a
+release PR:
+
+| npm package | GitHub organization/user | repository | workflow filename |
+| --- | --- | --- | --- |
+| `@projmux/linux-x64` | `crevissepartners` | `projmux` | `release.yml` |
+| `@projmux/linux-arm64` | `crevissepartners` | `projmux` | `release.yml` |
+| `@projmux/darwin-x64` | `crevissepartners` | `projmux` | `release.yml` |
+| `@projmux/darwin-arm64` | `crevissepartners` | `projmux` | `release.yml` |
+| `projmux` | `crevissepartners` | `projmux` | `release.yml` |
+
+Leave the npm trusted publisher environment field empty unless the workflow is
+later moved behind a GitHub deployment environment.
 
 Tag releases publish npm packages from GitHub Actions after release archives
 are uploaded. The workflow runs:
@@ -61,9 +72,9 @@ scripts/package-npm.sh --version "${GITHUB_REF_NAME#v}" --out dist/npm
 ```
 
 then publishes each staged package with `npm publish --access public`.
-Configure the repository secret `NPM_TOKEN` with an npm token that can publish
-both `projmux` and the `@projmux/*` platform packages. PR CI runs
-`make npm-pack` so package staging and dry-run packing fail before release.
+The npm publish job uses GitHub Actions OIDC (`id-token: write`) instead of a
+long-lived `NPM_TOKEN` secret. PR CI runs `make npm-pack` so package staging and
+dry-run packing fail before release.
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary
- switch npm release publishing from NPM_TOKEN to GitHub Actions OIDC trusted publishing
- run npm publish with id-token: write and Node 24
- document the required npm trusted publisher configuration for all projmux packages

## Validation
- make fmt
- make fix
- make test
- make test-integration
- make test-e2e
- make npm-pack