### PR TITLE
fix: reject go upgrade for npm installs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -318,7 +318,9 @@ projmux upgrade [--ref @latest|@<tag>|@<branch>]
 `go install`s the binary, atomically replaces the on-disk file, then
 runs `projmux tmux apply` (skipped with `--no-apply`). Reads
 `PROJMUX_PROJDIR` from the calling shell and memoizes the primary entry
-to `~/.config/projmux/projdir`.
+to `~/.config/projmux/projdir`. npm-installed binaries reject this
+command; use `projmux update apply` or `npm update -g projmux` for npm
+installs.
 
 ## sessions / session-popup / preview / pin / kill / prune / tag
 

--- a/internal/app/upgrade.go
+++ b/internal/app/upgrade.go
@@ -79,6 +79,10 @@ func (c *upgradeCommand) Run(args []string, stdout, stderr io.Writer) error {
 		return fmt.Errorf("upgrade does not accept positional arguments")
 	}
 
+	if source := c.installerSource(); source == "npm" {
+		return errors.New("projmux upgrade is for Go/source installs; npm installs should run 'projmux update apply' or 'npm update -g projmux'")
+	}
+
 	opts := upgradeOptions{
 		ref:     strings.TrimSpace(*ref),
 		target:  strings.TrimSpace(*target),
@@ -124,6 +128,19 @@ func (c *upgradeCommand) runDryRun(opts upgradeOptions, stdout io.Writer) error 
 		}
 	}
 	return nil
+}
+
+func (c *upgradeCommand) installerSource() string {
+	env := os.Environ()
+	if c.environ != nil {
+		env = c.environ()
+	}
+	for _, entry := range env {
+		if value, ok := strings.CutPrefix(entry, "PROJMUX_INSTALLER="); ok {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
 }
 
 func (c *upgradeCommand) runUpgrade(opts upgradeOptions, stdout, stderr io.Writer) error {

--- a/internal/app/upgrade_test.go
+++ b/internal/app/upgrade_test.go
@@ -213,6 +213,27 @@ func TestUpgradeRunReportsMissingGoToolchain(t *testing.T) {
 	}
 }
 
+func TestUpgradeRunRejectsNPMInstaller(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStubUpgradeCommand("/usr/local/lib/node_modules/projmux/node_modules/@projmux/linux-x64/bin/projmux")
+	cmd.environ = func() []string { return []string{"PATH=/usr/bin", "PROJMUX_INSTALLER=npm"} }
+	cmd.lookPath = func(string) (string, error) {
+		t.Fatalf("lookPath should not run for npm installs")
+		return "", nil
+	}
+
+	err := cmd.Run([]string{}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatalf("Run() error = nil, want npm installer rejection")
+	}
+	for _, want := range []string{"npm installs", "projmux update apply", "npm update -g projmux"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Run() error = %v, want %q", err, want)
+		}
+	}
+}
+
 func TestUpgradeRunHappyPathInvokesGoInstallAndApply(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- reject `projmux upgrade` when invoked through the npm shim
- direct npm-installed users to `projmux update apply` or `npm update -g projmux`
- document the installer-specific upgrade behavior

## Validation
- go test ./internal/app
- make fmt
- make fix
- make test
- make test-integration
- make test-e2e
- make npm-pack