### PR TITLE
fix: require enter to close usage hud popup

### DIFF
--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -54,7 +54,7 @@ bind-key -n MouseDown1Status if-shell -F "#{==:#{mouse_status_range},window}" \
 | `pwd`     | 0 | copy `#{pane_current_path}` to tmux buffer and show a compact path popup | `prefix s p`  |
 | `kube`    | 0 | `projmux tmux popup-toggle sessionizer`   | `prefix s k`  |
 | `git`     | 0 | `projmux tmux popup-toggle sessionizer`   | `prefix s g`  |
-| `usage`   | 1 | `display-popup -E -h 60% -w 80% -- projmux usage` | `prefix s u`  |
+| `usage`   | 1 | `display-popup -E -h 60% -w 80% -- projmux usage`, then wait for Enter | `prefix s u`  |
 | `notify`  | 1 | `projmux focus --target <newest> --source status-bar --kind segment-click`, then ack on success | `prefix s n`  |
 
 `notify` reads the pending queue only. For a live pane-state view that is

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -414,7 +414,7 @@ func (c *statusbarCommand) handleUsage(_ statusbarClickOptions, _, stderr io.Wri
 	if err != nil {
 		return c.runTmux(stderr, "display-message", "statusbar usage: cannot resolve projmux binary")
 	}
-	popupShell := tmuxShellQuote(binaryPath) + " usage; read -n1 -s"
+	popupShell := tmuxShellQuote(binaryPath) + " usage; printf '\\nPress Enter to close.\\n'; IFS= read -r _"
 	if err := c.runTmuxNoFallback(stderr, "display-popup", "-E", "-h", "60%", "-w", "80%", popupShell); err == nil {
 		return nil
 	}

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -305,7 +306,6 @@ func TestStatusbarClickPopupActionFailuresShowToast(t *testing.T) {
 		{name: "git", rangeID: "git", want: "statusbar git: popup failed"},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -358,6 +358,12 @@ func TestStatusbarClickUsageOpensPopup(t *testing.T) {
 	}
 	if !sawTmuxSubcommand(runner.calls, "display-popup") {
 		t.Fatalf("missing display-popup; calls = %#v", runner.calls)
+	}
+	if !sawTmuxPopupCommandContaining(runner.calls, "Press Enter to close.") {
+		t.Fatalf("missing enter-to-close prompt; calls = %#v", runner.calls)
+	}
+	if sawTmuxPopupCommandContaining(runner.calls, "read -n1 -s") {
+		t.Fatalf("usage popup should wait for Enter, not any key; calls = %#v", runner.calls)
 	}
 }
 
@@ -837,10 +843,8 @@ func sawTmuxSubcommand(calls []statusbarFakeCall, sub string) bool {
 		if c.name != "tmux" {
 			continue
 		}
-		for _, a := range c.args {
-			if a == sub {
-				return true
-			}
+		if slices.Contains(c.args, sub) {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
## Summary
- Make the usage HUD popup wait for Enter instead of any key
- Add an explicit Enter-to-close prompt to match the path popup behavior
- Pin the behavior in statusbar tests and docs

## Validation
- make fmt
- GOCACHE=/tmp/projmux-go-cache make fix (ran; unrelated go-fix churn was excluded from this PR)
- GOCACHE=/tmp/projmux-go-cache make test
- GOCACHE=/tmp/projmux-go-cache make test-integration (no suites yet)
- GOCACHE=/tmp/projmux-go-cache make test-e2e (no suites yet)
- git diff --check