### PR TITLE
feat: support bash shell config

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -82,7 +82,8 @@ projmux shell
 - [Go 1.24+](https://go.dev/dl/) — binary 설치/빌드에 필요.
 - [tmux](https://github.com/tmux/tmux/wiki/Installing) **≥ 3.4** — workspace 런타임. 이전 버전은 `display-popup -T` 등 projmux 가 사용하는 기능이 없습니다.
 - [fzf](https://github.com/junegunn/fzf#installation) **≥ 0.55** — popup/sidebar picker. 멀티라인 피커가 `--marker-multi-line`, `--gap-line`, `--highlight-line` 을 사용하며 모두 0.55 까지 도입됐습니다.
-- [zsh](https://zsh.sourceforge.io/) — `projmux shell` 이 만드는 앱 tmux 설정의 기본 shell.
+- `bash`, `zsh`, `sh` 같은 Unix shell — `projmux shell` 이 만드는 앱 tmux
+  설정은 절대 경로 `$SHELL` 을 사용하고, 없으면 `/bin/sh` 로 fallback 합니다.
 - [git](https://git-scm.com/downloads) — branch/status segment.
 - `stty` — POSIX 터미널 제어, `projmux setup` 에서 사용. macOS/Linux 기본 시스템에 이미 포함, Windows 호스트에선 해당 없음.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) — 선택, Kubernetes status segment 사용 시에만.
@@ -124,7 +125,7 @@ primary 프로젝트 루트입니다. 설정하지 않으면 projmux 는 canonic
 export PROJMUX_PROJDIR="/your/path"
 ```
 
-`~/.zshrc` (또는 사용 중인 shell rc 파일) 에 한 줄 추가하면 됩니다. 첫 실행
+`~/.bashrc`, `~/.zshrc` 또는 사용 중인 shell rc 파일에 한 줄 추가하면 됩니다. 첫 실행
 이후에는 `~/.config/projmux/projdir` 에 memoize 되므로, 이후 env 가 없어도 같은
 루트가 유지됩니다.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Open the app once, then use its generated tmux bindings to:
   `go install` or building from source.
 - [tmux](https://github.com/tmux/tmux/wiki/Installing) **≥ 3.4** — the workspace runtime. Earlier versions miss `display-popup -T` and other features projmux depends on.
 - [fzf](https://github.com/junegunn/fzf#installation) **≥ 0.55** — interactive popup/sidebar pickers. The multiline picker uses `--marker-multi-line`, `--gap-line`, and `--highlight-line`, which landed by 0.55.
-- [zsh](https://zsh.sourceforge.io/) — default shell of the generated app config (`projmux shell`).
+- A Unix shell such as `bash`, `zsh`, or `sh` — `projmux shell` uses your
+  absolute `$SHELL` for the generated app config, falling back to `/bin/sh`.
 - [git](https://git-scm.com/downloads) — branch/status metadata.
 - `stty` — POSIX terminal control, used by `projmux setup`. Already shipped by every macOS / Linux base system; not applicable on Windows hosts.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) — optional, only for the Kubernetes status segment.
@@ -120,7 +121,7 @@ sessions, saved workdirs, and weak common-folder probes (`~/source`, `~/work`,
 export PROJMUX_PROJDIR="/your/path"
 ```
 
-Add the line to `~/.zshrc` (or your shell's rc file). The resolved value is
+Add the line to `~/.bashrc`, `~/.zshrc`, or your shell's rc file. The resolved value is
 memoized to `~/.config/projmux/projdir` after first use, so later shells keep
 the same root even without the env var.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -365,7 +365,8 @@ flags with the top-level `switch` UX:
 - `current` — print `pane_current_path` for the active tmux pane (used
   by the shell jump binding).
 - `shell` — boot the isolated `-L projmux` tmux server with the
-  generated config.
+  generated config. The generated app config uses absolute `$SHELL` as the
+  tmux default shell when set, otherwise `/bin/sh`.
 - `attach auto [--keep=N] [--fallback=home|ephemeral]` — auto-attach to
   the most recent session, with bounded retention and a fallback policy.
 - `settings` — interactive configuration UI for the project picker, AI

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -40,7 +40,7 @@ The current target is a standalone app that can generate the tmux bindings and p
 
 ## What stays outside standalone projmux
 
-- zsh startup hooks
+- shell startup hooks
 - machine-specific install behavior
 - optional OS or terminal integration scripts that are not session-management features
 

--- a/docs/shell-autostart.md
+++ b/docs/shell-autostart.md
@@ -1,18 +1,20 @@
-# zsh Auto-Start
+# Shell Auto-Start
 
-If you want every new interactive zsh shell to drop you straight into the
-projmux app, add a guarded hook to `~/.zshrc`:
+If you want every new interactive bash or zsh shell to drop you straight into
+the projmux app, add a guarded hook to `~/.bashrc`, `~/.zshrc`, or the
+equivalent interactive rc file for your shell:
 
 ```sh
-if [[ -o interactive && -z "${TMUX:-}" ]] && command -v projmux >/dev/null 2>&1; then
+if [[ $- == *i* && -z "${TMUX:-}" ]] && command -v projmux >/dev/null 2>&1; then
   exec projmux shell
 fi
 ```
 
 The three guards each prevent a common breakage:
 
-- `-o interactive` — only fire for interactive shells. Without this you would
-  break `scp`, `ssh host cmd`, `git` over SSH, and any `zsh -c '...'` invocation.
+- `$- == *i*` — only fire for interactive shells. Without this you would
+  break `scp`, `ssh host cmd`, `git` over SSH, and any `bash -c '...'` or
+  `zsh -c '...'` invocation.
 - `-z "${TMUX:-}"` — skip when already inside tmux. Without this the hook
   recurses every time projmux opens a new pane.
 - `command -v projmux >/dev/null 2>&1` — skip on machines where projmux is not
@@ -22,6 +24,7 @@ The three guards each prevent a common breakage:
 To bypass the hook for one shell, set `TMUX` before launching:
 
 ```sh
+TMUX=1 bash
 TMUX=1 zsh
 ```
 

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -632,7 +632,7 @@ func (c *aiCommand) settingsRows() []intfzf.Entry {
 		{aiModeSelective, "show picker each time"},
 		{aiModeClaude, "always run Claude split"},
 		{aiModeCodex, "always run Codex split"},
-		{aiModeShell, "always open zsh split"},
+		{aiModeShell, "always open plain shell split"},
 	}
 	rows := make([]intfzf.Entry, 0, len(modes))
 	for _, item := range modes {
@@ -653,7 +653,7 @@ func (c *aiCommand) agentRows() []intfzf.Entry {
 		c.agentRow(aiModeClaude, "Anthropic CLI split"),
 		c.agentRow(aiModeCodex, "OpenAI Codex split"),
 		{
-			Label: fmt.Sprintf("%-8s \x1b[34m[READY]\x1b[0m Plain zsh split (\x1b[90mno agent\x1b[0m)", aiModeShell),
+			Label: fmt.Sprintf("%-8s \x1b[34m[READY]\x1b[0m Plain shell split (\x1b[90mno agent\x1b[0m)", aiModeShell),
 			Value: aiModeShell,
 		},
 	}
@@ -754,8 +754,9 @@ func (c *aiCommand) runAgentSplit(mode, direction string) error {
 	contextDir := c.resolveAgentContextDir(mode)
 	title := c.buildAgentTitle(mode, contextDir)
 	command := c.agentLaunchCommand(mode, agentBin, contextDir, title)
+	commandShell := posixCommandShell(c.lookupEnv)
 	if targetPane == "" {
-		return c.run("zsh", "-lc", command)
+		return c.run(commandShell, "-lc", command)
 	}
 
 	splitFlag := "-h"
@@ -766,7 +767,7 @@ func (c *aiCommand) runAgentSplit(mode, direction string) error {
 	if contextDir != "" {
 		args = append(args, "-c", contextDir)
 	}
-	args = append(args, "zsh", "-lc", command)
+	args = append(args, commandShell, "-lc", command)
 	out, err := c.read("tmux", args...)
 	if err != nil {
 		return err
@@ -793,7 +794,7 @@ func (c *aiCommand) runShellSplit(direction string) error {
 	if contextDir != "" {
 		args = append(args, "-c", contextDir)
 	}
-	args = append(args, "zsh", "-l")
+	args = append(args, loginShellCommand(defaultInteractiveShell(c.lookupEnv))...)
 	if err := c.run("tmux", args...); err != nil {
 		return err
 	}
@@ -1031,7 +1032,9 @@ func (c *aiCommand) buildAgentTitle(mode, contextDir string) string {
 func (c *aiCommand) agentLaunchCommand(mode, agentBin, contextDir, title string) string {
 	titleVar := "__" + mode + "_title"
 	parts := []string{}
-	// nvm/fnm/asdf/volta colocate `node` with the agent CLI; `zsh -lc` does not source their init scripts, so without this prepend the agent's `env node` shebang fails and the pane exits immediately.
+	// nvm/fnm/asdf/volta colocate `node` with the agent CLI; non-interactive
+	// login shells may not source their init scripts, so without this prepend
+	// the agent's `env node` shebang can fail and the pane exits immediately.
 	if binDir := filepath.Dir(agentBin); binDir != "" && binDir != "." && binDir != "/" {
 		parts = append(parts, "export PATH="+shellQuote(binDir)+`":$PATH"`)
 	}

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -225,6 +225,8 @@ func TestAISplitCodexRunsNativeTmuxSplitAndStartsWatcher(t *testing.T) {
 			return home
 		case "TMUX":
 			return "/tmp/tmux"
+		case "SHELL":
+			return "/bin/bash"
 		default:
 			return ""
 		}
@@ -254,7 +256,7 @@ func TestAISplitCodexRunsNativeTmuxSplitAndStartsWatcher(t *testing.T) {
 	}
 
 	commands := cmdRecorder(cmd).commands
-	if !containsAICommandArgs(commands, "tmux", []string{"split-window", "-P", "-F", "#{pane_id}", "-h", "-t", "%7", "-c", work, "zsh", "-lc"}) {
+	if !containsAICommandArgs(commands, "tmux", []string{"split-window", "-P", "-F", "#{pane_id}", "-h", "-t", "%7", "-c", work, "/bin/bash", "-lc"}) {
 		t.Fatalf("commands = %#v, want native tmux split-window", commands)
 	}
 	for _, want := range [][]string{
@@ -357,6 +359,8 @@ func TestAISplitShellUsesTmuxSplitWindow(t *testing.T) {
 			return work
 		case "TMUX_SPLIT_TARGET_PANE":
 			return "%9"
+		case "SHELL":
+			return "/bin/bash"
 		default:
 			return ""
 		}
@@ -377,13 +381,24 @@ func TestAISplitShellUsesTmuxSplitWindow(t *testing.T) {
 
 	want := []recordedAICommand{
 		{name: "tmux", args: []string{"display-message", "ai split default: shell"}},
-		{name: "tmux", args: []string{"split-window", "-v", "-t", "%9", "-c", work, "zsh", "-l"}},
+		{name: "tmux", args: []string{"split-window", "-v", "-t", "%9", "-c", work, "/bin/bash", "-l"}},
 		{name: "tmux", args: []string{"resize-pane", "-t", "%1", "-y", "7"}},
 		{name: "tmux", args: []string{"resize-pane", "-t", "%9", "-y", "7"}},
 		{name: "tmux", args: []string{"resize-pane", "-t", "%10", "-y", "6"}},
 	}
 	if !reflect.DeepEqual(cmdRecorder(cmd).commands, want) {
 		t.Fatalf("commands = %#v, want %#v", cmdRecorder(cmd).commands, want)
+	}
+}
+
+func TestAILabelsSayPlainShellNotZsh(t *testing.T) {
+	t.Parallel()
+
+	cmd := testAICommand(t.TempDir())
+	for _, row := range append(cmd.agentRows(), cmd.settingsRows()...) {
+		if strings.Contains(strings.ToLower(row.Label), "zsh") {
+			t.Fatalf("AI row label = %q, did not expect zsh-specific copy", row.Label)
+		}
 	}
 }
 

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -654,7 +654,7 @@ func (c *settingsCommand) aiEntries() []intfzf.Entry {
 		{aiModeSelective, "show picker each time"},
 		{aiModeClaude, "always run Claude split"},
 		{aiModeCodex, "always run Codex split"},
-		{aiModeShell, "always open zsh split"},
+		{aiModeShell, "always open plain shell split"},
 	}
 
 	entries := make([]intfzf.Entry, 0, len(modes)+1)

--- a/internal/app/shell.go
+++ b/internal/app/shell.go
@@ -265,10 +265,14 @@ func (c *shellCommand) writeAppConfig(path, binaryPath string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create shell app config directory: %w", err)
 	}
-	if err := c.writeFile(path, []byte(tmuxAppConfig(binaryPath)), 0o644); err != nil {
+	if err := c.writeFile(path, []byte(tmuxAppConfig(binaryPath, c.defaultShell())), 0o644); err != nil {
 		return fmt.Errorf("write shell app config: %w", err)
 	}
 	return nil
+}
+
+func (c *shellCommand) defaultShell() string {
+	return defaultInteractiveShell(c.lookupEnv)
 }
 
 func (c *shellCommand) defaultConfigPath() string {
@@ -354,6 +358,38 @@ func nonEmpty(value, fallback string) string {
 		return fallback
 	}
 	return value
+}
+
+const fallbackInteractiveShell = "/bin/sh"
+
+func defaultInteractiveShell(lookupEnv func(string) string) string {
+	if lookupEnv == nil {
+		return fallbackInteractiveShell
+	}
+	shell := strings.TrimSpace(lookupEnv("SHELL"))
+	if shell == "" || !filepath.IsAbs(shell) || strings.ContainsAny(shell, "\x00\r\n") {
+		return fallbackInteractiveShell
+	}
+	return shell
+}
+
+func posixCommandShell(lookupEnv func(string) string) string {
+	shell := defaultInteractiveShell(lookupEnv)
+	switch filepath.Base(shell) {
+	case "bash", "dash", "ksh", "mksh", "sh", "zsh":
+		return shell
+	default:
+		return fallbackInteractiveShell
+	}
+}
+
+func loginShellCommand(shell string) []string {
+	switch filepath.Base(shell) {
+	case "bash", "ksh", "mksh", "zsh":
+		return []string{shell, "-l"}
+	default:
+		return []string{shell}
+	}
 }
 
 func printShellUsage(w io.Writer) {

--- a/internal/app/shell_test.go
+++ b/internal/app/shell_test.go
@@ -28,6 +28,9 @@ func TestShellWritesAppConfigAndRunsIsolatedTmux(t *testing.T) {
 			if name == "XDG_CONFIG_HOME" {
 				return ""
 			}
+			if name == "SHELL" {
+				return "/bin/bash"
+			}
 			return os.Getenv(name)
 		},
 		homeDir:    func() (string, error) { return home, nil },
@@ -51,7 +54,7 @@ func TestShellWritesAppConfigAndRunsIsolatedTmux(t *testing.T) {
 		"set -g @projmux_app 1",
 		"set -g history-limit 10000",
 		"set -g set-clipboard on",
-		"set -g default-shell /usr/bin/zsh",
+		"set -g default-shell \"/bin/bash\"",
 		"set -ga update-environment \"WSL_DISTRO_NAME\"",
 		"set -g pane-border-status top",
 		"set -s user-keys[7] \"\\033[9008u\"",
@@ -96,6 +99,53 @@ func TestShellWritesAppConfigAndRunsIsolatedTmux(t *testing.T) {
 		if strings.HasPrefix(env, "TMUX=") {
 			t.Fatalf("runner env contains TMUX: %#v", recorder.env)
 		}
+	}
+}
+
+func TestShellAppConfigFallsBackToPortableShell(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	recorder := &recordingShellRunner{}
+	cmd := &shellCommand{
+		executable: func() (string, error) { return "/tmp/projmux", nil },
+		lookupEnv: func(name string) string {
+			if name == "HOME" {
+				return home
+			}
+			return ""
+		},
+		homeDir:    func() (string, error) { return home, nil },
+		getwd:      func() (string, error) { return "", nil },
+		writeFile:  os.WriteFile,
+		runCommand: recorder.run,
+	}
+
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	configPath := filepath.Join(home, ".config", "projmux", "tmux.conf")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "set -g default-shell \"/bin/sh\"") {
+		t.Fatalf("config = %q, want portable fallback shell", string(content))
+	}
+}
+
+func TestDefaultInteractiveShellKeepsConfiguredZsh(t *testing.T) {
+	t.Parallel()
+
+	got := defaultInteractiveShell(func(name string) string {
+		if name == "SHELL" {
+			return "/usr/bin/zsh"
+		}
+		return ""
+	})
+	if got != "/usr/bin/zsh" {
+		t.Fatalf("defaultInteractiveShell = %q, want configured zsh", got)
 	}
 }
 

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -370,7 +370,7 @@ func (c *tmuxCommand) runPrintAppConfig(args []string, stdout, stderr io.Writer)
 	if err != nil {
 		return err
 	}
-	_, err = io.WriteString(stdout, tmuxAppConfig(binaryPath))
+	_, err = io.WriteString(stdout, tmuxAppConfig(binaryPath, c.defaultShell()))
 	return err
 }
 
@@ -459,7 +459,7 @@ func (c *tmuxCommand) writeAppConfig(binaryOverride, configOverride string) (str
 	if err := os.MkdirAll(filepath.Dir(config), 0o755); err != nil {
 		return "", fmt.Errorf("create tmux app config directory: %w", err)
 	}
-	if err := c.writeFile(config, []byte(tmuxAppConfig(binaryPath)), 0o644); err != nil {
+	if err := c.writeFile(config, []byte(tmuxAppConfig(binaryPath, c.defaultShell())), 0o644); err != nil {
 		return "", fmt.Errorf("write tmux app config: %w", err)
 	}
 	return config, nil
@@ -753,6 +753,10 @@ func (c *tmuxCommand) expandHome(path string) string {
 	return path
 }
 
+func (c *tmuxCommand) defaultShell() string {
+	return defaultInteractiveShell(c.lookupEnv)
+}
+
 func tmuxStandaloneConfig(binaryPath string) string {
 	bin := tmuxShellQuote(binaryPath)
 	lines := []string{
@@ -828,8 +832,9 @@ func tmuxStandaloneConfig(binaryPath string) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
-func tmuxAppConfig(binaryPath string) string {
+func tmuxAppConfig(binaryPath, defaultShell string) string {
 	bin := tmuxShellQuote(binaryPath)
+	shell := tmuxConfigQuote(nonEmpty(strings.TrimSpace(defaultShell), fallbackInteractiveShell))
 	shellPaneLabelFormat := "#{?#{||:#{||:#{||:#{==:#{pane_current_command},zsh},#{==:#{pane_current_command},bash}},#{||:#{==:#{pane_current_command},fish},#{==:#{pane_current_command},sh}}},#{||:#{==:#{pane_current_command},nu},#{==:#{pane_current_command},xonsh}}},#{pane_current_command},#{pane_title}}"
 	paneLabelFormat := "#{?#{&&:#{!=:#{@projmux_ai_agent},},#{!=:#{@projmux_ai_topic},}},#{@projmux_ai_topic}," + shellPaneLabelFormat + "}"
 	paneBusyFormat := "#{||:#{==:#{@projmux_attention_state},busy},#{==:#{@projmux_ai_state},thinking}}"
@@ -843,7 +848,7 @@ func tmuxAppConfig(binaryPath string) string {
 		"set -g mouse on",
 		"set -g history-limit 10000",
 		"set -g set-clipboard on",
-		"set -g default-shell /usr/bin/zsh",
+		"set -g default-shell " + shell,
 		"set -g default-command \"\"",
 		"set -ga update-environment \"WSL_DISTRO_NAME\"",
 		"set -ga update-environment \"WSL_INTEROP\"",

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -561,7 +561,7 @@ func TestTmuxPrintAppConfigUsesIsolatedAppSettings(t *testing.T) {
 		"set -g @projmux_app 1",
 		"set -g history-limit 10000",
 		"set -g set-clipboard on",
-		"set -g default-shell /usr/bin/zsh",
+		"set -g default-shell \"/bin/sh\"",
 		"set -g default-command \"\"",
 		"set -ga update-environment \"WSL_DISTRO_NAME\"",
 		"set -ga update-environment \"VSCODE_IPC_HOOK_CLI\"",


### PR DESCRIPTION
## Summary
- use absolute $SHELL for generated projmux app tmux default-shell, with /bin/sh fallback
- run plain shell and agent splits through the configured shell where appropriate
- remove zsh-specific copy from UI labels and add bashrc/zshrc auto-start docs

## Tests
- make fmt-check
- go test ./internal/app
- bash -n scripts/test-docker-run.sh scripts/test-e2e-docker.sh scripts/test-install-smoke.sh scripts/test-integration-docker.sh test/e2e/linux-smoke.sh test/install/smoke.sh test/integration/linux-smoke.sh test/lib/smoke.sh
- make test-install-smoke
- make test-e2e
