### PR TITLE
fix(settings): prefill project root prompt when unconfigured

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -154,6 +154,8 @@ env 가 살아있는 첫 실행이 `~/.config/projmux/projdir` 에 값을 기록
 (`PROJMUX_PROJDIR`, `@projmux_projdir`, saved, not configured)를 보여주고,
 saved 값이 env/tmux 값에 shadow 되는 상황을 따로 표시합니다. 경로를 직접
 입력하거나 현재 project context 를 저장하거나 saved 값을 지울 수 있습니다.
+Project Root 가 설정되지 않은 경우 직접 입력 prompt 는 `$HOME` 을 수정 가능한
+fallback 으로 채웁니다. 저장하기 전까지는 effective root 로 간주하지 않습니다.
 
 ### 소스에서 빌드
 
@@ -238,7 +240,9 @@ root를 depth 3까지 스캔하므로 약한 probe 밖의 프로젝트도 picker
 
 - `Project Root` - saved primary root 를 설정/변경/해제합니다. Project Root 는
   primary project context 로 쓰는 한 개의 루트이며, `PROJMUX_PROJDIR` env 와
-  tmux `@projmux_projdir` 값이 있으면 saved 값보다 우선됩니다.
+  tmux `@projmux_projdir` 값이 있으면 saved 값보다 우선됩니다. root 가
+  설정되지 않았을 때 직접 입력 prompt 는 `$HOME` 을 미리 채워 picker 를 열 수
+  있게 하지만, 저장 전에는 암묵적인 saved root 로 쓰지 않습니다.
 - `+ Add Workdir...` - 디렉터리 하나를 saved workdirs 목록에 누적 추가.
 - `Workdirs` - 저장된 workdir 검토/삭제. 환경변수 `PROJMUX_MANAGED_ROOTS` /
   `TMUX_SESSIONIZER_ROOTS`가 설정되어 있으면 read-only 행으로 함께 표시되어

--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ You can also manage the saved value interactively with
 effective primary root and source (`PROJMUX_PROJDIR`, `@projmux_projdir`,
 saved, or not configured), shows when a saved value is shadowed by env/tmux,
 and lets you set a path directly, use the current project context, or clear the
-saved value.
+saved value. When no Project Root is configured, the direct-set prompt starts
+with `$HOME` as an editable fallback; it is not treated as the effective root
+until you save it.
 
 ### From source
 
@@ -231,7 +233,9 @@ includes:
 
 - `Project Root` - set, change, or clear the saved primary root. This is the
   one root used as the primary project context; env `PROJMUX_PROJDIR` and tmux
-  `@projmux_projdir` override the saved value until unset.
+  `@projmux_projdir` override the saved value until unset. If no root is
+  configured, the direct-set prompt pre-fills `$HOME` so the picker remains
+  usable without inventing an implicit saved root.
 - `+ Add Workdir...` - append a single directory to the saved workdirs list.
 - `Workdirs` - review and remove saved workdirs. The same picker also surfaces
   any active `PROJMUX_MANAGED_ROOTS` / `TMUX_SESSIONIZER_ROOTS` env values as

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -374,7 +374,9 @@ flags with the top-level `switch` UX:
   About/Update status. In Project Picker, `Project Root` manages the saved
   primary root (`~/.config/projmux/projdir`) and displays whether the effective
   value comes from `PROJMUX_PROJDIR`, tmux `@projmux_projdir`, saved config, or
-  no configured source. `Workdirs` remains separate: those entries are
+  no configured source. When no source is configured, the direct-set prompt
+  starts with `$HOME` as an editable fallback, but `$HOME` is not used as the
+  effective root unless saved. `Workdirs` remains separate: those entries are
   additional search roots, not the primary root. The About section reads the
   cached update status without network access;
   selecting Check Updates runs `projmux update check`, and Update Now runs

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -332,15 +332,17 @@ func (c *settingsCommand) runSetProjectRootTyped(stdout, stderr io.Writer) error
 		return errors.New("project root settings are not configured")
 	}
 
+	initialQuery := c.projectRootTypedInitialQuery()
 	result, err := c.runPicker(intfzf.Options{
-		UI:          "settings-project-root-typed",
-		Entries:     nil,
-		AcceptQuery: true,
-		Prompt:      "Type project root path > ",
-		Header:      "Type one absolute primary root path. Use Workdirs for additional search roots.",
-		Footer:      projmuxFooter("Enter: save  |  Esc/Alt+5/Ctrl+Alt+S: close"),
-		ExpectKeys:  []string{"enter"},
-		Bindings:    settingsCloseBindings(),
+		UI:           "settings-project-root-typed",
+		Entries:      nil,
+		AcceptQuery:  true,
+		InitialQuery: initialQuery,
+		Prompt:       "Type project root path > ",
+		Header:       "Type one absolute primary root path. If unconfigured, the prompt starts at $HOME; Workdirs are separate search roots.",
+		Footer:       projmuxFooter("Enter: save  |  Esc/Alt+5/Ctrl+Alt+S: close"),
+		ExpectKeys:   []string{"enter"},
+		Bindings:     settingsCloseBindings(),
 	})
 	if err != nil {
 		return err
@@ -361,6 +363,21 @@ func (c *settingsCommand) runSetProjectRootTyped(stdout, stderr io.Writer) error
 		return nil
 	}
 	return c.switcher.saveSavedProjdir(expanded, stdout)
+}
+
+func (c *settingsCommand) projectRootTypedInitialQuery() string {
+	if c.switcher == nil {
+		return ""
+	}
+	value, _, err := c.switcher.currentProjdirInfo()
+	if err == nil && strings.TrimSpace(value) != "" {
+		return value
+	}
+	homeDir, err := c.switcher.resolveHomeDir()
+	if err != nil {
+		return ""
+	}
+	return homeDir
 }
 
 func (c *settingsCommand) runAddWorkdir(stdout, stderr io.Writer) error {

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -946,6 +946,54 @@ func TestCurrentProjdirInfoSourcePriority(t *testing.T) {
 	}
 }
 
+func TestProjectRootTypedInitialQueryUsesEffectiveRootOrHome(t *testing.T) {
+	t.Parallel()
+
+	const home = "/home/tester"
+
+	tests := []struct {
+		name       string
+		lookup     func(string) string
+		tmuxOption func() string
+		load       func(string) (string, error)
+		want       string
+	}{
+		{
+			name:       "effective root",
+			lookup:     func(string) string { return "" },
+			tmuxOption: emptyTmuxOption,
+			load:       func(string) (string, error) { return "/from/saved", nil },
+			want:       "/from/saved",
+		},
+		{
+			name:       "unconfigured root",
+			lookup:     func(string) string { return "" },
+			tmuxOption: emptyTmuxOption,
+			load:       func(string) (string, error) { return "", nil },
+			want:       home,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := &settingsCommand{
+				switcher: &switchCommand{
+					homeDir:     func() (string, error) { return home, nil },
+					lookupEnv:   tc.lookup,
+					tmuxProjdir: tc.tmuxOption,
+					loadProjdir: tc.load,
+				},
+			}
+
+			if got := cmd.projectRootTypedInitialQuery(); got != tc.want {
+				t.Fatalf("projectRootTypedInitialQuery() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestProjectPickerEntriesIncludesProjdirRow(t *testing.T) {
 	t.Parallel()
 
@@ -1117,6 +1165,9 @@ func TestSettingsHubSetProjectRootTypedSavesProjdir(t *testing.T) {
 	}
 	if !typedOptions.AcceptQuery {
 		t.Fatalf("typed project root AcceptQuery = false, want true")
+	}
+	if got, want := typedOptions.InitialQuery, home; got != want {
+		t.Fatalf("typed project root InitialQuery = %q, want %q", got, want)
 	}
 	if got, want := readProjdirFile(t, home), target; got != want {
 		t.Fatalf("saved project root = %q, want %q", got, want)

--- a/internal/ui/fzf/runner.go
+++ b/internal/ui/fzf/runner.go
@@ -24,6 +24,7 @@ type Options struct {
 	PreviewCommand string
 	PreviewWindow  string
 	Bindings       []string
+	InitialQuery   string
 	// AcceptQuery surfaces the user-typed query alongside any selection.
 	// When true, the runner passes --print-query to fzf and Result.Query is
 	// populated from the first stdout line emitted by fzf. Existing callers
@@ -178,6 +179,9 @@ func runnerArgs(options Options, supportsFooter bool, filterFile string) []strin
 	)
 	if options.AcceptQuery {
 		args = append(args, "--print-query", "--bind", "enter:print-query+abort")
+	}
+	if options.InitialQuery != "" {
+		args = append(args, "--query", options.InitialQuery)
 	}
 	if options.Read0 {
 		args = append(args,

--- a/internal/ui/fzf/runner_test.go
+++ b/internal/ui/fzf/runner_test.go
@@ -362,6 +362,40 @@ func TestRunnerRunAcceptQueryReturnsQueryOnly(t *testing.T) {
 	}
 }
 
+func TestRunnerRunPassesInitialQuery(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeCommand{stdout: "/home/tester\n"}
+
+	r := &runner{
+		lookupPath:     func(string) (string, error) { return "/usr/bin/fzf", nil },
+		supportsFooter: func(string) bool { return true },
+		newCommand: func(name string, args ...string) command {
+			if !containsString(args, "--query") {
+				t.Fatalf("command args = %q, want --query", args)
+			}
+			if !containsString(args, "/home/tester") {
+				t.Fatalf("command args = %q, want initial query value", args)
+			}
+			return fake
+		},
+	}
+
+	got, err := r.Run(Options{
+		UI:           "popup",
+		AcceptQuery:  true,
+		InitialQuery: "/home/tester",
+		ExpectKeys:   []string{"enter"},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	want := Result{Query: "/home/tester"}
+	if got != want {
+		t.Fatalf("Run() = %#v, want %#v", got, want)
+	}
+}
+
 func TestRunnerRunAcceptQueryReturnsQueryAndSelection(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- prefill the Project Root direct-set fzf prompt with the effective root, or $HOME when unconfigured
- keep the effective Project Root source as not configured until the user explicitly saves a value
- document the editable $HOME prompt fallback

## Tests
- make fmt
- make fix
- make test
- go test ./internal/app ./internal/ui/fzf
- git diff --check