### PR TITLE
docs: clarify agent guide repo contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,17 +4,17 @@
 - `projmux` is a standalone tmux session-management application.
 - Keep portable session-management behavior in `projmux`.
 - Keep machine-local policy outside the application unless the migration plan explicitly calls for it.
+- Keep `AGENTS.md` focused on repo contract. Personal agent recipes, reverse-engineering notes, and machine-local operating memos belong in external local docs (Obsidian/dotfiles anchors), not this tracked file.
+- Local-only agent overlays may live in an untracked `AGENTS.local.md` anchored via dotfiles. This tracked file stays shareable and tool-agnostic.
 
 ## Startup Checks
-- Run `wt --version`.
-- Run `wt list`.
-- Confirm you are in the intended worktree with `pwd`.
+- Confirm you are in the intended checkout/worktree with `pwd`.
 - Check local state with `git status --short`.
 
-## Branch And Worktree Rules
+## Branch And Checkout Rules
 - Use one branch per task. Preferred names: `feat/<topic>`, `fix/<topic>`, `docs/<topic>`, `refactor/<topic>`, `chore/<topic>`.
-- Create or reuse the task worktree with `wt path --create <branch>`.
-- Keep one agent per worktree. Do not share a dirty worktree across agents.
+- Use a dedicated checkout/worktree per task when parallel work would otherwise collide.
+- Keep one agent per checkout/worktree. Do not share a dirty checkout across agents.
 - If another agent owns a file, do not overwrite their changes. Adjust around them or coordinate a handoff.
 - Keep changes narrow. Split docs, bootstrap, migration, and feature work into separate branches unless they are inseparable.
 
@@ -41,7 +41,7 @@
 - Promote the build only after merge:
   10. `git -C <repo> pull --ff-only`
   11. `make install` — atomic replace of `$(go env GOPATH)/bin/projmux` plus `projmux tmux apply`. **Never run it before step 10**; pre-merge state has not cleared CI yet and may not match what `main` will hold.
-  12. `wt cleanup --apply` to retire the merged worktree.
+  12. Retire the merged checkout/worktree with your local tooling if you used one.
 - If a target is missing for the area you are changing, add it or leave the repository in a state where the gap is explicit in docs and review notes.
 - If behavior changes, update the maintained test list in [docs/agent-workflow.md](docs/agent-workflow.md) in the same branch.
 - Do not skip `fmt` or `fix` because tests passed. Formatting, automatic fixes, and test execution are separate gates.
@@ -116,4 +116,4 @@ Tunables (rarely touched):
 ## Communication
 - Use concise progress updates.
 - Report blockers early, especially if they involve parity uncertainty or overlap with another agent's files.
-- When handing off, state the branch, worktree path, changed files, and remaining risks.
+- When handing off, state the branch, checkout/worktree path, changed files, and remaining risks.


### PR DESCRIPTION
## Summary

- Keep tracked `AGENTS.md` focused on portable repo contract.
- Move personal recipes/local operating notes out of scope for the tracked guide.
- Soften mandatory `wt` language to allow a normal checkout when worktree isolation is not needed.

## Validation

- `git diff --check`
