### PR TITLE
fix(notify): restore sidebar toggle

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -176,8 +176,9 @@ projmux notify reconcile [--json]
   reply badges that do not queue because no AI agent is attached, live AI
   reply panes missing a queue entry, matched AI reply entries, and stale
   queue entries whose live pane no longer matches. `--ui=sidebar` opens the
-  interactive notify list where Enter focuses and acks a target, `a` acks
-  the selected row, and `Ctrl-A` clears all.
+  compact interactive notify list where Enter focuses and acks a target, `a`
+  acks the selected row, and `Ctrl-A` clears all. The sidebar row keeps target
+  details searchable but displays only age, non-info severity, and text.
 - `ack <id>` removes one entry; `--all` flushes the queue.
 - `reconcile` — walks `tmux list-panes -a` and back-fills entries for
   panes whose attention state is `reply` AND whose AI agent option is

--- a/docs/notify-queue.md
+++ b/docs/notify-queue.md
@@ -84,7 +84,9 @@ preserves the stable JSON array used by scripts.
 `--ui=sidebar` opens the notify queue as an interactive right-side list when
 run inside the tmux popup surface. Enter focuses the selected target pane and
 acks the row after focus succeeds. `a` acks the selected row. `Ctrl-A` clears
-all rows via `notify ack --all`.
+all rows via `notify ack --all`. Rows are intentionally compact: the visible
+label keeps age, non-info severity, and text; id/source/target remain
+searchable.
 
 `--live` adds a non-mutating explanation view that reads
 `tmux list-panes -a` and compares the queue with live reply-state panes. It

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -342,13 +342,7 @@ func notifySidebarEntries(entries []notify.Notification, now time.Time) []intfzf
 			Window:  e.Window,
 			Pane:    e.Pane,
 		})
-		label := fmt.Sprintf("%-4s %-3s %-4s %-18s %s",
-			formatAge(now.Sub(e.CreatedAt)),
-			strings.ToUpper(shortNotifySeverity(e.Severity)),
-			shortNotifySource(e.Source),
-			target,
-			e.Text,
-		)
+		label := notifySidebarLabel(e, now)
 		out = append(out, intfzf.Entry{
 			Label:     notifyTableCell(label),
 			Value:     e.ID,
@@ -356,6 +350,18 @@ func notifySidebarEntries(entries []notify.Notification, now time.Time) []intfzf
 		})
 	}
 	return out
+}
+
+func notifySidebarLabel(e notify.Notification, now time.Time) string {
+	age := formatAge(now.Sub(e.CreatedAt))
+	text := strings.TrimSpace(e.Text)
+	if text == "" {
+		text = "(empty notification)"
+	}
+	if e.Severity == notify.SeverityInfo || strings.TrimSpace(e.Severity) == "" {
+		return fmt.Sprintf("%-4s %s", age, text)
+	}
+	return fmt.Sprintf("%-4s %-4s %s", age, strings.ToUpper(shortNotifySeverity(e.Severity)), text)
 }
 
 func shortNotifySeverity(severity string) string {

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -267,6 +267,9 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if len(picker.options.Entries) != 1 || picker.options.Entries[0].Value != "abc" {
 		t.Fatalf("entries = %#v", picker.options.Entries)
 	}
+	if label := picker.options.Entries[0].Label; !strings.Contains(label, "WARN deploy ok") || strings.Contains(label, "main:1.0") || strings.Contains(label, " ai ") {
+		t.Fatalf("sidebar label = %q, want compact age/severity/text without target/source columns", label)
+	}
 	if len(picker.options.Bindings) != 0 {
 		t.Fatalf("bindings = %#v, want none; fzf 0.71 rejects click bindings", picker.options.Bindings)
 	}

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -220,9 +220,7 @@ func (c *tmuxCommand) runPopupToggle(args []string, stderr io.Writer) error {
 	marker := popupMarkerPath(popupCtx.ClientKey, mode.Canonical)
 	if _, err := os.Stat(marker); err == nil {
 		targetPane := strings.TrimSpace(popupCtx.OriginPane)
-		if mode.Canonical == "notify-sidebar" {
-			targetPane = ""
-		} else if content, readErr := os.ReadFile(marker); readErr == nil && strings.TrimSpace(string(content)) != "" {
+		if content, readErr := os.ReadFile(marker); readErr == nil && strings.TrimSpace(string(content)) != "" {
 			targetPane = strings.TrimSpace(string(content))
 		}
 		if err := c.closePopup(ctx, targetPane); err != nil {

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -292,7 +292,7 @@ func TestAppRunTmuxPopupToggleOpensNotifySidebarOnRight(t *testing.T) {
 	}
 }
 
-func TestAppRunTmuxPopupToggleClosesNotifySidebarWithoutPaneTarget(t *testing.T) {
+func TestAppRunTmuxPopupToggleClosesNotifySidebarWithMarkerPane(t *testing.T) {
 	t.Parallel()
 
 	clientKey := "/dev/pts/projmux-test-notify-close"
@@ -316,7 +316,7 @@ func TestAppRunTmuxPopupToggleClosesNotifySidebarWithoutPaneTarget(t *testing.T)
 	}
 
 	got := runner.calls[len(runner.calls)-1]
-	want := recordedTmuxCall{name: "tmux", args: []string{"display-popup", "-C"}}
+	want := recordedTmuxCall{name: "tmux", args: []string{"display-popup", "-t", "%original", "-C"}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("close call = %#v, want %#v", got, want)
 	}


### PR DESCRIPTION
## Summary
- restore notify sidebar toggle by closing against the stored origin pane marker
- keep the sidebar anchored to the client right edge
- compact notify sidebar rows to visible age, non-info severity, and text while preserving target/source/id in search

## Verification
- make fmt
- make fix
- go test ./internal/app -run TestNotifyListSidebar|TestAppRunTmuxPopupToggle|TestPopupRightX
- make test
- git diff --check