### PR TITLE
fix(notify): target sidebar popup by client

### DIFF
--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -216,14 +216,20 @@ func (c *tmuxCommand) runPopupToggle(args []string, stderr io.Writer) error {
 	popupCtx := c.popupContext(ctx)
 	if mode.ClientKey != "" {
 		popupCtx.ClientKey = sanitizePopupKey(mode.ClientKey)
+		popupCtx.TargetClient = strings.TrimSpace(mode.ClientKey)
 	}
 	marker := popupMarkerPath(popupCtx.ClientKey, mode.Canonical)
 	if _, err := os.Stat(marker); err == nil {
 		targetPane := strings.TrimSpace(popupCtx.OriginPane)
+		targetClient := ""
 		if content, readErr := os.ReadFile(marker); readErr == nil && strings.TrimSpace(string(content)) != "" {
 			targetPane = strings.TrimSpace(string(content))
 		}
-		if err := c.closePopup(ctx, targetPane); err != nil {
+		if mode.Canonical == "notify-sidebar" {
+			targetPane = ""
+			targetClient = popupCtx.TargetClient
+		}
+		if err := c.closePopup(ctx, targetPane, targetClient); err != nil {
 			return err
 		}
 		_ = os.Remove(marker)
@@ -569,6 +575,7 @@ type tmuxPopupToggleMode struct {
 
 type tmuxPopupContext struct {
 	ClientKey     string
+	TargetClient  string
 	OriginPane    string
 	OriginSession string
 	ContextDir    string
@@ -587,6 +594,7 @@ func (c *tmuxCommand) popupContext(ctx context.Context) tmuxPopupContext {
 
 	return tmuxPopupContext{
 		ClientKey:     sanitizePopupKey(clientKey),
+		TargetClient:  clientKey,
 		OriginPane:    c.tmuxFormat(ctx, "#{pane_id}"),
 		OriginSession: c.tmuxFormat(ctx, "#S"),
 		ContextDir:    c.tmuxFormat(ctx, "#{pane_current_path}"),
@@ -606,8 +614,11 @@ func (c *tmuxCommand) tmuxFormat(ctx context.Context, format string) string {
 	return strings.TrimSpace(string(output))
 }
 
-func (c *tmuxCommand) closePopup(ctx context.Context, targetPane string) error {
+func (c *tmuxCommand) closePopup(ctx context.Context, targetPane, targetClient string) error {
 	args := []string{"display-popup"}
+	if strings.TrimSpace(targetClient) != "" {
+		args = append(args, "-c", targetClient)
+	}
 	if strings.TrimSpace(targetPane) != "" {
 		args = append(args, "-t", targetPane)
 	}
@@ -651,6 +662,7 @@ func buildPopupToggle(mode tmuxPopupToggleMode, binaryPath, marker string, ctx t
 		env["TMUX_SESSIONIZER_CONTEXT_PANE"] = ctx.OriginPane
 		commandArgs = []string{"switch", "--ui=sidebar"}
 	case "notify-sidebar":
+		options.Client = ctx.TargetClient
 		options.Target = ""
 		options.Width = popupSize(ctx.ClientWidth, 24, 64)
 		options.Height = popupSize(ctx.ClientHeight, 100, 20)

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -276,6 +276,7 @@ func TestAppRunTmuxPopupToggleOpensNotifySidebarOnRight(t *testing.T) {
 	got := runner.calls[len(runner.calls)-1]
 	wantPrefix := []string{
 		"display-popup",
+		"-c", "/dev/pts/projmux-test-notify",
 		"-E",
 		"-x", "136",
 		"-y", "0",
@@ -316,7 +317,7 @@ func TestAppRunTmuxPopupToggleClosesNotifySidebarWithMarkerPane(t *testing.T) {
 	}
 
 	got := runner.calls[len(runner.calls)-1]
-	want := recordedTmuxCall{name: "tmux", args: []string{"display-popup", "-t", "%original", "-C"}}
+	want := recordedTmuxCall{name: "tmux", args: []string{"display-popup", "-c", clientKey, "-C"}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("close call = %#v, want %#v", got, want)
 	}

--- a/internal/integrations/tmux/client.go
+++ b/internal/integrations/tmux/client.go
@@ -141,6 +141,7 @@ const (
 )
 
 type PopupOptions struct {
+	Client        string
 	Target        string
 	Cwd           string
 	Env           map[string]string
@@ -550,6 +551,9 @@ func BuildDisplayPopupArgs(command string, options PopupOptions) ([]string, erro
 	}
 
 	args := []string{"display-popup"}
+	if resolved.Client != "" {
+		args = append(args, "-c", resolved.Client)
+	}
 	if resolved.Target != "" {
 		args = append(args, "-t", resolved.Target)
 	}
@@ -854,6 +858,7 @@ func sessionPaneTarget(sessionName, windowIndex, paneIndex string) string {
 
 func resolvePopupOptions(options PopupOptions) (PopupOptions, error) {
 	resolved := PopupOptions{
+		Client:        strings.TrimSpace(options.Client),
 		Target:        strings.TrimSpace(options.Target),
 		Cwd:           strings.TrimSpace(options.Cwd),
 		Env:           cleanPopupEnv(options.Env),

--- a/internal/integrations/tmux/client_test.go
+++ b/internal/integrations/tmux/client_test.go
@@ -1014,6 +1014,7 @@ func TestBuildDisplayPopupArgsMapsStandalonePopupOptions(t *testing.T) {
 	t.Parallel()
 
 	args, err := BuildDisplayPopupArgs("printf hello", PopupOptions{
+		Client: "/dev/pts/7",
 		Target: "%1",
 		Cwd:    "/tmp/work",
 		Env: map[string]string{
@@ -1033,6 +1034,7 @@ func TestBuildDisplayPopupArgsMapsStandalonePopupOptions(t *testing.T) {
 
 	want := []string{
 		"display-popup",
+		"-c", "/dev/pts/7",
 		"-t", "%1",
 		"-E",
 		"-d", "/tmp/work",


### PR DESCRIPTION
## Summary
- Target notify sidebar popup open/close by tmux client with `display-popup -c`.
- Keep sessionizer/sidebar pane-target behavior unchanged.
- Cover client-target popup args and notify sidebar close behavior in tests.

## Verification
- `make fmt`
- `make fix`
- `go test ./internal/app -run 'TestAppRunTmuxPopupToggleOpensNotifySidebarOnRight|TestAppRunTmuxPopupToggleClosesNotifySidebarWithMarkerPane|TestAppRunTmuxPopupToggleOpensStandaloneSidebar|TestPopupRightX'`
- `go test ./internal/integrations/tmux -run TestBuildDisplayPopupArgs`
- `make test`
- `git diff --check`
- Live tmux smoke: `display-popup -c /dev/pts/2 ...` then `display-popup -c /dev/pts/2 -C`
