### PR TITLE
fix(notify): let sidebar close on alt-2

### DIFF
--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -281,6 +281,7 @@ func (c *notifyCommand) runSidebar(entries []notify.Notification, stdout, stderr
 		Header:     "Enter: focus | a: ack selected | Ctrl-A: clear all | Esc: close",
 		Footer:     "focus acks the selected notification",
 		ExpectKeys: []string{"a", "ctrl-a"},
+		Bindings:   []string{"alt-2:abort"},
 		Entries:    notifySidebarEntries(entries, now),
 	}
 	result, err := c.picker.Run(fzfOptions)

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -270,8 +271,8 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if label := picker.options.Entries[0].Label; !strings.Contains(label, "WARN deploy ok") || strings.Contains(label, "main:1.0") || strings.Contains(label, " ai ") {
 		t.Fatalf("sidebar label = %q, want compact age/severity/text without target/source columns", label)
 	}
-	if len(picker.options.Bindings) != 0 {
-		t.Fatalf("bindings = %#v, want none; fzf 0.71 rejects click bindings", picker.options.Bindings)
+	if got, want := picker.options.Bindings, []string{"alt-2:abort"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("bindings = %#v, want %#v", got, want)
 	}
 	if store.ackedID != "abc" {
 		t.Fatalf("ackedID = %q, want abc", store.ackedID)


### PR DESCRIPTION
## Summary
- Add notify sidebar fzf binding `alt-2:abort` so the launcher key closes the focused sidebar like Alt-1 sidebar behavior.
- Keep fzf 0.71-safe keyboard bindings only; no click bindings.

## Verification
- `make fmt`
- `make fix`
- `go test ./internal/app -run TestNotifyListSidebar`
- `make test`
- `git diff --check`
