### PR TITLE
feat(notify): add contextual sidebar badges

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -39,7 +39,7 @@
 - Picker focused unit coverage includes backend-neutral picker item/action mapping, fzf adapter output, native title-focused filtering, numeric selection, and shared close actions.
 - `make test-integration`: Docker-backed Linux integration smoke with real `tmux`, `fzf`, `git`, and `stty`; covers `doctor`, tmux config print/install/apply, and notify queue CRUD against isolated HOME/XDG paths.
 - `make test-install-smoke`: Docker-backed source install smoke; covers `make install`, atomic binary replacement, `tmux apply` against a live `projmux` socket, and post-install notify queue initialization.
-- `make test-e2e`: Docker-backed real-tmux workflow smoke for session/pane setup, app config sourcing, reply-state notify reconciliation, focus notify fallback, and status notify rendering. Host-only terminal, WSL, macOS, and GUI notification behavior remains outside Docker; see [docs/testing.md](testing.md).
+- `make test-e2e`: Docker-backed real-tmux workflow smoke for session/pane setup, app config sourcing, reply-state notify reconciliation, focus notify fallback, and status notify rendering with contextual project/state/agent badges. Host-only terminal, WSL, macOS, and GUI notification behavior remains outside Docker; see [docs/testing.md](testing.md).
 
 ## When To Update This List
 - A feature moves between unit, integration, and e2e coverage levels.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -228,9 +228,9 @@ projmux status notify [--max-width N]
   [bar] N% · weekly [bar] N%`. Degrades through six tiers as `--max-width`
   shrinks. Triggers an opportunistic, throttled refresh (per-adapter
   throttle, `30s` floor) so a stale cache self-heals.
-- `notify` — newest-first HUD pill `[ <agent|SEV> ] <text> · <target> ·
-  <age>   +<extras>`. Degrades through six tiers; default `--max-width`
-  is `200` runes.
+- `notify` — newest-first HUD pill with project, state, optional agent,
+  text, window/pane location, age, and `+<extras>`. Degrades through six
+  tiers; default `--max-width` is `200` runes.
 
 ## statusbar
 

--- a/docs/notify-queue.md
+++ b/docs/notify-queue.md
@@ -191,6 +191,8 @@ trigger a tmux error popup.
 
 `projmux status notify` is the HUD-style renderer wired to the tmux
 status interval. See [statusbar.md](statusbar.md) for the layout and
-the six degradation tiers. The renderer is silent on every failure mode
-(no store, list error, empty queue) so the status line never carries a
-stack trace.
+the six degradation tiers. It shows the newest pending item with a purple
+project badge, a state badge, an optional agent badge, text, window/pane
+location, age, and an extra-count marker. The renderer is silent on every
+failure mode (no store, list error, empty queue) so the status line never
+carries a stack trace.

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -62,6 +62,9 @@ bind-key -n MouseDown1Status if-shell -F "#{==:#{mouse_status_range},window}" \
 `notify` reads the pending queue only. For a live pane-state view that is
 independent of queued reminders, use `projmux attention list`. To explain why
 a live reply badge and the queue disagree, use `projmux notify list --live`.
+The notify segment renders the newest queued item as contextual badges:
+purple project, state (`NEED`/`INFO`/`WARN`/`CRIT`), optional agent, text,
+window/pane location, age, and `+N` for older pending entries.
 `usage` deliberately opens the detailed `projmux usage` table popup; it is the
 clear action surface for the compact HUD bar.
 

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -355,14 +355,72 @@ func notifySidebarEntries(entries []notify.Notification, now time.Time) []intfzf
 
 func notifySidebarLabel(e notify.Notification, now time.Time) string {
 	age := formatAge(now.Sub(e.CreatedAt))
-	text := strings.TrimSpace(e.Text)
+	agent, text := splitAgentPrefix(e)
 	if text == "" {
 		text = "(empty notification)"
 	}
-	if e.Severity == notify.SeverityInfo || strings.TrimSpace(e.Severity) == "" {
-		return fmt.Sprintf("%-4s %s", age, text)
+	parts := []string{
+		fmt.Sprintf("%-4s", age),
+		notifySidebarProjectBadge(notifyProjectName(e.Session)),
+		notifySidebarStateBadge(notifyStateLabel(e, text)),
 	}
-	return fmt.Sprintf("%-4s %-4s %s", age, strings.ToUpper(shortNotifySeverity(e.Severity)), text)
+	if agent != "" {
+		parts = append(parts, notifySidebarAgentBadge(agent))
+	}
+	if target := notifyPaneTarget(e); target != "" {
+		parts = append(parts, notifySidebarDim(target))
+	}
+	parts = append(parts, text)
+	return strings.Join(parts, " ")
+}
+
+const (
+	notifySidebarReset   = "\x1b[0m"
+	notifySidebarDimOpen = "\x1b[38;5;245m"
+	notifySidebarProject = "\x1b[1;38;5;231;48;5;90m"
+	notifySidebarInfo    = "\x1b[1;38;5;16;48;5;45m"
+	notifySidebarWarn    = "\x1b[1;38;5;16;48;5;220m"
+	notifySidebarCrit    = "\x1b[1;38;5;231;48;5;160m"
+	notifySidebarAgent   = "\x1b[1;38;5;16;48;5;51m"
+)
+
+func notifySidebarProjectBadge(project string) string {
+	project = strings.TrimSpace(project)
+	if project == "" {
+		project = "project"
+	}
+	return notifySidebarProject + " " + project + " " + notifySidebarReset
+}
+
+func notifySidebarStateBadge(label string) string {
+	label = strings.ToUpper(strings.TrimSpace(label))
+	if label == "" {
+		label = "INFO"
+	}
+	open := notifySidebarInfo
+	switch label {
+	case "WARN":
+		open = notifySidebarWarn
+	case "CRIT":
+		open = notifySidebarCrit
+	}
+	return open + " " + label + " " + notifySidebarReset
+}
+
+func notifySidebarAgentBadge(agent string) string {
+	agent = strings.TrimSpace(agent)
+	if agent == "" {
+		return ""
+	}
+	return notifySidebarAgent + " " + agent + " " + notifySidebarReset
+}
+
+func notifySidebarDim(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	return notifySidebarDimOpen + value + notifySidebarReset
 }
 
 func shortNotifySeverity(severity string) string {

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -268,8 +268,8 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if len(picker.options.Entries) != 1 || picker.options.Entries[0].Value != "abc" {
 		t.Fatalf("entries = %#v", picker.options.Entries)
 	}
-	if label := picker.options.Entries[0].Label; !strings.Contains(label, "WARN deploy ok") || strings.Contains(label, "main:1.0") || strings.Contains(label, " ai ") {
-		t.Fatalf("sidebar label = %q, want compact age/severity/text without target/source columns", label)
+	if label := picker.options.Entries[0].Label; !strings.Contains(label, " main ") || !strings.Contains(label, " WARN ") || !strings.Contains(label, "w1.p0") || !strings.Contains(label, "deploy ok") || strings.Contains(label, "main:1.0") || strings.Contains(label, " ai ") {
+		t.Fatalf("sidebar label = %q, want project/status/location/text without target/source columns", label)
 	}
 	if got, want := picker.options.Bindings, []string{"alt-2:abort"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("bindings = %#v, want %#v", got, want)

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -364,9 +364,11 @@ func (c *statusCommand) notifyStore() (notifyStore, error) {
 const (
 	notifyDimColor      = "colour245"
 	notifyCountColor    = "colour244"
+	notifyProjectOpen   = "#[bg=colour90,fg=colour231,bold]"
 	notifyBadgeInfoOpen = "#[bg=brightcyan,fg=black,bold]"
 	notifyBadgeWarnOpen = "#[bg=yellow,fg=black,bold]"
 	notifyBadgeCritOpen = "#[bg=red,fg=white,bold]"
+	notifyAgentOpen     = "#[bg=colour51,fg=black,bold]"
 	notifySeverityInfo  = "#[fg=brightcyan]"
 	notifySeverityWarn  = "#[fg=yellow]"
 	notifySeverityCrit  = "#[fg=red,bold]"
@@ -410,10 +412,14 @@ func formatStatusNotify(entries []notify.Notification, maxWidth int, now time.Ti
 	head := entries[0]
 	extras := len(entries) - 1
 
-	badge := renderNotifyBadge(head)
+	agent, text := splitAgentPrefix(head)
+	badge := assembleNotifyBadges(
+		renderNotifyProjectBadge(notifyProjectName(head.Session)),
+		renderNotifyBadge(notifyStateLabel(head, text), head.Severity),
+		renderNotifyAgentBadge(agent),
+	)
 	icon := renderNotifyIcon(head.Severity)
-	_, text := splitAgentPrefix(head)
-	target := compactTarget(head)
+	target := notifyPaneTarget(head)
 	age := ""
 	if !now.IsZero() && !head.CreatedAt.IsZero() {
 		age = formatRelativeAge(now.Sub(head.CreatedAt))
@@ -528,10 +534,36 @@ func tierBudget(maxWidth int, badge, target, age, plus string) int {
 // (` INFO ` / ` WARN ` / ` CRIT `). The badge always carries a trailing
 // `#[default]` so subsequent body text reverts to the terminal default fg
 // (no dim, no bold).
-func renderNotifyBadge(n notify.Notification) string {
-	open := notifyBadgeOpen(n.Severity)
-	label := notifyBadgeLabel(n)
+func assembleNotifyBadges(badges ...string) string {
+	parts := make([]string, 0, len(badges))
+	for _, badge := range badges {
+		badge = strings.TrimSpace(badge)
+		if badge != "" {
+			parts = append(parts, badge)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func renderNotifyProjectBadge(project string) string {
+	project = strings.TrimSpace(project)
+	if project == "" {
+		return ""
+	}
+	return notifyProjectOpen + " " + project + " " + notifyReset
+}
+
+func renderNotifyBadge(label, severity string) string {
+	open := notifyBadgeOpen(severity)
 	return open + " " + label + " " + notifyReset
+}
+
+func renderNotifyAgentBadge(agent string) string {
+	agent = strings.TrimSpace(agent)
+	if agent == "" {
+		return ""
+	}
+	return notifyAgentOpen + " " + agent + " " + notifyReset
 }
 
 // notifyBadgeOpen maps a severity to the bg/fg/bold opening directive for
@@ -548,21 +580,21 @@ func notifyBadgeOpen(severity string) string {
 	}
 }
 
-// notifyBadgeLabel returns the inner text of the badge: the agent name
-// when present, otherwise the severity label (`INFO`/`WARN`/`CRIT`).
-func notifyBadgeLabel(n notify.Notification) string {
-	agent, _ := splitAgentPrefix(n)
-	if agent != "" {
-		return agent
-	}
+func notifyStateLabel(n notify.Notification, text string) string {
 	switch n.Severity {
 	case notify.SeverityWarn:
 		return "WARN"
 	case notify.SeverityCritical:
 		return "CRIT"
-	default:
-		return "INFO"
 	}
+	normalized := strings.ToLower(strings.TrimSpace(text))
+	if n.Source == notify.SourceAI && (strings.Contains(normalized, "reply ready") ||
+		strings.Contains(normalized, "needs reply") ||
+		strings.Contains(normalized, "approval needed") ||
+		strings.Contains(normalized, "waiting for input")) {
+		return "NEED"
+	}
+	return "INFO"
 }
 
 // shrinkText shrinks s so its rune length is at most maxRunes, replacing
@@ -646,6 +678,32 @@ func compactTarget(n notify.Notification) string {
 		}
 	}
 	return out
+}
+
+func notifyProjectName(session string) string {
+	session = strings.TrimSpace(session)
+	if session == "" {
+		return ""
+	}
+	if _, after, ok := strings.Cut(session, "-"); ok && strings.TrimSpace(after) != "" {
+		return strings.TrimSpace(after)
+	}
+	return session
+}
+
+func notifyPaneTarget(n notify.Notification) string {
+	win := strings.TrimSpace(n.Window)
+	pane := strings.TrimSpace(n.Pane)
+	switch {
+	case win != "" && pane != "":
+		return "w" + win + ".p" + pane
+	case win != "":
+		return "w" + win
+	case pane != "":
+		return "p" + pane
+	default:
+		return ""
+	}
 }
 
 // formatRelativeAge renders a duration as `just now`, `<N>s` (only via the

--- a/internal/app/status_notify_test.go
+++ b/internal/app/status_notify_test.go
@@ -53,23 +53,26 @@ func TestStatusNotifyExternalEntryRendersInfoBadge(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[bg=brightcyan,fg=black,bold] INFO #[default]") {
-		t.Fatalf("stdout = %q, want INFO badge prefix", got)
+	if !strings.HasPrefix(got, "#[bg=colour90,fg=colour231,bold] main #[default]") {
+		t.Fatalf("stdout = %q, want project badge prefix", got)
+	}
+	if !strings.Contains(got, "#[bg=brightcyan,fg=black,bold] INFO #[default]") {
+		t.Fatalf("stdout = %q, want INFO badge", got)
 	}
 	if !strings.Contains(got, "hello world") {
 		t.Fatalf("stdout = %q, want body 'hello world'", got)
 	}
-	if !strings.Contains(got, "main:1.0") {
-		t.Fatalf("stdout = %q, want compact target 'main:1.0'", got)
+	if !strings.Contains(got, "w1.p0") {
+		t.Fatalf("stdout = %q, want pane target 'w1.p0'", got)
 	}
 	if !strings.Contains(got, "2m") {
 		t.Fatalf("stdout = %q, want age '2m'", got)
 	}
 	// Body text appears after the badge reset and BEFORE any dim escape —
 	// so the literal " hello world  " region must contain no `#[fg=colour`.
-	bodyStart := strings.Index(got, "#[default]") + len("#[default]")
+	bodyStart := strings.Index(got, " hello world")
 	dimStart := strings.Index(got, "#[fg=colour245]")
-	if bodyStart <= 0 || dimStart <= bodyStart {
+	if bodyStart < 0 || dimStart <= bodyStart {
 		t.Fatalf("stdout = %q, expected default-styled body before dim metadata", got)
 	}
 	body := got[bodyStart:dimStart]
@@ -82,7 +85,7 @@ func TestStatusNotifyExternalEntryRendersInfoBadge(t *testing.T) {
 }
 
 // AI-source entry whose text begins with `claude:` strips the prefix and
-// renders the agent name inside a brightcyan badge.
+// renders project, reply-needed state, and agent badges.
 func TestStatusNotifyAIEntryRendersAgentBadge(t *testing.T) {
 	t.Parallel()
 
@@ -106,8 +109,14 @@ func TestStatusNotifyAIEntryRendersAgentBadge(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[bg=brightcyan,fg=black,bold] claude #[default]") {
-		t.Fatalf("stdout = %q, want claude badge prefix", got)
+	for _, want := range []string{
+		"#[bg=colour90,fg=colour231,bold] s #[default]",
+		"#[bg=brightcyan,fg=black,bold] NEED #[default]",
+		"#[bg=colour51,fg=black,bold] claude #[default]",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, want badge %q", got, want)
+		}
 	}
 	if strings.Contains(got, "claude:") {
 		t.Fatalf("stdout = %q, agent prefix should have been stripped from text", got)
@@ -115,8 +124,8 @@ func TestStatusNotifyAIEntryRendersAgentBadge(t *testing.T) {
 	if !strings.Contains(got, "reply ready · review") {
 		t.Fatalf("stdout = %q, want body 'reply ready · review'", got)
 	}
-	if !strings.Contains(got, "s:1.0") {
-		t.Fatalf("stdout = %q, want compact target", got)
+	if !strings.Contains(got, "w1.p0") {
+		t.Fatalf("stdout = %q, want pane target", got)
 	}
 	if !strings.Contains(got, "#[fg=colour245]") {
 		t.Fatalf("stdout = %q, want dim metadata", got)
@@ -135,8 +144,8 @@ func TestStatusNotifyWarnEntryRendersYellowBadge(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[bg=yellow,fg=black,bold] WARN #[default]") {
-		t.Fatalf("stdout = %q, want yellow WARN badge prefix", got)
+	if !strings.HasPrefix(got, "#[bg=colour90,fg=colour231,bold] ops #[default]") || !strings.Contains(got, "#[bg=yellow,fg=black,bold] WARN #[default]") {
+		t.Fatalf("stdout = %q, want project + yellow WARN badges", got)
 	}
 }
 
@@ -152,8 +161,8 @@ func TestStatusNotifyCriticalEntryRendersRedBadge(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[bg=red,fg=white,bold] CRIT #[default]") {
-		t.Fatalf("stdout = %q, want red CRIT badge prefix", got)
+	if !strings.HasPrefix(got, "#[bg=colour90,fg=colour231,bold] prod #[default]") || !strings.Contains(got, "#[bg=red,fg=white,bold] CRIT #[default]") {
+		t.Fatalf("stdout = %q, want project + red CRIT badges", got)
 	}
 }
 
@@ -171,8 +180,8 @@ func TestStatusNotifyUnknownSeverityFallsBackToInfoBadge(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[bg=brightcyan,fg=black,bold] INFO #[default]") {
-		t.Fatalf("stdout = %q, want INFO fallback badge", got)
+	if !strings.HasPrefix(got, "#[bg=colour90,fg=colour231,bold] s #[default]") || !strings.Contains(got, "#[bg=brightcyan,fg=black,bold] INFO #[default]") {
+		t.Fatalf("stdout = %q, want project + INFO fallback badges", got)
 	}
 }
 
@@ -271,9 +280,11 @@ func TestStatusNotifyWidthTier1Long(t *testing.T) {
 		t.Fatalf("tier1 visualLen=%d > 80: %q", visualLen(out), out)
 	}
 	for _, want := range []string{
-		"#[bg=brightcyan,fg=black,bold] claude #[default]",
+		"#[bg=colour90,fg=colour231,bold] s #[default]",
+		"#[bg=brightcyan,fg=black,bold] NEED #[default]",
+		"#[bg=colour51,fg=black,bold] claude #[default]",
 		"reply ready · review",
-		"s:1.0",
+		"w1.p0",
 		"2m",
 		"+1",
 	} {
@@ -286,18 +297,18 @@ func TestStatusNotifyWidthTier1Long(t *testing.T) {
 func TestStatusNotifyWidthTier2DropsAge(t *testing.T) {
 	t.Parallel()
 
-	// With the canonical fixture the long form is 48 cells, so we pick a
-	// budget tight enough to force the tier-2 fallback (no age) but loose
-	// enough to keep the target.
+	// The project/state/agent badge stack makes this budget tight enough to
+	// drop both age and target while retaining the contextual badges.
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	out := formatStatusNotify(fixtureAIEntry(now), 45, now)
 	if visualLen(out) > 45 {
 		t.Fatalf("tier2 visualLen=%d > 45: %q", visualLen(out), out)
 	}
 	for _, want := range []string{
-		"#[bg=brightcyan,fg=black,bold] claude #[default]",
+		"#[bg=colour90,fg=colour231,bold] s #[default]",
+		"#[bg=brightcyan,fg=black,bold] NEED #[default]",
+		"#[bg=colour51,fg=black,bold] claude #[default]",
 		"reply ready · review",
-		"s:1.0",
 		"+1",
 	} {
 		if !strings.Contains(out, want) {
@@ -306,6 +317,9 @@ func TestStatusNotifyWidthTier2DropsAge(t *testing.T) {
 	}
 	if strings.Contains(out, "2m") {
 		t.Fatalf("tier2 must drop age: %q", out)
+	}
+	if strings.Contains(out, "w1.p0") {
+		t.Fatalf("tier2 must drop target: %q", out)
 	}
 }
 
@@ -318,15 +332,15 @@ func TestStatusNotifyWidthTier3DropsTarget(t *testing.T) {
 		t.Fatalf("tier3 visualLen=%d > 40: %q", visualLen(out), out)
 	}
 	for _, want := range []string{
-		"#[bg=brightcyan,fg=black,bold] claude #[default]",
-		"reply ready · review",
+		"#[bg=colour90,fg=colour231,bold] s #[default]",
+		"#[bg=brightcyan,fg=black,bold] NEED #[default]",
 		"+1",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("tier3 missing %q in %q", want, out)
 		}
 	}
-	if strings.Contains(out, "s:1.0") {
+	if strings.Contains(out, "w1.p0") {
 		t.Fatalf("tier3 must drop target: %q", out)
 	}
 	if strings.Contains(out, "2m") {
@@ -342,8 +356,8 @@ func TestStatusNotifyWidthTier4TruncatesText(t *testing.T) {
 	if visualLen(out) > 24 {
 		t.Fatalf("tier4 visualLen=%d > 24: %q", visualLen(out), out)
 	}
-	if !strings.Contains(out, "#[bg=brightcyan,fg=black,bold] claude #[default]") {
-		t.Fatalf("tier4 should still show badge: %q", out)
+	if strings.Contains(out, "bg=colour90") || strings.Contains(out, "bg=brightcyan") || strings.Contains(out, "bg=colour51") {
+		t.Fatalf("tier4 should drop badges before icon fallback at this width: %q", out)
 	}
 	if !strings.Contains(out, "+1") {
 		t.Fatalf("tier4 should still show count: %q", out)
@@ -399,28 +413,35 @@ func TestStatusNotifyAgentPrefixGracefulFallback(t *testing.T) {
 		name      string
 		text      string
 		wantAgent string // "" means INFO label badge
+		wantState string
 	}{
-		{name: "no colon", text: "reply ready", wantAgent: ""},
-		{name: "unknown agent", text: "gpt: reply ready", wantAgent: ""},
-		{name: "empty body after colon", text: "claude:", wantAgent: ""},
-		{name: "leading colon", text: ":hello", wantAgent: ""},
-		{name: "codex prefix", text: "codex: thought", wantAgent: "codex"},
-		{name: "claude prefix uppercase", text: "Claude: ready", wantAgent: "claude"},
+		{name: "no colon", text: "reply ready", wantAgent: "", wantState: "NEED"},
+		{name: "unknown agent", text: "gpt: reply ready", wantAgent: "", wantState: "NEED"},
+		{name: "empty body after colon", text: "claude:", wantAgent: "", wantState: "INFO"},
+		{name: "leading colon", text: ":hello", wantAgent: "", wantState: "INFO"},
+		{name: "codex prefix", text: "codex: thought", wantAgent: "codex", wantState: "INFO"},
+		{name: "claude prefix uppercase", text: "Claude: ready", wantAgent: "claude", wantState: "INFO"},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			out := formatStatusNotify([]notify.Notification{{
 				ID: "a", Text: tc.text, Severity: notify.SeverityInfo,
 				Source: notify.SourceAI, Session: "s", CreatedAt: now,
 			}}, 0, now)
-			wantBadge := "#[bg=brightcyan,fg=black,bold] INFO #[default]"
-			if tc.wantAgent != "" {
-				wantBadge = "#[bg=brightcyan,fg=black,bold] " + tc.wantAgent + " #[default]"
+			if !strings.HasPrefix(out, "#[bg=colour90,fg=colour231,bold] s #[default]") {
+				t.Fatalf("expected project badge at start of %q", out)
 			}
-			if !strings.HasPrefix(out, wantBadge) {
-				t.Fatalf("expected badge %q at start of %q", wantBadge, out)
+			wantStateBadge := "#[bg=brightcyan,fg=black,bold] " + tc.wantState + " #[default]"
+			if !strings.Contains(out, wantStateBadge) {
+				t.Fatalf("expected state badge %q in %q", wantStateBadge, out)
+			}
+			wantAgentBadge := "#[bg=colour51,fg=black,bold] " + tc.wantAgent + " #[default]"
+			if tc.wantAgent != "" && !strings.Contains(out, wantAgentBadge) {
+				t.Fatalf("expected agent badge %q in %q", wantAgentBadge, out)
+			}
+			if tc.wantAgent == "" && strings.Contains(out, "bg=colour51") {
+				t.Fatalf("did not expect agent badge in %q", out)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Render notify sidebar rows with project, state, optional agent, window/pane, age, and text.
- Align status notify HUD with the same project/state/agent badge model.
- Document the contextual notify segment layout.

## Verification
- go test ./internal/app -run TestNotifyListSidebar|TestStatusNotify
- make test
- make fmt
- make fix
- git diff --check
