### PR TITLE
fix(statusbar): open project sidebar from session badge

### DIFF
--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -52,7 +52,7 @@ bind-key -n MouseDown1Status if-shell -F "#{==:#{mouse_status_range},window}" \
 
 | Range id | Row | Click action                              | Keyboard      |
 | -------- | --- | ----------------------------------------- | ------------- |
-| `session` | 0 | `projmux tmux popup-toggle session-popup` | `prefix s s` |
+| `session` | 0 | `projmux tmux popup-toggle sessionizer-sidebar` | `prefix s s` |
 | `pwd`     | 0 | copy `#{pane_current_path}` to tmux buffer and show a compact path popup | `prefix s p`  |
 | `kube`    | 0 | `projmux tmux popup-toggle sessionizer`   | `prefix s k`  |
 | `git`     | 0 | `projmux tmux popup-toggle sessionizer`   | `prefix s g`  |

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -330,11 +330,11 @@ func (c *statusbarCommand) dispatchTable() map[statusbarRangeID]func(statusbarCl
 	}
 }
 
-// handleSession opens the existing session picker. It uses the same
+// handleSession opens the project sidebar. It uses the same
 // popup-toggle surface as the keyboard bindings so a second click/chord closes
 // the scoped popup instead of stacking another one.
 func (c *statusbarCommand) handleSession(_ statusbarClickOptions, _, stderr io.Writer) error {
-	return c.handlePopupToggle(stderr, "session", "session-popup")
+	return c.handlePopupToggle(stderr, "session", "sessionizer-sidebar")
 }
 
 // handlePwd shows the current pane's path in a small popup and copies it into

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -199,7 +199,7 @@ func TestStatusbarClickUnknownRangeWithMouseWindowSelectsWindow(t *testing.T) {
 	}
 }
 
-func TestStatusbarClickSessionOpensSessionPopup(t *testing.T) {
+func TestStatusbarClickSessionOpensProjectSidebar(t *testing.T) {
 	t.Parallel()
 
 	runner := &statusbarFakeRunner{}
@@ -208,8 +208,8 @@ func TestStatusbarClickSessionOpensSessionPopup(t *testing.T) {
 	if err := cmd.Run([]string{"click", "session"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if !sawProjmuxArgs(runner.calls, []string{"tmux", "popup-toggle", "session-popup"}) {
-		t.Fatalf("missing session popup-toggle; calls = %#v", runner.calls)
+	if !sawProjmuxArgs(runner.calls, []string{"tmux", "popup-toggle", "sessionizer-sidebar"}) {
+		t.Fatalf("missing sessionizer-sidebar popup-toggle; calls = %#v", runner.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Change the status-left session/project badge click to open the left project sidebar.
- Keep the same popup-toggle lifecycle by using sessionizer-sidebar, matching Alt-1.
- Update statusbar docs and unit coverage.

## Verification
- go test ./internal/app -run TestStatusbarClickSessionOpensProjectSidebar
- make test
- git diff --check

Worktree: /home/es5h/source/repos/projmux/.wt/fix/status-project-sidebar-click
