### PR TITLE
fix(notify): use outline status badges

### DIFF
--- a/docs/notify-queue.md
+++ b/docs/notify-queue.md
@@ -191,8 +191,8 @@ trigger a tmux error popup.
 
 `projmux status notify` is the HUD-style renderer wired to the tmux
 status interval. See [statusbar.md](statusbar.md) for the layout and
-the six degradation tiers. It shows the newest pending item with a purple
-project badge, a state badge, an optional agent badge, text, window/pane
-location, age, and an extra-count marker. The renderer is silent on every
-failure mode (no store, list error, empty queue) so the status line never
-carries a stack trace.
+the six degradation tiers. It shows the newest pending item with neutral
+project, state, and optional agent-colored outline badges, plus text,
+window/pane location, age, and an extra-count marker. The renderer is silent
+on every failure mode (no store, list error, empty queue) so the status line
+never carries a stack trace.

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -62,9 +62,10 @@ bind-key -n MouseDown1Status if-shell -F "#{==:#{mouse_status_range},window}" \
 `notify` reads the pending queue only. For a live pane-state view that is
 independent of queued reminders, use `projmux attention list`. To explain why
 a live reply badge and the queue disagree, use `projmux notify list --live`.
-The notify segment renders the newest queued item as contextual badges:
-purple project, state (`NEED`/`INFO`/`WARN`/`CRIT`), optional agent, text,
-window/pane location, age, and `+N` for older pending entries.
+The notify segment renders the newest queued item as contextual outline
+badges: neutral project, state (`NEED`/`INFO`/`WARN`/`CRIT`), optional
+agent-colored outline, text, window/pane location, age, and `+N` for older
+pending entries.
 `usage` deliberately opens the detailed `projmux usage` table popup; it is the
 clear action surface for the compact HUD bar.
 

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -377,11 +377,10 @@ func notifySidebarLabel(e notify.Notification, now time.Time) string {
 const (
 	notifySidebarReset   = "\x1b[0m"
 	notifySidebarDimOpen = "\x1b[38;5;245m"
-	notifySidebarProject = "\x1b[1;38;5;231;48;5;90m"
+	notifySidebarProject = "\x1b[1;38;5;250;48;5;236m"
 	notifySidebarInfo    = "\x1b[1;38;5;16;48;5;45m"
 	notifySidebarWarn    = "\x1b[1;38;5;16;48;5;220m"
 	notifySidebarCrit    = "\x1b[1;38;5;231;48;5;160m"
-	notifySidebarAgent   = "\x1b[1;38;5;16;48;5;51m"
 )
 
 func notifySidebarProjectBadge(project string) string {
@@ -412,7 +411,18 @@ func notifySidebarAgentBadge(agent string) string {
 	if agent == "" {
 		return ""
 	}
-	return notifySidebarAgent + " " + agent + " " + notifySidebarReset
+	return notifySidebarAgentOpen(agent) + " " + agent + " " + notifySidebarReset
+}
+
+func notifySidebarAgentOpen(agent string) string {
+	switch strings.ToLower(strings.TrimSpace(agent)) {
+	case "claude":
+		return "\x1b[1;38;5;16;48;5;208m"
+	case "codex":
+		return "\x1b[1;38;5;231;48;5;33m"
+	default:
+		return "\x1b[1;38;5;16;48;5;51m"
+	}
 }
 
 func notifySidebarDim(value string) string {

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -357,25 +357,24 @@ func (c *statusCommand) notifyStore() (notifyStore, error) {
 }
 
 // HUD-style design tokens for the notify status segment. The leading
-// severity+agent block is rendered as a solid color "badge" (bg fill) so
-// the segment reads as an actual notification pill instead of dim text.
+// project/state/agent badges use colored outlines rather than background
+// fills so they do not compete with the top-row project badge.
 // Reused dim color (`colour245`) keeps the metadata visually consistent
 // with the AI usage segment so the two read as one design family.
 const (
-	notifyDimColor      = "colour245"
-	notifyCountColor    = "colour244"
-	notifyProjectOpen   = "#[bg=colour90,fg=colour231,bold]"
-	notifyBadgeInfoOpen = "#[bg=brightcyan,fg=black,bold]"
-	notifyBadgeWarnOpen = "#[bg=yellow,fg=black,bold]"
-	notifyBadgeCritOpen = "#[bg=red,fg=white,bold]"
-	notifyAgentOpen     = "#[bg=colour51,fg=black,bold]"
-	notifySeverityInfo  = "#[fg=brightcyan]"
-	notifySeverityWarn  = "#[fg=yellow]"
-	notifySeverityCrit  = "#[fg=red,bold]"
-	notifyIcon          = "●"
-	notifyMidDot        = "·"
-	notifyEllipsis      = "…"
-	notifyReset         = "#[default]"
+	notifyDimColor     = "colour245"
+	notifyCountColor   = "colour244"
+	notifyProjectColor = "colour244"
+	notifyBadgeInfo    = "brightcyan"
+	notifyBadgeWarn    = "yellow"
+	notifyBadgeCrit    = "red"
+	notifySeverityInfo = "#[fg=brightcyan]"
+	notifySeverityWarn = "#[fg=yellow]"
+	notifySeverityCrit = "#[fg=red,bold]"
+	notifyIcon         = "●"
+	notifyMidDot       = "·"
+	notifyEllipsis     = "…"
+	notifyReset        = "#[default]"
 )
 
 // known agent prefixes recognised when stripping a leading `<agent>:` from
@@ -387,20 +386,19 @@ var notifyKnownAgents = []string{"claude", "codex"}
 // HUD-style tmux status segment. The output ends with a tmux `#[default]`
 // reset so adjacent segments are not stained by colors.
 //
-// Long form: `[ <agent|LABEL> ] <text>  · <target> · <age>   +<N>`
+// Long form: `<project> <state> [agent] <text>  · <target> · <age>   +<N>`
 //
-// The leading block is a solid color badge (bg=severity, fg=black/white,
-// bold) padded with a single space on each side. The body text uses the
-// terminal default foreground (no dim, no bold) so it pops against the
-// dim metadata that follows it.
+// The leading badges are outline boxes with colored borders and default
+// interior text. The body text uses the terminal default foreground
+// (no dim, no bold) so it pops against the dim metadata that follows it.
 //
 // The renderer degrades through six tiers as `maxWidth` shrinks:
 //
-//  1. Full long form: badge + text + target + age + count.
+//  1. Full long form: outline badges + text + target + age + count.
 //  2. Drop `<age>` (and its preceding `·`).
 //  3. Drop `<target>` (and its preceding `·`).
 //  4. Truncate `<text>` with a trailing `…`.
-//  5. Drop the badge entirely; fall back to a standalone `●` severity icon.
+//  5. Drop the badges entirely; fall back to a standalone `●` severity icon.
 //  6. Hard truncate everything (icon + count are still preserved).
 //
 // `now` is the wall-clock used to compute the relative age. Pass the zero
@@ -476,7 +474,7 @@ func formatStatusNotify(entries []notify.Notification, maxWidth int, now time.Ti
 //
 // Layout: `<badge> <text>  · <target> · <age><plus>`
 //
-// The badge already carries its own bg/fg styling and trailing `#[default]`,
+// The badge group already carries its own fg styling and trailing `#[default]`,
 // so we just concatenate it. The body text inherits the terminal default
 // foreground (deliberately not dim) so it pops next to the dim metadata.
 func assembleNotify(badge, text, target, age, plus string) string {
@@ -528,12 +526,7 @@ func tierBudget(maxWidth int, badge, target, age, plus string) int {
 	return room
 }
 
-// renderNotifyBadge builds the leading severity+agent pill. For ai-source
-// entries with a recognised `<agent>:` prefix, the badge text is the agent
-// name (e.g. ` claude `). Otherwise we fall back to a severity label
-// (` INFO ` / ` WARN ` / ` CRIT `). The badge always carries a trailing
-// `#[default]` so subsequent body text reverts to the terminal default fg
-// (no dim, no bold).
+// assembleNotifyBadges joins the leading project/state/agent outline badges.
 func assembleNotifyBadges(badges ...string) string {
 	parts := make([]string, 0, len(badges))
 	for _, badge := range badges {
@@ -550,12 +543,11 @@ func renderNotifyProjectBadge(project string) string {
 	if project == "" {
 		return ""
 	}
-	return notifyProjectOpen + " " + project + " " + notifyReset
+	return renderNotifyOutlineBadge(project, notifyProjectColor)
 }
 
 func renderNotifyBadge(label, severity string) string {
-	open := notifyBadgeOpen(severity)
-	return open + " " + label + " " + notifyReset
+	return renderNotifyOutlineBadge(label, notifyBadgeColor(severity))
 }
 
 func renderNotifyAgentBadge(agent string) string {
@@ -563,20 +555,43 @@ func renderNotifyAgentBadge(agent string) string {
 	if agent == "" {
 		return ""
 	}
-	return notifyAgentOpen + " " + agent + " " + notifyReset
+	return renderNotifyOutlineBadge(agent, notifyAgentColor(agent))
 }
 
-// notifyBadgeOpen maps a severity to the bg/fg/bold opening directive for
-// the badge. Unknown severities fall through to the info palette so we
-// never emit a stripped escape.
-func notifyBadgeOpen(severity string) string {
+func renderNotifyOutlineBadge(label, color string) string {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return ""
+	}
+	color = strings.TrimSpace(color)
+	if color == "" {
+		color = notifyDimColor
+	}
+	return "#[fg=" + color + ",bold]⟦" + notifyReset + " " + label + " " + "#[fg=" + color + ",bold]⟧" + notifyReset
+}
+
+func notifyAgentColor(agent string) string {
+	switch strings.ToLower(strings.TrimSpace(agent)) {
+	case "claude":
+		return "colour208"
+	case "codex":
+		return "colour33"
+	default:
+		return "colour51"
+	}
+}
+
+// notifyBadgeColor maps a severity to the state outline color. Unknown
+// severities fall through to the info palette so we never emit a stripped
+// escape.
+func notifyBadgeColor(severity string) string {
 	switch severity {
 	case notify.SeverityWarn:
-		return notifyBadgeWarnOpen
+		return notifyBadgeWarn
 	case notify.SeverityCritical:
-		return notifyBadgeCritOpen
+		return notifyBadgeCrit
 	default:
-		return notifyBadgeInfoOpen
+		return notifyBadgeInfo
 	}
 }
 

--- a/internal/app/status_notify_test.go
+++ b/internal/app/status_notify_test.go
@@ -53,10 +53,10 @@ func TestStatusNotifyExternalEntryRendersInfoBadge(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[bg=colour90,fg=colour231,bold] main #[default]") {
+	if !strings.HasPrefix(got, "#[fg=colour244,bold]⟦#[default] main #[fg=colour244,bold]⟧#[default]") {
 		t.Fatalf("stdout = %q, want project badge prefix", got)
 	}
-	if !strings.Contains(got, "#[bg=brightcyan,fg=black,bold] INFO #[default]") {
+	if !strings.Contains(got, "#[fg=brightcyan,bold]⟦#[default] INFO #[fg=brightcyan,bold]⟧#[default]") {
 		t.Fatalf("stdout = %q, want INFO badge", got)
 	}
 	if !strings.Contains(got, "hello world") {
@@ -110,9 +110,9 @@ func TestStatusNotifyAIEntryRendersAgentBadge(t *testing.T) {
 	}
 	got := stdout.String()
 	for _, want := range []string{
-		"#[bg=colour90,fg=colour231,bold] s #[default]",
-		"#[bg=brightcyan,fg=black,bold] NEED #[default]",
-		"#[bg=colour51,fg=black,bold] claude #[default]",
+		"#[fg=colour244,bold]⟦#[default] s #[fg=colour244,bold]⟧#[default]",
+		"#[fg=brightcyan,bold]⟦#[default] NEED #[fg=brightcyan,bold]⟧#[default]",
+		"#[fg=colour208,bold]⟦#[default] claude #[fg=colour208,bold]⟧#[default]",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stdout = %q, want badge %q", got, want)
@@ -144,7 +144,7 @@ func TestStatusNotifyWarnEntryRendersYellowBadge(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[bg=colour90,fg=colour231,bold] ops #[default]") || !strings.Contains(got, "#[bg=yellow,fg=black,bold] WARN #[default]") {
+	if !strings.HasPrefix(got, "#[fg=colour244,bold]⟦#[default] ops #[fg=colour244,bold]⟧#[default]") || !strings.Contains(got, "#[fg=yellow,bold]⟦#[default] WARN #[fg=yellow,bold]⟧#[default]") {
 		t.Fatalf("stdout = %q, want project + yellow WARN badges", got)
 	}
 }
@@ -161,7 +161,7 @@ func TestStatusNotifyCriticalEntryRendersRedBadge(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[bg=colour90,fg=colour231,bold] prod #[default]") || !strings.Contains(got, "#[bg=red,fg=white,bold] CRIT #[default]") {
+	if !strings.HasPrefix(got, "#[fg=colour244,bold]⟦#[default] prod #[fg=colour244,bold]⟧#[default]") || !strings.Contains(got, "#[fg=red,bold]⟦#[default] CRIT #[fg=red,bold]⟧#[default]") {
 		t.Fatalf("stdout = %q, want project + red CRIT badges", got)
 	}
 }
@@ -180,7 +180,7 @@ func TestStatusNotifyUnknownSeverityFallsBackToInfoBadge(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[bg=colour90,fg=colour231,bold] s #[default]") || !strings.Contains(got, "#[bg=brightcyan,fg=black,bold] INFO #[default]") {
+	if !strings.HasPrefix(got, "#[fg=colour244,bold]⟦#[default] s #[fg=colour244,bold]⟧#[default]") || !strings.Contains(got, "#[fg=brightcyan,bold]⟦#[default] INFO #[fg=brightcyan,bold]⟧#[default]") {
 		t.Fatalf("stdout = %q, want project + INFO fallback badges", got)
 	}
 }
@@ -280,10 +280,10 @@ func TestStatusNotifyWidthTier1Long(t *testing.T) {
 		t.Fatalf("tier1 visualLen=%d > 80: %q", visualLen(out), out)
 	}
 	for _, want := range []string{
-		"#[bg=colour90,fg=colour231,bold] s #[default]",
-		"#[bg=brightcyan,fg=black,bold] NEED #[default]",
-		"#[bg=colour51,fg=black,bold] claude #[default]",
-		"reply ready · review",
+		"#[fg=colour244,bold]⟦#[default] s #[fg=colour244,bold]⟧#[default]",
+		"#[fg=brightcyan,bold]⟦#[default] NEED #[fg=brightcyan,bold]⟧#[default]",
+		"#[fg=colour208,bold]⟦#[default] claude #[fg=colour208,bold]⟧#[default]",
+		"reply ready",
 		"w1.p0",
 		"2m",
 		"+1",
@@ -305,10 +305,10 @@ func TestStatusNotifyWidthTier2DropsAge(t *testing.T) {
 		t.Fatalf("tier2 visualLen=%d > 45: %q", visualLen(out), out)
 	}
 	for _, want := range []string{
-		"#[bg=colour90,fg=colour231,bold] s #[default]",
-		"#[bg=brightcyan,fg=black,bold] NEED #[default]",
-		"#[bg=colour51,fg=black,bold] claude #[default]",
-		"reply ready · review",
+		"#[fg=colour244,bold]⟦#[default] s #[fg=colour244,bold]⟧#[default]",
+		"#[fg=brightcyan,bold]⟦#[default] NEED #[fg=brightcyan,bold]⟧#[default]",
+		"#[fg=colour208,bold]⟦#[default] claude #[fg=colour208,bold]⟧#[default]",
+		"reply ready",
 		"+1",
 	} {
 		if !strings.Contains(out, want) {
@@ -332,8 +332,8 @@ func TestStatusNotifyWidthTier3DropsTarget(t *testing.T) {
 		t.Fatalf("tier3 visualLen=%d > 40: %q", visualLen(out), out)
 	}
 	for _, want := range []string{
-		"#[bg=colour90,fg=colour231,bold] s #[default]",
-		"#[bg=brightcyan,fg=black,bold] NEED #[default]",
+		"#[fg=colour244,bold]⟦#[default] s #[fg=colour244,bold]⟧#[default]",
+		"#[fg=brightcyan,bold]⟦#[default] NEED #[fg=brightcyan,bold]⟧#[default]",
 		"+1",
 	} {
 		if !strings.Contains(out, want) {
@@ -356,7 +356,7 @@ func TestStatusNotifyWidthTier4TruncatesText(t *testing.T) {
 	if visualLen(out) > 24 {
 		t.Fatalf("tier4 visualLen=%d > 24: %q", visualLen(out), out)
 	}
-	if strings.Contains(out, "bg=colour90") || strings.Contains(out, "bg=brightcyan") || strings.Contains(out, "bg=colour51") {
+	if strings.Contains(out, "⟦") {
 		t.Fatalf("tier4 should drop badges before icon fallback at this width: %q", out)
 	}
 	if !strings.Contains(out, "+1") {
@@ -367,8 +367,8 @@ func TestStatusNotifyWidthTier4TruncatesText(t *testing.T) {
 	}
 }
 
-// Tier 5 drops the bg-filled badge. The standalone severity-tinted `●`
-// icon (no bg fill) preserves a minimal severity hint for very narrow
+// Tier 5 drops the outline badges. The standalone severity-tinted `●`
+// icon preserves a minimal severity hint for very narrow
 // statuslines.
 func TestStatusNotifyWidthTier5DropsBadge(t *testing.T) {
 	t.Parallel()
@@ -378,8 +378,8 @@ func TestStatusNotifyWidthTier5DropsBadge(t *testing.T) {
 	if visualLen(out) > 14 {
 		t.Fatalf("tier5 visualLen=%d > 14: %q", visualLen(out), out)
 	}
-	if strings.Contains(out, "bg=brightcyan") {
-		t.Fatalf("tier5 must drop the bg-filled badge: %q", out)
+	if strings.Contains(out, "⟦") {
+		t.Fatalf("tier5 must drop the outline badges: %q", out)
 	}
 	if strings.Contains(out, "claude") {
 		t.Fatalf("tier5 must drop the agent label: %q", out)
@@ -429,18 +429,25 @@ func TestStatusNotifyAgentPrefixGracefulFallback(t *testing.T) {
 				ID: "a", Text: tc.text, Severity: notify.SeverityInfo,
 				Source: notify.SourceAI, Session: "s", CreatedAt: now,
 			}}, 0, now)
-			if !strings.HasPrefix(out, "#[bg=colour90,fg=colour231,bold] s #[default]") {
+			if !strings.HasPrefix(out, "#[fg=colour244,bold]⟦#[default] s #[fg=colour244,bold]⟧#[default]") {
 				t.Fatalf("expected project badge at start of %q", out)
 			}
-			wantStateBadge := "#[bg=brightcyan,fg=black,bold] " + tc.wantState + " #[default]"
+			wantStateBadge := "#[fg=brightcyan,bold]⟦#[default] " + tc.wantState + " #[fg=brightcyan,bold]⟧#[default]"
 			if !strings.Contains(out, wantStateBadge) {
 				t.Fatalf("expected state badge %q in %q", wantStateBadge, out)
 			}
-			wantAgentBadge := "#[bg=colour51,fg=black,bold] " + tc.wantAgent + " #[default]"
+			wantAgentColor := "colour51"
+			switch tc.wantAgent {
+			case "claude":
+				wantAgentColor = "colour208"
+			case "codex":
+				wantAgentColor = "colour33"
+			}
+			wantAgentBadge := "#[fg=" + wantAgentColor + ",bold]⟦#[default] " + tc.wantAgent + " #[fg=" + wantAgentColor + ",bold]⟧#[default]"
 			if tc.wantAgent != "" && !strings.Contains(out, wantAgentBadge) {
 				t.Fatalf("expected agent badge %q in %q", wantAgentBadge, out)
 			}
-			if tc.wantAgent == "" && strings.Contains(out, "bg=colour51") {
+			if tc.wantAgent == "" && (strings.Contains(out, "fg=colour51") || strings.Contains(out, "fg=colour208") || strings.Contains(out, "fg=colour33")) {
 				t.Fatalf("did not expect agent badge in %q", out)
 			}
 		})


### PR DESCRIPTION
## Summary
- render lower notify status badges as colored outlines instead of filled blocks
- move notify project color to a neutral palette so it does not compete with the top project badge
- keep the notify sidebar readable with neutral project blocks and agent-colored agent blocks

## Verification
- go test ./internal/app -run 'TestStatusNotify|TestNotifyListSidebar'\n- make test\n- make fmt\n- make fix (reverted unrelated go fix churn)\n- git diff --check