### PR TITLE
fix(notify): render compact HUD as notification block

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -178,7 +178,8 @@ projmux notify reconcile [--json]
   queue entries whose live pane no longer matches. `--ui=sidebar` opens the
   compact interactive notify list where Enter focuses and acks a target, `a`
   acks the selected row, and `Ctrl-A` clears all. The sidebar row keeps target
-  details searchable but displays only age, non-info severity, and text.
+  details searchable but displays only age, project, state, optional agent, and
+  text.
 - `ack <id>` removes one entry; `--all` flushes the queue.
 - `reconcile` — walks `tmux list-panes -a` and back-fills entries for
   panes whose attention state is `reply` AND whose AI agent option is
@@ -228,9 +229,10 @@ projmux status notify [--max-width N]
   [bar] N% · weekly [bar] N%`. Degrades through six tiers as `--max-width`
   shrinks. Triggers an opportunistic, throttled refresh (per-adapter
   throttle, `30s` floor) so a stale cache self-heals.
-- `notify` — newest-first HUD pill with project, state, optional agent,
-  text, window/pane location, age, and `+<extras>`. Degrades through six
-  tiers; default `--max-width` is `200` runes.
+- `notify` — newest-first HUD block with project, state, optional agent, text,
+  age, and `+<extras>`. Window/pane ids remain routable metadata but are not
+  displayed in the compact HUD. Degrades through width tiers; default
+  `--max-width` is `200` runes.
 
 ## statusbar
 

--- a/docs/notify-queue.md
+++ b/docs/notify-queue.md
@@ -191,8 +191,8 @@ trigger a tmux error popup.
 
 `projmux status notify` is the HUD-style renderer wired to the tmux
 status interval. See [statusbar.md](statusbar.md) for the layout and
-the six degradation tiers. It shows the newest pending item with neutral
-project, state, and optional agent-colored outline badges, plus text,
-window/pane location, age, and an extra-count marker. The renderer is silent
-on every failure mode (no store, list error, empty queue) so the status line
-never carries a stack trace.
+degradation tiers. It shows the newest pending item as a single notification
+block with project, state, optional agent, text, age, and an extra-count
+marker. Window/pane ids remain routable metadata but are not displayed in the
+compact HUD. The renderer is silent on every failure mode (no store, list
+error, empty queue) so the status line never carries a stack trace.

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -62,10 +62,10 @@ bind-key -n MouseDown1Status if-shell -F "#{==:#{mouse_status_range},window}" \
 `notify` reads the pending queue only. For a live pane-state view that is
 independent of queued reminders, use `projmux attention list`. To explain why
 a live reply badge and the queue disagree, use `projmux notify list --live`.
-The notify segment renders the newest queued item as contextual outline
-badges: neutral project, state (`NEED`/`INFO`/`WARN`/`CRIT`), optional
-agent-colored outline, text, window/pane location, age, and `+N` for older
-pending entries.
+The notify segment renders the newest queued item as a single notification
+block: project, state (`NEED`/`INFO`/`WARN`/`CRIT`), optional agent, text,
+age, and `+N` for older pending entries. Window/pane ids are not shown in the
+compact status segment.
 `usage` deliberately opens the detailed `projmux usage` table popup; it is the
 clear action surface for the compact HUD bar.
 

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -367,9 +367,6 @@ func notifySidebarLabel(e notify.Notification, now time.Time) string {
 	if agent != "" {
 		parts = append(parts, notifySidebarAgentBadge(agent))
 	}
-	if target := notifyPaneTarget(e); target != "" {
-		parts = append(parts, notifySidebarDim(target))
-	}
 	parts = append(parts, text)
 	return strings.Join(parts, " ")
 }
@@ -377,7 +374,7 @@ func notifySidebarLabel(e notify.Notification, now time.Time) string {
 const (
 	notifySidebarReset   = "\x1b[0m"
 	notifySidebarDimOpen = "\x1b[38;5;245m"
-	notifySidebarProject = "\x1b[1;38;5;250;48;5;236m"
+	notifySidebarProject = "\x1b[1;38;5;231;48;5;90m"
 	notifySidebarInfo    = "\x1b[1;38;5;16;48;5;45m"
 	notifySidebarWarn    = "\x1b[1;38;5;16;48;5;220m"
 	notifySidebarCrit    = "\x1b[1;38;5;231;48;5;160m"

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -268,8 +268,8 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if len(picker.options.Entries) != 1 || picker.options.Entries[0].Value != "abc" {
 		t.Fatalf("entries = %#v", picker.options.Entries)
 	}
-	if label := picker.options.Entries[0].Label; !strings.Contains(label, " main ") || !strings.Contains(label, " WARN ") || !strings.Contains(label, "w1.p0") || !strings.Contains(label, "deploy ok") || strings.Contains(label, "main:1.0") || strings.Contains(label, " ai ") {
-		t.Fatalf("sidebar label = %q, want project/status/location/text without target/source columns", label)
+	if label := picker.options.Entries[0].Label; !strings.Contains(label, " main ") || !strings.Contains(label, " WARN ") || !strings.Contains(label, "deploy ok") || strings.Contains(label, "w1.p0") || strings.Contains(label, "main:1.0") || strings.Contains(label, " ai ") {
+		t.Fatalf("sidebar label = %q, want project/status/text without target/source columns", label)
 	}
 	if got, want := picker.options.Bindings, []string{"alt-2:abort"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("bindings = %#v, want %#v", got, want)

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -356,25 +356,27 @@ func (c *statusCommand) notifyStore() (notifyStore, error) {
 	return c.notifyStoreFn()
 }
 
-// HUD-style design tokens for the notify status segment. The leading
-// project/state/agent badges use colored outlines rather than background
-// fills so they do not compete with the top-row project badge.
-// Reused dim color (`colour245`) keeps the metadata visually consistent
-// with the AI usage segment so the two read as one design family.
+// HUD-style design tokens for the notify status segment. The whole segment
+// carries a notification-colored background; badges are stronger blocks on top
+// of that same line instead of separate outline glyphs.
 const (
-	notifyDimColor     = "colour245"
-	notifyCountColor   = "colour244"
-	notifyProjectColor = "colour244"
-	notifyBadgeInfo    = "brightcyan"
-	notifyBadgeWarn    = "yellow"
-	notifyBadgeCrit    = "red"
-	notifySeverityInfo = "#[fg=brightcyan]"
-	notifySeverityWarn = "#[fg=yellow]"
-	notifySeverityCrit = "#[fg=red,bold]"
-	notifyIcon         = "●"
-	notifyMidDot       = "·"
-	notifyEllipsis     = "…"
-	notifyReset        = "#[default]"
+	notifyLineOpen      = "#[bg=colour24,fg=colour231]"
+	notifyLineDimOpen   = "#[bg=colour24,fg=colour117]"
+	notifyLineCountOpen = "#[bg=colour24,fg=colour153,bold]"
+	notifyProjectOpen   = "#[bg=colour31,fg=colour231,bold]"
+	notifyBadgeInfoOpen = "#[bg=brightcyan,fg=black,bold]"
+	notifyBadgeWarnOpen = "#[bg=yellow,fg=black,bold]"
+	notifyBadgeCritOpen = "#[bg=red,fg=white,bold]"
+	notifyAgentOpen     = "#[bg=colour51,fg=black,bold]"
+	notifyAgentClaude   = "#[bg=colour208,fg=black,bold]"
+	notifyAgentCodex    = "#[bg=colour33,fg=colour231,bold]"
+	notifySeverityInfo  = "#[bg=colour24,fg=brightcyan]"
+	notifySeverityWarn  = "#[bg=colour24,fg=yellow]"
+	notifySeverityCrit  = "#[bg=colour24,fg=red,bold]"
+	notifyIcon          = "●"
+	notifyMidDot        = "·"
+	notifyEllipsis      = "…"
+	notifyReset         = "#[default]"
 )
 
 // known agent prefixes recognised when stripping a leading `<agent>:` from
@@ -386,20 +388,18 @@ var notifyKnownAgents = []string{"claude", "codex"}
 // HUD-style tmux status segment. The output ends with a tmux `#[default]`
 // reset so adjacent segments are not stained by colors.
 //
-// Long form: `<project> <state> [agent] <text>  · <target> · <age>   +<N>`
+// Long form: `<project> <state> [agent] <text>  · <age>   +<N>`
 //
-// The leading badges are outline boxes with colored borders and default
-// interior text. The body text uses the terminal default foreground
-// (no dim, no bold) so it pops against the dim metadata that follows it.
+// The segment background carries the notification affordance. The body text
+// uses the line foreground so it stays readable next to the stronger badges.
 //
-// The renderer degrades through six tiers as `maxWidth` shrinks:
+// The renderer degrades through five tiers as `maxWidth` shrinks:
 //
-//  1. Full long form: outline badges + text + target + age + count.
+//  1. Full long form: line block + badges + text + age + count.
 //  2. Drop `<age>` (and its preceding `·`).
-//  3. Drop `<target>` (and its preceding `·`).
-//  4. Truncate `<text>` with a trailing `…`.
-//  5. Drop the badges entirely; fall back to a standalone `●` severity icon.
-//  6. Hard truncate everything (icon + count are still preserved).
+//  3. Truncate `<text>` with a trailing `…`.
+//  4. Drop the badges entirely; fall back to a standalone `●` severity icon.
+//  5. Hard truncate everything (icon + count are still preserved).
 //
 // `now` is the wall-clock used to compute the relative age. Pass the zero
 // time to suppress the age field entirely.
@@ -417,33 +417,30 @@ func formatStatusNotify(entries []notify.Notification, maxWidth int, now time.Ti
 		renderNotifyAgentBadge(agent),
 	)
 	icon := renderNotifyIcon(head.Severity)
-	target := notifyPaneTarget(head)
 	age := ""
 	if !now.IsZero() && !head.CreatedAt.IsZero() {
 		age = formatRelativeAge(now.Sub(head.CreatedAt))
 	}
 	plus := ""
 	if extras > 0 {
-		plus = fmt.Sprintf("   #[fg=%s]+%d%s", notifyCountColor, extras, notifyReset)
+		plus = fmt.Sprintf("   %s+%d%s", notifyLineCountOpen, extras, notifyLineOpen)
 	}
 
 	tiers := []func() string{
 		// Tier 1: full long form.
-		func() string { return assembleNotify(badge, text, target, age, plus) },
+		func() string { return assembleNotify(badge, text, age, plus) },
 		// Tier 2: drop age.
-		func() string { return assembleNotify(badge, text, target, "", plus) },
-		// Tier 3: drop target (and age).
-		func() string { return assembleNotify(badge, text, "", "", plus) },
-		// Tier 4: truncate text with trailing ellipsis.
+		func() string { return assembleNotify(badge, text, "", plus) },
+		// Tier 3: truncate text with trailing ellipsis.
 		func() string {
-			budget := tierBudget(maxWidth, badge, "", "", plus)
+			budget := tierBudget(maxWidth, badge, "", plus)
 			truncated := shrinkText(text, budget)
-			return assembleNotify(badge, truncated, "", "", plus)
+			return assembleNotify(badge, truncated, "", plus)
 		},
-		// Tier 5: drop badge — fall back to bare severity icon + text.
+		// Tier 4: drop badge — fall back to bare severity icon + text.
 		func() string {
 			iconLead := icon + "  "
-			budget := tierBudget(maxWidth, iconLead, "", "", plus)
+			budget := tierBudget(maxWidth, iconLead, "", plus)
 			truncated := shrinkText(text, budget)
 			if truncated == "" {
 				return iconLead + plus
@@ -457,7 +454,7 @@ func formatStatusNotify(entries []notify.Notification, maxWidth int, now time.Ti
 			continue
 		}
 		if maxWidth <= 0 || visualLen(out) <= maxWidth {
-			return out + notifyReset
+			return notifyLineOpen + out + notifyReset
 		}
 	}
 
@@ -465,44 +462,31 @@ func formatStatusNotify(entries []notify.Notification, maxWidth int, now time.Ti
 	// in between. The reset directive is appended unconditionally so we
 	// never leak color into the next segment.
 	short := icon + "  " + text + plus
-	return truncateWithEllipsis(short, maxWidth) + notifyReset
+	return notifyLineOpen + truncateWithEllipsis(short, maxWidth) + notifyReset
 }
 
 // assembleNotify glues the long-form parts together. Empty parts are
 // omitted along with their preceding separator so we can reuse this for
 // every degradation tier.
 //
-// Layout: `<badge> <text>  · <target> · <age><plus>`
+// Layout: `<badge> <text>  · <age><plus>`
 //
-// The badge group already carries its own fg styling and trailing `#[default]`,
-// so we just concatenate it. The body text inherits the terminal default
-// foreground (deliberately not dim) so it pops next to the dim metadata.
-func assembleNotify(badge, text, target, age, plus string) string {
+// The badge group already restores `notifyLineOpen`, so subsequent text stays
+// on the notification background.
+func assembleNotify(badge, text, age, plus string) string {
 	var b strings.Builder
 	b.WriteString(badge)
 	if text != "" {
 		b.WriteString(" ")
 		b.WriteString(text)
 	}
-	if target != "" {
-		b.WriteString("  ")
-		b.WriteString("#[fg=")
-		b.WriteString(notifyDimColor)
-		b.WriteString("]")
-		b.WriteString(notifyMidDot)
-		b.WriteString(" ")
-		b.WriteString(target)
-		b.WriteString(notifyReset)
-	}
 	if age != "" {
 		b.WriteString(" ")
-		b.WriteString("#[fg=")
-		b.WriteString(notifyDimColor)
-		b.WriteString("]")
+		b.WriteString(notifyLineDimOpen)
 		b.WriteString(notifyMidDot)
 		b.WriteString(" ")
 		b.WriteString(age)
-		b.WriteString(notifyReset)
+		b.WriteString(notifyLineOpen)
 	}
 	if plus != "" {
 		b.WriteString(plus)
@@ -516,17 +500,17 @@ func assembleNotify(badge, text, target, age, plus string) string {
 //
 // The text is rendered with a single leading space, which we charge back
 // here so callers don't need to know the assembly's gap rules.
-func tierBudget(maxWidth int, badge, target, age, plus string) int {
+func tierBudget(maxWidth int, badge, age, plus string) int {
 	if maxWidth <= 0 {
 		return 0
 	}
-	overhead := visualLen(assembleNotify(badge, "", target, age, plus))
+	overhead := visualLen(assembleNotify(badge, "", age, plus))
 	textGap := 1
 	room := max(maxWidth-overhead-textGap, 1)
 	return room
 }
 
-// assembleNotifyBadges joins the leading project/state/agent outline badges.
+// assembleNotifyBadges joins the leading project/state/agent block badges.
 func assembleNotifyBadges(badges ...string) string {
 	parts := make([]string, 0, len(badges))
 	for _, badge := range badges {
@@ -543,11 +527,11 @@ func renderNotifyProjectBadge(project string) string {
 	if project == "" {
 		return ""
 	}
-	return renderNotifyOutlineBadge(project, notifyProjectColor)
+	return renderNotifyBlockBadge(project, notifyProjectOpen)
 }
 
 func renderNotifyBadge(label, severity string) string {
-	return renderNotifyOutlineBadge(label, notifyBadgeColor(severity))
+	return renderNotifyBlockBadge(label, notifyBadgeOpen(severity))
 }
 
 func renderNotifyAgentBadge(agent string) string {
@@ -555,43 +539,43 @@ func renderNotifyAgentBadge(agent string) string {
 	if agent == "" {
 		return ""
 	}
-	return renderNotifyOutlineBadge(agent, notifyAgentColor(agent))
+	return renderNotifyBlockBadge(agent, notifyAgentOpenFor(agent))
 }
 
-func renderNotifyOutlineBadge(label, color string) string {
+func renderNotifyBlockBadge(label, open string) string {
 	label = strings.TrimSpace(label)
 	if label == "" {
 		return ""
 	}
-	color = strings.TrimSpace(color)
-	if color == "" {
-		color = notifyDimColor
+	open = strings.TrimSpace(open)
+	if open == "" {
+		open = notifyProjectOpen
 	}
-	return "#[fg=" + color + ",bold]⟦" + notifyReset + " " + label + " " + "#[fg=" + color + ",bold]⟧" + notifyReset
+	return open + " " + label + " " + notifyLineOpen
 }
 
-func notifyAgentColor(agent string) string {
+func notifyAgentOpenFor(agent string) string {
 	switch strings.ToLower(strings.TrimSpace(agent)) {
 	case "claude":
-		return "colour208"
+		return notifyAgentClaude
 	case "codex":
-		return "colour33"
+		return notifyAgentCodex
 	default:
-		return "colour51"
+		return notifyAgentOpen
 	}
 }
 
-// notifyBadgeColor maps a severity to the state outline color. Unknown
+// notifyBadgeOpen maps a severity to the state block color. Unknown
 // severities fall through to the info palette so we never emit a stripped
 // escape.
-func notifyBadgeColor(severity string) string {
+func notifyBadgeOpen(severity string) string {
 	switch severity {
 	case notify.SeverityWarn:
-		return notifyBadgeWarn
+		return notifyBadgeWarnOpen
 	case notify.SeverityCritical:
-		return notifyBadgeCrit
+		return notifyBadgeCritOpen
 	default:
-		return notifyBadgeInfo
+		return notifyBadgeInfoOpen
 	}
 }
 
@@ -640,7 +624,7 @@ func renderNotifyIcon(severity string) string {
 	case notify.SeverityCritical:
 		color = notifySeverityCrit
 	}
-	return color + notifyIcon + notifyReset
+	return color + notifyIcon + notifyLineOpen
 }
 
 // splitAgentPrefix extracts the leading `<agent>:` from the queue entry's
@@ -675,26 +659,6 @@ func isKnownAgent(name string) bool {
 	return slices.Contains(notifyKnownAgents, name)
 }
 
-// compactTarget renders the entry's target as `<sess>:<window>.<pane>`.
-// Empty session yields the empty string; empty window/pane segments are
-// dropped so we never emit dangling `:` or `.` separators.
-func compactTarget(n notify.Notification) string {
-	sess := strings.TrimSpace(n.Session)
-	if sess == "" {
-		return ""
-	}
-	out := sess
-	win := strings.TrimSpace(n.Window)
-	if win != "" {
-		out += ":" + win
-		pane := strings.TrimSpace(n.Pane)
-		if pane != "" {
-			out += "." + pane
-		}
-	}
-	return out
-}
-
 func notifyProjectName(session string) string {
 	session = strings.TrimSpace(session)
 	if session == "" {
@@ -704,21 +668,6 @@ func notifyProjectName(session string) string {
 		return strings.TrimSpace(after)
 	}
 	return session
-}
-
-func notifyPaneTarget(n notify.Notification) string {
-	win := strings.TrimSpace(n.Window)
-	pane := strings.TrimSpace(n.Pane)
-	switch {
-	case win != "" && pane != "":
-		return "w" + win + ".p" + pane
-	case win != "":
-		return "w" + win
-	case pane != "":
-		return "p" + pane
-	default:
-		return ""
-	}
 }
 
 // formatRelativeAge renders a duration as `just now`, `<N>s` (only via the

--- a/internal/app/status_notify_test.go
+++ b/internal/app/status_notify_test.go
@@ -53,31 +53,26 @@ func TestStatusNotifyExternalEntryRendersInfoBadge(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[fg=colour244,bold]⟦#[default] main #[fg=colour244,bold]⟧#[default]") {
+	if !strings.HasPrefix(got, notifyLineOpen+renderNotifyProjectBadge("main")) {
 		t.Fatalf("stdout = %q, want project badge prefix", got)
 	}
-	if !strings.Contains(got, "#[fg=brightcyan,bold]⟦#[default] INFO #[fg=brightcyan,bold]⟧#[default]") {
+	if !strings.Contains(got, renderNotifyBadge("INFO", notify.SeverityInfo)) {
 		t.Fatalf("stdout = %q, want INFO badge", got)
 	}
 	if !strings.Contains(got, "hello world") {
 		t.Fatalf("stdout = %q, want body 'hello world'", got)
 	}
-	if !strings.Contains(got, "w1.p0") {
-		t.Fatalf("stdout = %q, want pane target 'w1.p0'", got)
+	if strings.Contains(got, "w1.p0") {
+		t.Fatalf("stdout = %q, must not include pane target", got)
 	}
 	if !strings.Contains(got, "2m") {
 		t.Fatalf("stdout = %q, want age '2m'", got)
 	}
-	// Body text appears after the badge reset and BEFORE any dim escape —
-	// so the literal " hello world  " region must contain no `#[fg=colour`.
+	// Body text appears after the badge reset and before any dim metadata.
 	bodyStart := strings.Index(got, " hello world")
-	dimStart := strings.Index(got, "#[fg=colour245]")
+	dimStart := strings.Index(got, notifyLineDimOpen)
 	if bodyStart < 0 || dimStart <= bodyStart {
-		t.Fatalf("stdout = %q, expected default-styled body before dim metadata", got)
-	}
-	body := got[bodyStart:dimStart]
-	if strings.Contains(body, "#[") {
-		t.Fatalf("body region %q must be unstyled (default fg)", body)
+		t.Fatalf("stdout = %q, expected body before dim metadata", got)
 	}
 	if !strings.HasSuffix(got, "#[default]") {
 		t.Fatalf("stdout = %q, want trailing '#[default]'", got)
@@ -110,9 +105,9 @@ func TestStatusNotifyAIEntryRendersAgentBadge(t *testing.T) {
 	}
 	got := stdout.String()
 	for _, want := range []string{
-		"#[fg=colour244,bold]⟦#[default] s #[fg=colour244,bold]⟧#[default]",
-		"#[fg=brightcyan,bold]⟦#[default] NEED #[fg=brightcyan,bold]⟧#[default]",
-		"#[fg=colour208,bold]⟦#[default] claude #[fg=colour208,bold]⟧#[default]",
+		notifyLineOpen + renderNotifyProjectBadge("s"),
+		renderNotifyBadge("NEED", notify.SeverityInfo),
+		renderNotifyAgentBadge("claude"),
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stdout = %q, want badge %q", got, want)
@@ -124,10 +119,10 @@ func TestStatusNotifyAIEntryRendersAgentBadge(t *testing.T) {
 	if !strings.Contains(got, "reply ready · review") {
 		t.Fatalf("stdout = %q, want body 'reply ready · review'", got)
 	}
-	if !strings.Contains(got, "w1.p0") {
-		t.Fatalf("stdout = %q, want pane target", got)
+	if strings.Contains(got, "w1.p0") {
+		t.Fatalf("stdout = %q, must not include pane target", got)
 	}
-	if !strings.Contains(got, "#[fg=colour245]") {
+	if !strings.Contains(got, notifyLineDimOpen) {
 		t.Fatalf("stdout = %q, want dim metadata", got)
 	}
 }
@@ -144,7 +139,7 @@ func TestStatusNotifyWarnEntryRendersYellowBadge(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[fg=colour244,bold]⟦#[default] ops #[fg=colour244,bold]⟧#[default]") || !strings.Contains(got, "#[fg=yellow,bold]⟦#[default] WARN #[fg=yellow,bold]⟧#[default]") {
+	if !strings.HasPrefix(got, notifyLineOpen+renderNotifyProjectBadge("ops")) || !strings.Contains(got, renderNotifyBadge("WARN", notify.SeverityWarn)) {
 		t.Fatalf("stdout = %q, want project + yellow WARN badges", got)
 	}
 }
@@ -161,7 +156,7 @@ func TestStatusNotifyCriticalEntryRendersRedBadge(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[fg=colour244,bold]⟦#[default] prod #[fg=colour244,bold]⟧#[default]") || !strings.Contains(got, "#[fg=red,bold]⟦#[default] CRIT #[fg=red,bold]⟧#[default]") {
+	if !strings.HasPrefix(got, notifyLineOpen+renderNotifyProjectBadge("prod")) || !strings.Contains(got, renderNotifyBadge("CRIT", notify.SeverityCritical)) {
 		t.Fatalf("stdout = %q, want project + red CRIT badges", got)
 	}
 }
@@ -180,7 +175,7 @@ func TestStatusNotifyUnknownSeverityFallsBackToInfoBadge(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	got := stdout.String()
-	if !strings.HasPrefix(got, "#[fg=colour244,bold]⟦#[default] s #[fg=colour244,bold]⟧#[default]") || !strings.Contains(got, "#[fg=brightcyan,bold]⟦#[default] INFO #[fg=brightcyan,bold]⟧#[default]") {
+	if !strings.HasPrefix(got, notifyLineOpen+renderNotifyProjectBadge("s")) || !strings.Contains(got, renderNotifyBadge("INFO", notify.SeverityInfo)) {
 		t.Fatalf("stdout = %q, want project + INFO fallback badges", got)
 	}
 }
@@ -205,7 +200,7 @@ func TestStatusNotifyMultipleEntriesAppendsPlusCount(t *testing.T) {
 	if !strings.Contains(got, "newest") {
 		t.Fatalf("stdout = %q, want headline 'newest'", got)
 	}
-	if !strings.Contains(got, "#[fg=colour244]+2#[default]") {
+	if !strings.Contains(got, notifyLineCountOpen+"+2"+notifyLineOpen) {
 		t.Fatalf("stdout = %q, want dim count escape", got)
 	}
 }
@@ -244,8 +239,7 @@ func TestStatusNotifyMissingStoreFactoryReturnsEmpty(t *testing.T) {
 }
 
 // fixtureAIEntry returns a canonical ai-source claude entry (2m old) used
-// by the width-tier table. Target is the spec example `s:1.0` so the long
-// form fits inside the 80-rune budget.
+// by the width-tier table.
 func fixtureAIEntry(now time.Time) []notify.Notification {
 	return []notify.Notification{
 		{
@@ -280,11 +274,10 @@ func TestStatusNotifyWidthTier1Long(t *testing.T) {
 		t.Fatalf("tier1 visualLen=%d > 80: %q", visualLen(out), out)
 	}
 	for _, want := range []string{
-		"#[fg=colour244,bold]⟦#[default] s #[fg=colour244,bold]⟧#[default]",
-		"#[fg=brightcyan,bold]⟦#[default] NEED #[fg=brightcyan,bold]⟧#[default]",
-		"#[fg=colour208,bold]⟦#[default] claude #[fg=colour208,bold]⟧#[default]",
+		notifyLineOpen + renderNotifyProjectBadge("s"),
+		renderNotifyBadge("NEED", notify.SeverityInfo),
+		renderNotifyAgentBadge("claude"),
 		"reply ready",
-		"w1.p0",
 		"2m",
 		"+1",
 	} {
@@ -298,16 +291,16 @@ func TestStatusNotifyWidthTier2DropsAge(t *testing.T) {
 	t.Parallel()
 
 	// The project/state/agent badge stack makes this budget tight enough to
-	// drop both age and target while retaining the contextual badges.
+	// drop age while retaining the contextual badges.
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	out := formatStatusNotify(fixtureAIEntry(now), 45, now)
 	if visualLen(out) > 45 {
 		t.Fatalf("tier2 visualLen=%d > 45: %q", visualLen(out), out)
 	}
 	for _, want := range []string{
-		"#[fg=colour244,bold]⟦#[default] s #[fg=colour244,bold]⟧#[default]",
-		"#[fg=brightcyan,bold]⟦#[default] NEED #[fg=brightcyan,bold]⟧#[default]",
-		"#[fg=colour208,bold]⟦#[default] claude #[fg=colour208,bold]⟧#[default]",
+		notifyLineOpen + renderNotifyProjectBadge("s"),
+		renderNotifyBadge("NEED", notify.SeverityInfo),
+		renderNotifyAgentBadge("claude"),
 		"reply ready",
 		"+1",
 	} {
@@ -318,12 +311,9 @@ func TestStatusNotifyWidthTier2DropsAge(t *testing.T) {
 	if strings.Contains(out, "2m") {
 		t.Fatalf("tier2 must drop age: %q", out)
 	}
-	if strings.Contains(out, "w1.p0") {
-		t.Fatalf("tier2 must drop target: %q", out)
-	}
 }
 
-func TestStatusNotifyWidthTier3DropsTarget(t *testing.T) {
+func TestStatusNotifyWidthTier3TruncatesText(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
@@ -332,19 +322,19 @@ func TestStatusNotifyWidthTier3DropsTarget(t *testing.T) {
 		t.Fatalf("tier3 visualLen=%d > 40: %q", visualLen(out), out)
 	}
 	for _, want := range []string{
-		"#[fg=colour244,bold]⟦#[default] s #[fg=colour244,bold]⟧#[default]",
-		"#[fg=brightcyan,bold]⟦#[default] NEED #[fg=brightcyan,bold]⟧#[default]",
+		notifyLineOpen + renderNotifyProjectBadge("s"),
+		renderNotifyBadge("NEED", notify.SeverityInfo),
 		"+1",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("tier3 missing %q in %q", want, out)
 		}
 	}
-	if strings.Contains(out, "w1.p0") {
-		t.Fatalf("tier3 must drop target: %q", out)
-	}
 	if strings.Contains(out, "2m") {
 		t.Fatalf("tier3 must drop age: %q", out)
+	}
+	if !strings.Contains(out, "…") {
+		t.Fatalf("tier3 should truncate text with ellipsis: %q", out)
 	}
 }
 
@@ -356,7 +346,7 @@ func TestStatusNotifyWidthTier4TruncatesText(t *testing.T) {
 	if visualLen(out) > 24 {
 		t.Fatalf("tier4 visualLen=%d > 24: %q", visualLen(out), out)
 	}
-	if strings.Contains(out, "⟦") {
+	if strings.Contains(out, " NEED ") || strings.Contains(out, " claude ") {
 		t.Fatalf("tier4 should drop badges before icon fallback at this width: %q", out)
 	}
 	if !strings.Contains(out, "+1") {
@@ -367,9 +357,8 @@ func TestStatusNotifyWidthTier4TruncatesText(t *testing.T) {
 	}
 }
 
-// Tier 5 drops the outline badges. The standalone severity-tinted `●`
-// icon preserves a minimal severity hint for very narrow
-// statuslines.
+// Tier 5 drops the block badges. The standalone severity-tinted `●`
+// icon preserves a minimal severity hint for very narrow statuslines.
 func TestStatusNotifyWidthTier5DropsBadge(t *testing.T) {
 	t.Parallel()
 
@@ -378,13 +367,13 @@ func TestStatusNotifyWidthTier5DropsBadge(t *testing.T) {
 	if visualLen(out) > 14 {
 		t.Fatalf("tier5 visualLen=%d > 14: %q", visualLen(out), out)
 	}
-	if strings.Contains(out, "⟦") {
-		t.Fatalf("tier5 must drop the outline badges: %q", out)
+	if strings.Contains(out, " NEED ") || strings.Contains(out, " claude ") {
+		t.Fatalf("tier5 must drop the block badges: %q", out)
 	}
 	if strings.Contains(out, "claude") {
 		t.Fatalf("tier5 must drop the agent label: %q", out)
 	}
-	if !strings.Contains(out, "#[fg=brightcyan]●#[default]") {
+	if !strings.Contains(out, notifySeverityInfo+notifyIcon+notifyLineOpen) {
 		t.Fatalf("tier5 should still show the icon-only severity hint: %q", out)
 	}
 	if !strings.Contains(out, "+1") {
@@ -429,25 +418,18 @@ func TestStatusNotifyAgentPrefixGracefulFallback(t *testing.T) {
 				ID: "a", Text: tc.text, Severity: notify.SeverityInfo,
 				Source: notify.SourceAI, Session: "s", CreatedAt: now,
 			}}, 0, now)
-			if !strings.HasPrefix(out, "#[fg=colour244,bold]⟦#[default] s #[fg=colour244,bold]⟧#[default]") {
+			if !strings.HasPrefix(out, notifyLineOpen+renderNotifyProjectBadge("s")) {
 				t.Fatalf("expected project badge at start of %q", out)
 			}
-			wantStateBadge := "#[fg=brightcyan,bold]⟦#[default] " + tc.wantState + " #[fg=brightcyan,bold]⟧#[default]"
+			wantStateBadge := renderNotifyBadge(tc.wantState, notify.SeverityInfo)
 			if !strings.Contains(out, wantStateBadge) {
 				t.Fatalf("expected state badge %q in %q", wantStateBadge, out)
 			}
-			wantAgentColor := "colour51"
-			switch tc.wantAgent {
-			case "claude":
-				wantAgentColor = "colour208"
-			case "codex":
-				wantAgentColor = "colour33"
-			}
-			wantAgentBadge := "#[fg=" + wantAgentColor + ",bold]⟦#[default] " + tc.wantAgent + " #[fg=" + wantAgentColor + ",bold]⟧#[default]"
+			wantAgentBadge := renderNotifyAgentBadge(tc.wantAgent)
 			if tc.wantAgent != "" && !strings.Contains(out, wantAgentBadge) {
 				t.Fatalf("expected agent badge %q in %q", wantAgentBadge, out)
 			}
-			if tc.wantAgent == "" && (strings.Contains(out, "fg=colour51") || strings.Contains(out, "fg=colour208") || strings.Contains(out, "fg=colour33")) {
+			if tc.wantAgent == "" && (strings.Contains(out, notifyAgentOpen) || strings.Contains(out, notifyAgentClaude) || strings.Contains(out, notifyAgentCodex)) {
 				t.Fatalf("did not expect agent badge in %q", out)
 			}
 		})
@@ -478,26 +460,6 @@ func TestFormatRelativeAgeBuckets(t *testing.T) {
 	for _, tc := range cases {
 		if got := formatRelativeAge(tc.dur); got != tc.want {
 			t.Fatalf("formatRelativeAge(%v) = %q, want %q", tc.dur, got, tc.want)
-		}
-	}
-}
-
-func TestStatusNotifyCompactTarget(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		n    notify.Notification
-		want string
-	}{
-		{notify.Notification{Session: "s"}, "s"},
-		{notify.Notification{Session: "s", Window: "1"}, "s:1"},
-		{notify.Notification{Session: "s", Window: "1", Pane: "0"}, "s:1.0"},
-		{notify.Notification{Session: ""}, ""},
-		{notify.Notification{Session: "  s  ", Window: " 1 ", Pane: " 0 "}, "s:1.0"},
-	}
-	for _, tc := range cases {
-		if got := compactTarget(tc.n); got != tc.want {
-			t.Fatalf("compactTarget(%+v) = %q, want %q", tc.n, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- render the compact notify HUD as a full notification-colored block instead of outline/cap badges
- hide window/pane ids from the compact status/sidebar display while keeping them searchable/routable
- restore the notify sidebar project badge to the purple project color

## Verification
- go test ./internal/app -run 'TestStatusNotify|TestNotifyListSidebar'\n- make fmt\n- make fix (reverted unrelated go fix churn)\n- make test\n- git diff --check