### PR TITLE
fix: render notify sidebar cards

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -33,9 +33,10 @@
 - Current focused unit coverage also includes strict notify SOT behavior
   (TTL does not remove rows, focus does not ack, reconcile reports stale
   rows), `notify list --live` queue/live explanations, notify sidebar
-  focus/ack/clear-all actions, and `focus` dispatch diagnostics for session
-  fallback, unresolved targets, window fallback, pane fallback, explicit id
-  failures, and notify-only fallback.
+  two-line card rendering with queued-state metadata plus focus/ack/clear-all
+  actions, and `focus` dispatch diagnostics for session fallback, unresolved
+  targets, window fallback, pane fallback, explicit id failures, and
+  notify-only fallback.
 - Picker focused unit coverage includes backend-neutral picker item/action mapping, fzf adapter output, native title-focused filtering, numeric selection, and shared close actions.
 - `make test-integration`: Docker-backed Linux integration smoke with real `tmux`, `fzf`, `git`, and `stty`; covers `doctor`, tmux config print/install/apply, and notify queue CRUD against isolated HOME/XDG paths.
 - `make test-install-smoke`: Docker-backed source install smoke; covers `make install`, atomic binary replacement, `tmux apply` against a live `projmux` socket, and post-install notify queue initialization.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -177,9 +177,10 @@ projmux notify reconcile [--json]
   reply panes missing a queue entry, matched AI reply entries, and stale
   queue entries whose live pane no longer matches. `--ui=sidebar` opens the
   compact interactive notify list where Enter focuses and acks a target, `a`
-  acks the selected row, and `Ctrl-A` clears all. The sidebar row keeps target
-  details searchable but displays only age, project, state, optional agent, and
-  text.
+  acks the selected row, and `Ctrl-A` clears all; opening or navigating the
+  sidebar does not ack. The sidebar uses two-line cards with notification text
+  first and compact project/queued/state/age/target metadata below, while
+  keeping ids, source, and target details searchable.
 - `ack <id>` removes one entry; `--all` flushes the queue.
 - `reconcile` — walks `tmux list-panes -a` and back-fills entries for
   panes whose attention state is `reply` AND whose AI agent option is

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -277,6 +277,7 @@ func (c *notifyCommand) runSidebar(entries []notify.Notification, stdout, stderr
 	now := c.clock()
 	fzfOptions := intfzf.Options{
 		UI:         "notify-sidebar",
+		Read0:      true,
 		Prompt:     "notilist> ",
 		Header:     "Enter: focus | a: ack selected | Ctrl-A: clear all | Esc: close",
 		Footer:     "focus acks the selected notification",
@@ -345,7 +346,7 @@ func notifySidebarEntries(entries []notify.Notification, now time.Time) []intfzf
 		})
 		label := notifySidebarLabel(e, now)
 		out = append(out, intfzf.Entry{
-			Label:     notifyTableCell(label),
+			Label:     label,
 			Value:     e.ID,
 			SearchKey: strings.Join([]string{e.ID, e.Text, e.Severity, e.Source, target}, " "),
 		})
@@ -355,26 +356,47 @@ func notifySidebarEntries(entries []notify.Notification, now time.Time) []intfzf
 
 func notifySidebarLabel(e notify.Notification, now time.Time) string {
 	age := formatAge(now.Sub(e.CreatedAt))
-	agent, text := splitAgentPrefix(e)
+	text := notifySidebarLabelCell(e.Text)
 	if text == "" {
 		text = "(empty notification)"
 	}
-	parts := []string{
-		fmt.Sprintf("%-4s", age),
+	metaParts := []string{
 		notifySidebarProjectBadge(notifyProjectName(e.Session)),
+		notifySidebarConsumptionBadge("queued"),
 		notifySidebarStateBadge(notifyStateLabel(e, text)),
+		notifySidebarDim(age),
 	}
-	if agent != "" {
-		parts = append(parts, notifySidebarAgentBadge(agent))
+	if target := notifySidebarTarget(e); target != "" {
+		metaParts = append(metaParts, notifySidebarDim(target))
 	}
-	parts = append(parts, text)
-	return strings.Join(parts, " ")
+	return text + "\n  " + strings.Join(metaParts, " ")
+}
+
+func notifySidebarLabelCell(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.ReplaceAll(value, "\t", " ")
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	return strings.TrimSpace(value)
+}
+
+func notifySidebarTarget(e notify.Notification) string {
+	pane := strings.TrimSpace(e.Pane)
+	if strings.HasPrefix(pane, "%") {
+		pane = ""
+	}
+	return notifySidebarLabelCell(notify.FormatTarget(notify.Target{
+		Session: e.Session,
+		Window:  e.Window,
+		Pane:    pane,
+	}))
 }
 
 const (
 	notifySidebarReset   = "\x1b[0m"
 	notifySidebarDimOpen = "\x1b[38;5;245m"
 	notifySidebarProject = "\x1b[1;38;5;231;48;5;90m"
+	notifySidebarQueued  = "\x1b[38;5;16;48;5;250m"
 	notifySidebarInfo    = "\x1b[1;38;5;16;48;5;45m"
 	notifySidebarWarn    = "\x1b[1;38;5;16;48;5;220m"
 	notifySidebarCrit    = "\x1b[1;38;5;231;48;5;160m"
@@ -386,6 +408,14 @@ func notifySidebarProjectBadge(project string) string {
 		project = "project"
 	}
 	return notifySidebarProject + " " + project + " " + notifySidebarReset
+}
+
+func notifySidebarConsumptionBadge(label string) string {
+	label = strings.ToLower(strings.TrimSpace(label))
+	if label == "" {
+		label = "queued"
+	}
+	return notifySidebarQueued + " " + label + " " + notifySidebarReset
 }
 
 func notifySidebarStateBadge(label string) string {

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -240,7 +240,7 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 		listEntries: []notify.Notification{
 			{
 				ID:        "abc",
-				Text:      "deploy ok",
+				Text:      "codex: deploy ok",
 				Severity:  notify.SeverityWarn,
 				Source:    notify.SourceAI,
 				Socket:    "projmux",
@@ -265,11 +265,30 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if picker.options.UI != "notify-sidebar" {
 		t.Fatalf("picker UI = %q, want notify-sidebar", picker.options.UI)
 	}
+	if !picker.options.Read0 {
+		t.Fatal("picker Read0 = false, want true")
+	}
 	if len(picker.options.Entries) != 1 || picker.options.Entries[0].Value != "abc" {
 		t.Fatalf("entries = %#v", picker.options.Entries)
 	}
-	if label := picker.options.Entries[0].Label; !strings.Contains(label, " main ") || !strings.Contains(label, " WARN ") || !strings.Contains(label, "deploy ok") || strings.Contains(label, "w1.p0") || strings.Contains(label, "main:1.0") || strings.Contains(label, " ai ") {
-		t.Fatalf("sidebar label = %q, want project/status/text without target/source columns", label)
+	entry := picker.options.Entries[0]
+	labelLines := strings.Split(entry.Label, "\n")
+	if len(labelLines) != 2 {
+		t.Fatalf("sidebar label = %q, want two-line card", entry.Label)
+	}
+	if labelLines[0] != "codex: deploy ok" {
+		t.Fatalf("sidebar first line = %q, want notification text", labelLines[0])
+	}
+	if meta := labelLines[1]; !strings.Contains(meta, " main ") || !strings.Contains(meta, " queued ") || !strings.Contains(meta, " WARN ") || !strings.Contains(meta, "30s") || !strings.Contains(meta, "main:1.0") || strings.Contains(meta, " ai ") {
+		t.Fatalf("sidebar metadata = %q, want project/queued/status/age/target without source", meta)
+	}
+	if strings.Contains(entry.Label, "abc") {
+		t.Fatalf("sidebar label = %q, want hidden queue id", entry.Label)
+	}
+	for _, want := range []string{"abc", "codex: deploy ok", "warn", "ai", "main:1.0"} {
+		if !strings.Contains(entry.SearchKey, want) {
+			t.Fatalf("search key = %q, want %q", entry.SearchKey, want)
+		}
 	}
 	if got, want := picker.options.Bindings, []string{"alt-2:abort"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("bindings = %#v, want %#v", got, want)
@@ -283,6 +302,36 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	wantArgs := []string{"focus", "--target", "main:1.0", "--source", "notify-sidebar", "--kind", "row-select", "--socket", "projmux"}
 	if !equalStringSlices(runner.calls[0].args, wantArgs) {
 		t.Fatalf("focus args = %#v, want %#v", runner.calls[0].args, wantArgs)
+	}
+}
+
+func TestNotifySidebarLabelDoesNotExposeRawPaneID(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	label := notifySidebarLabel(notify.Notification{
+		ID:        "abc",
+		Text:      "deploy\nok",
+		Severity:  notify.SeverityInfo,
+		Source:    notify.SourceExternal,
+		Session:   "main",
+		Window:    "1",
+		Pane:      "%42",
+		CreatedAt: now.Add(-2 * time.Minute),
+	}, now)
+
+	lines := strings.Split(label, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("sidebar label = %q, want two lines", label)
+	}
+	if lines[0] != "deploy ok" {
+		t.Fatalf("first line = %q, want sanitized text", lines[0])
+	}
+	if strings.Contains(label, "%42") {
+		t.Fatalf("sidebar label = %q, want raw pane id hidden", label)
+	}
+	if !strings.Contains(lines[1], "main:1") {
+		t.Fatalf("metadata = %q, want session/window target fallback", lines[1])
 	}
 }
 


### PR DESCRIPTION
## Summary
- render Alt-2 notify sidebar rows as two-line cards using fzf read0
- show notification text first with queued/project/state/age/target metadata below
- keep queue ids/source/target searchable while avoiding raw pane ids in visible cards

## Validation
- make fmt
- GOCACHE=/tmp/projmux-go-cache make fix (go fix attempted broad rewrites; incidental rewrites were reverted to keep this PR scoped)
- GOCACHE=/tmp/projmux-go-cache make test
- GOCACHE=/tmp/projmux-go-cache go test ./internal/app ./internal/ui/fzf ./internal/ui/render