### PR TITLE
fix: require fzf 0.65

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -34,7 +34,7 @@ attention signal을 함께 제공합니다. 자체 tmux 앱(`projmux shell`)으�
   swallow 하는지 진단한 뒤, Ghostty 또는 Windows Terminal 설정에 맞는
   CSI-u 바인딩을 자동 머지한다.
 - **`projmux doctor`** — 런타임 의존성 점검 + 최소 버전 강제 (tmux 3.4,
-  fzf 0.55).
+  fzf 0.65.0).
 - **`projmux focus`** — AI reply-ready 와 status-bar notify 클릭이 공유하는
   통합 switch-client 디스패처.
 - **영속 notify queue** — `projmux notify push|list|ack|reconcile` 가 TTL,
@@ -81,7 +81,7 @@ projmux shell
 
 - [Go 1.24+](https://go.dev/dl/) — binary 설치/빌드에 필요.
 - [tmux](https://github.com/tmux/tmux/wiki/Installing) **≥ 3.4** — workspace 런타임. 이전 버전은 `display-popup -T` 등 projmux 가 사용하는 기능이 없습니다.
-- [fzf](https://github.com/junegunn/fzf#installation) **≥ 0.55** — popup/sidebar picker. 멀티라인 피커가 `--marker-multi-line`, `--gap-line`, `--highlight-line` 을 사용하며 모두 0.55 까지 도입됐습니다.
+- [fzf](https://github.com/junegunn/fzf#installation) **≥ 0.65.0** — popup/sidebar picker. `PATH` 에 있는 `fzf` 실행 파일이 `fzf --version` 에서 0.65.0 이상을 보고해야 합니다. Ubuntu 24 apt 같은 distro package 는 너무 오래됐을 수 있으니 upstream GitHub Releases, Homebrew, 또는 버전을 확인할 수 있는 다른 설치 경로를 사용하세요. `npm i fzf` 는 JavaScript fuzzy-search library 이며 projmux 가 실행하는 junegunn/fzf CLI binary 가 아닙니다.
 - `bash`, `zsh`, `sh` 같은 Unix shell — `projmux shell` 이 만드는 앱 tmux
   설정은 절대 경로 `$SHELL` 을 사용하고, 없으면 `/bin/sh` 로 fallback 합니다.
 - [git](https://git-scm.com/downloads) — branch/status segment.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Open the app once, then use its generated tmux bindings to:
 - [Go 1.24+](https://go.dev/dl/) — required only when installing with
   `go install` or building from source.
 - [tmux](https://github.com/tmux/tmux/wiki/Installing) **≥ 3.4** — the workspace runtime. Earlier versions miss `display-popup -T` and other features projmux depends on.
-- [fzf](https://github.com/junegunn/fzf#installation) **≥ 0.55** — interactive popup/sidebar pickers. The multiline picker uses `--marker-multi-line`, `--gap-line`, and `--highlight-line`, which landed by 0.55.
+- [fzf](https://github.com/junegunn/fzf#installation) **≥ 0.65.0** — interactive popup/sidebar pickers. The `fzf` executable on `PATH` must report at least 0.65.0 from `fzf --version`; distro packages such as Ubuntu 24 apt may be too old, so use upstream GitHub Releases, Homebrew, or another install method with a version check. `npm i fzf` installs a JavaScript fuzzy-search library, not the junegunn/fzf CLI binary that projmux executes.
 - A Unix shell such as `bash`, `zsh`, or `sh` — `projmux shell` uses your
   absolute `$SHELL` for the generated app config, falling back to `/bin/sh`.
 - [git](https://git-scm.com/downloads) — branch/status metadata.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -104,7 +104,7 @@ projmux doctor [--json]
 projmux doctor --install-missing [--dry-run] [--include-optional]
 ```
 
-Runs a dependency check: `tmux ≥ 3.4`, `fzf ≥ 0.55`, `git`, `stty` (POSIX
+Runs a dependency check: `tmux ≥ 3.4`, `fzf ≥ 0.65.0`, `git`, `stty` (POSIX
 only), and `kubectl` (optional). Exit code `0` even when optional deps are
 missing; non-zero only when a required dep is missing or stale. `--json`
 emits a machine-readable array; the default is the human report with
@@ -114,7 +114,10 @@ dependencies. `--dry-run` prints those commands without executing them.
 `--include-optional` also includes optional missing dependencies such as
 `kubectl` when an install command is available. Install flags cannot be
 combined with `--json`. Doctor does not diagnose terminal key delivery; use
-`projmux setup` for that.
+`projmux setup` for that. For fzf, doctor requires the junegunn/fzf CLI
+executable on `PATH` to report at least 0.65.0 from `fzf --version`; the npm
+package `fzf` is a JavaScript library and is not a valid CLI install path for
+projmux.
 
 ## focus
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,7 +19,7 @@ core that 0.3 had landed.
 ### Diagnostics
 
 - `projmux doctor` — runtime dependency report. Enforces minimum tmux
-  3.4 and fzf 0.55 (`stale` status when present but below the floor).
+  3.4 and fzf 0.65.0 (`stale` status when present but below the floor).
 
 ### Focus
 

--- a/internal/app/doctor.go
+++ b/internal/app/doctor.go
@@ -59,6 +59,9 @@ type doctorDep struct {
 	// FallbackHint is a non-OS-specific extra suggestion appended after the
 	// detected install command (e.g. `go install` for fzf).
 	FallbackHint string
+	// ManualInstallHint is rendered as guidance but is never treated as an
+	// automatically runnable install command.
+	ManualInstallHint string
 	// OptionalNote is the human-readable explanation rendered for optional
 	// deps regardless of presence.
 	OptionalNote string
@@ -90,11 +93,14 @@ func doctorDeps() []doctorDep {
 	return []doctorDep{
 		{Name: "tmux", Required: true, Category: doctorCategoryCore, MinVersion: "3.4"},
 		{
-			Name:         "fzf",
-			Required:     true,
-			Category:     doctorCategoryCore,
-			FallbackHint: "or: go install github.com/junegunn/fzf@latest",
-			MinVersion:   "0.55",
+			Name:     "fzf",
+			Required: true,
+			Category: doctorCategoryCore,
+			ManualInstallHint: "install the junegunn/fzf CLI executable >= 0.65.0 from " +
+				"https://github.com/junegunn/fzf/releases, Homebrew, or another source that passes " +
+				"`fzf --version`; distro packages such as Ubuntu 24 apt may be too old; " +
+				"`npm i fzf` is a JavaScript library, not the CLI projmux executes",
+			MinVersion: "0.65.0",
 		},
 		{Name: "git", Required: true, Category: doctorCategoryWorkflow},
 		{Name: "stty", Required: true, Category: doctorCategoryWorkflow, SkipOnWindows: true},
@@ -159,18 +165,30 @@ type doctorInstallOptions struct {
 
 func (c *doctorCommand) installMissing(results []doctorResult, opts doctorInstallOptions, stdout, stderr io.Writer) error {
 	commands := doctorInstallCommands(results, opts.IncludeOptional)
+	manual := doctorManualInstallResults(results, opts.IncludeOptional)
+	unresolved := doctorUnresolvedInstallResults(results, opts.IncludeOptional)
 	if len(commands) == 0 {
-		if _, err := fmt.Fprintln(stdout, "no installable missing dependencies"); err != nil {
+		for _, r := range manual {
+			if _, err := fmt.Fprintf(stdout, "manual install required for %s: %s\n", r.Name, r.Install); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(stdout, "no automatically installable missing dependencies; follow the guidance above"); err != nil {
 			return err
 		}
-		for _, r := range results {
-			if r.Required && (r.Status == doctorStatusMissing || r.Status == doctorStatusStale) {
-				return fmt.Errorf("missing required dependencies; no install command was detected")
-			}
+		if hasRequiredDoctorResults(unresolved) {
+			return fmt.Errorf("missing required dependencies; manual install required for %s", doctorResultNames(unresolved))
 		}
 		return nil
 	}
 
+	if len(manual) > 0 {
+		for _, r := range manual {
+			if _, err := fmt.Fprintf(stdout, "manual install required for %s: %s\n", r.Name, r.Install); err != nil {
+				return err
+			}
+		}
+	}
 	for _, command := range commands {
 		if opts.DryRun {
 			if _, err := fmt.Fprintf(stdout, "would install %s: %s\n", command.Dep, command.String()); err != nil {
@@ -186,8 +204,12 @@ func (c *doctorCommand) installMissing(results []doctorResult, opts doctorInstal
 		}
 	}
 	if !opts.DryRun {
-		_, err := fmt.Fprintln(stdout, "install commands completed; rerun projmux doctor to verify")
-		return err
+		if _, err := fmt.Fprintln(stdout, "install commands completed; rerun projmux doctor to verify"); err != nil {
+			return err
+		}
+	}
+	if hasRequiredDoctorResults(unresolved) {
+		return fmt.Errorf("missing required dependencies; manual install required for %s", doctorResultNames(unresolved))
 	}
 	return nil
 }
@@ -220,9 +242,63 @@ func doctorInstallCommands(results []doctorResult, includeOptional bool) []docto
 	return out
 }
 
+func doctorManualInstallResults(results []doctorResult, includeOptional bool) []doctorResult {
+	var out []doctorResult
+	for _, r := range results {
+		if !doctorInstallEligible(r, includeOptional) {
+			continue
+		}
+		if _, ok := parseDoctorInstallCommand(r.Name, r.Install); !ok && strings.TrimSpace(r.Install) != "" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func doctorUnresolvedInstallResults(results []doctorResult, includeOptional bool) []doctorResult {
+	var out []doctorResult
+	for _, r := range results {
+		if !doctorInstallEligible(r, includeOptional) {
+			continue
+		}
+		if _, ok := parseDoctorInstallCommand(r.Name, r.Install); !ok {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func doctorInstallEligible(r doctorResult, includeOptional bool) bool {
+	installableStatus := r.Status == doctorStatusMissing || r.Status == doctorStatusStale
+	if includeOptional {
+		installableStatus = installableStatus || r.Status == doctorStatusHint
+	}
+	return installableStatus && (r.Required || includeOptional)
+}
+
+func hasRequiredDoctorResults(results []doctorResult) bool {
+	for _, r := range results {
+		if r.Required {
+			return true
+		}
+	}
+	return false
+}
+
+func doctorResultNames(results []doctorResult) string {
+	names := make([]string, 0, len(results))
+	for _, r := range results {
+		names = append(names, r.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
 func parseDoctorInstallCommand(dep, hint string) (doctorInstallCommand, bool) {
 	command := strings.TrimSpace(hint)
 	if command == "" {
+		return doctorInstallCommand{}, false
+	}
+	if strings.HasPrefix(command, "manual:") {
 		return doctorInstallCommand{}, false
 	}
 	if before, _, ok := strings.Cut(command, ";"); ok {
@@ -375,6 +451,9 @@ func writeDoctorJSON(w io.Writer, results []doctorResult) error {
 func detectInstallHint(dep doctorDep, host string, lookPath func(string) (string, error)) string {
 	if lookPath == nil {
 		return ""
+	}
+	if dep.ManualInstallHint != "" {
+		return "manual: " + dep.ManualInstallHint
 	}
 	pkg := func(key string) string {
 		if name, ok := dep.PackageNames[key]; ok && name != "" {

--- a/internal/app/doctor_test.go
+++ b/internal/app/doctor_test.go
@@ -316,18 +316,18 @@ func TestDetectInstallHintByOSAndPM(t *testing.T) {
 			want:    "scoop install git",
 		},
 		{
-			name:     "fzf appends go install fallback on linux apt",
-			dep:      doctorDep{Name: "fzf", FallbackHint: "or: go install github.com/junegunn/fzf@latest"},
-			host:     "linux",
-			present:  map[string]bool{"apt-get": true},
-			contains: []string{"sudo apt-get install -y fzf", "or: go install github.com/junegunn/fzf@latest"},
+			name:    "manual install hint suppresses linux apt command",
+			dep:     doctorDep{Name: "fzf", ManualInstallHint: "install the junegunn/fzf CLI >= 0.65.0"},
+			host:    "linux",
+			present: map[string]bool{"apt-get": true},
+			want:    "manual: install the junegunn/fzf CLI >= 0.65.0",
 		},
 		{
-			name:    "fzf falls back to go install when no PM detected",
-			dep:     doctorDep{Name: "fzf", FallbackHint: "or: go install github.com/junegunn/fzf@latest"},
+			name:    "manual install hint works without package manager",
+			dep:     doctorDep{Name: "fzf", ManualInstallHint: "install the junegunn/fzf CLI >= 0.65.0"},
 			host:    "linux",
 			present: map[string]bool{},
-			want:    "or: go install github.com/junegunn/fzf@latest",
+			want:    "manual: install the junegunn/fzf CLI >= 0.65.0",
 		},
 		{
 			name:    "linux no package manager returns empty",
@@ -370,7 +370,7 @@ func TestDetectInstallHintByOSAndPM(t *testing.T) {
 	}
 }
 
-func TestDoctorFzfHintAlwaysIncludesGoInstallFallback(t *testing.T) {
+func TestDoctorFzfHintIsManualCLIGuidance(t *testing.T) {
 	t.Parallel()
 
 	hosts := []struct {
@@ -407,8 +407,13 @@ func TestDoctorFzfHintAlwaysIncludesGoInstallFallback(t *testing.T) {
 				return "", errors.New("not found")
 			}
 			got := detectInstallHint(fzfDep, tc.host, lookPath)
-			if !strings.Contains(got, "go install github.com/junegunn/fzf@latest") {
-				t.Fatalf("fzf hint missing go install fallback on %s: %q", tc.name, got)
+			for _, want := range []string{"manual:", "junegunn/fzf CLI", "0.65.0", "`fzf --version`", "`npm i fzf`"} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("fzf hint on %s missing %q: %q", tc.name, want, got)
+				}
+			}
+			if strings.Contains(got, "apt-get install") {
+				t.Fatalf("fzf hint should not imply apt installs a sufficient version: %q", got)
 			}
 		})
 	}
@@ -540,10 +545,10 @@ func TestVersionAtLeast(t *testing.T) {
 		{"3.4 >= 3.4", "3.4", "3.4", true, true},
 		{"3.3 < 3.4", "3.3", "3.4", false, true},
 		{"3.4a >= 3.4", "3.4a", "3.4", true, true},
-		{"0.55 >= 0.55", "0.55", "0.55", true, true},
-		{"0.54 < 0.55", "0.54", "0.55", false, true},
-		{"0.71.0 >= 0.55", "0.71.0", "0.55", true, true},
-		{"garbage lenient", "garbage", "0.55", true, false},
+		{"0.65.0 >= 0.65.0", "0.65.0", "0.65.0", true, true},
+		{"0.64.0 < 0.65.0", "0.64.0", "0.65.0", false, true},
+		{"0.71.0 >= 0.65.0", "0.71.0", "0.65.0", true, true},
+		{"garbage lenient", "garbage", "0.65.0", true, false},
 	}
 
 	for _, tc := range cases {
@@ -564,7 +569,7 @@ func TestDoctorStaleFzfFailsRequired(t *testing.T) {
 	cmd := newStubDoctorCommandWithVersions(
 		"linux",
 		map[string]bool{"tmux": true, "fzf": true, "git": true, "stty": true, "kubectl": true, "apt-get": true},
-		map[string]string{"fzf": "0.54 (devel)"},
+		map[string]string{"fzf": "fzf 0.64.0 (distro build)"},
 	)
 
 	var stdout, stderr bytes.Buffer
@@ -576,13 +581,48 @@ func TestDoctorStaleFzfFailsRequired(t *testing.T) {
 		t.Fatalf("error = %v, want mention of missing required dependencies", err)
 	}
 	out := stdout.String()
-	for _, want := range []string{"[stale]", "fzf", "minimum 0.55; found 0.54 (devel)"} {
+	for _, want := range []string{"[stale]", "fzf", "minimum 0.65.0; found fzf 0.64.0 (distro build)", "junegunn/fzf CLI", "`npm i fzf`"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("output missing %q\nfull output:\n%s", want, out)
 		}
 	}
+	if strings.Contains(out, "sudo apt-get install -y fzf") {
+		t.Fatalf("stale fzf guidance should not imply apt install is enough:\n%s", out)
+	}
 	if !strings.Contains(out, "1 stale") {
 		t.Fatalf("summary line missing stale count:\n%s", out)
+	}
+}
+
+func TestDoctorInstallMissingStaleFzfRequiresManualInstall(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStubDoctorCommandWithVersions(
+		"linux",
+		map[string]bool{"tmux": true, "fzf": true, "git": true, "stty": true, "kubectl": true, "apt-get": true},
+		map[string]string{"fzf": "0.64.0 (Ubuntu package)"},
+	)
+
+	var stdout bytes.Buffer
+	err := cmd.Run([]string{"--install-missing", "--dry-run"}, &stdout, &bytes.Buffer{})
+	if err == nil {
+		t.Fatalf("Run() error = nil, want manual install failure")
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"manual install required for fzf",
+		"junegunn/fzf CLI executable >= 0.65.0",
+		"Ubuntu 24 apt may be too old",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "would install fzf: sudo apt-get install") {
+		t.Fatalf("install-missing should not dry-run apt for stale fzf:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "manual install required for fzf") {
+		t.Fatalf("Run() error = %v, want manual install mention", err)
 	}
 }
 
@@ -669,7 +709,7 @@ func TestDoctorStaleFzfSerializesToJSON(t *testing.T) {
 	cmd := newStubDoctorCommandWithVersions(
 		"linux",
 		map[string]bool{"tmux": true, "fzf": true, "git": true, "stty": true, "kubectl": true, "apt-get": true},
-		map[string]string{"fzf": "0.54 (devel)"},
+		map[string]string{"fzf": "0.64.0 (devel)"},
 	)
 
 	var stdout bytes.Buffer


### PR DESCRIPTION
## Summary
- raise the documented and doctor-enforced fzf minimum to 0.65.0
- make fzf install-missing guidance manual instead of suggesting Ubuntu apt when it may be stale
- clarify that npm's fzf package is not the junegunn/fzf CLI executable projmux runs

## Validation
- GOCACHE=/tmp/projmux-go-cache go test ./internal/app
- git diff --check