### PR TITLE
fix: polish statusbar popups

### DIFF
--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -53,7 +53,7 @@ bind-key -n MouseDown1Status if-shell -F "#{==:#{mouse_status_range},window}" \
 | Range id | Row | Click action                              | Keyboard      |
 | -------- | --- | ----------------------------------------- | ------------- |
 | `session` | 0 | `projmux tmux popup-toggle sessionizer-sidebar` | `prefix s s` |
-| `pwd`     | 0 | copy `#{pane_current_path}` to tmux buffer and show a compact path popup | `prefix s p`  |
+| `pwd`     | 0 | copy `#{pane_current_path}` to tmux buffer and show a compact `Path copied` popup | `prefix s p`  |
 | `kube`    | 0 | `projmux tmux popup-toggle sessionizer`   | `prefix s k`  |
 | `git`     | 0 | `projmux tmux popup-toggle sessionizer`   | `prefix s g`  |
 | `usage`   | 1 | `display-popup -E -h 60% -w 80% -- projmux usage`, then wait for Enter | `prefix s u`  |
@@ -68,6 +68,13 @@ age, and `+N` for older pending entries. Window/pane ids are not shown in the
 compact status segment.
 `usage` deliberately opens the detailed `projmux usage` table popup; it is the
 clear action surface for the compact HUD bar.
+
+The path popup uses a short title, one-line copy status, the current path, and
+an `Enter closes this popup` prompt. If the tmux buffer write fails, it keeps
+the same compact surface with `Current path` as the title and a copy-unavailable
+message. The notification HUD detail surface (`Alt-2` / `User2`) opens the
+right-side `Notifications` popup with newest-first rows; selecting a row still
+focuses and acknowledges that notification.
 
 Empty `#{mouse_status_range}` (a click on whitespace) falls through to
 `select-window -t @<mouse_window>` when `--mouse-window` is non-empty,

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -278,9 +278,9 @@ func (c *notifyCommand) runSidebar(entries []notify.Notification, stdout, stderr
 	fzfOptions := intfzf.Options{
 		UI:         "notify-sidebar",
 		Read0:      true,
-		Prompt:     "notilist> ",
-		Header:     "Enter: focus | a: ack selected | Ctrl-A: clear all | Esc: close",
-		Footer:     "focus acks the selected notification",
+		Prompt:     "Notify > ",
+		Header:     "Pending notifications, newest first",
+		Footer:     "Enter: focus + ack  |  a: ack  |  Ctrl-A: clear all  |  Esc/Alt-2: close",
 		ExpectKeys: []string{"a", "ctrl-a"},
 		Bindings:   []string{"alt-2:abort"},
 		Entries:    notifySidebarEntries(entries, now),

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -268,6 +268,15 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if !picker.options.Read0 {
 		t.Fatal("picker Read0 = false, want true")
 	}
+	if got, want := picker.options.Prompt, "Notify > "; got != want {
+		t.Fatalf("picker prompt = %q, want %q", got, want)
+	}
+	if got, want := picker.options.Header, "Pending notifications, newest first"; got != want {
+		t.Fatalf("picker header = %q, want %q", got, want)
+	}
+	if got, want := picker.options.Footer, "Enter: focus + ack  |  a: ack  |  Ctrl-A: clear all  |  Esc/Alt-2: close"; got != want {
+		t.Fatalf("picker footer = %q, want %q", got, want)
+	}
 	if len(picker.options.Entries) != 1 || picker.options.Entries[0].Value != "abc" {
 		t.Fatalf("entries = %#v", picker.options.Entries)
 	}

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -362,9 +362,9 @@ func (c *statusbarCommand) handlePwd(_ statusbarClickOptions, _, stderr io.Write
 	if err := c.runTmuxNoFallback(stderr,
 		"display-popup",
 		"-E",
-		"-w", "80%",
-		"-h", "7",
-		"-T", "projmux path",
+		"-w", "76%",
+		"-h", "8",
+		"-T", statusbarPathPopupTitle(copied),
 		statusbarPathPopupCommand(path, copied),
 	); err == nil {
 		return nil
@@ -535,15 +535,33 @@ func focusFailureSummary(err error) string {
 }
 
 func statusbarPathPopupCommand(path string, copied bool) string {
-	title := "Current pane path:"
+	title := "Current path"
+	body := "Path shown below; tmux paste buffer unavailable."
 	if copied {
-		title = "Copied current pane path to tmux paste buffer:"
+		title = "Path copied"
+		body = "Current pane path is in the tmux paste buffer."
 	}
-	return "printf '%s\\n\\n%s\\n\\n%s\\n' " +
-		tmuxShellQuote(title) + " " +
-		tmuxShellQuote(path) + " " +
-		tmuxShellQuote("Press Enter to close.") +
-		"; IFS= read -r _"
+
+	lines := []string{
+		"\033[1;38;5;45m" + title + "\033[0m",
+		"\033[38;5;245m" + body + "\033[0m",
+		"",
+		"\033[38;5;231m" + path + "\033[0m",
+		"",
+		"\033[38;5;245mEnter closes this popup.\033[0m",
+	}
+	quoted := make([]string, 0, len(lines))
+	for _, line := range lines {
+		quoted = append(quoted, tmuxShellQuote(line))
+	}
+	return "printf '%s\\n' " + strings.Join(quoted, " ") + "; IFS= read -r _"
+}
+
+func statusbarPathPopupTitle(copied bool) string {
+	if copied {
+		return "Path copied"
+	}
+	return "Current path"
 }
 
 func shortenStatusbarToast(value string, max int) string {

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -235,7 +235,10 @@ func TestStatusbarClickPwdOpensPathPopupAndCopiesBuffer(t *testing.T) {
 	if !sawTmuxSubcommand(runner.calls, "display-popup") {
 		t.Fatalf("missing path display-popup; calls = %#v", runner.calls)
 	}
-	if !sawTmuxPopupCommandContaining(runner.calls, "Copied current pane path to tmux paste buffer:") {
+	if !sawTmuxArgsContainInOrder(runner.calls, []string{"display-popup", "-T", "Path copied"}) {
+		t.Fatalf("missing path popup title; calls = %#v", runner.calls)
+	}
+	if !sawTmuxPopupCommandContaining(runner.calls, "Current pane path is in the tmux paste buffer.") {
 		t.Fatalf("missing copied path popup body; calls = %#v", runner.calls)
 	}
 }
@@ -856,6 +859,24 @@ func sawTmuxArgs(calls []statusbarFakeCall, want []string) bool {
 			continue
 		}
 		if equalStringSlices(c.args, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func sawTmuxArgsContainInOrder(calls []statusbarFakeCall, want []string) bool {
+	for _, c := range calls {
+		if c.name != "tmux" {
+			continue
+		}
+		next := 0
+		for _, arg := range c.args {
+			if next < len(want) && arg == want[next] {
+				next++
+			}
+		}
+		if next == len(want) {
 			return true
 		}
 	}

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -664,11 +664,11 @@ func buildPopupToggle(mode tmuxPopupToggleMode, binaryPath, marker string, ctx t
 	case "notify-sidebar":
 		options.Client = ctx.TargetClient
 		options.Target = ""
-		options.Width = popupSize(ctx.ClientWidth, 24, 64)
-		options.Height = popupSize(ctx.ClientHeight, 100, 20)
+		options.Width = popupSize(ctx.ClientWidth, 32, 72)
+		options.Height = popupSize(ctx.ClientHeight, 60, 18)
 		options.X = popupRightX(ctx.ClientWidth, options.Width)
 		options.Y = "0"
-		options.Title = "projmux notify"
+		options.Title = "Notifications"
 		commandArgs = []string{"notify", "list", "--ui=sidebar"}
 	case "ai-split-picker-right", "ai-split-picker-down":
 		options.Width = popupSize(ctx.ClientWidth, 40, 96)

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -278,11 +278,11 @@ func TestAppRunTmuxPopupToggleOpensNotifySidebarOnRight(t *testing.T) {
 		"display-popup",
 		"-c", "/dev/pts/projmux-test-notify",
 		"-E",
-		"-x", "136",
+		"-x", "128",
 		"-y", "0",
-		"-w", "64",
-		"-h", "50",
-		"-T", "projmux notify",
+		"-w", "72",
+		"-h", "30",
+		"-T", "Notifications",
 	}
 	if got.name != "tmux" || len(got.args) < len(wantPrefix)+1 || !reflect.DeepEqual(got.args[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("display call = %#v, want prefix %#v", got, wantPrefix)


### PR DESCRIPTION
## Summary
- polish the pwd/path popup with clearer title/body, ANSI styling, and compact copy status
- make the notification sidebar popup smaller and titled Notifications
- clean up notify sidebar prompt/header/footer copy while preserving focus+ack behavior and card rows

## Validation
- GOCACHE=/tmp/projmux-go-cache go test ./internal/app ./internal/integrations/tmux
- git diff --check