### PR TITLE
fix: restore notify agent badges

### DIFF
--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -356,7 +356,8 @@ func notifySidebarEntries(entries []notify.Notification, now time.Time) []intfzf
 
 func notifySidebarLabel(e notify.Notification, now time.Time) string {
 	age := formatAge(now.Sub(e.CreatedAt))
-	text := notifySidebarLabelCell(e.Text)
+	agent, text := splitAgentPrefix(e)
+	text = notifySidebarLabelCell(text)
 	if text == "" {
 		text = "(empty notification)"
 	}
@@ -364,6 +365,10 @@ func notifySidebarLabel(e notify.Notification, now time.Time) string {
 		notifySidebarAge(age),
 		notifySidebarProjectBadge(notifyProjectName(e.Session)),
 	}
+	if agent != "" {
+		metaParts = append(metaParts, notifySidebarAgentBadge(agent))
+	}
+	metaParts = append(metaParts, notifySidebarStateBadge(notifyStateLabel(e, text)))
 	if window := notifySidebarTargetPart("window", e.Window); window != "" {
 		metaParts = append(metaParts, window)
 	}
@@ -397,6 +402,9 @@ const (
 	notifySidebarReset   = "\x1b[0m"
 	notifySidebarDimOpen = "\x1b[38;5;245m"
 	notifySidebarProject = "\x1b[1;38;5;231;48;5;90m"
+	notifySidebarInfo    = "\x1b[1;38;5;16;48;5;45m"
+	notifySidebarWarn    = "\x1b[1;38;5;16;48;5;220m"
+	notifySidebarCrit    = "\x1b[1;38;5;231;48;5;160m"
 )
 
 func notifySidebarAge(age string) string {
@@ -426,6 +434,40 @@ func notifySidebarTargetPart(label, value string) string {
 		return ""
 	}
 	return notifySidebarDim(label + " " + value)
+}
+
+func notifySidebarStateBadge(label string) string {
+	label = strings.ToUpper(strings.TrimSpace(label))
+	if label == "" {
+		label = "INFO"
+	}
+	open := notifySidebarInfo
+	switch label {
+	case "WARN":
+		open = notifySidebarWarn
+	case "CRIT":
+		open = notifySidebarCrit
+	}
+	return open + " " + label + " " + notifySidebarReset
+}
+
+func notifySidebarAgentBadge(agent string) string {
+	agent = strings.TrimSpace(agent)
+	if agent == "" {
+		return ""
+	}
+	return notifySidebarAgentOpen(agent) + " " + agent + " " + notifySidebarReset
+}
+
+func notifySidebarAgentOpen(agent string) string {
+	switch strings.ToLower(strings.TrimSpace(agent)) {
+	case "claude":
+		return "\x1b[1;38;5;16;48;5;208m"
+	case "codex":
+		return "\x1b[1;38;5;231;48;5;33m"
+	default:
+		return "\x1b[1;38;5;16;48;5;51m"
+	}
 }
 
 func notifySidebarDim(value string) string {

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -240,7 +240,7 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 		listEntries: []notify.Notification{
 			{
 				ID:        "abc",
-				Text:      "codex: deploy ok",
+				Text:      "codex: reply ready",
 				Severity:  notify.SeverityWarn,
 				Source:    notify.SourceAI,
 				Socket:    "projmux",
@@ -285,16 +285,16 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if len(labelLines) != 2 {
 		t.Fatalf("sidebar label = %q, want two-line card", entry.Label)
 	}
-	if labelLines[0] != "codex: deploy ok" {
+	if labelLines[0] != "reply ready" {
 		t.Fatalf("sidebar first line = %q, want notification text", labelLines[0])
 	}
-	if meta := labelLines[1]; !strings.Contains(meta, " age 30s ") || !strings.Contains(meta, " main ") || !strings.Contains(meta, "window 1") || !strings.Contains(meta, "pane 0") || strings.Contains(meta, " queued ") || strings.Contains(meta, " WARN ") || strings.Contains(meta, " ai ") {
-		t.Fatalf("sidebar metadata = %q, want age/project/window/pane without queued/status/source", meta)
+	if meta := labelLines[1]; !strings.Contains(meta, " age 30s ") || !strings.Contains(meta, " main ") || !strings.Contains(meta, " codex ") || !strings.Contains(meta, " WARN ") || !strings.Contains(meta, "window 1") || !strings.Contains(meta, "pane 0") || strings.Contains(meta, " queued ") || strings.Contains(meta, " ai ") {
+		t.Fatalf("sidebar metadata = %q, want age/project/agent/status/window/pane without queued/source", meta)
 	}
 	if strings.Contains(entry.Label, "abc") {
 		t.Fatalf("sidebar label = %q, want hidden queue id", entry.Label)
 	}
-	for _, want := range []string{"abc", "codex: deploy ok", "warn", "ai", "main:1.0"} {
+	for _, want := range []string{"abc", "codex: reply ready", "warn", "ai", "main:1.0"} {
 		if !strings.Contains(entry.SearchKey, want) {
 			t.Fatalf("search key = %q, want %q", entry.SearchKey, want)
 		}


### PR DESCRIPTION
## Summary
- restore agent-colored block badges in notify sidebar cards
- restore state badges such as WARN/NEED/INFO while keeping queued/source hidden
- keep notification text first and age/project/window/pane metadata in the card

## Validation
- GOCACHE=/tmp/projmux-go-cache go test ./internal/app
- git diff --check