### PR TITLE
docs: simplify readme onboarding

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -1,312 +1,103 @@
 # projmux
 
-터미널에서 프로젝트별 tmux 작업 공간을 만들고 유지하는 도구입니다.
+프로젝트별 tmux workspace를 빠르게 전환하고, preview/status context/AI pane
+attention까지 함께 다루는 터미널 workspace 도구입니다.
 
-`projmux`는 프로젝트 디렉터리를 오래 유지되는 tmux workspace로 매핑하고,
-preview, sidebar navigation, 생성된 keybinding, status metadata, AI pane
-attention signal을 함께 제공합니다. 자체 tmux 앱(`projmux shell`)으로 실행할
-수도 있고, 기존 tmux 서버에 같은 기능을 설치할 수도 있습니다.
+[![npm version](https://img.shields.io/npm/v/projmux?logo=npm)](https://www.npmjs.com/package/projmux)
+[![CI](https://github.com/crevissepartners/projmux/actions/workflows/ci.yml/badge.svg)](https://github.com/crevissepartners/projmux/actions/workflows/ci.yml)
 
 [English README](README.md)
 
-## 왜 projmux인가
+> 데모: 현재 저장소에 포함된 demo asset은 없습니다. 앞으로는 `projmux shell`에서
+> sidebar가 열린 짧은 GIF나 screenshot이 가장 적절한 시각 자료입니다.
 
-많은 tmux project switcher는 "디렉터리를 고르고 세션에 붙는다"에서 멈춥니다.
-`projmux`는 그 흐름을 기본값으로 삼고, 매일 쓰는 터미널 workspace에 필요한
-앱 수준의 요소를 더합니다.
+## 무엇인가
 
-- **프로젝트 정체성이 안정적으로 유지됩니다.** directory, pin, live session,
-  preview selection, lifecycle command가 같은 session model을 공유합니다.
-- **전환하기 전에 맥락을 볼 수 있습니다.** popup과 sidebar에서 session,
-  window, pane, git branch, Kubernetes context, pane metadata를 미리 봅니다.
-- **tmux layer를 손으로 이어 붙이지 않습니다.** popup launcher, window/pane
-  rename, status segment, pane border, attention badge, app mode에 필요한 tmux
-  설정을 `projmux`가 생성합니다.
-- **AI pane을 일급 workspace 요소로 다룹니다.** Codex/Claude pane을 실행하고,
-  agent 이름, topic, thinking/waiting 상태, pane/window/session badge, desktop
-  notification까지 tmux 안에서 추적합니다.
-- **격리 실행과 기존 tmux 통합 중 선택할 수 있습니다.** `projmux shell`로 자체
-  tmux 앱을 쓰거나, 생성된 snippet을 기존 tmux 서버에 설치할 수 있습니다.
+`projmux`는 프로젝트 디렉터리를 오래 유지되는 tmux session으로 연결합니다.
+프로젝트 전환, session preview, AI split 실행, tmux 안의 상태 표시를 한
+키보드 중심 workspace 앱으로 묶습니다.
 
-## 0.4 주요 변경
-
-- **`projmux setup` / `projmux init`** — 터미널이 어떤 키 시퀀스를
-  swallow 하는지 진단한 뒤, Ghostty 또는 Windows Terminal 설정에 맞는
-  CSI-u 바인딩을 자동 머지한다.
-- **`projmux doctor`** — 런타임 의존성 점검 + 최소 버전 강제 (tmux 3.4,
-  fzf 0.65.0).
-- **`projmux focus`** — AI reply-ready 와 status-bar notify 클릭이 공유하는
-  통합 switch-client 디스패처.
-- **영속 notify queue** — `projmux notify push|list|ack|reconcile` 가 TTL,
-  severity, source, target 메타데이터를 가진 큐를 디스크에 보존한다.
-  자세한 내용은 [notify-queue.md](docs/notify-queue.md).
-- **Authoritative 사용량 추적** — `projmux usage` 가 Claude OAuth usage
-  endpoint 와 Codex 로컬 rollout 의 `rate_limits` 를 직접 읽는다.
-  자세한 내용은 [usage-tracking.md](docs/usage-tracking.md).
-- **Two-line clickable status bar** — row 0 는 native window list 를 그대로
-  살려 탭 클릭으로 전환할 수 있고, row 1 은 좌측 notify HUD 와 우측 usage
-  HUD 로 분할된다. 폭이 좁아지면 두 세그먼트 모두 단계적으로 축소된다.
-  자세한 내용은 [statusbar.md](docs/statusbar.md).
-
-## 무엇을 하나
-
-- 프로젝트 디렉터리에서 tmux session을 만들거나 기존 session으로 전환.
-- 기존 session을 window/pane preview와 함께 탐색.
-- `fzf` 기반 popup/sidebar navigation 제공.
-- 자주 쓰는 프로젝트 pin 관리와 일반적인 source root 자동 탐색.
-- window/pane preview 선택 상태 저장 및 빠른 순환.
-- launcher, rename prompt, pane border, status segment, attention hook을 위한
-  tmux binding 생성.
-- git branch와 Kubernetes context/namespace를 status area에 표시.
-- Two-line clickable status bar — row 0 의 native 윈도우 목록은 탭 클릭으로
-  바로 전환되고, row 1 은 notify(좌)와 AI usage(우) HUD 세그먼트로 분할된다.
-- Codex/Claude/plain shell split을 만들고 agent/topic/status/notification 상태를
-  tmux UI에 표시.
+터미널 workspace를 한 명령으로 열고, 한 세트의 키로 project/window/pane,
+notification, settings 사이를 오가고 싶을 때 사용합니다.
 
 ## 요구 사항
 
-- [Go 1.24+](https://go.dev/dl/) — binary 설치/빌드에 필요.
-- [tmux](https://github.com/tmux/tmux/wiki/Installing) **≥ 3.4** — workspace 런타임. 이전 버전은 `display-popup -T` 등 projmux 가 사용하는 기능이 없습니다.
-- [fzf](https://github.com/junegunn/fzf#installation) **≥ 0.65.0** — popup/sidebar picker. `PATH` 에 있는 `fzf` 실행 파일이 `fzf --version` 에서 0.65.0 이상을 보고해야 합니다. Ubuntu 24 apt 같은 distro package 는 너무 오래됐을 수 있으니 upstream GitHub Releases, Homebrew, 또는 버전을 확인할 수 있는 다른 설치 경로를 사용하세요. `npm i fzf` 는 JavaScript fuzzy-search library 이며 projmux 가 실행하는 junegunn/fzf CLI binary 가 아닙니다.
-- `bash`, `zsh`, `sh` 같은 Unix shell — `projmux shell` 이 만드는 앱 tmux
-  설정은 절대 경로 `$SHELL` 을 사용하고, 없으면 `/bin/sh` 로 fallback 합니다.
-- [git](https://git-scm.com/downloads) — branch/status segment.
-- `stty` — POSIX 터미널 제어, `projmux setup` 에서 사용. macOS/Linux 기본 시스템에 이미 포함, Windows 호스트에선 해당 없음.
-- [kubectl](https://kubernetes.io/docs/tasks/tools/) — 선택, Kubernetes status segment 사용 시에만.
+- [Node.js](https://nodejs.org/)와 npm: 기본 설치 경로에 필요합니다.
+- [tmux](https://github.com/tmux/tmux/wiki/Installing) **3.4 이상**.
+- [fzf](https://github.com/junegunn/fzf#installation) **0.65.0 이상**.
 
-데스크톱 알림: Linux 는 `notify-send`, WSL 은 `powershell.exe` 토스트를 사용합니다.
-다른 실행 파일로 보내려면 `PROJMUX_NOTIFY_HOOK` 을 설정하세요.
-
-`projmux doctor` 를 실행하면 위 의존성이 모두 PATH 에 있는지, tmux/fzf 가
-최소 지원 버전을 만족하는지 한 번에 확인할 수 있습니다.
+설치 후 `projmux doctor`로 로컬 runtime을 확인하세요. 필요한 `fzf`는
+junegunn/fzf CLI binary입니다. `npm i fzf`는 다른 JavaScript library입니다.
 
 ## 설치
 
 ```sh
-go install github.com/crevissepartners/projmux/cmd/projmux@latest
-```
-
-binary 는 `$(go env GOBIN)` (설정된 경우) 또는 `$(go env GOPATH)/bin`
-(기본값 `~/go/bin`) 에 떨어집니다. 해당 디렉터리가 `PATH` 에 있어야 합니다:
-
-```sh
-export PATH="$(go env GOPATH)/bin:$PATH"
-```
-
-확인:
-
-```sh
+npm install -g projmux
 projmux version
 ```
 
-### 선택: `PROJMUX_PROJDIR`
+npm package는 작은 Node.js shim과 Linux/macOS x64/arm64용 projmux binary를
+설치합니다. 일반 사용자의 기본 배포 경로는 npm입니다.
 
-`PROJMUX_PROJDIR` 은 명시적으로 설정했을 때 projmux 가 picker/탐색에서 사용할
-primary 프로젝트 루트입니다. 설정하지 않으면 projmux 는 canonical repo root 를
-가정하지 않습니다. 탐색은 pin, 살아 있는 session, saved workdirs, 그리고 존재할
-때만 참고하는 약한 common-folder probe(`~/source`, `~/work`, `~/projects`,
-`~/src`, `~/code`) 를 사용합니다.
-
-```sh
-export PROJMUX_PROJDIR="/your/path"
-```
-
-`~/.bashrc`, `~/.zshrc` 또는 사용 중인 shell rc 파일에 한 줄 추가하면 됩니다. 첫 실행
-이후에는 `~/.config/projmux/projdir` 에 memoize 되므로, 이후 env 가 없어도 같은
-루트가 유지됩니다.
-
-`PROJMUX_PROJDIR` 은 OS-native PATH 형식의 multi-path 도 받습니다 (Linux/macOS
-는 `:`, Windows 는 `;`). 첫 번째 비어있지 않은 항목이 primary 프로젝트 루트가
-되고, 이후 항목은 `PROJMUX_MANAGED_ROOTS` 처럼 managed roots 검색 목록 앞에
-prepend 됩니다. saved 파일에는 primary 만 memoize 됩니다.
-
-```sh
-# Linux/macOS — primary repo + 보조 검색 root
-export PROJMUX_PROJDIR="/main/repos:/srv/work/repos"
-```
-
-#### 최초 설치 시 projdir 지정
-
-```sh
-PROJMUX_PROJDIR=/your/path go install github.com/crevissepartners/projmux/cmd/projmux@latest
-PROJMUX_PROJDIR=/your/path projmux tmux apply
-```
-
-env 가 살아있는 첫 실행이 `~/.config/projmux/projdir` 에 값을 기록하므로,
-이후 새 shell 에서 env 없이도 같은 루트가 유지됩니다.
-
-저장된 값은 `projmux settings > Project Picker > Project Root` 에서도 관리할
-수 있습니다. 이 화면은 현재 effective primary root 와 source
-(`PROJMUX_PROJDIR`, `@projmux_projdir`, saved, not configured)를 보여주고,
-saved 값이 env/tmux 값에 shadow 되는 상황을 따로 표시합니다. 경로를 직접
-입력하거나 현재 project context 를 저장하거나 saved 값을 지울 수 있습니다.
-Project Root 가 설정되지 않은 경우 직접 입력 prompt 는 `$HOME` 을 수정 가능한
-fallback 으로 채웁니다. 저장하기 전까지는 effective root 로 간주하지 않습니다.
-
-### 소스에서 빌드
-
-```sh
-git clone https://github.com/crevissepartners/projmux.git
-cd projmux
-make install
-```
-
-`make install` 은 빌드 후 `$(go env GOPATH)/bin/projmux` 를 atomically 교체하고
-`projmux tmux apply` 를 실행해 동작 중인 `-L projmux` 서버가 즉시 새 binding 을
-반영하도록 합니다. 설치 위치는 `INSTALL_DIR=/usr/local/bin` 으로 override.
+수동 Go 설치, source checkout, GitHub Release, packaging 세부 사항은
+[Install](docs/install.md)을 참고하세요.
 
 ## 빠른 시작
 
-격리된 projmux tmux 앱을 실행합니다:
+격리된 projmux tmux 앱을 엽니다:
 
 ```sh
 projmux shell
 ```
 
-앱 안에서는 생성된 keybinding으로 프로젝트 전환, session preview, AI split,
-settings, notify/usage status surface를 사용합니다. 전체 키맵은
-[터미널 키 설정](docs/keybindings.md)을 참고하세요.
+앱 안에서:
 
-키가 동작하지 않으면 tmux 밖에서 `projmux setup`을 실행하고,
-`projmux init [terminal] --apply`로 지원 터미널 fallback을 적용하세요.
-의존성이 이상하면 `projmux doctor`를 실행하세요.
+- `Alt-1`: project sidebar.
+- `Alt-3`: existing-session picker.
+- `Alt-4`: AI split picker.
+- `Alt-5`: settings.
+- `Alt-6`: project switcher popup.
 
-## 업그레이드
+전체 key map은 [Terminal Keybindings](docs/keybindings.md)를 참고하세요. 키가
+동작하지 않으면 tmux 밖에서 `projmux setup`을 실행한 뒤,
+지원 터미널에서는 `projmux init [terminal] --apply`를 사용하세요.
 
-`projmux upgrade` 는 `go install` 로 binary 를 다시 받아 atomically 교체하고,
-동작 중인 `-L projmux` 서버에 라이브 tmux 설정까지 다시 적용합니다.
+## 일상 사용
 
-```sh
-projmux upgrade                                  # @latest 로 교체 + apply
-projmux upgrade --ref @v0.2.0                    # 특정 tag 고정
-projmux upgrade --ref @main                      # branch tracking
-projmux upgrade --target /usr/local/bin/projmux  # 다른 경로 교체
-projmux upgrade --no-apply                       # 'projmux tmux apply' 생략
-projmux upgrade --dry-run                        # 실행 없이 단계만 출력
-```
+- project directory를 고르면 projmux가 tmux session을 만들거나 재사용합니다.
+- 중요한 project는 pin으로 고정합니다.
+- 전환 전에 window, pane, git branch, Kubernetes context, AI pane state를
+  preview합니다.
+- env var를 직접 편집하지 않고 Settings > Project Picker에서 root와 workdir을
+  추가할 수 있습니다.
+- Settings > About > Update 또는 `projmux update apply`로 업그레이드합니다.
 
-upgrade 는 호출 shell 의 `PROJMUX_PROJDIR` 을 읽어 primary (첫 번째) 경로를
-`~/.config/projmux/projdir` 에 memoize 하므로, 새 binary 도 같은 프로젝트 루트
-컨텍스트를 유지합니다.
+`PROJMUX_PROJDIR`, managed roots, notification, usage tracking 같은 자세한
+설정은 [Configuration](docs/configuration.md)을 참고하세요. installer별 update
+동작은 [Upgrading](docs/upgrading.md)에 있습니다.
 
-업그레이드와 동시에 새 프로젝트 루트로 전환하고 싶다면 env 와 함께 호출하세요:
+## 추가 문서
 
-```sh
-PROJMUX_PROJDIR=/new/path projmux upgrade
-
-# multi-path 도 동일하게 동작합니다. saved 파일에는 primary 만 기록됩니다.
-PROJMUX_PROJDIR="/main/repos:/secondary/repos" projmux upgrade   # Linux/macOS
-# Windows: PROJMUX_PROJDIR="C:\main\repos;C:\secondary\repos"
-```
-
-## 사용법
-
-일상 작업은 `projmux shell` 안의 tmux 키바인딩으로 진행합니다 —
-[터미널 키 설정](docs/keybindings.md) 참고. pin / preview / status helper /
-`upgrade` 같은 CLI 전체 표면은 `projmux help` 또는 `<command> --help` 로 확인할
-수 있습니다.
-
-## 프로젝트 탐색 방식
-
-`projmux switch`는 pinned directory, 현재 살아 있는 tmux session, 발견된
-project root를 합쳐 후보를 만듭니다. 명시적인 검색 root 가 없으면 기본 탐색은
-존재하는 경우 `~/source`, `~/work`, `~/projects`, `~/src`, `~/code` 같은 약한
-common-folder probe 를 참고합니다. canonical `~/source/repos` root 는 가정하지
-않습니다. `projmux settings`의 `Project Picker > Add Project...`는 filesystem
-root를 depth 3까지 스캔하므로 약한 probe 밖의 프로젝트도 picker 후보로 추가할
-수 있습니다. 세션 이름은 정규화된 디렉터리 경로에서 만들어지므로 같은 프로젝트는
-다시 실행해도 같은 tmux 세션으로 연결됩니다.
-
-탐색 root를 영구적으로 커스터마이즈하려면 Project Picker 섹션의 다음 항목을
-사용하세요:
-
-- `Project Root` - saved primary root 를 설정/변경/해제합니다. Project Root 는
-  primary project context 로 쓰는 한 개의 루트이며, `PROJMUX_PROJDIR` env 와
-  tmux `@projmux_projdir` 값이 있으면 saved 값보다 우선됩니다. root 가
-  설정되지 않았을 때 직접 입력 prompt 는 `$HOME` 을 미리 채워 picker 를 열 수
-  있게 하지만, 저장 전에는 암묵적인 saved root 로 쓰지 않습니다.
-- `+ Add Workdir...` - 디렉터리 하나를 saved workdirs 목록에 누적 추가.
-- `Workdirs` - 저장된 workdir 검토/삭제. 환경변수 `PROJMUX_MANAGED_ROOTS` /
-  `TMUX_SESSIONIZER_ROOTS`가 설정되어 있으면 read-only 행으로 함께 표시되어
-  saved 목록 대신 env list가 우선되는 이유를 한눈에 볼 수 있습니다.
-
-`Add Workdir > Type path manually...`를 고르면 파일시스템 스캔을 건너뛰고
-경로를 직접 입력할 수 있습니다. 스캔에 부담이 큰 WSL 마운트
-(`/mnt/c/Users/...`), 대용량 NFS, 프로젝트별 임시 루트 등에 활용하세요.
-
-저장 파일은 `~/.config/projmux/workdirs`이며, 절대경로 한 줄당 한 항목이고
-`#`로 시작하는 줄은 주석으로 무시됩니다. env가 설정되어 있을 때는 무시되며
-env가 비었을 때만 사용됩니다.
-
-## Hooks
-
-projmux는 새 tmux 세션을 만들 때마다 선택적 사용자 스크립트
-`~/.config/projmux/hooks/post-create`를 실행합니다. `tmux set-environment`로
-세션별 환경 변수를 주입하거나(예: 프로젝트 경로별 `GH_TOKEN` 선택) 다른
-부수 효과를 걸 때 활용하세요. 파일이 없거나 실행 비트가 빠져 있으면 조용히
-건너뛰며, hook 실패는 세션 생성을 막지 않습니다. 환경 변수 계약, 예시,
-문제 해결은 [Hooks](docs/hooks.md)를 참고하세요.
-
-## 환경 변수
-
-| 변수 | 용도 |
-| --- | --- |
-| `PROJMUX_PROJDIR` | 현재 shell 의 명시적 primary 프로젝트 루트. OS-native PATH 형식 multi-value 지원: 첫 항목이 primary repo root (saved 파일에 memoize), 이후 항목은 managed-roots 검색 목록 앞에 prepend. |
-| `PROJMUX_MANAGED_ROOTS` | 콜론 구분 검색 root 목록. saved/heuristic 목록보다 우선. |
-| `PROJMUX_NOTIFY_HOOK` | AI desktop notification 을 내장 sender 대신 받는 외부 실행 파일. |
-| `PROJMUX_USAGE_STATE_DIR` | AI 사용량 snapshot 캐시 디렉터리. 기본값은 `<state>/projmux/usage`. Dropbox/iCloud 같은 동기화 위치를 가리키게 하면 여러 머신 사이에서 authoritative 사용량을 공유할 수 있다. |
-| `PROJMUX_USAGE_DEBUG` | 비어 있지 않으면 `projmux status usage` 의 adapter 오류를 swallow 하지 않고 stderr 로 surface 한다. |
-| `PROJMUX_USAGE_LIMITS_PATH` | 사용 중단 (deprecated). limit 값은 upstream API (Anthropic OAuth usage endpoint, Codex `rate_limits`) 에서 직접 가져오므로 이 변수는 읽되 무시된다. |
-
-## AI 사용량 추적
-
-`projmux usage` 는 Claude Code 와 Codex CLI 양쪽의 authoritative 5시간 / 주간
-사용률을 보고한다. 두 어댑터 모두 upstream 의 계정 뷰를 직접 읽으므로 `claude
-/usage` 와 `codex` 가 native 로 보여주는 숫자와 일치한다:
-
-- **Claude** — `~/.claude/.credentials.json` 의 bearer 토큰으로
-  `GET https://api.anthropic.com/api/oauth/usage` 호출. 401 응답 시 한 번의
-  refresh round-trip 을 수행해 credentials 파일을 회전된 토큰으로 다시 쓴다.
-  토큰은 로그에 기록되지 않는다.
-- **Codex** — 가장 최근의 `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` 에서
-  마지막 `rate_limits` 페이로드를 읽는다. `primary` 는 5시간 창,
-  `secondary` 는 주간 창에 매핑된다.
-
-Snapshot 은 `<state>/projmux/usage/snapshots.json` (또는
-`PROJMUX_USAGE_STATE_DIR`) 에 저장되며, tmux 상태바에서 `projmux status
-usage` 가 실행될 때 최대 30초 주기로만 refresh 된다.
-
-## 범위
-
-`projmux`는 portable한 세션 관리 핵심을 담당합니다. 예를 들어 session naming,
-project discovery, pin, preview state, tmux orchestration, status segment,
-생성 가능한 tmux binding이 여기에 속합니다.
+- [Install](docs/install.md)
+- [Configuration](docs/configuration.md)
+- [Terminal Keybindings](docs/keybindings.md)
+- [CLI Reference](docs/cli.md)
+- [Statusbar](docs/statusbar.md)
+- [Hooks](docs/hooks.md)
+- [Usage tracking](docs/usage-tracking.md)
+- [Agent Workflow](docs/agent-workflow.md)
 
 ## 개발
-
-자주 쓰는 명령:
 
 ```sh
 make build
 make fmt
 make fix
 make test
-make test-integration
-make test-e2e
-make verify
 ```
 
-추가 문서:
-
-- [Architecture](docs/architecture.md)
-- [CLI Reference](docs/cli.md)
-- [Statusbar](docs/statusbar.md)
-- [Notify queue](docs/notify-queue.md)
-- [Usage tracking](docs/usage-tracking.md)
-- [Hooks](docs/hooks.md)
-- [Repo Layout](docs/repo-layout.md)
-- [터미널 키 설정](docs/keybindings.md)
-- [Agent Workflow](docs/agent-workflow.md)
+기여자용 세부 사항은 [Testing](docs/testing.md), [Architecture](docs/architecture.md),
+[Repo Layout](docs/repo-layout.md)을 참고하세요.
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -1,306 +1,105 @@
 # projmux
 
-Project-aware tmux workspace management for people who live in terminals.
-
-`projmux` turns project directories into durable tmux workspaces with previews,
-sidebar navigation, generated keybindings, status metadata, and AI-pane
-attention signals. It can run as its own tmux app (`projmux shell`) or install
-the same behavior into your existing tmux server.
+Project-aware tmux workspaces with fast switching, previews, status context,
+and AI-pane attention built in.
 
 [![npm version](https://img.shields.io/npm/v/projmux?logo=npm)](https://www.npmjs.com/package/projmux)
 [![CI](https://github.com/crevissepartners/projmux/actions/workflows/ci.yml/badge.svg)](https://github.com/crevissepartners/projmux/actions/workflows/ci.yml)
 
-[한국어 README](README-ko.md)
+[Korean README](README-ko.md)
 
-## Why projmux
+> Demo: there is no checked-in demo asset yet. A short GIF or screenshot of
+> `projmux shell` with the sidebar open would be the right future visual.
 
-Most tmux project switchers stop at "pick a directory and attach a session".
-`projmux` treats that as the foundation, then adds the app-level pieces needed
-for a daily terminal workspace:
+## What It Is
 
-- **Project identity stays stable.** Directories, pins, live sessions, preview
-  selection, and lifecycle commands all use the same normalized session model.
-- **The UI shows context before you switch.** Popup and sidebar pickers preview
-  sessions, windows, panes, git branch, Kubernetes context, and pane metadata.
-- **The tmux layer is generated, not hand-spliced.** `projmux` writes the tmux
-  config it needs for popup launchers, window/pane rename flows, status
-  segments, pane borders, attention badges, and app mode.
-- **AI panes are first-class.** Codex and Claude panes can be launched,
-  labeled, tracked as thinking or waiting, surfaced in pane/window/session
-  badges, and announced through desktop notifications.
-- **You can choose isolation or integration.** Use `projmux shell` as a
-  self-contained tmux app, or install the generated snippet into your normal
-  tmux server.
+`projmux` turns project directories into durable tmux sessions. It gives you a
+keyboard-first workspace app for switching projects, previewing sessions,
+opening AI splits, and keeping useful context visible in tmux.
 
-## What It Does
-
-- Creates or switches to tmux sessions from project directories.
-- Shows existing sessions with window and pane previews.
-- Provides popup and sidebar navigation surfaces backed by `fzf`.
-- Pins important projects and scans common source roots for new ones.
-- Persists preview selection for fast window and pane cycling.
-- Generates tmux bindings for launchers, rename prompts, pane borders, status
-  segments, and attention hooks.
-- Displays git branch and Kubernetes context/namespace in the status area.
-- Renders a two-line clickable status bar with click-to-switch tabs on
-  row 0 and HUD-style notify (left) and AI usage (right) segments on
-  row 1.
-- Launches AI splits and keeps their agent name, topic, status, and
-  notification state visible in tmux.
+Use it when you want one command to open your terminal workspace and one set of
+keys to move between projects, windows, panes, notifications, and settings.
 
 ## Requirements
 
-- [Node.js](https://nodejs.org/) and npm — required for the recommended npm
-  install path.
-- [Go 1.24+](https://go.dev/dl/) — required only when installing with
-  `go install` or building from source.
-- [tmux](https://github.com/tmux/tmux/wiki/Installing) **≥ 3.4** — the workspace runtime. Earlier versions miss `display-popup -T` and other features projmux depends on.
-- [fzf](https://github.com/junegunn/fzf#installation) **≥ 0.65.0** — interactive popup/sidebar pickers. The `fzf` executable on `PATH` must report at least 0.65.0 from `fzf --version`; distro packages such as Ubuntu 24 apt may be too old, so use upstream GitHub Releases, Homebrew, or another install method with a version check. `npm i fzf` installs a JavaScript fuzzy-search library, not the junegunn/fzf CLI binary that projmux executes.
-- A Unix shell such as `bash`, `zsh`, or `sh` — `projmux shell` uses your
-  absolute `$SHELL` for the generated app config, falling back to `/bin/sh`.
-- [git](https://git-scm.com/downloads) — branch/status metadata.
-- `stty` — POSIX terminal control, used by `projmux setup`. Already shipped by every macOS / Linux base system; not applicable on Windows hosts.
-- [kubectl](https://kubernetes.io/docs/tasks/tools/) — optional, only for the Kubernetes status segment.
+- [Node.js](https://nodejs.org/) and npm, for the main install path.
+- [tmux](https://github.com/tmux/tmux/wiki/Installing) **3.4 or newer**.
+- [fzf](https://github.com/junegunn/fzf#installation) **0.65.0 or newer**.
 
-Desktop notifications: Linux uses `notify-send`; WSL routes Windows toasts via
-`powershell.exe`. Override either with `PROJMUX_NOTIFY_HOOK`.
-
-Run `projmux doctor` any time to verify runtime dependencies are on `PATH`
-and that tmux/fzf meet the minimum supported versions. Terminal key delivery
-is diagnosed separately with `projmux setup`.
+Run `projmux doctor` after installing to check the local runtime. The `fzf`
+requirement is the junegunn/fzf CLI binary; `npm i fzf` is a different
+JavaScript library.
 
 ## Install
 
 ```sh
 npm install -g projmux
-```
-
-npm installs a small Node.js shim plus the matching platform binary package
-for Linux and macOS on x64 or arm64. The shim marks the install as npm-managed
-so `projmux update` and the Settings About screen can use the right upgrade
-path.
-
-Verify:
-
-```sh
 projmux version
 ```
 
-If npm is not a fit for your machine, install with Go:
+The npm package installs a small Node.js shim plus the matching projmux binary
+for Linux and macOS on x64 or arm64. npm is the primary distribution path for
+normal users.
 
-```sh
-go install github.com/crevissepartners/projmux/cmd/projmux@latest
-```
-
-This drops the binary in `$(go env GOBIN)` (when set) or `$(go env GOPATH)/bin`
-(default `~/go/bin`). Make sure that directory is on your `PATH`.
-
-### Optional: `PROJMUX_PROJDIR`
-
-`PROJMUX_PROJDIR` is the primary project root projmux uses for picker and
-discovery when you explicitly configure it. It is optional; when unset,
-projmux does not assume a canonical repo root. Discovery still uses pins, live
-sessions, saved workdirs, and weak common-folder probes (`~/source`, `~/work`,
-`~/projects`, `~/src`, `~/code`) when they exist.
-
-```sh
-export PROJMUX_PROJDIR="/your/path"
-```
-
-Add the line to `~/.bashrc`, `~/.zshrc`, or your shell's rc file. The resolved value is
-memoized to `~/.config/projmux/projdir` after first use, so later shells keep
-the same root even without the env var.
-
-`PROJMUX_PROJDIR` accepts an OS-native PATH-style multi-value (`:` on
-Linux/macOS, `;` on Windows). The first non-empty entry is the primary
-project root; any additional entries are prepended to the managed-roots
-search list, so they participate in discovery just like
-`PROJMUX_MANAGED_ROOTS`. Only the primary path is memoized to
-`~/.config/projmux/projdir`.
-
-```sh
-# Linux/macOS — primary repo + secondary search root
-export PROJMUX_PROJDIR="/main/repos:/srv/work/repos"
-```
-
-#### Set the project root during setup
-
-```sh
-PROJMUX_PROJDIR=/your/path projmux shell
-```
-
-The first invocation that sees the env var writes
-`~/.config/projmux/projdir`, so later shells without the env var still
-resolve the same root.
-
-You can also manage the saved value interactively with
-`projmux settings > Project Picker > Project Root`. That screen shows the
-effective primary root and source (`PROJMUX_PROJDIR`, `@projmux_projdir`,
-saved, or not configured), shows when a saved value is shadowed by env/tmux,
-and lets you set a path directly, use the current project context, or clear the
-saved value. When no Project Root is configured, the direct-set prompt starts
-with `$HOME` as an editable fallback; it is not treated as the effective root
-until you save it.
-
-### From source
-
-```sh
-git clone https://github.com/crevissepartners/projmux.git
-cd projmux
-make install
-```
-
-`make install` builds, atomically replaces `$(go env GOPATH)/bin/projmux`, and
-runs `projmux tmux apply` so the live `-L projmux` server picks up new bindings
-without a restart. Override the destination with `INSTALL_DIR=/usr/local/bin`.
+Manual Go, source checkout, GitHub Release, and packaging details live in
+[Install](docs/install.md).
 
 ## Quick Start
 
-Launch the isolated projmux tmux app:
+Open the isolated projmux tmux app:
 
 ```sh
 projmux shell
 ```
 
-Inside the app, use the generated keybindings for project switching, session
-previews, AI splits, settings, and notify/usage status surfaces. See
-[Terminal Keybindings](docs/keybindings.md) for the full map.
+Inside the app:
 
-If keys do not fire, run `projmux setup` outside tmux and apply a supported
-terminal fallback with `projmux init [terminal] --apply`. If dependencies look
-wrong, run `projmux doctor`.
+- `Alt-1` opens the project sidebar.
+- `Alt-3` opens the existing-session picker.
+- `Alt-4` opens the AI split picker.
+- `Alt-5` opens settings.
+- `Alt-6` opens the project switcher popup.
 
-## Upgrading
+See [Terminal Keybindings](docs/keybindings.md) for the full key map. If a key
+does not fire, run `projmux setup` outside tmux, then use
+`projmux init [terminal] --apply` for supported terminal fallbacks.
 
-The Settings About screen is the normal interactive update surface: it shows
-cached release status, installer source, Check Updates, Update Now, and
-release notes. The startup update prompt uses the same cache and never reaches
-the network.
-To refresh the cached release status manually, run:
+## Day-To-Day Use
 
-```sh
-projmux update check
-```
+- Pick a project directory and projmux creates or reuses its tmux session.
+- Pin important projects so they stay easy to reach.
+- Preview windows, panes, git branch, Kubernetes context, and AI pane state
+  before switching.
+- Use Settings > Project Picker to add roots and workdirs without editing env
+  vars.
+- Use Settings > About > Update or `projmux update apply` to upgrade.
 
-Use Settings > About > Update or `projmux update apply` to update through the
-detected installer. See [Upgrading](docs/upgrading.md) for npm, Go, GitHub
-Release, and source-checkout details.
+For detailed configuration, including `PROJMUX_PROJDIR`, managed roots,
+notifications, and usage tracking, see [Configuration](docs/configuration.md).
+For update behavior by installer type, see [Upgrading](docs/upgrading.md).
 
-## Usage
+## More Docs
 
-Day-to-day, projmux is driven by tmux keybindings inside `projmux shell` — see
-[Terminal Keybindings](docs/keybindings.md). For the full CLI surface (pins,
-preview state, status helpers, updates, etc.), run `projmux help` or
-`<command> --help`.
-
-## How It Finds Projects
-
-`projmux switch` combines pinned directories, live tmux sessions, and discovered
-project roots. When no explicit search roots are configured, discovery uses
-weak common-folder probes such as `~/source`, `~/work`, `~/projects`, `~/src`,
-and `~/code` if they exist; it does not assume a canonical `~/source/repos`
-root. `projmux settings` also has `Project Picker > Add Project...`, which
-scans filesystem roots up to depth 3 so projects outside the weak probes can be
-added to the picker. Session names are derived from normalized directory paths,
-so a project keeps the same tmux session name across launches.
-
-For permanent search-root customization, the Project Picker section also
-includes:
-
-- `Project Root` - set, change, or clear the saved primary root. This is the
-  one root used as the primary project context; env `PROJMUX_PROJDIR` and tmux
-  `@projmux_projdir` override the saved value until unset. If no root is
-  configured, the direct-set prompt pre-fills `$HOME` so the picker remains
-  usable without inventing an implicit saved root.
-- `+ Add Workdir...` - append a single directory to the saved workdirs list.
-- `Workdirs` - review and remove saved workdirs. The same picker also surfaces
-  any active `PROJMUX_MANAGED_ROOTS` / `TMUX_SESSIONIZER_ROOTS` env values as
-  read-only rows so you can see why an env list might be overriding the saved
-  file.
-
-`Add Workdir > Type path manually...` gives you a typed entry that skips the
-filesystem scan. Use it for paths you do not want crawled, e.g. WSL mounts
-(`/mnt/c/Users/...`), large NFS mounts, or per-project temp roots.
-
-The saved file lives at `~/.config/projmux/workdirs` (one absolute path per
-line, `#` comments allowed). It is consulted only when the env vars are unset.
-
-Settings > Status Bar controls the optional cwd/git leading decoration. The
-default is `off` so terminals without icon fonts render cleanly; `symbol`
-restores the Nerd Font-style folder/git icons, and `emoji` uses emoji
-decorators. The saved value lives at
-`~/.config/projmux/statusbar-decoration`.
-
-## Hooks
-
-projmux runs an optional user script at `~/.config/projmux/hooks/post-create`
-whenever it creates a new tmux session. Use it to inject per-session env via
-`tmux set-environment` (e.g. picking a `GH_TOKEN` based on the project path).
-Missing or non-executable hooks are skipped silently; failures never block
-session creation. See [Hooks](docs/hooks.md) for the env contract, examples,
-and troubleshooting.
-
-## Environment Variables
-
-| Variable | Purpose |
-| --- | --- |
-| `PROJMUX_PROJDIR` | Explicit primary project root for the current shell. Accepts an OS-native PATH-style multi-value: the first entry is the primary repo root (memoized to `~/.config/projmux/projdir`), and any additional entries are prepended to the managed-roots search list. |
-| `PROJMUX_MANAGED_ROOTS` | Colon-separated list of search roots. Overrides the saved/heuristic list. |
-| `PROJMUX_NOTIFY_HOOK` | External executable that receives AI desktop notifications instead of the built-in sender. |
-| `PROJMUX_USAGE_STATE_DIR` | Override directory for the AI-usage snapshot cache. Defaults to `<state>/projmux/usage`. Point this at a synced location (Dropbox, iCloud Drive, etc) to share authoritative usage between machines. |
-| `PROJMUX_USAGE_DEBUG` | When non-empty, surfaces adapter errors from `projmux status usage` to stderr instead of swallowing them. |
-| `PROJMUX_USAGE_LIMITS_PATH` | Deprecated. Limits now come from the upstream APIs (Anthropic OAuth usage endpoint, Codex `rate_limits`); this variable is read but ignored. |
-
-## AI usage tracking
-
-`projmux usage` reports authoritative 5-hour and weekly utilisation for both
-Claude Code and the Codex CLI. Both adapters read from the upstream's own
-view of your account so the percentages match what `claude /usage` and
-`codex` show natively:
-
-- **Claude** — calls `GET https://api.anthropic.com/api/oauth/usage` with the
-  bearer token in `~/.claude/.credentials.json`. The adapter performs a
-  single refresh round-trip on 401 and rewrites the credentials file with
-  the rotated tokens. Tokens are never logged.
-- **Codex** — reads the most recent `rate_limits` payload from the newest
-  `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`. `primary` maps to the 5h
-  window, `secondary` to the weekly window.
-
-Snapshots are persisted under `<state>/projmux/usage/snapshots.json` (or
-`PROJMUX_USAGE_STATE_DIR`) and refreshed at most every 30 seconds when
-`projmux status usage` runs in the tmux status bar.
-
-## Scope
-
-`projmux` owns the portable session-management core: naming, discovery, pins,
-preview state, tmux orchestration, status segments, and generated tmux bindings.
+- [Install](docs/install.md)
+- [Configuration](docs/configuration.md)
+- [Terminal Keybindings](docs/keybindings.md)
+- [CLI Reference](docs/cli.md)
+- [Statusbar](docs/statusbar.md)
+- [Hooks](docs/hooks.md)
+- [Usage tracking](docs/usage-tracking.md)
+- [Agent Workflow](docs/agent-workflow.md)
 
 ## Development
-
-Useful commands:
 
 ```sh
 make build
 make fmt
 make fix
 make test
-make test-integration
-make test-e2e
-make verify
 ```
 
-More documentation:
-
-- [Architecture](docs/architecture.md)
-- [CLI Reference](docs/cli.md)
-- [Statusbar](docs/statusbar.md)
-- [Notify queue](docs/notify-queue.md)
-- [Usage tracking](docs/usage-tracking.md)
-- [Upgrading](docs/upgrading.md)
-- [Hooks](docs/hooks.md)
-- [Repo Layout](docs/repo-layout.md)
-- [Terminal Keybindings](docs/keybindings.md)
-- [Agent Workflow](docs/agent-workflow.md)
+See [Testing](docs/testing.md), [Architecture](docs/architecture.md), and
+[Repo Layout](docs/repo-layout.md) for contributor details.
 
 ## License
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,127 @@
+# Configuration
+
+Most users can configure projmux from `projmux settings`. Environment variables
+are available for repeatable shell setup, managed machines, or advanced
+overrides.
+
+## Project Discovery
+
+`projmux switch` combines pinned directories, live tmux sessions, and
+discovered project roots.
+
+When no explicit roots are configured, discovery uses weak probes only when
+those folders exist:
+
+- `~/source`
+- `~/work`
+- `~/projects`
+- `~/src`
+- `~/code`
+
+It does not assume a canonical repo root.
+
+Use Settings > Project Picker for the normal interactive flow:
+
+- `Project Root` sets, changes, or clears the saved primary root.
+- `+ Add Workdir...` appends one directory to the saved workdirs list.
+- `Workdirs` reviews and removes saved workdirs.
+
+`Add Workdir > Type path manually...` skips the filesystem scan and is useful
+for large mounts, WSL paths, NFS paths, or temporary project roots.
+
+The saved workdir file is:
+
+```text
+~/.config/projmux/workdirs
+```
+
+It stores one absolute path per line. Lines beginning with `#` are comments.
+The file is read only when no env root list is set.
+
+## Environment Variables
+
+| Variable | Purpose |
+| --- | --- |
+| `PROJMUX_PROJDIR` | Explicit primary project root. Accepts an OS-native PATH-style multi-value: the first non-empty entry is the primary root and later entries are prepended to managed-root discovery. The primary value is memoized to `~/.config/projmux/projdir`. |
+| `PROJMUX_MANAGED_ROOTS` | Search-root override. Uses the OS-native path-list separator and takes priority over the saved workdirs file and default weak probes. |
+| `TMUX_SESSIONIZER_ROOTS` | Legacy alias still honored at runtime for managed roots. |
+| `PROJMUX_NOTIFY_HOOK` | External executable that receives AI desktop notifications instead of the built-in Linux/WSL sender. |
+| `PROJMUX_WSL_TOAST_ICON_DIR` | Directory used when copying the WSL toast icon into a Windows-readable path. |
+| `PROJMUX_USAGE_STATE_DIR` | Override directory for AI usage snapshots. Defaults to `<state>/projmux/usage`. Point this at a synced directory to share authoritative usage across machines. |
+| `PROJMUX_USAGE_DEBUG` | When non-empty, prints adapter errors from `projmux status usage` to stderr. |
+| `PROJMUX_USAGE_LIMITS_PATH` | Deprecated. Read but ignored; limits now come from upstream APIs and local Codex rollout state. |
+| `PROJMUX_FOCUS_DEBUG` | When non-empty, `projmux focus` prints one telemetry line to stderr. |
+| `PROJMUX_PICKER_BACKEND` | Set to `native` to opt into the experimental native picker backend. `fzf` remains the default and stable backend. |
+| `PROJMUX_INSTALLER` | Installer source hint used by update flows. npm installs set this automatically; advanced release installs can set `github-release`. |
+
+Example:
+
+```sh
+export PROJMUX_PROJDIR="/main/repos:/srv/work/repos"
+```
+
+On Linux and macOS the separator is `:`. On Windows-style paths the separator
+is `;`.
+
+## tmux Project Root Option
+
+The switch command also reads this tmux option:
+
+```tmux
+set-option -g @projmux_projdir /path/to/repos
+```
+
+An env `PROJMUX_PROJDIR` value takes priority over the tmux option. The tmux
+option takes priority over the saved projdir file.
+
+## Notifications
+
+When `PROJMUX_NOTIFY_HOOK` is unset, projmux uses:
+
+- `notify-send` on Linux.
+- PowerShell toasts on WSL.
+
+When the hook is set, projmux invokes it with positional arguments:
+
+```text
+summary body urgency app-name tag group icon-path
+```
+
+Hook details for new-session lifecycle hooks live in [Hooks](hooks.md).
+
+## Usage Tracking
+
+`projmux usage` and the status-bar usage segment store snapshots under:
+
+```text
+${PROJMUX_USAGE_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/projmux/usage}/snapshots.json
+```
+
+See [Usage tracking](usage-tracking.md) for adapter behavior, throttling, and
+failure handling.
+
+## Status Bar Decoration
+
+Settings > Status Bar controls the optional cwd/git leading decoration:
+
+- `off` is the default and avoids icon-font assumptions.
+- `symbol` restores the Nerd Font-style folder/git icons.
+- `emoji` uses emoji decorators.
+
+The saved value lives at:
+
+```text
+~/.config/projmux/statusbar-decoration
+```
+
+## Rare Tunables
+
+These are intended for debugging or local policy, not routine setup:
+
+| Variable | Purpose |
+| --- | --- |
+| `PROJMUX_TMUX_NOTIFY_DEDUPE_SECONDS` | Collapse window for duplicate AI notifications keyed on `(summary, tag)`. |
+| `PROJMUX_CODEX_TITLE_WATCH_INTERVAL` | Title-watch loop pacing for Codex panes. |
+| `PROJMUX_CODEX_REPLY_SETTLE_LOOPS` | Reply-detection settle-loop pacing for Codex panes. |
+| `TMUX_KUBE_CACHE_TTL` | Kubernetes status segment cache TTL. |
+| `TMUX_KUBE_TIMEOUT` | kubectl invocation budget for the Kubernetes status segment. |

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,99 @@
+# Install
+
+The recommended install path is npm:
+
+```sh
+npm install -g projmux
+projmux version
+```
+
+The `projmux` npm package installs a small Node.js shim plus one
+platform-specific Go binary package for Linux and macOS on x64 or arm64. The
+shim sets `PROJMUX_INSTALLER=npm` so Settings > About and `projmux update`
+can use npm-aware update guidance.
+
+After installing, run:
+
+```sh
+projmux doctor
+```
+
+`doctor` checks that runtime tools such as `tmux` and the junegunn/fzf CLI are
+available and new enough.
+
+## Runtime Tools
+
+Normal use needs:
+
+- Node.js and npm for the npm install channel.
+- tmux 3.4 or newer.
+- fzf 0.65.0 or newer.
+
+Useful optional tools:
+
+- `git` for branch/status metadata.
+- `kubectl` for the Kubernetes status segment.
+- `notify-send` on Linux, or `powershell.exe` under WSL, for built-in desktop
+  notifications.
+
+## Go Install
+
+Use this only when npm is not the right fit for your machine or workflow:
+
+```sh
+go install github.com/crevissepartners/projmux/cmd/projmux@latest
+```
+
+This requires Go 1.24 or newer. The binary is written to `$(go env GOBIN)` when
+set, otherwise `$(go env GOPATH)/bin` (usually `~/go/bin`). Make sure that
+directory is on `PATH`.
+
+Go-managed installs can update through:
+
+```sh
+projmux upgrade
+```
+
+See [Upgrading](upgrading.md) for version pinning and installer-specific
+update behavior.
+
+## Source Checkout
+
+Source installs are for contributors or users who intentionally track a local
+checkout:
+
+```sh
+git clone https://github.com/crevissepartners/projmux.git
+cd projmux
+make install
+```
+
+`make install` builds the binary, atomically replaces
+`$(go env GOPATH)/bin/projmux`, runs `projmux tmux apply`, and reconciles the
+notify queue. Override the destination with `INSTALL_DIR=/usr/local/bin`.
+
+Update source checkouts with the repository workflow:
+
+```sh
+git pull --ff-only
+make install
+```
+
+## GitHub Release Binary
+
+GitHub Release tarballs are supported by the updater when the install is
+marked as release-managed:
+
+```sh
+export PROJMUX_INSTALLER=github-release
+```
+
+With that set, `projmux update apply` downloads the latest matching release
+asset, replaces the current executable, and reapplies the live tmux config
+unless `--no-apply` is used.
+
+## npm Packaging Details
+
+Repository packaging and publish details are maintained in
+[npm Distribution](npm-distribution.md). That document is for maintainers; end
+users should not need it for installation.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "files": [
     "npm/projmux.js",
+    "docs/*.md",
     "README.md",
     "README-ko.md",
     "LICENSE"

--- a/scripts/package-npm.sh
+++ b/scripts/package-npm.sh
@@ -68,9 +68,11 @@ NODE
 stage_main() {
   local dir="$out/projmux"
   mkdir -p "$dir/npm"
+  mkdir -p "$dir/docs"
   cp "$root/package.json" "$dir/package.json"
   cp "$root/npm/projmux.js" "$dir/npm/projmux.js"
   cp "$root/README.md" "$root/README-ko.md" "$root/LICENSE" "$dir/"
+  cp "$root"/docs/*.md "$dir/docs/"
   chmod 0755 "$dir/npm/projmux.js"
   patch_version "$dir/package.json"
 }


### PR DESCRIPTION
## Summary
- Shrink README/README-ko into npm-first onboarding pages with minimal requirements
- Move manual install, source checkout, release binary, and package details into docs/install.md
- Move project discovery and environment variable details into docs/configuration.md
- Include docs/*.md in the root npm package so README links resolve from npm package views

## Validation
- git diff --check
- make fmt-check
- make npm-pack