### PR TITLE
fix(notify): make sidebar navigation-only

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -179,11 +179,11 @@ projmux notify reconcile [--json]
   reply badges that do not queue because no AI agent is attached, live AI
   reply panes missing a queue entry, matched AI reply entries, and stale
   queue entries whose live pane no longer matches. `--ui=sidebar` opens the
-  compact interactive notify list where Enter focuses and acks a target, `a`
-  acks the selected row, and `Ctrl-A` clears all; opening or navigating the
+  compact interactive notify list where Enter focuses and acks a target, `x`
+  acks the selected row, and `Ctrl-X` clears all; opening or navigating the
   sidebar does not ack. The sidebar uses two-line cards with notification text
-  first and compact age/project/window/pane metadata below, while keeping ids,
-  source, severity, and target details searchable.
+  first and compact age/project/window/pane metadata below. Hidden queue ids
+  remain action values, but the sidebar has no search input.
 - `ack <id>` removes one entry; `--all` flushes the queue.
 - `reconcile` — walks `tmux list-panes -a` and back-fills entries for
   panes whose attention state is `reply` AND whose AI agent option is

--- a/docs/notify-queue.md
+++ b/docs/notify-queue.md
@@ -83,10 +83,11 @@ preserves the stable JSON array used by scripts.
 
 `--ui=sidebar` opens the notify queue as an interactive right-side list when
 run inside the tmux popup surface. Enter focuses the selected target pane and
-acks the row after focus succeeds. `a` acks the selected row. `Ctrl-A` clears
+acks the row after focus succeeds. `x` acks the selected row. `Ctrl-X` clears
 all rows via `notify ack --all`. Rows are intentionally compact: the visible
 label keeps notification text first, then age, project, window, and pane
-metadata; id/source/severity/target remain searchable.
+metadata; hidden queue ids remain action values but the sidebar has no search
+input.
 
 `--live` adds a non-mutating explanation view that reads
 `tmux list-panes -a` and compares the queue with live reply-state panes. It

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -276,14 +276,15 @@ func (c *notifyCommand) runSidebar(entries []notify.Notification, stdout, stderr
 	}
 	now := c.clock()
 	fzfOptions := intfzf.Options{
-		UI:         "notify-sidebar",
-		Read0:      true,
-		Prompt:     "Notify > ",
-		Header:     "Pending notifications, newest first",
-		Footer:     "Enter: focus + ack  |  a: ack  |  Ctrl-A: clear all  |  Esc/Alt-2: close",
-		ExpectKeys: []string{"a", "ctrl-a"},
-		Bindings:   []string{"alt-2:abort"},
-		Entries:    notifySidebarEntries(entries, now),
+		UI:            "notify-sidebar",
+		Read0:         true,
+		Prompt:        "Notify > ",
+		Header:        "Pending notifications, newest first",
+		Footer:        "Enter: focus + ack  |  x: ack  |  Ctrl-X: clear all  |  Esc/Alt-2: close",
+		ExpectKeys:    []string{"x", "ctrl-x"},
+		Bindings:      []string{"alt-2:abort"},
+		Entries:       notifySidebarEntries(entries, now),
+		DisableSearch: true,
 	}
 	result, err := c.picker.Run(fzfOptions)
 	if err != nil {
@@ -298,14 +299,14 @@ func (c *notifyCommand) runSidebar(entries []notify.Notification, stdout, stderr
 		return err
 	}
 	switch result.Key {
-	case "ctrl-a":
+	case "ctrl-x":
 		removed, err := store.AckAll()
 		if err != nil {
 			return fmt.Errorf("clear all notifications: %w", err)
 		}
 		_, err = fmt.Fprintf(stdout, "cleared %d notification(s)\n", removed)
 		return err
-	case "a":
+	case "x":
 		if err := store.Ack(id); err != nil {
 			return fmt.Errorf("ack notification: %w", err)
 		}
@@ -331,24 +332,16 @@ const notifySidebarEmptyValue = "__projmux_notify_empty__"
 func notifySidebarEntries(entries []notify.Notification, now time.Time) []intfzf.Entry {
 	if len(entries) == 0 {
 		return []intfzf.Entry{{
-			Label:     "No pending notifications",
-			Value:     notifySidebarEmptyValue,
-			SearchKey: "empty no pending notifications",
+			Label: "No pending notifications",
+			Value: notifySidebarEmptyValue,
 		}}
 	}
 	out := make([]intfzf.Entry, 0, len(entries))
 	for _, e := range entries {
-		target := notify.FormatTarget(notify.Target{
-			Socket:  e.Socket,
-			Session: e.Session,
-			Window:  e.Window,
-			Pane:    e.Pane,
-		})
 		label := notifySidebarLabel(e, now)
 		out = append(out, intfzf.Entry{
-			Label:     label,
-			Value:     e.ID,
-			SearchKey: strings.Join([]string{e.ID, e.Text, e.Severity, e.Source, target}, " "),
+			Label: label,
+			Value: e.ID,
 		})
 	}
 	return out

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -268,14 +268,20 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if !picker.options.Read0 {
 		t.Fatal("picker Read0 = false, want true")
 	}
+	if !picker.options.DisableSearch {
+		t.Fatal("picker DisableSearch = false, want true")
+	}
 	if got, want := picker.options.Prompt, "Notify > "; got != want {
 		t.Fatalf("picker prompt = %q, want %q", got, want)
 	}
 	if got, want := picker.options.Header, "Pending notifications, newest first"; got != want {
 		t.Fatalf("picker header = %q, want %q", got, want)
 	}
-	if got, want := picker.options.Footer, "Enter: focus + ack  |  a: ack  |  Ctrl-A: clear all  |  Esc/Alt-2: close"; got != want {
+	if got, want := picker.options.Footer, "Enter: focus + ack  |  x: ack  |  Ctrl-X: clear all  |  Esc/Alt-2: close"; got != want {
 		t.Fatalf("picker footer = %q, want %q", got, want)
+	}
+	if got, want := picker.options.ExpectKeys, []string{"x", "ctrl-x"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("expect keys = %#v, want %#v", got, want)
 	}
 	if len(picker.options.Entries) != 1 || picker.options.Entries[0].Value != "abc" {
 		t.Fatalf("entries = %#v", picker.options.Entries)
@@ -294,10 +300,8 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if strings.Contains(entry.Label, "abc") {
 		t.Fatalf("sidebar label = %q, want hidden queue id", entry.Label)
 	}
-	for _, want := range []string{"abc", "codex: reply ready", "warn", "ai", "main:1.0"} {
-		if !strings.Contains(entry.SearchKey, want) {
-			t.Fatalf("search key = %q, want %q", entry.SearchKey, want)
-		}
+	if entry.SearchKey != "" {
+		t.Fatalf("search key = %q, want empty for navigation-only sidebar", entry.SearchKey)
 	}
 	if got, want := picker.options.Bindings, []string{"alt-2:abort"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("bindings = %#v, want %#v", got, want)
@@ -387,7 +391,7 @@ func TestNotifyListSidebarAcksSelectedRow(t *testing.T) {
 	store := &stubNotifyStore{
 		listEntries: []notify.Notification{{ID: "abc", Text: "deploy ok", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"}},
 	}
-	picker := &stubNotifyPicker{result: intfzf.Result{Key: "a", Value: "abc"}}
+	picker := &stubNotifyPicker{result: intfzf.Result{Key: "x", Value: "abc"}}
 	cmd := newCmd(store)
 	cmd.picker = picker
 
@@ -410,7 +414,7 @@ func TestNotifyListSidebarClearAll(t *testing.T) {
 		listEntries: []notify.Notification{{ID: "abc", Text: "deploy ok", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"}},
 		ackAll:      1,
 	}
-	picker := &stubNotifyPicker{result: intfzf.Result{Key: "ctrl-a", Value: "abc"}}
+	picker := &stubNotifyPicker{result: intfzf.Result{Key: "ctrl-x", Value: "abc"}}
 	cmd := newCmd(store)
 	cmd.picker = picker
 

--- a/internal/ui/fzf/runner.go
+++ b/internal/ui/fzf/runner.go
@@ -25,6 +25,10 @@ type Options struct {
 	PreviewWindow  string
 	Bindings       []string
 	InitialQuery   string
+	// DisableSearch makes fzf a navigation-only list. It hides the input
+	// section, disables query matching, and suppresses projmux's SearchKey
+	// reload filter.
+	DisableSearch bool
 	// AcceptQuery surfaces the user-typed query alongside any selection.
 	// When true, the runner passes --print-query to fzf and Result.Query is
 	// populated from the first stdout line emitted by fzf. Existing callers
@@ -153,7 +157,7 @@ func selectedResultWithQuery(selection string, expectKeys []string) Result {
 }
 
 func runnerArgs(options Options, supportsFooter bool, filterFile string) []string {
-	searchKeyed := hasSearchKey(options)
+	searchKeyed := searchKeyEnabled(options)
 	args := []string{
 		"--prompt", resolvedPrompt(options),
 		"--height", "100%",
@@ -167,7 +171,9 @@ func runnerArgs(options Options, supportsFooter bool, filterFile string) []strin
 	} else {
 		args = append(args, "--with-nth", "1")
 	}
-	if filterFile != "" {
+	if options.DisableSearch {
+		args = append(args, "--disabled", "--no-input")
+	} else if filterFile != "" {
 		args = append(args, "--disabled", "--bind", "change:reload("+searchKeyFilterCommand(filterFile)+")")
 	}
 	if !options.AcceptQuery {
@@ -259,7 +265,7 @@ func renderedInput(options Options) string {
 
 func renderedEntries(options Options) []string {
 	if len(options.Entries) != 0 {
-		searchKeyed := hasSearchKey(options)
+		searchKeyed := searchKeyEnabled(options)
 		lines := make([]string, 0, len(options.Entries))
 		for _, entry := range options.Entries {
 			if searchKeyed {
@@ -340,7 +346,7 @@ func firstLine(value string) string {
 }
 
 func searchKeyFilterFile(options Options, input string) (string, func(), error) {
-	if !hasSearchKey(options) {
+	if !searchKeyEnabled(options) {
 		return "", func() {}, nil
 	}
 
@@ -370,6 +376,10 @@ func searchKeyFilterCommand(path string) string {
 
 func searchKeyValuePlaceholder(command string) string {
 	return strings.ReplaceAll(command, "{2}", "{3}")
+}
+
+func searchKeyEnabled(options Options) bool {
+	return !options.DisableSearch && hasSearchKey(options)
 }
 
 func shellQuote(value string) string {

--- a/internal/ui/fzf/runner_test.go
+++ b/internal/ui/fzf/runner_test.go
@@ -245,6 +245,66 @@ func TestRunnerRunSupportsSearchKeyedEntries(t *testing.T) {
 	}
 }
 
+func TestRunnerRunDisableSearchKeepsNotifySidebarNavigationOnly(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeCommand{stdout: "workspace\n  ~/workspace\t/home/tester/workspace\x00"}
+
+	r := &runner{
+		lookupPath:     func(string) (string, error) { return "/usr/bin/fzf", nil },
+		supportsFooter: func(string) bool { return true },
+		newCommand: func(name string, args ...string) command {
+			want := []string{
+				"--prompt", "Notify > ",
+				"--height", "100%",
+				"--layout", "reverse",
+				"--border",
+				"--ansi",
+				"--delimiter", "\t",
+				"--with-nth", "1",
+				"--disabled",
+				"--no-input",
+				"--exit-0",
+				"--scrollbar", "█",
+				"--info", "inline-right",
+				"--read0",
+				"--print0",
+				"--highlight-line",
+				"--gap",
+				"--gap-line", "─",
+				"--pointer", "▌",
+				"--marker-multi-line", "┃┃┃",
+				"--color", "current-bg:#263238,current-fg:#ffffff,current-hl:#ffcc66,selected-bg:#1f292d,gutter:#263238,pointer:#e12672,marker:#e12672",
+				"--bind", "right:execute-silent(open {2})",
+			}
+			if got := args; !equalStrings(got, want) {
+				t.Fatalf("command args = %q, want %q", got, want)
+			}
+			return fake
+		},
+	}
+
+	got, err := r.Run(Options{
+		UI:            "notify-sidebar",
+		Read0:         true,
+		Prompt:        "Notify > ",
+		DisableSearch: true,
+		Bindings:      []string{"right:execute-silent(open {2})"},
+		Entries: []Entry{
+			{SearchKey: "workspace", Label: "workspace\n  ~/workspace", Value: "/home/tester/workspace"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got != (Result{Value: "/home/tester/workspace"}) {
+		t.Fatalf("Run() = %#v, want hidden value", got)
+	}
+	if got, want := fake.stdin.String(), "workspace\n  ~/workspace\t/home/tester/workspace"; got != want {
+		t.Fatalf("stdin = %q, want %q", got, want)
+	}
+}
+
 func TestRunnerRunRewritesSearchKeyedValuePlaceholders(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- disable fzf search/input for `notify list --ui=sidebar`
- change sidebar shortcuts to `x` for row ack and `Ctrl-X` for clear all
- update notify CLI docs for the navigation-only sidebar

## Validation
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache go test ./internal/app ./internal/ui/fzf`
- `GOCACHE=/tmp/projmux-go-cache make test` attempted; local environment fails in `internal/integrations/hooks` with `text file busy`, reproduced on unchanged main checkout
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
