### PR TITLE
chore: refresh go fix rewrites

### DIFF
--- a/internal/app/init_ghostty_test.go
+++ b/internal/app/init_ghostty_test.go
@@ -34,7 +34,6 @@ func TestGhosttyAdapterDetect(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			env := func(k string) string { return tc.env[k] }
@@ -340,7 +339,6 @@ func TestParseGhosttyKeybind(t *testing.T) {
 		{line: "font-size = 14", wantOk: false},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.line, func(t *testing.T) {
 			t.Parallel()
 			gotTrigger, gotAction, gotOk := parseGhosttyKeybind(tc.line)

--- a/internal/app/init_windows_terminal.go
+++ b/internal/app/init_windows_terminal.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -325,9 +326,7 @@ func (w *WindowsTerminalAdapter) PlanMerge(currentConfig string, fileExists bool
 				for k := range existingAction {
 					delete(existingAction, k)
 				}
-				for k, v := range desiredAction {
-					existingAction[k] = v
-				}
+				maps.Copy(existingAction, desiredAction)
 				actionChanged = true
 				dirty = true
 			}
@@ -345,9 +344,7 @@ func (w *WindowsTerminalAdapter) PlanMerge(currentConfig string, fileExists bool
 				for k := range existingKB {
 					delete(existingKB, k)
 				}
-				for k, v := range desiredKB {
-					existingKB[k] = v
-				}
+				maps.Copy(existingKB, desiredKB)
 				kbChanged = true
 				dirty = true
 			}

--- a/internal/app/init_windows_terminal_test.go
+++ b/internal/app/init_windows_terminal_test.go
@@ -79,7 +79,6 @@ func TestWTAdapterDetect(t *testing.T) {
 		{name: "empty", env: map[string]string{}, want: false},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if got := a.Detect(envFn(tc.env)); got != tc.want {

--- a/internal/core/focus/parse.go
+++ b/internal/core/focus/parse.go
@@ -125,8 +125,8 @@ func Parse(spec string) (Target, error) {
 }
 
 func assignWindow(target *Target, raw string) error {
-	if strings.HasPrefix(raw, "@") {
-		body := strings.TrimPrefix(raw, "@")
+	if after, ok := strings.CutPrefix(raw, "@"); ok {
+		body := after
 		if body == "" {
 			return errors.New("window id '@' must be followed by digits")
 		}
@@ -150,8 +150,8 @@ func assignWindow(target *Target, raw string) error {
 }
 
 func assignPane(target *Target, raw string) error {
-	if strings.HasPrefix(raw, "%") {
-		body := strings.TrimPrefix(raw, "%")
+	if after, ok := strings.CutPrefix(raw, "%"); ok {
+		body := after
 		if body == "" {
 			return errors.New("pane id '%' must be followed by digits")
 		}

--- a/internal/core/focus/resolve.go
+++ b/internal/core/focus/resolve.go
@@ -91,10 +91,7 @@ func tokens(name string) []string {
 }
 
 func sharedPrefixTokens(a, b []string) int {
-	limit := len(a)
-	if len(b) < limit {
-		limit = len(b)
-	}
+	limit := min(len(b), len(a))
 	for i := 0; i < limit; i++ {
 		if a[i] != b[i] {
 			return i

--- a/internal/core/notify/store.go
+++ b/internal/core/notify/store.go
@@ -354,7 +354,7 @@ func (s *Store) withLock(fn func() error) error {
 
 func (s *Store) acquireLock() error {
 	delay := defaultLockBaseDelay
-	for attempt := 0; attempt < defaultLockMaxAttempts; attempt++ {
+	for range defaultLockMaxAttempts {
 		f, err := os.OpenFile(s.lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 		if err == nil {
 			_, _ = fmt.Fprintf(f, "pid=%d\n", os.Getpid())

--- a/internal/core/usage/adapters/claude/claude.go
+++ b/internal/core/usage/adapters/claude/claude.go
@@ -283,20 +283,15 @@ func (a *Adapter) recordBackoff(now time.Time, retryAfter time.Duration) {
 	a.consecutive429++
 	var dur time.Duration
 	if retryAfter > 0 {
-		dur = retryAfter
-		// Server told us a value but it's smaller than our anti-hammer
-		// floor: bump it up. This protects against pathological 429
-		// loops where Retry-After: 1 would otherwise let the CLI
-		// re-hit Anthropic once per second.
-		if dur < retryAfterFloor {
-			dur = retryAfterFloor
-		}
+		dur = max(
+			// Server told us a value but it's smaller than our anti-hammer
+			// floor: bump it up. This protects against pathological 429
+			// loops where Retry-After: 1 would otherwise let the CLI
+			// re-hit Anthropic once per second.
+			retryAfter, retryAfterFloor)
 	} else {
 		// 30m, 60m, 60m (cap). n=1 → 30m, n>=2 → 60m.
-		shift := a.consecutive429 - 1
-		if shift < 0 {
-			shift = 0
-		}
+		shift := max(a.consecutive429-1, 0)
 		if shift > 30 {
 			shift = 30 // guard against overflow on absurd streaks.
 		}

--- a/internal/core/usage/hud.go
+++ b/internal/core/usage/hud.go
@@ -29,10 +29,7 @@ func BarFillCount(pct float64) int {
 	if pct >= 100 {
 		return BarCells
 	}
-	cells := int(pct/100.0*float64(BarCells) + 0.5)
-	if cells < 0 {
-		cells = 0
-	}
+	cells := max(int(pct/100.0*float64(BarCells)+0.5), 0)
 	if cells > BarCells {
 		cells = BarCells
 	}
@@ -47,7 +44,7 @@ func RenderBar(pct float64) string {
 	var b strings.Builder
 	b.Grow(BarCells + 2)
 	b.WriteByte('[')
-	for i := 0; i < BarCells; i++ {
+	for i := range BarCells {
 		if i < filled {
 			b.WriteRune(BarFilledRune)
 		} else {
@@ -72,7 +69,7 @@ func RenderColoredBar(pct float64, fillColor, emptyColor string) string {
 			b.WriteString(fillColor)
 			b.WriteByte(']')
 		}
-		for i := 0; i < filled; i++ {
+		for range filled {
 			b.WriteRune(BarFilledRune)
 		}
 	}

--- a/internal/core/usage/hud_test.go
+++ b/internal/core/usage/hud_test.go
@@ -26,7 +26,6 @@ func TestBarFillCountBoundaryCases(t *testing.T) {
 		{"one-fifty", 150, 10}, // saturates at full.
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if got := BarFillCount(tc.pct); got != tc.want {

--- a/internal/core/usage/manager_test.go
+++ b/internal/core/usage/manager_test.go
@@ -193,7 +193,7 @@ func TestMaybeCollectZeroThrottleAlwaysRuns(t *testing.T) {
 	adapter := &countingAdapter{name: "claude"}
 	mgr, _ := newTestManager(t, adapter, now)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		ran, err := mgr.MaybeCollect(context.Background(), 0)
 		if err != nil {
 			t.Fatalf("iter %d: %v", i, err)

--- a/internal/integrations/hooks/hooks.go
+++ b/internal/integrations/hooks/hooks.go
@@ -215,7 +215,7 @@ func (p *linePrefixer) Flush() {
 	p.buf.Reset()
 }
 
-func warnf(w io.Writer, format string, args ...interface{}) {
+func warnf(w io.Writer, format string, args ...any) {
 	if w == nil {
 		return
 	}


### PR DESCRIPTION
## Summary
- apply the current `go fix ./...` mechanical rewrites
- remove obsolete loop variable captures
- use newer standard library helpers where `go fix` rewrites them

## Validation
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `make fmt`
- `git diff --check`
- `GOCACHE=/tmp/projmux-go-cache make test` passed outside the sandbox after the sandboxed run hit the known localhost `httptest` restriction
