### PR TITLE
fix(notify): decorate sidebar popup title

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -402,7 +402,7 @@ flags with the top-level `switch` UX:
 - `attach auto [--keep=N] [--fallback=home|ephemeral]` — auto-attach to
   the most recent session, with bounded retention and a fallback policy.
 - `settings` — interactive configuration UI for the project picker, AI
-  splits, Status Bar cwd/git decoration, Project Root management, the
+  splits, Icons & Decorations mode, Project Root management, the
   switcher's saved workdirs list, and About/Update status. In Project Picker,
   `Project Root` manages the saved
   primary root (`~/.config/projmux/projdir`) and displays whether the effective
@@ -410,7 +410,7 @@ flags with the top-level `switch` UX:
   no configured source. When no source is configured, the direct-set prompt
   starts with `$HOME` as an editable fallback, but `$HOME` is not used as the
   effective root unless saved. `Workdirs` remains separate: those entries are
-  additional search roots, not the primary root. Status Bar stores
+  additional search roots, not the primary root. Icons & Decorations stores
   `~/.config/projmux/statusbar-decoration` as `off` (default), `symbol`, or
   `emoji` and updates the live tmux option when available. The About section
   reads the cached update status without network access;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,12 +100,12 @@ ${PROJMUX_USAGE_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/projmux/usage}/
 See [Usage tracking](usage-tracking.md) for adapter behavior, throttling, and
 failure handling.
 
-## Status Bar Decoration
+## Decoration Mode
 
-Settings > Status Bar controls the optional cwd/git leading decoration:
+Settings > Icons & Decorations controls optional status and popup decoration:
 
 - `off` is the default and avoids icon-font assumptions.
-- `symbol` restores the Nerd Font-style folder/git icons.
+- `symbol` restores the Nerd Font-style folder/git/bell icons.
 - `emoji` uses emoji decorators.
 
 The saved value lives at:

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -73,8 +73,9 @@ The path popup uses a short title, one-line copy status, the current path, and
 an `Enter closes this popup` prompt. If the tmux buffer write fails, it keeps
 the same compact surface with `Current path` as the title and a copy-unavailable
 message. The notification HUD detail surface (`Alt-2` / `User2`) opens the
-right-side `Notifications` popup with newest-first rows; selecting a row still
-focuses and acknowledges that notification.
+right-side notification popup with newest-first rows; its popup title follows
+the decoration mode (`off` leaves it untitled, `symbol`/`emoji` show a bell).
+Selecting a row still focuses and acknowledges that notification.
 
 Empty `#{mouse_status_range}` (a click on whitespace) falls through to
 `select-window -t @<mouse_window>` when `--mouse-window` is non-empty,
@@ -128,10 +129,10 @@ emits a deterministic block per segment), regenerate, and re-apply:
 projmux tmux apply
 ```
 
-Settings > Status Bar > cwd/git leading decoration controls the optional
-prefix before the path and git branch. The persisted enum lives at
+Settings > Icons & Decorations controls the optional decoration mode used by
+the path, git branch, and notification popup. The persisted enum lives at
 `~/.config/projmux/statusbar-decoration`; valid values are `off` (default,
-font-safe), `symbol` (Nerd Font-style folder/git icons), and `emoji`.
+font-safe), `symbol` (Nerd Font-style folder/git/bell icons), and `emoji`.
 Settings also updates tmux `@projmux_statusbar_decoration` for the live
 server when run inside tmux.
 

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -162,7 +162,7 @@ func (c *settingsCommand) rootEntries() []intfzf.Entry {
 			Value: settingsSectionProject,
 		},
 		{
-			Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Status Bar", "cwd/git leading decoration"),
+			Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Icons & Decorations", "status and popup decoration mode"),
 			Value: settingsSectionStatusbar,
 		},
 		{
@@ -198,8 +198,8 @@ func (c *settingsCommand) sectionOptions(section string) (intfzf.Options, error)
 		return intfzf.Options{
 			UI:         "settings-statusbar",
 			Entries:    c.statusbarEntries(),
-			Prompt:     "Settings > Status Bar > ",
-			Header:     "Set cwd/git leading decoration",
+			Prompt:     "Settings > Icons & Decorations > ",
+			Header:     "Set status and popup decoration mode",
 			Footer:     projmuxFooter("Enter: apply  |  Back row: parent  |  Esc/Alt+5/Ctrl+Alt+S: close"),
 			ExpectKeys: []string{"enter"},
 			Bindings:   settingsCloseBindings(),
@@ -912,9 +912,9 @@ func (c *settingsCommand) statusbarEntries() []intfzf.Entry {
 		mode config.StatusbarDecoration
 		desc string
 	}{
-		{config.StatusbarDecorationOff, "no cwd/git prefix; safest for all fonts"},
-		{config.StatusbarDecorationSymbol, "Nerd Font-style folder and git icons"},
-		{config.StatusbarDecorationEmoji, "emoji folder and branch icons"},
+		{config.StatusbarDecorationOff, "no status or popup icon prefix; safest for all fonts"},
+		{config.StatusbarDecorationSymbol, "Nerd Font-style status and notification icons"},
+		{config.StatusbarDecorationEmoji, "emoji status and notification icons"},
 	}
 
 	entries := make([]intfzf.Entry, 0, len(modes)+1)
@@ -949,9 +949,9 @@ func (c *settingsCommand) setStatusbarDecoration(value string) error {
 	}
 	if c.lookupEnv != nil && strings.TrimSpace(c.lookupEnv("TMUX")) != "" && c.runCommand != nil {
 		if err := c.runCommand("tmux", "set-option", "-g", statusbarDecorationTmuxOption, string(mode)); err != nil {
-			return fmt.Errorf("set live tmux statusbar decoration: %w", err)
+			return fmt.Errorf("set live tmux decoration mode: %w", err)
 		}
-		_ = c.runCommand("tmux", "display-message", "statusbar decoration: "+string(mode))
+		_ = c.runCommand("tmux", "display-message", "decoration mode: "+string(mode))
 	}
 	return nil
 }

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -65,6 +65,9 @@ func TestSettingsHubSetsAIDefaultMode(t *testing.T) {
 	if !hasEntryValue(rootOptions.Entries, settingsSectionStatusbar) {
 		t.Fatalf("root settings entries = %#v, want statusbar section", rootOptions.Entries)
 	}
+	if !hasEntryLabelContaining(rootOptions.Entries, "Icons & Decorations") {
+		t.Fatalf("root settings entries = %#v, want generic decoration section label", rootOptions.Entries)
+	}
 	if !hasEntryValue(rootOptions.Entries, settingsSectionAbout) {
 		t.Fatalf("root settings entries = %#v, want about section", rootOptions.Entries)
 	}
@@ -123,6 +126,12 @@ func TestSettingsHubSetsStatusbarDecoration(t *testing.T) {
 	if got, want := statusbarOptions.UI, "settings-statusbar"; got != want {
 		t.Fatalf("statusbar settings UI = %q, want %q", got, want)
 	}
+	if got, want := statusbarOptions.Prompt, "Settings > Icons & Decorations > "; got != want {
+		t.Fatalf("statusbar settings prompt = %q, want %q", got, want)
+	}
+	if got, want := statusbarOptions.Header, "Set status and popup decoration mode"; got != want {
+		t.Fatalf("statusbar settings header = %q, want %q", got, want)
+	}
 	if !hasEntryValue(statusbarOptions.Entries, settingsActionPrefixStatusbar+string(config.StatusbarDecorationOff)) {
 		t.Fatalf("statusbar settings entries = %#v, want off row", statusbarOptions.Entries)
 	}
@@ -146,7 +155,7 @@ func TestSettingsHubSetsStatusbarDecoration(t *testing.T) {
 	}
 	if !reflect.DeepEqual(tmuxCalls, [][]string{
 		{"tmux", "set-option", "-g", statusbarDecorationTmuxOption, "emoji"},
-		{"tmux", "display-message", "statusbar decoration: emoji"},
+		{"tmux", "display-message", "decoration mode: emoji"},
 	}) {
 		t.Fatalf("tmux calls = %#v", tmuxCalls)
 	}

--- a/internal/app/statusbar_decoration.go
+++ b/internal/app/statusbar_decoration.go
@@ -60,3 +60,14 @@ func statusbarGitDecorator(mode config.StatusbarDecoration) string {
 		return ""
 	}
 }
+
+func notificationPopupTitle(mode config.StatusbarDecoration) string {
+	switch mode {
+	case config.StatusbarDecorationSymbol:
+		return ""
+	case config.StatusbarDecorationEmoji:
+		return "🔔"
+	default:
+		return ""
+	}
+}

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -584,6 +584,7 @@ type tmuxPopupContext struct {
 	ContextDir    string
 	ClientWidth   int
 	ClientHeight  int
+	Decoration    config.StatusbarDecoration
 }
 
 func (c *tmuxCommand) popupContext(ctx context.Context) tmuxPopupContext {
@@ -594,6 +595,11 @@ func (c *tmuxCommand) popupContext(ctx context.Context) tmuxPopupContext {
 	if clientKey == "" {
 		clientKey = "unknown"
 	}
+	rawDecoration := c.tmuxFormat(ctx, "#{"+statusbarDecorationTmuxOption+"}")
+	decoration := config.NormalizeStatusbarDecoration(rawDecoration)
+	if strings.TrimSpace(rawDecoration) == "" {
+		decoration = loadStatusbarDecoration(c.homeDir, c.lookupEnv)
+	}
 
 	return tmuxPopupContext{
 		ClientKey:     sanitizePopupKey(clientKey),
@@ -603,6 +609,7 @@ func (c *tmuxCommand) popupContext(ctx context.Context) tmuxPopupContext {
 		ContextDir:    c.tmuxFormat(ctx, "#{pane_current_path}"),
 		ClientWidth:   parseTmuxPositiveInt(c.tmuxFormat(ctx, "#{client_width}")),
 		ClientHeight:  parseTmuxPositiveInt(c.tmuxFormat(ctx, "#{client_height}")),
+		Decoration:    decoration,
 	}
 }
 
@@ -671,7 +678,7 @@ func buildPopupToggle(mode tmuxPopupToggleMode, binaryPath, marker string, ctx t
 		options.Height = popupSize(ctx.ClientHeight, 100, 20)
 		options.X = popupRightX(ctx.ClientWidth, options.Width)
 		options.Y = "0"
-		options.Title = "Notifications"
+		options.Title = notificationPopupTitle(ctx.Decoration)
 		commandArgs = []string{"notify", "list", "--ui=sidebar"}
 	case "ai-split-picker-right", "ai-split-picker-down":
 		options.Width = popupSize(ctx.ClientWidth, 40, 96)

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -254,43 +255,64 @@ func TestAppRunTmuxPopupToggleOpensStandaloneSidebar(t *testing.T) {
 func TestAppRunTmuxPopupToggleOpensNotifySidebarOnRight(t *testing.T) {
 	t.Parallel()
 
-	marker := popupMarkerPath(sanitizePopupKey("/dev/pts/projmux-test-notify"), "notify-sidebar")
-	_ = os.Remove(marker)
-	defer os.Remove(marker)
+	for _, tt := range []struct {
+		name       string
+		decoration string
+		wantTitle  string
+	}{
+		{name: "off", decoration: "off"},
+		{name: "symbol", decoration: "symbol", wantTitle: ""},
+		{name: "emoji", decoration: "emoji", wantTitle: "🔔"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	runner := &recordingTmuxRunner{formats: map[string]string{
-		"#{client_tty}":    "/dev/pts/projmux-test-notify",
-		"#{pane_id}":       "%1",
-		"#S":               "work",
-		"#{client_width}":  "200",
-		"#{client_height}": "50",
-	}}
-	cmd := &tmuxCommand{
-		runner:     runner,
-		executable: func() (string, error) { return "/tmp/proj mux/bin/projmux", nil },
-	}
+			clientKey := "/dev/pts/projmux-test-notify-" + tt.name
+			marker := popupMarkerPath(sanitizePopupKey(clientKey), "notify-sidebar")
+			_ = os.Remove(marker)
+			defer os.Remove(marker)
 
-	if err := cmd.Run([]string{"popup-toggle", "notify-sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
-		t.Fatalf("Run() error = %v", err)
-	}
+			runner := &recordingTmuxRunner{formats: map[string]string{
+				"#{client_tty}":                    clientKey,
+				"#{pane_id}":                       "%1",
+				"#S":                               "work",
+				"#{client_width}":                  "200",
+				"#{client_height}":                 "50",
+				"#{@projmux_statusbar_decoration}": tt.decoration,
+			}}
+			cmd := &tmuxCommand{
+				runner:     runner,
+				executable: func() (string, error) { return "/tmp/proj mux/bin/projmux", nil },
+			}
 
-	got := runner.calls[len(runner.calls)-1]
-	wantPrefix := []string{
-		"display-popup",
-		"-c", "/dev/pts/projmux-test-notify",
-		"-E",
-		"-x", "128",
-		"-y", "0",
-		"-w", "72",
-		"-h", "50",
-		"-T", "Notifications",
-	}
-	if got.name != "tmux" || len(got.args) < len(wantPrefix)+1 || !reflect.DeepEqual(got.args[:len(wantPrefix)], wantPrefix) {
-		t.Fatalf("display call = %#v, want prefix %#v", got, wantPrefix)
-	}
-	command := got.args[len(got.args)-1]
-	if !strings.Contains(command, "'/tmp/proj mux/bin/projmux' 'notify' 'list' '--ui=sidebar'") {
-		t.Fatalf("popup command = %q, want notify sidebar command", command)
+			if err := cmd.Run([]string{"popup-toggle", "notify-sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+
+			got := runner.calls[len(runner.calls)-1]
+			wantPrefix := []string{
+				"display-popup",
+				"-c", clientKey,
+				"-E",
+				"-x", "128",
+				"-y", "0",
+				"-w", "72",
+				"-h", "50",
+			}
+			if tt.wantTitle != "" {
+				wantPrefix = append(wantPrefix, "-T", tt.wantTitle)
+			}
+			if got.name != "tmux" || len(got.args) < len(wantPrefix)+1 || !reflect.DeepEqual(got.args[:len(wantPrefix)], wantPrefix) {
+				t.Fatalf("display call = %#v, want prefix %#v", got, wantPrefix)
+			}
+			if tt.wantTitle == "" && slices.Contains(got.args, "-T") {
+				t.Fatalf("display call = %#v, want no title option", got)
+			}
+			command := got.args[len(got.args)-1]
+			if !strings.Contains(command, "'/tmp/proj mux/bin/projmux' 'notify' 'list' '--ui=sidebar'") {
+				t.Fatalf("popup command = %q, want notify sidebar command", command)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- make the Alt-2 notify sidebar popup title follow the decoration mode
- use no popup title for `off`, a Nerd Font bell for `symbol`, and an emoji bell for `emoji`
- rename Settings copy from Status Bar to Icons & Decorations while keeping the existing file and tmux option compatible

## Validation
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
