### PR TITLE
fix(statusbar): refine notify and git decorations

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -222,9 +222,11 @@ projmux status usage  [--max-width N] [--force|-f]
 projmux status notify [--max-width N]
 ```
 
-- `git` — `#[bold,fg=colour16,bg=colour45] <branch> #[default]` for the
-  pane's `pane_current_path` (or the supplied path). Empty when not in a
-  repo.
+- `git` — `#[bold,fg=colour16,bg=colour45] <branch> <state> #[default]` for
+  the pane's `pane_current_path` (or the supplied path). Empty when not in a
+  repo. `<state>` is omitted when clean, otherwise it may include `*` for
+  local changes, `+N` staged entries, and `↑N`/`↓N` ahead/behind counts, with
+  compact per-token colors in tmux output.
 - `kube` — `⎈ <context>/<namespace>` segment. Reads
   `~/.cache/tmux/kube-segment-<session>.txt` first (TTL governed by
   `TMUX_KUBE_CACHE_TTL`, default `5s`). Picks up a per-session

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,11 +102,11 @@ failure handling.
 
 ## Decoration Mode
 
-Settings > Icons & Decorations controls optional status and popup decoration:
+Settings > Icons & Decorations controls optional status and picker decoration:
 
 - `off` is the default and avoids icon-font assumptions.
-- `symbol` restores the Nerd Font-style folder/git/bell icons.
-- `emoji` uses emoji decorators.
+- `symbol` restores the Nerd Font-style folder, GitHub, and bell icons.
+- `emoji` uses emoji decorators, including the notify sidebar header bell.
 
 The saved value lives at:
 

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -27,7 +27,11 @@ row 1  #[range=user|notify] <notify HUD pill> #[norange]
   `isWindowListRangeToken` fallback is now defense-in-depth only.
   The session, pwd, kube, and git segments on this row are wrapped
   in `#[range=user|<id>]` ranges and dispatched through the projmux
-  handler.
+  handler. The git segment shows the current branch or detached commit,
+  then compact state indicators when available: `*` for local changes,
+  `+N` for staged entries, and `↑N`/`↓N` for ahead/behind counts. Each
+  state token gets its own compact foreground color while preserving the
+  existing branch block background.
 - Row 1 splits the line with `#[align=left]` (the pending AI notify
   queue, capped at 80
   cells) and `#[align=right]` (usage, capped at 120 cells). `notify` is the
@@ -73,9 +77,10 @@ The path popup uses a short title, one-line copy status, the current path, and
 an `Enter closes this popup` prompt. If the tmux buffer write fails, it keeps
 the same compact surface with `Current path` as the title and a copy-unavailable
 message. The notification HUD detail surface (`Alt-2` / `User2`) opens the
-right-side notification popup with newest-first rows; its popup title follows
-the decoration mode (`off` leaves it untitled, `symbol`/`emoji` show a bell).
-Selecting a row still focuses and acknowledges that notification.
+right-side notification popup with newest-first rows. The popup itself is
+untitled; when decoration mode is `symbol` or `emoji`, the bell appears before
+the fzf header text instead. Selecting a row still focuses and acknowledges
+that notification.
 
 Empty `#{mouse_status_range}` (a click on whitespace) falls through to
 `select-window -t @<mouse_window>` when `--mouse-window` is non-empty,
@@ -130,9 +135,9 @@ projmux tmux apply
 ```
 
 Settings > Icons & Decorations controls the optional decoration mode used by
-the path, git branch, and notification popup. The persisted enum lives at
+the path, git branch, and notification sidebar header. The persisted enum lives at
 `~/.config/projmux/statusbar-decoration`; valid values are `off` (default,
-font-safe), `symbol` (Nerd Font-style folder/git/bell icons), and `emoji`.
+font-safe), `symbol` (Nerd Font-style folder/GitHub/bell icons), and `emoji`.
 Settings also updates tmux `@projmux_statusbar_decoration` for the live
 server when run inside tmux.
 

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -33,6 +33,8 @@ type notifyCommand struct {
 	runner     tmuxRunner
 	picker     intfzf.Runner
 	executable func() (string, error)
+	lookupEnv  func(string) string
+	homeDir    func() (string, error)
 }
 
 func newNotifyCommand() *notifyCommand {
@@ -41,6 +43,8 @@ func newNotifyCommand() *notifyCommand {
 		runner:     reconcileDefaultRunner(),
 		picker:     intfzf.NewRunner(),
 		executable: os.Executable,
+		lookupEnv:  os.Getenv,
+		homeDir:    os.UserHomeDir,
 	}
 	paths, err := config.DefaultPathsFromEnv()
 	if err != nil {
@@ -279,7 +283,7 @@ func (c *notifyCommand) runSidebar(entries []notify.Notification, stdout, stderr
 		UI:            "notify-sidebar",
 		Read0:         true,
 		Prompt:        "Notify > ",
-		Header:        "Pending notifications, newest first",
+		Header:        notifyHeaderDecorator(c.statusbarDecoration()) + "Pending notifications, newest first",
 		Footer:        "Enter: focus + ack  |  x: ack  |  Ctrl-X: clear all  |  Esc/Alt-2: close",
 		ExpectKeys:    []string{"x", "ctrl-x"},
 		Bindings:      []string{"alt-2:abort"},
@@ -507,6 +511,16 @@ func (c *notifyCommand) focusNotification(entry notify.Notification, source, kin
 		return fmt.Errorf("focus notification: %w", err)
 	}
 	return nil
+}
+
+func (c *notifyCommand) statusbarDecoration() config.StatusbarDecoration {
+	if envValue(c.lookupEnv, "TMUX") != "" && c.runner != nil {
+		out, err := c.runner.Run(context.Background(), "tmux", "show-option", "-gqv", statusbarDecorationTmuxOption)
+		if err == nil && strings.TrimSpace(string(out)) != "" {
+			return config.NormalizeStatusbarDecoration(string(out))
+		}
+	}
+	return loadStatusbarDecoration(c.homeDir, c.lookupEnv)
 }
 
 // --- ack ---------------------------------------------------------------------

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -318,6 +318,49 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	}
 }
 
+func TestNotifyListSidebarHeaderDecoration(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name       string
+		decoration string
+		wantHeader string
+	}{
+		{name: "off", decoration: "off", wantHeader: "Pending notifications, newest first"},
+		{name: "symbol", decoration: "symbol", wantHeader: " Pending notifications, newest first"},
+		{name: "emoji", decoration: "emoji", wantHeader: "🔔 Pending notifications, newest first"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &stubNotifyStore{}
+			picker := &stubNotifyPicker{}
+			runner := &focusFakeRunner{respond: func(args []string) ([]byte, error) {
+				if reflect.DeepEqual(args, []string{"show-option", "-gqv", statusbarDecorationTmuxOption}) {
+					return []byte(tt.decoration + "\n"), nil
+				}
+				return nil, errors.New("unexpected runner call")
+			}}
+			cmd := newCmd(store)
+			cmd.lookupEnv = func(name string) string {
+				if name == "TMUX" {
+					return "/tmp/tmux"
+				}
+				return ""
+			}
+			cmd.picker = picker
+			cmd.runner = runner
+
+			if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if got := picker.options.Header; got != tt.wantHeader {
+				t.Fatalf("picker header = %q, want %q", got, tt.wantHeader)
+			}
+		})
+	}
+}
+
 func TestNotifySidebarLabelDoesNotExposeRawPaneID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -103,8 +103,75 @@ func (c *statusCommand) runGit(args []string, stdout, stderr io.Writer) error {
 	if branch == "" {
 		return nil
 	}
-	_, err := fmt.Fprintf(stdout, " #[bold,fg=colour16,bg=colour45] %s%s #[default]", statusbarGitDecorator(c.statusbarDecoration()), branch)
+	segment := branch
+	if state := parseGitPorcelainStatus(c.readTrimmed("git", "-C", path, "status", "--porcelain=v1", "--branch")); state != "" {
+		segment += " " + state
+	}
+	_, err := fmt.Fprintf(stdout, " #[bold,fg=colour16,bg=colour45] %s%s #[default]", statusbarGitDecorator(c.statusbarDecoration()), segment)
 	return err
+}
+
+func parseGitPorcelainStatus(raw string) string {
+	var (
+		staged      int
+		ahead       int
+		behind      int
+		hasWorktree bool
+	)
+	for line := range strings.SplitSeq(raw, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "## ") {
+			ahead, behind = parseGitAheadBehind(line)
+			continue
+		}
+		hasWorktree = true
+		if len(line) >= 2 && line[0] != ' ' && line[0] != '?' && line[0] != '!' {
+			staged++
+		}
+	}
+	parts := []string{}
+	if hasWorktree {
+		parts = append(parts, gitStateToken("colour88", "*"))
+	}
+	if staged > 0 {
+		parts = append(parts, gitStateToken("colour22", fmt.Sprintf("+%d", staged)))
+	}
+	if ahead > 0 {
+		parts = append(parts, gitStateToken("colour17", fmt.Sprintf("↑%d", ahead)))
+	}
+	if behind > 0 {
+		parts = append(parts, gitStateToken("colour94", fmt.Sprintf("↓%d", behind)))
+	}
+	return strings.Join(parts, " ")
+}
+
+func gitStateToken(color, label string) string {
+	return fmt.Sprintf("#[fg=%s]%s#[fg=colour16]", color, label)
+}
+
+func parseGitAheadBehind(line string) (int, int) {
+	start := strings.Index(line, "[")
+	end := strings.LastIndex(line, "]")
+	if start < 0 || end <= start {
+		return 0, 0
+	}
+	ahead := 0
+	behind := 0
+	for part := range strings.SplitSeq(line[start+1:end], ",") {
+		fields := strings.Fields(strings.TrimSpace(part))
+		if len(fields) != 2 {
+			continue
+		}
+		switch fields[0] {
+		case "ahead":
+			ahead = parsePositiveInt(fields[1])
+		case "behind":
+			behind = parsePositiveInt(fields[1])
+		}
+	}
+	return ahead, behind
 }
 
 func (c *statusCommand) statusbarDecoration() config.StatusbarDecoration {

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -132,7 +132,34 @@ func TestStatusGitPrintsConfiguredEmojiDecoratorFromConfig(t *testing.T) {
 	if err := cmd.Run([]string{"git", "/repo"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	want := " #[bold,fg=colour16,bg=colour45] #[fg=colour17]🌿 #[fg=colour16]main #[default]"
+	want := " #[bold,fg=colour16,bg=colour45] #[fg=colour17]🐙 #[fg=colour16]main #[default]"
+	if got := stdout.String(); got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestStatusGitPrintsStateIndicators(t *testing.T) {
+	t.Parallel()
+
+	cmd := testStatusCommand(t.TempDir())
+	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		switch {
+		case name == "git" && reflect.DeepEqual(args, []string{"-C", "/repo", "rev-parse", "--is-inside-work-tree"}):
+			return []byte("true\n"), nil
+		case name == "git" && reflect.DeepEqual(args, []string{"-C", "/repo", "symbolic-ref", "--quiet", "--short", "HEAD"}):
+			return []byte("main\n"), nil
+		case name == "git" && reflect.DeepEqual(args, []string{"-C", "/repo", "status", "--porcelain=v1", "--branch"}):
+			return []byte("## main...origin/main [ahead 2, behind 1]\nM  staged.go\n M dirty.go\nA  added.go\n?? new.go\n"), nil
+		default:
+			return nil, os.ErrNotExist
+		}
+	}
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"git", "/repo"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	want := " #[bold,fg=colour16,bg=colour45] main #[fg=colour88]*#[fg=colour16] #[fg=colour22]+2#[fg=colour16] #[fg=colour17]↑2#[fg=colour16] #[fg=colour94]↓1#[fg=colour16] #[default]"
 	if got := stdout.String(); got != want {
 		t.Fatalf("stdout = %q, want %q", got, want)
 	}

--- a/internal/app/statusbar_decoration.go
+++ b/internal/app/statusbar_decoration.go
@@ -47,7 +47,7 @@ func statusbarCwdSegmentFormat() string {
 }
 
 func statusbarCwdDecoratorFormat() string {
-	return "#{?#{==:#{@projmux_statusbar_decoration},symbol},#[fg=colour244] ,#{?#{==:#{@projmux_statusbar_decoration},emoji},#[fg=colour244]📁 ,}}"
+	return "#{?#{==:#{@projmux_statusbar_decoration},symbol},#[fg=colour33] ,#{?#{==:#{@projmux_statusbar_decoration},emoji},#[fg=colour244]📁 ,}}"
 }
 
 func statusbarGitDecorator(mode config.StatusbarDecoration) string {
@@ -55,18 +55,18 @@ func statusbarGitDecorator(mode config.StatusbarDecoration) string {
 	case config.StatusbarDecorationSymbol:
 		return "#[fg=colour17] #[fg=colour16]"
 	case config.StatusbarDecorationEmoji:
-		return "#[fg=colour17]🌿 #[fg=colour16]"
+		return "#[fg=colour17]🐙 #[fg=colour16]"
 	default:
 		return ""
 	}
 }
 
-func notificationPopupTitle(mode config.StatusbarDecoration) string {
+func notifyHeaderDecorator(mode config.StatusbarDecoration) string {
 	switch mode {
 	case config.StatusbarDecorationSymbol:
-		return ""
+		return " "
 	case config.StatusbarDecorationEmoji:
-		return "🔔"
+		return "🔔 "
 	default:
 		return ""
 	}

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -678,7 +678,6 @@ func buildPopupToggle(mode tmuxPopupToggleMode, binaryPath, marker string, ctx t
 		options.Height = popupSize(ctx.ClientHeight, 100, 20)
 		options.X = popupRightX(ctx.ClientWidth, options.Width)
 		options.Y = "0"
-		options.Title = notificationPopupTitle(ctx.Decoration)
 		commandArgs = []string{"notify", "list", "--ui=sidebar"}
 	case "ai-split-picker-right", "ai-split-picker-down":
 		options.Width = popupSize(ctx.ClientWidth, 40, 96)

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -258,11 +258,10 @@ func TestAppRunTmuxPopupToggleOpensNotifySidebarOnRight(t *testing.T) {
 	for _, tt := range []struct {
 		name       string
 		decoration string
-		wantTitle  string
 	}{
 		{name: "off", decoration: "off"},
-		{name: "symbol", decoration: "symbol", wantTitle: ""},
-		{name: "emoji", decoration: "emoji", wantTitle: "🔔"},
+		{name: "symbol", decoration: "symbol"},
+		{name: "emoji", decoration: "emoji"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -299,13 +298,10 @@ func TestAppRunTmuxPopupToggleOpensNotifySidebarOnRight(t *testing.T) {
 				"-w", "72",
 				"-h", "50",
 			}
-			if tt.wantTitle != "" {
-				wantPrefix = append(wantPrefix, "-T", tt.wantTitle)
-			}
 			if got.name != "tmux" || len(got.args) < len(wantPrefix)+1 || !reflect.DeepEqual(got.args[:len(wantPrefix)], wantPrefix) {
 				t.Fatalf("display call = %#v, want prefix %#v", got, wantPrefix)
 			}
-			if tt.wantTitle == "" && slices.Contains(got.args, "-T") {
+			if slices.Contains(got.args, "-T") {
 				t.Fatalf("display call = %#v, want no title option", got)
 			}
 			command := got.args[len(got.args)-1]
@@ -534,7 +530,7 @@ func TestTmuxPrintConfigUsesStandaloneBindings(t *testing.T) {
 		"'/tmp/proj mux/bin/projmux' status git",
 		"set -g @projmux_statusbar_decoration off",
 		"set -g status 2",
-		"#[range=user|pwd]#{?#{==:#{@projmux_statusbar_decoration},symbol},#[fg=colour244] ,#{?#{==:#{@projmux_statusbar_decoration},emoji},#[fg=colour244]📁 ,}}#[fg=colour250]#{=-28/...:pane_current_path}#[norange]",
+		"#[range=user|pwd]#{?#{==:#{@projmux_statusbar_decoration},symbol},#[fg=colour33] ,#{?#{==:#{@projmux_statusbar_decoration},emoji},#[fg=colour244]📁 ,}}#[fg=colour250]#{=-28/...:pane_current_path}#[norange]",
 		" %Y-%m-%d %H:%M",
 		"range=user|notify",
 		"range=user|usage",
@@ -753,7 +749,7 @@ func TestTmuxPrintAppConfigUsesIsolatedAppSettings(t *testing.T) {
 		"set -g status-left \"#[range=user|session]#[bold,fg=colour231,bg=colour90] #{s|^[^-]*-||:session_name} #[default]#[norange]\"",
 		"#[bold,fg=colour231,bg=colour90] #{s|^[^-]*-||:session_name} #[default]",
 		"set -g @projmux_statusbar_decoration off",
-		"#[range=user|pwd]#{?#{==:#{@projmux_statusbar_decoration},symbol},#[fg=colour244] ,#{?#{==:#{@projmux_statusbar_decoration},emoji},#[fg=colour244]📁 ,}}#[fg=colour250]#{=-28/...:pane_current_path}#[norange]",
+		"#[range=user|pwd]#{?#{==:#{@projmux_statusbar_decoration},symbol},#[fg=colour33] ,#{?#{==:#{@projmux_statusbar_decoration},emoji},#[fg=colour244]📁 ,}}#[fg=colour250]#{=-28/...:pane_current_path}#[norange]",
 		"'/tmp/projmux' tmux popup-toggle --client #{client_tty} sessionizer-sidebar",
 		" %Y-%m-%d %H:%M#[default]",
 		"set -g status 2",


### PR DESCRIPTION
## Summary
- move the notify sidebar bell from the tmux popup title into the fzf header
- keep the notify popup itself untitled
- change emoji git decoration from leaf to octocat-style `🐙`
- color symbol-mode folder decoration and git state tokens
- add compact git state indicators for dirty, staged, ahead, and behind state

## Validation
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
