### PR TITLE
feat(picker): make native picker default

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,8 +44,8 @@ Responsibilities:
 Picker data is modeled independently from fzf rows. The app builds
 backend-neutral `picker.Item` values (`Title`, `Value`, `SearchText`,
 `MetaLines`, `Badges`, `PreviewTarget`) and then adapts them to the selected
-backend. `fzf` remains the default, stable backend; the native backend is
-opt-in through `PROJMUX_PICKER_BACKEND=native` while it reaches full parity.
+backend. Native is the default backend, while `PROJMUX_PICKER_BACKEND=fzf`
+keeps the external fzf backend available as an explicit fallback.
 
 Responsibilities:
 - rows for popup and sidebar views

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,10 +60,9 @@ sub-verbs are entry hooks invoked by tmux keybindings (e.g.
 `sidebar-focus` is wired to the sidebar's focus binding so navigation keeps
 the active session in sync).
 
-Settings > Labs > Picker Engine can opt into the experimental native picker
-backend. `PROJMUX_PICKER_BACKEND=native` is still supported as an environment
-override and takes priority over the saved Labs setting. fzf remains the default
-and fallback backend while native parity continues to mature.
+Settings > Labs > Picker Engine can switch between the default native picker
+backend and the external fzf fallback. `PROJMUX_PICKER_BACKEND=fzf` is supported
+as an environment override and takes priority over the saved Labs setting.
 
 ## setup
 
@@ -415,7 +414,7 @@ flags with the top-level `switch` UX:
   additional search roots, not the primary root. Icons & Decorations stores
   `~/.config/projmux/statusbar-decoration` as `off` (default), `symbol`, or
   `emoji` and updates the live tmux option when available. Labs stores
-  `~/.config/projmux/picker-backend` as `fzf` (default) or `native` and updates
+  `~/.config/projmux/picker-backend` as `native` (default) or `fzf` and updates
   the live tmux `PROJMUX_PICKER_BACKEND` environment when available. The About
   section reads the cached update status without network access;
   selecting Check Updates runs `projmux update check`, and Update Now runs

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ The file is read only when no env root list is set.
 | `PROJMUX_USAGE_DEBUG` | When non-empty, prints adapter errors from `projmux status usage` to stderr. |
 | `PROJMUX_USAGE_LIMITS_PATH` | Deprecated. Read but ignored; limits now come from upstream APIs and local Codex rollout state. |
 | `PROJMUX_FOCUS_DEBUG` | When non-empty, `projmux focus` prints one telemetry line to stderr. |
-| `PROJMUX_PICKER_BACKEND` | Set to `native` to opt into the experimental native picker backend. `fzf` remains the default and stable backend. |
+| `PROJMUX_PICKER_BACKEND` | Override the picker backend. Native is the default; set `fzf` to use the external fzf backend. |
 | `PROJMUX_INSTALLER` | Installer source hint used by update flows. npm installs set this automatically; advanced release installs can set `github-release`. |
 
 Example:

--- a/docs/native-picker-no-fzf-poc.md
+++ b/docs/native-picker-no-fzf-poc.md
@@ -1,8 +1,7 @@
-# Experimental Native Picker Engine
+# Native Picker Engine
 
-This note tracks the experimental native picker engine. It does not change the
-public doctor dependency policy: `fzf` remains a required production dependency
-and the `internal/ui/fzf` backend remains the default/fallback path.
+This note tracks the native picker engine. Native is the default picker backend,
+while the `internal/ui/fzf` backend remains available as an explicit fallback.
 
 The fzf compatibility surface for the native engine is tracked in
 [native-picker-parity.md](native-picker-parity.md).
@@ -26,12 +25,12 @@ The fzf compatibility surface for the native engine is tracked in
 - `intfzf.NewPickerRunner()` wraps fzf behind the same `picker.Runner`
   interface as the native runner. This is the current DI boundary for swapping
   picker engines while keeping fzf available.
-- Settings > Labs > Picker Engine stores the experimental selection in
+- Settings > Labs > Picker Engine stores the backend selection in
   `~/.config/projmux/picker-backend` and updates the live tmux environment so
   new picker popups can switch between `fzf` and `native` without restarting
   the app server.
-- `PROJMUX_PICKER_BACKEND=native` remains an explicit environment override and
-  takes priority over the saved Labs setting.
+- Native is the default backend. `PROJMUX_PICKER_BACKEND=fzf` remains an
+  explicit environment override and takes priority over the saved Labs setting.
 - Picker flows covered by the native path include AI picker/settings, shell
   update prompt, settings hub sections, switch settings/add-pin, the main
   project switcher list, recent sessions, and notify sidebar.
@@ -70,7 +69,7 @@ The fzf compatibility surface for the native engine is tracked in
   wider than the existing fzf sidebar surface on normal terminals.
 - Native Alt-2 notify sidebar popups keep the fzf baseline width contract
   (`24%`, minimum `64`) while still letting the native picker own the frame.
-- Native sidebar popups reserve three rows at the bottom for the tmux statusbar
+- Native sidebar popups reserve two rows at the bottom for the tmux statusbar
   area instead of using the full client height.
 - Simple native lists use the available terminal height after header, prompt,
   footer, and preview reservations instead of a fixed page-sized viewport.
@@ -79,9 +78,10 @@ The fzf compatibility surface for the native engine is tracked in
   expect/action keys still work.
 - Native frame content now uses the full inner border width so prompt/list/footer
   separators reach the right border like fzf.
-- Native frames can render an optional title inside the top border when
-  `picker.Options.Title` is set; empty titles keep the default border unchanged.
-  The native Alt-1 project sidebar uses this for a `Projects` titlebar.
+- Native frames can render an optional picker-owned titlebar row below the top
+  border when `picker.Options.Title` is set; empty titles keep the default frame
+  unchanged. The native Alt-1 project sidebar uses this for a `Projects`
+  titlebar.
 - Native width/truncation uses terminal cell width for Korean/CJK text, emoji,
   and combining marks instead of raw rune count, so localized project names and
   decorated notify headers do not push the right frame border out of alignment.
@@ -149,9 +149,9 @@ The fzf compatibility surface for the native engine is tracked in
   switch and sessions popup flows type a filtered query, send `Right` and
   `Alt-Down`, and assert the stored preview window/pane cursor for the selected
   session.
-- Public doctor dependency policy still treats `fzf` as required. The Labs
-  setting is experimental and does not make native the default production
-  backend.
+- Public doctor dependency policy remains separate from picker backend
+  selection. Native is the default picker backend, and fzf remains available as
+  an explicit fallback.
 
 ## Interactive No-fzf Sandbox
 

--- a/docs/native-picker-parity.md
+++ b/docs/native-picker-parity.md
@@ -1,8 +1,8 @@
 # Native Picker fzf Parity Map
 
 This audit note reverse-engineers the subset of fzf behavior that projmux
-currently uses and maps it to native picker evidence. It supports the
-experimental native picker engine and is not a public dependency-policy change.
+currently uses and maps it to native picker evidence. It supports the default
+native picker engine and is not a public dependency-policy change.
 
 ## App fzf Surface
 
@@ -46,8 +46,8 @@ experimental native picker engine and is not a public dependency-policy change.
 | fzf navigation keys | interactive selection in searchable lists | Covered | native maps CSI-u `Ctrl-J` plus `Ctrl-N` to down and `Ctrl-P`/`Ctrl-K` to up when not claimed by a custom action; raw LF remains Enter for PTY compatibility; `TestNativeInteractiveSupportsFZFNavigationKeys` |
 | alternate-screen lifecycle | fzf fullscreen picker screen restore | Covered | native frame updates and screen exit return to column 0 before terminal control sequences, screen exit resets styles plus clears the alternate buffer from the home cursor before restore, and real TTY restores get a short settle window before caller handoff; `nativeScreenEnter`; `TestNativeInteractiveUsesAlternateScreen`; `TestRenderFullFrameUpdateAlwaysHomesAndWritesFrame` |
 | frame content width | fzf border inner width | Covered | `ContentLayout` uses the frame inner width so separators and rows reach the right border; `TestRendererContentLayoutUsesFrameInnerWidth` |
-| tmux popup frame interaction | native picker popups launched through `popup-toggle` | Covered for native backend popups | `popup-toggle` passes tmux `display-popup -B` when `PROJMUX_PICKER_BACKEND=native`, so the native picker owns the visible frame instead of double-drawing with the tmux popup border; native Alt-1 uses a compact native-only minimum while fzf keeps the previous project sidebar minimum; Alt-1/Alt-2 sidebar heights reserve three bottom statusbar rows; Alt-2 notify sidebar keeps the fzf-like `24%` / min `64` baseline; `TestAppRunTmuxPopupToggleUsesBorderlessPopupForNativeBackend`; `TestSessionizerSidebarWidthKeepsFZFMinimum`; `TestSidebarPopupHeightLeavesStatusbarRows`; `TestNotifySidebarWidthMatchesFZFBaseline`; `TestAppRunTmuxPopupToggleKeepsNotifySidebarFZFSizingForNative` |
-| optional native titlebar | native picker popup frame | Covered for empty-title compatibility and opt-in titles | `picker.Options.Title`; `RenderFrameWithTitle`; empty titles keep the prior border unchanged, non-empty titles render in the top border, and the native Alt-1 project sidebar opts into `Projects`; `TestRendererRenderFrameWithTitleKeepsDefaultWhenTitleEmpty`; `TestRendererRenderFrameWithTitleUsesTopBorderTitle`; `TestNativeInteractiveRendersOptionalTitlebar`; `TestSwitchCommandNativeSidebarSetsTitle` |
+| tmux popup frame interaction | native picker popups launched through `popup-toggle` | Covered for native backend popups | `popup-toggle` passes tmux `display-popup -B` when `PROJMUX_PICKER_BACKEND=native`, so the native picker owns the visible frame instead of double-drawing with the tmux popup border; native Alt-1 uses a compact native-only minimum while fzf keeps the previous project sidebar minimum; Alt-1/Alt-2 sidebar heights reserve two bottom statusbar rows; Alt-2 notify sidebar keeps the fzf-like `24%` / min `64` baseline; `TestAppRunTmuxPopupToggleUsesBorderlessPopupForNativeBackend`; `TestSessionizerSidebarWidthKeepsFZFMinimum`; `TestSidebarPopupHeightLeavesStatusbarRows`; `TestNotifySidebarWidthMatchesFZFBaseline`; `TestAppRunTmuxPopupToggleKeepsNotifySidebarFZFSizingForNative` |
+| optional native titlebar | native picker popup frame | Covered for empty-title compatibility and opt-in titles | `picker.Options.Title`; `RenderFrameWithTitle`; `ContentLayoutWithTitle`; empty titles keep the prior frame unchanged, non-empty titles render in a picker-owned row below the top border, and the native Alt-1 project sidebar opts into `Projects`; `TestRendererRenderFrameWithTitleKeepsDefaultWhenTitleEmpty`; `TestRendererRenderFrameWithTitleUsesTitlebarRow`; `TestRendererContentLayoutWithTitleReservesTitlebarRow`; `TestNativeInteractiveRendersOptionalTitlebar`; `TestSwitchCommandNativeSidebarSetsTitle` |
 | redraw flicker/top clipping | keyboard navigation in exact-height tmux popup | Partially covered | native redraws use synchronized updates plus coalesced row diffs after the first frame, skip unchanged frames, render frame diffs before sidebar focus commands, frame rendering avoids trailing bottom-border CRLF, and screen exit clears the alternate buffer before restore; `TestNativeInteractiveWrapsRedrawsInSynchronizedUpdates`; `TestFrameUpdateRendererSkipsUnchangedFrame`; `TestFrameUpdateRendererCoalescesEachFrameUpdate`; `TestRendererRenderFrameUsesCRLFRowsForRawTTY`; `TestNativeInteractiveUsesAlternateScreen` |
 
 ## Native Surface Architecture
@@ -70,7 +70,8 @@ experimental native picker engine and is not a public dependency-policy change.
 - Settings > Labs > Picker Engine persists the selected backend in
   `~/.config/projmux/picker-backend` and updates the live tmux server
   environment through `PROJMUX_PICKER_BACKEND`, while direct environment
-  overrides still win over saved config.
+  overrides still win over saved config. Native is the default when no saved
+  backend or override exists; `fzf` remains available as an explicit fallback.
 - The split lets projmux grow a first-party picker design independently from
   the fzf compatibility adapter.
 
@@ -120,8 +121,9 @@ experimental native picker engine and is not a public dependency-policy change.
 - Mouse support is intentionally narrow in this POC: primary click applies the
   clicked row, release events are ignored, and wheel input moves selection.
   Drag gestures and the full fzf mouse grammar are follow-up work.
-- The public doctor/docs dependency policy still says `fzf` is required. This
-  is intentional while the native engine remains experimental.
+- The public doctor/docs dependency policy is tracked separately from picker
+  backend selection. Native is the default picker backend, while fzf remains an
+  explicit fallback.
 - Draft PR: https://github.com/crevissepartners/projmux/pull/98.
 
 ## Commands

--- a/docs/picker-ui-plan.md
+++ b/docs/picker-ui-plan.md
@@ -13,10 +13,10 @@ or session title, instead of matching every contextual preview line.
 The picker contract is split in two layers:
 
 - `internal/ui/picker` owns backend-neutral items, actions, preview metadata,
-  backend selection, title-focused filtering, and the opt-in native runner.
+  backend selection, title-focused filtering, and the default native runner.
 - `internal/ui/fzf` adapts that model into the historical fzf command line.
 
-The default fzf backend still sends one logical row per item:
+The fzf fallback backend sends one logical row per item:
 
 ```text
 <visible label>\t<selection value>
@@ -100,12 +100,12 @@ Current implementation:
   `SearchText`, `MetaLines`, `Badges`, and `PreviewTarget`.
 - `picker.Options` carries backend-neutral actions, preview metadata, prompt,
   footer, initial query, and multiline intent.
-- fzf remains the default backend and renders the same popup/sidebar surfaces.
-- `PROJMUX_PICKER_BACKEND=native` opts into the native runner. It supports
+- Native is the default backend and renders the popup/sidebar surfaces.
+- `PROJMUX_PICKER_BACKEND=fzf` opts into the external fzf runner. Native supports
   multiline item rendering, title-focused search via `SearchText`, numeric
   selection, and shared close actions.
-- Switcher popup/sidebar still use the fzf backend for full preview and key
-  action parity. Native preview panes, raw-key navigation, and sidebar focus
-  tracking remain follow-up work.
+- Switcher popup/sidebar use the selected backend for preview and key action
+  parity, including native preview panes, raw-key navigation, and sidebar focus
+  tracking.
 
-fzf can stay as the stable fallback while the native picker reaches parity.
+fzf can stay as the stable fallback while the native picker continues to mature.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -73,9 +73,9 @@ v0.4 shipped.
 
 - Picker-domain model separate from fzf row encoding (kept fzf as the
   stable fallback backend). Done in the 0.5 picker contract slice.
-- Opt-in native picker backend for multi-line card rows and
-  title-focused search. Done in the 0.5 picker contract slice via
-  `PROJMUX_PICKER_BACKEND=native`.
+- Native picker backend for multi-line card rows and title-focused search.
+  Done in the 0.5 picker contract slice, later promoted to the default picker
+  backend with `PROJMUX_PICKER_BACKEND=fzf` kept as the explicit fallback.
 - Port switcher popup/sidebar surfaces after parity tests cover
   selection, preview, and key actions.
 

--- a/internal/app/native_picker.go
+++ b/internal/app/native_picker.go
@@ -10,7 +10,10 @@ import (
 func runPickerOptionBackend(lookupEnv func(string) string, native intpicker.Runner, fzf intfzf.Runner, options intfzf.Options) (intfzf.Result, error) {
 	if resolvePickerBackend(lookupEnv) == intpicker.BackendNative {
 		if native == nil {
-			return intfzf.Result{}, fmt.Errorf("native picker is not configured")
+			if fzf == nil {
+				return intfzf.Result{}, fmt.Errorf("native picker is not configured")
+			}
+			return fzf.Run(options)
 		}
 		result, err := native.Run(intfzf.PickerOptions(options))
 		return intfzf.ResultFromPicker(result), err

--- a/internal/app/native_picker_test.go
+++ b/internal/app/native_picker_test.go
@@ -65,7 +65,18 @@ func TestRunPickerOptionBackendUsesSavedNativeBackend(t *testing.T) {
 	var fzfCalled bool
 	nativeCalled := false
 	result, err := runPickerOptionBackend(
-		os.Getenv,
+		func(name string) string {
+			switch name {
+			case intpicker.BackendEnv:
+				return ""
+			case "XDG_CONFIG_HOME":
+				return configHome
+			case "XDG_STATE_HOME":
+				return t.TempDir()
+			default:
+				return os.Getenv(name)
+			}
+		},
 		pickerRunnerFunc(func(options intpicker.Options) (intpicker.Result, error) {
 			nativeCalled = true
 			return intpicker.Result{Key: "enter", Value: "ai"}, nil
@@ -87,6 +98,50 @@ func TestRunPickerOptionBackendUsesSavedNativeBackend(t *testing.T) {
 	}
 	if fzfCalled {
 		t.Fatal("fzf runner was called for saved native picker backend")
+	}
+	if result.Value != "ai" {
+		t.Fatalf("result = %#v, want native selection", result)
+	}
+}
+
+func TestRunPickerOptionBackendDefaultsToNativeBackend(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	var fzfCalled bool
+	var nativeCalled bool
+	result, err := runPickerOptionBackend(
+		func(name string) string {
+			switch name {
+			case intpicker.BackendEnv:
+				return ""
+			case "XDG_CONFIG_HOME":
+				return configHome
+			case "XDG_STATE_HOME":
+				return t.TempDir()
+			default:
+				return os.Getenv(name)
+			}
+		},
+		pickerRunnerFunc(func(options intpicker.Options) (intpicker.Result, error) {
+			nativeCalled = true
+			return intpicker.Result{Key: "enter", Value: "ai"}, nil
+		}),
+		switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+			fzfCalled = true
+			return intfzf.Result{}, nil
+		}),
+		intfzf.Options{UI: "settings"},
+	)
+	if err != nil {
+		t.Fatalf("runPickerOptionBackend() error = %v", err)
+	}
+	if !nativeCalled {
+		t.Fatal("native runner was not called for default picker backend")
+	}
+	if fzfCalled {
+		t.Fatal("fzf runner was called for default picker backend")
 	}
 	if result.Value != "ai" {
 		t.Fatalf("result = %#v, want native selection", result)

--- a/internal/app/picker_backend.go
+++ b/internal/app/picker_backend.go
@@ -22,11 +22,11 @@ func resolvePickerBackendWithConfig(homeDir func() (string, error), lookupEnv fu
 
 	paths, err := pickerBackendConfigPaths(homeDir, lookupEnv)
 	if err != nil {
-		return intpicker.BackendFZF
+		return intpicker.BackendNative
 	}
 	mode, err := config.LoadPickerBackendFile(paths.PickerBackendFile())
 	if err != nil {
-		return intpicker.BackendFZF
+		return intpicker.BackendNative
 	}
 	return pickerBackendFromConfig(mode)
 }
@@ -42,16 +42,20 @@ func pickerBackendFromEnv(lookupEnv func(string) string) (intpicker.Backend, boo
 	switch strings.ToLower(raw) {
 	case string(intpicker.BackendNative):
 		return intpicker.BackendNative, true
-	default:
+	case string(intpicker.BackendFZF):
 		return intpicker.BackendFZF, true
+	default:
+		return intpicker.BackendNative, true
 	}
 }
 
 func pickerBackendFromConfig(mode config.PickerBackend) intpicker.Backend {
-	if config.NormalizePickerBackend(string(mode)) == config.PickerBackendNative {
+	switch config.NormalizePickerBackend(string(mode)) {
+	case config.PickerBackendFZF:
+		return intpicker.BackendFZF
+	default:
 		return intpicker.BackendNative
 	}
-	return intpicker.BackendFZF
 }
 
 func pickerBackendConfigPaths(homeDir func() (string, error), lookupEnv func(string) string) (config.Paths, error) {

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -982,8 +982,8 @@ func (c *settingsCommand) labsEntries() []intfzf.Entry {
 		name string
 		desc string
 	}{
-		{config.PickerBackendFZF, "fzf", "stable external picker backend"},
-		{config.PickerBackendNative, "native", "experimental projmux picker engine; no fzf required"},
+		{config.PickerBackendNative, "native", "default projmux picker engine; no fzf required"},
+		{config.PickerBackendFZF, "fzf", "external fzf fallback backend"},
 	}
 
 	entries := make([]intfzf.Entry, 0, len(modes)+2)
@@ -1016,11 +1016,11 @@ func (c *settingsCommand) currentPickerBackend() (config.PickerBackend, string) 
 
 	paths, err := pickerBackendConfigPaths(c.homeDir, c.lookupEnv)
 	if err != nil {
-		return config.PickerBackendFZF, "default"
+		return config.DefaultPickerBackend, "default"
 	}
 	mode, err := config.LoadPickerBackendFile(paths.PickerBackendFile())
 	if err != nil {
-		return config.PickerBackendFZF, "default"
+		return config.DefaultPickerBackend, "default"
 	}
 	if _, err := osStat(paths.PickerBackendFile()); err == nil {
 		return mode, "saved"

--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -1489,7 +1489,11 @@ func (c *switchCommand) runPicker(plan switchPlan) (intpicker.Result, error) {
 func (c *switchCommand) runPickerBackend(fzfOptions intfzf.Options, pickerOptions intpicker.Options) (intpicker.Result, error) {
 	if resolvePickerBackend(c.lookupEnv) == intpicker.BackendNative {
 		if c.nativePicker == nil {
-			return intpicker.Result{}, fmt.Errorf("native switch picker is not configured")
+			result, err := c.runner.Run(fzfOptions)
+			if err != nil {
+				return intpicker.Result{}, fmt.Errorf("run switch picker: %w", err)
+			}
+			return intfzf.ResultToPicker(result), nil
 		}
 		result, err := c.nativePicker.Run(pickerOptions)
 		if err != nil {

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -488,6 +488,7 @@ func TestNewSwitchCommandUsesEnvAndDefaultPinStore(t *testing.T) {
 	t.Setenv("TMUX", "")
 	t.Setenv(projdirEnvVar, fixture.path("rp"))
 	t.Setenv(managedRootsEnvVar, fixture.path("managed"))
+	t.Setenv(intpicker.BackendEnv, string(intpicker.BackendFZF))
 
 	paths, err := config.DefaultPathsFromEnv()
 	if err != nil {
@@ -586,6 +587,7 @@ func TestNewSwitchCommandDoesNotInferRepoRootFromHomeSourceRepos(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", fixture.path("xdg-state"))
 	t.Setenv("TMUX", "")
 	t.Setenv(projdirEnvVar, "")
+	t.Setenv(intpicker.BackendEnv, string(intpicker.BackendFZF))
 	t.Chdir(fixture.path("home/source/repos/app/nested"))
 
 	cmd := newSwitchCommand()

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -755,7 +755,7 @@ func sidebarPopupHeight(clientHeight int) string {
 	if clientHeight <= 0 {
 		return "100%"
 	}
-	return fmt.Sprintf("%d", max(clientHeight-3, 1))
+	return fmt.Sprintf("%d", max(clientHeight-2, 1))
 }
 
 func inheritPopupPickerEnv(env map[string]string, lookupEnv func(string) string) {

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -81,6 +81,8 @@ func TestAppRunTmuxPopupSwitchUsesCurrentPanePathAndDefaultOptions(t *testing.T)
 	wantOptions := inttmux.PopupOptions{
 		Width:         "80%",
 		Height:        "70%",
+		Env:           map[string]string{intpicker.BackendEnv: string(intpicker.BackendNative)},
+		NoBorder:      true,
 		CloseBehavior: inttmux.PopupCloseOnExit,
 	}
 	if !reflect.DeepEqual(popup.options, wantOptions) {
@@ -116,6 +118,8 @@ func TestAppRunTmuxPopupSessionsUsesDefaultOptions(t *testing.T) {
 	wantOptions := inttmux.PopupOptions{
 		Width:         "80%",
 		Height:        "75%",
+		Env:           map[string]string{intpicker.BackendEnv: string(intpicker.BackendNative)},
+		NoBorder:      true,
 		CloseBehavior: inttmux.PopupCloseOnExit,
 	}
 	if !reflect.DeepEqual(popup.options, wantOptions) {
@@ -204,6 +208,8 @@ func TestAppRunTmuxPopupCommandsUseMinimumReadableSizes(t *testing.T) {
 			wantOptions: inttmux.PopupOptions{
 				Width:         "120",
 				Height:        "28",
+				Env:           map[string]string{intpicker.BackendEnv: string(intpicker.BackendNative)},
+				NoBorder:      true,
 				CloseBehavior: inttmux.PopupCloseOnExit,
 			},
 		},
@@ -214,6 +220,8 @@ func TestAppRunTmuxPopupCommandsUseMinimumReadableSizes(t *testing.T) {
 			wantOptions: inttmux.PopupOptions{
 				Width:         "120",
 				Height:        "28",
+				Env:           map[string]string{intpicker.BackendEnv: string(intpicker.BackendNative)},
+				NoBorder:      true,
 				CloseBehavior: inttmux.PopupCloseOnExit,
 			},
 		},
@@ -278,15 +286,17 @@ func TestAppRunTmuxPopupToggleOpensStandaloneSidebar(t *testing.T) {
 		"display-popup",
 		"-t", "%1",
 		"-E",
+		"-B",
 		"-d", "/tmp/work tree",
 		"-e", "PROJMUX_NATIVE_LAUNCH_KEY=alt-1",
+		"-e", "PROJMUX_PICKER_BACKEND=native",
 		"-e", "TMUX_SESSIONIZER_CONTEXT_DIR=/tmp/work tree",
 		"-e", "TMUX_SESSIONIZER_CONTEXT_PANE=%1",
 		"-e", "TMUX_SESSIONIZER_CONTEXT_SESSION=work",
 		"-x", "0",
 		"-y", "0",
-		"-w", "56",
-		"-h", "47",
+		"-w", "40",
+		"-h", "48",
 	}
 	if got.name != "tmux" || len(got.args) < len(wantPrefix)+1 || !reflect.DeepEqual(got.args[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("display call = %#v, want prefix %#v", got, wantPrefix)
@@ -378,7 +388,7 @@ func TestNotifySidebarWidthMatchesFZFBaseline(t *testing.T) {
 func TestSidebarPopupHeightLeavesStatusbarRows(t *testing.T) {
 	t.Parallel()
 
-	if got, want := sidebarPopupHeight(50), "47"; got != want {
+	if got, want := sidebarPopupHeight(50), "48"; got != want {
 		t.Fatalf("sidebarPopupHeight(50) = %q, want %q", got, want)
 	}
 	if got, want := sidebarPopupHeight(1), "1"; got != want {
@@ -464,7 +474,7 @@ func TestAppRunTmuxPopupToggleKeepsNotifySidebarFZFSizingForNative(t *testing.T)
 	if !containsTmuxArgPair(got.args, "-x", "136") {
 		t.Fatalf("display call = %#v, want right edge position based on fzf baseline width", got)
 	}
-	if !containsTmuxArgPair(got.args, "-h", "47") {
+	if !containsTmuxArgPair(got.args, "-h", "48") {
 		t.Fatalf("display call = %#v, want native notify sidebar to leave statusbar rows uncovered", got)
 	}
 }
@@ -510,11 +520,13 @@ func TestAppRunTmuxPopupToggleOpensNotifySidebarOnRight(t *testing.T) {
 				"display-popup",
 				"-c", clientKey,
 				"-E",
+				"-B",
 				"-e", "PROJMUX_NATIVE_LAUNCH_KEY=alt-2",
+				"-e", "PROJMUX_PICKER_BACKEND=native",
 				"-x", "136",
 				"-y", "0",
 				"-w", "64",
-				"-h", "47",
+				"-h", "48",
 			}
 			if got.name != "tmux" || len(got.args) < len(wantPrefix)+1 || !reflect.DeepEqual(got.args[:len(wantPrefix)], wantPrefix) {
 				t.Fatalf("display call = %#v, want prefix %#v", got, wantPrefix)
@@ -637,8 +649,10 @@ func TestAppRunTmuxPopupToggleOpensWideAIPicker(t *testing.T) {
 		"display-popup",
 		"-t", "%1",
 		"-E",
+		"-B",
 		"-d", "/tmp/work tree",
 		"-e", "PROJMUX_NATIVE_LAUNCH_KEY=alt-4",
+		"-e", "PROJMUX_PICKER_BACKEND=native",
 		"-e", "TMUX_SPLIT_CONTEXT_DIR=/tmp/work tree",
 		"-e", "TMUX_SPLIT_TARGET_PANE=%1",
 		"-w", "96",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -137,8 +137,8 @@ func TestPickerBackendRoundtrip(t *testing.T) {
 	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), "config", PickerBackendFileName)
-	if got, err := LoadPickerBackendFile(path); err != nil || got != PickerBackendFZF {
-		t.Fatalf("LoadPickerBackendFile(missing) = %q, %v; want %q, nil", got, err, PickerBackendFZF)
+	if got, err := LoadPickerBackendFile(path); err != nil || got != DefaultPickerBackend {
+		t.Fatalf("LoadPickerBackendFile(missing) = %q, %v; want %q, nil", got, err, DefaultPickerBackend)
 	}
 
 	if err := SavePickerBackendFile(path, PickerBackendNative); err != nil {
@@ -164,8 +164,8 @@ func TestPickerBackendNormalizesInvalidValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadPickerBackendFile() error = %v", err)
 	}
-	if got != PickerBackendFZF {
-		t.Fatalf("LoadPickerBackendFile() = %q, want %q", got, PickerBackendFZF)
+	if got != DefaultPickerBackend {
+		t.Fatalf("LoadPickerBackendFile() = %q, want %q", got, DefaultPickerBackend)
 	}
 }
 

--- a/internal/config/picker.go
+++ b/internal/config/picker.go
@@ -11,18 +11,21 @@ import (
 const (
 	PickerBackendFileName = "picker-backend"
 
-	PickerBackendFZF    PickerBackend = "fzf"
-	PickerBackendNative PickerBackend = "native"
+	PickerBackendFZF     PickerBackend = "fzf"
+	PickerBackendNative  PickerBackend = "native"
+	DefaultPickerBackend               = PickerBackendNative
 )
 
 type PickerBackend string
 
 func NormalizePickerBackend(value string) PickerBackend {
 	switch strings.ToLower(strings.TrimSpace(value)) {
+	case string(PickerBackendFZF):
+		return PickerBackendFZF
 	case string(PickerBackendNative):
 		return PickerBackendNative
 	default:
-		return PickerBackendFZF
+		return DefaultPickerBackend
 	}
 }
 
@@ -32,14 +35,14 @@ func (p Paths) PickerBackendFile() string {
 
 func LoadPickerBackendFile(path string) (PickerBackend, error) {
 	if strings.TrimSpace(path) == "" {
-		return PickerBackendFZF, nil
+		return DefaultPickerBackend, nil
 	}
 	content, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return PickerBackendFZF, nil
+			return DefaultPickerBackend, nil
 		}
-		return PickerBackendFZF, fmt.Errorf("read picker backend file: %w", err)
+		return DefaultPickerBackend, fmt.Errorf("read picker backend file: %w", err)
 	}
 	return NormalizePickerBackend(string(content)), nil
 }

--- a/internal/ui/picker/backend.go
+++ b/internal/ui/picker/backend.go
@@ -85,12 +85,12 @@ func ResolveBackend(lookup func(string) string) Backend {
 		raw = lookup(BackendEnv)
 	}
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "", string(BackendFZF):
+	case string(BackendFZF):
 		return BackendFZF
 	case string(BackendNative):
 		return BackendNative
 	default:
-		return BackendFZF
+		return BackendNative
 	}
 }
 
@@ -702,12 +702,15 @@ func nativeMouseItemIndex(options Options, items []Item, selected int, layout na
 	if x <= 1 || y <= 1 {
 		return selected, false
 	}
-	contentLayout := nativeContentLayout(layout)
+	contentLayout := nativeContentLayout(layout, options.Title)
 	contentX := x - 2
 	if contentX < 0 || contentX >= contentLayout.Cols {
 		return selected, false
 	}
 	contentRow := y - 2
+	if strings.TrimSpace(options.Title) != "" {
+		contentRow--
+	}
 	if contentRow < 0 || contentRow >= contentLayout.Rows {
 		return selected, false
 	}
@@ -1236,7 +1239,7 @@ func renderNativeInteractiveWithCursor(w io.Writer, options Options, items []Ite
 }
 
 func nativeInteractiveFrame(options Options, items []Item, query string, queryCursor, selected, previewOffset int, layout nativeLayout) string {
-	contentLayout := nativeContentLayout(layout)
+	contentLayout := nativeContentLayout(layout, options.Title)
 	var body strings.Builder
 	renderNativeInteractiveContent(&body, options, items, query, queryCursor, selected, previewOffset, contentLayout)
 	var frame strings.Builder
@@ -1244,8 +1247,8 @@ func nativeInteractiveFrame(options Options, items []Item, query string, queryCu
 	return frame.String()
 }
 
-func nativeContentLayout(layout nativeLayout) nativeLayout {
-	content := projmuxpicker.DefaultRenderer().ContentLayout(projmuxpicker.Layout{Rows: layout.Rows, Cols: layout.Cols})
+func nativeContentLayout(layout nativeLayout, title string) nativeLayout {
+	content := projmuxpicker.DefaultRenderer().ContentLayoutWithTitle(projmuxpicker.Layout{Rows: layout.Rows, Cols: layout.Cols}, title)
 	return nativeLayout{Rows: content.Rows, Cols: content.Cols}
 }
 

--- a/internal/ui/picker/backend_test.go
+++ b/internal/ui/picker/backend_test.go
@@ -12,28 +12,28 @@ import (
 	"github.com/crevissepartners/projmux/internal/ui/projmuxpicker"
 )
 
-func TestResolveBackendDefaultsToFZF(t *testing.T) {
+func TestResolveBackendDefaultsToNative(t *testing.T) {
 	t.Parallel()
 
-	if got := ResolveBackend(nil); got != BackendFZF {
-		t.Fatalf("ResolveBackend(nil) = %q, want %q", got, BackendFZF)
+	if got := ResolveBackend(nil); got != BackendNative {
+		t.Fatalf("ResolveBackend(nil) = %q, want %q", got, BackendNative)
 	}
-	if got := ResolveBackend(func(string) string { return "unknown" }); got != BackendFZF {
-		t.Fatalf("ResolveBackend(unknown) = %q, want %q", got, BackendFZF)
+	if got := ResolveBackend(func(string) string { return "unknown" }); got != BackendNative {
+		t.Fatalf("ResolveBackend(unknown) = %q, want %q", got, BackendNative)
 	}
 }
 
-func TestResolveBackendAllowsNativeOptIn(t *testing.T) {
+func TestResolveBackendAllowsFZFOverride(t *testing.T) {
 	t.Parallel()
 
 	got := ResolveBackend(func(name string) string {
 		if name != BackendEnv {
 			t.Fatalf("env name = %q, want %q", name, BackendEnv)
 		}
-		return "native"
+		return "fzf"
 	})
-	if got != BackendNative {
-		t.Fatalf("ResolveBackend(native) = %q, want %q", got, BackendNative)
+	if got != BackendFZF {
+		t.Fatalf("ResolveBackend(fzf) = %q, want %q", got, BackendFZF)
 	}
 }
 
@@ -691,9 +691,12 @@ func TestNativeInteractiveRendersOptionalTitlebar(t *testing.T) {
 		Items: []Item{{Title: "api", Value: "/repo/api"}},
 	}, []Item{{Title: "api", Value: "/repo/api"}}, "", 0, 0, nativeLayout{Rows: 8, Cols: 40})
 
-	firstLine := strings.Split(out.String(), "\r\n")[0]
-	if !strings.Contains(firstLine, " Projects ") {
-		t.Fatalf("native output first line = %q, want optional titlebar", firstLine)
+	lines := strings.Split(out.String(), "\r\n")
+	if strings.Contains(lines[0], "Projects") {
+		t.Fatalf("native top frame row = %q, want title outside border row", lines[0])
+	}
+	if !strings.Contains(lines[1], " Projects ") {
+		t.Fatalf("native titlebar row = %q, want optional titlebar", lines[1])
 	}
 }
 

--- a/internal/ui/projmuxpicker/frame.go
+++ b/internal/ui/projmuxpicker/frame.go
@@ -82,13 +82,18 @@ func RenderFullFrameUpdate(w io.Writer, frame string) {
 }
 
 func (r Renderer) ContentLayout(layout Layout) Layout {
+	return r.ContentLayoutWithTitle(layout, "")
+}
+
+func (r Renderer) ContentLayoutWithTitle(layout Layout, title string) Layout {
 	if layout.Rows <= 0 {
 		layout.Rows = DefaultRows
 	}
 	if layout.Cols <= 0 {
 		layout.Cols = DefaultCols
 	}
-	rows := max(layout.Rows-2, 1)
+	rows := layout.Rows - 2 - frameTitlebarRows(title)
+	rows = max(rows, 1)
 	cols := max(layout.Cols-2, 1)
 	return Layout{Rows: rows, Cols: cols}
 }
@@ -111,12 +116,16 @@ func (r Renderer) RenderFrameWithTitle(w io.Writer, content, title string, layou
 		height = DefaultRows
 	}
 	innerWidth := width - 2
-	innerHeight := max(height-2, 1)
+	titlebarRows := frameTitlebarRows(title)
+	innerHeight := max(height-2-titlebarRows, 0)
 
 	theme := r.Theme
 	lines := strings.Split(strings.TrimRight(content, "\n"), "\n")
-	fmt.Fprint(w, frameTopBorder(theme, innerWidth, title))
-	fmt.Fprint(w, "\r\n")
+	fmt.Fprintf(w, "%s%s%s\r\n", theme.TopLeft, strings.Repeat(theme.Horizontal, innerWidth), theme.TopRight)
+	if titlebarRows > 0 {
+		fmt.Fprint(w, frameTitlebarLine(theme, innerWidth, title))
+		fmt.Fprint(w, "\r\n")
+	}
 	for i := range innerHeight {
 		line := ""
 		if i < len(lines) {
@@ -127,10 +136,17 @@ func (r Renderer) RenderFrameWithTitle(w io.Writer, content, title string, layou
 	fmt.Fprintf(w, "%s%s%s", theme.BottomLeft, strings.Repeat(theme.Horizontal, innerWidth), theme.BottomRight)
 }
 
-func frameTopBorder(theme Theme, innerWidth int, title string) string {
+func frameTitlebarRows(title string) int {
+	if strings.TrimSpace(title) == "" {
+		return 0
+	}
+	return 1
+}
+
+func frameTitlebarLine(theme Theme, innerWidth int, title string) string {
 	title = strings.TrimSpace(title)
 	if title == "" || innerWidth < 4 {
-		return theme.TopLeft + strings.Repeat(theme.Horizontal, innerWidth) + theme.TopRight
+		return theme.Vertical + strings.Repeat(" ", innerWidth) + theme.Vertical
 	}
 	labelWidthLimit := innerWidth - 2
 	label := " " + TruncateANSI(title, labelWidthLimit) + " "
@@ -139,13 +155,10 @@ func frameTopBorder(theme Theme, innerWidth int, title string) string {
 		label = TruncateANSI(label, innerWidth)
 		labelWidth = VisibleLen(label)
 	}
-	leftRuleWidth := 1
-	rightRuleWidth := max(innerWidth-leftRuleWidth-labelWidth, 0)
-	return theme.TopLeft +
-		strings.Repeat(theme.Horizontal, leftRuleWidth) +
+	return theme.Vertical +
 		label +
-		strings.Repeat(theme.Horizontal, rightRuleWidth) +
-		theme.TopRight
+		strings.Repeat(" ", max(innerWidth-labelWidth, 0)) +
+		theme.Vertical
 }
 
 func writeFrameDiff(w io.Writer, previous, next string) {

--- a/internal/ui/projmuxpicker/frame_test.go
+++ b/internal/ui/projmuxpicker/frame_test.go
@@ -60,18 +60,39 @@ func TestRendererRenderFrameWithTitleKeepsDefaultWhenTitleEmpty(t *testing.T) {
 	}
 }
 
-func TestRendererRenderFrameWithTitleUsesTopBorderTitle(t *testing.T) {
+func TestRendererRenderFrameWithTitleUsesTitlebarRow(t *testing.T) {
 	t.Parallel()
 
 	var out bytes.Buffer
-	DefaultRenderer().RenderFrameWithTitle(&out, "hello", "Projects", Layout{Rows: 4, Cols: 24})
+	DefaultRenderer().RenderFrameWithTitle(&out, "hello", "Projects", Layout{Rows: 5, Cols: 24})
 
 	lines := strings.Split(out.String(), "\r\n")
-	if !strings.Contains(lines[0], " Projects ") {
-		t.Fatalf("top frame row = %q, want title in top border", lines[0])
+	if got, want := len(lines), 5; got != want {
+		t.Fatalf("frame line count = %d, want exact layout rows %d: %q", got, want, out.String())
 	}
-	if got, want := VisibleLen(lines[0]), 24; got != want {
-		t.Fatalf("top frame width = %d, want %d: %q", got, want, lines[0])
+	if strings.Contains(lines[0], "Projects") {
+		t.Fatalf("top frame row = %q, want plain border without title text", lines[0])
+	}
+	if !strings.Contains(lines[1], " Projects ") {
+		t.Fatalf("titlebar row = %q, want title inside picker-owned titlebar", lines[1])
+	}
+	if got, want := VisibleLen(lines[1]), 24; got != want {
+		t.Fatalf("titlebar row width = %d, want %d: %q", got, want, lines[1])
+	}
+	if !strings.Contains(lines[2], "hello") {
+		t.Fatalf("content row = %q, want content below titlebar", lines[2])
+	}
+}
+
+func TestRendererContentLayoutWithTitleReservesTitlebarRow(t *testing.T) {
+	t.Parallel()
+
+	layout := DefaultRenderer().ContentLayoutWithTitle(Layout{Rows: 10, Cols: 40}, "Projects")
+	if got, want := layout.Rows, 7; got != want {
+		t.Fatalf("ContentLayoutWithTitle().Rows = %d, want frame inner height minus titlebar %d", got, want)
+	}
+	if got, want := layout.Cols, 38; got != want {
+		t.Fatalf("ContentLayoutWithTitle().Cols = %d, want frame inner width %d", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make native the default picker backend while keeping fzf as an explicit fallback
- render native picker titles as a picker-owned titlebar row below the top border
- set Alt-1/Alt-2 sidebar popup height to client_height-2 and keep native sidebar chrome borderless

## Validation
- make fmt
- make fix
- env -u PROJMUX_PICKER_BACKEND HOME=/tmp/projmux-test-home XDG_CONFIG_HOME=/tmp/projmux-test-config XDG_STATE_HOME=/tmp/projmux-test-state GOCACHE=/tmp/projmux-go-build make test
- make test-integration (blocked: docker CLI is not available in this WSL distro)
- make test-e2e (blocked: docker CLI is not available in this WSL distro)
- git diff --check