### PR TITLE
fix(picker): trigger native mouse clicks on release

### DIFF
--- a/docs/native-picker-no-fzf-poc.md
+++ b/docs/native-picker-no-fzf-poc.md
@@ -91,9 +91,9 @@ The fzf compatibility surface for the native engine is tracked in
   multi-line card gaps share the same `projmuxpicker` separator primitive for a
   more consistent native surface.
 - Native interactive mode enables SGR mouse reporting while the alternate screen
-  is active. Primary click applies the clicked row, release events are ignored,
-  mouse wheel moves selection up/down, and reporting is disabled again during
-  screen restore.
+  is active. Primary mouse down focuses the row under the cursor, primary mouse
+  up applies it, mouse wheel moves selection up/down, and reporting is disabled
+  again during screen restore.
 - When terminal size detection is unavailable, native picker falls back to a
   conservative 80x24 terminal instead of assuming a wider surface. Interactive
   tmux popups still use the detected popup size when `stty size` is available.

--- a/docs/native-picker-parity.md
+++ b/docs/native-picker-parity.md
@@ -42,7 +42,7 @@ native picker engine and is not a public dependency-policy change.
 | `--print-query` accept-query mode | typed settings path prompts | Covered | `Options.AcceptQuery`; `TestNativeRunnerAcceptsTypedQuery` |
 | query cursor editing | typed settings path prompts | Covered | Left/Right, Ctrl-A/E, Delete, Backspace, Ctrl-U/W query editing plus visible prompt cursor; `TestNativeInteractiveEditsTypedQueryAtCursor`; `TestNativeInteractiveSupportsQueryLineEditingKeys`; `TestNativeInteractiveCtrlUDeletesBeforeCursor`; `TestNativePromptLineRendersQueryCursor` |
 | terminal arrow key variants | interactive selection in tmux/docker | Covered | CSI, SS3/application cursor, modified CSI tests; app TTY `/dev/tty` fallback; raw TTY EOF polling keeps split ESC sequences from leaking into the query |
-| mouse support | optional fzf mouse picker interaction | Partially covered | native enables SGR mouse reporting in interactive alternate-screen mode, primary click applies the clicked row, release events are ignored, and wheel input moves selection; drag gestures remain outside this POC; `TestNativeInteractiveSupportsMouseClickSelection`; `TestNativeInteractiveIgnoresMouseReleaseBeforeClick`; `TestNativeInteractiveSupportsMouseWheelSelection`; Docker no-fzf e2e clicks the AI settings row under a PTY |
+| mouse support | optional fzf mouse picker interaction | Partially covered | native enables SGR mouse reporting in interactive alternate-screen mode, primary mouse down focuses the clicked row, primary mouse up applies it, and wheel input moves selection; drag gestures remain outside this POC; `TestNativeInteractiveSelectsOnMouseRelease`; `TestNativeInteractiveMouseDownOnlyFocuses`; `TestNativeInteractiveIgnoresMouseReleaseBeforeDown`; `TestNativeInteractiveSupportsMouseWheelSelection`; Docker no-fzf e2e clicks the AI settings row under a PTY |
 | fzf navigation keys | interactive selection in searchable lists | Covered | native maps CSI-u `Ctrl-J` plus `Ctrl-N` to down and `Ctrl-P`/`Ctrl-K` to up when not claimed by a custom action; raw LF remains Enter for PTY compatibility; `TestNativeInteractiveSupportsFZFNavigationKeys` |
 | alternate-screen lifecycle | fzf fullscreen picker screen restore | Covered | native frame updates and screen exit return to column 0 before terminal control sequences, screen exit resets styles plus clears the alternate buffer from the home cursor before restore, and real TTY restores get a short settle window before caller handoff; `nativeScreenEnter`; `TestNativeInteractiveUsesAlternateScreen`; `TestRenderFullFrameUpdateAlwaysHomesAndWritesFrame` |
 | frame content width | fzf border inner width | Covered | `ContentLayout` uses the frame inner width so separators and rows reach the right border; `TestRendererContentLayoutUsesFrameInnerWidth` |
@@ -118,8 +118,8 @@ native picker engine and is not a public dependency-policy change.
   gap, and consecutive bonuses. Very large `query * row` matrices intentionally
   fall back to the greedy scorer to avoid pathological memory use. Search-keyed
   app pickers preserve fzf's `--disabled` reload order instead of score-sorting.
-- Mouse support is intentionally narrow in this POC: primary click applies the
-  clicked row, release events are ignored, and wheel input moves selection.
+- Mouse support is intentionally narrow in this POC: primary mouse down focuses
+  the clicked row, primary mouse up applies it, and wheel input moves selection.
   Drag gestures and the full fzf mouse grammar are follow-up work.
 - The public doctor/docs dependency policy is tracked separately from picker
   backend selection. Native is the default picker backend, while fzf remains an

--- a/internal/ui/picker/backend.go
+++ b/internal/ui/picker/backend.go
@@ -403,6 +403,7 @@ func runNativeInteractive(in io.Reader, out io.Writer, options Options) (Result,
 	selected := options.InitialIndex
 	focusedValue := ""
 	previewOffset := 0
+	primaryMouseDown := false
 	launchKey := strings.ToLower(strings.TrimSpace(os.Getenv(NativeLaunchKeyEnv)))
 	layout := detectNativeLayout(in)
 	renderer := projmuxpicker.FrameUpdateRenderer{}
@@ -443,18 +444,32 @@ func runNativeInteractive(in io.Reader, out io.Writer, options Options) (Result,
 			continue
 		}
 		if key.HasMouse {
-			if nextSelected, ok := nativeMouseSelection(options, items, selected, layout, key.Mouse); ok {
-				selected = nextSelected
+			if key.Mouse.Release {
+				if key.Mouse.Button == 0 && primaryMouseDown {
+					primaryMouseDown = false
+					if nextSelected, ok := nativeMouseItemIndex(options, items, selected, layout, key.Mouse.X, key.Mouse.Y); ok {
+						selected = nextSelected
+						result := nativeAcceptSelectedResult(options, items, selected, query)
+						nativeDebugLogf("interactive ui=%q result=select mouse=release value=%q query=%q", options.UI, result.Value, result.Query)
+						return result, nil
+					}
+				}
 				if key.Mouse.Button == 0 {
-					result := nativeAcceptSelectedResult(options, items, selected, query)
-					nativeDebugLogf("interactive ui=%q result=select mouse=click value=%q query=%q", options.UI, result.Value, result.Query)
-					return result, nil
+					primaryMouseDown = false
 				}
 				continue
 			}
-			if key.Mouse.Release {
+			if nextSelected, ok := nativeMouseSelection(options, items, selected, layout, key.Mouse); ok {
+				selected = nextSelected
+				if key.Mouse.Button == 0 {
+					primaryMouseDown = true
+				}
 				continue
 			}
+			if key.Mouse.Button == 0 {
+				primaryMouseDown = false
+			}
+			continue
 		}
 
 		if action, ok := findAction(options.Actions, key.Name); ok {

--- a/internal/ui/picker/backend_test.go
+++ b/internal/ui/picker/backend_test.go
@@ -760,10 +760,10 @@ func TestNativeInteractiveSupportsApplicationCursorKeys(t *testing.T) {
 	}
 }
 
-func TestNativeInteractiveSupportsMouseClickSelection(t *testing.T) {
+func TestNativeInteractiveSelectsOnMouseRelease(t *testing.T) {
 	t.Parallel()
 
-	result, err := runNativeInteractive(strings.NewReader("\x1b[<0;3;5M"), io.Discard, Options{
+	result, err := runNativeInteractive(strings.NewReader("\x1b[<0;3;5M\x1b[<0;3;5m"), io.Discard, Options{
 		UI: "switch",
 		Items: []Item{
 			{Title: "api", Value: "/repo/api"},
@@ -774,14 +774,14 @@ func TestNativeInteractiveSupportsMouseClickSelection(t *testing.T) {
 		t.Fatalf("runNativeInteractive() error = %v", err)
 	}
 	if result.Key != "enter" || result.Value != "/repo/web" {
-		t.Fatalf("result = %#v, want mouse click to select web", result)
+		t.Fatalf("result = %#v, want mouse release to select web", result)
 	}
 }
 
-func TestNativeInteractiveIgnoresMouseReleaseBeforeClick(t *testing.T) {
+func TestNativeInteractiveMouseDownOnlyFocuses(t *testing.T) {
 	t.Parallel()
 
-	result, err := runNativeInteractive(strings.NewReader("\x1b[<0;3;5m\x1b[<0;3;5M"), io.Discard, Options{
+	result, err := runNativeInteractive(strings.NewReader("\x1b[<0;3;5M\r"), io.Discard, Options{
 		UI: "switch",
 		Items: []Item{
 			{Title: "api", Value: "/repo/api"},
@@ -792,7 +792,25 @@ func TestNativeInteractiveIgnoresMouseReleaseBeforeClick(t *testing.T) {
 		t.Fatalf("runNativeInteractive() error = %v", err)
 	}
 	if result.Key != "enter" || result.Value != "/repo/web" {
-		t.Fatalf("result = %#v, want release ignored and next click to select web", result)
+		t.Fatalf("result = %#v, want mouse down to focus web before enter", result)
+	}
+}
+
+func TestNativeInteractiveIgnoresMouseReleaseBeforeDown(t *testing.T) {
+	t.Parallel()
+
+	result, err := runNativeInteractive(strings.NewReader("\x1b[<0;3;5m\x1b[<0;3;5M\x1b[<0;3;5m"), io.Discard, Options{
+		UI: "switch",
+		Items: []Item{
+			{Title: "api", Value: "/repo/api"},
+			{Title: "web", Value: "/repo/web"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runNativeInteractive() error = %v", err)
+	}
+	if result.Key != "enter" || result.Value != "/repo/web" {
+		t.Fatalf("result = %#v, want release before down ignored and later mouse up to select web", result)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make native primary mouse down focus the row without accepting it
- trigger the native picker selection on the matching primary mouse up event
- update mouse behavior docs and tests

## Validation
- make fmt
- make fix
- env -u PROJMUX_PICKER_BACKEND HOME=/tmp/projmux-test-home XDG_CONFIG_HOME=/tmp/projmux-test-config XDG_STATE_HOME=/tmp/projmux-test-state GOCACHE=/tmp/projmux-go-build go test ./internal/ui/picker
- env -u PROJMUX_PICKER_BACKEND HOME=/tmp/projmux-test-home XDG_CONFIG_HOME=/tmp/projmux-test-config XDG_STATE_HOME=/tmp/projmux-test-state GOCACHE=/tmp/projmux-go-build make test
- make test-integration (blocked: docker CLI is not available in this WSL distro)
- make test-e2e (blocked: docker CLI is not available in this WSL distro)
- git diff --check