### PR TITLE
fix(picker): keep multiline partial gap rows

### DIFF
--- a/internal/ui/picker/backend.go
+++ b/internal/ui/picker/backend.go
@@ -1381,11 +1381,26 @@ func nativeAppendPartialNextItemLines(items []Item, lines []string, next, select
 		return lines
 	}
 	out := append([]string(nil), lines...)
-	nextLines := nativeInteractiveItemLines(items[next], next == selected, true)
+	nextLines := nativePartialNextItemLines(items, next, selected)
 	if len(nextLines) > remaining {
 		nextLines = nextLines[:remaining]
 	}
 	return append(out, nextLines...)
+}
+
+func nativePartialNextItemLines(items []Item, next, selected int) []string {
+	if next < 0 || next >= len(items) {
+		return nil
+	}
+	if next == 0 {
+		return nativeInteractiveItemLines(items[next], next == selected, true)
+	}
+	withNext := nativeInteractiveListLines(items, next-1, next+1, selected, true)
+	withoutNext := nativeInteractiveListLines(items, next-1, next, selected, true)
+	if len(withNext) <= len(withoutNext) {
+		return nativeInteractiveItemLines(items[next], next == selected, true)
+	}
+	return withNext[len(withoutNext):]
 }
 
 func nativeChromeLineCount(options Options) int {

--- a/internal/ui/picker/backend_test.go
+++ b/internal/ui/picker/backend_test.go
@@ -1458,14 +1458,49 @@ func TestNativeInteractiveShowsPartialNextMultilineItem(t *testing.T) {
 	}, items, "", 0, 0, nativeLayout{Rows: 9, Cols: 48})
 
 	rendered := out.String()
-	if !strings.Contains(rendered, "item 1") || !strings.Contains(rendered, "detail 1a") {
-		t.Fatalf("native output = %q, want first rows of next multiline item in remaining viewport", rendered)
+	if !strings.Contains(rendered, "item 1") {
+		t.Fatalf("native output = %q, want next multiline item to start in remaining viewport", rendered)
 	}
-	if strings.Contains(rendered, "detail 1b") {
+	if !strings.Contains(rendered, "  "+projmuxpicker.MutedStart+strings.Repeat(nativeGapLine, 8)) {
+		t.Fatalf("native output = %q, want separator before partial next multiline item", rendered)
+	}
+	if strings.Contains(rendered, "detail 1a") || strings.Contains(rendered, "detail 1b") {
 		t.Fatalf("native output = %q, want next item clipped to available viewport rows", rendered)
 	}
 	if !strings.Contains(rendered, nativeScrollbar) {
 		t.Fatalf("native output = %q, want scrollbar for clipped multiline list", rendered)
+	}
+}
+
+func TestNativePartialNextMultilineItemKeepsGapLine(t *testing.T) {
+	t.Parallel()
+
+	items := []Item{
+		{Label: "item 0\n  detail 0a\n  detail 0b", Value: "0"},
+		{Label: "item 1\n  detail 1a", Value: "1"},
+	}
+	lines := nativeInteractiveListLines(items, 0, 1, 0, true)
+
+	oneRemaining := nativeAppendPartialNextItemLines(items, lines, 1, 0, 4)
+	if len(oneRemaining) != 4 {
+		t.Fatalf("partial lines len = %d, want 4: %#v", len(oneRemaining), oneRemaining)
+	}
+	gapOnly := nativeRenderableListLine(oneRemaining[3], 48)
+	if !strings.Contains(gapOnly, strings.Repeat(nativeGapLine, 8)) || strings.Contains(gapOnly, "item 1") {
+		t.Fatalf("partial line = %q, want separator before next item when only one row remains", gapOnly)
+	}
+
+	twoRemaining := nativeAppendPartialNextItemLines(items, lines, 1, 0, 5)
+	if len(twoRemaining) != 5 {
+		t.Fatalf("partial lines len = %d, want 5: %#v", len(twoRemaining), twoRemaining)
+	}
+	gap := nativeRenderableListLine(twoRemaining[3], 48)
+	next := nativeRenderableListLine(twoRemaining[4], 48)
+	if !strings.Contains(gap, strings.Repeat(nativeGapLine, 8)) {
+		t.Fatalf("gap line = %q, want separator before partial next item", gap)
+	}
+	if !strings.Contains(next, "item 1") {
+		t.Fatalf("next line = %q, want first row of partial next item after separator", next)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Preserve the multiline gap separator before a partially visible next item
- Prefer the separator row when only one viewport row remains below a multiline item
- Add regression coverage for one-row and two-row partial next-item cases

## Validation
- `GOCACHE=/tmp/projmux-go-test go test ./internal/ui/picker`
- `make fmt`
- `make fix`
- `GOCACHE=/tmp/projmux-go-test make test` (sandbox blocked httptest listen; passed with escalated user environment)
- `make test-integration` (blocked locally: Docker CLI not installed in this WSL distro)
- `make test-e2e` (blocked locally: Docker CLI not installed in this WSL distro)