### PR TITLE
fix(picker): align multiline gap separators

### DIFF
--- a/internal/ui/picker/backend_test.go
+++ b/internal/ui/picker/backend_test.go
@@ -1461,7 +1461,7 @@ func TestNativeInteractiveShowsPartialNextMultilineItem(t *testing.T) {
 	if !strings.Contains(rendered, "item 1") {
 		t.Fatalf("native output = %q, want next multiline item to start in remaining viewport", rendered)
 	}
-	if !strings.Contains(rendered, "  "+projmuxpicker.MutedStart+strings.Repeat(nativeGapLine, 8)) {
+	if !strings.Contains(rendered, projmuxpicker.MutedStart+strings.Repeat(nativeGapLine, 8)) {
 		t.Fatalf("native output = %q, want separator before partial next multiline item", rendered)
 	}
 	if strings.Contains(rendered, "detail 1a") || strings.Contains(rendered, "detail 1b") {
@@ -1752,8 +1752,8 @@ func TestNativeInteractiveRendersMultilineGapLine(t *testing.T) {
 	}, "", 0, 0, nativeLayout{Rows: 24, Cols: 80})
 
 	rendered := out.String()
-	if !strings.Contains(rendered, "  "+projmuxpicker.MutedStart+strings.Repeat(nativeGapLine, 8)) {
-		t.Fatalf("native output = %q, want muted fzf-like multiline gap line", rendered)
+	if !strings.Contains(rendered, projmuxpicker.MutedStart+strings.Repeat(nativeGapLine, 8)) {
+		t.Fatalf("native output = %q, want muted fzf-like full-width multiline gap line", rendered)
 	}
 	if strings.Contains(rendered, nativeGapSentinel) {
 		t.Fatalf("native output leaked gap sentinel: %q", rendered)

--- a/internal/ui/projmuxpicker/surface.go
+++ b/internal/ui/projmuxpicker/surface.go
@@ -228,10 +228,10 @@ func RenderableListLine(line string, width int) string {
 	if line != gapSentinel {
 		return PadStyledLine(line, width)
 	}
-	if width <= 4 {
-		return SeparatorLine(1)
+	if width <= 0 {
+		return ""
 	}
-	return "  " + SeparatorLine(width-2)
+	return SeparatorLine(width)
 }
 
 func PadStyledLine(line string, width int) string {

--- a/internal/ui/projmuxpicker/surface_test.go
+++ b/internal/ui/projmuxpicker/surface_test.go
@@ -71,6 +71,22 @@ func TestRenderableListLinePadsUnselectedStyleAfterReset(t *testing.T) {
 	}
 }
 
+func TestRenderableListLineRendersGapAtFullListWidth(t *testing.T) {
+	t.Parallel()
+
+	rendered := RenderableListLine(gapSentinel, 12)
+
+	if strings.HasPrefix(rendered, " ") {
+		t.Fatalf("RenderableListLine(gap) = %q, want no leading indent", rendered)
+	}
+	if got := VisibleLen(rendered); got != 12 {
+		t.Fatalf("VisibleLen(RenderableListLine(gap)) = %d, want 12", got)
+	}
+	if !strings.Contains(rendered, strings.Repeat(GapLine, 12)) {
+		t.Fatalf("RenderableListLine(gap) = %q, want full-width gap line", rendered)
+	}
+}
+
 func TestInteractiveRowLinesUsesCurrentStyleForSimpleSelection(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Render multiline list gap separators at the full list width instead of adding a left gutter
- Keep item text indentation unchanged while removing the separator's visible left offset
- Update native picker and surface tests for full-width gap rows

## Validation
- `GOCACHE=/tmp/projmux-go-test go test ./internal/ui/projmuxpicker`
- `GOCACHE=/tmp/projmux-go-test go test ./internal/ui/picker`
- `make fmt`
- `make fix`
- `GOCACHE=/tmp/projmux-go-test make test` (sandbox blocked httptest listen; passed with escalated user environment)
- `make test-integration` (blocked locally: Docker CLI not installed in this WSL distro)
- `make test-e2e` (blocked locally: Docker CLI not installed in this WSL distro)