### PR TITLE
refactor(picker): rename legacy adapter

### DIFF
--- a/docs/native-picker-no-fzf-poc.md
+++ b/docs/native-picker-no-fzf-poc.md
@@ -15,9 +15,10 @@ The fzf compatibility surface for the native engine is tracked in
   responsible for backend routing, keyboard input, filtering, preview command
   execution, and result contracts, while moving visual composition into
   `projmuxpicker` so projmux can evolve a native picker design without coupling
-  every visual tweak to the fzf adapter.
-- `internal/ui/fzf` remains as a legacy adapter between the old option/result
-  shape and the backend-neutral `picker.Options` contract. App code should
+  every visual tweak to the legacy picker option/result adapter.
+- `internal/ui/pickercompat` remains as a legacy picker option/result adapter
+  between the old option/result shape and the backend-neutral `picker.Options`
+  contract. App code should
   describe picker intent as rows, actions, preview commands, and initial focus,
   then route through the native picker.
 - Settings > Labs remains available for experimental settings, but picker
@@ -126,7 +127,8 @@ The fzf compatibility surface for the native engine is tracked in
 ## Experimental Boundaries
 
 - The `projmuxpicker` package is intended as a foundation that can be carried
-  forward, along with the legacy option/result mapping in `internal/ui/fzf`.
+  forward, along with the legacy picker option/result mapping in
+  `internal/ui/pickercompat`.
   Its frame, row, preview, theme, ANSI, and redraw modules are foundation code;
   Docker sandbox scripts and dependency-policy notes remain support
   scaffolding.

--- a/docs/native-picker-parity.md
+++ b/docs/native-picker-parity.md
@@ -14,8 +14,8 @@ native picker engine and is not a public dependency-policy change.
 | `--header` | AI, settings, shell update, notify | Covered | `renderNativeInteractive`, `renderNative`; settings native tests |
 | `--footer` / `--footer-border line` | AI, settings, shell update, switch, sessions, notify | Covered for interactive native screens | `renderNativeInteractive` reserves bottom footer space and renders a separator line; `TestNativeInteractiveRendersFooterAtBottom` |
 | `--ansi` | colored row labels from render package | Covered | native writes row labels directly, strips ANSI escapes from default search text, restores selected-row styling after embedded ANSI resets, and measures rendered cell width for Korean/CJK text, emoji, and combining marks; `TestFilterItemsIgnoresANSIEscapeSequences`; `TestNativeInteractiveUsesCurrentStyleForSimpleSelection`; `TestVisibleLenUsesTerminalCellWidth`; Docker e2e shows ANSI rows |
-| hidden value after tab delimiter | all picker selections and default fzf matching | Covered by `picker.Item.Value` and default search text | `fzf.PickerOptions`; `TestNativeRunnerFiltersAndSelectsByNumber`; `TestFilterItemsSearchesHiddenValueWhenNoSearchKey` |
-| plain fzf candidates without structured entries | legacy runner call shape | Covered | `fzf.PickerOptions`; `TestPickerOptionsFromFZFMapsCandidatesWhenEntriesAreEmpty` |
+| hidden value after tab delimiter | all picker selections and default fzf matching | Covered by `picker.Item.Value` and default search text | `pickercompat.PickerOptions`; `TestNativeRunnerFiltersAndSelectsByNumber`; `TestFilterItemsSearchesHiddenValueWhenNoSearchKey` |
+| plain fzf candidates without structured entries | legacy runner call shape | Covered | `pickercompat.PickerOptions`; `TestPickerOptionsFromLegacyPickerMapsCandidatesWhenEntriesAreEmpty` |
 | search key filtering (`--nth`/reload filter file) | switch/sessions/notify entries | Covered by `Item.SearchText` with fzf reload order preservation | `FilterItems`; `TestFilterItemsUsesSearchTextNotMetadata`; `TestFilterItemsPreservesSearchKeyOrder` |
 | default `--smart-case` matching | all searchable picker rows | Covered | native filter keeps lower-case queries case-insensitive and uppercase queries case-sensitive; `TestFilterItemsUsesFZFSmartCase` |
 | fzf match highlighting | searchable simple picker rows | Covered for non-search-key simple rows | native highlights matched visible label runes while preserving embedded ANSI style; search-key reload lists intentionally keep fzf disabled-filter rendering without match highlights; `TestNativeInteractiveHighlightsSimpleQueryMatches`; `TestNativeInteractiveDoesNotHighlightSearchKeyReloadLists` |
@@ -26,14 +26,14 @@ native picker engine and is not a public dependency-policy change.
 | `--gap --gap-line ─` | switch, sessions, notify multi-line rows | Covered for app multiline rows | `nativeGapLine`, row-budgeted range; `TestNativeInteractiveRendersMultilineGapLine`, `TestNativeVisibleRangeCountsMultilineRenderedRows` |
 | selected multi-line marker | selected switch/session/notify cards | Covered for app multiline rows | native uses the same compact pointer-width red `▌` gutter as the first selected project line, and metadata lines align to the project-name column without the old deeper indent; `nativeContinuation`; `TestNativeInteractiveRendersSelectedMultilineContinuationMarker`; `TestInteractiveRowLinesUsesCompactSelectedMetaIndent`; `TestInteractiveRowLinesAlignsUnselectedMetaWithProjectName` |
 | fzf current row colors | simple and multi-line rows | Covered for app rows | `nativeCurrentStart`, `nativePointer`; pointer/continuation gutter tokens carry the current-row background; `TestNativeSelectedContentKeepsCurrentStyleAfterReset`; `TestNativeInteractiveUsesCurrentStyleForSimpleSelection` |
-| `--expect` keys | Enter/Ctrl-X/Alt-P/notify keys | Covered | `fzf.PickerOptions`; `TestNativeInteractiveSupportsCustomExpectKeys` |
+| `--expect` keys | Enter/Ctrl-X/Alt-P/notify keys | Covered | `pickercompat.PickerOptions`; `TestNativeInteractiveSupportsCustomExpectKeys` |
 | printable expect keys | notify sidebar `x` ack | Covered | `TestNativeInteractiveSupportsPrintableExpectKeys`; Docker no-fzf e2e |
 | control expect keys | notify sidebar `Ctrl-X`, settings `Ctrl-Alt-S` close | Covered | `TestNativeInteractiveSupportsControlExpectKeys`; `TestNativeInteractiveSupportsControlAltCloseKeys` |
 | close `--bind key:abort` | Esc, Ctrl-C, Alt-N, Ctrl-Alt-S variants | Covered | `CloseActions`; `TestNativeRunnerUsesSharedCloseActions` |
 | terminal CSI-u key encoding | app keybind probe sequences, Ghostty/kitty-style modified keys | Covered | native handles app-specific Alt keys, generic modified letters/digits, and non-text keys such as Enter/Esc/Backspace/Tab; `TestNativeInteractiveSupportsCSIuAppKeyBindings` |
-| `execute-silent(...)+refresh-preview` | switch/session preview cycling | Covered for command execution and rerender loop | `fzf.PickerOptions`/`fzf.OptionsFromPicker`; `TestNativeInteractiveRunsCustomActionCommandAndRefreshes`; `TestPickerOptionsMapsFZFBindingsToContractActions`; Docker no-fzf e2e sends `Right` and `Alt-Down` before selection |
+| `execute-silent(...)+refresh-preview` | switch/session preview cycling | Covered for command execution and rerender loop | `pickercompat.PickerOptions`/`pickercompat.OptionsFromPicker`; `TestNativeInteractiveRunsCustomActionCommandAndRefreshes`; `TestPickerOptionsMapsLegacyBindingsToContractActions`; Docker no-fzf e2e sends `Right` and `Alt-Down` before selection |
 | `focus:execute-silent(...)` | switch sidebar focus | Covered | native renders the selection frame diff before running sidebar focus commands so movement stays visible before tmux focus side effects; `runNativeFocusAction`; `TestNativeInteractiveRunsFocusActionOnSelectionChange` |
-| `start:pos(N)` | switch sidebar initial row | Covered | `fzf.PickerOptions`/`fzf.OptionsFromPicker`; `TestPickerOptionsFromFZFMapsStartPosToInitialIndex`; `TestPickerOptionsMapsFZFBindingsToContractActions` |
+| `start:pos(N)` | switch sidebar initial row | Covered | `pickercompat.PickerOptions`/`pickercompat.OptionsFromPicker`; `TestPickerOptionsFromLegacyPickerMapsStartPosToInitialIndex`; `TestPickerOptionsMapsLegacyBindingsToContractActions` |
 | `--preview` | switch, sessions | Covered by command output | `nativePreviewLines`; `TestNativeInteractiveRendersSelectedPreview` |
 | `--preview-window right,60%,border-left` | switch popup, sessions popup | Covered for projmux option shape | `renderNativeSplitPreview` renders a single-column left border without a synthetic title row, uses fzf-measured percent sizing, normalizes preview tabs/control bytes before clipping, and pads both panes to fixed row widths so long preview rows do not wrap into extra vertical rows; `TestNativeInteractiveRendersWidePreviewBesideList`; `TestNativePreviewWidthUsesPreviewWindowPercent`; `TestRenderSplitPreviewRowsPadsBothPanes`; `TestRenderSplitPreviewRowsNormalizesPreviewTabsBeforeTruncating` |
 | `--preview-window down,25%,border-top` | switch sidebar | Covered for projmux option shape | `renderNativeDownPreview` renders an immediate top border without a synthetic title row, uses fzf-measured percent sizing, and pads preview rows to the surface width; `TestNativeInteractiveRendersDownPreviewBelowList`; `TestNativePreviewHeightUsesPreviewWindowPercent`; `TestRenderDownPreviewPadsPreviewRows` |
@@ -59,14 +59,14 @@ native picker engine and is not a public dependency-policy change.
   redraw updates, ANSI width/truncation, theme tokens, prompt/footer/list
   rendering, selected row styling, scrollbars/gap rows, and preview pane
   geometry/rendering.
-- `internal/ui/fzf` remains as the compatibility adapter from legacy
-  `fzf.Options` to `picker.Options` for the native backend. This keeps app code
+- `internal/ui/pickercompat` remains as the legacy picker option/result adapter
+  from legacy option shapes to `picker.Options` for the native backend. This keeps app code
   closer to a DI-style picker contract instead of embedding binding strings at
   each call site.
 - Settings > Labs remains available, but picker backend selection has been
   retired. Legacy saved/env backend values normalize to native.
 - The split lets projmux grow a first-party picker design independently from
-  the fzf compatibility adapter.
+  the legacy picker option/result adapter.
 
 ## Verified Flows
 

--- a/docs/picker-ui-plan.md
+++ b/docs/picker-ui-plan.md
@@ -14,8 +14,8 @@ The picker contract is split in two layers:
 
 - `internal/ui/picker` owns backend-neutral items, actions, preview metadata,
   title-focused filtering, and the native runner.
-- `internal/ui/fzf` is a retired compatibility adapter for old option/result
-  structs. Product flows do not execute the external fzf binary.
+- `internal/ui/pickercompat` is a retired legacy picker option/result adapter
+  for old structs. Product flows do not execute the external fzf binary.
 
 ## fzf Capability Check
 

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -21,8 +21,8 @@ projmux/
       tmux/
     state/
     ui/
-      fzf/
       picker/
+      pickercompat/
       projmuxpicker/
       render/
     version/
@@ -39,7 +39,7 @@ projmux/
 - `internal/core` contains product behavior that should be testable without tmux.
 - `internal/integrations/tmux` should be the only place that knows tmux command strings and output formats.
 - `internal/ui/picker` and `internal/ui/projmuxpicker` own native picker behavior.
-- `internal/ui/fzf` remains as a legacy option/result adapter; product code should route through the native picker.
+- `internal/ui/pickercompat` remains as a legacy picker option/result adapter; product code should route through the native picker.
 - `scripts/` is for development tooling only, not product logic.
 
 ## Early implementation order

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -17,8 +17,8 @@ import (
 	"time"
 	"unicode/utf16"
 
-	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
 
 const (
@@ -36,7 +36,7 @@ const (
 )
 
 type aiCommandRunner interface {
-	Run(options intfzf.Options) (intfzf.Result, error)
+	Run(options intpickercompat.Options) (intpickercompat.Result, error)
 }
 
 type aiCommand struct {
@@ -577,7 +577,7 @@ func (c *aiCommand) runSettings(args []string, stdout, stderr io.Writer) error {
 	if c.nativePicker == nil {
 		return errors.New("native picker is not configured")
 	}
-	result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, intfzf.Options{
+	result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, intpickercompat.Options{
 		UI:         "ai-settings",
 		Entries:    c.settingsRows(),
 		Title:      "AI Settings - Default Ctrl+Shift+R/L split mode",
@@ -598,11 +598,11 @@ func (c *aiCommand) runSettings(args []string, stdout, stderr io.Writer) error {
 	return c.setMode(result.Value)
 }
 
-func (c *aiCommand) runAgentPicker(direction string) (intfzf.Result, error) {
+func (c *aiCommand) runAgentPicker(direction string) (intpickercompat.Result, error) {
 	if c.nativePicker == nil {
-		return intfzf.Result{}, errors.New("native picker is not configured")
+		return intpickercompat.Result{}, errors.New("native picker is not configured")
 	}
-	return runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, intfzf.Options{
+	return runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, intpickercompat.Options{
 		UI:         "ai-picker",
 		Entries:    c.agentRows(),
 		Title:      "AI Launch - Split direction: " + direction,
@@ -613,7 +613,7 @@ func (c *aiCommand) runAgentPicker(direction string) (intfzf.Result, error) {
 	})
 }
 
-func (c *aiCommand) settingsRows() []intfzf.Entry {
+func (c *aiCommand) settingsRows() []intpickercompat.Entry {
 	current := c.getMode()
 	modes := []struct {
 		mode string
@@ -624,13 +624,13 @@ func (c *aiCommand) settingsRows() []intfzf.Entry {
 		{aiModeCodex, "always run Codex split"},
 		{aiModeShell, "always open plain shell split"},
 	}
-	rows := make([]intfzf.Entry, 0, len(modes))
+	rows := make([]intpickercompat.Entry, 0, len(modes))
 	for _, item := range modes {
 		tag := ansiDim("[ ]")
 		if item.mode == current {
 			tag = "\x1b[32m[ACTIVE]\x1b[0m"
 		}
-		rows = append(rows, intfzf.Entry{
+		rows = append(rows, intpickercompat.Entry{
 			Label:     fmt.Sprintf("%s \x1b[36m%-9s\x1b[0m  \x1b[90m%s\x1b[0m", tag, item.mode, item.desc),
 			Value:     item.mode,
 			SearchKey: item.mode + " " + item.desc,
@@ -639,8 +639,8 @@ func (c *aiCommand) settingsRows() []intfzf.Entry {
 	return rows
 }
 
-func (c *aiCommand) agentRows() []intfzf.Entry {
-	rows := []intfzf.Entry{
+func (c *aiCommand) agentRows() []intpickercompat.Entry {
+	rows := []intpickercompat.Entry{
 		c.agentRow(aiModeCodex, "OpenAI Codex split"),
 		c.agentRow(aiModeClaude, "Anthropic CLI split"),
 		{
@@ -652,12 +652,12 @@ func (c *aiCommand) agentRows() []intfzf.Entry {
 	return rows
 }
 
-func (c *aiCommand) agentRow(mode, desc string) intfzf.Entry {
+func (c *aiCommand) agentRow(mode, desc string) intpickercompat.Entry {
 	status := "\x1b[33m[MISSING]\x1b[0m"
 	if c.agentAvailable(mode) {
 		status = "\x1b[32m[READY]\x1b[0m"
 	}
-	return intfzf.Entry{
+	return intpickercompat.Entry{
 		Label:     fmt.Sprintf("%-8s %s %s", mode, status, desc),
 		Value:     mode,
 		SearchKey: mode + " " + desc,

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -16,7 +16,7 @@ import (
 	"time"
 	"unicode/utf16"
 
-	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
 
 func TestAISettingsGetAndSetMode(t *testing.T) {
@@ -72,10 +72,10 @@ func TestAISettingsSetModeDisplaysTmuxToastInsideTmux(t *testing.T) {
 
 func TestAISettingsPickerSetsSelectedMode(t *testing.T) {
 	home := t.TempDir()
-	runner := &capturingAIRunner{result: intfzf.Result{Key: "enter", Value: "shell"}}
+	runner := &capturingAIRunner{result: intpickercompat.Result{Key: "enter", Value: "shell"}}
 	cmd := testAICommand(home)
 	cmd.runner = runner
-	cmd.nativePicker = nativePickerFromFZFRunner(runner)
+	cmd.nativePicker = nativePickerFromLegacyRunner(runner)
 
 	if err := cmd.Run([]string{"settings"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run settings picker error = %v", err)
@@ -105,7 +105,7 @@ func TestAIPickerShowsKeyFooter(t *testing.T) {
 	runner := &capturingAIRunner{}
 	cmd := testAICommand(home)
 	cmd.runner = runner
-	cmd.nativePicker = nativePickerFromFZFRunner(runner)
+	cmd.nativePicker = nativePickerFromLegacyRunner(runner)
 
 	if _, err := cmd.runAgentPicker("right"); err != nil {
 		t.Fatalf("runAgentPicker error = %v", err)
@@ -1343,12 +1343,12 @@ func TestAINotificationMessageLabelsClaudeAndAvoidsRootProject(t *testing.T) {
 }
 
 type capturingAIRunner struct {
-	options intfzf.Options
-	result  intfzf.Result
+	options intpickercompat.Options
+	result  intpickercompat.Result
 	err     error
 }
 
-func (r *capturingAIRunner) Run(options intfzf.Options) (intfzf.Result, error) {
+func (r *capturingAIRunner) Run(options intpickercompat.Options) (intpickercompat.Result, error) {
 	r.options = options
 	return r.result, r.err
 }
@@ -1366,7 +1366,7 @@ func testAICommand(home string) *aiCommand {
 	recorder := &aiCommandRecorder{}
 	cmd := &aiCommand{
 		runner:       &capturingAIRunner{},
-		nativePicker: nativePickerFromFZFRunner(&capturingAIRunner{}),
+		nativePicker: nativePickerFromLegacyRunner(&capturingAIRunner{}),
 		executable:   func() (string, error) { return "/tmp/projmux", nil },
 		lookupEnv: func(name string) string {
 			switch name {

--- a/internal/app/native_picker.go
+++ b/internal/app/native_picker.go
@@ -3,24 +3,24 @@ package app
 import (
 	"fmt"
 
-	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
 
-func runPickerOptionBackend(lookupEnv func(string) string, native intpicker.Runner, fzf intfzf.Runner, options intfzf.Options) (intfzf.Result, error) {
+func runPickerOptionBackend(lookupEnv func(string) string, native intpicker.Runner, legacy intpickercompat.Runner, options intpickercompat.Options) (intpickercompat.Result, error) {
 	_ = lookupEnv
-	_ = fzf
+	_ = legacy
 	if native == nil {
-		return intfzf.Result{}, fmt.Errorf("native picker is not configured")
+		return intpickercompat.Result{}, fmt.Errorf("native picker is not configured")
 	}
-	result, err := native.Run(intfzf.PickerOptions(options))
-	return intfzf.ResultFromPicker(result), err
+	result, err := native.Run(intpickercompat.PickerOptions(options))
+	return intpickercompat.ResultFromPicker(result), err
 }
 
-func pickerOptionsFromFZF(options intfzf.Options) intpicker.Options {
-	return intfzf.PickerOptions(options)
+func pickerOptionsFromLegacyPicker(options intpickercompat.Options) intpicker.Options {
+	return intpickercompat.PickerOptions(options)
 }
 
-func pickerCommandFromFZFBinding(action string) string {
-	return intfzf.PickerCommandFromBinding(action)
+func pickerCommandFromLegacyBinding(action string) string {
+	return intpickercompat.PickerCommandFromBinding(action)
 }

--- a/internal/app/native_picker_test.go
+++ b/internal/app/native_picker_test.go
@@ -6,17 +6,17 @@ import (
 	"testing"
 
 	"github.com/crevissepartners/projmux/internal/config"
-	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
 
-func nativePickerFromFZFRunner(r intfzf.Runner) intpicker.Runner {
+func nativePickerFromLegacyRunner(r intpickercompat.Runner) intpicker.Runner {
 	return pickerRunnerFunc(func(options intpicker.Options) (intpicker.Result, error) {
-		result, err := r.Run(intfzf.OptionsFromPicker(options))
+		result, err := r.Run(intpickercompat.OptionsFromPicker(options))
 		if err != nil {
 			return intpicker.Result{}, err
 		}
-		return intfzf.ResultToPicker(result), nil
+		return intpickercompat.ResultToPicker(result), nil
 	})
 }
 
@@ -42,20 +42,20 @@ func TestRunPickerOptionBackendUsesNativeWhenRequested(t *testing.T) {
 			return ""
 		},
 		native,
-		switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			fzfCalled = true
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		intfzf.Options{
+		intpickercompat.Options{
 			UI:      "settings",
-			Entries: []intfzf.Entry{{Label: "AI Settings", Value: "ai"}},
+			Entries: []intpickercompat.Entry{{Label: "AI Settings", Value: "ai"}},
 		},
 	)
 	if err != nil {
 		t.Fatalf("runPickerOptionBackend() error = %v", err)
 	}
 	if fzfCalled {
-		t.Fatal("fzf runner was called for native backend")
+		t.Fatal("legacy runner was called for native backend")
 	}
 	if result.Key != "enter" || result.Value != "ai" {
 		t.Fatalf("result = %#v, want native selection", result)
@@ -91,13 +91,13 @@ func TestRunPickerOptionBackendUsesSavedNativeBackend(t *testing.T) {
 			nativeCalled = true
 			return intpicker.Result{Key: "enter", Value: "ai"}, nil
 		}),
-		switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			fzfCalled = true
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		intfzf.Options{
+		intpickercompat.Options{
 			UI:      "settings",
-			Entries: []intfzf.Entry{{Label: "AI Settings", Value: "ai"}},
+			Entries: []intpickercompat.Entry{{Label: "AI Settings", Value: "ai"}},
 		},
 	)
 	if err != nil {
@@ -107,7 +107,7 @@ func TestRunPickerOptionBackendUsesSavedNativeBackend(t *testing.T) {
 		t.Fatal("native runner was not called for saved native picker backend")
 	}
 	if fzfCalled {
-		t.Fatal("fzf runner was called for saved native picker backend")
+		t.Fatal("legacy runner was called for saved native picker backend")
 	}
 	if result.Value != "ai" {
 		t.Fatalf("result = %#v, want native selection", result)
@@ -138,11 +138,11 @@ func TestRunPickerOptionBackendDefaultsToNativeBackend(t *testing.T) {
 			nativeCalled = true
 			return intpicker.Result{Key: "enter", Value: "ai"}, nil
 		}),
-		switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			fzfCalled = true
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		intfzf.Options{UI: "settings"},
+		intpickercompat.Options{UI: "settings"},
 	)
 	if err != nil {
 		t.Fatalf("runPickerOptionBackend() error = %v", err)
@@ -151,14 +151,14 @@ func TestRunPickerOptionBackendDefaultsToNativeBackend(t *testing.T) {
 		t.Fatal("native runner was not called for default picker backend")
 	}
 	if fzfCalled {
-		t.Fatal("fzf runner was called for default picker backend")
+		t.Fatal("legacy runner was called for default picker backend")
 	}
 	if result.Value != "ai" {
 		t.Fatalf("result = %#v, want native selection", result)
 	}
 }
 
-func TestRunPickerOptionBackendIgnoresLegacyFZFEnvOverride(t *testing.T) {
+func TestRunPickerOptionBackendIgnoresLegacyBackendEnvOverride(t *testing.T) {
 	configHome := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", configHome)
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
@@ -181,27 +181,27 @@ func TestRunPickerOptionBackendIgnoresLegacyFZFEnvOverride(t *testing.T) {
 			nativeCalled = true
 			return intpicker.Result{Key: "enter", Value: "ai"}, nil
 		}),
-		switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			fzfCalled = true
-			return intfzf.Result{Key: "enter", Value: "fzf"}, nil
+			return intpickercompat.Result{Key: "enter", Value: "fzf"}, nil
 		}),
-		intfzf.Options{UI: "settings"},
+		intpickercompat.Options{UI: "settings"},
 	)
 	if err != nil {
 		t.Fatalf("runPickerOptionBackend() error = %v", err)
 	}
 	if !nativeCalled {
-		t.Fatal("native runner was not called despite legacy fzf env")
+		t.Fatal("native runner was not called despite legacy backend env")
 	}
 	if fzfCalled {
-		t.Fatal("fzf runner was called despite legacy fzf env")
+		t.Fatal("legacy runner was called despite legacy backend env")
 	}
 	if result.Value != "ai" {
 		t.Fatalf("result = %#v, want native selection", result)
 	}
 }
 
-func TestRunPickerOptionBackendErrorsWhenNativeMissingWithoutCallingFZF(t *testing.T) {
+func TestRunPickerOptionBackendErrorsWhenNativeMissingWithoutCallingLegacyRunner(t *testing.T) {
 	t.Parallel()
 
 	var fzfCalled bool
@@ -213,50 +213,50 @@ func TestRunPickerOptionBackendErrorsWhenNativeMissingWithoutCallingFZF(t *testi
 			return ""
 		},
 		nil,
-		switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			fzfCalled = true
-			return intfzf.Result{Key: "enter", Value: "fzf"}, nil
+			return intpickercompat.Result{Key: "enter", Value: "fzf"}, nil
 		}),
-		intfzf.Options{UI: "settings"},
+		intpickercompat.Options{UI: "settings"},
 	)
 
 	if err == nil || !strings.Contains(err.Error(), "native picker is not configured") {
 		t.Fatalf("runPickerOptionBackend() error = %v, want native picker error", err)
 	}
 	if fzfCalled {
-		t.Fatal("fzf runner was called when native picker was missing")
+		t.Fatal("legacy runner was called when native picker was missing")
 	}
 }
 
-func TestProductionPickerConstructorsDoNotCreateFZFRunner(t *testing.T) {
+func TestProductionPickerConstructorsDoNotCreateLegacyRunner(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
 	if cmd := newAICommand(); cmd.runner != nil {
-		t.Fatal("newAICommand() created fzf runner")
+		t.Fatal("newAICommand() created legacy runner")
 	}
 	if cmd := newSettingsCommand(testAICommand(t.TempDir()), testSettingsSwitchCommand(t, &stubSwitchPinStore{}), nil); cmd.runner != nil {
-		t.Fatal("newSettingsCommand() created fzf runner")
+		t.Fatal("newSettingsCommand() created legacy runner")
 	}
 	if cmd := newSwitchCommand(); cmd.runner != nil {
-		t.Fatal("newSwitchCommand() created fzf runner")
+		t.Fatal("newSwitchCommand() created legacy runner")
 	}
 	if cmd := newSessionsCommand(); cmd.runner != nil {
-		t.Fatal("newSessionsCommand() created fzf runner")
+		t.Fatal("newSessionsCommand() created legacy runner")
 	}
 	if cmd := newNotifyCommand(); cmd.picker != nil {
-		t.Fatal("newNotifyCommand() created fzf runner")
+		t.Fatal("newNotifyCommand() created legacy runner")
 	}
 	if cmd := newShellCommand(nil); cmd.updatePromptRunner != nil {
-		t.Fatal("newShellCommand() created fzf runner")
+		t.Fatal("newShellCommand() created legacy runner")
 	}
 }
 
-func TestPickerOptionsFromFZFMapsCandidatesWhenEntriesAreEmpty(t *testing.T) {
+func TestPickerOptionsFromLegacyPickerMapsCandidatesWhenEntriesAreEmpty(t *testing.T) {
 	t.Parallel()
 
-	options := pickerOptionsFromFZF(intfzf.Options{
+	options := pickerOptionsFromLegacyPicker(intpickercompat.Options{
 		UI:         "legacy",
 		Candidates: []string{"/tmp/project-a", " ", "/tmp/project-b"},
 	})
@@ -272,7 +272,7 @@ func TestPickerOptionsFromFZFMapsCandidatesWhenEntriesAreEmpty(t *testing.T) {
 	}
 }
 
-func TestSettingsNativeBackendDoesNotCallFZF(t *testing.T) {
+func TestSettingsNativeBackendDoesNotCallLegacyRunner(t *testing.T) {
 	t.Parallel()
 
 	home := t.TempDir()
@@ -288,9 +288,9 @@ func TestSettingsNativeBackendDoesNotCallFZF(t *testing.T) {
 			return ""
 		},
 		nativePicker: intpicker.NativeRunner{In: strings.NewReader("2\n4\n"), Out: &out},
-		runner: switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			fzfCalled = true
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
 	}
 
@@ -298,7 +298,7 @@ func TestSettingsNativeBackendDoesNotCallFZF(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	if fzfCalled {
-		t.Fatal("fzf runner was called for native settings backend")
+		t.Fatal("legacy runner was called for native settings backend")
 	}
 	if got, want := readModeFile(t, home), "codex\n"; got != want {
 		t.Fatalf("mode file = %q, want %q", got, want)
@@ -308,10 +308,10 @@ func TestSettingsNativeBackendDoesNotCallFZF(t *testing.T) {
 	}
 }
 
-func TestPickerActionsFromFZFPreservesExecuteSilentCommand(t *testing.T) {
+func TestPickerActionsFromLegacyBindingPreservesExecuteSilentCommand(t *testing.T) {
 	t.Parallel()
 
-	options := pickerOptionsFromFZF(intfzf.Options{
+	options := pickerOptionsFromLegacyPicker(intpickercompat.Options{
 		Bindings: []string{"right:execute-silent(exec '/tmp/projmux' 'switch' 'cycle-window' {2} 'next')+refresh-preview"},
 	})
 	if len(options.Actions) != 1 {
@@ -323,10 +323,10 @@ func TestPickerActionsFromFZFPreservesExecuteSilentCommand(t *testing.T) {
 	}
 }
 
-func TestPickerOptionsFromFZFMapsStartPosToInitialIndex(t *testing.T) {
+func TestPickerOptionsFromLegacyPickerMapsStartPosToInitialIndex(t *testing.T) {
 	t.Parallel()
 
-	options := pickerOptionsFromFZF(intfzf.Options{
+	options := pickerOptionsFromLegacyPicker(intpickercompat.Options{
 		Bindings: []string{
 			"focus:execute-silent(exec '/tmp/projmux' 'switch' 'sidebar-focus' {2})",
 			"start:pos(3)",

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/notify"
-	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
 
 // notifyStore is the subset of *notify.Store the CLI dispatcher needs. The
@@ -32,7 +32,7 @@ type notifyCommand struct {
 	storeErr   error
 	now        func() time.Time
 	runner     tmuxRunner
-	picker     intfzf.Runner
+	picker     intpickercompat.Runner
 	native     intpicker.Runner
 	executable func() (string, error)
 	lookupEnv  func(string) string
@@ -281,7 +281,7 @@ func (c *notifyCommand) runSidebar(entries []notify.Notification, stdout, stderr
 		return errors.New("native picker is not configured")
 	}
 	now := c.clock()
-	fzfOptions := intfzf.Options{
+	compatOptions := intpickercompat.Options{
 		UI:            "notify-sidebar",
 		Read0:         true,
 		Title:         notifyHeaderDecorator(c.statusbarDecoration()) + "Pending Notifications",
@@ -293,7 +293,7 @@ func (c *notifyCommand) runSidebar(entries []notify.Notification, stdout, stderr
 		Entries:       notifySidebarEntries(entries, now),
 		DisableSearch: true,
 	}
-	result, err := runPickerOptionBackend(c.lookupEnv, c.native, c.picker, fzfOptions)
+	result, err := runPickerOptionBackend(c.lookupEnv, c.native, c.picker, compatOptions)
 	if err != nil {
 		return fmt.Errorf("run notify sidebar: %w", err)
 	}
@@ -336,17 +336,17 @@ func (c *notifyCommand) runSidebar(entries []notify.Notification, stdout, stderr
 
 const notifySidebarEmptyValue = "__projmux_notify_empty__"
 
-func notifySidebarEntries(entries []notify.Notification, now time.Time) []intfzf.Entry {
+func notifySidebarEntries(entries []notify.Notification, now time.Time) []intpickercompat.Entry {
 	if len(entries) == 0 {
-		return []intfzf.Entry{{
+		return []intpickercompat.Entry{{
 			Label: "No pending notifications",
 			Value: notifySidebarEmptyValue,
 		}}
 	}
-	out := make([]intfzf.Entry, 0, len(entries))
+	out := make([]intpickercompat.Entry, 0, len(entries))
 	for _, e := range entries {
 		label := notifySidebarLabel(e, now)
-		out = append(out, intfzf.Entry{
+		out = append(out, intpickercompat.Entry{
 			Label: label,
 			Value: e.ID,
 		})

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/crevissepartners/projmux/internal/core/notify"
-	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
 
 type stubNotifyStore struct {
@@ -30,19 +30,19 @@ type stubNotifyStore struct {
 }
 
 type stubNotifyPicker struct {
-	options intfzf.Options
-	result  intfzf.Result
+	options intpickercompat.Options
+	result  intpickercompat.Result
 	err     error
 }
 
-func (p *stubNotifyPicker) Run(options intfzf.Options) (intfzf.Result, error) {
+func (p *stubNotifyPicker) Run(options intpickercompat.Options) (intpickercompat.Result, error) {
 	p.options = options
 	return p.result, p.err
 }
 
-type notifyPickerFunc func(options intfzf.Options) (intfzf.Result, error)
+type notifyPickerFunc func(options intpickercompat.Options) (intpickercompat.Result, error)
 
-func (f notifyPickerFunc) Run(options intfzf.Options) (intfzf.Result, error) {
+func (f notifyPickerFunc) Run(options intpickercompat.Options) (intpickercompat.Result, error) {
 	return f(options)
 }
 
@@ -259,11 +259,11 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 			},
 		},
 	}
-	picker := &stubNotifyPicker{result: intfzf.Result{Value: "abc"}}
+	picker := &stubNotifyPicker{result: intpickercompat.Result{Value: "abc"}}
 	runner := &focusFakeRunner{}
 	cmd := newCmd(store)
 	cmd.picker = picker
-	cmd.native = nativePickerFromFZFRunner(picker)
+	cmd.native = nativePickerFromLegacyRunner(picker)
 	cmd.runner = runner
 	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
 
@@ -357,7 +357,7 @@ func TestNotifyListSidebarTitleDecoration(t *testing.T) {
 				return ""
 			}
 			cmd.picker = picker
-			cmd.native = nativePickerFromFZFRunner(picker)
+			cmd.native = nativePickerFromLegacyRunner(picker)
 			cmd.runner = runner
 
 			if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
@@ -403,7 +403,7 @@ func TestNotifySidebarLabelDoesNotExposeRawPaneID(t *testing.T) {
 	}
 }
 
-func TestNotifySidebarNativeBackendDoesNotCallFZF(t *testing.T) {
+func TestNotifySidebarNativeBackendDoesNotCallLegacyRunner(t *testing.T) {
 	store := &stubNotifyStore{
 		listEntries: []notify.Notification{{
 			ID:        "abc",
@@ -438,9 +438,9 @@ func TestNotifySidebarNativeBackendDoesNotCallFZF(t *testing.T) {
 		}
 		return ""
 	}
-	cmd.picker = notifyPickerFunc(func(intfzf.Options) (intfzf.Result, error) {
+	cmd.picker = notifyPickerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 		fzfCalled = true
-		return intfzf.Result{}, nil
+		return intpickercompat.Result{}, nil
 	})
 	cmd.runner = runner
 	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
@@ -450,7 +450,7 @@ func TestNotifySidebarNativeBackendDoesNotCallFZF(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	if fzfCalled {
-		t.Fatal("fzf picker was called for native notify backend")
+		t.Fatal("legacy picker was called for native notify backend")
 	}
 	if !nativeCalled {
 		t.Fatal("native picker was not called")
@@ -489,13 +489,13 @@ func TestNotifyListSidebarDoesNotAckWhenFocusFails(t *testing.T) {
 			},
 		},
 	}
-	picker := &stubNotifyPicker{result: intfzf.Result{Value: "abc"}}
+	picker := &stubNotifyPicker{result: intpickercompat.Result{Value: "abc"}}
 	runner := &focusFakeRunner{respond: func([]string) ([]byte, error) {
 		return nil, errors.New("focus failed")
 	}}
 	cmd := newCmd(store)
 	cmd.picker = picker
-	cmd.native = nativePickerFromFZFRunner(picker)
+	cmd.native = nativePickerFromLegacyRunner(picker)
 	cmd.runner = runner
 	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
 
@@ -514,10 +514,10 @@ func TestNotifyListSidebarAcksSelectedRow(t *testing.T) {
 	store := &stubNotifyStore{
 		listEntries: []notify.Notification{{ID: "abc", Text: "deploy ok", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"}},
 	}
-	picker := &stubNotifyPicker{result: intfzf.Result{Key: "x", Value: "abc"}}
+	picker := &stubNotifyPicker{result: intpickercompat.Result{Key: "x", Value: "abc"}}
 	cmd := newCmd(store)
 	cmd.picker = picker
-	cmd.native = nativePickerFromFZFRunner(picker)
+	cmd.native = nativePickerFromLegacyRunner(picker)
 
 	var stdout bytes.Buffer
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &stdout, &bytes.Buffer{}); err != nil {
@@ -538,10 +538,10 @@ func TestNotifyListSidebarClearAll(t *testing.T) {
 		listEntries: []notify.Notification{{ID: "abc", Text: "deploy ok", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"}},
 		ackAll:      1,
 	}
-	picker := &stubNotifyPicker{result: intfzf.Result{Key: "ctrl-x", Value: "abc"}}
+	picker := &stubNotifyPicker{result: intpickercompat.Result{Key: "ctrl-x", Value: "abc"}}
 	cmd := newCmd(store)
 	cmd.picker = picker
-	cmd.native = nativePickerFromFZFRunner(picker)
+	cmd.native = nativePickerFromLegacyRunner(picker)
 
 	var stdout bytes.Buffer
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &stdout, &bytes.Buffer{}); err != nil {

--- a/internal/app/sessions.go
+++ b/internal/app/sessions.go
@@ -10,8 +10,8 @@ import (
 
 	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
-	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 	intrender "github.com/crevissepartners/projmux/internal/ui/render"
 )
 
@@ -34,7 +34,7 @@ type sessionsKiller interface {
 }
 
 type sessionsRunner interface {
-	Run(options intfzf.Options) (intfzf.Result, error)
+	Run(options intpickercompat.Options) (intpickercompat.Result, error)
 }
 
 type sessionsCommand struct {
@@ -132,7 +132,7 @@ func (c *sessionsCommand) Run(args []string, stdout, stderr io.Writer) error {
 		if err != nil {
 			return err
 		}
-		result, err := runPickerOptionBackend(c.lookupEnv, c.native, c.runner, intfzf.Options{
+		result, err := runPickerOptionBackend(c.lookupEnv, c.native, c.runner, intpickercompat.Options{
 			UI:             *ui,
 			Entries:        rowsToEntries(rows),
 			Prompt:         "› ",
@@ -300,10 +300,10 @@ func sessionsPickerFooter() string {
 	}, "\n"))
 }
 
-func rowsToEntries(rows []intrender.SessionRow) []intfzf.Entry {
-	entries := make([]intfzf.Entry, 0, len(rows))
+func rowsToEntries(rows []intrender.SessionRow) []intpickercompat.Entry {
+	entries := make([]intpickercompat.Entry, 0, len(rows))
 	for _, row := range rows {
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: row.Label,
 			Value: row.Value,
 		})

--- a/internal/app/sessions_test.go
+++ b/internal/app/sessions_test.go
@@ -8,14 +8,14 @@ import (
 
 	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
-	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
 
 func TestAppRunSessionsDefaultsToPopupAndOpensSelectedSession(t *testing.T) {
 	t.Parallel()
 
-	var gotOptions intfzf.Options
+	var gotOptions intpickercompat.Options
 	app := &App{
 		sessions: &sessionsCommand{
 			recent: sessionsRecentFunc(func(context.Context) ([]inttmux.RecentSessionSummary, error) {
@@ -33,13 +33,13 @@ func TestAppRunSessionsDefaultsToPopupAndOpensSelectedSession(t *testing.T) {
 					},
 				},
 			},
-			runner: sessionsRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+			runner: sessionsRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 				gotOptions = options
-				return intfzf.Result{Value: "repo-b"}, nil
+				return intpickercompat.Result{Value: "repo-b"}, nil
 			}),
-			native: nativePickerFromFZFRunner(sessionsRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+			native: nativePickerFromLegacyRunner(sessionsRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 				gotOptions = options
-				return intfzf.Result{Value: "repo-b"}, nil
+				return intpickercompat.Result{Value: "repo-b"}, nil
 			})),
 			executable: func() (string, error) { return "/tmp/proj mux/bin/projmux", nil },
 			opener:     &recordingSessionsOpener{},
@@ -63,7 +63,7 @@ func TestAppRunSessionsDefaultsToPopupAndOpensSelectedSession(t *testing.T) {
 	if got, want := gotOptions.ExpectKeys, []string{sessionsKillExpectKey}; !equalStrings(got, want) {
 		t.Fatalf("runner expect keys = %q, want %q", got, want)
 	}
-	if got, want := gotOptions.Entries, []intfzf.Entry{
+	if got, want := gotOptions.Entries, []intpickercompat.Entry{
 		{Label: "[ ]  \x1b[32m[Attached]\x1b[0m  \x1b[34m3 Windows\x1b[0m  repo-b", Value: "repo-b"},
 		{Label: "[ ]  \x1b[33m[Detached]\x1b[0m  home", Value: "home"},
 	}; !equalEntries(got, want) {
@@ -102,18 +102,18 @@ func TestAppRunSessionsDefaultsToPopupAndOpensSelectedSession(t *testing.T) {
 func TestSessionsCommandSupportsSidebarUI(t *testing.T) {
 	t.Parallel()
 
-	var gotOptions intfzf.Options
+	var gotOptions intpickercompat.Options
 	cmd := &sessionsCommand{
 		recent: sessionsRecentFunc(func(context.Context) ([]inttmux.RecentSessionSummary, error) {
 			return []inttmux.RecentSessionSummary{{Name: "repo-b"}}, nil
 		}),
-		runner: sessionsRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: sessionsRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotOptions = options
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		native: nativePickerFromFZFRunner(sessionsRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		native: nativePickerFromLegacyRunner(sessionsRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotOptions = options
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 		executable: func() (string, error) { return "/tmp/projmux", nil },
 		opener:     &recordingSessionsOpener{},
@@ -136,7 +136,7 @@ func TestSessionsCommandSupportsSidebarUI(t *testing.T) {
 	}
 }
 
-func TestSessionsCommandNativeBackendDoesNotCallFZF(t *testing.T) {
+func TestSessionsCommandNativeBackendDoesNotCallLegacyRunner(t *testing.T) {
 	t.Parallel()
 
 	var fzfCalled bool
@@ -145,9 +145,9 @@ func TestSessionsCommandNativeBackendDoesNotCallFZF(t *testing.T) {
 		recent: sessionsRecentFunc(func(context.Context) ([]inttmux.RecentSessionSummary, error) {
 			return []inttmux.RecentSessionSummary{{Name: "repo-b"}}, nil
 		}),
-		runner: sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		runner: sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			fzfCalled = true
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
 		native: pickerRunnerFunc(func(options intpicker.Options) (intpicker.Result, error) {
 			if options.UI != switchUIPopup {
@@ -172,7 +172,7 @@ func TestSessionsCommandNativeBackendDoesNotCallFZF(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	if fzfCalled {
-		t.Fatal("fzf runner was called for native sessions backend")
+		t.Fatal("legacy runner was called for native sessions backend")
 	}
 	if opener.openSessionName != "repo-b" {
 		t.Fatalf("open session = %q, want repo-b", opener.openSessionName)
@@ -186,7 +186,7 @@ func TestSessionsCommandCtrlXKillsSelectedSessionAndReopensPicker(t *testing.T) 
 	runnerCalls := 0
 	opener := &recordingSessionsOpener{}
 	killer := &recordingSessionsKiller{}
-	var gotOptions []intfzf.Options
+	var gotOptions []intpickercompat.Options
 	cmd := &sessionsCommand{
 		recent: sessionsRecentFunc(func(context.Context) ([]inttmux.RecentSessionSummary, error) {
 			recentCalls++
@@ -198,21 +198,21 @@ func TestSessionsCommandCtrlXKillsSelectedSessionAndReopensPicker(t *testing.T) 
 			}
 			return []inttmux.RecentSessionSummary{{Name: "home", Attached: true}}, nil
 		}),
-		runner: sessionsRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: sessionsRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotOptions = append(gotOptions, options)
 			runnerCalls++
 			if runnerCalls == 1 {
-				return intfzf.Result{Key: sessionsKillExpectKey, Value: "repo-b"}, nil
+				return intpickercompat.Result{Key: sessionsKillExpectKey, Value: "repo-b"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		native: nativePickerFromFZFRunner(sessionsRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		native: nativePickerFromLegacyRunner(sessionsRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotOptions = append(gotOptions, options)
 			runnerCalls++
 			if runnerCalls == 1 {
-				return intfzf.Result{Key: sessionsKillExpectKey, Value: "repo-b"}, nil
+				return intpickercompat.Result{Key: sessionsKillExpectKey, Value: "repo-b"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 		executable: func() (string, error) { return "/tmp/projmux", nil },
 		opener:     opener,
@@ -256,19 +256,19 @@ func TestSessionsCommandCtrlXSwitchesToFallbackBeforeKillingAttachedSession(t *t
 			}
 			return []inttmux.RecentSessionSummary{{Name: "home", Attached: true}}, nil
 		}),
-		runner: sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		runner: sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			runnerCalls++
 			if runnerCalls == 1 {
-				return intfzf.Result{Key: sessionsKillExpectKey, Value: "repo-b"}, nil
+				return intpickercompat.Result{Key: sessionsKillExpectKey, Value: "repo-b"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		native: nativePickerFromFZFRunner(sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		native: nativePickerFromLegacyRunner(sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			runnerCalls++
 			if runnerCalls == 1 {
-				return intfzf.Result{Key: sessionsKillExpectKey, Value: "repo-b"}, nil
+				return intpickercompat.Result{Key: sessionsKillExpectKey, Value: "repo-b"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 		executable: func() (string, error) { return "/tmp/projmux", nil },
 		opener:     opener,
@@ -296,19 +296,19 @@ func TestSessionsCommandCtrlXBlocksAttachedSessionKillWithoutFallback(t *testing
 		recent: sessionsRecentFunc(func(context.Context) ([]inttmux.RecentSessionSummary, error) {
 			return []inttmux.RecentSessionSummary{{Name: "repo-b", Attached: true}}, nil
 		}),
-		runner: sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		runner: sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			runnerCalls++
 			if runnerCalls == 1 {
-				return intfzf.Result{Key: sessionsKillExpectKey, Value: "repo-b"}, nil
+				return intpickercompat.Result{Key: sessionsKillExpectKey, Value: "repo-b"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		native: nativePickerFromFZFRunner(sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		native: nativePickerFromLegacyRunner(sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			runnerCalls++
 			if runnerCalls == 1 {
-				return intfzf.Result{Key: sessionsKillExpectKey, Value: "repo-b"}, nil
+				return intpickercompat.Result{Key: sessionsKillExpectKey, Value: "repo-b"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 		executable: func() (string, error) { return "/tmp/projmux", nil },
 		opener:     opener,
@@ -337,11 +337,11 @@ func TestSessionsCommandAllowsEmptySelection(t *testing.T) {
 		recent: sessionsRecentFunc(func(context.Context) ([]inttmux.RecentSessionSummary, error) {
 			return []inttmux.RecentSessionSummary{{Name: "repo-b"}}, nil
 		}),
-		runner: sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-			return intfzf.Result{}, nil
+		runner: sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+			return intpickercompat.Result{}, nil
 		}),
-		native: nativePickerFromFZFRunner(sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-			return intfzf.Result{}, nil
+		native: nativePickerFromLegacyRunner(sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+			return intpickercompat.Result{}, nil
 		})),
 		executable: func() (string, error) { return "/tmp/projmux", nil },
 		opener:     opener,
@@ -363,13 +363,13 @@ func TestSessionsCommandReturnsWithoutPickerWhenRecentListIsEmpty(t *testing.T) 
 		recent: sessionsRecentFunc(func(context.Context) ([]inttmux.RecentSessionSummary, error) {
 			return nil, nil
 		}),
-		runner: sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		runner: sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			called = true
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		native: nativePickerFromFZFRunner(sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		native: nativePickerFromLegacyRunner(sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			called = true
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 		executable: func() (string, error) { return "/tmp/projmux", nil },
 		opener:     &recordingSessionsOpener{},
@@ -462,11 +462,11 @@ func TestSessionsCommandPropagatesSetupErrors(t *testing.T) {
 				recent: sessionsRecentFunc(func(context.Context) ([]inttmux.RecentSessionSummary, error) {
 					return []inttmux.RecentSessionSummary{{Name: "repo-b"}}, nil
 				}),
-				runner: sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-					return intfzf.Result{}, nil
+				runner: sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{}, nil
 				}),
-				native: nativePickerFromFZFRunner(sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-					return intfzf.Result{}, nil
+				native: nativePickerFromLegacyRunner(sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{}, nil
 				})),
 			},
 			want: "sessions executable resolver is not configured",
@@ -477,8 +477,8 @@ func TestSessionsCommandPropagatesSetupErrors(t *testing.T) {
 				recent: sessionsRecentFunc(func(context.Context) ([]inttmux.RecentSessionSummary, error) {
 					return []inttmux.RecentSessionSummary{{Name: "repo-b"}}, nil
 				}),
-				runner:     sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil }),
-				native:     nativePickerFromFZFRunner(sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil })),
+				runner:     sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil }),
+				native:     nativePickerFromLegacyRunner(sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil })),
 				executable: func() (string, error) { return "", errors.New("not found") },
 			},
 			want: "resolve sessions executable",
@@ -489,11 +489,11 @@ func TestSessionsCommandPropagatesSetupErrors(t *testing.T) {
 				recent: sessionsRecentFunc(func(context.Context) ([]inttmux.RecentSessionSummary, error) {
 					return []inttmux.RecentSessionSummary{{Name: "repo-b"}}, nil
 				}),
-				runner: sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-					return intfzf.Result{}, errors.New("fzf failed")
+				runner: sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{}, errors.New("picker failed")
 				}),
-				native: nativePickerFromFZFRunner(sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-					return intfzf.Result{}, errors.New("fzf failed")
+				native: nativePickerFromLegacyRunner(sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{}, errors.New("picker failed")
 				})),
 				executable: func() (string, error) { return "/tmp/projmux", nil },
 			},
@@ -505,11 +505,11 @@ func TestSessionsCommandPropagatesSetupErrors(t *testing.T) {
 				recent: sessionsRecentFunc(func(context.Context) ([]inttmux.RecentSessionSummary, error) {
 					return []inttmux.RecentSessionSummary{{Name: "repo-b"}}, nil
 				}),
-				runner: sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-					return intfzf.Result{Value: "repo-b"}, nil
+				runner: sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{Value: "repo-b"}, nil
 				}),
-				native: nativePickerFromFZFRunner(sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-					return intfzf.Result{Value: "repo-b"}, nil
+				native: nativePickerFromLegacyRunner(sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{Value: "repo-b"}, nil
 				})),
 				executable: func() (string, error) { return "/tmp/projmux", nil },
 			},
@@ -521,9 +521,13 @@ func TestSessionsCommandPropagatesSetupErrors(t *testing.T) {
 				recent: sessionsRecentFunc(func(context.Context) ([]inttmux.RecentSessionSummary, error) {
 					return []inttmux.RecentSessionSummary{{Name: "repo-b"}}, nil
 				}),
-				store:      &recordingSessionsStore{err: errors.New("state failed")},
-				runner:     sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{Value: "repo-b"}, nil }),
-				native:     nativePickerFromFZFRunner(sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{Value: "repo-b"}, nil })),
+				store: &recordingSessionsStore{err: errors.New("state failed")},
+				runner: sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{Value: "repo-b"}, nil
+				}),
+				native: nativePickerFromLegacyRunner(sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{Value: "repo-b"}, nil
+				})),
 				executable: func() (string, error) { return "/tmp/projmux", nil },
 				opener:     &recordingSessionsOpener{},
 			},
@@ -535,11 +539,11 @@ func TestSessionsCommandPropagatesSetupErrors(t *testing.T) {
 				recent: sessionsRecentFunc(func(context.Context) ([]inttmux.RecentSessionSummary, error) {
 					return []inttmux.RecentSessionSummary{{Name: "repo-b"}}, nil
 				}),
-				runner: sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-					return intfzf.Result{Value: "repo-b"}, nil
+				runner: sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{Value: "repo-b"}, nil
 				}),
-				native: nativePickerFromFZFRunner(sessionsRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-					return intfzf.Result{Value: "repo-b"}, nil
+				native: nativePickerFromLegacyRunner(sessionsRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{Value: "repo-b"}, nil
 				})),
 				executable: func() (string, error) { return "/tmp/projmux", nil },
 				opener:     &recordingSessionsOpener{openErr: errors.New("attach failed")},
@@ -569,9 +573,9 @@ func (f sessionsRecentFunc) RecentSessionSummaries(ctx context.Context) ([]inttm
 	return f(ctx)
 }
 
-type sessionsRunnerFunc func(options intfzf.Options) (intfzf.Result, error)
+type sessionsRunnerFunc func(options intpickercompat.Options) (intpickercompat.Result, error)
 
-func (f sessionsRunnerFunc) Run(options intfzf.Options) (intfzf.Result, error) {
+func (f sessionsRunnerFunc) Run(options intpickercompat.Options) (intpickercompat.Result, error) {
 	return f(options)
 }
 

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/crevissepartners/projmux/internal/config"
-	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 	intrender "github.com/crevissepartners/projmux/internal/ui/render"
 	"github.com/crevissepartners/projmux/internal/version"
 )
@@ -23,7 +23,7 @@ type settingsCommand struct {
 	ai           *aiCommand
 	switcher     *switchCommand
 	update       *updateCommand
-	runner       intfzf.Runner
+	runner       intpickercompat.Runner
 	nativePicker intpicker.Runner
 	homeDir      func() (string, error)
 	lookupEnv    func(string) string
@@ -84,7 +84,7 @@ func (c *settingsCommand) Run(args []string, stdout, stderr io.Writer) error {
 	}
 
 	for {
-		result, err := c.runPicker(intfzf.Options{
+		result, err := c.runPicker(intpickercompat.Options{
 			UI:         "settings",
 			Entries:    c.rootEntries(),
 			Title:      "Settings",
@@ -144,19 +144,19 @@ func (c *settingsCommand) runSection(section string, stdout, stderr io.Writer) e
 	}
 }
 
-func (c *settingsCommand) runPicker(options intfzf.Options) (intfzf.Result, error) {
+func (c *settingsCommand) runPicker(options intpickercompat.Options) (intpickercompat.Result, error) {
 	result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, options)
 	if err != nil {
 		if isNoSelectionExit(err) {
-			return intfzf.Result{}, errSettingsClosed
+			return intpickercompat.Result{}, errSettingsClosed
 		}
-		return intfzf.Result{}, fmt.Errorf("run settings picker: %w", err)
+		return intpickercompat.Result{}, fmt.Errorf("run settings picker: %w", err)
 	}
 	return result, nil
 }
 
-func (c *settingsCommand) rootEntries() []intfzf.Entry {
-	return []intfzf.Entry{
+func (c *settingsCommand) rootEntries() []intpickercompat.Entry {
+	return []intpickercompat.Entry{
 		{
 			Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Project Picker", "project roots, workdirs, and pins"),
 			Value: settingsSectionProject,
@@ -180,10 +180,10 @@ func (c *settingsCommand) rootEntries() []intfzf.Entry {
 	}
 }
 
-func (c *settingsCommand) sectionOptions(section string) (intfzf.Options, error) {
+func (c *settingsCommand) sectionOptions(section string) (intpickercompat.Options, error) {
 	switch section {
 	case settingsSectionAI:
-		return intfzf.Options{
+		return intpickercompat.Options{
 			UI:         "settings-ai",
 			Entries:    c.aiEntries(),
 			Title:      "AI Settings - Default Ctrl+Shift+R/L split mode",
@@ -193,7 +193,7 @@ func (c *settingsCommand) sectionOptions(section string) (intfzf.Options, error)
 			Bindings:   settingsCloseBindings(),
 		}, nil
 	case settingsSectionProject:
-		return intfzf.Options{
+		return intpickercompat.Options{
 			UI:         "settings-project-picker",
 			Entries:    c.projectPickerEntries(),
 			Title:      "Project Picker - Project roots, workdirs, and pinned projects",
@@ -203,7 +203,7 @@ func (c *settingsCommand) sectionOptions(section string) (intfzf.Options, error)
 			Bindings:   settingsCloseBindings(),
 		}, nil
 	case settingsSectionStatusbar:
-		return intfzf.Options{
+		return intpickercompat.Options{
 			UI:         "settings-statusbar",
 			Entries:    c.statusbarEntries(),
 			Title:      "Appearance - Status and popup decoration mode",
@@ -213,7 +213,7 @@ func (c *settingsCommand) sectionOptions(section string) (intfzf.Options, error)
 			Bindings:   settingsCloseBindings(),
 		}, nil
 	case settingsSectionLabs:
-		return intfzf.Options{
+		return intpickercompat.Options{
 			UI:         "settings-labs",
 			Entries:    c.labsEntries(),
 			Title:      "Labs - Experimental features",
@@ -223,7 +223,7 @@ func (c *settingsCommand) sectionOptions(section string) (intfzf.Options, error)
 			Bindings:   settingsCloseBindings(),
 		}, nil
 	case settingsSectionAbout:
-		return intfzf.Options{
+		return intpickercompat.Options{
 			UI:         "settings-about",
 			Entries:    c.aboutEntries(),
 			Title:      "About - Version, updates, key setup",
@@ -233,7 +233,7 @@ func (c *settingsCommand) sectionOptions(section string) (intfzf.Options, error)
 			Bindings:   settingsCloseBindings(),
 		}, nil
 	default:
-		return intfzf.Options{}, fmt.Errorf("unknown settings section: %s", section)
+		return intpickercompat.Options{}, fmt.Errorf("unknown settings section: %s", section)
 	}
 }
 
@@ -306,9 +306,9 @@ func (c *settingsCommand) runAddProject(stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	entries = append([]intfzf.Entry{settingsBackEntry()}, entries...)
+	entries = append([]intpickercompat.Entry{settingsBackEntry()}, entries...)
 
-	result, err := c.runPicker(intfzf.Options{
+	result, err := c.runPicker(intpickercompat.Options{
 		UI:         "settings-project-add",
 		Entries:    entries,
 		Title:      "Add Project - Choose a filesystem directory",
@@ -337,7 +337,7 @@ func (c *settingsCommand) runProjectRootSettings(stdout, stderr io.Writer) error
 			return err
 		}
 
-		result, err := c.runPicker(intfzf.Options{
+		result, err := c.runPicker(intpickercompat.Options{
 			UI:         "settings-project-root",
 			Entries:    entries,
 			Title:      "Project Root - Manage the primary root",
@@ -377,7 +377,7 @@ func (c *settingsCommand) runSetProjectRootTyped(stdout, stderr io.Writer) error
 	}
 
 	initialQuery := c.projectRootTypedInitialQuery()
-	result, err := c.runPicker(intfzf.Options{
+	result, err := c.runPicker(intpickercompat.Options{
 		UI:           "settings-project-root-typed",
 		Entries:      nil,
 		AcceptQuery:  true,
@@ -433,12 +433,12 @@ func (c *settingsCommand) runAddWorkdir(stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	entries = append([]intfzf.Entry{
+	entries = append([]intpickercompat.Entry{
 		settingsBackEntry(),
 		settingsWorkdirTypedEntry(),
 	}, entries...)
 
-	result, err := c.runPicker(intfzf.Options{
+	result, err := c.runPicker(intpickercompat.Options{
 		UI:         "settings-workdir-add",
 		Entries:    entries,
 		Title:      "Add Workdir - Choose or type a directory to scan",
@@ -466,8 +466,8 @@ func (c *settingsCommand) runAddWorkdir(stdout, stderr io.Writer) error {
 // settingsWorkdirTypedEntry surfaces the "Type path manually..." row that
 // bypasses the filesystem scan and lets the user type an absolute path
 // directly. Useful for heavy WSL mounts (/mnt/c/Users/...), large NFS, etc.
-func settingsWorkdirTypedEntry() intfzf.Entry {
-	return intfzf.Entry{
+func settingsWorkdirTypedEntry() intpickercompat.Entry {
+	return intpickercompat.Entry{
 		Label: settingsLabel(settingsGlyphType, settingsColorType, "Type path manually...", "skip filesystem scan"),
 		Value: settingsWorkdirTyped,
 	}
@@ -483,7 +483,7 @@ func (c *settingsCommand) runAddWorkdirTyped(stdout, stderr io.Writer) error {
 		return errors.New("project picker settings are not configured")
 	}
 
-	result, err := c.runPicker(intfzf.Options{
+	result, err := c.runPicker(intpickercompat.Options{
 		UI:          "settings-workdir-typed",
 		Entries:     nil,
 		AcceptQuery: true,
@@ -554,7 +554,7 @@ func (c *settingsCommand) runWorkdirsList(stdout, stderr io.Writer) error {
 			return err
 		}
 
-		result, err := c.runPicker(intfzf.Options{
+		result, err := c.runPicker(intpickercompat.Options{
 			UI:         "settings-workdirs",
 			Entries:    entries,
 			Title:      "Workdirs - Add or remove scan roots",
@@ -588,8 +588,8 @@ func (c *settingsCommand) runWorkdirsList(stdout, stderr io.Writer) error {
 	}
 }
 
-func (c *settingsCommand) workdirListEntries() ([]intfzf.Entry, error) {
-	entries := []intfzf.Entry{
+func (c *settingsCommand) workdirListEntries() ([]intpickercompat.Entry, error) {
+	entries := []intpickercompat.Entry{
 		settingsBackEntry(),
 		{
 			Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, "Add Workdir...", "append a directory to the saved workdirs list"),
@@ -597,7 +597,7 @@ func (c *settingsCommand) workdirListEntries() ([]intfzf.Entry, error) {
 		},
 	}
 	if c.switcher == nil {
-		return append(entries, intfzf.Entry{
+		return append(entries, intpickercompat.Entry{
 			Label: settingsLabelDim("(no saved workdirs)", ""),
 			Value: settingsNoopValue,
 		}), nil
@@ -609,13 +609,13 @@ func (c *settingsCommand) workdirListEntries() ([]intfzf.Entry, error) {
 	}
 
 	if len(saved) == 0 {
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabelDim("(no saved workdirs)", ""),
 			Value: settingsNoopValue,
 		})
 	} else {
 		for _, dir := range saved {
-			entries = append(entries, intfzf.Entry{
+			entries = append(entries, intpickercompat.Entry{
 				Label: settingsLabel(settingsGlyphRemove, settingsColorRemove, "Remove", dir+"  (saved)"),
 				Value: settingsActionPrefixWorkdir + "remove:" + dir,
 			})
@@ -626,7 +626,7 @@ func (c *settingsCommand) workdirListEntries() ([]intfzf.Entry, error) {
 		if strings.TrimSpace(src.Value) == "" {
 			continue
 		}
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabelInfo(src.Name, src.Value, "env, read-only"),
 			Value: settingsNoopValue,
 		})
@@ -641,7 +641,7 @@ func (c *settingsCommand) runPinnedProjects(stdout, stderr io.Writer) error {
 			return err
 		}
 
-		result, err := c.runPicker(intfzf.Options{
+		result, err := c.runPicker(intpickercompat.Options{
 			UI:         "settings-project-pins",
 			Entries:    entries,
 			Title:      "Pinned Projects - Add or remove pins",
@@ -675,17 +675,17 @@ func (c *settingsCommand) runPinnedProjects(stdout, stderr io.Writer) error {
 	}
 }
 
-func (c *settingsCommand) projectPickerEntries() []intfzf.Entry {
-	entries := []intfzf.Entry{
+func (c *settingsCommand) projectPickerEntries() []intpickercompat.Entry {
+	entries := []intpickercompat.Entry{
 		settingsBackEntry(),
 	}
 
 	entries = append(entries, c.projectRootEntry())
-	entries = append(entries, intfzf.Entry{
+	entries = append(entries, intpickercompat.Entry{
 		Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Workdirs", "add or remove scan roots"),
 		Value: settingsWorkdirList,
 	})
-	entries = append(entries, intfzf.Entry{
+	entries = append(entries, intpickercompat.Entry{
 		Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Pinned Projects", "add or remove pins"),
 		Value: settingsProjectPins,
 	})
@@ -694,39 +694,39 @@ func (c *settingsCommand) projectPickerEntries() []intfzf.Entry {
 
 // projectRootEntry renders the resolved primary root with its source label.
 // Opening it manages the saved project root; rendering never memoizes env state.
-func (c *settingsCommand) projectRootEntry() intfzf.Entry {
+func (c *settingsCommand) projectRootEntry() intpickercompat.Entry {
 	if c.switcher == nil {
-		return intfzf.Entry{
+		return intpickercompat.Entry{
 			Label: settingsLabelDim("Project Root", "unavailable"),
 			Value: settingsNoopValue,
 		}
 	}
 	value, source, err := c.switcher.currentProjdirInfo()
 	if err != nil || value == "" {
-		return intfzf.Entry{
+		return intpickercompat.Entry{
 			Label: settingsLabelDim("Project Root", "not configured"),
 			Value: settingsProjectRootManage,
 		}
 	}
-	return intfzf.Entry{
+	return intpickercompat.Entry{
 		Label: settingsLabelInfo("Project Root", value, source),
 		Value: settingsProjectRootManage,
 	}
 }
 
-func (c *settingsCommand) projectRootHintEntry() intfzf.Entry {
+func (c *settingsCommand) projectRootHintEntry() intpickercompat.Entry {
 	// Keep the entire hint in one dim run so search substrings such as
 	// "Set PROJMUX_PROJDIR" stay contiguous in the rendered label.
-	return intfzf.Entry{
+	return intpickercompat.Entry{
 		Label: "  " + settingsColorDim + "Project Root is the primary root. Workdirs are extra search roots. Set PROJMUX_PROJDIR, @projmux_projdir, or the saved ~/.config/projmux/projdir value." + settingsColorReset,
 		Value: settingsNoopValue,
 	}
 }
 
-func (c *settingsCommand) projectRootEntries() ([]intfzf.Entry, error) {
-	entries := []intfzf.Entry{settingsBackEntry()}
+func (c *settingsCommand) projectRootEntries() ([]intpickercompat.Entry, error) {
+	entries := []intpickercompat.Entry{settingsBackEntry()}
 	if c.switcher == nil {
-		return append(entries, intfzf.Entry{
+		return append(entries, intpickercompat.Entry{
 			Label: settingsLabelDim("Project Root", "unavailable"),
 			Value: settingsNoopValue,
 		}), nil
@@ -738,24 +738,24 @@ func (c *settingsCommand) projectRootEntries() ([]intfzf.Entry, error) {
 	}
 
 	entries = append(entries,
-		intfzf.Entry{
+		intpickercompat.Entry{
 			Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, "Set Project Root...", "save one primary root path directly"),
 			Value: settingsProjdirSetTyped,
 		},
 		c.setCurrentProjectRootEntry(),
-		intfzf.Entry{
+		intpickercompat.Entry{
 			Label: settingsLabel(settingsGlyphRemove, settingsColorRemove, "Clear Saved Project Root", "remove ~/.config/projmux/projdir"),
 			Value: settingsProjdirClear,
 		},
 	)
 
 	if info.EffectiveValue == "" {
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabelInfo("Effective Project Root", "not configured", "no env, tmux option, or saved value"),
 			Value: settingsNoopValue,
 		})
 	} else {
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabelInfo("Effective Project Root", info.EffectiveValue, info.EffectiveSource),
 			Value: settingsNoopValue,
 		})
@@ -763,22 +763,22 @@ func (c *settingsCommand) projectRootEntries() ([]intfzf.Entry, error) {
 
 	switch {
 	case info.SavedValue == "":
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabelInfo("Saved Project Root", "not set", "~/.config/projmux/projdir"),
 			Value: settingsNoopValue,
 		})
 	case info.EffectiveSource == projdirSourceSaved:
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabelInfo("Saved Project Root", info.SavedValue, "active"),
 			Value: settingsNoopValue,
 		})
 	case info.EffectiveSource == projdirSourceUnresolved:
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabelInfo("Saved Project Root", info.SavedValue, "saved"),
 			Value: settingsNoopValue,
 		})
 	default:
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabelInfo("Saved Project Root", info.SavedValue, "shadowed by "+info.EffectiveSource),
 			Value: settingsNoopValue,
 		})
@@ -786,7 +786,7 @@ func (c *settingsCommand) projectRootEntries() ([]intfzf.Entry, error) {
 
 	entries = append(entries,
 		c.projectRootHintEntry(),
-		intfzf.Entry{
+		intpickercompat.Entry{
 			Label: "  " + settingsColorDim + "Env PROJMUX_PROJDIR and tmux @projmux_projdir override the saved value until unset." + settingsColorReset,
 			Value: settingsNoopValue,
 		},
@@ -794,9 +794,9 @@ func (c *settingsCommand) projectRootEntries() ([]intfzf.Entry, error) {
 	return entries, nil
 }
 
-func (c *settingsCommand) setCurrentProjectRootEntry() intfzf.Entry {
+func (c *settingsCommand) setCurrentProjectRootEntry() intpickercompat.Entry {
 	if c.switcher == nil {
-		return intfzf.Entry{
+		return intpickercompat.Entry{
 			Label: settingsLabelDim("Use Current Project as Root", "unavailable"),
 			Value: settingsNoopValue,
 		}
@@ -804,7 +804,7 @@ func (c *settingsCommand) setCurrentProjectRootEntry() intfzf.Entry {
 
 	homeDir, err := c.switcher.resolveHomeDir()
 	if err != nil {
-		return intfzf.Entry{
+		return intpickercompat.Entry{
 			Label: settingsLabelDim("Use Current Project as Root", "home unavailable"),
 			Value: settingsNoopValue,
 		}
@@ -812,20 +812,20 @@ func (c *settingsCommand) setCurrentProjectRootEntry() intfzf.Entry {
 	repoRoot, _, _ := c.switcher.currentProjdirInfo()
 	currentTarget, err := c.switcher.resolveSwitchTargetNoMemoize(nil, "settings project root")
 	if err != nil || currentTarget == "" || currentTarget == switchSettingsSentinel {
-		return intfzf.Entry{
+		return intpickercompat.Entry{
 			Label: settingsLabelDim("Use Current Project as Root", "no project context"),
 			Value: settingsNoopValue,
 		}
 	}
-	return intfzf.Entry{
+	return intpickercompat.Entry{
 		Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, "Use Current Project as Root", intrender.PrettyPath(currentTarget, homeDir, repoRoot)),
 		Value: settingsProjdirSetCurrent,
 	}
 }
 
-func (c *settingsCommand) addCurrentProjectEntry() intfzf.Entry {
+func (c *settingsCommand) addCurrentProjectEntry() intpickercompat.Entry {
 	if c.switcher == nil {
-		return intfzf.Entry{
+		return intpickercompat.Entry{
 			Label: settingsLabelDim("Add Current Project", "unavailable"),
 			Value: settingsNoopValue,
 		}
@@ -833,14 +833,14 @@ func (c *settingsCommand) addCurrentProjectEntry() intfzf.Entry {
 
 	pins, err := c.switcher.loadPins()
 	if err != nil {
-		return intfzf.Entry{
+		return intpickercompat.Entry{
 			Label: settingsLabelDim("Add Current Project", "pins unavailable"),
 			Value: settingsNoopValue,
 		}
 	}
 	homeDir, err := c.switcher.resolveHomeDir()
 	if err != nil {
-		return intfzf.Entry{
+		return intpickercompat.Entry{
 			Label: settingsLabelDim("Add Current Project", "home unavailable"),
 			Value: settingsNoopValue,
 		}
@@ -848,25 +848,25 @@ func (c *settingsCommand) addCurrentProjectEntry() intfzf.Entry {
 	repoRoot := c.switcher.switchRepoRoot(homeDir)
 	currentTarget, err := c.switcher.resolveSwitchTarget(nil, "settings project picker")
 	if err != nil || currentTarget == "" || currentTarget == switchSettingsSentinel {
-		return intfzf.Entry{
+		return intpickercompat.Entry{
 			Label: settingsLabelDim("Add Current Project", "no project context"),
 			Value: settingsNoopValue,
 		}
 	}
 	if containsString(pins, currentTarget) {
-		return intfzf.Entry{
+		return intpickercompat.Entry{
 			Label: settingsLabelDim("Add Current Project", "already pinned  "+intrender.PrettyPath(currentTarget, homeDir, repoRoot)),
 			Value: settingsNoopValue,
 		}
 	}
-	return intfzf.Entry{
+	return intpickercompat.Entry{
 		Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, "Add Current Project", intrender.PrettyPath(currentTarget, homeDir, repoRoot)),
 		Value: settingsActionPrefixSwitch + "add:" + currentTarget,
 	}
 }
 
-func (c *settingsCommand) pinnedProjectEntries() ([]intfzf.Entry, error) {
-	entries := []intfzf.Entry{
+func (c *settingsCommand) pinnedProjectEntries() ([]intpickercompat.Entry, error) {
+	entries := []intpickercompat.Entry{
 		settingsBackEntry(),
 		{
 			Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, "Add Project...", "scan filesystem roots"),
@@ -875,7 +875,7 @@ func (c *settingsCommand) pinnedProjectEntries() ([]intfzf.Entry, error) {
 		c.addCurrentProjectEntry(),
 	}
 	if c.switcher == nil {
-		return append(entries, intfzf.Entry{
+		return append(entries, intpickercompat.Entry{
 			Label: settingsLabelDim("(no pinned projects)", ""),
 			Value: settingsNoopValue,
 		}), nil
@@ -892,18 +892,18 @@ func (c *settingsCommand) pinnedProjectEntries() ([]intfzf.Entry, error) {
 	repoRoot := c.switcher.switchRepoRoot(homeDir)
 
 	if len(pins) == 0 {
-		return append(entries, intfzf.Entry{
+		return append(entries, intpickercompat.Entry{
 			Label: settingsLabelDim("(no pinned projects)", ""),
 			Value: settingsNoopValue,
 		}), nil
 	}
 
-	entries = append(entries, intfzf.Entry{
+	entries = append(entries, intpickercompat.Entry{
 		Label: settingsLabel(settingsGlyphRemove, settingsColorRemove, "Clear all pins", ""),
 		Value: settingsActionPrefixSwitch + "clear",
 	})
 	for _, pin := range pins {
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabel(settingsGlyphRemove, settingsColorRemove, "Remove", intrender.PrettyPath(pin, homeDir, repoRoot)),
 			Value: settingsActionPrefixSwitch + "pin:" + pin,
 		})
@@ -911,7 +911,7 @@ func (c *settingsCommand) pinnedProjectEntries() ([]intfzf.Entry, error) {
 	return entries, nil
 }
 
-func (c *settingsCommand) aiEntries() []intfzf.Entry {
+func (c *settingsCommand) aiEntries() []intpickercompat.Entry {
 	if c.ai == nil {
 		return nil
 	}
@@ -927,7 +927,7 @@ func (c *settingsCommand) aiEntries() []intfzf.Entry {
 		{aiModeShell, "always open plain shell split"},
 	}
 
-	entries := make([]intfzf.Entry, 0, len(modes)+1)
+	entries := make([]intpickercompat.Entry, 0, len(modes)+1)
 	entries = append(entries, settingsBackEntry())
 	for _, item := range modes {
 		glyph := settingsGlyphInactive
@@ -936,7 +936,7 @@ func (c *settingsCommand) aiEntries() []intfzf.Entry {
 			glyph = settingsGlyphToggle
 			color = settingsColorAdd
 		}
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabel(glyph, color, item.mode, item.desc),
 			Value: settingsActionPrefixAI + item.mode,
 		})
@@ -944,7 +944,7 @@ func (c *settingsCommand) aiEntries() []intfzf.Entry {
 	return entries
 }
 
-func (c *settingsCommand) statusbarEntries() []intfzf.Entry {
+func (c *settingsCommand) statusbarEntries() []intpickercompat.Entry {
 	current := c.currentStatusbarDecoration()
 	modes := []struct {
 		mode config.StatusbarDecoration
@@ -955,7 +955,7 @@ func (c *settingsCommand) statusbarEntries() []intfzf.Entry {
 		{config.StatusbarDecorationEmoji, "emoji status and notification icons"},
 	}
 
-	entries := make([]intfzf.Entry, 0, len(modes)+1)
+	entries := make([]intpickercompat.Entry, 0, len(modes)+1)
 	entries = append(entries, settingsBackEntry())
 	for _, item := range modes {
 		glyph := settingsGlyphInactive
@@ -964,7 +964,7 @@ func (c *settingsCommand) statusbarEntries() []intfzf.Entry {
 			glyph = settingsGlyphToggle
 			color = settingsColorAdd
 		}
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabel(glyph, color, string(item.mode), item.desc),
 			Value: settingsActionPrefixStatusbar + string(item.mode),
 		})
@@ -994,12 +994,12 @@ func (c *settingsCommand) setStatusbarDecoration(value string) error {
 	return nil
 }
 
-func (c *settingsCommand) labsEntries() []intfzf.Entry {
+func (c *settingsCommand) labsEntries() []intpickercompat.Entry {
 	current, source := c.currentPickerBackend()
-	entries := make([]intfzf.Entry, 0, 2)
+	entries := make([]intpickercompat.Entry, 0, 2)
 	entries = append(entries, settingsBackEntry())
 	if source != "" {
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabelInfo("Picker source", string(current), source),
 			Value: settingsNoopValue,
 		})
@@ -1044,7 +1044,7 @@ func (c *settingsCommand) setPickerBackend(value string) error {
 	return nil
 }
 
-func (c *settingsCommand) aboutEntries() []intfzf.Entry {
+func (c *settingsCommand) aboutEntries() []intpickercompat.Entry {
 	status, statusErr := updateStatus{}, errors.New("update status is not configured")
 	if c.update != nil {
 		status, statusErr = c.update.status()
@@ -1064,10 +1064,10 @@ func (c *settingsCommand) aboutEntries() []intfzf.Entry {
 		{"Windows Term.", "actions sendInput tmux/meta sequences; keybindings attach keys"},
 		{"Docs", "docs/keybindings.md has copyable terminal examples"},
 	}
-	entries := make([]intfzf.Entry, 0, len(rows)+8)
+	entries := make([]intpickercompat.Entry, 0, len(rows)+8)
 	entries = append(entries, settingsBackEntry())
 	if statusErr != nil {
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabelInfo("Update", "status unavailable", statusErr.Error()),
 			Value: settingsNoopValue,
 		})
@@ -1077,36 +1077,36 @@ func (c *settingsCommand) aboutEntries() []intfzf.Entry {
 			latest = "unknown"
 		}
 		entries = append(entries,
-			intfzf.Entry{
+			intpickercompat.Entry{
 				Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, "Update Now", "run installer-specific update command"),
 				Value: settingsUpdateApply,
 			},
-			intfzf.Entry{
+			intpickercompat.Entry{
 				Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, "Check Updates", "refresh cached GitHub release metadata"),
 				Value: settingsUpdateCheck,
 			},
-			intfzf.Entry{
+			intpickercompat.Entry{
 				Label: settingsLabelInfo("Latest", latest, status.CacheState),
 				Value: settingsNoopValue,
 			},
-			intfzf.Entry{
+			intpickercompat.Entry{
 				Label: settingsLabelInfo("Update state", status.UpdateState, ""),
 				Value: settingsNoopValue,
 			},
-			intfzf.Entry{
+			intpickercompat.Entry{
 				Label: settingsLabelInfo("Installer", status.Installer.Source, status.Installer.Note),
 				Value: settingsNoopValue,
 			},
 		)
 		if status.ReleaseURL != "" {
-			entries = append(entries, intfzf.Entry{
+			entries = append(entries, intpickercompat.Entry{
 				Label: settingsLabelInfo("Release notes", status.ReleaseURL, ""),
 				Value: settingsNoopValue,
 			})
 		}
 	}
 	for _, r := range rows {
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabelInfo(r.name, r.value, ""),
 			Value: settingsNoopValue,
 		})
@@ -1163,8 +1163,8 @@ func (c *settingsCommand) execute(value string, stdout, stderr io.Writer) error 
 	}
 }
 
-func settingsBackEntry() intfzf.Entry {
-	return intfzf.Entry{
+func settingsBackEntry() intpickercompat.Entry {
+	return intpickercompat.Entry{
 		Label: settingsLabel(settingsGlyphBack, settingsColorBack, "Back", ""),
 		Value: settingsBackValue,
 	}

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/candidates"
-	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 	"github.com/crevissepartners/projmux/internal/version"
 )
 
@@ -25,34 +25,34 @@ func TestSettingsHubSetsAIDefaultMode(t *testing.T) {
 	ai := testAICommand(home)
 	switcher := testSettingsSwitchCommand(t, &stubSwitchPinStore{})
 	var calls int
-	var rootOptions intfzf.Options
-	var aiOptions intfzf.Options
+	var rootOptions intpickercompat.Options
+	var aiOptions intpickercompat.Options
 	cmd := &settingsCommand{
 		ai:       ai,
 		switcher: switcher,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			if calls == 1 {
 				rootOptions = options
-				return intfzf.Result{Key: "enter", Value: settingsSectionAI}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionAI}, nil
 			}
 			if calls == 2 {
 				aiOptions = options
-				return intfzf.Result{Key: "enter", Value: settingsActionPrefixAI + "codex"}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixAI + "codex"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			if calls == 1 {
 				rootOptions = options
-				return intfzf.Result{Key: "enter", Value: settingsSectionAI}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionAI}, nil
 			}
 			if calls == 2 {
 				aiOptions = options
-				return intfzf.Result{Key: "enter", Value: settingsActionPrefixAI + "codex"}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixAI + "codex"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 	}
 
@@ -126,7 +126,7 @@ func TestSettingsHubKeepsLabsSectionWithoutPickerBackendChoices(t *testing.T) {
 
 	home := t.TempDir()
 	var calls int
-	var labsOptions intfzf.Options
+	var labsOptions intpickercompat.Options
 	var tmuxCalls [][]string
 	cmd := &settingsCommand{
 		ai:       testAICommand(home),
@@ -142,28 +142,28 @@ func TestSettingsHubKeepsLabsSectionWithoutPickerBackendChoices(t *testing.T) {
 			tmuxCalls = append(tmuxCalls, append([]string{name}, args...))
 			return nil
 		},
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionLabs}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionLabs}, nil
 			case 2:
 				labsOptions = options
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionLabs}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionLabs}, nil
 			case 2:
 				labsOptions = options
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -201,7 +201,7 @@ func TestSettingsHubSetsStatusbarDecoration(t *testing.T) {
 
 	home := t.TempDir()
 	var calls int
-	var statusbarOptions intfzf.Options
+	var statusbarOptions intpickercompat.Options
 	var tmuxCalls [][]string
 	cmd := &settingsCommand{
 		ai:       testAICommand(home),
@@ -217,28 +217,28 @@ func TestSettingsHubSetsStatusbarDecoration(t *testing.T) {
 			tmuxCalls = append(tmuxCalls, append([]string{name}, args...))
 			return nil
 		},
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionStatusbar}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionStatusbar}, nil
 			case 2:
 				statusbarOptions = options
-				return intfzf.Result{Key: "enter", Value: settingsActionPrefixStatusbar + string(config.StatusbarDecorationEmoji)}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixStatusbar + string(config.StatusbarDecorationEmoji)}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionStatusbar}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionStatusbar}, nil
 			case 2:
 				statusbarOptions = options
-				return intfzf.Result{Key: "enter", Value: settingsActionPrefixStatusbar + string(config.StatusbarDecorationEmoji)}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixStatusbar + string(config.StatusbarDecorationEmoji)}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -296,13 +296,13 @@ func TestSettingsHubRunsProjectPickerActions(t *testing.T) {
 	cmd := &settingsCommand{
 		ai:       testAICommand(t.TempDir()),
 		switcher: switcher,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			if calls == 1 {
 				if got, want := options.UI, "settings"; got != want {
 					t.Fatalf("settings UI = %q, want %q", got, want)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			}
 			if calls == 2 {
 				if got, want := options.UI, "settings-project-picker"; got != want {
@@ -311,17 +311,17 @@ func TestSettingsHubRunsProjectPickerActions(t *testing.T) {
 				if !hasEntryValue(options.Entries, settingsBackValue) {
 					t.Fatalf("project settings entries = %#v, want back entry", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsActionPrefixSwitch + "add:/home/tester/source/repos/app"}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixSwitch + "add:/home/tester/source/repos/app"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			if calls == 1 {
 				if got, want := options.UI, "settings"; got != want {
 					t.Fatalf("settings UI = %q, want %q", got, want)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			}
 			if calls == 2 {
 				if got, want := options.UI, "settings-project-picker"; got != want {
@@ -330,9 +330,9 @@ func TestSettingsHubRunsProjectPickerActions(t *testing.T) {
 				if !hasEntryValue(options.Entries, settingsBackValue) {
 					t.Fatalf("project settings entries = %#v, want back entry", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsActionPrefixSwitch + "add:/home/tester/source/repos/app"}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixSwitch + "add:/home/tester/source/repos/app"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 	}
 
@@ -368,49 +368,49 @@ func TestSettingsHubShowsAboutSection(t *testing.T) {
 	})
 
 	var calls int
-	var aboutOptions intfzf.Options
+	var aboutOptions intpickercompat.Options
 	cmd := &settingsCommand{
 		ai:       testAICommand(t.TempDir()),
 		switcher: testSettingsSwitchCommand(t, &stubSwitchPinStore{}),
 		update:   update,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionAbout}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionAbout}, nil
 			case 2:
 				aboutOptions = options
-				return intfzf.Result{Key: "enter", Value: settingsNoopValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsNoopValue}, nil
 			case 3:
 				if got, want := options.UI, "settings-about"; got != want {
 					t.Fatalf("settings about UI after noop = %q, want %q", got, want)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 4:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			default:
 				t.Fatalf("unexpected settings picker call %d", calls)
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionAbout}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionAbout}, nil
 			case 2:
 				aboutOptions = options
-				return intfzf.Result{Key: "enter", Value: settingsNoopValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsNoopValue}, nil
 			case 3:
 				if got, want := options.UI, "settings-about"; got != want {
 					t.Fatalf("settings about UI after noop = %q, want %q", got, want)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 4:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			default:
 				t.Fatalf("unexpected settings picker call %d", calls)
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -491,42 +491,42 @@ func TestSettingsHubRunsUpdateApplyAction(t *testing.T) {
 		ai:       testAICommand(t.TempDir()),
 		switcher: testSettingsSwitchCommand(t, &stubSwitchPinStore{}),
 		update:   update,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionAbout}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionAbout}, nil
 			case 2:
 				if !hasEntryValue(options.Entries, settingsUpdateApply) {
 					t.Fatalf("settings about entries = %#v, want update apply action", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsUpdateApply}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsUpdateApply}, nil
 			case 3:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 4:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			default:
 				t.Fatalf("unexpected settings picker call %d", calls)
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionAbout}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionAbout}, nil
 			case 2:
 				if !hasEntryValue(options.Entries, settingsUpdateApply) {
 					t.Fatalf("settings about entries = %#v, want update apply action", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsUpdateApply}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsUpdateApply}, nil
 			case 3:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 4:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			default:
 				t.Fatalf("unexpected settings picker call %d", calls)
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -556,49 +556,49 @@ func TestSettingsHubRunsUpdateCheckAction(t *testing.T) {
 	})}
 
 	var calls int
-	var refreshedAbout intfzf.Options
+	var refreshedAbout intpickercompat.Options
 	cmd := &settingsCommand{
 		ai:       testAICommand(t.TempDir()),
 		switcher: testSettingsSwitchCommand(t, &stubSwitchPinStore{}),
 		update:   update,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionAbout}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionAbout}, nil
 			case 2:
 				if !hasEntryValue(options.Entries, settingsUpdateCheck) {
 					t.Fatalf("settings about entries = %#v, want update check action", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsUpdateCheck}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsUpdateCheck}, nil
 			case 3:
 				refreshedAbout = options
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 4:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			default:
 				t.Fatalf("unexpected settings picker call %d", calls)
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionAbout}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionAbout}, nil
 			case 2:
 				if !hasEntryValue(options.Entries, settingsUpdateCheck) {
 					t.Fatalf("settings about entries = %#v, want update check action", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsUpdateCheck}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsUpdateCheck}, nil
 			case 3:
 				refreshedAbout = options
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 4:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			default:
 				t.Fatalf("unexpected settings picker call %d", calls)
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -630,11 +630,11 @@ func TestSettingsHubAddProjectScansFilesystem(t *testing.T) {
 	cmd := &settingsCommand{
 		ai:       testAICommand(t.TempDir()),
 		switcher: switcher,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
 				if hasEntryValue(options.Entries, settingsProjectAdd) {
 					t.Fatalf("project settings entries = %#v, want Add Project moved out of root", options.Entries)
@@ -642,7 +642,7 @@ func TestSettingsHubAddProjectScansFilesystem(t *testing.T) {
 				if !hasEntryValue(options.Entries, settingsProjectPins) {
 					t.Fatalf("project settings entries = %#v, want Pinned Projects", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsProjectPins}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjectPins}, nil
 			case 3:
 				if got, want := options.UI, "settings-project-pins"; got != want {
 					t.Fatalf("pinned projects UI = %q, want %q", got, want)
@@ -653,7 +653,7 @@ func TestSettingsHubAddProjectScansFilesystem(t *testing.T) {
 				if got := entryIndexLabelContaining(options.Entries, "Add Current Project"); got != 2 {
 					t.Fatalf("pinned project entries = %#v, want Add Current Project at index 2, got %d", options.Entries, got)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsProjectAdd}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjectAdd}, nil
 			case 4:
 				if got, want := options.UI, "settings-project-add"; got != want {
 					t.Fatalf("add project UI = %q, want %q", got, want)
@@ -668,16 +668,16 @@ func TestSettingsHubAddProjectScansFilesystem(t *testing.T) {
 				if hasEntryValue(options.Entries, settingsActionPrefixSwitch+"add:"+filepath.Join(home, ".cache")) {
 					t.Fatalf("add project entries = %#v, want hidden non-whitelist skipped", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsActionPrefixSwitch + "add:" + app}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixSwitch + "add:" + app}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
 				if hasEntryValue(options.Entries, settingsProjectAdd) {
 					t.Fatalf("project settings entries = %#v, want Add Project moved out of root", options.Entries)
@@ -685,7 +685,7 @@ func TestSettingsHubAddProjectScansFilesystem(t *testing.T) {
 				if !hasEntryValue(options.Entries, settingsProjectPins) {
 					t.Fatalf("project settings entries = %#v, want Pinned Projects", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsProjectPins}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjectPins}, nil
 			case 3:
 				if got, want := options.UI, "settings-project-pins"; got != want {
 					t.Fatalf("pinned projects UI = %q, want %q", got, want)
@@ -696,7 +696,7 @@ func TestSettingsHubAddProjectScansFilesystem(t *testing.T) {
 				if got := entryIndexLabelContaining(options.Entries, "Add Current Project"); got != 2 {
 					t.Fatalf("pinned project entries = %#v, want Add Current Project at index 2, got %d", options.Entries, got)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsProjectAdd}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjectAdd}, nil
 			case 4:
 				if got, want := options.UI, "settings-project-add"; got != want {
 					t.Fatalf("add project UI = %q, want %q", got, want)
@@ -711,9 +711,9 @@ func TestSettingsHubAddProjectScansFilesystem(t *testing.T) {
 				if hasEntryValue(options.Entries, settingsActionPrefixSwitch+"add:"+filepath.Join(home, ".cache")) {
 					t.Fatalf("add project entries = %#v, want hidden non-whitelist skipped", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsActionPrefixSwitch + "add:" + app}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixSwitch + "add:" + app}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -737,13 +737,13 @@ func TestSettingsHubPinnedProjectsRemovesPins(t *testing.T) {
 	cmd := &settingsCommand{
 		ai:       testAICommand(t.TempDir()),
 		switcher: switcher,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsProjectPins}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjectPins}, nil
 			case 3:
 				if got, want := options.UI, "settings-project-pins"; got != want {
 					t.Fatalf("pinned projects UI = %q, want %q", got, want)
@@ -751,18 +751,18 @@ func TestSettingsHubPinnedProjectsRemovesPins(t *testing.T) {
 				if !hasEntryValue(options.Entries, settingsActionPrefixSwitch+"clear") {
 					t.Fatalf("pinned project entries = %#v, want clear", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsActionPrefixSwitch + "pin:" + pin}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixSwitch + "pin:" + pin}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsProjectPins}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjectPins}, nil
 			case 3:
 				if got, want := options.UI, "settings-project-pins"; got != want {
 					t.Fatalf("pinned projects UI = %q, want %q", got, want)
@@ -770,9 +770,9 @@ func TestSettingsHubPinnedProjectsRemovesPins(t *testing.T) {
 				if !hasEntryValue(options.Entries, settingsActionPrefixSwitch+"clear") {
 					t.Fatalf("pinned project entries = %#v, want clear", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsActionPrefixSwitch + "pin:" + pin}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixSwitch + "pin:" + pin}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -832,16 +832,16 @@ func TestSettingsHubAddWorkdirAppendsToSavedFile(t *testing.T) {
 	cmd := &settingsCommand{
 		ai:       testAICommand(t.TempDir()),
 		switcher: switcher,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
 				if hasEntryValue(options.Entries, settingsWorkdirAdd) {
 					t.Fatalf("project settings entries = %#v, want Add Workdir moved out of root", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirList}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirList}, nil
 			case 3:
 				if got, want := options.UI, "settings-workdirs"; got != want {
 					t.Fatalf("workdirs list UI = %q, want %q", got, want)
@@ -849,7 +849,7 @@ func TestSettingsHubAddWorkdirAppendsToSavedFile(t *testing.T) {
 				if got := entryIndexValue(options.Entries, settingsWorkdirAdd); got != 1 {
 					t.Fatalf("workdirs list entries = %#v, want Add Workdir at index 1, got %d", options.Entries, got)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
 			case 4:
 				if got, want := options.UI, "settings-workdir-add"; got != want {
 					t.Fatalf("add workdir UI = %q, want %q", got, want)
@@ -859,21 +859,21 @@ func TestSettingsHubAddWorkdirAppendsToSavedFile(t *testing.T) {
 				if !hasEntryValue(options.Entries, want) {
 					t.Fatalf("add workdir entries = %#v, want value %q", options.Entries, want)
 				}
-				return intfzf.Result{Key: "enter", Value: want}, nil
+				return intpickercompat.Result{Key: "enter", Value: want}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
 				if hasEntryValue(options.Entries, settingsWorkdirAdd) {
 					t.Fatalf("project settings entries = %#v, want Add Workdir moved out of root", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirList}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirList}, nil
 			case 3:
 				if got, want := options.UI, "settings-workdirs"; got != want {
 					t.Fatalf("workdirs list UI = %q, want %q", got, want)
@@ -881,7 +881,7 @@ func TestSettingsHubAddWorkdirAppendsToSavedFile(t *testing.T) {
 				if got := entryIndexValue(options.Entries, settingsWorkdirAdd); got != 1 {
 					t.Fatalf("workdirs list entries = %#v, want Add Workdir at index 1, got %d", options.Entries, got)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
 			case 4:
 				if got, want := options.UI, "settings-workdir-add"; got != want {
 					t.Fatalf("add workdir UI = %q, want %q", got, want)
@@ -891,9 +891,9 @@ func TestSettingsHubAddWorkdirAppendsToSavedFile(t *testing.T) {
 				if !hasEntryValue(options.Entries, want) {
 					t.Fatalf("add workdir entries = %#v, want value %q", options.Entries, want)
 				}
-				return intfzf.Result{Key: "enter", Value: want}, nil
+				return intpickercompat.Result{Key: "enter", Value: want}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -938,13 +938,13 @@ func TestSettingsHubWorkdirsListRemovesSavedEntry(t *testing.T) {
 	cmd := &settingsCommand{
 		ai:       testAICommand(t.TempDir()),
 		switcher: switcher,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirList}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirList}, nil
 			case 3:
 				if got, want := options.UI, "settings-workdirs"; got != want {
 					t.Fatalf("workdirs list UI = %q, want %q", got, want)
@@ -953,21 +953,21 @@ func TestSettingsHubWorkdirsListRemovesSavedEntry(t *testing.T) {
 				if !hasEntryValue(options.Entries, want) {
 					t.Fatalf("workdirs list entries = %#v, want %q", options.Entries, want)
 				}
-				return intfzf.Result{Key: "enter", Value: want}, nil
+				return intpickercompat.Result{Key: "enter", Value: want}, nil
 			case 4:
 				// After remove, list should be empty (just back + placeholder).
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirList}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirList}, nil
 			case 3:
 				if got, want := options.UI, "settings-workdirs"; got != want {
 					t.Fatalf("workdirs list UI = %q, want %q", got, want)
@@ -976,12 +976,12 @@ func TestSettingsHubWorkdirsListRemovesSavedEntry(t *testing.T) {
 				if !hasEntryValue(options.Entries, want) {
 					t.Fatalf("workdirs list entries = %#v, want %q", options.Entries, want)
 				}
-				return intfzf.Result{Key: "enter", Value: want}, nil
+				return intpickercompat.Result{Key: "enter", Value: want}, nil
 			case 4:
 				// After remove, list should be empty (just back + placeholder).
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -1057,41 +1057,41 @@ func TestAddWorkdirEntriesIncludesTypedRow(t *testing.T) {
 	switcher := testSettingsSwitchCommandWithHome(t, home, &stubSwitchPinStore{})
 	switcher.loadWorkdirs = func(string) ([]string, error) { return nil, nil }
 
-	var addOptions intfzf.Options
+	var addOptions intpickercompat.Options
 	var calls int
 	cmd := &settingsCommand{
 		ai:       testAICommand(t.TempDir()),
 		switcher: switcher,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirList}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirList}, nil
 			case 3:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
 			case 4:
 				addOptions = options
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirList}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirList}, nil
 			case 3:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
 			case 4:
 				addOptions = options
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -1121,63 +1121,63 @@ func TestSettingsHubAddWorkdirTypedAppendsTypedPath(t *testing.T) {
 	switcher := testSettingsSwitchCommandWithHome(t, home, &stubSwitchPinStore{})
 	switcher.loadWorkdirs = func(string) ([]string, error) { return nil, nil }
 
-	var typedOptions intfzf.Options
+	var typedOptions intpickercompat.Options
 	var calls int
 	cmd := &settingsCommand{
 		ai:       testAICommand(t.TempDir()),
 		switcher: switcher,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirList}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirList}, nil
 			case 3:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
 			case 4:
 				if !hasEntryValue(options.Entries, settingsWorkdirTyped) {
 					t.Fatalf("add workdir entries = %#v, want typed row", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirTyped}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirTyped}, nil
 			case 5:
 				typedOptions = options
-				return intfzf.Result{Key: "enter", Query: typed}, nil
+				return intpickercompat.Result{Key: "enter", Query: typed}, nil
 			case 6:
 				// After typed flow returns, the workdirs list reopens. Close it.
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 7:
 				// After typed flow returns, the project picker reopens. Close it.
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirList}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirList}, nil
 			case 3:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
 			case 4:
 				if !hasEntryValue(options.Entries, settingsWorkdirTyped) {
 					t.Fatalf("add workdir entries = %#v, want typed row", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirTyped}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirTyped}, nil
 			case 5:
 				typedOptions = options
-				return intfzf.Result{Key: "enter", Query: typed}, nil
+				return intpickercompat.Result{Key: "enter", Query: typed}, nil
 			case 6:
 				// After typed flow returns, the workdirs list reopens. Close it.
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 7:
 				// After typed flow returns, the project picker reopens. Close it.
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -1221,54 +1221,54 @@ func TestSettingsHubAddWorkdirTypedRejectsRelativePath(t *testing.T) {
 	cmd := &settingsCommand{
 		ai:       testAICommand(t.TempDir()),
 		switcher: switcher,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirList}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirList}, nil
 			case 3:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
 			case 4:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirTyped}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirTyped}, nil
 			case 5:
-				return intfzf.Result{Key: "enter", Query: "relative/path"}, nil
+				return intpickercompat.Result{Key: "enter", Query: "relative/path"}, nil
 			case 6:
 				// After typed-flow falls back, settings should return to the
 				// workdirs list. Close it.
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 7:
 				// After typed-flow falls back, settings should return to the
 				// project picker section. Close to terminate the run.
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirList}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirList}, nil
 			case 3:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirAdd}, nil
 			case 4:
-				return intfzf.Result{Key: "enter", Value: settingsWorkdirTyped}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsWorkdirTyped}, nil
 			case 5:
-				return intfzf.Result{Key: "enter", Query: "relative/path"}, nil
+				return intpickercompat.Result{Key: "enter", Query: "relative/path"}, nil
 			case 6:
 				// After typed-flow falls back, settings should return to the
 				// workdirs list. Close it.
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 7:
 				// After typed-flow falls back, settings should return to the
 				// project picker section. Close to terminate the run.
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			default:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -1297,38 +1297,38 @@ func TestSettingsHubBackReturnsToRoot(t *testing.T) {
 	cmd := &settingsCommand{
 		ai:       testAICommand(t.TempDir()),
 		switcher: testSettingsSwitchCommand(t, &stubSwitchPinStore{}),
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionAI}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionAI}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 3:
 				if got, want := options.UI, "settings"; got != want {
 					t.Fatalf("settings UI after back = %q, want %q", got, want)
 				}
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			default:
 				t.Fatalf("unexpected settings picker call %d", calls)
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionAI}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionAI}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 3:
 				if got, want := options.UI, "settings"; got != want {
 					t.Fatalf("settings UI after back = %q, want %q", got, want)
 				}
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			default:
 				t.Fatalf("unexpected settings picker call %d", calls)
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -1365,11 +1365,11 @@ func testSettingsSwitchCommandWithHome(t *testing.T, home string, store *stubSwi
 			return []string{filepath.Join(home, "source", "repos", "app")}, nil
 		},
 		pinStore: func() (switchPinStore, error) { return store, nil },
-		runner: switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-			return intfzf.Result{}, nil
+		runner: switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+			return intpickercompat.Result{}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-			return intfzf.Result{}, nil
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+			return intpickercompat.Result{}, nil
 		})),
 		sessions:   &capturingSwitchSessionExecutor{},
 		identity:   stubSwitchIdentityResolver{name: "app"},
@@ -1659,21 +1659,21 @@ func TestSettingsHubSetProjectRootTypedSavesProjdir(t *testing.T) {
 	switcher.saveProjdir = config.SaveProjdir
 	switcher.loadWorkdirs = func(string) ([]string, error) { return nil, nil }
 
-	var typedOptions intfzf.Options
+	var typedOptions intpickercompat.Options
 	var calls int
 	cmd := &settingsCommand{
 		ai:       testAICommand(t.TempDir()),
 		switcher: switcher,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
 				if !hasEntryValue(options.Entries, settingsProjectRootManage) {
 					t.Fatalf("project picker entries = %#v, want project root management row", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsProjectRootManage}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjectRootManage}, nil
 			case 3:
 				if got, want := options.UI, "settings-project-root"; got != want {
 					t.Fatalf("project root UI = %q, want %q", got, want)
@@ -1684,31 +1684,31 @@ func TestSettingsHubSetProjectRootTypedSavesProjdir(t *testing.T) {
 				if got := options.Header; got != "" {
 					t.Fatalf("project root header = %q, want description only in title", got)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsProjdirSetTyped}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjdirSetTyped}, nil
 			case 4:
 				typedOptions = options
-				return intfzf.Result{Key: "enter", Query: target}, nil
+				return intpickercompat.Result{Key: "enter", Query: target}, nil
 			case 5:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 6:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 7:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			default:
 				t.Fatalf("unexpected settings picker call %d", calls)
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
 				if !hasEntryValue(options.Entries, settingsProjectRootManage) {
 					t.Fatalf("project picker entries = %#v, want project root management row", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsProjectRootManage}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjectRootManage}, nil
 			case 3:
 				if got, want := options.UI, "settings-project-root"; got != want {
 					t.Fatalf("project root UI = %q, want %q", got, want)
@@ -1719,19 +1719,19 @@ func TestSettingsHubSetProjectRootTypedSavesProjdir(t *testing.T) {
 				if got := options.Header; got != "" {
 					t.Fatalf("project root header = %q, want description only in title", got)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsProjdirSetTyped}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjdirSetTyped}, nil
 			case 4:
 				typedOptions = options
-				return intfzf.Result{Key: "enter", Query: target}, nil
+				return intpickercompat.Result{Key: "enter", Query: target}, nil
 			case 5:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 6:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 7:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			default:
 				t.Fatalf("unexpected settings picker call %d", calls)
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -1775,50 +1775,50 @@ func TestSettingsHubUseCurrentProjectAsRootSavesProjdir(t *testing.T) {
 	cmd := &settingsCommand{
 		ai:       testAICommand(t.TempDir()),
 		switcher: switcher,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsProjectRootManage}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjectRootManage}, nil
 			case 3:
 				if !hasEntryLabelContaining(options.Entries, "Use Current Project as Root") {
 					t.Fatalf("project root entries = %#v, want current project action", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsProjdirSetCurrent}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjdirSetCurrent}, nil
 			case 4:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 5:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 6:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			default:
 				t.Fatalf("unexpected settings picker call %d", calls)
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsProjectRootManage}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjectRootManage}, nil
 			case 3:
 				if !hasEntryLabelContaining(options.Entries, "Use Current Project as Root") {
 					t.Fatalf("project root entries = %#v, want current project action", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsProjdirSetCurrent}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjdirSetCurrent}, nil
 			case 4:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 5:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 6:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			default:
 				t.Fatalf("unexpected settings picker call %d", calls)
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -1854,50 +1854,50 @@ func TestSettingsHubClearProjectRootRemovesSavedProjdir(t *testing.T) {
 	cmd := &settingsCommand{
 		ai:       testAICommand(t.TempDir()),
 		switcher: switcher,
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsProjectRootManage}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjectRootManage}, nil
 			case 3:
 				if !hasEntryLabelContaining(options.Entries, "/saved/root") {
 					t.Fatalf("project root entries = %#v, want saved value", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsProjdirClear}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjdirClear}, nil
 			case 4:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 5:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 6:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			default:
 				t.Fatalf("unexpected settings picker call %d", calls)
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			calls++
 			switch calls {
 			case 1:
-				return intfzf.Result{Key: "enter", Value: settingsSectionProject}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionProject}, nil
 			case 2:
-				return intfzf.Result{Key: "enter", Value: settingsProjectRootManage}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjectRootManage}, nil
 			case 3:
 				if !hasEntryLabelContaining(options.Entries, "/saved/root") {
 					t.Fatalf("project root entries = %#v, want saved value", options.Entries)
 				}
-				return intfzf.Result{Key: "enter", Value: settingsProjdirClear}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsProjdirClear}, nil
 			case 4:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 5:
-				return intfzf.Result{Key: "enter", Value: settingsBackValue}, nil
+				return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 			case 6:
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			default:
 				t.Fatalf("unexpected settings picker call %d", calls)
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}
 		})),
 	}
@@ -1914,7 +1914,7 @@ func TestSettingsHubClearProjectRootRemovesSavedProjdir(t *testing.T) {
 	}
 }
 
-func hasEntryValue(entries []intfzf.Entry, value string) bool {
+func hasEntryValue(entries []intpickercompat.Entry, value string) bool {
 	for _, entry := range entries {
 		if entry.Value == value {
 			return true
@@ -1923,7 +1923,7 @@ func hasEntryValue(entries []intfzf.Entry, value string) bool {
 	return false
 }
 
-func entryIndexValue(entries []intfzf.Entry, value string) int {
+func entryIndexValue(entries []intpickercompat.Entry, value string) int {
 	for i, entry := range entries {
 		if entry.Value == value {
 			return i
@@ -1932,7 +1932,7 @@ func entryIndexValue(entries []intfzf.Entry, value string) int {
 	return -1
 }
 
-func entryValues(entries []intfzf.Entry) []string {
+func entryValues(entries []intpickercompat.Entry) []string {
 	values := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		values = append(values, entry.Value)
@@ -1940,7 +1940,7 @@ func entryValues(entries []intfzf.Entry) []string {
 	return values
 }
 
-func hasEntryLabelContaining(entries []intfzf.Entry, value string) bool {
+func hasEntryLabelContaining(entries []intpickercompat.Entry, value string) bool {
 	for _, entry := range entries {
 		if strings.Contains(entry.Label, value) {
 			return true
@@ -1949,7 +1949,7 @@ func hasEntryLabelContaining(entries []intfzf.Entry, value string) bool {
 	return false
 }
 
-func entryIndexLabelContaining(entries []intfzf.Entry, value string) int {
+func entryIndexLabelContaining(entries []intpickercompat.Entry, value string) int {
 	for i, entry := range entries {
 		if strings.Contains(entry.Label, value) {
 			return i

--- a/internal/app/shell.go
+++ b/internal/app/shell.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
 
 const (
@@ -33,7 +33,7 @@ type shellCommand struct {
 	writeFile          func(string, []byte, os.FileMode) error
 	runCommand         func(ctx context.Context, env []string, name string, args ...string) error
 	update             *updateCommand
-	updatePromptRunner intfzf.Runner
+	updatePromptRunner intpickercompat.Runner
 	nativePicker       intpicker.Runner
 }
 
@@ -156,15 +156,15 @@ func shouldPromptShellUpdate(status updateStatus) bool {
 	}
 }
 
-func shellUpdatePromptOptions(status updateStatus) intfzf.Options {
+func shellUpdatePromptOptions(status updateStatus) intpickercompat.Options {
 	latest := strings.TrimSpace(status.LatestVersion)
 	current := strings.TrimSpace(status.CurrentVersion)
-	return intfzf.Options{
+	return intpickercompat.Options{
 		UI:     "shell-update",
 		Prompt: "Update > ",
 		Header: fmt.Sprintf("projmux %s is available (current %s)", latest, current),
 		Footer: "Enter: choose  |  Esc: continue shell",
-		Entries: []intfzf.Entry{
+		Entries: []intpickercompat.Entry{
 			{
 				Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, "Update Now", "run projmux update apply"),
 				Value: shellUpdateApply,

--- a/internal/app/shell_test.go
+++ b/internal/app/shell_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
 
 func TestShellWritesAppConfigAndRunsIsolatedTmux(t *testing.T) {
@@ -219,7 +219,7 @@ func TestShellPromptsForCachedNPMUpdateAndApplies(t *testing.T) {
 
 	home := t.TempDir()
 	recorder := &recordingShellRunner{}
-	var promptOptions intfzf.Options
+	var promptOptions intpickercompat.Options
 	cmd := &shellCommand{
 		executable: func() (string, error) { return "/tmp/projmux", nil },
 		lookupEnv:  func(string) string { return "" },
@@ -227,13 +227,13 @@ func TestShellPromptsForCachedNPMUpdateAndApplies(t *testing.T) {
 		writeFile:  os.WriteFile,
 		runCommand: recorder.run,
 		update:     update,
-		updatePromptRunner: shellUpdateRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		updatePromptRunner: shellUpdateRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			promptOptions = options
-			return intfzf.Result{Value: shellUpdateApply}, nil
+			return intpickercompat.Result{Value: shellUpdateApply}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(shellUpdateRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(shellUpdateRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			promptOptions = options
-			return intfzf.Result{Value: shellUpdateApply}, nil
+			return intpickercompat.Result{Value: shellUpdateApply}, nil
 		})),
 	}
 
@@ -293,11 +293,11 @@ func TestShellUpdatePromptLaterContinuesWithoutApplying(t *testing.T) {
 		writeFile:  os.WriteFile,
 		runCommand: recorder.run,
 		update:     update,
-		updatePromptRunner: shellUpdateRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
-			return intfzf.Result{Value: shellUpdateLater}, nil
+		updatePromptRunner: shellUpdateRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
+			return intpickercompat.Result{Value: shellUpdateLater}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(shellUpdateRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
-			return intfzf.Result{Value: shellUpdateLater}, nil
+		nativePicker: nativePickerFromLegacyRunner(shellUpdateRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
+			return intpickercompat.Result{Value: shellUpdateLater}, nil
 		})),
 	}
 
@@ -336,13 +336,13 @@ func TestShellUpdatePromptSkipsSelectedVersion(t *testing.T) {
 		writeFile:  os.WriteFile,
 		runCommand: recorder.run,
 		update:     update,
-		updatePromptRunner: shellUpdateRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		updatePromptRunner: shellUpdateRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			promptCalls++
-			return intfzf.Result{Value: shellUpdateSkip}, nil
+			return intpickercompat.Result{Value: shellUpdateSkip}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(shellUpdateRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(shellUpdateRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			promptCalls++
-			return intfzf.Result{Value: shellUpdateSkip}, nil
+			return intpickercompat.Result{Value: shellUpdateSkip}, nil
 		})),
 	}
 
@@ -397,13 +397,13 @@ func TestShellSkipsPromptWithoutFreshSupportedUpdate(t *testing.T) {
 		writeFile:  os.WriteFile,
 		runCommand: recorder.run,
 		update:     update,
-		updatePromptRunner: shellUpdateRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		updatePromptRunner: shellUpdateRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			t.Fatalf("unexpected update prompt: %#v", options)
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(shellUpdateRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(shellUpdateRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			t.Fatalf("unexpected update prompt: %#v", options)
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 	}
 
@@ -486,8 +486,8 @@ func (r *recordingShellRunner) run(_ context.Context, env []string, name string,
 	return nil
 }
 
-type shellUpdateRunnerFunc func(options intfzf.Options) (intfzf.Result, error)
+type shellUpdateRunnerFunc func(options intpickercompat.Options) (intpickercompat.Result, error)
 
-func (f shellUpdateRunnerFunc) Run(options intfzf.Options) (intfzf.Result, error) {
+func (f shellUpdateRunnerFunc) Run(options intpickercompat.Options) (intpickercompat.Result, error) {
 	return f(options)
 }

--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -19,8 +19,8 @@ import (
 	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
 	coretags "github.com/crevissepartners/projmux/internal/core/tags"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
-	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 	intrender "github.com/crevissepartners/projmux/internal/ui/render"
 )
 
@@ -66,7 +66,7 @@ type switchTagStore interface {
 type switchTagStoreFactory func() (switchTagStore, error)
 
 type switchRunner interface {
-	Run(options intfzf.Options) (intfzf.Result, error)
+	Run(options intpickercompat.Options) (intpickercompat.Result, error)
 }
 
 type switchSessionExecutor interface {
@@ -127,7 +127,7 @@ type switchKubeInfo struct {
 type switchPlan struct {
 	UI            string
 	Candidates    []string
-	Rows          []intfzf.Entry
+	Rows          []intpickercompat.Entry
 	Items         []intpicker.Item
 	SessionNames  map[string]string
 	Action        string
@@ -410,7 +410,7 @@ func (c *switchCommand) runSettings(stdout, stderr io.Writer) error {
 			return err
 		}
 
-		result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, intfzf.Options{
+		result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, intpickercompat.Options{
 			UI:      "settings",
 			Entries: entries,
 		})
@@ -466,7 +466,7 @@ func (c *switchCommand) runAddPinInteractive(stdout io.Writer) error {
 		return nil
 	}
 
-	result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, intfzf.Options{
+	result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, intpickercompat.Options{
 		UI:      "pin",
 		Entries: entries,
 	})
@@ -1475,18 +1475,18 @@ func (c *switchCommand) runPicker(plan switchPlan) (intpicker.Result, error) {
 		options.Actions = append(options.Actions, surface.Actions...)
 		options.InitialIndex = surface.InitialIndex
 		options.InitialIndexSet = surface.InitialIndexSet
-		fzfOptions := intfzf.OptionsFromPicker(options)
-		fzfOptions.Candidates = plan.Candidates
-		return c.runPickerBackend(fzfOptions, options)
+		compatOptions := intpickercompat.OptionsFromPicker(options)
+		compatOptions.Candidates = plan.Candidates
+		return c.runPickerBackend(compatOptions, options)
 	}
 
-	fzfOptions := intfzf.OptionsFromPicker(options)
-	fzfOptions.Candidates = plan.Candidates
-	return c.runPickerBackend(fzfOptions, options)
+	compatOptions := intpickercompat.OptionsFromPicker(options)
+	compatOptions.Candidates = plan.Candidates
+	return c.runPickerBackend(compatOptions, options)
 }
 
-func (c *switchCommand) runPickerBackend(fzfOptions intfzf.Options, pickerOptions intpicker.Options) (intpicker.Result, error) {
-	_ = fzfOptions
+func (c *switchCommand) runPickerBackend(compatOptions intpickercompat.Options, pickerOptions intpicker.Options) (intpicker.Result, error) {
+	_ = compatOptions
 	_ = resolvePickerBackend(c.lookupEnv)
 	if c.nativePicker == nil {
 		return intpicker.Result{}, fmt.Errorf("native picker is not configured")
@@ -1777,7 +1777,7 @@ func (c *switchCommand) addPin(target string, stdout io.Writer) error {
 	return err
 }
 
-func (c *switchCommand) renderRows(ctx context.Context, ui string, candidatePaths []string) ([]intfzf.Entry, []intpicker.Item, map[string]string, error) {
+func (c *switchCommand) renderRows(ctx context.Context, ui string, candidatePaths []string) ([]intpickercompat.Entry, []intpicker.Item, map[string]string, error) {
 	renderCandidates := make([]intrender.SwitchCandidate, 0, len(candidatePaths))
 	existingBySession, err := c.lookupExistingSessions(ctx, candidatePaths)
 	if err != nil {
@@ -1842,7 +1842,7 @@ func (c *switchCommand) renderRows(ctx context.Context, ui string, candidatePath
 
 	sortSwitchCandidates(renderCandidates, homeDir)
 	rows := intrender.BuildSwitchRows(renderCandidates)
-	entries := make([]intfzf.Entry, 0, len(rows))
+	entries := make([]intpickercompat.Entry, 0, len(rows))
 	items := make([]intpicker.Item, 0, len(rows))
 	for _, row := range rows {
 		item := row.Item
@@ -1851,7 +1851,7 @@ func (c *switchCommand) renderRows(ctx context.Context, ui string, candidatePath
 			item.MetaLines = nil
 		}
 		items = append(items, item)
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label:     item.EffectiveLabel(),
 			Value:     row.Value,
 			SearchKey: item.EffectiveSearchText(),
@@ -2090,7 +2090,7 @@ func printSwitchUsage(w io.Writer) {
 	fmt.Fprintln(w, "  alt-p         Toggle a pin on the focused candidate and reopen the picker")
 }
 
-func (c *switchCommand) settingsEntries() ([]intfzf.Entry, error) {
+func (c *switchCommand) settingsEntries() ([]intpickercompat.Entry, error) {
 	pins, err := c.loadPins()
 	if err != nil {
 		return nil, err
@@ -2102,26 +2102,26 @@ func (c *switchCommand) settingsEntries() ([]intfzf.Entry, error) {
 	}
 	repoRoot := c.switchRepoRoot(homeDir)
 
-	entries := make([]intfzf.Entry, 0, len(pins)+3)
-	entries = append(entries, intfzf.Entry{
+	entries := make([]intpickercompat.Entry, 0, len(pins)+3)
+	entries = append(entries, intpickercompat.Entry{
 		Label: "+ Add pin...",
 		Value: "add-interactive",
 	})
 	currentTarget, err := c.resolveSwitchTarget(nil, "switch settings")
 	if err == nil && currentTarget != "" && currentTarget != switchSettingsSentinel && !containsString(pins, currentTarget) {
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: "+ Add current pin  " + intrender.PrettyPath(currentTarget, homeDir, repoRoot),
 			Value: "add:" + currentTarget,
 		})
 	}
 	if len(pins) != 0 {
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: "x Clear all pins",
 			Value: "clear",
 		})
 	}
 	for _, pin := range pins {
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: "x Remove  " + intrender.PrettyPath(pin, homeDir, repoRoot),
 			Value: "pin:" + pin,
 		})
@@ -2129,7 +2129,7 @@ func (c *switchCommand) settingsEntries() ([]intfzf.Entry, error) {
 	return entries, nil
 }
 
-func (c *switchCommand) addPinEntries() ([]intfzf.Entry, error) {
+func (c *switchCommand) addPinEntries() ([]intpickercompat.Entry, error) {
 	inputs, err := c.candidateInputs("")
 	if err != nil {
 		return nil, err
@@ -2155,13 +2155,13 @@ func (c *switchCommand) addPinEntries() ([]intfzf.Entry, error) {
 	}
 	repoRoot := c.switchRepoRoot(homeDir)
 
-	entries := make([]intfzf.Entry, 0, len(paths))
+	entries := make([]intpickercompat.Entry, 0, len(paths))
 	for _, path := range paths {
 		if path == switchSettingsSentinel || containsString(pins, path) {
 			continue
 		}
 
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: intrender.PrettyPath(path, homeDir, repoRoot),
 			Value: path,
 		})
@@ -2170,7 +2170,7 @@ func (c *switchCommand) addPinEntries() ([]intfzf.Entry, error) {
 	return entries, nil
 }
 
-func (c *switchCommand) filesystemPinEntries() ([]intfzf.Entry, error) {
+func (c *switchCommand) filesystemPinEntries() ([]intpickercompat.Entry, error) {
 	paths, err := c.filesystemPinCandidates()
 	if err != nil {
 		return nil, err
@@ -2187,12 +2187,12 @@ func (c *switchCommand) filesystemPinEntries() ([]intfzf.Entry, error) {
 	}
 	repoRoot := c.switchRepoRoot(homeDir)
 
-	entries := make([]intfzf.Entry, 0, len(paths))
+	entries := make([]intpickercompat.Entry, 0, len(paths))
 	for _, path := range paths {
 		if containsString(pins, path) {
 			continue
 		}
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, intrender.PrettyPath(path, homeDir, repoRoot), ""),
 			Value: "switch:add:" + path,
 		})
@@ -2202,7 +2202,7 @@ func (c *switchCommand) filesystemPinEntries() ([]intfzf.Entry, error) {
 
 // filesystemWorkdirEntries renders filesystem-scan entries that map to the
 // "workdir:add:<path>" settings action. Already-saved workdirs are skipped.
-func (c *switchCommand) filesystemWorkdirEntries() ([]intfzf.Entry, error) {
+func (c *switchCommand) filesystemWorkdirEntries() ([]intpickercompat.Entry, error) {
 	paths, err := c.filesystemPinCandidates()
 	if err != nil {
 		return nil, err
@@ -2223,12 +2223,12 @@ func (c *switchCommand) filesystemWorkdirEntries() ([]intfzf.Entry, error) {
 	}
 	repoRoot := c.switchRepoRoot(homeDir)
 
-	entries := make([]intfzf.Entry, 0, len(paths))
+	entries := make([]intpickercompat.Entry, 0, len(paths))
 	for _, path := range paths {
 		if _, ok := savedSet[path]; ok {
 			continue
 		}
-		entries = append(entries, intfzf.Entry{
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, intrender.PrettyPath(path, homeDir, repoRoot), ""),
 			Value: "workdir:add:" + path,
 		})

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -12,15 +12,15 @@ import (
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/candidates"
 	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
-	intfzf "github.com/crevissepartners/projmux/internal/ui/fzf"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
 
 func TestAppRunSwitchDefaultsToPopupAndOpensSelectedSession(t *testing.T) {
 	t.Parallel()
 
 	var gotInputs candidates.Inputs
-	var gotRunnerOptions intfzf.Options
+	var gotRunnerOptions intpickercompat.Options
 	executor := &capturingSwitchSessionExecutor{
 		exists: map[string]bool{"workspace": true},
 	}
@@ -34,13 +34,13 @@ func TestAppRunSwitchDefaultsToPopupAndOpensSelectedSession(t *testing.T) {
 			pinStore: func() (switchPinStore, error) {
 				return &stubSwitchPinStore{list: []string{"/pins/app"}}, nil
 			},
-			runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+			runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 				gotRunnerOptions = options
-				return intfzf.Result{Value: "/home/tester/workspace"}, nil
+				return intpickercompat.Result{Value: "/home/tester/workspace"}, nil
 			}),
-			nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+			nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 				gotRunnerOptions = options
-				return intfzf.Result{Value: "/home/tester/workspace"}, nil
+				return intpickercompat.Result{Value: "/home/tester/workspace"}, nil
 			})),
 			sessions:   executor,
 			executable: func() (string, error) { return "/tmp/projmux", nil },
@@ -133,7 +133,7 @@ func TestAppRunSwitchDefaultsToPopupAndOpensSelectedSession(t *testing.T) {
 	}; !equalStrings(got, want) {
 		t.Fatalf("runner bindings = %q, want %q", got, want)
 	}
-	if got, want := gotRunnerOptions.Entries, []intfzf.Entry{
+	if got, want := gotRunnerOptions.Entries, []intpickercompat.Entry{
 		{Label: "\x1b[1m\x1b[32mworkspace\x1b[0m\n  \x1b[38;5;242m~/workspace\x1b[0m", Value: "/home/tester/workspace"},
 	}; !equalEntries(got, want) {
 		t.Fatalf("runner entries = %#v, want %#v", got, want)
@@ -152,7 +152,7 @@ func TestAppRunSwitchDefaultsToPopupAndOpensSelectedSession(t *testing.T) {
 	}
 }
 
-func TestAppRunSwitchLegacyFZFBackendUsesNativeRunner(t *testing.T) {
+func TestAppRunSwitchLegacyBackendValueUsesNativeRunner(t *testing.T) {
 	t.Parallel()
 
 	var fzfCalled bool
@@ -169,9 +169,9 @@ func TestAppRunSwitchLegacyFZFBackendUsesNativeRunner(t *testing.T) {
 			pinStore: func() (switchPinStore, error) {
 				return &stubSwitchPinStore{}, nil
 			},
-			runner: switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+			runner: switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 				fzfCalled = true
-				return intfzf.Result{}, nil
+				return intpickercompat.Result{}, nil
 			}),
 			nativePicker: pickerRunnerFunc(func(options intpicker.Options) (intpicker.Result, error) {
 				gotNativeOptions = options
@@ -196,7 +196,7 @@ func TestAppRunSwitchLegacyFZFBackendUsesNativeRunner(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	if fzfCalled {
-		t.Fatal("fzf runner was called for native backend")
+		t.Fatal("legacy runner was called for native backend")
 	}
 	if got, want := gotNativeOptions.UI, switchUIPopup; got != want {
 		t.Fatalf("native UI = %q, want %q", got, want)
@@ -218,19 +218,19 @@ func TestAppRunSwitchLegacyFZFBackendUsesNativeRunner(t *testing.T) {
 func TestSwitchCommandSupportsSidebarUI(t *testing.T) {
 	t.Parallel()
 
-	var gotRunnerOptions intfzf.Options
+	var gotRunnerOptions intpickercompat.Options
 	cmd := &switchCommand{
 		discover: func(candidates.Inputs) ([]string, error) {
 			return []string{"/tmp/app"}, nil
 		},
 		pinStore: func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotRunnerOptions = options
-			return intfzf.Result{Value: "/tmp/app"}, nil
+			return intpickercompat.Result{Value: "/tmp/app"}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotRunnerOptions = options
-			return intfzf.Result{Value: "/tmp/app"}, nil
+			return intpickercompat.Result{Value: "/tmp/app"}, nil
 		})),
 		sessions:   &capturingSwitchSessionExecutor{},
 		executable: func() (string, error) { return "/tmp/projmux", nil },
@@ -272,7 +272,7 @@ func TestSwitchCommandSupportsSidebarUI(t *testing.T) {
 	}; !equalStrings(got, want) {
 		t.Fatalf("runner bindings = %q, want %q", got, want)
 	}
-	if got, want := gotRunnerOptions.Entries, []intfzf.Entry{
+	if got, want := gotRunnerOptions.Entries, []intpickercompat.Entry{
 		{Label: "\x1b[1mapp\x1b[0m\n  \x1b[38;5;242m/tmp/app\x1b[0m", Value: "/tmp/app"},
 	}; !equalEntries(got, want) {
 		t.Fatalf("runner entries = %#v, want %#v", got, want)
@@ -288,9 +288,9 @@ func TestSwitchCommandNativeSidebarSetsTitle(t *testing.T) {
 			return []string{"/tmp/app"}, nil
 		},
 		pinStore: func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner: switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-			t.Fatal("fzf runner should not be called for native sidebar")
-			return intfzf.Result{}, nil
+		runner: switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+			t.Fatal("legacy runner should not be called for native sidebar")
+			return intpickercompat.Result{}, nil
 		}),
 		nativePicker: pickerRunnerFunc(func(options intpicker.Options) (intpicker.Result, error) {
 			gotNativeOptions = options
@@ -324,19 +324,19 @@ func TestSwitchCommandNativeSidebarSetsTitle(t *testing.T) {
 func TestSwitchCommandSidebarRowsIncludeAttentionBadge(t *testing.T) {
 	t.Parallel()
 
-	var gotRunnerOptions intfzf.Options
+	var gotRunnerOptions intpickercompat.Options
 	cmd := &switchCommand{
 		discover: func(candidates.Inputs) ([]string, error) {
 			return []string{"/tmp/app"}, nil
 		},
 		pinStore: func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotRunnerOptions = options
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotRunnerOptions = options
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 		sessions: &capturingSwitchSessionExecutor{exists: map[string]bool{"tmp-app": true}},
 		inventory: &stubPreviewInventory{panes: []corepreview.Pane{{
@@ -363,19 +363,19 @@ func TestSwitchCommandSidebarRowsIncludeAttentionBadge(t *testing.T) {
 func TestSwitchCommandSidebarUsesContextSessionForInitialPosition(t *testing.T) {
 	t.Parallel()
 
-	var gotRunnerOptions intfzf.Options
+	var gotRunnerOptions intpickercompat.Options
 	cmd := &switchCommand{
 		discover: func(candidates.Inputs) ([]string, error) {
 			return []string{"/tmp/a", "/tmp/b"}, nil
 		},
 		pinStore: func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotRunnerOptions = options
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotRunnerOptions = options
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 		sessions: &capturingSwitchSessionExecutor{
 			exists: map[string]bool{"session-b": true},
@@ -444,19 +444,19 @@ func TestSwitchCommandSidebarFocusOpensExistingSession(t *testing.T) {
 func TestSwitchCommandMarksExistingSessionsInRows(t *testing.T) {
 	t.Parallel()
 
-	var gotRunnerOptions intfzf.Options
+	var gotRunnerOptions intpickercompat.Options
 	cmd := &switchCommand{
 		discover: func(candidates.Inputs) ([]string, error) {
 			return []string{"/tmp/new-app", "/tmp/live-app"}, nil
 		},
 		pinStore: func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotRunnerOptions = options
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotRunnerOptions = options
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 		sessions: &capturingSwitchSessionExecutor{
 			exists: map[string]bool{"tmp-live-app": true},
@@ -480,7 +480,7 @@ func TestSwitchCommandMarksExistingSessionsInRows(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 
-	if got, want := gotRunnerOptions.Entries, []intfzf.Entry{
+	if got, want := gotRunnerOptions.Entries, []intpickercompat.Entry{
 		{Label: "\x1b[1m\x1b[32mlive-app\x1b[0m\n  \x1b[38;5;242m/tmp/live-app\x1b[0m", Value: "/tmp/live-app"},
 	}; !equalEntries(got, want) {
 		t.Fatalf("runner entries = %#v, want %#v", got, want)
@@ -521,10 +521,10 @@ func TestNewSwitchCommandUsesEnvAndDefaultPinStore(t *testing.T) {
 	t.Chdir(fixture.path("managed/work-a/nested"))
 
 	cmd := newSwitchCommand()
-	fakeRunner := &capturingSwitchRunner{result: intfzf.Result{Value: fixture.path("managed/work-a")}}
+	fakeRunner := &capturingSwitchRunner{result: intpickercompat.Result{Value: fixture.path("managed/work-a")}}
 	fakeExecutor := &capturingSwitchSessionExecutor{}
 	cmd.runner = fakeRunner
-	cmd.nativePicker = nativePickerFromFZFRunner(fakeRunner)
+	cmd.nativePicker = nativePickerFromLegacyRunner(fakeRunner)
 	cmd.sessions = fakeExecutor
 	cmd.executable = func() (string, error) { return "/tmp/projmux", nil }
 
@@ -540,7 +540,7 @@ func TestNewSwitchCommandUsesEnvAndDefaultPinStore(t *testing.T) {
 	if got, want := stdout.String(), ""; got != want {
 		t.Fatalf("stdout = %q, want %q", got, want)
 	}
-	wantEntries := []intfzf.Entry{
+	wantEntries := []intpickercompat.Entry{
 		{Label: "\x1b[1mhome\x1b[0m\n  \x1b[38;5;242m~\x1b[0m", Value: fixture.path("home")},
 		{Label: "\x1b[1mapp\x1b[0m \x1b[33m*\x1b[0m\n  \x1b[38;5;242m" + fixture.path("pins/app") + "\x1b[0m", Value: fixture.path("pins/app")},
 		{Label: "\x1b[1mrepo-a\x1b[0m\n  \x1b[38;5;242m~rp/repo-a\x1b[0m", Value: fixture.path("rp/repo-a")},
@@ -599,9 +599,9 @@ func TestNewSwitchCommandDoesNotInferRepoRootFromHomeSourceRepos(t *testing.T) {
 	t.Chdir(fixture.path("home/source/repos/app/nested"))
 
 	cmd := newSwitchCommand()
-	fakeRunner := &capturingSwitchRunner{result: intfzf.Result{}}
+	fakeRunner := &capturingSwitchRunner{result: intpickercompat.Result{}}
 	cmd.runner = fakeRunner
-	cmd.nativePicker = nativePickerFromFZFRunner(fakeRunner)
+	cmd.nativePicker = nativePickerFromLegacyRunner(fakeRunner)
 	cmd.sessions = &capturingSwitchSessionExecutor{}
 	cmd.executable = func() (string, error) { return "/tmp/projmux", nil }
 
@@ -609,7 +609,7 @@ func TestNewSwitchCommandDoesNotInferRepoRootFromHomeSourceRepos(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 
-	wantEntries := []intfzf.Entry{
+	wantEntries := []intpickercompat.Entry{
 		{Label: "\x1b[1mhome\x1b[0m\n  \x1b[38;5;242m~\x1b[0m", Value: fixture.path("home")},
 		{Label: "\x1b[1mrepos\x1b[0m\n  \x1b[38;5;242m~/source/repos\x1b[0m", Value: fixture.path("home/source/repos")},
 	}
@@ -646,8 +646,8 @@ func TestSwitchCommandRejectsInvalidUsage(t *testing.T) {
 			err := (&switchCommand{
 				discover:     func(candidates.Inputs) ([]string, error) { return nil, nil },
 				pinStore:     func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-				runner:       switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil }),
-				nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil })),
+				runner:       switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil }),
+				nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil })),
 				sessions:     &capturingSwitchSessionExecutor{},
 				identity:     stubSwitchIdentityResolver{name: "tmp"},
 				validate:     func(string) error { return nil },
@@ -695,8 +695,8 @@ func TestSwitchCommandPropagatesSetupErrors(t *testing.T) {
 			cmd: &switchCommand{
 				homeDir:      func() (string, error) { return "/home/tester", nil },
 				pinStore:     func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-				runner:       switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil }),
-				nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil })),
+				runner:       switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil }),
+				nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil })),
 				workingDir: func() (string, error) {
 					return "", errors.New("no cwd")
 				},
@@ -711,11 +711,11 @@ func TestSwitchCommandPropagatesSetupErrors(t *testing.T) {
 				pinStore:   func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
 				workingDir: func() (string, error) { return "/tmp", nil },
 				identity:   stubSwitchIdentityResolver{name: "tmp-app"},
-				runner: switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-					return intfzf.Result{}, errors.New("fzf exploded")
+				runner: switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{}, errors.New("picker exploded")
 				}),
-				nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
-					return intfzf.Result{}, errors.New("fzf exploded")
+				nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{}, errors.New("picker exploded")
 				})),
 			},
 			want: "run native switch picker",
@@ -723,28 +723,36 @@ func TestSwitchCommandPropagatesSetupErrors(t *testing.T) {
 		{
 			name: "identity setup",
 			cmd: &switchCommand{
-				discover:     func(candidates.Inputs) ([]string, error) { return []string{"/tmp/app"}, nil },
-				homeDir:      func() (string, error) { return "/home/tester", nil },
-				pinStore:     func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-				workingDir:   func() (string, error) { return "/tmp", nil },
-				runner:       switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{Value: "/tmp/app"}, nil }),
-				nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{Value: "/tmp/app"}, nil })),
-				validate:     func(string) error { return nil },
-				identityErr:  errors.New("missing home"),
+				discover:   func(candidates.Inputs) ([]string, error) { return []string{"/tmp/app"}, nil },
+				homeDir:    func() (string, error) { return "/home/tester", nil },
+				pinStore:   func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
+				workingDir: func() (string, error) { return "/tmp", nil },
+				runner: switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{Value: "/tmp/app"}, nil
+				}),
+				nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{Value: "/tmp/app"}, nil
+				})),
+				validate:    func(string) error { return nil },
+				identityErr: errors.New("missing home"),
 			},
 			want: "configure session identity resolver",
 		},
 		{
 			name: "open session",
 			cmd: &switchCommand{
-				discover:     func(candidates.Inputs) ([]string, error) { return []string{"/tmp/app"}, nil },
-				homeDir:      func() (string, error) { return "/home/tester", nil },
-				pinStore:     func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-				workingDir:   func() (string, error) { return "/tmp", nil },
-				runner:       switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{Value: "/tmp/app"}, nil }),
-				nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{Value: "/tmp/app"}, nil })),
-				identity:     stubSwitchIdentityResolver{name: "tmp-app"},
-				validate:     func(string) error { return nil },
+				discover:   func(candidates.Inputs) ([]string, error) { return []string{"/tmp/app"}, nil },
+				homeDir:    func() (string, error) { return "/home/tester", nil },
+				pinStore:   func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
+				workingDir: func() (string, error) { return "/tmp", nil },
+				runner: switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{Value: "/tmp/app"}, nil
+				}),
+				nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return intpickercompat.Result{Value: "/tmp/app"}, nil
+				})),
+				identity: stubSwitchIdentityResolver{name: "tmp-app"},
+				validate: func(string) error { return nil },
 				sessions: &capturingSwitchSessionExecutor{
 					openErr: errors.New("attach exploded"),
 				},
@@ -774,8 +782,8 @@ func TestSwitchCommandAllowsEmptySelection(t *testing.T) {
 	cmd := &switchCommand{
 		discover:     func(candidates.Inputs) ([]string, error) { return []string{"/tmp/a"}, nil },
 		pinStore:     func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner:       switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil }),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil })),
+		runner:       switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil }),
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil })),
 		sessions:     &capturingSwitchSessionExecutor{},
 		identity:     stubSwitchIdentityResolver{name: "tmp-a"},
 		validate:     func(string) error { return nil },
@@ -844,8 +852,8 @@ func TestSwitchCommandUsesWeakManagedRootHeuristicsWhenEnvUnset(t *testing.T) {
 			return []string{"/tmp/app"}, nil
 		},
 		pinStore:     func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner:       switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil }),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil })),
+		runner:       switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil }),
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil })),
 		sessions:     &capturingSwitchSessionExecutor{},
 		identity:     stubSwitchIdentityResolver{name: "tmp-app"},
 		validate:     func(string) error { return nil },
@@ -880,8 +888,8 @@ func TestSwitchCommandUsesSavedWorkdirsWhenEnvUnset(t *testing.T) {
 			return []string{"/tmp/app"}, nil
 		},
 		pinStore:     func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner:       switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil }),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil })),
+		runner:       switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil }),
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil })),
 		sessions:     &capturingSwitchSessionExecutor{},
 		identity:     stubSwitchIdentityResolver{name: "tmp-app"},
 		validate:     func(string) error { return nil },
@@ -919,8 +927,8 @@ func TestSwitchCommandManagedRootsEnvBeatsSavedWorkdirs(t *testing.T) {
 			return []string{"/tmp/app"}, nil
 		},
 		pinStore:     func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner:       switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil }),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil })),
+		runner:       switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil }),
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil })),
 		sessions:     &capturingSwitchSessionExecutor{},
 		identity:     stubSwitchIdentityResolver{name: "tmp-app"},
 		validate:     func(string) error { return nil },
@@ -963,8 +971,8 @@ func TestSwitchCommandMultiPathProjdirSplitsPrimaryAndExtras(t *testing.T) {
 			return []string{"/tmp/app"}, nil
 		},
 		pinStore:     func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner:       switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil }),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil })),
+		runner:       switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil }),
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil })),
 		sessions:     &capturingSwitchSessionExecutor{},
 		identity:     stubSwitchIdentityResolver{name: "tmp-app"},
 		validate:     func(string) error { return nil },
@@ -1006,8 +1014,8 @@ func TestSwitchCommandMultiPathProjdirCombinesWithManagedRootsEnv(t *testing.T) 
 			return []string{"/tmp/app"}, nil
 		},
 		pinStore:     func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner:       switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil }),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil })),
+		runner:       switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil }),
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil })),
 		sessions:     &capturingSwitchSessionExecutor{},
 		identity:     stubSwitchIdentityResolver{name: "tmp-app"},
 		validate:     func(string) error { return nil },
@@ -1041,8 +1049,8 @@ func TestSwitchCommandSinglePathProjdirRetainsSavedWorkdirs(t *testing.T) {
 			return []string{"/tmp/app"}, nil
 		},
 		pinStore:     func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner:       switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil }),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) { return intfzf.Result{}, nil })),
+		runner:       switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil }),
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) { return intpickercompat.Result{}, nil })),
 		sessions:     &capturingSwitchSessionExecutor{},
 		identity:     stubSwitchIdentityResolver{name: "tmp-app"},
 		validate:     func(string) error { return nil },
@@ -1259,7 +1267,7 @@ func TestSwitchCommandSettingsMenuOffersAddCurrentPin(t *testing.T) {
 		t.Fatalf("settingsEntries() error = %v", err)
 	}
 
-	want := []intfzf.Entry{
+	want := []intpickercompat.Entry{
 		{Label: "+ Add pin...", Value: "add-interactive"},
 		{Label: "+ Add current pin  ~rp/new-app", Value: "add:/home/tester/source/repos/new-app"},
 		{Label: "x Clear all pins", Value: "clear"},
@@ -1297,7 +1305,7 @@ func TestSwitchCommandSettingsMenuSkipsAddWhenCurrentTargetAlreadyPinned(t *test
 		t.Fatalf("settingsEntries() error = %v", err)
 	}
 
-	want := []intfzf.Entry{
+	want := []intpickercompat.Entry{
 		{Label: "+ Add pin...", Value: "add-interactive"},
 		{Label: "x Clear all pins", Value: "clear"},
 		{Label: "x Remove  ~rp/app", Value: "pin:/home/tester/source/repos/app"},
@@ -1401,7 +1409,7 @@ func TestSwitchCommandCyclePaneNoOpsForNewSessionCandidates(t *testing.T) {
 func TestSwitchCommandPickerCtrlXSwitchesToPreviousActiveSessionBeforeKill(t *testing.T) {
 	t.Parallel()
 
-	var gotRunnerOptions []intfzf.Options
+	var gotRunnerOptions []intpickercompat.Options
 	executor := &capturingSwitchSessionExecutor{
 		exists: map[string]bool{
 			"tmp-app":      true,
@@ -1416,21 +1424,21 @@ func TestSwitchCommandPickerCtrlXSwitchesToPreviousActiveSessionBeforeKill(t *te
 			return []string{"/tmp/app", "/tmp/previous"}, nil
 		},
 		pinStore: func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotRunnerOptions = append(gotRunnerOptions, options)
 			call++
 			if call == 1 {
-				return intfzf.Result{Key: switchKillExpectKey, Value: "/tmp/app"}, nil
+				return intpickercompat.Result{Key: switchKillExpectKey, Value: "/tmp/app"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotRunnerOptions = append(gotRunnerOptions, options)
 			call++
 			if call == 1 {
-				return intfzf.Result{Key: switchKillExpectKey, Value: "/tmp/app"}, nil
+				return intpickercompat.Result{Key: switchKillExpectKey, Value: "/tmp/app"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 		sessions:   executor,
 		executable: func() (string, error) { return "/tmp/projmux", nil },
@@ -1494,19 +1502,19 @@ func TestSwitchCommandPickerCtrlXBlocksKillWithoutPreviousLiveSession(t *testing
 			return []string{"/tmp/app"}, nil
 		},
 		pinStore: func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner: switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			call++
 			if call == 1 {
-				return intfzf.Result{Key: switchKillExpectKey, Value: "/tmp/app"}, nil
+				return intpickercompat.Result{Key: switchKillExpectKey, Value: "/tmp/app"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			call++
 			if call == 1 {
-				return intfzf.Result{Key: switchKillExpectKey, Value: "/tmp/app"}, nil
+				return intpickercompat.Result{Key: switchKillExpectKey, Value: "/tmp/app"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 		sessions:   executor,
 		identity:   stubSwitchIdentityResolver{name: "tmp-app"},
@@ -1536,19 +1544,19 @@ func TestSwitchCommandPickerCtrlXDoesNotKillHome(t *testing.T) {
 			return []string{"/home/tester"}, nil
 		},
 		pinStore: func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
-		runner: switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			call++
 			if call == 1 {
-				return intfzf.Result{Key: switchKillExpectKey, Value: "/home/tester"}, nil
+				return intpickercompat.Result{Key: switchKillExpectKey, Value: "/home/tester"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
 			call++
 			if call == 1 {
-				return intfzf.Result{Key: switchKillExpectKey, Value: "/home/tester"}, nil
+				return intpickercompat.Result{Key: switchKillExpectKey, Value: "/home/tester"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 		sessions:   executor,
 		identity:   stubSwitchIdentityResolver{name: "home"},
@@ -1568,7 +1576,7 @@ func TestSwitchCommandPickerCtrlXDoesNotKillHome(t *testing.T) {
 func TestSwitchCommandPickerAltPLoopsUntilSelection(t *testing.T) {
 	t.Parallel()
 
-	var gotRunnerOptions []intfzf.Options
+	var gotRunnerOptions []intpickercompat.Options
 	store := &stubSwitchPinStore{toggled: true}
 	executor := &capturingSwitchSessionExecutor{}
 	call := 0
@@ -1578,21 +1586,21 @@ func TestSwitchCommandPickerAltPLoopsUntilSelection(t *testing.T) {
 			return []string{"/tmp/app"}, nil
 		},
 		pinStore: func() (switchPinStore, error) { return store, nil },
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotRunnerOptions = append(gotRunnerOptions, options)
 			call++
 			if call == 1 {
-				return intfzf.Result{Key: switchPinExpectKey, Value: "/tmp/app"}, nil
+				return intpickercompat.Result{Key: switchPinExpectKey, Value: "/tmp/app"}, nil
 			}
-			return intfzf.Result{Value: "/tmp/app"}, nil
+			return intpickercompat.Result{Value: "/tmp/app"}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			gotRunnerOptions = append(gotRunnerOptions, options)
 			call++
 			if call == 1 {
-				return intfzf.Result{Key: switchPinExpectKey, Value: "/tmp/app"}, nil
+				return intpickercompat.Result{Key: switchPinExpectKey, Value: "/tmp/app"}, nil
 			}
-			return intfzf.Result{Value: "/tmp/app"}, nil
+			return intpickercompat.Result{Value: "/tmp/app"}, nil
 		})),
 		sessions:   executor,
 		identity:   stubSwitchIdentityResolver{name: "tmp-app"},
@@ -1637,19 +1645,19 @@ func TestSwitchCommandSettingsSubcommandRunsSettingsMenu(t *testing.T) {
 			return []string{"/tmp/app"}, nil
 		},
 		pinStore: func() (switchPinStore, error) { return store, nil },
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			runnerCalls++
 			if runnerCalls == 1 {
-				return intfzf.Result{Value: "clear"}, nil
+				return intpickercompat.Result{Value: "clear"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			runnerCalls++
 			if runnerCalls == 1 {
-				return intfzf.Result{Value: "clear"}, nil
+				return intpickercompat.Result{Value: "clear"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 		sessions:   &capturingSwitchSessionExecutor{},
 		identity:   stubSwitchIdentityResolver{name: "tmp-app"},
@@ -1680,19 +1688,19 @@ func TestSwitchCommandSettingsMenuAddCurrentPin(t *testing.T) {
 			return []string{"/home/tester/source/repos/new-app"}, nil
 		},
 		pinStore: func() (switchPinStore, error) { return store, nil },
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			runnerCalls++
 			if runnerCalls == 1 {
-				return intfzf.Result{Value: "add:/home/tester/source/repos/new-app"}, nil
+				return intpickercompat.Result{Value: "add:/home/tester/source/repos/new-app"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			runnerCalls++
 			if runnerCalls == 1 {
-				return intfzf.Result{Value: "add:/home/tester/source/repos/new-app"}, nil
+				return intpickercompat.Result{Value: "add:/home/tester/source/repos/new-app"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 		sessions:   &capturingSwitchSessionExecutor{},
 		identity:   stubSwitchIdentityResolver{name: "new-app"},
@@ -1736,51 +1744,51 @@ func TestSwitchCommandSettingsMenuInteractiveAddPin(t *testing.T) {
 			}, nil
 		},
 		pinStore: func() (switchPinStore, error) { return store, nil },
-		runner: switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			runnerCalls++
 			if runnerCalls == 1 {
 				if got, want := options.UI, "settings"; got != want {
 					t.Fatalf("settings picker UI = %q, want %q", got, want)
 				}
-				return intfzf.Result{Value: "add-interactive"}, nil
+				return intpickercompat.Result{Value: "add-interactive"}, nil
 			}
 			if runnerCalls == 2 {
 				if got, want := options.UI, "pin"; got != want {
 					t.Fatalf("add-pin picker UI = %q, want %q", got, want)
 				}
-				wantEntries := []intfzf.Entry{
+				wantEntries := []intpickercompat.Entry{
 					{Label: "~rp/new-app", Value: "/home/tester/source/repos/new-app"},
 					{Label: "~rp/lib", Value: "/home/tester/source/repos/lib"},
 				}
 				if !equalEntries(options.Entries, wantEntries) {
 					t.Fatalf("add-pin entries = %#v, want %#v", options.Entries, wantEntries)
 				}
-				return intfzf.Result{Value: "/home/tester/source/repos/lib"}, nil
+				return intpickercompat.Result{Value: "/home/tester/source/repos/lib"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		}),
-		nativePicker: nativePickerFromFZFRunner(switchRunnerFunc(func(options intfzf.Options) (intfzf.Result, error) {
+		nativePicker: nativePickerFromLegacyRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
 			runnerCalls++
 			if runnerCalls == 1 {
 				if got, want := options.UI, "settings"; got != want {
 					t.Fatalf("settings picker UI = %q, want %q", got, want)
 				}
-				return intfzf.Result{Value: "add-interactive"}, nil
+				return intpickercompat.Result{Value: "add-interactive"}, nil
 			}
 			if runnerCalls == 2 {
 				if got, want := options.UI, "pin"; got != want {
 					t.Fatalf("add-pin picker UI = %q, want %q", got, want)
 				}
-				wantEntries := []intfzf.Entry{
+				wantEntries := []intpickercompat.Entry{
 					{Label: "~rp/new-app", Value: "/home/tester/source/repos/new-app"},
 					{Label: "~rp/lib", Value: "/home/tester/source/repos/lib"},
 				}
 				if !equalEntries(options.Entries, wantEntries) {
 					t.Fatalf("add-pin entries = %#v, want %#v", options.Entries, wantEntries)
 				}
-				return intfzf.Result{Value: "/home/tester/source/repos/lib"}, nil
+				return intpickercompat.Result{Value: "/home/tester/source/repos/lib"}, nil
 			}
-			return intfzf.Result{}, nil
+			return intpickercompat.Result{}, nil
 		})),
 		sessions:   &capturingSwitchSessionExecutor{},
 		identity:   stubSwitchIdentityResolver{name: "new-app"},
@@ -1920,19 +1928,19 @@ func TestSwitchCommandTogglePinSnapsExplicitPathToCandidate(t *testing.T) {
 	}
 }
 
-type switchRunnerFunc func(options intfzf.Options) (intfzf.Result, error)
+type switchRunnerFunc func(options intpickercompat.Options) (intpickercompat.Result, error)
 
-func (f switchRunnerFunc) Run(options intfzf.Options) (intfzf.Result, error) {
+func (f switchRunnerFunc) Run(options intpickercompat.Options) (intpickercompat.Result, error) {
 	return f(options)
 }
 
 type capturingSwitchRunner struct {
-	last   intfzf.Options
-	result intfzf.Result
+	last   intpickercompat.Options
+	result intpickercompat.Result
 	err    error
 }
 
-func (r *capturingSwitchRunner) Run(options intfzf.Options) (intfzf.Result, error) {
+func (r *capturingSwitchRunner) Run(options intpickercompat.Options) (intpickercompat.Result, error) {
 	r.last = options
 	return r.result, r.err
 }
@@ -2086,7 +2094,7 @@ func equalStrings(got, want []string) bool {
 	return true
 }
 
-func equalEntries(got, want []intfzf.Entry) bool {
+func equalEntries(got, want []intpickercompat.Entry) bool {
 	if len(got) != len(want) {
 		return false
 	}

--- a/internal/ui/pickercompat/picker.go
+++ b/internal/ui/pickercompat/picker.go
@@ -1,4 +1,4 @@
-package fzf
+package pickercompat
 
 import (
 	"strconv"
@@ -17,7 +17,7 @@ func OptionsFromPicker(options picker.Options) Options {
 		})
 	}
 
-	fzfOptions := Options{
+	compatOptions := Options{
 		UI:             options.UI,
 		Entries:        entries,
 		Read0:          options.MultiLine,
@@ -38,23 +38,23 @@ func OptionsFromPicker(options picker.Options) Options {
 		}
 		switch action.Intent {
 		case picker.ActionClose:
-			fzfOptions.Bindings = append(fzfOptions.Bindings, key+":abort")
+			compatOptions.Bindings = append(compatOptions.Bindings, key+":abort")
 		case picker.ActionAccept, picker.ActionCustom:
 			if action.Intent == picker.ActionCustom && strings.TrimSpace(action.Command) != "" {
 				binding := key + ":execute-silent(" + strings.TrimSpace(action.Command) + ")"
 				if action.Refresh {
 					binding += "+refresh-preview"
 				}
-				fzfOptions.Bindings = append(fzfOptions.Bindings, binding)
+				compatOptions.Bindings = append(compatOptions.Bindings, binding)
 				continue
 			}
-			fzfOptions.ExpectKeys = append(fzfOptions.ExpectKeys, key)
+			compatOptions.ExpectKeys = append(compatOptions.ExpectKeys, key)
 		}
 	}
 	if options.InitialIndexSet || options.InitialIndex > 0 {
-		fzfOptions.Bindings = append(fzfOptions.Bindings, "start:pos("+strconv.Itoa(options.InitialIndex+1)+")")
+		compatOptions.Bindings = append(compatOptions.Bindings, "start:pos("+strconv.Itoa(options.InitialIndex+1)+")")
 	}
-	return fzfOptions
+	return compatOptions
 }
 
 func ResultToPicker(result Result) picker.Result {

--- a/internal/ui/pickercompat/picker_test.go
+++ b/internal/ui/pickercompat/picker_test.go
@@ -1,4 +1,4 @@
-package fzf
+package pickercompat
 
 import (
 	"reflect"
@@ -65,7 +65,7 @@ func TestOptionsFromPickerMapsItemsActionsAndPreview(t *testing.T) {
 	}
 }
 
-func TestPickerOptionsMapsFZFBindingsToContractActions(t *testing.T) {
+func TestPickerOptionsMapsLegacyBindingsToContractActions(t *testing.T) {
 	t.Parallel()
 
 	options := PickerOptions(Options{
@@ -91,7 +91,7 @@ func TestPickerOptionsMapsFZFBindingsToContractActions(t *testing.T) {
 		t.Fatalf("DisableSearch/AcceptQuery = %t/%t, want true/true", options.DisableSearch, options.AcceptQuery)
 	}
 	if len(options.Items) != 1 || options.Items[0].SearchText != "api service" {
-		t.Fatalf("Items = %#v, want fzf entry mapped to picker item", options.Items)
+		t.Fatalf("Items = %#v, want legacy entry mapped to picker item", options.Items)
 	}
 	if len(options.Actions) != 2 {
 		t.Fatalf("Actions = %#v, want close and command actions", options.Actions)

--- a/internal/ui/pickercompat/types.go
+++ b/internal/ui/pickercompat/types.go
@@ -1,4 +1,4 @@
-package fzf
+package pickercompat
 
 type Options struct {
 	UI             string


### PR DESCRIPTION
## Summary
- rename the remaining legacy picker adapter package from internal/ui/fzf to internal/ui/pickercompat
- replace intfzf/FZF helper names with pickercompat/legacy naming in app code and tests
- update docs so fzf remains only historical/parity context, not a current adapter package name

## Validation
- make fmt
- GOCACHE=/tmp/projmux-go-cache make fix
- GOCACHE=/tmp/projmux-go-cache make test
- GOCACHE=/tmp/projmux-go-cache make test-integration (Docker socket escalation)
- GOCACHE=/tmp/projmux-go-cache make test-e2e (Docker socket escalation)
- make fmt-check
- git diff --check