### PR TITLE
fix: normalize native picker frame chrome

### DIFF
--- a/docs/native-picker-parity.md
+++ b/docs/native-picker-parity.md
@@ -68,6 +68,15 @@ native picker engine and is not a public dependency-policy change.
 - The split lets projmux grow a first-party picker design independently from
   the legacy picker option/result adapter.
 
+## Frame Chrome ANSI
+
+Native picker frame chrome is normalized in `internal/ui/projmuxpicker`.
+Titlebars restore the titlebar style after embedded ANSI resets, search prompt
+and footer separators fill the available frame width, and header, row, footer,
+and preview lines close any active SGR style before padding or frame borders can
+inherit it. This phase does not add popup modes or change the `popup-toggle`
+contract; native popups still rely on the existing borderless tmux popup path.
+
 ## Verified Flows
 
 - `ai` picker/settings: native backend routing covered by app tests. Docker

--- a/internal/ui/picker/backend.go
+++ b/internal/ui/picker/backend.go
@@ -1282,7 +1282,7 @@ func nativeContentLayout(layout nativeLayout, title string) nativeLayout {
 func renderNativeInteractiveContent(w io.Writer, options Options, items []Item, query string, queryCursor, selected, previewOffset int, layout nativeLayout) {
 	var screen strings.Builder
 	if header := strings.TrimSpace(options.Header); header != "" {
-		fmt.Fprintln(&screen, header)
+		fmt.Fprintln(&screen, nativeHeaderLine(header, layout.Cols))
 	}
 	if !options.DisableSearch {
 		prompt := strings.TrimSpace(options.Prompt)
@@ -1453,6 +1453,10 @@ func nativeTextLineCount(value string) int {
 
 func nativeSearchSeparatorLine(cols int) string {
 	return projmuxpicker.SeparatorLine(cols)
+}
+
+func nativeHeaderLine(header string, cols int) string {
+	return projmuxpicker.HeaderLine(header, cols)
 }
 
 func renderNativeFrame(w io.Writer, content string, layout nativeLayout) {

--- a/internal/ui/projmuxpicker/ansi.go
+++ b/internal/ui/projmuxpicker/ansi.go
@@ -1,6 +1,7 @@
 package projmuxpicker
 
 import (
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -28,6 +29,60 @@ func PadRight(value string, width int) string {
 		return value
 	}
 	return value + strings.Repeat(" ", width-length)
+}
+
+func closeStyledLine(line string) string {
+	if hasActiveStyle(line) {
+		return line + Reset
+	}
+	return line
+}
+
+func hasActiveStyle(value string) bool {
+	active := false
+	for i := 0; i < len(value); {
+		if value[i] != '\x1b' {
+			i++
+			continue
+		}
+		start := i
+		i++
+		for i < len(value) && value[i] != 'm' {
+			i++
+		}
+		if i >= len(value) {
+			break
+		}
+		sequence := value[start : i+1]
+		i++
+		if !strings.HasPrefix(sequence, "\x1b[") {
+			continue
+		}
+		params := strings.TrimSuffix(strings.TrimPrefix(sequence, "\x1b["), "m")
+		active = sgrLeavesStyleActive(params, active)
+	}
+	return active
+}
+
+func sgrLeavesStyleActive(params string, active bool) bool {
+	if params == "" {
+		return false
+	}
+	for field := range strings.SplitSeq(params, ";") {
+		code, err := strconv.Atoi(field)
+		if err != nil {
+			continue
+		}
+		switch code {
+		case 0:
+			active = false
+		case 22, 23, 24, 25, 27, 28, 29, 39, 49, 59:
+			// These only clear one SGR attribute. Other attributes may still be active.
+		default:
+			active = true
+		}
+	}
+	return active
 }
 
 func TruncateANSI(value string, width int) string {

--- a/internal/ui/projmuxpicker/frame.go
+++ b/internal/ui/projmuxpicker/frame.go
@@ -133,7 +133,7 @@ func (r Renderer) RenderFrameWithTitle(w io.Writer, content, title string, layou
 		if i < len(lines) {
 			line = TruncateANSI(strings.TrimRight(lines[i], "\r"), innerWidth)
 		}
-		fmt.Fprintf(w, "%s%s%s\r\n", theme.Vertical, PadRight(line, innerWidth), theme.Vertical)
+		fmt.Fprintf(w, "%s%s%s\r\n", theme.Vertical, PadStyledLine(line, innerWidth), theme.Vertical)
 	}
 	fmt.Fprintf(w, "%s%s%s", theme.BottomLeft, strings.Repeat(theme.Horizontal, innerWidth), theme.BottomRight)
 }

--- a/internal/ui/projmuxpicker/preview.go
+++ b/internal/ui/projmuxpicker/preview.go
@@ -82,8 +82,8 @@ func RenderSplitPreviewRows(w io.Writer, listLines, previewLines []string, layou
 			right = previewLines[i]
 		}
 		right = normalizePreviewLine(right)
-		right = PadRight(TruncateANSI(right, previewWidth), previewWidth)
-		fmt.Fprintf(w, "%s│%s\n", PadRight(TruncateANSI(left, listWidth), listWidth), right)
+		right = PadStyledLine(TruncateANSI(right, previewWidth), previewWidth)
+		fmt.Fprintf(w, "%s│%s\n", PadStyledLine(TruncateANSI(left, listWidth), listWidth), right)
 	}
 }
 
@@ -95,7 +95,7 @@ func RenderDownPreview(w io.Writer, previewLines []string, layout Layout) {
 	fmt.Fprintln(w, SeparatorLine(width))
 	for _, line := range previewLines {
 		line = normalizePreviewLine(line)
-		fmt.Fprintln(w, PadRight(TruncateANSI(line, width), width))
+		fmt.Fprintln(w, PadStyledLine(TruncateANSI(line, width), width))
 	}
 }
 
@@ -110,7 +110,7 @@ func RenderInlinePreviewRows(w io.Writer, previewLines []string, layout Layout) 
 	for _, line := range previewLines {
 		line = normalizePreviewLine(line)
 		if width > 0 {
-			line = PadRight(TruncateANSI(line, width), width)
+			line = PadStyledLine(TruncateANSI(line, width), width)
 		}
 		fmt.Fprintln(w, line)
 	}

--- a/internal/ui/projmuxpicker/surface.go
+++ b/internal/ui/projmuxpicker/surface.go
@@ -43,9 +43,20 @@ func FooterBlockLines(footer string, cols int) []string {
 	}
 	lines := []string{SeparatorLine(cols)}
 	for line := range strings.SplitSeq(footer, "\n") {
-		lines = append(lines, TruncateANSI(strings.TrimRight(line, "\r"), cols))
+		lines = append(lines, ChromeLine(strings.TrimRight(line, "\r"), cols))
 	}
 	return lines
+}
+
+func HeaderLine(header string, cols int) string {
+	return ChromeLine(strings.TrimRight(header, "\r"), cols)
+}
+
+func ChromeLine(line string, cols int) string {
+	if cols <= 0 {
+		cols = DefaultCols
+	}
+	return PadStyledLine(TruncateANSI(line, cols), cols)
 }
 
 func SeparatorLine(cols int) string {
@@ -85,9 +96,9 @@ func PromptLineWithRenderedQuery(prompt, query, renderedQuery string, matches, t
 	}
 	padding := cols - VisibleLen(line) - VisibleLen(info)
 	if padding < 2 {
-		return line + "  " + info
+		return PadStyledLine(line+"  "+info, cols)
 	}
-	return line + strings.Repeat(" ", padding) + info
+	return PadStyledLine(line+strings.Repeat(" ", padding)+info, cols)
 }
 
 func QueryWithCursor(query string, cursor int) string {
@@ -188,7 +199,7 @@ func ListLinesWithScrollbarRows(lines []string, total, start, end, width, rows i
 			line = lines[i]
 		}
 		line = RenderableListLine(line, width-1)
-		rendered = append(rendered, PadRight(TruncateANSI(line, width-1), width-1)+marker)
+		rendered = append(rendered, PadStyledLine(TruncateANSI(line, width-1), width-1)+marker)
 	}
 	return rendered
 }
@@ -235,12 +246,22 @@ func RenderableListLine(line string, width int) string {
 }
 
 func PadStyledLine(line string, width int) string {
-	if width <= 0 || VisibleLen(line) >= width {
-		return line
+	if width <= 0 {
+		return closeStyledLine(line)
 	}
-	padding := strings.Repeat(" ", width-VisibleLen(line))
+	visible := VisibleLen(line)
+	if visible >= width {
+		return closeStyledLine(line)
+	}
+	padding := strings.Repeat(" ", width-visible)
 	if strings.HasSuffix(line, Reset) && padsInsideFinalStyle(line) {
 		return strings.TrimSuffix(line, Reset) + padding + Reset
+	}
+	if hasActiveStyle(line) {
+		if padsInsideFinalStyle(line) {
+			return line + padding + Reset
+		}
+		return line + Reset + padding
 	}
 	return line + padding
 }

--- a/internal/ui/projmuxpicker/surface_test.go
+++ b/internal/ui/projmuxpicker/surface_test.go
@@ -20,6 +20,72 @@ func TestPromptLineWithCursorRendersInlineCount(t *testing.T) {
 	}
 }
 
+func TestFrameChromeANSIGoldenLines(t *testing.T) {
+	t.Parallel()
+
+	footerLines := FooterBlockLines("\x1b[32mEnter: open\x1b[0m", 18)
+	if len(footerLines) != 2 {
+		t.Fatalf("FooterBlockLines() len = %d, want 2: %#v", len(footerLines), footerLines)
+	}
+	row := RenderableListLine(InteractiveRowLines(Row{
+		Label: "\x1b[36mapi\x1b[0m",
+	}, true, false)[0], 18)
+	cases := []struct {
+		name      string
+		line      string
+		want      string
+		wantWidth int
+	}{
+		{
+			name:      "title",
+			line:      frameTitlebarLine(DefaultTheme, 18, "\x1b[31mProjects\x1b[0m"),
+			want:      "│" + TitlebarStart + " \x1b[31mProjects" + Reset + TitlebarStart + strings.Repeat(" ", 9) + Reset + "│",
+			wantWidth: 20,
+		},
+		{
+			name:      "header",
+			line:      HeaderLine("\x1b[36mPinned", 18),
+			want:      "\x1b[36mPinned" + Reset + strings.Repeat(" ", 12),
+			wantWidth: 18,
+		},
+		{
+			name:      "search prompt",
+			line:      PromptLineWithCursor("› ", "api", 3, 2, 9, 18),
+			want:      MutedStart + "Search" + Reset + " › api" + CursorStart + " " + Reset + "  " + MutedStart + "2/9" + Reset,
+			wantWidth: 18,
+		},
+		{
+			name:      "row",
+			line:      row,
+			want:      Pointer + "\x1b[36mapi" + Reset + CurrentStart + strings.Repeat(" ", 13) + Reset,
+			wantWidth: 18,
+		},
+		{
+			name:      "footer separator",
+			line:      footerLines[0],
+			want:      MutedStart + strings.Repeat(GapLine, 18) + Reset,
+			wantWidth: 18,
+		},
+		{
+			name:      "footer text",
+			line:      footerLines[1],
+			want:      "\x1b[32mEnter: open" + Reset + strings.Repeat(" ", 7),
+			wantWidth: 18,
+		},
+	}
+	for _, tt := range cases {
+		if tt.line != tt.want {
+			t.Fatalf("%s line = %q, want %q", tt.name, tt.line, tt.want)
+		}
+		if hasActiveStyle(tt.line) {
+			t.Fatalf("%s line = %q, want no active style at line end", tt.name, tt.line)
+		}
+		if got := VisibleLen(tt.line); got != tt.wantWidth {
+			t.Fatalf("%s width = %d, want %d: %q", tt.name, got, tt.wantWidth, tt.line)
+		}
+	}
+}
+
 func TestSeparatorLineUsesMutedChromeAtFullWidth(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- normalize native picker chrome lines so title/header/search/footer/preview styling closes consistently before frame borders and padding
- add focused ANSI golden regression coverage for frame chrome
- document the frame chrome ANSI contract in docs/native-picker-parity.md

## Validation
- make fmt
- make fix
- GOCACHE=/tmp/projmux-go-cache make test (rerun outside sandbox for local httptest socket binding)
- make test-integration (Docker-backed, outside sandbox)
- make test-e2e (Docker-backed, outside sandbox)