### PR TITLE
feat(keybindings): confirm lab plain overrides

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -31,7 +31,12 @@ Settings > Labs > Diagnose keybindings reuses the same probe and terminal
 fallback engines from `projmux setup` and `projmux init`. It lists the
 keybinding catalog, lets you press one action key at a time from inside the
 app, distinguishes plain / CSI-u / unexpected / timeout outcomes, and exposes
-preview/apply rows for supported terminal fallbacks.
+preview/apply rows for supported terminal fallbacks. When an unexpected
+sequence can be safely read as a tmux plain chord, the Lab shows an explicit
+`Save as plain override` row with the suggested chord; it never overwrites
+`keymap.toml` from an unexpected sequence unless you select that confirmation
+row. The Lab also shows whether the detected terminal can reload config after
+fallback apply or needs a restart/manual reload.
 
 > 한국어 요약: 대부분의 터미널은 `projmux shell` 만으로 아래 키가 바로 동작합니다.
 > 동작하지 않으면 `projmux setup` 으로 어떤 키가 막혔는지 진단하고,
@@ -136,6 +141,9 @@ tailored to the detected terminal (Ghostty, WezTerm, kitty, iTerm2,
 Alacritty, Windows Terminal, foot, VS Code, …). When projmux ships an init
 adapter for the terminal, the summary gives both the dry-run preview and the
 exact apply command, e.g. `projmux init ghostty --apply`.
+Settings > Labs also includes a concise after-apply hint: Ghostty/WezTerm/kitty
+can reload config, Windows Terminal and iTerm2 generally need a restarted tab
+or session, and unknown terminals are marked manual.
 
 Useful flags:
 

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -1419,6 +1419,12 @@ func (c *settingsCommand) runLabKeybindingDetail(actionID string, stdout, stderr
 				return err
 			}
 		default:
+			if chord, ok := strings.CutPrefix(op, "save-plain-override:"); ok {
+				if err := c.saveKeymapAndApply(actionID, settingsKeymapFieldPlain, &chord, stdout); err != nil {
+					return err
+				}
+				continue
+			}
 			return fmt.Errorf("unknown lab keybinding operation: %s", op)
 		}
 	}
@@ -1434,6 +1440,9 @@ func parseLabKeybindingAction(value, actionID string) (string, bool) {
 	case "probe", "init-preview", "init-apply", "save-plain":
 		return op, true
 	default:
+		if strings.HasPrefix(op, "save-plain-override:") && strings.TrimPrefix(op, "save-plain-override:") != "" {
+			return op, true
+		}
 		return "", false
 	}
 }
@@ -1501,6 +1510,10 @@ func (c *settingsCommand) labKeybindingDetailEntries(actionID string) ([]intpick
 			Value: settingsNoopValue,
 		},
 		{
+			Label: settingsLabelInfo("After fallback apply", terminal.ReloadCapability().Label, terminal.ReloadCapability().Summary),
+			Value: settingsNoopValue,
+		},
+		{
 			Label: settingsLabelInfo("Plain chord", keybindingValueSummary(action.PlainChord, defaultAction.PlainChord), "tmux"),
 			Value: settingsNoopValue,
 		},
@@ -1561,6 +1574,12 @@ func labProbeOutcomeEntries(prefix string, action, defaultAction keyBindingActio
 			Label: settingsLabelInfo("Unexpected sequence", visibleEscape(string(res.Sequence)), "no keymap overwrite"),
 			Value: settingsNoopValue,
 		})
+		if chord, ok := suggestedPlainChordForSequence(res.Sequence); ok {
+			entries = append(entries, intpickercompat.Entry{
+				Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, "Save as plain override", "write plain = "+chord+" and reload app config"),
+				Value: prefix + "save-plain-override:" + chord,
+			})
+		}
 	case probeStatusTimeout:
 		desc := "terminal fallback unavailable"
 		if cmd := terminal.InitCommand(); cmd != "" {
@@ -1617,13 +1636,14 @@ func (c *settingsCommand) runLabTerminalInit(apply bool, stdout, stderr io.Write
 }
 
 func labTerminalSupportSummary(terminal terminalInfo) string {
+	activation := terminal.ReloadCapability()
 	if cmd := terminal.InitCommand(); cmd != "" {
-		return "supported fallback: " + strings.TrimSuffix(cmd, " --apply")
+		return "supported fallback: " + strings.TrimSuffix(cmd, " --apply") + "; after apply: " + activation.Label
 	}
 	if hint := terminal.RemediationHint(); hint != "" {
-		return hint
+		return hint + "; after apply: " + activation.Label
 	}
-	return "no automatic fallback adapter"
+	return "no automatic fallback adapter; after apply: " + activation.Label
 }
 
 func (c *settingsCommand) writeTmuxAppConfig() (string, error) {

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -843,10 +843,11 @@ func TestSettingsLabsKeybindingDetailShowsProbeOutcomes(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name      string
-		seed      string
-		result    probeResult
-		wantLabel []string
+		name       string
+		seed       string
+		result     probeResult
+		wantLabel  []string
+		wantAbsent []string
 	}{
 		{
 			name: "plain",
@@ -871,7 +872,8 @@ func TestSettingsLabsKeybindingDetailShowsProbeOutcomes(t *testing.T) {
 				probeKey{ActionID: "sessionizer-sidebar", Label: "Alt-1", Plain: "\x1b1", CSIu: "\x1b[9005u", UserKey: "User4"},
 				[]byte("\x1b[A"),
 			),
-			wantLabel: []string{"Unexpected sequence", "no keymap overwrite"},
+			wantLabel:  []string{"Unexpected sequence", "no keymap overwrite"},
+			wantAbsent: []string{"Save as plain override"},
 		},
 		{
 			name: "timeout",
@@ -914,7 +916,88 @@ func TestSettingsLabsKeybindingDetailShowsProbeOutcomes(t *testing.T) {
 					t.Fatalf("entries = %#v, want label containing %q", entries, want)
 				}
 			}
+			for _, absent := range tc.wantAbsent {
+				if hasEntryLabelContaining(entries, absent) {
+					t.Fatalf("entries = %#v, did not want label containing %q", entries, absent)
+				}
+			}
 		})
+	}
+}
+
+func TestSettingsLabsUnknownProbeSaveOverrideUsesSuggestedPlainChord(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	var tmuxCalls [][]string
+	var calls int
+	cmd := testKeybindingSettingsCommand(t, home, func(options intpickercompat.Options) (intpickercompat.Result, error) {
+		calls++
+		switch calls {
+		case 1:
+			return intpickercompat.Result{Key: "enter", Value: settingsSectionLabs}, nil
+		case 2:
+			return intpickercompat.Result{Key: "enter", Value: settingsLabKeybindings}, nil
+		case 3:
+			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixLabKeymap + "sessionizer-sidebar"}, nil
+		case 4:
+			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixLabKeymap + "sessionizer-sidebar:probe"}, nil
+		case 5:
+			if !hasEntryLabelContaining(options.Entries, "Unexpected sequence") {
+				t.Fatalf("detail entries = %#v, want unexpected sequence row", options.Entries)
+			}
+			if !hasEntryLabelContaining(options.Entries, "Save as plain override") {
+				t.Fatalf("detail entries = %#v, want save override row", options.Entries)
+			}
+			if !hasEntryLabelContaining(options.Entries, "plain = M-a") {
+				t.Fatalf("detail entries = %#v, want suggested M-a description", options.Entries)
+			}
+			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixLabKeymap + "sessionizer-sidebar:save-plain-override:M-a"}, nil
+		case 6:
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		case 7:
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		case 8:
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		case 9:
+			return intpickercompat.Result{}, nil
+		default:
+			t.Fatalf("unexpected settings picker call %d", calls)
+			return intpickercompat.Result{}, nil
+		}
+	})
+	cmd.lookupEnv = func(name string) string {
+		switch name {
+		case "TMUX":
+			return "/tmp/tmux,1,0"
+		case "TERM_PROGRAM":
+			return "ghostty"
+		default:
+			return ""
+		}
+	}
+	cmd.runCommand = func(name string, args ...string) error {
+		tmuxCalls = append(tmuxCalls, append([]string{name}, args...))
+		return nil
+	}
+	cmd.probeKeybinding = func(key probeKey, timeout time.Duration) (probeResult, error) {
+		return classifyProbeInput(key, []byte("\x1ba")), nil
+	}
+
+	var stdout bytes.Buffer
+	if err := cmd.Run(nil, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	keymap := readFile(t, filepath.Join(home, ".config", "projmux", "keymap.toml"))
+	if !strings.Contains(keymap, "[bindings.sessionizer-sidebar]\nplain = \"M-a\"\n") {
+		t.Fatalf("keymap = %q, want M-a plain override", keymap)
+	}
+	configPath := filepath.Join(home, ".config", "projmux", "tmux.conf")
+	if !reflect.DeepEqual(tmuxCalls, [][]string{{"tmux", "source-file", configPath}}) {
+		t.Fatalf("tmux calls = %#v, want source-file app config", tmuxCalls)
+	}
+	if !strings.Contains(stdout.String(), "reloaded tmux config") {
+		t.Fatalf("stdout = %q, want reload message", stdout.String())
 	}
 }
 
@@ -990,6 +1073,51 @@ func TestSettingsLabsPlainProbeSaveUsesKeymapApplyPath(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "reloaded tmux config") {
 		t.Fatalf("stdout = %q, want reload message", stdout.String())
+	}
+}
+
+func TestSettingsLabsTerminalReloadCapabilityRows(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		env  map[string]string
+		want []string
+	}{
+		{
+			name: "ghostty reload",
+			env:  map[string]string{"TERM_PROGRAM": "ghostty"},
+			want: []string{"After fallback apply", "ghostty reload-config", "reload Ghostty config"},
+		},
+		{
+			name: "wsl windows terminal restart",
+			env:  map[string]string{"WSL_DISTRO_NAME": "Ubuntu"},
+			want: []string{"After fallback apply", "restart terminal", "restart Windows Terminal tabs"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			home := t.TempDir()
+			cmd := testKeybindingSettingsCommand(t, home, func(options intpickercompat.Options) (intpickercompat.Result, error) {
+				return intpickercompat.Result{}, nil
+			})
+			cmd.lookupEnv = func(name string) string {
+				return tc.env[name]
+			}
+
+			entries, _, err := cmd.labKeybindingDetailEntries("sessionizer-sidebar")
+			if err != nil {
+				t.Fatalf("labKeybindingDetailEntries() error = %v", err)
+			}
+			for _, want := range tc.want {
+				if !hasEntryLabelContaining(entries, want) {
+					t.Fatalf("entries = %#v, want label containing %q", entries, want)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/app/setup.go
+++ b/internal/app/setup.go
@@ -256,6 +256,29 @@ func classifyProbeInput(key probeKey, seq []byte) probeResult {
 	return res
 }
 
+func suggestedPlainChordForSequence(seq []byte) (string, bool) {
+	if len(seq) == 0 || isAmbiguousEnterSequence(seq) {
+		return "", false
+	}
+	got := string(seq)
+	for _, action := range defaultKeyBindingCatalog() {
+		if action.ProbePlain != "" && action.PlainChord != "" && action.ProbePlain == got && !isAmbiguousEnterSequence([]byte(action.ProbePlain)) {
+			return action.PlainChord, true
+		}
+	}
+	if len(seq) == 2 && seq[0] == 0x1b && seq[1] >= 0x21 && seq[1] <= 0x7e {
+		return "M-" + string(seq[1]), true
+	}
+	if len(seq) == 1 && seq[0] >= 0x01 && seq[0] <= 0x1a {
+		return fmt.Sprintf("C-%c", 'a'+seq[0]-1), true
+	}
+	return "", false
+}
+
+func isAmbiguousEnterSequence(seq []byte) bool {
+	return len(seq) == 1 && (seq[0] == '\r' || seq[0] == '\n')
+}
+
 func renderProbeStatus(res probeResult) string {
 	switch res.Status {
 	case probeStatusPlain:
@@ -310,6 +333,9 @@ func renderProbeSummary(w io.Writer, terminal terminalInfo, results []probeResul
 	}
 	if hint := terminal.RemediationHint(); hint != "" {
 		fmt.Fprintln(w, "  - Manual fallback:", hint)
+	}
+	if activation := terminal.ReloadCapability(); activation.Summary != "" {
+		fmt.Fprintln(w, "  - After applying fallback:", activation.Summary)
 	}
 	fmt.Fprintln(w, "  - For unsupported terminals, bind each failing key to the matching CSI-u sequence")
 	fmt.Fprintln(w, "    from `projmux setup --non-interactive`.")
@@ -374,6 +400,29 @@ func (t terminalInfo) RemediationHint() string {
 		return "VS Code terminal swallows many shortcuts; consider running projmux in an external terminal"
 	}
 	return ""
+}
+
+type terminalReloadCapability struct {
+	Label   string
+	Summary string
+}
+
+var terminalReloadCapabilities = map[string]terminalReloadCapability{
+	"ghostty":          {Label: "ghostty reload-config", Summary: "reload Ghostty config"},
+	"wezterm":          {Label: "reload config", Summary: "reload WezTerm config"},
+	"kitty":            {Label: "reload config", Summary: "reload kitty config"},
+	"windows-terminal": {Label: "restart terminal", Summary: "restart Windows Terminal tabs"},
+	"iterm2":           {Label: "restart session", Summary: "restart iTerm2 sessions"},
+}
+
+func (t terminalInfo) ReloadCapability() terminalReloadCapability {
+	if capability, ok := terminalReloadCapabilities[t.Slug]; ok {
+		return capability
+	}
+	return terminalReloadCapability{
+		Label:   "manual",
+		Summary: "reload or restart manually if your terminal requires it",
+	}
 }
 
 // detectTerminal performs a best-effort identification of the host terminal

--- a/internal/app/setup_test.go
+++ b/internal/app/setup_test.go
@@ -245,6 +245,35 @@ func TestRenderProbeSummaryAllPass(t *testing.T) {
 	}
 }
 
+func TestSuggestedPlainChordForSequence(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		seq  []byte
+		want string
+		ok   bool
+	}{
+		{name: "alt printable", seq: []byte("\x1ba"), want: "M-a", ok: true},
+		{name: "alt digit", seq: []byte("\x1b7"), want: "M-7", ok: true},
+		{name: "control byte", seq: []byte{0x01}, want: "C-a", ok: true},
+		{name: "catalog plain sequence", seq: []byte("\x1b[1;4D"), want: "M-S-Left", ok: true},
+		{name: "enter is ambiguous", seq: []byte("\r"), ok: false},
+		{name: "arrow is not a plain tmux chord", seq: []byte("\x1b[A"), ok: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := suggestedPlainChordForSequence(tc.seq)
+			if got != tc.want || ok != tc.ok {
+				t.Fatalf("suggestedPlainChordForSequence(%q) = %q, %v; want %q, %v", tc.seq, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
 func TestSetupCommandRunNonInteractive(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add explicit Settings Lab confirmation before saving parseable unexpected key sequences as plain overrides
- show terminal reload/restart guidance in keybinding diagnostic rows
- document the confirmation and after-apply behavior

## Validation
- make fmt
- GOCACHE=/tmp/projmux-go-cache make fix
- GOCACHE=/tmp/projmux-go-cache make test (sandbox failed on localhost socket/text-file-busy; escalated rerun passed)
- GOCACHE=/tmp/projmux-go-cache make test-integration
- GOCACHE=/tmp/projmux-go-cache make test-e2e