### PR TITLE
fix: avoid nested statusbar popup frames

### DIFF
--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -652,11 +652,8 @@ func statusbarUsagePopup(state statusbarUsageState, now time.Time) statusbarUsag
 	title := "Usage"
 	lines := statusbarUsagePopupLines(state, now, width-2)
 	content := strings.Join(lines, "\n")
-	height := projmuxpicker.RenderedTextLineCount(content) + 4 + projmuxpicker.TitlebarRows(title)
-	var frame strings.Builder
-	projmuxpicker.DefaultRenderer().RenderFrameWithTitle(&frame, content, title, projmuxpicker.Layout{Rows: height, Cols: width})
-
-	payload := strings.ReplaceAll(strings.TrimRight(frame.String(), "\r\n"), "\r\n", "\n") + "\n"
+	height := projmuxpicker.RenderedTextLineCount(content) + 2
+	payload := strings.TrimRight(content, "\n") + "\n"
 	command := "printf %s " + tmuxShellQuote(payload) + "; IFS= read -r _"
 	return statusbarUsagePopupView{
 		Title:   title,
@@ -956,10 +953,8 @@ func statusbarPathPopup(path string, metadata statusbarPathMetadata) statusbarPa
 	lines = append(lines, "", projmuxpicker.MutedStart+"Enter closes this popup."+projmuxpicker.Reset)
 
 	content := strings.Join(lines, "\n")
-	height := projmuxpicker.RenderedTextLineCount(content) + 4 + projmuxpicker.TitlebarRows(title)
-	var frame strings.Builder
-	projmuxpicker.DefaultRenderer().RenderFrameWithTitle(&frame, content, title, projmuxpicker.Layout{Rows: height, Cols: width})
-	payload := strings.ReplaceAll(strings.TrimRight(frame.String(), "\r\n"), "\r\n", "\n") + "\n"
+	height := projmuxpicker.RenderedTextLineCount(content) + 2
+	payload := strings.TrimRight(content, "\n") + "\n"
 	command := "printf %s " + tmuxShellQuote(payload) + "; IFS= read -r _"
 	return statusbarPathPopupView{
 		Title:   title,

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -278,6 +278,9 @@ func TestStatusbarClickPwdOpensPathPopupWithoutCopy(t *testing.T) {
 	if strings.Contains(command, "printf '%s\\n'") || strings.Contains(command, "read -n1") {
 		t.Fatalf("popup command uses brittle output/read shape: %q", command)
 	}
+	if strings.ContainsAny(command, "╭╮╰╯│") {
+		t.Fatalf("path popup must rely on tmux chrome, not an inner frame: %q", command)
+	}
 }
 
 func TestStatusbarPathMetadataPreservesGitRootWithSpaces(t *testing.T) {
@@ -490,6 +493,9 @@ func TestStatusbarClickUsageOpensNativeHUDPopup(t *testing.T) {
 	}
 	if !strings.Contains(command, "; IFS= read -r _") {
 		t.Fatalf("usage popup command = %q, want simple Enter read", command)
+	}
+	if strings.ContainsAny(command, "╭╮╰╯│") {
+		t.Fatalf("usage popup must rely on tmux chrome, not an inner frame: %q", command)
 	}
 	for _, call := range runner.calls {
 		if call.name == "/usr/local/bin/projmux" || sawArgsContain(call.args, "popup-toggle") {


### PR DESCRIPTION
## Summary
- render cwd and usage statusbar popups as content-only inside tmux display-popup chrome
- remove inner projmuxpicker frames that overflowed tmux popup content width
- add tests that popup commands do not include inner frame border characters

## Validation
- GOCACHE=/tmp/projmux-go-cache go test ./internal/app -run 'TestStatusbarClickPwd|TestStatusbarClickUsage|TestStatusbarUsage'
- GOCACHE=/tmp/projmux-go-cache make fmt
- GOCACHE=/tmp/projmux-go-cache make fix
- GOCACHE=/tmp/projmux-go-cache make test (sandbox failed on httptest socket; escalated run passed)
- GOCACHE=/tmp/projmux-go-cache make test-integration
- GOCACHE=/tmp/projmux-go-cache make test-e2e
- git diff --check