### PR TITLE
fix: show hook trust prompt in wide popup

### DIFF
--- a/internal/app/hook_trust_popup.go
+++ b/internal/app/hook_trust_popup.go
@@ -1,0 +1,240 @@
+package app
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/crevissepartners/projmux/internal/integrations/hooks"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+)
+
+const (
+	hookTrustPopupTitle           = "Trust project hook"
+	hookTrustPopupWidth           = "90"
+	hookTrustPopupHeight          = "24"
+	hookTrustPopupTargetClientEnv = "PROJMUX_HOOK_TRUST_TARGET_CLIENT"
+	hookTrustPopupTargetPaneEnv   = "PROJMUX_HOOK_TRUST_TARGET_PANE"
+)
+
+func tmuxProjectHookPrompt(lookupEnv func(string) string, executable func() (string, error), runner tmuxRunner) hooks.ProjectHookPrompt {
+	if lookupEnv == nil {
+		lookupEnv = os.Getenv
+	}
+	return func(req hooks.ProjectHookPromptRequest) hooks.ProjectHookDecision {
+		if strings.TrimSpace(lookupEnv("TMUX")) == "" || executable == nil || runner == nil {
+			return hooks.ProjectHookDeny
+		}
+		binaryPath, err := executable()
+		if err != nil || strings.TrimSpace(binaryPath) == "" {
+			return hooks.ProjectHookDeny
+		}
+		decision, err := runTmuxHookTrustPopup(context.Background(), runner, binaryPath, req, hookTrustPopupTarget{
+			client: firstNonEmpty(
+				lookupEnv(hookTrustPopupTargetClientEnv),
+				lookupEnv("PROJMUX_POPUP_TARGET_CLIENT"),
+			),
+			pane: firstNonEmpty(
+				lookupEnv(hookTrustPopupTargetPaneEnv),
+				lookupEnv("PROJMUX_POPUP_TARGET_PANE"),
+				lookupEnv("TMUX_SESSIONIZER_CONTEXT_PANE"),
+			),
+		})
+		if err != nil {
+			return hooks.ProjectHookDeny
+		}
+		return decision
+	}
+}
+
+type hookTrustPopupTarget struct {
+	client string
+	pane   string
+}
+
+func runTmuxHookTrustPopup(ctx context.Context, runner tmuxRunner, binaryPath string, req hooks.ProjectHookPromptRequest, target hookTrustPopupTarget) (hooks.ProjectHookDecision, error) {
+	requestFile, err := os.CreateTemp("", "projmux-hook-trust-request-*.json")
+	if err != nil {
+		return hooks.ProjectHookDeny, err
+	}
+	requestPath := requestFile.Name()
+	defer os.Remove(requestPath)
+	defer requestFile.Close()
+
+	encoder := json.NewEncoder(requestFile)
+	if err := encoder.Encode(req); err != nil {
+		return hooks.ProjectHookDeny, err
+	}
+	if err := requestFile.Chmod(0o600); err != nil {
+		return hooks.ProjectHookDeny, err
+	}
+	if err := requestFile.Close(); err != nil {
+		return hooks.ProjectHookDeny, err
+	}
+
+	decisionFile, err := os.CreateTemp("", "projmux-hook-trust-decision-*.txt")
+	if err != nil {
+		return hooks.ProjectHookDeny, err
+	}
+	decisionPath := decisionFile.Name()
+	defer os.Remove(decisionPath)
+	if err := decisionFile.Chmod(0o600); err != nil {
+		_ = decisionFile.Close()
+		return hooks.ProjectHookDeny, err
+	}
+	if err := decisionFile.Close(); err != nil {
+		return hooks.ProjectHookDeny, err
+	}
+
+	args, err := buildHookTrustPopupArgs(binaryPath, requestPath, decisionPath, target)
+	if err != nil {
+		return hooks.ProjectHookDeny, err
+	}
+	if _, err := runner.Run(ctx, "tmux", args...); err != nil {
+		return hooks.ProjectHookDeny, err
+	}
+
+	rawDecision, err := os.ReadFile(decisionPath)
+	if err != nil {
+		return hooks.ProjectHookDeny, err
+	}
+	decision := parseHookTrustDecision(string(rawDecision))
+	if decision == "" {
+		return hooks.ProjectHookDeny, nil
+	}
+	return decision, nil
+}
+
+func buildHookTrustPopupArgs(binaryPath, requestPath, decisionPath string, target hookTrustPopupTarget) ([]string, error) {
+	binaryPath = strings.TrimSpace(binaryPath)
+	requestPath = strings.TrimSpace(requestPath)
+	decisionPath = strings.TrimSpace(decisionPath)
+	if binaryPath == "" {
+		return nil, errors.New("hook trust popup binary path is required")
+	}
+	if requestPath == "" {
+		return nil, errors.New("hook trust popup request path is required")
+	}
+	if decisionPath == "" {
+		return nil, errors.New("hook trust popup decision path is required")
+	}
+	command := strings.Join([]string{
+		tmuxShellQuote(binaryPath),
+		"tmux",
+		"hook-trust-prompt",
+		"--request",
+		tmuxShellQuote(requestPath),
+		"--decision",
+		tmuxShellQuote(decisionPath),
+	}, " ")
+	return inttmux.BuildDisplayPopupArgs(command, inttmux.PopupOptions{
+		Client:        strings.TrimSpace(target.client),
+		Target:        strings.TrimSpace(target.pane),
+		CloseBehavior: inttmux.PopupCloseOnExit,
+		Width:         hookTrustPopupWidth,
+		Height:        hookTrustPopupHeight,
+		Title:         hookTrustPopupTitle,
+	})
+}
+
+func (c *tmuxCommand) runHookTrustPrompt(args []string, stdout, stderr io.Writer) error {
+	return c.runHookTrustPromptWithReader(args, os.Stdin, stdout, stderr)
+}
+
+func (c *tmuxCommand) runHookTrustPromptWithReader(args []string, reader io.Reader, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("tmux hook-trust-prompt", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	requestPath := fs.String("request", "", "path to project hook trust request JSON")
+	decisionPath := fs.String("decision", "", "path to write the selected trust decision")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 || strings.TrimSpace(*requestPath) == "" || strings.TrimSpace(*decisionPath) == "" {
+		return errors.New("tmux hook-trust-prompt requires --request <path> --decision <path>")
+	}
+
+	rawRequest, err := os.ReadFile(*requestPath)
+	if err != nil {
+		return fmt.Errorf("read hook trust request: %w", err)
+	}
+	var req hooks.ProjectHookPromptRequest
+	if err := json.Unmarshal(rawRequest, &req); err != nil {
+		return fmt.Errorf("parse hook trust request: %w", err)
+	}
+	decision := hookTrustPopupPrompt(reader, stdout, req)
+	if err := os.WriteFile(*decisionPath, []byte(string(decision)+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write hook trust decision: %w", err)
+	}
+	return nil
+}
+
+func hookTrustPopupPrompt(reader io.Reader, writer io.Writer, req hooks.ProjectHookPromptRequest) hooks.ProjectHookDecision {
+	fmt.Fprintln(writer, "Project-local hook requires trust")
+	fmt.Fprintln(writer)
+	fmt.Fprintln(writer, "Repo")
+	fmt.Fprintf(writer, "  %s\n", req.RepoPath)
+	fmt.Fprintln(writer, "Hook")
+	fmt.Fprintf(writer, "  %s\n", req.RelativePath)
+	if req.PreviousSHA256 != "" {
+		fmt.Fprintln(writer, "Trusted SHA256")
+		fmt.Fprintf(writer, "  %s\n", req.PreviousSHA256)
+	}
+	fmt.Fprintln(writer, "Current SHA256")
+	fmt.Fprintf(writer, "  %s\n", req.SHA256)
+	if strings.TrimSpace(req.Preview) != "" {
+		fmt.Fprintln(writer)
+		fmt.Fprintln(writer, "Preview")
+		for line := range strings.SplitSeq(req.Preview, "\n") {
+			fmt.Fprintf(writer, "  %s\n", line)
+		}
+	}
+
+	fmt.Fprintln(writer)
+	fmt.Fprintln(writer, "[o] once    run this time only")
+	fmt.Fprintln(writer, "[a] always  trust this exact file hash")
+	fmt.Fprintln(writer, "[d] deny    skip this hook")
+
+	input := bufio.NewReader(reader)
+	for range 3 {
+		fmt.Fprint(writer, "Select [o/a/d], then Enter: ")
+		line, err := input.ReadString('\n')
+		if err != nil && len(line) == 0 {
+			fmt.Fprintln(writer)
+			return hooks.ProjectHookDeny
+		}
+		decision := parseHookTrustDecision(line)
+		if decision != "" {
+			return decision
+		}
+		fmt.Fprintln(writer, "Please enter o, a, or d.")
+	}
+	return hooks.ProjectHookDeny
+}
+
+func parseHookTrustDecision(value string) hooks.ProjectHookDecision {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "o", "once", string(hooks.ProjectHookAllowOnce):
+		return hooks.ProjectHookAllowOnce
+	case "a", "always", string(hooks.ProjectHookAllowAlways):
+		return hooks.ProjectHookAllowAlways
+	case "d", "deny", "n", "no":
+		return hooks.ProjectHookDeny
+	default:
+		return ""
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/app/hook_trust_popup_test.go
+++ b/internal/app/hook_trust_popup_test.go
@@ -1,0 +1,162 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/integrations/hooks"
+)
+
+func TestBuildHookTrustPopupArgsTargetsWidePopup(t *testing.T) {
+	args, err := buildHookTrustPopupArgs(
+		"/tmp/proj mux/bin/projmux",
+		"/tmp/request file.json",
+		"/tmp/decision file.txt",
+		hookTrustPopupTarget{client: "/dev/pts/7", pane: "%3"},
+	)
+	if err != nil {
+		t.Fatalf("buildHookTrustPopupArgs() error = %v", err)
+	}
+
+	wantPrefix := []string{
+		"display-popup",
+		"-c", "/dev/pts/7",
+		"-t", "%3",
+		"-E",
+		"-w", hookTrustPopupWidth,
+		"-h", hookTrustPopupHeight,
+		"-T", hookTrustPopupTitle,
+	}
+	if len(args) != len(wantPrefix)+1 || !reflect.DeepEqual(args[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("popup args = %#v, want prefix %#v", args, wantPrefix)
+	}
+
+	command := args[len(args)-1]
+	for _, want := range []string{
+		"'/tmp/proj mux/bin/projmux' tmux hook-trust-prompt",
+		"--request '/tmp/request file.json'",
+		"--decision '/tmp/decision file.txt'",
+	} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("popup command = %q, want substring %q", command, want)
+		}
+	}
+}
+
+func TestHookTrustPromptWritesDecision(t *testing.T) {
+	dir := t.TempDir()
+	requestPath := filepath.Join(dir, "request.json")
+	decisionPath := filepath.Join(dir, "decision.txt")
+	request := `{"RepoPath":"/workspace/repo","RelativePath":".projmux/config.toml","SHA256":"abc123","Preview":"[startup]\nrun = \"agent\""}`
+	if err := os.WriteFile(requestPath, []byte(request), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &tmuxCommand{}
+	var stdout, stderr bytes.Buffer
+	err := cmd.runHookTrustPromptWithReader(
+		[]string{"--request", requestPath, "--decision", decisionPath},
+		strings.NewReader("a\n"),
+		&stdout,
+		&stderr,
+	)
+	if err != nil {
+		t.Fatalf("runHookTrustPromptWithReader() error = %v, stderr = %q", err, stderr.String())
+	}
+
+	rawDecision, err := os.ReadFile(decisionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.TrimSpace(string(rawDecision)), string(hooks.ProjectHookAllowAlways); got != want {
+		t.Fatalf("decision = %q, want %q", got, want)
+	}
+	for _, want := range []string{
+		"Project-local hook requires trust",
+		"[a] always",
+		".projmux/config.toml",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want substring %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestTmuxProjectHookPromptUsesDisplayPopupDecision(t *testing.T) {
+	dir := t.TempDir()
+	runner := &hookTrustPopupRecordingRunner{}
+	prompt := tmuxProjectHookPrompt(
+		func(name string) string {
+			switch name {
+			case "TMUX":
+				return "/tmp/tmux/default,1,0"
+			case hookTrustPopupTargetClientEnv:
+				return "/dev/pts/9"
+			case hookTrustPopupTargetPaneEnv:
+				return "%9"
+			default:
+				return ""
+			}
+		},
+		func() (string, error) { return filepath.Join(dir, "projmux"), nil },
+		runner,
+	)
+
+	decision := prompt(hooks.ProjectHookPromptRequest{
+		RepoPath:     "/repo",
+		RelativePath: ".projmux/config.toml",
+		SHA256:       "abc123",
+	})
+
+	if decision != hooks.ProjectHookAllowOnce {
+		t.Fatalf("decision = %q, want allow-once", decision)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("tmux calls = %#v, want one display-popup call", runner.calls)
+	}
+	call := runner.calls[0]
+	if call.name != "tmux" || len(call.args) == 0 || call.args[0] != "display-popup" {
+		t.Fatalf("tmux call = %#v, want display-popup", call)
+	}
+	command := call.args[len(call.args)-1]
+	if !strings.Contains(command, "tmux hook-trust-prompt") {
+		t.Fatalf("popup command = %q, want hook trust prompt", command)
+	}
+	if !containsTmuxArgPair(call.args, "-c", "/dev/pts/9") || !containsTmuxArgPair(call.args, "-t", "%9") {
+		t.Fatalf("tmux call args = %#v, want target client and pane", call.args)
+	}
+}
+
+type hookTrustPopupRecordingRunner struct {
+	calls []recordedTmuxCall
+}
+
+func (r *hookTrustPopupRecordingRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, recordedTmuxCall{name: name, args: append([]string(nil), args...)})
+	if name != "tmux" || len(args) == 0 {
+		return nil, nil
+	}
+	command := args[len(args)-1]
+	decisionPath := singleQuotedFlagValue(command, "--decision")
+	if decisionPath != "" {
+		_ = os.WriteFile(decisionPath, []byte(string(hooks.ProjectHookAllowOnce)+"\n"), 0o600)
+	}
+	return nil, nil
+}
+
+func singleQuotedFlagValue(command, flag string) string {
+	_, after, ok := strings.Cut(command, flag+" '")
+	if !ok {
+		return ""
+	}
+	value, _, ok := strings.Cut(after, "'")
+	if !ok {
+		return ""
+	}
+	return value
+}

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -69,6 +69,8 @@ func (c *tmuxCommand) Run(args []string, stdout, stderr io.Writer) error {
 	}
 
 	switch fs.Arg(0) {
+	case "hook-trust-prompt":
+		return c.runHookTrustPrompt(fs.Args()[1:], stdout, stderr)
 	case "popup-preview":
 		return c.runPopupPreview(fs.Args()[1:], stderr)
 	case "popup-switch":
@@ -695,6 +697,15 @@ func buildPopupToggle(mode tmuxPopupToggleMode, binaryPath, marker string, ctx t
 	return buildPopupToggleWithPickerBackend(mode, binaryPath, marker, ctx, resolvePickerBackend(os.Getenv), os.Getenv)
 }
 
+func addHookTrustPopupTargetEnv(env map[string]string, ctx tmuxPopupContext) {
+	if strings.TrimSpace(ctx.TargetClient) != "" {
+		env[hookTrustPopupTargetClientEnv] = ctx.TargetClient
+	}
+	if strings.TrimSpace(ctx.OriginPane) != "" {
+		env[hookTrustPopupTargetPaneEnv] = ctx.OriginPane
+	}
+}
+
 func buildPopupToggleWithPickerBackend(mode tmuxPopupToggleMode, binaryPath, marker string, ctx tmuxPopupContext, backend intpicker.Backend, lookupEnv func(string) string) (string, inttmux.PopupOptions, error) {
 	options := inttmux.PopupOptions{
 		Target:        ctx.OriginPane,
@@ -713,6 +724,7 @@ func buildPopupToggleWithPickerBackend(mode tmuxPopupToggleMode, binaryPath, mar
 		options.Width = popupSize(ctx.ClientWidth, 80, 120)
 		options.Height = popupSize(ctx.ClientHeight, 70, 28)
 		cwd = ctx.ContextDir
+		addHookTrustPopupTargetEnv(env, ctx)
 		env["TMUX_SESSIONIZER_CONTEXT_DIR"] = ctx.ContextDir
 		env["TMUX_SESSIONIZER_CONTEXT_SESSION"] = ctx.OriginSession
 		env["TMUX_SESSIONIZER_CONTEXT_PANE"] = ctx.OriginPane
@@ -723,6 +735,7 @@ func buildPopupToggleWithPickerBackend(mode tmuxPopupToggleMode, binaryPath, mar
 		options.X = "0"
 		options.Y = "0"
 		cwd = ctx.ContextDir
+		addHookTrustPopupTargetEnv(env, ctx)
 		env["TMUX_SESSIONIZER_CONTEXT_DIR"] = ctx.ContextDir
 		env["TMUX_SESSIONIZER_CONTEXT_SESSION"] = ctx.OriginSession
 		env["TMUX_SESSIONIZER_CONTEXT_PANE"] = ctx.OriginPane

--- a/internal/app/tmux_client.go
+++ b/internal/app/tmux_client.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"os"
+	"strings"
 
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/integrations/hooks"
@@ -26,6 +27,10 @@ func defaultLifecycleHookRunner() *hooks.Runner {
 	if err != nil {
 		return nil
 	}
+	prompt := hooks.ProjectHookPrompt(nil)
+	if strings.TrimSpace(os.Getenv("TMUX")) != "" {
+		prompt = tmuxProjectHookPrompt(os.Getenv, os.Executable, inttmux.ExecRunner{})
+	}
 	return &hooks.Runner{
 		GlobalHookPaths: map[hooks.Event][]string{
 			hooks.EventPreCreate:   {paths.HookPath(config.PreCreateHookFileName)},
@@ -34,6 +39,7 @@ func defaultLifecycleHookRunner() *hooks.Runner {
 			hooks.EventPostAttach:  {paths.HookPath(config.PostAttachHookFileName)},
 		},
 		DiscoverProjectHooks: true,
+		ProjectHookPrompt:    prompt,
 		Logger:               os.Stderr,
 		Timeout:              hooks.DefaultPostCreateTimeout,
 		Version:              version.String(),

--- a/internal/app/tmux_client_test.go
+++ b/internal/app/tmux_client_test.go
@@ -15,6 +15,7 @@ func TestDefaultLifecycleHookRunnerWiresGlobalEventPaths(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", configHome)
 	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("TMUX", "")
 
 	runner := defaultLifecycleHookRunner()
 	if runner == nil {
@@ -35,5 +36,24 @@ func TestDefaultLifecycleHookRunnerWiresGlobalEventPaths(t *testing.T) {
 	}
 	if !runner.DiscoverProjectHooks {
 		t.Fatal("DiscoverProjectHooks = false, want true")
+	}
+	if runner.ProjectHookPrompt != nil {
+		t.Fatal("ProjectHookPrompt = non-nil outside tmux, want terminal fallback")
+	}
+}
+
+func TestDefaultLifecycleHookRunnerUsesPopupPromptInsideTmux(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Setenv("TMUX", "/tmp/tmux/default,1,0")
+
+	runner := defaultLifecycleHookRunner()
+	if runner == nil {
+		t.Fatal("defaultLifecycleHookRunner() = nil")
+	}
+	if runner.ProjectHookPrompt == nil {
+		t.Fatal("ProjectHookPrompt = nil inside tmux, want popup prompt")
 	}
 }

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -288,6 +288,8 @@ func TestAppRunTmuxPopupToggleOpensStandaloneSidebar(t *testing.T) {
 		"-E",
 		"-B",
 		"-d", "/tmp/work tree",
+		"-e", "PROJMUX_HOOK_TRUST_TARGET_CLIENT=/dev/pts/projmux-test-sidebar",
+		"-e", "PROJMUX_HOOK_TRUST_TARGET_PANE=%1",
 		"-e", "PROJMUX_NATIVE_LAUNCH_KEY=alt-1",
 		"-e", "PROJMUX_PICKER_BACKEND=native",
 		"-e", "TMUX_SESSIONIZER_CONTEXT_DIR=/tmp/work tree",
@@ -772,6 +774,7 @@ func TestBuildPopupTogglePropagatesPickerEnvironment(t *testing.T) {
 		"PROJMUX_NATIVE_TTY_FALLBACK='0'",
 		"PROJMUX_PROJDIR='/workspace/projects'",
 		"PROJMUX_MANAGED_ROOTS='/workspace/projects'",
+		hookTrustPopupTargetPaneEnv + "='%1'",
 	} {
 		if !strings.Contains(command, want) {
 			t.Fatalf("popup command = %q, want substring %q", command, want)
@@ -783,6 +786,7 @@ func TestBuildPopupTogglePropagatesPickerEnvironment(t *testing.T) {
 		"PROJMUX_NATIVE_TTY_FALLBACK": "0",
 		"PROJMUX_PROJDIR":             "/workspace/projects",
 		"PROJMUX_MANAGED_ROOTS":       "/workspace/projects",
+		hookTrustPopupTargetPaneEnv:   "%1",
 	} {
 		if got := options.Env[key]; got != want {
 			t.Fatalf("options.Env[%q] = %q, want %q", key, got, want)


### PR DESCRIPTION
## Summary
- route project-local hook trust confirmation through a dedicated wide tmux popup when running inside tmux
- pass original popup client/pane context from sessionizer popups so the trust prompt is not constrained by the sidebar PTY
- add tests for popup args, decision handoff, and tmux prompt wiring

## Tests
- `GOCACHE=/tmp/projmux-go-cache make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `git diff --check`