### PR TITLE
fix: hand off sidebar hook trust to wide popup

### DIFF
--- a/internal/app/hook_trust_popup.go
+++ b/internal/app/hook_trust_popup.go
@@ -19,6 +19,7 @@ const (
 	hookTrustPopupTitle           = "Trust project hook"
 	hookTrustPopupWidth           = "90"
 	hookTrustPopupHeight          = "24"
+	hookTrustInlineEnv            = "PROJMUX_HOOK_TRUST_INLINE"
 	hookTrustPopupTargetClientEnv = "PROJMUX_HOOK_TRUST_TARGET_CLIENT"
 	hookTrustPopupTargetPaneEnv   = "PROJMUX_HOOK_TRUST_TARGET_PANE"
 )

--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -28,6 +28,7 @@ const (
 	switchUIFlag             = "ui"
 	switchUIPopup            = "popup"
 	switchUISidebar          = "sidebar"
+	switchOpenTrustPopup     = "open"
 	switchKillExpectKey      = "ctrl-x"
 	switchPinExpectKey       = "alt-p"
 	switchSettingsSentinel   = "__projmux_settings__"
@@ -97,6 +98,7 @@ type switchCommand struct {
 	pinStore        switchPinStoreFactory
 	tagStore        switchTagStoreFactory
 	runner          switchRunner
+	tmuxRunner      tmuxRunner
 	sessions        switchSessionExecutor
 	previewStore    switchPreviewStore
 	previewStoreErr error
@@ -147,6 +149,7 @@ func newSwitchCommand() *switchCommand {
 		discover:     candidates.Discover,
 		pinStore:     newDefaultSwitchPinStore,
 		tagStore:     newDefaultSwitchTagStore,
+		tmuxRunner:   inttmux.ExecRunner{},
 		sessions:     client,
 		inventory:    tmuxPreviewInventory{client: client},
 		executable:   os.Executable,
@@ -202,6 +205,8 @@ func (c *switchCommand) Run(args []string, stdout, stderr io.Writer) error {
 			return c.runTogglePin(args[1:], stdout, stderr)
 		case "kill":
 			return c.runKill(args[1:], stdout, stderr)
+		case "open":
+			return c.runOpen(args[1:], stderr)
 		case "settings":
 			return c.runSettings(stdout, stderr)
 		case "preview":
@@ -353,6 +358,23 @@ func (c *switchCommand) runKill(args []string, stdout, stderr io.Writer) error {
 	}
 
 	return c.killFocusedSession(context.Background(), sessionName, "", stdout)
+}
+
+func (c *switchCommand) runOpen(args []string, stderr io.Writer) error {
+	fs := flag.NewFlagSet("switch open", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		printSwitchUsage(stderr)
+	}
+	if err := fs.Parse(args); err != nil {
+		printSwitchUsage(stderr)
+		return err
+	}
+	if fs.NArg() != 1 {
+		printSwitchUsage(stderr)
+		return fmt.Errorf("switch open requires exactly 1 argument: <path>")
+	}
+	return c.openTarget(context.Background(), cleanOptionalPath(fs.Arg(0)))
 }
 
 func (c *switchCommand) runPreview(args []string, stdout, stderr io.Writer) error {
@@ -1401,14 +1423,122 @@ func (c *switchCommand) execute(ctx context.Context, plan switchPlan, stdout io.
 		return false, fmt.Errorf("switch session executor is not configured")
 	}
 
-	if err := c.sessions.EnsureSession(ctx, plan.SessionName, plan.Selection); err != nil {
-		return false, fmt.Errorf("ensure tmux session %q: %w", plan.SessionName, err)
-	}
-	if err := c.sessions.OpenSession(ctx, plan.SessionName); err != nil {
-		return false, fmt.Errorf("open tmux session %q: %w", plan.SessionName, err)
+	if plan.UI == switchUISidebar && c.projectMayNeedHookTrust(plan.Selection) {
+		exists, err := c.switchSessionExists(ctx, plan.SessionName)
+		if err != nil {
+			return false, err
+		}
+		if exists {
+			return false, c.openTarget(ctx, plan.Selection)
+		}
+		if err := c.launchSidebarOpenPopup(ctx, plan.Selection); err != nil {
+			return false, err
+		}
+		return false, nil
 	}
 
+	if err := c.openTarget(ctx, plan.Selection); err != nil {
+		return false, err
+	}
 	return false, nil
+}
+
+func (c *switchCommand) openTarget(ctx context.Context, target string) error {
+	target = cleanOptionalPath(target)
+	if target == "" || target == switchSettingsSentinel {
+		return nil
+	}
+	if c.identityErr != nil {
+		return fmt.Errorf("configure session identity resolver: %w", c.identityErr)
+	}
+	if c.identity == nil {
+		return fmt.Errorf("switch session identity resolver is not configured")
+	}
+	if c.sessions == nil {
+		return fmt.Errorf("switch session executor is not configured")
+	}
+
+	sessionName, err := c.identity.SessionIdentityForPath(target)
+	if err != nil {
+		return fmt.Errorf("resolve switch session identity: %w", err)
+	}
+	if sessionName == "" {
+		return fmt.Errorf("switch command requires a target session")
+	}
+	if err := c.sessions.EnsureSession(ctx, sessionName, target); err != nil {
+		return fmt.Errorf("ensure tmux session %q: %w", sessionName, err)
+	}
+	if err := c.sessions.OpenSession(ctx, sessionName); err != nil {
+		return fmt.Errorf("open tmux session %q: %w", sessionName, err)
+	}
+	return nil
+}
+
+func (c *switchCommand) launchSidebarOpenPopup(ctx context.Context, target string) error {
+	if c.tmuxRunner == nil {
+		return fmt.Errorf("switch tmux runner is not configured")
+	}
+	if c.executable == nil {
+		return fmt.Errorf("switch executable resolver is not configured")
+	}
+	binaryPath, err := c.executable()
+	if err != nil {
+		return fmt.Errorf("resolve switch executable: %w", err)
+	}
+	command := strings.Join([]string{
+		tmuxShellQuote(binaryPath),
+		"switch",
+		switchOpenTrustPopup,
+		tmuxShellQuote(target),
+	}, " ")
+	args, err := inttmux.BuildDisplayPopupArgs(command, inttmux.PopupOptions{
+		Client:        strings.TrimSpace(c.env(hookTrustPopupTargetClientEnv)),
+		CloseBehavior: inttmux.PopupCloseOnExit,
+		Cwd:           target,
+		Env: map[string]string{
+			hookTrustInlineEnv: "1",
+		},
+		Width:  hookTrustPopupWidth,
+		Height: hookTrustPopupHeight,
+		Title:  "Open project",
+	})
+	if err != nil {
+		return fmt.Errorf("build switch open popup: %w", err)
+	}
+	displayCommand := tmuxShellCommand(append([]string{"tmux"}, args...)...)
+	if _, err := c.tmuxRunner.Run(ctx, "tmux", "run-shell", "-b", "sleep 0.05; "+displayCommand); err != nil {
+		return fmt.Errorf("launch switch open popup: %w", err)
+	}
+	return nil
+}
+
+func (c *switchCommand) projectMayNeedHookTrust(target string) bool {
+	target = cleanOptionalPath(target)
+	if target == "" {
+		return false
+	}
+	paths := []string{
+		filepath.Join(target, ".projmux", "config.toml"),
+		filepath.Join(target, ".projmux", "post-create"),
+		filepath.Join(target, ".projmux", "hooks", "pre-create"),
+		filepath.Join(target, ".projmux", "hooks", "post-create"),
+		filepath.Join(target, ".projmux", "hooks", "pane-startup"),
+		filepath.Join(target, ".projmux", "hooks", "post-attach"),
+	}
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func tmuxShellCommand(parts ...string) string {
+	quoted := make([]string, 0, len(parts))
+	for _, part := range parts {
+		quoted = append(quoted, tmuxShellQuote(part))
+	}
+	return strings.Join(quoted, " ")
 }
 
 func (c *switchCommand) runSidebarFocus(args []string, _ io.Writer, stderr io.Writer) error {
@@ -2077,6 +2207,7 @@ func printSwitchUsage(w io.Writer) {
 	fmt.Fprintln(w, "  projmux switch toggle-tag [path]")
 	fmt.Fprintln(w, "  projmux switch toggle-pin [path]")
 	fmt.Fprintln(w, "  projmux switch kill [path]")
+	fmt.Fprintln(w, "  projmux switch open <path>")
 	fmt.Fprintln(w, "  projmux switch settings")
 	fmt.Fprintln(w, "  projmux switch preview [path]")
 	fmt.Fprintln(w, "  projmux switch cycle-pane <path> <next|prev>")

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -152,6 +152,101 @@ func TestAppRunSwitchDefaultsToPopupAndOpensSelectedSession(t *testing.T) {
 	}
 }
 
+func TestSwitchExecuteSidebarHookProjectLaunchesWideOpenPopup(t *testing.T) {
+	t.Parallel()
+
+	target := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(target, ".projmux"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, ".projmux", "config.toml"), []byte("[startup]\nrun = \"agent\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sessions := &capturingSwitchSessionExecutor{exists: map[string]bool{"target": false}}
+	tmuxRunner := &recordingTmuxRunner{}
+	cmd := &switchCommand{
+		tmuxRunner: tmuxRunner,
+		sessions:   sessions,
+		executable: func() (string, error) { return "/tmp/projmux", nil },
+		identity:   stubSwitchIdentityResolver{name: "target"},
+		lookupEnv: func(name string) string {
+			if name == hookTrustPopupTargetClientEnv {
+				return "/dev/pts/9"
+			}
+			return ""
+		},
+	}
+
+	reopen, err := cmd.execute(context.Background(), switchPlan{
+		UI:          switchUISidebar,
+		Selection:   target,
+		SessionName: "target",
+	}, nil)
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+	if reopen {
+		t.Fatal("execute() reopen = true, want false")
+	}
+	if sessions.ensureSessionName != "" || sessions.openSessionName != "" {
+		t.Fatalf("sessions = ensure %q open %q, want handoff only", sessions.ensureSessionName, sessions.openSessionName)
+	}
+	if len(tmuxRunner.calls) != 1 {
+		t.Fatalf("tmux calls = %#v, want one run-shell handoff", tmuxRunner.calls)
+	}
+	call := tmuxRunner.calls[0]
+	if call.name != "tmux" || len(call.args) != 3 || call.args[0] != "run-shell" || call.args[1] != "-b" {
+		t.Fatalf("tmux call = %#v, want run-shell -b", call)
+	}
+	for _, want := range []string{
+		"display-popup",
+		"'-c' '/dev/pts/9'",
+		"PROJMUX_HOOK_TRUST_INLINE=1",
+		"'-w' '90'",
+		"'-h' '24'",
+		"switch open",
+		tmuxShellQuote(target),
+	} {
+		if !strings.Contains(call.args[2], want) {
+			t.Fatalf("run-shell command = %q, want substring %q", call.args[2], want)
+		}
+	}
+}
+
+func TestSwitchExecuteSidebarExistingHookProjectOpensDirectly(t *testing.T) {
+	t.Parallel()
+
+	target := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(target, ".projmux"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, ".projmux", "config.toml"), []byte("[startup]\nrun = \"agent\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sessions := &capturingSwitchSessionExecutor{exists: map[string]bool{"target": true}}
+	tmuxRunner := &recordingTmuxRunner{}
+	cmd := &switchCommand{
+		tmuxRunner: tmuxRunner,
+		sessions:   sessions,
+		identity:   stubSwitchIdentityResolver{name: "target"},
+	}
+
+	_, err := cmd.execute(context.Background(), switchPlan{
+		UI:          switchUISidebar,
+		Selection:   target,
+		SessionName: "target",
+	}, nil)
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+	if sessions.ensureSessionName != "target" || sessions.openSessionName != "target" {
+		t.Fatalf("sessions = ensure %q open %q, want direct open target", sessions.ensureSessionName, sessions.openSessionName)
+	}
+	if len(tmuxRunner.calls) != 0 {
+		t.Fatalf("tmux calls = %#v, want none", tmuxRunner.calls)
+	}
+}
+
 func TestAppRunSwitchDeprecatedBackendValueUsesNativeRunner(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/tmux_client.go
+++ b/internal/app/tmux_client.go
@@ -28,7 +28,7 @@ func defaultLifecycleHookRunner() *hooks.Runner {
 		return nil
 	}
 	prompt := hooks.ProjectHookPrompt(nil)
-	if strings.TrimSpace(os.Getenv("TMUX")) != "" {
+	if strings.TrimSpace(os.Getenv("TMUX")) != "" && strings.TrimSpace(os.Getenv(hookTrustInlineEnv)) == "" {
 		prompt = tmuxProjectHookPrompt(os.Getenv, os.Executable, inttmux.ExecRunner{})
 	}
 	return &hooks.Runner{

--- a/internal/app/tmux_client_test.go
+++ b/internal/app/tmux_client_test.go
@@ -57,3 +57,20 @@ func TestDefaultLifecycleHookRunnerUsesPopupPromptInsideTmux(t *testing.T) {
 		t.Fatal("ProjectHookPrompt = nil inside tmux, want popup prompt")
 	}
 }
+
+func TestDefaultLifecycleHookRunnerUsesTerminalPromptWhenInlineTrustSet(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Setenv("TMUX", "/tmp/tmux/default,1,0")
+	t.Setenv(hookTrustInlineEnv, "1")
+
+	runner := defaultLifecycleHookRunner()
+	if runner == nil {
+		t.Fatal("defaultLifecycleHookRunner() = nil")
+	}
+	if runner.ProjectHookPrompt != nil {
+		t.Fatal("ProjectHookPrompt = non-nil with inline trust env, want terminal fallback")
+	}
+}


### PR DESCRIPTION
## Summary
- avoid waiting on a nested trust popup inside the sessionizer sidebar
- hand off hook-bearing sidebar selections to a dedicated 90x24 Open project popup
- run trust confirmation inline inside that wide popup, then continue through a hidden switch open command

## Verification
- reproduced tokscale-test selection with .bin/projmux: parent switch exits and wide popup process remains waiting for trust input
- `GOCACHE=/tmp/projmux-go-cache make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test` (first run hit unrelated hooks test text-file-busy flake; rerun passed)
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `git diff --check`