### PR TITLE
fix: align popup content styling

### DIFF
--- a/internal/app/hook_trust_popup.go
+++ b/internal/app/hook_trust_popup.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/integrations/hooks"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+	"github.com/crevissepartners/projmux/internal/ui/projmuxpicker"
 )
 
 const (
 	hookTrustPopupTitle           = "Trust project hook"
 	hookTrustPopupWidth           = "90"
 	hookTrustPopupHeight          = "24"
+	hookTrustPopupContentWidth    = 86
 	hookTrustInlineEnv            = "PROJMUX_HOOK_TRUST_INLINE"
 	hookTrustPopupTargetClientEnv = "PROJMUX_HOOK_TRUST_TARGET_CLIENT"
 	hookTrustPopupTargetPaneEnv   = "PROJMUX_HOOK_TRUST_TARGET_PANE"
@@ -176,34 +178,33 @@ func (c *tmuxCommand) runHookTrustPromptWithReader(args []string, reader io.Read
 }
 
 func hookTrustPopupPrompt(reader io.Reader, writer io.Writer, req hooks.ProjectHookPromptRequest) hooks.ProjectHookDecision {
-	fmt.Fprintln(writer, "Project-local hook requires trust")
+	fmt.Fprintln(writer, projmuxpicker.CurrentStart+" Project hook trust "+projmuxpicker.Reset)
+	fmt.Fprintln(writer, hookTrustMuted("Project-local automation is disabled until this file hash is trusted."))
 	fmt.Fprintln(writer)
-	fmt.Fprintln(writer, "Repo")
-	fmt.Fprintf(writer, "  %s\n", req.RepoPath)
-	fmt.Fprintln(writer, "Hook")
-	fmt.Fprintf(writer, "  %s\n", req.RelativePath)
+	writeHookTrustField(writer, "repo", req.RepoPath)
+	writeHookTrustField(writer, "hook", req.RelativePath)
 	if req.PreviousSHA256 != "" {
-		fmt.Fprintln(writer, "Trusted SHA256")
-		fmt.Fprintf(writer, "  %s\n", req.PreviousSHA256)
+		writeHookTrustField(writer, "trusted sha", req.PreviousSHA256)
 	}
-	fmt.Fprintln(writer, "Current SHA256")
-	fmt.Fprintf(writer, "  %s\n", req.SHA256)
+	writeHookTrustField(writer, "current sha", req.SHA256)
 	if strings.TrimSpace(req.Preview) != "" {
 		fmt.Fprintln(writer)
-		fmt.Fprintln(writer, "Preview")
+		fmt.Fprintln(writer, projmuxpicker.SeparatorLine(hookTrustPopupContentWidth))
+		fmt.Fprintln(writer, hookTrustMuted("preview"))
 		for line := range strings.SplitSeq(req.Preview, "\n") {
-			fmt.Fprintf(writer, "  %s\n", line)
+			fmt.Fprintln(writer, "  "+projmuxpicker.TruncateANSI(line, hookTrustPopupContentWidth-2))
 		}
 	}
 
 	fmt.Fprintln(writer)
-	fmt.Fprintln(writer, "[o] once    run this time only")
-	fmt.Fprintln(writer, "[a] always  trust this exact file hash")
-	fmt.Fprintln(writer, "[d] deny    skip this hook")
+	fmt.Fprintln(writer, projmuxpicker.SeparatorLine(hookTrustPopupContentWidth))
+	fmt.Fprintln(writer, hookTrustActionLine("[o] once", "run this time only"))
+	fmt.Fprintln(writer, hookTrustActionLine("[a] always", "trust this exact file hash"))
+	fmt.Fprintln(writer, hookTrustActionLine("[d] deny", "skip this hook"))
 
 	input := bufio.NewReader(reader)
 	for range 3 {
-		fmt.Fprint(writer, "Select [o/a/d], then Enter: ")
+		fmt.Fprint(writer, "\n"+hookTrustMuted("choice")+"  ")
 		line, err := input.ReadString('\n')
 		if err != nil && len(line) == 0 {
 			fmt.Fprintln(writer)
@@ -213,9 +214,29 @@ func hookTrustPopupPrompt(reader io.Reader, writer io.Writer, req hooks.ProjectH
 		if decision != "" {
 			return decision
 		}
-		fmt.Fprintln(writer, "Please enter o, a, or d.")
+		fmt.Fprintln(writer, hookTrustMuted("Enter o, a, or d."))
 	}
 	return hooks.ProjectHookDeny
+}
+
+func writeHookTrustField(w io.Writer, label, value string) {
+	label = strings.TrimSpace(label)
+	value = strings.TrimSpace(value)
+	if value == "" {
+		value = "-"
+	}
+	fmt.Fprintf(w, "%s  %s\n",
+		hookTrustMuted(fmt.Sprintf("%-11s", label)),
+		projmuxpicker.TruncateANSI(value, hookTrustPopupContentWidth-13),
+	)
+}
+
+func hookTrustActionLine(action, detail string) string {
+	return fmt.Sprintf("  %-12s %s", action, hookTrustMuted(detail))
+}
+
+func hookTrustMuted(value string) string {
+	return projmuxpicker.MutedStart + value + projmuxpicker.Reset
 }
 
 func parseHookTrustDecision(value string) hooks.ProjectHookDecision {

--- a/internal/app/hook_trust_popup_test.go
+++ b/internal/app/hook_trust_popup_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/crevissepartners/projmux/internal/integrations/hooks"
+	"github.com/crevissepartners/projmux/internal/ui/projmuxpicker"
 )
 
 func TestBuildHookTrustPopupArgsTargetsWidePopup(t *testing.T) {
@@ -77,7 +78,8 @@ func TestHookTrustPromptWritesDecision(t *testing.T) {
 		t.Fatalf("decision = %q, want %q", got, want)
 	}
 	for _, want := range []string{
-		"Project-local hook requires trust",
+		"Project hook trust",
+		projmuxpicker.MutedStart,
 		"[a] always",
 		".projmux/config.toml",
 	} {

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -667,6 +667,9 @@ func statusbarUsagePopup(state statusbarUsageState, now time.Time) statusbarUsag
 func statusbarUsagePopupLines(state statusbarUsageState, now time.Time, cols int) []string {
 	rows := statusbarUsageRows(state.Snapshots)
 	lines := []string{
+		statusbarPopupTitleLine("Usage HUD"),
+		dimANSI("AI token usage windows from the local cache."),
+		"",
 		statusbarUsageSyncLine(state, now),
 		"",
 		statusbarUsageHeaderLine(),
@@ -681,7 +684,7 @@ func statusbarUsagePopupLines(state statusbarUsageState, now time.Time, cols int
 			lines = append(lines, row.render())
 		}
 	}
-	lines = append(lines, "", projmuxpicker.MutedStart+"Enter closes this popup."+projmuxpicker.Reset)
+	lines = append(lines, statusbarPopupFooterLines(cols)...)
 	return lines
 }
 
@@ -932,25 +935,22 @@ func statusbarPathPopup(path string, metadata statusbarPathMetadata) statusbarPa
 
 	const width = 84
 	contentWidth := width - 2
-	pathWidth := max(contentWidth-4, 24)
 	lines := []string{
-		projmuxpicker.HighlightStart + "Current pane path" + projmuxpicker.Reset,
+		statusbarPopupTitleLine("Current path"),
+		dimANSI("Active pane working directory."),
 		"",
-		projmuxpicker.MutedStart + "cwd" + projmuxpicker.Reset,
 	}
-	for _, line := range wrapStatusbarText(path, pathWidth) {
-		lines = append(lines, "  "+line)
-	}
+	lines = append(lines, statusbarFieldLines("cwd", path, contentWidth)...)
 	if metadata.Project != "" || metadata.Git != "" {
-		lines = append(lines, "")
+		lines = append(lines, "", projmuxpicker.SeparatorLine(contentWidth))
 		if metadata.Project != "" {
-			lines = append(lines, statusbarMetaLine("project", metadata.Project))
+			lines = append(lines, statusbarFieldLines("project", metadata.Project, contentWidth)...)
 		}
 		if metadata.Git != "" {
-			lines = append(lines, statusbarMetaLine("git", metadata.Git))
+			lines = append(lines, statusbarFieldLines("git", metadata.Git, contentWidth)...)
 		}
 	}
-	lines = append(lines, "", projmuxpicker.MutedStart+"Enter closes this popup."+projmuxpicker.Reset)
+	lines = append(lines, statusbarPopupFooterLines(contentWidth)...)
 
 	content := strings.Join(lines, "\n")
 	height := projmuxpicker.RenderedTextLineCount(content) + 2
@@ -965,8 +965,41 @@ func statusbarPathPopup(path string, metadata statusbarPathMetadata) statusbarPa
 	}
 }
 
-func statusbarMetaLine(label, value string) string {
-	return projmuxpicker.MutedStart + label + projmuxpicker.Reset + "  " + value
+func statusbarPopupTitleLine(title string) string {
+	return projmuxpicker.CurrentStart + " " + strings.TrimSpace(title) + " " + projmuxpicker.Reset
+}
+
+func statusbarPopupFooterLines(cols int) []string {
+	return []string{
+		"",
+		projmuxpicker.SeparatorLine(cols),
+		projmuxpicker.MutedStart + "Enter closes this popup." + projmuxpicker.Reset,
+	}
+}
+
+func statusbarFieldLines(label, value string, cols int) []string {
+	const labelWidth = 11
+	label = strings.TrimSpace(label)
+	value = strings.TrimSpace(value)
+	if value == "" {
+		value = "-"
+	}
+	valueWidth := max(cols-labelWidth-2, 24)
+	wrapped := wrapStatusbarText(value, valueWidth)
+	if len(wrapped) == 0 {
+		wrapped = []string{"-"}
+	}
+	lines := make([]string, 0, len(wrapped))
+	prefix := projmuxpicker.MutedStart + fmt.Sprintf("%-*s", labelWidth, label) + projmuxpicker.Reset + "  "
+	continuation := strings.Repeat(" ", labelWidth+2)
+	for i, line := range wrapped {
+		if i == 0 {
+			lines = append(lines, prefix+line)
+		} else {
+			lines = append(lines, continuation+line)
+		}
+	}
+	return lines
 }
 
 func wrapStatusbarText(value string, width int) []string {

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -272,6 +272,9 @@ func TestStatusbarClickPwdOpensPathPopupWithoutCopy(t *testing.T) {
 	if !strings.HasPrefix(command, "printf %s ") {
 		t.Fatalf("popup command = %q, want single-payload printf %%s", command)
 	}
+	if !strings.Contains(command, "Current path") || !strings.Contains(command, projmuxpicker.CurrentStart) {
+		t.Fatalf("path popup command = %q, want styled content title", command)
+	}
 	if !strings.Contains(command, "; IFS= read -r _") {
 		t.Fatalf("popup command = %q, want simple Enter read", command)
 	}
@@ -478,7 +481,7 @@ func TestStatusbarClickUsageOpensNativeHUDPopup(t *testing.T) {
 	if !sawTmuxPopupCommandContaining(runner.calls, "80%") {
 		t.Fatalf("missing percentage value; calls = %#v", runner.calls)
 	}
-	if sawTmuxPopupCommandContaining(runner.calls, "/usr/local/bin/projmux") || sawTmuxPopupCommandContaining(runner.calls, " usage") {
+	if sawTmuxPopupCommandContaining(runner.calls, "/usr/local/bin/projmux") || sawTmuxPopupCommandContaining(runner.calls, "'usage'") {
 		t.Fatalf("usage popup should render structured content, not run raw projmux usage; calls = %#v", runner.calls)
 	}
 	if sawTmuxPopupCommandContaining(runner.calls, "read -n1 -s") {
@@ -490,6 +493,9 @@ func TestStatusbarClickUsageOpensNativeHUDPopup(t *testing.T) {
 	}
 	if !strings.HasPrefix(command, "printf %s ") || strings.Contains(command, "printf '%s\\n'") {
 		t.Fatalf("usage popup command = %q, want single-payload printf", command)
+	}
+	if !strings.Contains(command, "Usage HUD") || !strings.Contains(command, projmuxpicker.CurrentStart) {
+		t.Fatalf("usage popup command = %q, want styled content title", command)
 	}
 	if !strings.Contains(command, "; IFS= read -r _") {
 		t.Fatalf("usage popup command = %q, want simple Enter read", command)


### PR DESCRIPTION
## Summary
- restyle the hook trust gate with the same native popup color tokens, muted labels, separators, and compact action rows
- align cwd popup content with title/subtitle, label-value rows, wrapped continuations, and standard footer chrome
- align usage HUD with a styled content title, subtitle, and standard footer separator

## Tests
- `GOCACHE=/tmp/projmux-go-cache make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `git diff --check`