### PR TITLE
feat: add settings axis metadata

### DIFF
--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -36,6 +36,70 @@ type settingsCommand struct {
 
 var errSettingsClosed = errors.New("settings closed")
 
+type SettingsAxis uint8
+
+const (
+	settingsAxisGlobal SettingsAxis = 1 << iota
+	settingsAxisProject
+	settingsAxisBoth = settingsAxisGlobal | settingsAxisProject
+)
+
+type settingsEntryMeta struct {
+	Name string
+	Axis SettingsAxis
+}
+
+var settingsEntryCatalog = map[string]settingsEntryMeta{
+	settingsBackValue:          {Name: "Back", Axis: settingsAxisGlobal},
+	settingsNoopValue:          {Name: "Info", Axis: settingsAxisGlobal},
+	settingsSectionProject:     {Name: "Project Picker", Axis: settingsAxisGlobal},
+	settingsSectionAI:          {Name: "AI Settings", Axis: settingsAxisGlobal},
+	settingsSectionStatusbar:   {Name: "Appearance", Axis: settingsAxisGlobal},
+	settingsSectionKeybindings: {Name: "Keybindings", Axis: settingsAxisGlobal},
+	settingsSectionLabs:        {Name: "Labs", Axis: settingsAxisGlobal},
+	settingsSectionAbout:       {Name: "About", Axis: settingsAxisGlobal},
+	settingsProjectAdd:         {Name: "Add Project", Axis: settingsAxisGlobal},
+	settingsProjectPins:        {Name: "Pinned Projects", Axis: settingsAxisGlobal},
+	settingsProjectRootManage:  {Name: "Project Root", Axis: settingsAxisGlobal},
+	settingsProjdirClear:       {Name: "Clear Project Root", Axis: settingsAxisGlobal},
+	settingsProjdirSetCurrent:  {Name: "Use Current Project as Root", Axis: settingsAxisGlobal},
+	settingsProjdirSetTyped:    {Name: "Set Project Root", Axis: settingsAxisGlobal},
+	settingsWorkdirAdd:         {Name: "Add Workdir", Axis: settingsAxisGlobal},
+	settingsWorkdirList:        {Name: "Workdirs", Axis: settingsAxisGlobal},
+	settingsWorkdirTyped:       {Name: "Type Workdir", Axis: settingsAxisGlobal},
+	settingsLabKeybindings:     {Name: "Diagnose Keybindings", Axis: settingsAxisGlobal},
+	settingsUpdateApply:        {Name: "Update Now", Axis: settingsAxisGlobal},
+	settingsUpdateCheck:        {Name: "Check Updates", Axis: settingsAxisGlobal},
+}
+
+var settingsEntryPrefixCatalog = []struct {
+	prefix string
+	meta   settingsEntryMeta
+}{
+	{settingsActionPrefixAI, settingsEntryMeta{Name: "AI Settings", Axis: settingsAxisGlobal}},
+	{settingsActionPrefixHooks, settingsEntryMeta{Name: "Project hook policy", Axis: settingsAxisGlobal}},
+	{settingsActionPrefixKeymap, settingsEntryMeta{Name: "Keybindings", Axis: settingsAxisGlobal}},
+	{settingsActionPrefixLabKeymap, settingsEntryMeta{Name: "Keybinding diagnostics", Axis: settingsAxisGlobal}},
+	{settingsActionPrefixPicker, settingsEntryMeta{Name: "Picker backend", Axis: settingsAxisGlobal}},
+	{settingsActionPrefixProjdir, settingsEntryMeta{Name: "Project Root", Axis: settingsAxisGlobal}},
+	{settingsActionPrefixStatusbar, settingsEntryMeta{Name: "Appearance", Axis: settingsAxisGlobal}},
+	{settingsActionPrefixSwitch, settingsEntryMeta{Name: "Pinned Projects", Axis: settingsAxisGlobal}},
+	{settingsActionPrefixUpdate, settingsEntryMeta{Name: "About", Axis: settingsAxisGlobal}},
+	{settingsActionPrefixWorkdir, settingsEntryMeta{Name: "Workdirs", Axis: settingsAxisGlobal}},
+}
+
+func settingsEntryMetaForValue(value string) (settingsEntryMeta, bool) {
+	if meta, ok := settingsEntryCatalog[value]; ok {
+		return meta, true
+	}
+	for _, candidate := range settingsEntryPrefixCatalog {
+		if strings.HasPrefix(value, candidate.prefix) {
+			return candidate.meta, true
+		}
+	}
+	return settingsEntryMeta{}, false
+}
+
 const (
 	settingsBackValue             = "__settings_back__"
 	settingsNoopValue             = "__settings_noop__"

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -18,6 +18,124 @@ import (
 	"github.com/crevissepartners/projmux/internal/version"
 )
 
+func TestSettingsRootEntriesHaveAxisMetadata(t *testing.T) {
+	t.Parallel()
+
+	cmd := &settingsCommand{}
+	want := map[string]settingsEntryMeta{
+		settingsSectionProject:     {Name: "Project Picker", Axis: settingsAxisGlobal},
+		settingsSectionAI:          {Name: "AI Settings", Axis: settingsAxisGlobal},
+		settingsSectionStatusbar:   {Name: "Appearance", Axis: settingsAxisGlobal},
+		settingsSectionKeybindings: {Name: "Keybindings", Axis: settingsAxisGlobal},
+		settingsSectionLabs:        {Name: "Labs", Axis: settingsAxisGlobal},
+		settingsSectionAbout:       {Name: "About", Axis: settingsAxisGlobal},
+	}
+
+	seen := map[string]bool{}
+	for _, entry := range cmd.rootEntries() {
+		meta, ok := settingsEntryMetaForValue(entry.Value)
+		if !ok {
+			t.Fatalf("root entry value %q missing settings axis metadata", entry.Value)
+		}
+		if got := meta; got != want[entry.Value] {
+			t.Fatalf("root entry value %q metadata = %#v, want %#v", entry.Value, got, want[entry.Value])
+		}
+		seen[entry.Value] = true
+	}
+	for value := range want {
+		if !seen[value] {
+			t.Fatalf("root entries missing catalogued value %q", value)
+		}
+	}
+}
+
+func TestSettingsEntryCatalogClassifiesRelevantRowsAndActions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		value string
+		axis  SettingsAxis
+	}{
+		{settingsProjectRootManage, settingsAxisGlobal},
+		{settingsWorkdirList, settingsAxisGlobal},
+		{settingsProjectPins, settingsAxisGlobal},
+		{settingsActionPrefixAI + aiModeCodex, settingsAxisGlobal},
+		{settingsActionPrefixStatusbar + string(config.StatusbarDecorationSymbol), settingsAxisGlobal},
+		{settingsActionPrefixKeymap + "settings", settingsAxisGlobal},
+		{settingsActionPrefixHooks + string(config.ProjectHooksOn), settingsAxisGlobal},
+	}
+
+	for _, tc := range cases {
+		meta, ok := settingsEntryMetaForValue(tc.value)
+		if !ok {
+			t.Fatalf("settings entry value %q missing catalog metadata", tc.value)
+		}
+		if got := meta.Axis; got != tc.axis {
+			t.Fatalf("settings entry value %q axis = %b, want %b", tc.value, got, tc.axis)
+		}
+	}
+}
+
+func TestSettingsEntryBuildersEmitCataloguedValues(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cmd := &settingsCommand{
+		ai:       testAICommand(home),
+		switcher: testSettingsSwitchCommandWithHome(t, home, &stubSwitchPinStore{}),
+		homeDir:  func() (string, error) { return home, nil },
+		lookupEnv: func(string) string {
+			return ""
+		},
+	}
+
+	assertCataloguedEntries := func(name string, entries []intpickercompat.Entry) {
+		t.Helper()
+		for _, entry := range entries {
+			if _, ok := settingsEntryMetaForValue(entry.Value); !ok {
+				t.Fatalf("%s entry value %q missing settings axis metadata", name, entry.Value)
+			}
+		}
+	}
+
+	assertCataloguedEntries("root", cmd.rootEntries())
+	assertCataloguedEntries("ai", cmd.aiEntries())
+	assertCataloguedEntries("appearance", cmd.statusbarEntries())
+	assertCataloguedEntries("project picker", cmd.projectPickerEntries())
+	assertCataloguedEntries("labs", cmd.labsEntries())
+
+	projectRootEntries, err := cmd.projectRootEntries()
+	if err != nil {
+		t.Fatalf("projectRootEntries() error = %v", err)
+	}
+	assertCataloguedEntries("project root", projectRootEntries)
+
+	workdirEntries, err := cmd.workdirListEntries()
+	if err != nil {
+		t.Fatalf("workdirListEntries() error = %v", err)
+	}
+	assertCataloguedEntries("workdirs", workdirEntries)
+
+	pinnedProjectEntries, err := cmd.pinnedProjectEntries()
+	if err != nil {
+		t.Fatalf("pinnedProjectEntries() error = %v", err)
+	}
+	assertCataloguedEntries("pinned projects", pinnedProjectEntries)
+
+	for _, value := range []string{
+		settingsActionPrefixKeymap + "settings",
+		settingsActionPrefixLabKeymap + "settings",
+		settingsActionPrefixWorkdir + "remove:/tmp/work",
+		settingsActionPrefixSwitch + "add:/tmp/project",
+		settingsActionPrefixSwitch + "pin:/tmp/project",
+		settingsActionPrefixSwitch + "clear",
+	} {
+		if _, ok := settingsEntryMetaForValue(value); !ok {
+			t.Fatalf("representative generated value %q missing settings axis metadata", value)
+		}
+	}
+}
+
 func TestSettingsHubSetsAIDefaultMode(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add explicit Settings axis metadata for current settings sections and actions
- classify current global settings policy entries without changing UI behavior
- add regression coverage for catalogued settings values

## Tests
- make fmt
- GOCACHE=/tmp/projmux-go-cache make fix
- GOCACHE=/tmp/projmux-go-cache make test
- GOCACHE=/tmp/projmux-go-cache make test-integration
- GOCACHE=/tmp/projmux-go-cache make test-e2e