### PR TITLE
feat: add session snapshot store

### DIFF
--- a/internal/integrations/sessionstate/store.go
+++ b/internal/integrations/sessionstate/store.go
@@ -1,0 +1,292 @@
+// Package sessionstate stores versioned tmux session snapshots.
+//
+// Phase 1 writes snapshots with a same-directory temp file followed by atomic
+// rename. It does not use a cross-process file lock yet.
+package sessionstate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// Version is the current on-disk session snapshot schema version.
+	Version = 1
+
+	sessionDirName = "sessions"
+	fileMode       = 0o644
+)
+
+var (
+	ErrInvalidSessionName = errors.New("invalid session name")
+	ErrNotFound           = errors.New("session snapshot not found")
+	ErrMissingVersion     = errors.New("session snapshot version is missing")
+	ErrUnsupportedVersion = errors.New("unsupported session snapshot version")
+	ErrInvalidSnapshot    = errors.New("invalid session snapshot")
+	ErrMalformedJSON      = errors.New("malformed session snapshot JSON")
+)
+
+// Snapshot is the versioned on-disk record for one tmux session. Phase 1 only
+// records enough metadata to read and write the snapshot; replay is handled by
+// a later phase.
+type Snapshot struct {
+	Version    int       `json:"version"`
+	Session    string    `json:"session"`
+	DefaultCWD string    `json:"default_cwd,omitempty"`
+	SavedAt    time.Time `json:"saved_at"`
+	Windows    []Window  `json:"windows"`
+}
+
+// Window describes one tmux window in session order.
+type Window struct {
+	Index           int    `json:"index"`
+	Name            string `json:"name"`
+	Layout          string `json:"layout,omitempty"`
+	ActivePaneIndex int    `json:"active_pane_index"`
+	Panes           []Pane `json:"panes"`
+}
+
+// Pane describes one tmux pane and the recipe metadata needed by future replay.
+type Pane struct {
+	Index  int    `json:"index"`
+	CWD    string `json:"cwd"`
+	Recipe Recipe `json:"recipe"`
+}
+
+// Recipe records how a pane should be classified for future restore.
+type Recipe struct {
+	Kind     string `json:"kind"`
+	Agent    string `json:"agent,omitempty"`
+	ResumeID string `json:"resume_id,omitempty"`
+	Topic    string `json:"topic,omitempty"`
+}
+
+const (
+	RecipeKindShell = "shell"
+	RecipeKindAgent = "agent"
+)
+
+// ShellRecipe returns the plain-shell recipe form.
+func ShellRecipe() Recipe {
+	return Recipe{Kind: RecipeKindShell}
+}
+
+// AgentRecipe returns the agent recipe form with resume metadata.
+func AgentRecipe(agent, resumeID, topic string) Recipe {
+	return Recipe{
+		Kind:     RecipeKindAgent,
+		Agent:    agent,
+		ResumeID: resumeID,
+		Topic:    topic,
+	}
+}
+
+// Store persists session snapshots below Dir.
+type Store struct {
+	Dir string
+}
+
+// NewStore builds a session snapshot store rooted at dir. Tests should pass a
+// temp directory here to avoid writing to the real user state directory.
+func NewStore(dir string) Store {
+	return Store{Dir: dir}
+}
+
+// NewDefaultStoreFromEnv resolves the default
+// ${XDG_STATE_HOME:-$HOME/.local/state}/projmux/sessions store.
+func NewDefaultStoreFromEnv() (Store, error) {
+	dir, err := DefaultDirFromEnv()
+	if err != nil {
+		return Store{}, err
+	}
+	return NewStore(dir), nil
+}
+
+// DefaultDirFromEnv resolves the default session snapshot directory.
+func DefaultDirFromEnv() (string, error) {
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("sessionstate: resolve user home: %w", err)
+		}
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(stateHome, "projmux", sessionDirName), nil
+}
+
+// Path returns the snapshot JSON path for session.
+func (s Store) Path(session string) (string, error) {
+	if err := validateSessionName(session); err != nil {
+		return "", err
+	}
+	return filepath.Join(s.Dir, session+".json"), nil
+}
+
+// Load reads and validates a session snapshot.
+func (s Store) Load(session string) (Snapshot, error) {
+	path, err := s.Path(session)
+	if err != nil {
+		return Snapshot{}, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Snapshot{}, fmt.Errorf("%w: %s", ErrNotFound, path)
+		}
+		return Snapshot{}, fmt.Errorf("sessionstate: read snapshot %s: %w", path, err)
+	}
+
+	var snap Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return Snapshot{}, fmt.Errorf("%w %s: %w", ErrMalformedJSON, path, err)
+	}
+	if err := snap.Validate(); err != nil {
+		return Snapshot{}, fmt.Errorf("sessionstate: validate snapshot %s: %w", path, err)
+	}
+	if snap.Session != session {
+		return Snapshot{}, fmt.Errorf("%w: path session %q does not match snapshot session %q", ErrInvalidSnapshot, session, snap.Session)
+	}
+	return snap.normalize(), nil
+}
+
+// Save validates and atomically writes snap to its session path using a
+// same-directory temp file followed by rename.
+func (s Store) Save(snap Snapshot) error {
+	if err := snap.Validate(); err != nil {
+		return err
+	}
+
+	snap = snap.normalize()
+	path, err := s.Path(snap.Session)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(s.Dir, 0o755); err != nil {
+		return fmt.Errorf("sessionstate: create snapshot dir %s: %w", s.Dir, err)
+	}
+
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return fmt.Errorf("sessionstate: encode snapshot: %w", err)
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(s.Dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("sessionstate: create temp snapshot: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if err := tmp.Chmod(fileMode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sessionstate: chmod temp snapshot: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sessionstate: write temp snapshot: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("sessionstate: close temp snapshot: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("sessionstate: rename temp snapshot: %w", err)
+	}
+	cleanup = false
+	return nil
+}
+
+// Validate checks the schema version and required restore metadata.
+func (s Snapshot) Validate() error {
+	if s.Version == 0 {
+		return ErrMissingVersion
+	}
+	if s.Version != Version {
+		return fmt.Errorf("%w: %d", ErrUnsupportedVersion, s.Version)
+	}
+	if err := validateSessionName(s.Session); err != nil {
+		return err
+	}
+	if s.SavedAt.IsZero() {
+		return fmt.Errorf("%w: saved_at is required", ErrInvalidSnapshot)
+	}
+	if s.DefaultCWD != "" && !filepath.IsAbs(s.DefaultCWD) {
+		return fmt.Errorf("%w: default_cwd must be absolute", ErrInvalidSnapshot)
+	}
+	for wi, window := range s.Windows {
+		if window.Index < 0 {
+			return fmt.Errorf("%w: window %d index must be non-negative", ErrInvalidSnapshot, wi)
+		}
+		if window.ActivePaneIndex < 0 {
+			return fmt.Errorf("%w: window %d active_pane_index must be non-negative", ErrInvalidSnapshot, wi)
+		}
+		activePaneFound := len(window.Panes) == 0
+		for pi, pane := range window.Panes {
+			if pane.Index < 0 {
+				return fmt.Errorf("%w: window %d pane %d index must be non-negative", ErrInvalidSnapshot, wi, pi)
+			}
+			if pane.Index == window.ActivePaneIndex {
+				activePaneFound = true
+			}
+			if pane.CWD == "" {
+				return fmt.Errorf("%w: window %d pane %d cwd is required", ErrInvalidSnapshot, wi, pi)
+			}
+			if !filepath.IsAbs(pane.CWD) {
+				return fmt.Errorf("%w: window %d pane %d cwd must be absolute", ErrInvalidSnapshot, wi, pi)
+			}
+			if err := pane.Recipe.Validate(); err != nil {
+				return fmt.Errorf("%w: window %d pane %d recipe: %w", ErrInvalidSnapshot, wi, pi, err)
+			}
+		}
+		if !activePaneFound {
+			return fmt.Errorf("%w: window %d active_pane_index %d does not match a pane index", ErrInvalidSnapshot, wi, window.ActivePaneIndex)
+		}
+	}
+	return nil
+}
+
+// Validate checks that the recipe is one of the Phase 1 forms.
+func (r Recipe) Validate() error {
+	switch r.Kind {
+	case RecipeKindShell:
+		if r.Agent != "" || r.ResumeID != "" || r.Topic != "" {
+			return fmt.Errorf("%w: shell recipe cannot include agent metadata", ErrInvalidSnapshot)
+		}
+	case RecipeKindAgent:
+		if strings.TrimSpace(r.Agent) == "" {
+			return fmt.Errorf("%w: agent recipe requires agent", ErrInvalidSnapshot)
+		}
+	case "":
+		return fmt.Errorf("%w: recipe kind is required", ErrInvalidSnapshot)
+	default:
+		return fmt.Errorf("%w: unsupported recipe kind %q", ErrInvalidSnapshot, r.Kind)
+	}
+	return nil
+}
+
+func (s Snapshot) normalize() Snapshot {
+	s.SavedAt = s.SavedAt.UTC()
+	return s
+}
+
+func validateSessionName(session string) error {
+	if strings.TrimSpace(session) == "" {
+		return ErrInvalidSessionName
+	}
+	if session == "." || session == ".." || filepath.IsAbs(session) || strings.ContainsAny(session, `/\`) {
+		return fmt.Errorf("%w: %q", ErrInvalidSessionName, session)
+	}
+	return nil
+}

--- a/internal/integrations/sessionstate/store_test.go
+++ b/internal/integrations/sessionstate/store_test.go
@@ -1,0 +1,342 @@
+package sessionstate
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStoreRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore(t.TempDir())
+	want := sampleSnapshot()
+
+	if err := store.Save(want); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	got, err := store.Load(want.Session)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Load() = %#v, want %#v", got, want)
+	}
+
+	data, err := os.ReadFile(mustPath(t, store, want.Session))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal(raw) error = %v", err)
+	}
+	if raw["default_cwd"] != want.DefaultCWD {
+		t.Fatalf("default_cwd = %#v, want %q", raw["default_cwd"], want.DefaultCWD)
+	}
+	windows, ok := raw["windows"].([]any)
+	if !ok || len(windows) != 1 {
+		t.Fatalf("windows = %#v, want one window", raw["windows"])
+	}
+	window, ok := windows[0].(map[string]any)
+	if !ok {
+		t.Fatalf("window = %#v, want object", windows[0])
+	}
+	if window["layout"] != want.Windows[0].Layout {
+		t.Fatalf("layout = %#v, want %q", window["layout"], want.Windows[0].Layout)
+	}
+	if window["active_pane_index"] != float64(want.Windows[0].ActivePaneIndex) {
+		t.Fatalf("active_pane_index = %#v, want %d", window["active_pane_index"], want.Windows[0].ActivePaneIndex)
+	}
+}
+
+func TestStoreDefaultPathFromEnvUsesXDGStateHome(t *testing.T) {
+	xdgState := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", xdgState)
+
+	store, err := NewDefaultStoreFromEnv()
+	if err != nil {
+		t.Fatalf("NewDefaultStoreFromEnv() error = %v", err)
+	}
+
+	path, err := store.Path("home")
+	if err != nil {
+		t.Fatalf("Path() error = %v", err)
+	}
+	want := filepath.Join(xdgState, "projmux", "sessions", "home.json")
+	if path != want {
+		t.Fatalf("Path() = %q, want %q", path, want)
+	}
+}
+
+func TestStoreDefaultPathFromEnvFallsBackToHomeState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", "")
+
+	store, err := NewDefaultStoreFromEnv()
+	if err != nil {
+		t.Fatalf("NewDefaultStoreFromEnv() error = %v", err)
+	}
+
+	path, err := store.Path("home")
+	if err != nil {
+		t.Fatalf("Path() error = %v", err)
+	}
+	want := filepath.Join(home, ".local", "state", "projmux", "sessions", "home.json")
+	if path != want {
+		t.Fatalf("Path() = %q, want %q", path, want)
+	}
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewStore(t.TempDir()).Load("missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Load() error = %v, want %v", err, ErrNotFound)
+	}
+}
+
+func TestLoadMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore(t.TempDir())
+	path := mustPath(t, store, "home")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"version":`), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := store.Load("home")
+	if !errors.Is(err, ErrMalformedJSON) {
+		t.Fatalf("Load() error = %v, want %v", err, ErrMalformedJSON)
+	}
+}
+
+func TestLoadMissingVersion(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore(t.TempDir())
+	writeSnapshotJSON(t, store, "home", map[string]any{
+		"session":  "home",
+		"saved_at": "2026-05-11T12:34:56Z",
+		"windows":  []any{},
+	})
+
+	_, err := store.Load("home")
+	if !errors.Is(err, ErrMissingVersion) {
+		t.Fatalf("Load() error = %v, want %v", err, ErrMissingVersion)
+	}
+}
+
+func TestLoadUnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore(t.TempDir())
+	writeSnapshotJSON(t, store, "home", map[string]any{
+		"version":  2,
+		"session":  "home",
+		"saved_at": "2026-05-11T12:34:56Z",
+		"windows":  []any{},
+	})
+
+	_, err := store.Load("home")
+	if !errors.Is(err, ErrUnsupportedVersion) {
+		t.Fatalf("Load() error = %v, want %v", err, ErrUnsupportedVersion)
+	}
+}
+
+func TestLoadRejectsMissingPaneCWD(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore(t.TempDir())
+	writeSnapshotJSON(t, store, "home", map[string]any{
+		"version":  Version,
+		"session":  "home",
+		"saved_at": "2026-05-11T12:34:56Z",
+		"windows": []any{
+			map[string]any{
+				"index": 0,
+				"name":  "main",
+				"panes": []any{
+					map[string]any{
+						"index":  0,
+						"recipe": map[string]any{"kind": "shell"},
+					},
+				},
+			},
+		},
+	})
+
+	_, err := store.Load("home")
+	if !errors.Is(err, ErrInvalidSnapshot) || !strings.Contains(err.Error(), "cwd is required") {
+		t.Fatalf("Load() error = %v, want invalid snapshot cwd error", err)
+	}
+}
+
+func TestLoadRejectsInvalidDefaultCWD(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore(t.TempDir())
+	snap := sampleSnapshot()
+	snap.DefaultCWD = "relative"
+	writeSnapshotJSON(t, store, "home", snap)
+
+	_, err := store.Load("home")
+	if !errors.Is(err, ErrInvalidSnapshot) || !strings.Contains(err.Error(), "default_cwd") {
+		t.Fatalf("Load() error = %v, want invalid default_cwd error", err)
+	}
+}
+
+func TestLoadRejectsInvalidActivePaneIndex(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore(t.TempDir())
+	snap := sampleSnapshot()
+	snap.Windows[0].ActivePaneIndex = 9
+	writeSnapshotJSON(t, store, "home", snap)
+
+	_, err := store.Load("home")
+	if !errors.Is(err, ErrInvalidSnapshot) || !strings.Contains(err.Error(), "active_pane_index") {
+		t.Fatalf("Load() error = %v, want invalid active_pane_index error", err)
+	}
+}
+
+func TestSaveRejectsUnsafeSessionName(t *testing.T) {
+	t.Parallel()
+
+	snap := sampleSnapshot()
+	snap.Session = "../home"
+	if err := NewStore(t.TempDir()).Save(snap); !errors.Is(err, ErrInvalidSessionName) {
+		t.Fatalf("Save() error = %v, want %v", err, ErrInvalidSessionName)
+	}
+}
+
+func TestSaveUsesFinalPathAndCleansTempFile(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore(t.TempDir())
+	snap := sampleSnapshot()
+	if err := store.Save(snap); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	path := mustPath(t, store, snap.Session)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Stat(final) error = %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(store.Dir, ".*.tmp-*"))
+	if err != nil {
+		t.Fatalf("Glob() error = %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temp files left behind = %v, want none", matches)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != fileMode {
+		t.Fatalf("mode = %v, want %v", got, os.FileMode(fileMode))
+	}
+}
+
+func TestRecipeJSONForms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   Recipe
+		want string
+	}{
+		{
+			name: "shell",
+			in:   ShellRecipe(),
+			want: `{"kind":"shell"}`,
+		},
+		{
+			name: "agent",
+			in:   AgentRecipe("claude", "abcdef-1234", "keybinding in-app"),
+			want: `{"kind":"agent","agent":"claude","resume_id":"abcdef-1234","topic":"keybinding in-app"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := json.Marshal(tt.in)
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+			if string(got) != tt.want {
+				t.Fatalf("Marshal() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func sampleSnapshot() Snapshot {
+	return Snapshot{
+		Version:    Version,
+		Session:    "home",
+		DefaultCWD: "/home/tester/source/repos/projmux",
+		SavedAt:    time.Date(2026, 5, 11, 12, 34, 56, 0, time.UTC),
+		Windows: []Window{
+			{
+				Index:           0,
+				Name:            "projmux",
+				Layout:          "d3a9,120x36,0,0{60x36,0,0,1,59x36,61,0,2}",
+				ActivePaneIndex: 1,
+				Panes: []Pane{
+					{
+						Index:  0,
+						CWD:    "/home/tester/source/repos/projmux",
+						Recipe: ShellRecipe(),
+					},
+					{
+						Index:  1,
+						CWD:    "/home/tester/source/repos/projmux",
+						Recipe: AgentRecipe("claude", "abcdef-1234", "keybinding in-app"),
+					},
+				},
+			},
+		},
+	}
+}
+
+func mustPath(t *testing.T, store Store, session string) string {
+	t.Helper()
+
+	path, err := store.Path(session)
+	if err != nil {
+		t.Fatalf("Path() error = %v", err)
+	}
+	return path
+}
+
+func writeSnapshotJSON(t *testing.T, store Store, session string, body any) {
+	t.Helper()
+
+	path := mustPath(t, store, session)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add versioned session snapshot schema for session/window/pane metadata
- add XDG state-backed snapshot store with atomic JSON save/load
- cover shell and agent recipe forms plus malformed/unsupported snapshot cases

## Tests
- make fmt
- GOCACHE=/tmp/projmux-go-cache make fix
- GOCACHE=/tmp/projmux-go-cache make test
- GOCACHE=/tmp/projmux-go-cache make test-integration
- GOCACHE=/tmp/projmux-go-cache make test-e2e

## Notes
- Phase 1 intentionally does not implement layout replay, tmux send-keys, agent resume adapters, or cross-process file locking.