### PR TITLE
feat: add session snapshot replay

### DIFF
--- a/internal/integrations/sessionstate/replay.go
+++ b/internal/integrations/sessionstate/replay.go
@@ -1,0 +1,209 @@
+package sessionstate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Runner is the command execution surface used by replay. It intentionally
+// matches the tmux command runner shape used elsewhere without importing tmux.
+type Runner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// ReplayOptions controls cwd fallback behavior while restoring a snapshot.
+type ReplayOptions struct {
+	// FallbackCWD is used when a stored cwd no longer exists. When empty or
+	// unusable, panes fall back to the snapshot default cwd and then $HOME.
+	FallbackCWD string
+}
+
+// ReplayResult reports non-fatal restore decisions.
+type ReplayResult struct {
+	Warnings []ReplayWarning
+}
+
+// ReplayWarning describes a cwd fallback used during restore.
+type ReplayWarning struct {
+	Scope       string
+	WindowIndex int
+	PaneIndex   int
+	CWD         string
+	FallbackCWD string
+	Reason      string
+}
+
+// Replay creates a detached tmux session and replays its saved window, pane,
+// and layout metadata. It intentionally does not execute shell, startup, or
+// agent recipes; later phases can layer command replay on top.
+func Replay(ctx context.Context, runner Runner, snap Snapshot, opts ReplayOptions) (ReplayResult, error) {
+	var result ReplayResult
+	if runner == nil {
+		return result, fmt.Errorf("sessionstate: replay runner is required")
+	}
+	if err := snap.Validate(); err != nil {
+		return result, err
+	}
+
+	resolver, err := newCWDResolver(opts, snap.DefaultCWD)
+	if err != nil {
+		return result, err
+	}
+
+	windows := sortedWindows(snap.Windows)
+	sessionCWD := resolver.resolveSession(snap.DefaultCWD, &result)
+	firstWindowName := ""
+	createCWD := sessionCWD
+	if len(windows) > 0 {
+		firstWindowName = windows[0].Name
+		if panes := sortedPanes(windows[0].Panes); len(panes) > 0 {
+			createCWD = resolver.resolvePane(panes[0].CWD, windows[0].Index, panes[0].Index, &result)
+		}
+	}
+
+	if _, err := runner.Run(ctx, "tmux", "new-session", "-d", "-s", snap.Session, "-c", createCWD); err != nil {
+		return result, fmt.Errorf("replay tmux session %q: %w", snap.Session, err)
+	}
+	if len(windows) == 0 {
+		return result, nil
+	}
+	if strings.TrimSpace(firstWindowName) != "" {
+		if _, err := runner.Run(ctx, "tmux", "rename-window", "-t", windowTarget(snap.Session, windows[0].Index), firstWindowName); err != nil {
+			return result, fmt.Errorf("replay tmux window %d name: %w", windows[0].Index, err)
+		}
+	}
+
+	for windowOffset, window := range windows {
+		panes := sortedPanes(window.Panes)
+		windowCWD := sessionCWD
+		if len(panes) > 0 {
+			if windowOffset == 0 {
+				windowCWD = createCWD
+			} else {
+				windowCWD = resolver.resolvePane(panes[0].CWD, window.Index, panes[0].Index, &result)
+			}
+		}
+
+		if windowOffset > 0 {
+			args := []string{"new-window", "-d", "-t", windowTarget(snap.Session, window.Index), "-c", windowCWD}
+			if strings.TrimSpace(window.Name) != "" {
+				args = append(args, "-n", window.Name)
+			}
+			if _, err := runner.Run(ctx, "tmux", args...); err != nil {
+				return result, fmt.Errorf("replay tmux window %d: %w", window.Index, err)
+			}
+		}
+
+		for paneOffset := 1; paneOffset < len(panes); paneOffset++ {
+			pane := panes[paneOffset]
+			cwd := resolver.resolvePane(pane.CWD, window.Index, pane.Index, &result)
+			targetPane := panes[paneOffset-1].Index
+			if _, err := runner.Run(ctx, "tmux", "split-window", "-d", "-t", paneTarget(snap.Session, window.Index, targetPane), "-c", cwd); err != nil {
+				return result, fmt.Errorf("replay tmux window %d pane %d: %w", window.Index, pane.Index, err)
+			}
+		}
+
+		if strings.TrimSpace(window.Layout) != "" {
+			if _, err := runner.Run(ctx, "tmux", "select-layout", "-t", windowTarget(snap.Session, window.Index), window.Layout); err != nil {
+				return result, fmt.Errorf("replay tmux window %d layout: %w", window.Index, err)
+			}
+		}
+		if len(panes) > 0 {
+			if _, err := runner.Run(ctx, "tmux", "select-pane", "-t", paneTarget(snap.Session, window.Index, window.ActivePaneIndex)); err != nil {
+				return result, fmt.Errorf("replay tmux window %d active pane %d: %w", window.Index, window.ActivePaneIndex, err)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+type cwdResolver struct {
+	fallbackCWD string
+	defaultCWD  string
+	homeCWD     string
+}
+
+func newCWDResolver(opts ReplayOptions, defaultCWD string) (cwdResolver, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return cwdResolver{}, fmt.Errorf("sessionstate: resolve fallback home: %w", err)
+	}
+	resolver := cwdResolver{homeCWD: home}
+	if isExistingDir(opts.FallbackCWD) {
+		resolver.fallbackCWD = opts.FallbackCWD
+	}
+	if isExistingDir(defaultCWD) {
+		resolver.defaultCWD = defaultCWD
+	}
+	return resolver, nil
+}
+
+func (r cwdResolver) resolveSession(cwd string, result *ReplayResult) string {
+	return r.resolve(cwd, "session", -1, -1, []string{r.fallbackCWD, r.homeCWD}, result)
+}
+
+func (r cwdResolver) resolvePane(cwd string, windowIndex, paneIndex int, result *ReplayResult) string {
+	return r.resolve(cwd, "pane", windowIndex, paneIndex, []string{r.fallbackCWD, r.defaultCWD, r.homeCWD}, result)
+}
+
+func (r cwdResolver) resolve(cwd, scope string, windowIndex, paneIndex int, fallbacks []string, result *ReplayResult) string {
+	if isExistingDir(cwd) {
+		return cwd
+	}
+
+	fallback := r.homeCWD
+	for _, candidate := range fallbacks {
+		if isExistingDir(candidate) {
+			fallback = candidate
+			break
+		}
+	}
+	if result != nil && strings.TrimSpace(cwd) != "" {
+		result.Warnings = append(result.Warnings, ReplayWarning{
+			Scope:       scope,
+			WindowIndex: windowIndex,
+			PaneIndex:   paneIndex,
+			CWD:         cwd,
+			FallbackCWD: fallback,
+			Reason:      "cwd does not exist",
+		})
+	}
+	return fallback
+}
+
+func isExistingDir(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func sortedWindows(windows []Window) []Window {
+	out := append([]Window(nil), windows...)
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Index < out[j].Index
+	})
+	return out
+}
+
+func sortedPanes(panes []Pane) []Pane {
+	out := append([]Pane(nil), panes...)
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Index < out[j].Index
+	})
+	return out
+}
+
+func windowTarget(session string, windowIndex int) string {
+	return session + ":" + strconv.Itoa(windowIndex)
+}
+
+func paneTarget(session string, windowIndex, paneIndex int) string {
+	return windowTarget(session, windowIndex) + "." + strconv.Itoa(paneIndex)
+}

--- a/internal/integrations/sessionstate/replay_test.go
+++ b/internal/integrations/sessionstate/replay_test.go
@@ -1,0 +1,224 @@
+package sessionstate
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReplaySingleWindowSinglePane(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	snap := replaySnapshot(cwd)
+	snap.Windows = []Window{
+		{
+			Index:           0,
+			Name:            "main",
+			Layout:          "b25d,120x36,0,0,1",
+			ActivePaneIndex: 0,
+			Panes: []Pane{
+				{Index: 0, CWD: cwd, Recipe: ShellRecipe()},
+			},
+		},
+	}
+	runner := &recordingReplayRunner{}
+
+	result, err := Replay(context.Background(), runner, snap, ReplayOptions{})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("Replay() warnings = %#v, want none", result.Warnings)
+	}
+
+	want := []replayCommand{
+		{name: "tmux", args: []string{"new-session", "-d", "-s", "home", "-c", cwd}},
+		{name: "tmux", args: []string{"rename-window", "-t", "home:0", "main"}},
+		{name: "tmux", args: []string{"select-layout", "-t", "home:0", "b25d,120x36,0,0,1"}},
+		{name: "tmux", args: []string{"select-pane", "-t", "home:0.0"}},
+	}
+	if !reflect.DeepEqual(runner.commands, want) {
+		t.Fatalf("commands = %#v, want %#v", runner.commands, want)
+	}
+}
+
+func TestReplaySplitPaneLayoutCommandOrder(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	second := t.TempDir()
+	third := t.TempDir()
+	snap := replaySnapshot(cwd)
+	snap.Windows = []Window{
+		{
+			Index:           0,
+			Name:            "main",
+			Layout:          "d3a9,120x36,0,0{60x36,0,0,1,59x36,61,0,2}",
+			ActivePaneIndex: 2,
+			Panes: []Pane{
+				{Index: 0, CWD: cwd, Recipe: ShellRecipe()},
+				{Index: 1, CWD: second, Recipe: ShellRecipe()},
+				{Index: 2, CWD: third, Recipe: ShellRecipe()},
+			},
+		},
+		{
+			Index:           1,
+			Name:            "logs",
+			Layout:          "a111,100x20,0,0,3",
+			ActivePaneIndex: 0,
+			Panes: []Pane{
+				{Index: 0, CWD: second, Recipe: ShellRecipe()},
+			},
+		},
+	}
+	runner := &recordingReplayRunner{}
+
+	if _, err := Replay(context.Background(), runner, snap, ReplayOptions{}); err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+
+	want := []replayCommand{
+		{name: "tmux", args: []string{"new-session", "-d", "-s", "home", "-c", cwd}},
+		{name: "tmux", args: []string{"rename-window", "-t", "home:0", "main"}},
+		{name: "tmux", args: []string{"split-window", "-d", "-t", "home:0.0", "-c", second}},
+		{name: "tmux", args: []string{"split-window", "-d", "-t", "home:0.1", "-c", third}},
+		{name: "tmux", args: []string{"select-layout", "-t", "home:0", "d3a9,120x36,0,0{60x36,0,0,1,59x36,61,0,2}"}},
+		{name: "tmux", args: []string{"select-pane", "-t", "home:0.2"}},
+		{name: "tmux", args: []string{"new-window", "-d", "-t", "home:1", "-c", second, "-n", "logs"}},
+		{name: "tmux", args: []string{"select-layout", "-t", "home:1", "a111,100x20,0,0,3"}},
+		{name: "tmux", args: []string{"select-pane", "-t", "home:1.0"}},
+	}
+	if !reflect.DeepEqual(runner.commands, want) {
+		t.Fatalf("commands = %#v, want %#v", runner.commands, want)
+	}
+}
+
+func TestReplayMissingPaneCWDFallsBackWithWarning(t *testing.T) {
+	t.Parallel()
+
+	defaultCWD := t.TempDir()
+	fallback := t.TempDir()
+	missing := defaultCWD + "/missing"
+	snap := replaySnapshot(defaultCWD)
+	snap.Windows = []Window{
+		{
+			Index:           0,
+			Name:            "main",
+			ActivePaneIndex: 1,
+			Panes: []Pane{
+				{Index: 0, CWD: defaultCWD, Recipe: ShellRecipe()},
+				{Index: 1, CWD: missing, Recipe: ShellRecipe()},
+			},
+		},
+	}
+	runner := &recordingReplayRunner{}
+
+	result, err := Replay(context.Background(), runner, snap, ReplayOptions{FallbackCWD: fallback})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("warnings = %#v, want one warning", result.Warnings)
+	}
+	warning := result.Warnings[0]
+	if warning.Scope != "pane" || warning.WindowIndex != 0 || warning.PaneIndex != 1 || warning.CWD != missing || warning.FallbackCWD != fallback {
+		t.Fatalf("warning = %#v, want pane cwd fallback to supplied dir", warning)
+	}
+	if !hasReplayCommand(runner.commands, []string{"split-window", "-d", "-t", "home:0.0", "-c", fallback}) {
+		t.Fatalf("commands = %#v, want split-window using fallback cwd", runner.commands)
+	}
+}
+
+func TestReplayActivePaneSelection(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	snap := replaySnapshot(cwd)
+	snap.Windows = []Window{
+		{
+			Index:           0,
+			Name:            "work",
+			ActivePaneIndex: 1,
+			Panes: []Pane{
+				{Index: 0, CWD: cwd, Recipe: ShellRecipe()},
+				{Index: 1, CWD: cwd, Recipe: ShellRecipe()},
+			},
+		},
+	}
+	runner := &recordingReplayRunner{}
+
+	if _, err := Replay(context.Background(), runner, snap, ReplayOptions{}); err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if got := runner.commands[len(runner.commands)-1].args; !reflect.DeepEqual(got, []string{"select-pane", "-t", "home:0.1"}) {
+		t.Fatalf("last command args = %#v, want active pane selection", got)
+	}
+}
+
+func TestReplayDoesNotExecuteRecipes(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	snap := replaySnapshot(cwd)
+	snap.Windows = []Window{
+		{
+			Index:           0,
+			Name:            "agent",
+			ActivePaneIndex: 0,
+			Panes: []Pane{
+				{Index: 0, CWD: cwd, Recipe: AgentRecipe("claude", "abcdef-1234", "topic")},
+			},
+		},
+	}
+	runner := &recordingReplayRunner{}
+
+	if _, err := Replay(context.Background(), runner, snap, ReplayOptions{}); err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	for _, command := range runner.commands {
+		if len(command.args) > 0 && command.args[0] == "send-keys" {
+			t.Fatalf("Replay() executed recipe via send-keys: %#v", command)
+		}
+		if strings.Contains(strings.Join(command.args, " "), "abcdef-1234") {
+			t.Fatalf("Replay() included resume metadata in tmux commands: %#v", command)
+		}
+	}
+}
+
+func replaySnapshot(defaultCWD string) Snapshot {
+	return Snapshot{
+		Version:    Version,
+		Session:    "home",
+		DefaultCWD: defaultCWD,
+		SavedAt:    time.Date(2026, 5, 11, 12, 34, 56, 0, time.UTC),
+	}
+}
+
+type replayCommand struct {
+	name string
+	args []string
+}
+
+type recordingReplayRunner struct {
+	commands []replayCommand
+}
+
+func (r *recordingReplayRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	r.commands = append(r.commands, replayCommand{
+		name: name,
+		args: append([]string(nil), args...),
+	})
+	return nil, nil
+}
+
+func hasReplayCommand(commands []replayCommand, args []string) bool {
+	for _, command := range commands {
+		if reflect.DeepEqual(command.args, args) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- add a self-contained sessionstate replay API for v1 snapshots
- replay tmux session/window/pane/layout metadata without executing recipes
- report cwd fallback warnings for missing pane/session directories

## Tests
- gofmt
- git diff --check
- GOCACHE=/tmp/projmux-go-cache go test ./internal/integrations/sessionstate ./internal/integrations/tmux
- GOCACHE=/tmp/projmux-go-cache make test
- GOCACHE=/tmp/projmux-go-cache make test-integration
- GOCACHE=/tmp/projmux-go-cache make test-e2e

## Notes
- Agent resume, startup command execution, and active-window restore remain follow-up phases.