### PR TITLE
feat: add settings hooks read-only page

### DIFF
--- a/internal/app/hookmaker.go
+++ b/internal/app/hookmaker.go
@@ -1,0 +1,183 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/integrations/hooks"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
+)
+
+type settingsHookEvent struct {
+	Name string
+}
+
+var settingsHookEvents = []settingsHookEvent{
+	{Name: string(hooks.EventPreCreate)},
+	{Name: string(hooks.EventPostCreate)},
+	{Name: string(hooks.EventPaneStartup)},
+	{Name: string(hooks.EventPostAttach)},
+}
+
+type settingsHookPathState struct {
+	status string
+	path   string
+	note   string
+}
+
+func (c *settingsCommand) globalHookEntries() []intpickercompat.Entry {
+	entries := []intpickercompat.Entry{settingsBackEntry()}
+
+	paths, err := pickerBackendConfigPaths(c.homeDir, c.lookupEnv)
+	if err != nil {
+		return append(entries, intpickercompat.Entry{
+			Label: settingsLabelDim("Hooks", err.Error()),
+			Value: settingsNoopValue,
+		})
+	}
+
+	for _, event := range settingsHookEvents {
+		path := paths.HookPath(event.Name)
+		entries = append(entries, settingsHookEntry(event.Name, settingsHookPathStateFor(path)))
+	}
+	return entries
+}
+
+func (c *settingsCommand) projectHookEntries(ctx settingsProjectContext) []intpickercompat.Entry {
+	entries := []intpickercompat.Entry{settingsBackEntry()}
+	if !ctx.hasProject() {
+		return append(entries,
+			intpickercompat.Entry{
+				Label: settingsLabelDim("Project context", "no project - open Settings from a project pane or set PROJMUX_CWD"),
+				Value: settingsNoopValue,
+			},
+			intpickercompat.Entry{
+				Label: settingsLabelDim("Hooks (project)", "disabled - no project context"),
+				Value: settingsNoopValue,
+			},
+		)
+	}
+
+	entries = append(entries, intpickercompat.Entry{
+		Label: settingsLabelInfo("Project context", ctx.Path, ctx.Source),
+		Value: settingsNoopValue,
+	})
+	for _, event := range settingsHookEvents {
+		entries = append(entries, settingsHookEntry(event.Name, settingsProjectHookPathState(ctx.Path, event.Name)))
+	}
+	return append(entries, settingsProjectConfigEntry(ctx.Path))
+}
+
+func settingsProjectHookPathState(projectPath, event string) settingsHookPathState {
+	candidates := []string{
+		filepath.Join(projectPath, ".projmux", event),
+		filepath.Join(projectPath, ".projmux", config.HooksDirName, event),
+	}
+	var inactive settingsHookPathState
+	for _, path := range candidates {
+		state := settingsHookPathStateFor(path)
+		if state.status == "active" {
+			return state
+		}
+		if state.status == "inactive" && inactive.path == "" {
+			inactive = state
+		}
+	}
+	if inactive.path != "" {
+		return inactive
+	}
+	return settingsHookPathState{
+		status: "missing",
+		path:   strings.Join(candidates, " or "),
+	}
+}
+
+func settingsHookPathStateFor(path string) settingsHookPathState {
+	state := settingsHookPathState{status: "missing", path: path}
+	info, err := osStat(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			state.status = "unreadable"
+			state.note = err.Error()
+		}
+		return state
+	}
+	if info.IsDir() {
+		state.status = "inactive"
+		state.note = "directory"
+		return state
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		state.status = "inactive"
+		state.note = "not executable"
+		return state
+	}
+	state.status = "active"
+	return state
+}
+
+func settingsHookEntry(event string, state settingsHookPathState) intpickercompat.Entry {
+	glyph := settingsGlyphInactive
+	color := settingsColorDim
+	if state.status == "active" {
+		glyph = settingsGlyphToggle
+		color = settingsColorAdd
+	}
+	desc := state.status + " - " + state.path
+	if state.note != "" {
+		desc += " (" + state.note + ")"
+	}
+	return intpickercompat.Entry{
+		Label: settingsLabel(glyph, color, event, desc),
+		Value: settingsNoopValue,
+	}
+}
+
+func settingsProjectConfigEntry(projectPath string) intpickercompat.Entry {
+	path := filepath.Join(projectPath, ".projmux", "config.toml")
+	state := settingsProjectConfigState(path)
+	return intpickercompat.Entry{
+		Label: settingsLabel(settingsGlyphInfo, settingsColorInfo, "config.toml", state),
+		Value: settingsNoopValue,
+	}
+}
+
+func settingsProjectConfigState(path string) string {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "missing - " + path
+		}
+		return "unreadable - " + path
+	}
+	cfg, err := hooks.ParseProjectConfig(string(content))
+	if err != nil {
+		return "present - " + path + " (parse error)"
+	}
+	summary := settingsProjectConfigSummary(cfg)
+	if summary == "" {
+		return "present - " + path
+	}
+	return fmt.Sprintf("present - %s (%s)", path, summary)
+}
+
+func settingsProjectConfigSummary(cfg hooks.ProjectConfig) string {
+	parts := make([]string, 0, 4)
+	if len(cfg.Hooks) > 0 {
+		parts = append(parts, fmt.Sprintf("%d hook commands", len(cfg.Hooks)))
+	}
+	if strings.TrimSpace(cfg.StartupRun) != "" {
+		parts = append(parts, "startup")
+	}
+	if len(cfg.Env) > 0 {
+		parts = append(parts, fmt.Sprintf("%d env vars", len(cfg.Env)))
+	}
+	if cfg.Kube.Context != "" || cfg.Kube.Namespace != "" {
+		parts = append(parts, "kube")
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/app/hookmaker_test.go
+++ b/internal/app/hookmaker_test.go
@@ -1,0 +1,188 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
+)
+
+func TestSettingsGlobalHooksListShowsActiveAndMissingPaths(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := t.TempDir()
+	active := filepath.Join(configHome, "projmux", "hooks", "post-create")
+	mkdirAll(t, filepath.Dir(active))
+	if err := os.WriteFile(active, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &settingsCommand{
+		homeDir: func() (string, error) { return home, nil },
+		lookupEnv: func(name string) string {
+			if name == "XDG_CONFIG_HOME" {
+				return configHome
+			}
+			return ""
+		},
+	}
+
+	entries := cmd.globalHookEntries()
+	assertEntryLabelContainsAll(t, entries, "post-create", "active", active)
+	assertEntryLabelContainsAll(t, entries, "pane-startup", "missing", filepath.Join(configHome, "projmux", "hooks", "pane-startup"))
+}
+
+func TestSettingsProjectHooksListWithContext(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	postCreate := filepath.Join(repo, ".projmux", "post-create")
+	paneStartup := filepath.Join(repo, ".projmux", "hooks", "pane-startup")
+	mkdirAll(t, filepath.Dir(paneStartup))
+	if err := os.WriteFile(postCreate, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paneStartup, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".projmux", "config.toml"), []byte(`
+[startup]
+run = "codex"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &settingsCommand{
+		lookupEnv: func(name string) string {
+			if name == "PROJMUX_CWD" {
+				return repo
+			}
+			return ""
+		},
+	}
+
+	options := cmd.rootOptions(settingsRootTabProject)
+	if !hasEntryValue(options.Entries, settingsSectionProjectHooks) {
+		t.Fatalf("project tab entries = %#v, want project Hooks page row", options.Entries)
+	}
+
+	hookOptions, err := cmd.sectionOptions(settingsSectionProjectHooks)
+	if err != nil {
+		t.Fatalf("sectionOptions(project hooks) error = %v", err)
+	}
+	assertEntryLabelContainsAll(t, hookOptions.Entries, "post-create", "active", postCreate)
+	assertEntryLabelContainsAll(t, hookOptions.Entries, "pane-startup", "active", paneStartup)
+	assertEntryLabelContainsAll(t, hookOptions.Entries, "pre-create", "missing", filepath.Join(repo, ".projmux", "pre-create"))
+	assertEntryLabelContainsAll(t, hookOptions.Entries, "config.toml", "present", "startup")
+}
+
+func TestSettingsProjectHooksNoProjectUsesDisabledState(t *testing.T) {
+	t.Parallel()
+
+	cmd := &settingsCommand{lookupEnv: func(string) string { return "" }}
+	options, err := cmd.sectionOptions(settingsSectionProjectHooks)
+	if err != nil {
+		t.Fatalf("sectionOptions(project hooks) error = %v", err)
+	}
+	assertEntryLabelContainsAll(t, options.Entries, "Hooks (project)", "disabled", "no project context")
+	if hasEntryLabelContaining(options.Entries, "post-create") {
+		t.Fatalf("project hooks entries = %#v, want no hook event rows without project context", options.Entries)
+	}
+}
+
+func TestSettingsHookMakerExcludesInternalTmuxHooks(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	internalHook := filepath.Join(repo, ".projmux", "hooks", "after-select-pane")
+	mkdirAll(t, filepath.Dir(internalHook))
+	if err := os.WriteFile(internalHook, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &settingsCommand{
+		lookupEnv: func(name string) string {
+			if name == "PROJMUX_CWD" {
+				return repo
+			}
+			return ""
+		},
+	}
+	entries := cmd.projectHookEntries(cmd.resolveSettingsProjectContext())
+	for _, label := range []string{"after-select-pane", "pane-focus-in", "pane-focus-out"} {
+		if hasEntryLabelContaining(entries, label) {
+			t.Fatalf("project hook entries = %#v, want no internal tmux hook %q", entries, label)
+		}
+	}
+}
+
+func TestSettingsHookMakerDoesNotMutateTrustStore(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := t.TempDir()
+	stateHome := t.TempDir()
+	repo := t.TempDir()
+	active := filepath.Join(repo, ".projmux", "hooks", "post-create")
+	mkdirAll(t, filepath.Dir(active))
+	if err := os.WriteFile(active, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	trustStore := filepath.Join(stateHome, "projmux", "trusted-projects.json")
+	mkdirAll(t, filepath.Dir(trustStore))
+	const sentinel = `{"sentinel":true}`
+	if err := os.WriteFile(trustStore, []byte(sentinel), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &settingsCommand{
+		homeDir: func() (string, error) { return home, nil },
+		lookupEnv: func(name string) string {
+			switch name {
+			case "PROJMUX_CWD":
+				return repo
+			case "XDG_CONFIG_HOME":
+				return configHome
+			case "XDG_STATE_HOME":
+				return stateHome
+			default:
+				return ""
+			}
+		},
+		runCommand: func(name string, args ...string) error {
+			t.Fatalf("read-only hook maker invoked command %s %#v", name, args)
+			return nil
+		},
+	}
+
+	_ = cmd.globalHookEntries()
+	_ = cmd.projectHookEntries(cmd.resolveSettingsProjectContext())
+
+	got, err := os.ReadFile(trustStore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != sentinel {
+		t.Fatalf("trust store = %q, want unchanged %q", got, sentinel)
+	}
+}
+
+func assertEntryLabelContainsAll(t *testing.T, entries []intpickercompat.Entry, parts ...string) {
+	t.Helper()
+	for _, entry := range entries {
+		matches := true
+		for _, part := range parts {
+			if !strings.Contains(entry.Label, part) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return
+		}
+	}
+	t.Fatalf("entries = %#v, want one label containing all %#v", entries, parts)
+}

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -62,6 +62,8 @@ var settingsEntryCatalog = map[string]settingsEntryMeta{
 	settingsRootTabGlobalValue:  {Name: "Global Settings", Axis: settingsAxisBoth},
 	settingsRootTabProjectValue: {Name: "Project Settings", Axis: settingsAxisBoth},
 	settingsSectionProject:      {Name: "Project Picker", Axis: settingsAxisGlobal},
+	settingsSectionGlobalHooks:  {Name: "Hooks", Axis: settingsAxisGlobal},
+	settingsSectionProjectHooks: {Name: "Hooks", Axis: settingsAxisProject},
 	settingsSectionAI:           {Name: "AI Settings", Axis: settingsAxisGlobal},
 	settingsSectionStatusbar:    {Name: "Appearance", Axis: settingsAxisGlobal},
 	settingsSectionKeybindings:  {Name: "Keybindings", Axis: settingsAxisGlobal},
@@ -115,6 +117,8 @@ const (
 	settingsRootTabGlobalValue    = "__settings_tab_global__"
 	settingsRootTabProjectValue   = "__settings_tab_project__"
 	settingsSectionAI             = "section:ai"
+	settingsSectionGlobalHooks    = "section:hooks-global"
+	settingsSectionProjectHooks   = "section:hooks-project"
 	settingsSectionKeybindings    = "section:keybindings"
 	settingsSectionProject        = "section:project-picker"
 	settingsSectionStatusbar      = "section:statusbar"
@@ -310,6 +314,10 @@ func (c *settingsCommand) rootEntriesForAxis(axis SettingsAxis) []intpickercompa
 			Value: settingsSectionAI,
 		},
 		{
+			Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Hooks", "global lifecycle hook paths"),
+			Value: settingsSectionGlobalHooks,
+		},
+		{
 			Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Appearance", "status and popup decoration mode"),
 			Value: settingsSectionStatusbar,
 		},
@@ -397,12 +405,8 @@ func (c *settingsCommand) projectTabEntries() []intpickercompat.Entry {
 			Value: settingsNoopValue,
 		},
 		intpickercompat.Entry{
-			Label: settingsLabelDim("Hooks (project)", filepath.Join(ctx.Path, ".projmux", "hooks")),
-			Value: settingsNoopValue,
-		},
-		intpickercompat.Entry{
-			Label: settingsLabelDim("config.toml", filepath.Join(ctx.Path, ".projmux", "config.toml")),
-			Value: settingsNoopValue,
+			Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Hooks (project)", filepath.Join(ctx.Path, ".projmux")),
+			Value: settingsSectionProjectHooks,
 		},
 		intpickercompat.Entry{
 			Label: settingsLabelDim("Effective merge view", "Phase 3"),
@@ -533,6 +537,27 @@ func (c *settingsCommand) sectionOptions(section string) (intpickercompat.Option
 			Title:      "AI Settings - Default Ctrl+Shift+R/L split mode",
 			Prompt:     "Settings > AI Settings > ",
 			Footer:     projmuxFooter("Enter: apply  |  Back row: parent  |  Esc/Alt+5/Ctrl+Alt+S: close"),
+			ExpectKeys: []string{"enter"},
+			Bindings:   settingsCloseBindings(),
+		}, nil
+	case settingsSectionGlobalHooks:
+		return intpickercompat.Options{
+			UI:         "settings-hooks-global",
+			Entries:    c.globalHookEntries(),
+			Title:      "Hooks - Global lifecycle hook paths",
+			Prompt:     "Settings > Hooks > ",
+			Footer:     projmuxFooter("Enter: inspect  |  Back row: parent  |  Esc/Alt+5/Ctrl+Alt+S: close"),
+			ExpectKeys: []string{"enter"},
+			Bindings:   settingsCloseBindings(),
+		}, nil
+	case settingsSectionProjectHooks:
+		ctx := c.resolveSettingsProjectContext()
+		return intpickercompat.Options{
+			UI:         "settings-hooks-project",
+			Entries:    c.projectHookEntries(ctx),
+			Title:      "Hooks - Project lifecycle hook paths",
+			Prompt:     "Settings > Project > Hooks > ",
+			Footer:     projmuxFooter("Enter: inspect  |  Back row: parent  |  Esc/Alt+5/Ctrl+Alt+S: close"),
 			ExpectKeys: []string{"enter"},
 			Bindings:   settingsCloseBindings(),
 		}, nil

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -24,6 +24,7 @@ func TestSettingsRootEntriesHaveAxisMetadata(t *testing.T) {
 	cmd := &settingsCommand{}
 	want := map[string]settingsEntryMeta{
 		settingsSectionProject:     {Name: "Project Picker", Axis: settingsAxisGlobal},
+		settingsSectionGlobalHooks: {Name: "Hooks", Axis: settingsAxisGlobal},
 		settingsSectionAI:          {Name: "AI Settings", Axis: settingsAxisGlobal},
 		settingsSectionStatusbar:   {Name: "Appearance", Axis: settingsAxisGlobal},
 		settingsSectionKeybindings: {Name: "Keybindings", Axis: settingsAxisGlobal},
@@ -77,6 +78,7 @@ func TestSettingsRootOptionsDefaultGlobalTab(t *testing.T) {
 		settingsRootTabProjectValue,
 		settingsSectionProject,
 		settingsSectionAI,
+		settingsSectionGlobalHooks,
 		settingsSectionStatusbar,
 		settingsSectionKeybindings,
 		settingsSectionLabs,
@@ -266,6 +268,8 @@ func TestSettingsEntryCatalogClassifiesRelevantRowsAndActions(t *testing.T) {
 	}{
 		{settingsRootTabGlobalValue, settingsAxisBoth},
 		{settingsRootTabProjectValue, settingsAxisBoth},
+		{settingsSectionGlobalHooks, settingsAxisGlobal},
+		{settingsSectionProjectHooks, settingsAxisProject},
 		{settingsProjectRootManage, settingsAxisGlobal},
 		{settingsWorkdirList, settingsAxisGlobal},
 		{settingsProjectPins, settingsAxisGlobal},
@@ -406,6 +410,7 @@ func TestSettingsHubSetsAIDefaultMode(t *testing.T) {
 		settingsRootTabProjectValue,
 		settingsSectionProject,
 		settingsSectionAI,
+		settingsSectionGlobalHooks,
 		settingsSectionStatusbar,
 		settingsSectionKeybindings,
 		settingsSectionLabs,


### PR DESCRIPTION
## Summary
- add read-only Hooks pages to Settings Global and Project tabs
- list supported lifecycle hook paths and project config summaries
- keep hook editing, trust mutation, form editing, CLI, and effective merge view deferred

## Tests
- make fmt
- GOCACHE=/tmp/projmux-go-cache make fix
- GOCACHE=/tmp/projmux-go-cache make test
- GOCACHE=/tmp/projmux-go-cache make test-integration
- GOCACHE=/tmp/projmux-go-cache make test-e2e
- git diff --check

## Notes
- Phase 1 is read-only and intentionally excludes projmux-owned internal tmux hooks.