### PR TITLE
feat: add settings effective merge view

### DIFF
--- a/internal/app/effective_merge.go
+++ b/internal/app/effective_merge.go
@@ -1,0 +1,197 @@
+package app
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/crevissepartners/projmux/internal/integrations/hooks"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
+)
+
+// effective_merge.go implements the Settings popup "Effective merge view"
+// page for the Project tab. It reads the global config.toml (if present)
+// and the project-local .projmux/config.toml, calls hooks.MergeEffective,
+// and renders one row per merged entry with a per-row source label of
+// global / project / merged / default.
+
+// runEffectiveMergeSection drives the Effective merge view picker page.
+func (c *settingsCommand) runEffectiveMergeSection(stdout, stderr io.Writer) error {
+	for {
+		ctx := c.resolveSettingsProjectContext()
+		options := c.effectiveMergeOptions(ctx)
+		result, err := c.runPicker(options)
+		if err != nil {
+			return err
+		}
+		action := strings.TrimSpace(result.Value)
+		if result.Key != "enter" || action == "" {
+			return errSettingsClosed
+		}
+		switch action {
+		case settingsBackValue:
+			return nil
+		case settingsNoopValue:
+			continue
+		default:
+			return fmt.Errorf("unknown effective merge action: %s", action)
+		}
+	}
+}
+
+func (c *settingsCommand) effectiveMergeOptions(ctx settingsProjectContext) intpickercompat.Options {
+	return intpickercompat.Options{
+		UI:         "settings-effective-merge",
+		Entries:    c.effectiveMergeEntries(ctx),
+		Title:      "Effective merge view - global + project config",
+		Prompt:     "Settings > Project > Effective merge view > ",
+		Footer:     projmuxFooter("Enter: back  |  Back row: parent  |  Esc/Alt+5/Ctrl+Alt+S: close"),
+		ExpectKeys: []string{"enter"},
+		Bindings:   settingsCloseBindings(),
+	}
+}
+
+func (c *settingsCommand) effectiveMergeEntries(ctx settingsProjectContext) []intpickercompat.Entry {
+	entries := []intpickercompat.Entry{settingsBackEntry()}
+	if !ctx.hasProject() {
+		return append(entries, intpickercompat.Entry{
+			Label: settingsLabelDim("Effective merge view", "disabled - no project context"),
+			Value: settingsNoopValue,
+		})
+	}
+
+	globalCfg, globalPath, globalErr := c.loadGlobalConfigForMerge()
+	projectCfg, projectPath, projectErr := c.loadProjectConfigForMerge(ctx)
+
+	entries = append(entries,
+		intpickercompat.Entry{
+			Label: settingsLabelInfo("Project context", ctx.Path, ctx.Source),
+			Value: settingsNoopValue,
+		},
+		intpickercompat.Entry{
+			Label: settingsLabelInfo("Global config", globalPath, sourceFileState(globalCfg, globalErr, globalPath)),
+			Value: settingsNoopValue,
+		},
+		intpickercompat.Entry{
+			Label: settingsLabelInfo("Project config", projectPath, sourceFileState(projectCfg, projectErr, projectPath)),
+			Value: settingsNoopValue,
+		},
+	)
+
+	if globalErr != nil {
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabelDim("Global parse error", globalErr.Error()),
+			Value: settingsNoopValue,
+		})
+	}
+	if projectErr != nil {
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabelDim("Project parse error", projectErr.Error()),
+			Value: settingsNoopValue,
+		})
+	}
+
+	merged := hooks.MergeEffective(globalCfg, projectCfg)
+	entries = append(entries, renderEffectiveSection(merged.Env)...)
+	entries = append(entries, renderEffectiveSection(merged.Kube)...)
+	entries = append(entries, renderEffectiveSection(merged.Startup)...)
+	return entries
+}
+
+// renderEffectiveSection emits one section header row plus one row per
+// entry. Sensitive env keys have their values redacted in display.
+func renderEffectiveSection(section hooks.EffectiveSection) []intpickercompat.Entry {
+	header := intpickercompat.Entry{
+		Label: settingsLabelInfo("["+section.Name+"]", "", string(section.Source)),
+		Value: settingsNoopValue,
+	}
+	entries := []intpickercompat.Entry{header}
+	if len(section.Entries) == 0 {
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabelDim("  (no entries)", string(hooks.EffectiveSourceDefault)),
+			Value: settingsNoopValue,
+		})
+		return entries
+	}
+	for _, entry := range section.Entries {
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabelInfo("  "+entry.Key, effectiveEntryDisplayValue(section.Name, entry), string(entry.Source)),
+			Value: settingsNoopValue,
+		})
+	}
+	return entries
+}
+
+// effectiveEntryDisplayValue applies redaction to env values and falls back
+// to (unset) for empty scalars on the kube / startup sections.
+func effectiveEntryDisplayValue(sectionName string, entry hooks.EffectiveEntry) string {
+	if sectionName == "env" {
+		return hooks.DisplayEnvValue(entry.Key, entry.Value)
+	}
+	if strings.TrimSpace(entry.Value) == "" {
+		return "(unset)"
+	}
+	return entry.Value
+}
+
+// loadGlobalConfigForMerge resolves the global config.toml path and parses
+// it. A missing file yields an empty ProjectConfig and nil error — that
+// matches the policy used everywhere else: "no file" is not an error.
+func (c *settingsCommand) loadGlobalConfigForMerge() (hooks.ProjectConfig, string, error) {
+	path, err := c.globalConfigFilePath()
+	if err != nil {
+		return hooks.ProjectConfig{}, "", err
+	}
+	cfg, err := hooks.LoadProjectConfigFile(path)
+	return cfg, path, err
+}
+
+// loadProjectConfigForMerge resolves the project config.toml path and
+// parses it. A missing file yields an empty ProjectConfig and nil error.
+func (c *settingsCommand) loadProjectConfigForMerge(ctx settingsProjectContext) (hooks.ProjectConfig, string, error) {
+	path := settingsProjectConfigPath(ctx)
+	cfg, err := hooks.LoadProjectConfigFile(path)
+	return cfg, path, err
+}
+
+func (c *settingsCommand) globalConfigFilePath() (string, error) {
+	paths, err := pickerBackendConfigPaths(c.homeDir, c.lookupEnv)
+	if err != nil {
+		return "", err
+	}
+	return paths.GlobalConfigFile(), nil
+}
+
+// sourceFileState returns a short annotation that explains whether the file
+// at path was found, missing, or failed to parse. The settings popup
+// renders this in the dim source slot of the info row.
+func sourceFileState(cfg hooks.ProjectConfig, err error, path string) string {
+	if err != nil {
+		return "parse error"
+	}
+	if strings.TrimSpace(path) == "" {
+		return "unresolved path"
+	}
+	if !configHasContent(cfg) {
+		return "missing or empty"
+	}
+	return "loaded"
+}
+
+// configHasContent reports whether the parsed config carries any data —
+// used to label the source slot in the file info rows.
+func configHasContent(cfg hooks.ProjectConfig) bool {
+	if len(cfg.Env) > 0 {
+		return true
+	}
+	if cfg.Kube.Context != "" || cfg.Kube.Namespace != "" {
+		return true
+	}
+	if strings.TrimSpace(cfg.StartupRun) != "" {
+		return true
+	}
+	if len(cfg.Hooks) > 0 {
+		return true
+	}
+	return false
+}

--- a/internal/app/effective_merge_test.go
+++ b/internal/app/effective_merge_test.go
@@ -1,0 +1,267 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/integrations/hooks"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
+)
+
+// TestEffectiveMergeEntriesDisabledWithoutProject confirms the
+// Effective merge view page degrades gracefully when no project context
+// is available (e.g. user opened Settings from a non-project shell).
+func TestEffectiveMergeEntriesDisabledWithoutProject(t *testing.T) {
+	t.Parallel()
+
+	cmd := &settingsCommand{lookupEnv: func(string) string { return "" }}
+	entries := cmd.effectiveMergeEntries(settingsProjectContext{})
+
+	if len(entries) == 0 {
+		t.Fatalf("entries empty, want at least Back + disabled row")
+	}
+	if !hasEntryValue(entries, settingsBackValue) {
+		t.Fatalf("entries missing Back row: %#v", entries)
+	}
+	if !hasEntryLabelContaining(entries, "disabled - no project context") {
+		t.Fatalf("entries missing disabled row: %#v", entries)
+	}
+}
+
+// TestEffectiveMergeEntriesShowSourceLabels verifies the spec requirement:
+// each merged row carries one of the four source labels (project / global /
+// merged / default), and the project-wins policy applies on conflict.
+func TestEffectiveMergeEntriesShowSourceLabels(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := filepath.Join(home, ".config")
+	mustMkdirAll(t, filepath.Join(configHome, "projmux"))
+	if err := os.WriteFile(filepath.Join(configHome, "projmux", "config.toml"), []byte(strings.Join([]string{
+		`[env]`,
+		`EDITOR = "vim"`,
+		`DATABASE_URL = "postgres://global"`,
+		`[kube]`,
+		`namespace = "team-foo"`,
+	}, "\n")), 0o644); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+
+	project := filepath.Join(home, "repo")
+	mustMkdirAll(t, filepath.Join(project, ".projmux"))
+	if err := os.WriteFile(filepath.Join(project, ".projmux", "config.toml"), []byte(strings.Join([]string{
+		`[env]`,
+		`DATABASE_URL = "postgres://project"`,
+		`GH_TOKEN = "ghp_secret"`,
+		`[kube]`,
+		`context = "dev-cluster"`,
+		`[startup]`,
+		`run = "claude"`,
+	}, "\n")), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+
+	cmd := &settingsCommand{
+		homeDir: func() (string, error) { return home, nil },
+		lookupEnv: func(name string) string {
+			if name == "XDG_CONFIG_HOME" {
+				return configHome
+			}
+			return ""
+		},
+	}
+	ctx := newSettingsProjectContext(project, "test")
+	entries := cmd.effectiveMergeEntries(ctx)
+
+	// Section headers — env should report merged (both axes contributed);
+	// kube also merged (project context + global namespace); startup is
+	// project-only.
+	requireEntryLabelContains(t, entries, "[env]", "(merged)")
+	requireEntryLabelContains(t, entries, "[kube]", "(merged)")
+	requireEntryLabelContains(t, entries, "[startup]", "(project)")
+
+	// Per-row labels — conflict resolves to project; non-conflicting keys
+	// keep their origin axis.
+	requireEntryLabelContains(t, entries, "DATABASE_URL", "(project)")
+	requireEntryLabelContains(t, entries, "DATABASE_URL", "postgres://project")
+	requireEntryLabelContains(t, entries, "EDITOR", "(global)")
+	requireEntryLabelContains(t, entries, "EDITOR", "vim")
+	requireEntryLabelContains(t, entries, "GH_TOKEN", "(project)")
+	requireEntryLabelContains(t, entries, "context", "(project)")
+	requireEntryLabelContains(t, entries, "context", "dev-cluster")
+	requireEntryLabelContains(t, entries, "namespace", "(global)")
+	requireEntryLabelContains(t, entries, "namespace", "team-foo")
+	requireEntryLabelContains(t, entries, "run", "claude")
+	requireEntryLabelContains(t, entries, "run", "(project)")
+}
+
+// TestEffectiveMergeEntriesRedactSensitiveEnv verifies the spec
+// requirement: env keys flagged as sensitive (TOKEN / SECRET / KEY /
+// PASSWORD) never expose their value in the popup.
+func TestEffectiveMergeEntriesRedactSensitiveEnv(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := filepath.Join(home, ".config")
+	mustMkdirAll(t, filepath.Join(configHome, "projmux"))
+
+	project := filepath.Join(home, "repo")
+	mustMkdirAll(t, filepath.Join(project, ".projmux"))
+	if err := os.WriteFile(filepath.Join(project, ".projmux", "config.toml"), []byte(strings.Join([]string{
+		`[env]`,
+		`GH_TOKEN = "ghp_abcDEF123"`,
+		`API_SECRET = "shhh"`,
+		`OPENAI_API_KEY = "sk-xxxxxxxx"`,
+		`DB_PASSWORD = "p4ss"`,
+		`EDITOR = "vim"`,
+	}, "\n")), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+
+	cmd := &settingsCommand{
+		homeDir: func() (string, error) { return home, nil },
+		lookupEnv: func(name string) string {
+			if name == "XDG_CONFIG_HOME" {
+				return configHome
+			}
+			return ""
+		},
+	}
+	ctx := newSettingsProjectContext(project, "test")
+	entries := cmd.effectiveMergeEntries(ctx)
+
+	for _, secret := range []string{"ghp_abcDEF123", "shhh", "sk-xxxxxxxx", "p4ss"} {
+		for _, entry := range entries {
+			if strings.Contains(entry.Label, secret) {
+				t.Fatalf("entry label %q leaked sensitive value %q", entry.Label, secret)
+			}
+		}
+	}
+	// EDITOR is not sensitive — its value should appear verbatim.
+	requireEntryLabelContains(t, entries, "EDITOR", "vim")
+	// Each sensitive key still has a row with the redaction sentinel.
+	for _, key := range []string{"GH_TOKEN", "API_SECRET", "OPENAI_API_KEY", "DB_PASSWORD"} {
+		requireEntryLabelContains(t, entries, key, hooks.SensitiveRedaction)
+	}
+}
+
+// TestEffectiveMergeEntriesHandleMissingGlobal verifies the spec note:
+// when global config.toml is absent, every project value is labelled
+// project (or default for unset scalars) — the page still renders.
+func TestEffectiveMergeEntriesHandleMissingGlobal(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	project := filepath.Join(home, "repo")
+	mustMkdirAll(t, filepath.Join(project, ".projmux"))
+	if err := os.WriteFile(filepath.Join(project, ".projmux", "config.toml"), []byte(strings.Join([]string{
+		`[env]`,
+		`EDITOR = "vim"`,
+		`[startup]`,
+		`run = "claude"`,
+	}, "\n")), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+
+	cmd := &settingsCommand{
+		homeDir: func() (string, error) { return home, nil },
+		lookupEnv: func(string) string {
+			return ""
+		},
+	}
+	ctx := newSettingsProjectContext(project, "test")
+	entries := cmd.effectiveMergeEntries(ctx)
+
+	// EDITOR exists only in project → project label.
+	requireEntryLabelContains(t, entries, "EDITOR", "(project)")
+	// kube scalars unset on both axes → default label.
+	requireEntryLabelContains(t, entries, "context", "(default)")
+	requireEntryLabelContains(t, entries, "context", "(unset)")
+	requireEntryLabelContains(t, entries, "namespace", "(default)")
+}
+
+// TestRunSectionDispatchesEffectiveMerge confirms runSection routes the
+// effective-merge section value to the new handler — guards against
+// regressions where a new section is added but the dispatch table is
+// forgotten.
+func TestRunSectionDispatchesEffectiveMerge(t *testing.T) {
+	t.Parallel()
+
+	// Drive the picker once: first call returns the page entries (so we
+	// can assert the section opened), second call returns Back to exit.
+	var calls int
+	runner := switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
+		calls++
+		if calls == 1 {
+			// Confirm the popup UI key matches the effective merge page.
+			if got, want := options.UI, "settings-effective-merge"; got != want {
+				t.Fatalf("first picker UI = %q, want %q", got, want)
+			}
+		}
+		return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+	})
+
+	cmd := &settingsCommand{
+		runner:       runner,
+		nativePicker: nativePickerFromCompatRunner(runner),
+		lookupEnv:    func(string) string { return "" },
+	}
+	if err := cmd.runSection(settingsSectionEffectiveMerge, nil, nil); err != nil {
+		t.Fatalf("runSection() error = %v", err)
+	}
+	if calls < 1 {
+		t.Fatalf("runSection did not invoke picker (calls = %d)", calls)
+	}
+}
+
+// --- helpers --------------------------------------------------------------
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+}
+
+func requireEntryLabelContains(t *testing.T, entries []intpickercompat.Entry, key, fragment string) {
+	t.Helper()
+	for _, entry := range entries {
+		if strings.Contains(entry.Label, key) && strings.Contains(entry.Label, fragment) {
+			return
+		}
+	}
+	t.Fatalf("entries missing label containing %q + %q\nentries:\n%s", key, fragment, debugDumpEntries(entries))
+}
+
+func debugDumpEntries(entries []intpickercompat.Entry) string {
+	var b strings.Builder
+	for _, e := range entries {
+		b.WriteString("  ")
+		b.WriteString(stripAnsi(e.Label))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func stripAnsi(s string) string {
+	// Cheap ANSI strip — good enough for test diagnostics.
+	out := make([]byte, 0, len(s))
+	i := 0
+	for i < len(s) {
+		if s[i] == 0x1b {
+			j := i + 1
+			for j < len(s) && s[j] != 'm' {
+				j++
+			}
+			if j < len(s) {
+				i = j + 1
+				continue
+			}
+		}
+		out = append(out, s[i])
+		i++
+	}
+	return string(out)
+}

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -58,31 +58,32 @@ type settingsEntryMeta struct {
 }
 
 var settingsEntryCatalog = map[string]settingsEntryMeta{
-	settingsBackValue:            {Name: "Back", Axis: settingsAxisBoth},
-	settingsNoopValue:            {Name: "Info", Axis: settingsAxisBoth},
-	settingsRootTabGlobalValue:   {Name: "Global Settings", Axis: settingsAxisBoth},
-	settingsRootTabProjectValue:  {Name: "Project Settings", Axis: settingsAxisBoth},
-	settingsSectionProject:       {Name: "Project Picker", Axis: settingsAxisGlobal},
-	settingsSectionGlobalHooks:   {Name: "Hooks", Axis: settingsAxisGlobal},
-	settingsSectionProjectHooks:  {Name: "Hooks", Axis: settingsAxisProject},
-	settingsSectionProjectConfig: {Name: "Project Config", Axis: settingsAxisProject},
-	settingsSectionAI:            {Name: "AI Settings", Axis: settingsAxisGlobal},
-	settingsSectionStatusbar:     {Name: "Appearance", Axis: settingsAxisGlobal},
-	settingsSectionKeybindings:   {Name: "Keybindings", Axis: settingsAxisGlobal},
-	settingsSectionLabs:          {Name: "Labs", Axis: settingsAxisGlobal},
-	settingsSectionAbout:         {Name: "About", Axis: settingsAxisGlobal},
-	settingsProjectAdd:           {Name: "Add Project", Axis: settingsAxisGlobal},
-	settingsProjectPins:          {Name: "Pinned Projects", Axis: settingsAxisGlobal},
-	settingsProjectRootManage:    {Name: "Project Root", Axis: settingsAxisGlobal},
-	settingsProjdirClear:         {Name: "Clear Project Root", Axis: settingsAxisGlobal},
-	settingsProjdirSetCurrent:    {Name: "Use Current Project as Root", Axis: settingsAxisGlobal},
-	settingsProjdirSetTyped:      {Name: "Set Project Root", Axis: settingsAxisGlobal},
-	settingsWorkdirAdd:           {Name: "Add Workdir", Axis: settingsAxisGlobal},
-	settingsWorkdirList:          {Name: "Workdirs", Axis: settingsAxisGlobal},
-	settingsWorkdirTyped:         {Name: "Type Workdir", Axis: settingsAxisGlobal},
-	settingsLabKeybindings:       {Name: "Diagnose Keybindings", Axis: settingsAxisGlobal},
-	settingsUpdateApply:          {Name: "Update Now", Axis: settingsAxisGlobal},
-	settingsUpdateCheck:          {Name: "Check Updates", Axis: settingsAxisGlobal},
+	settingsBackValue:             {Name: "Back", Axis: settingsAxisBoth},
+	settingsNoopValue:             {Name: "Info", Axis: settingsAxisBoth},
+	settingsRootTabGlobalValue:    {Name: "Global Settings", Axis: settingsAxisBoth},
+	settingsRootTabProjectValue:   {Name: "Project Settings", Axis: settingsAxisBoth},
+	settingsSectionProject:        {Name: "Project Picker", Axis: settingsAxisGlobal},
+	settingsSectionGlobalHooks:    {Name: "Hooks", Axis: settingsAxisGlobal},
+	settingsSectionProjectHooks:   {Name: "Hooks", Axis: settingsAxisProject},
+	settingsSectionProjectConfig:  {Name: "Project Config", Axis: settingsAxisProject},
+	settingsSectionEffectiveMerge: {Name: "Effective merge view", Axis: settingsAxisProject},
+	settingsSectionAI:             {Name: "AI Settings", Axis: settingsAxisGlobal},
+	settingsSectionStatusbar:      {Name: "Appearance", Axis: settingsAxisGlobal},
+	settingsSectionKeybindings:    {Name: "Keybindings", Axis: settingsAxisGlobal},
+	settingsSectionLabs:           {Name: "Labs", Axis: settingsAxisGlobal},
+	settingsSectionAbout:          {Name: "About", Axis: settingsAxisGlobal},
+	settingsProjectAdd:            {Name: "Add Project", Axis: settingsAxisGlobal},
+	settingsProjectPins:           {Name: "Pinned Projects", Axis: settingsAxisGlobal},
+	settingsProjectRootManage:     {Name: "Project Root", Axis: settingsAxisGlobal},
+	settingsProjdirClear:          {Name: "Clear Project Root", Axis: settingsAxisGlobal},
+	settingsProjdirSetCurrent:     {Name: "Use Current Project as Root", Axis: settingsAxisGlobal},
+	settingsProjdirSetTyped:       {Name: "Set Project Root", Axis: settingsAxisGlobal},
+	settingsWorkdirAdd:            {Name: "Add Workdir", Axis: settingsAxisGlobal},
+	settingsWorkdirList:           {Name: "Workdirs", Axis: settingsAxisGlobal},
+	settingsWorkdirTyped:          {Name: "Type Workdir", Axis: settingsAxisGlobal},
+	settingsLabKeybindings:        {Name: "Diagnose Keybindings", Axis: settingsAxisGlobal},
+	settingsUpdateApply:           {Name: "Update Now", Axis: settingsAxisGlobal},
+	settingsUpdateCheck:           {Name: "Check Updates", Axis: settingsAxisGlobal},
 }
 
 var settingsEntryPrefixCatalog = []struct {
@@ -126,6 +127,7 @@ const (
 	settingsSectionGlobalHooks        = "section:hooks-global"
 	settingsSectionProjectHooks       = "section:hooks-project"
 	settingsSectionProjectConfig      = "section:project-config"
+	settingsSectionEffectiveMerge     = "section:effective-merge"
 	settingsSectionKeybindings        = "section:keybindings"
 	settingsSectionProject            = "section:project-picker"
 	settingsSectionStatusbar          = "section:statusbar"
@@ -232,6 +234,9 @@ func (c *settingsCommand) runSection(section string, stdout, stderr io.Writer) e
 	}
 	if section == settingsSectionProjectConfig {
 		return c.runProjectConfigSection(stdout, stderr)
+	}
+	if section == settingsSectionEffectiveMerge {
+		return c.runEffectiveMergeSection(stdout, stderr)
 	}
 	if section == settingsSectionKeybindings {
 		return c.runKeybindingsSection(stdout, stderr)
@@ -454,7 +459,7 @@ func (c *settingsCommand) projectTabEntries() []intpickercompat.Entry {
 				Value: settingsNoopValue,
 			},
 			{
-				Label: settingsLabelDim("Effective merge view", "Phase 3"),
+				Label: settingsLabelDim("Effective merge view", "disabled - no project context"),
 				Value: settingsNoopValue,
 			},
 		}
@@ -476,8 +481,8 @@ func (c *settingsCommand) projectTabEntries() []intpickercompat.Entry {
 			Value: settingsSectionProjectConfig,
 		},
 		{
-			Label: settingsLabelDim("Effective merge view", "Phase 3"),
-			Value: settingsNoopValue,
+			Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Effective merge view", "global + project merge with source labels"),
+			Value: settingsSectionEffectiveMerge,
 		},
 	}
 }

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -535,6 +535,7 @@ func TestSettingsEntryCatalogClassifiesRelevantRowsAndActions(t *testing.T) {
 		{settingsSectionGlobalHooks, settingsAxisGlobal},
 		{settingsSectionProjectHooks, settingsAxisProject},
 		{settingsSectionProjectConfig, settingsAxisProject},
+		{settingsSectionEffectiveMerge, settingsAxisProject},
 		{settingsProjectRootManage, settingsAxisGlobal},
 		{settingsWorkdirList, settingsAxisGlobal},
 		{settingsProjectPins, settingsAxisGlobal},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ const (
 	KeymapFileName          = "keymap.toml"
 	HooksDirName            = "hooks"
 	ProjectHooksFileName    = "project-hooks"
+	GlobalConfigFileName    = "config.toml"
 	PostCreateHookFileName  = "post-create"
 	PaneStartupHookFileName = "pane-startup"
 	PostAttachHookFileName  = "post-attach"
@@ -83,6 +84,13 @@ func (p Paths) PostCreateHookPath() string {
 // HookPath returns the default location for a named global lifecycle hook.
 func (p Paths) HookPath(name string) string {
 	return filepath.Join(p.ConfigDir, HooksDirName, name)
+}
+
+// GlobalConfigFile returns the default location for the optional
+// global projmux config.toml that mirrors the project-local config schema
+// (env, kube, startup, hooks).
+func (p Paths) GlobalConfigFile() string {
+	return filepath.Join(p.ConfigDir, GlobalConfigFileName)
 }
 
 // ProjdirFile returns the path to the persisted projdir file rooted at the

--- a/internal/integrations/hooks/effective.go
+++ b/internal/integrations/hooks/effective.go
@@ -1,0 +1,243 @@
+package hooks
+
+import (
+	"os"
+	"sort"
+	"strings"
+)
+
+// EffectiveSource names the axis a merged config entry came from. The four
+// labels intentionally mirror the settings popup design language so the UI
+// and any future programmatic consumer (hook CLI, doctor) read the same.
+type EffectiveSource string
+
+const (
+	// EffectiveSourceProject means the resolved value was defined in the
+	// project-local config (.projmux/config.toml). A project value also wins
+	// when the same key was defined globally — Phase B merge policy.
+	EffectiveSourceProject EffectiveSource = "project"
+	// EffectiveSourceGlobal means the resolved value was defined in the
+	// global config (~/.config/projmux/config.toml) and was not overridden
+	// by a project value.
+	EffectiveSourceGlobal EffectiveSource = "global"
+	// EffectiveSourceMerged is a section-level label used when the section
+	// contains keys from both axes (e.g. some env vars come from global,
+	// others from project). Individual rows still carry one of the three
+	// single-axis labels.
+	EffectiveSourceMerged EffectiveSource = "merged"
+	// EffectiveSourceDefault means the value is unset on both axes and
+	// falls back to projmux's built-in default (typically empty).
+	EffectiveSourceDefault EffectiveSource = "default"
+)
+
+// EffectiveEntry is a single key-value pair in the merged effective view,
+// annotated with the source axis the value was resolved from.
+type EffectiveEntry struct {
+	Key    string
+	Value  string
+	Source EffectiveSource
+}
+
+// EffectiveSection is the merge result for one config section, with a
+// section-level source label that summarizes which axes contributed.
+type EffectiveSection struct {
+	Name    string
+	Source  EffectiveSource
+	Entries []EffectiveEntry
+}
+
+// EffectiveConfig is the full merged view of the data-only config sections
+// ([env] / [kube] / [startup]). Hook entries ([hooks.*]) are intentionally
+// out of scope — the dedicated Hooks page surfaces those.
+type EffectiveConfig struct {
+	Env     EffectiveSection
+	Kube    EffectiveSection
+	Startup EffectiveSection
+}
+
+// Sections returns the merged sections in stable display order.
+func (c EffectiveConfig) Sections() []EffectiveSection {
+	return []EffectiveSection{c.Env, c.Kube, c.Startup}
+}
+
+// MergeEffective merges global + project config into a single effective view
+// with per-entry source labels. The merge policy is "project wins" — when
+// the same key is defined on both axes, the project value is kept and the
+// resulting entry is labelled EffectiveSourceProject. The function is pure;
+// it does not read the filesystem.
+func MergeEffective(global, project ProjectConfig) EffectiveConfig {
+	return EffectiveConfig{
+		Env:     mergeEffectiveEnv(global, project),
+		Kube:    mergeEffectiveKube(global, project),
+		Startup: mergeEffectiveStartup(global, project),
+	}
+}
+
+func mergeEffectiveEnv(global, project ProjectConfig) EffectiveSection {
+	section := EffectiveSection{Name: "env"}
+	keys := map[string]struct{}{}
+	for k := range global.Env {
+		keys[k] = struct{}{}
+	}
+	for k := range project.Env {
+		keys[k] = struct{}{}
+	}
+	sorted := make([]string, 0, len(keys))
+	for k := range keys {
+		sorted = append(sorted, k)
+	}
+	sort.Strings(sorted)
+	for _, key := range sorted {
+		projectValue, hasProject := project.Env[key]
+		globalValue, hasGlobal := global.Env[key]
+		switch {
+		case hasProject:
+			// Project wins over global on conflict.
+			section.Entries = append(section.Entries, EffectiveEntry{
+				Key:    key,
+				Value:  projectValue,
+				Source: EffectiveSourceProject,
+			})
+		case hasGlobal:
+			section.Entries = append(section.Entries, EffectiveEntry{
+				Key:    key,
+				Value:  globalValue,
+				Source: EffectiveSourceGlobal,
+			})
+		}
+	}
+	section.Source = summarizeSectionSource(section.Entries)
+	return section
+}
+
+func mergeEffectiveKube(global, project ProjectConfig) EffectiveSection {
+	section := EffectiveSection{Name: "kube"}
+	section.Entries = append(section.Entries,
+		resolveScalarEntry("context", project.Kube.Context, global.Kube.Context),
+		resolveScalarEntry("namespace", project.Kube.Namespace, global.Kube.Namespace),
+	)
+	section.Source = summarizeSectionSource(section.Entries)
+	return section
+}
+
+func mergeEffectiveStartup(global, project ProjectConfig) EffectiveSection {
+	section := EffectiveSection{Name: "startup"}
+	section.Entries = append(section.Entries,
+		resolveScalarEntry("run", project.StartupRun, global.StartupRun),
+	)
+	section.Source = summarizeSectionSource(section.Entries)
+	return section
+}
+
+// resolveScalarEntry resolves a single-valued field with project-wins policy.
+// An empty string is treated as "unset" on either axis — this matches how
+// the project config parser normalizes trimmed-empty values.
+func resolveScalarEntry(key, projectValue, globalValue string) EffectiveEntry {
+	projectValue = strings.TrimSpace(projectValue)
+	globalValue = strings.TrimSpace(globalValue)
+	switch {
+	case projectValue != "":
+		return EffectiveEntry{Key: key, Value: projectValue, Source: EffectiveSourceProject}
+	case globalValue != "":
+		return EffectiveEntry{Key: key, Value: globalValue, Source: EffectiveSourceGlobal}
+	default:
+		return EffectiveEntry{Key: key, Value: "", Source: EffectiveSourceDefault}
+	}
+}
+
+// summarizeSectionSource returns the section-level label by inspecting the
+// per-entry sources. A section is "merged" when at least one project entry
+// AND at least one global entry are present. Otherwise the dominant axis
+// becomes the section label; if no entries resolved at all (every scalar
+// fell back to default), the section is labelled "default".
+func summarizeSectionSource(entries []EffectiveEntry) EffectiveSource {
+	hasProject, hasGlobal, hasResolved := false, false, false
+	for _, e := range entries {
+		switch e.Source {
+		case EffectiveSourceProject:
+			hasProject = true
+			hasResolved = true
+		case EffectiveSourceGlobal:
+			hasGlobal = true
+			hasResolved = true
+		}
+	}
+	switch {
+	case hasProject && hasGlobal:
+		return EffectiveSourceMerged
+	case hasProject:
+		return EffectiveSourceProject
+	case hasGlobal:
+		return EffectiveSourceGlobal
+	case !hasResolved:
+		return EffectiveSourceDefault
+	default:
+		return EffectiveSourceDefault
+	}
+}
+
+// LoadProjectConfigFile reads + parses a config.toml file. A missing file
+// resolves to an empty ProjectConfig, matching the policy used everywhere
+// else in the settings UI — "no file" is not an error.
+func LoadProjectConfigFile(path string) (ProjectConfig, error) {
+	if strings.TrimSpace(path) == "" {
+		return ProjectConfig{}, nil
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ProjectConfig{}, nil
+		}
+		return ProjectConfig{}, err
+	}
+	return ParseProjectConfig(string(content))
+}
+
+// sensitiveEnvKeyPattern lists the case-insensitive substrings that flag an
+// env key as carrying credentials. Matching keys have their value replaced
+// with the redaction sentinel in display contexts. The list is intentionally
+// conservative — projmux is a tmux launcher, so over-redacting is preferable
+// to leaking a token into a settings popup.
+var sensitiveEnvKeyPattern = []string{
+	"TOKEN",
+	"SECRET",
+	"KEY",
+	"PASSWORD",
+	"PASSWD",
+	"CREDENTIAL",
+}
+
+// SensitiveRedaction is the display sentinel substituted for sensitive
+// env values. Exported so the settings UI and any future formatter share
+// one constant.
+const SensitiveRedaction = "<redacted>"
+
+// IsSensitiveEnvKey reports whether key looks like it carries a credential
+// and should be redacted in display. Match is case-insensitive on substrings
+// — KEY matches API_KEY and OPENAI_API_KEY but also AES_KEY_FILE, which is
+// the conservative trade-off.
+func IsSensitiveEnvKey(key string) bool {
+	upper := strings.ToUpper(strings.TrimSpace(key))
+	if upper == "" {
+		return false
+	}
+	for _, needle := range sensitiveEnvKeyPattern {
+		if strings.Contains(upper, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// DisplayEnvValue returns the value formatted for the settings popup,
+// substituting the redaction sentinel when the key flags as sensitive.
+// An empty value resolves to "(unset)" so the row reads as a state row.
+func DisplayEnvValue(key, value string) string {
+	if IsSensitiveEnvKey(key) {
+		return SensitiveRedaction
+	}
+	if strings.TrimSpace(value) == "" {
+		return "(unset)"
+	}
+	return value
+}

--- a/internal/integrations/hooks/effective_test.go
+++ b/internal/integrations/hooks/effective_test.go
@@ -1,0 +1,210 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestMergeEffectiveProjectWinsConflicts(t *testing.T) {
+	t.Parallel()
+
+	global := ProjectConfig{
+		StartupRun: "global-cmd",
+		Env: map[string]string{
+			"EDITOR":       "vim",
+			"DATABASE_URL": "postgres://global",
+		},
+		Kube: KubeConfig{
+			Context:   "global-cluster",
+			Namespace: "default",
+		},
+	}
+	project := ProjectConfig{
+		StartupRun: "claude",
+		Env: map[string]string{
+			"DATABASE_URL": "postgres://project",
+			"GH_TOKEN":     "ghp_abc",
+		},
+		Kube: KubeConfig{
+			Context: "dev-cluster",
+		},
+	}
+
+	got := MergeEffective(global, project)
+
+	// [env] — DATABASE_URL conflict → project wins; EDITOR only in global;
+	// GH_TOKEN only in project. Section label = merged.
+	wantEnv := []EffectiveEntry{
+		{Key: "DATABASE_URL", Value: "postgres://project", Source: EffectiveSourceProject},
+		{Key: "EDITOR", Value: "vim", Source: EffectiveSourceGlobal},
+		{Key: "GH_TOKEN", Value: "ghp_abc", Source: EffectiveSourceProject},
+	}
+	if !reflect.DeepEqual(got.Env.Entries, wantEnv) {
+		t.Fatalf("env entries = %+v, want %+v", got.Env.Entries, wantEnv)
+	}
+	if got.Env.Source != EffectiveSourceMerged {
+		t.Fatalf("env section source = %q, want merged", got.Env.Source)
+	}
+
+	// [kube] — context: project wins (project value); namespace: only in global.
+	wantKube := []EffectiveEntry{
+		{Key: "context", Value: "dev-cluster", Source: EffectiveSourceProject},
+		{Key: "namespace", Value: "default", Source: EffectiveSourceGlobal},
+	}
+	if !reflect.DeepEqual(got.Kube.Entries, wantKube) {
+		t.Fatalf("kube entries = %+v, want %+v", got.Kube.Entries, wantKube)
+	}
+	if got.Kube.Source != EffectiveSourceMerged {
+		t.Fatalf("kube section source = %q, want merged", got.Kube.Source)
+	}
+
+	// [startup] — single scalar, project wins.
+	wantStartup := []EffectiveEntry{
+		{Key: "run", Value: "claude", Source: EffectiveSourceProject},
+	}
+	if !reflect.DeepEqual(got.Startup.Entries, wantStartup) {
+		t.Fatalf("startup entries = %+v, want %+v", got.Startup.Entries, wantStartup)
+	}
+	if got.Startup.Source != EffectiveSourceProject {
+		t.Fatalf("startup section source = %q, want project", got.Startup.Source)
+	}
+}
+
+func TestMergeEffectiveDefaultsWhenBothEmpty(t *testing.T) {
+	t.Parallel()
+
+	got := MergeEffective(ProjectConfig{}, ProjectConfig{})
+
+	if len(got.Env.Entries) != 0 {
+		t.Fatalf("env entries = %+v, want empty", got.Env.Entries)
+	}
+	if got.Env.Source != EffectiveSourceDefault {
+		t.Fatalf("env source on empty merge = %q, want default", got.Env.Source)
+	}
+	// kube / startup always emit scalar rows (so the UI keeps stable
+	// row positions); when unset they label as default.
+	for _, entry := range got.Kube.Entries {
+		if entry.Source != EffectiveSourceDefault {
+			t.Fatalf("kube entry %q source = %q, want default", entry.Key, entry.Source)
+		}
+	}
+	if got.Kube.Source != EffectiveSourceDefault {
+		t.Fatalf("kube section source = %q, want default", got.Kube.Source)
+	}
+	for _, entry := range got.Startup.Entries {
+		if entry.Source != EffectiveSourceDefault {
+			t.Fatalf("startup entry %q source = %q, want default", entry.Key, entry.Source)
+		}
+	}
+}
+
+func TestMergeEffectiveGlobalOnlySectionLabel(t *testing.T) {
+	t.Parallel()
+
+	global := ProjectConfig{
+		Env: map[string]string{"EDITOR": "vim"},
+		Kube: KubeConfig{
+			Namespace: "team-foo",
+		},
+	}
+	got := MergeEffective(global, ProjectConfig{})
+
+	if got.Env.Source != EffectiveSourceGlobal {
+		t.Fatalf("env section source = %q, want global (only global entries)", got.Env.Source)
+	}
+	if got.Kube.Source != EffectiveSourceGlobal {
+		t.Fatalf("kube section source = %q, want global (only global namespace defined)", got.Kube.Source)
+	}
+}
+
+func TestMergeEffectiveProjectOnlySectionLabel(t *testing.T) {
+	t.Parallel()
+
+	project := ProjectConfig{
+		StartupRun: "claude",
+		Env:        map[string]string{"GH_TOKEN": "ghp_xxx"},
+	}
+	got := MergeEffective(ProjectConfig{}, project)
+
+	if got.Env.Source != EffectiveSourceProject {
+		t.Fatalf("env section source = %q, want project", got.Env.Source)
+	}
+	if got.Startup.Source != EffectiveSourceProject {
+		t.Fatalf("startup section source = %q, want project", got.Startup.Source)
+	}
+}
+
+func TestLoadProjectConfigFileMissingReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg, err := LoadProjectConfigFile(filepath.Join(dir, "config.toml"))
+	if err != nil {
+		t.Fatalf("LoadProjectConfigFile() missing path error = %v", err)
+	}
+	if !reflect.DeepEqual(cfg, (ProjectConfig{})) {
+		t.Fatalf("missing config = %+v, want zero ProjectConfig", cfg)
+	}
+}
+
+func TestLoadProjectConfigFileParsesWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte("[env]\nEDITOR = \"vim\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := LoadProjectConfigFile(path)
+	if err != nil {
+		t.Fatalf("LoadProjectConfigFile() error = %v", err)
+	}
+	if got, want := cfg.Env["EDITOR"], "vim"; got != want {
+		t.Fatalf("env EDITOR = %q, want %q", got, want)
+	}
+}
+
+func TestIsSensitiveEnvKey(t *testing.T) {
+	t.Parallel()
+
+	sensitive := []string{
+		"GH_TOKEN",
+		"OPENAI_API_KEY",
+		"DATABASE_PASSWORD",
+		"MY_SECRET",
+		"AWS_CREDENTIAL_FILE",
+		"some_password_x", // case-insensitive
+	}
+	for _, key := range sensitive {
+		if !IsSensitiveEnvKey(key) {
+			t.Fatalf("IsSensitiveEnvKey(%q) = false, want true", key)
+		}
+	}
+	nonSensitive := []string{
+		"EDITOR",
+		"DATABASE_URL",
+		"PATH",
+		"",
+	}
+	for _, key := range nonSensitive {
+		if IsSensitiveEnvKey(key) {
+			t.Fatalf("IsSensitiveEnvKey(%q) = true, want false", key)
+		}
+	}
+}
+
+func TestDisplayEnvValueRedactsSensitive(t *testing.T) {
+	t.Parallel()
+
+	if got := DisplayEnvValue("GH_TOKEN", "ghp_abc123"); got != SensitiveRedaction {
+		t.Fatalf("DisplayEnvValue sensitive = %q, want %q", got, SensitiveRedaction)
+	}
+	if got := DisplayEnvValue("EDITOR", "vim"); got != "vim" {
+		t.Fatalf("DisplayEnvValue plain = %q, want vim", got)
+	}
+	if got := DisplayEnvValue("EDITOR", ""); got != "(unset)" {
+		t.Fatalf("DisplayEnvValue empty = %q, want (unset)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Implements Phase 3 of the Settings global/project split roadmap: the **Effective merge view** Project tab page that surfaces the merged result of `[env]`, `[kube]`, and `[startup]` from the global config.toml and the project-local `.projmux/config.toml`, with a per-row source label (`project` / `global` / `merged` / `default`).

## Spec coverage

- New "Effective merge view" row in the Settings popup Project tab, opened with Enter — the row was a Phase 3 placeholder in Phase 2.5; this PR activates it.
- Reads global config (`~/.config/projmux/config.toml`) and project config (`<repo>/.projmux/config.toml`). A missing file resolves to an empty config (not an error), matching the policy used elsewhere in the settings UI.
- Merge policy: **project wins** on conflict (per Phase B spec).
- `[hooks.*]` is intentionally out of scope — Hook maker Phase 4 owns that surface. This PR only merges the data sections.

## Merge engine

Located at `internal/integrations/hooks/effective.go`:

- `MergeEffective(global, project ProjectConfig) EffectiveConfig` — pure function, no filesystem access. Hook maker Phase 4 and any future `projmux hook` CLI can reuse it.
- `LoadProjectConfigFile(path string) (ProjectConfig, error)` — shared "no file is not an error" loader.
- `IsSensitiveEnvKey(key string) bool` + `DisplayEnvValue(key, value string) string` + `SensitiveRedaction = "<redacted>"` — redaction helpers, also reusable from the hook CLI.

A new `config.GlobalConfigFileName` constant and `Paths.GlobalConfigFile()` method anchor the global config.toml location in the standard XDG layout.

## Source label semantics

| Label     | Per-row meaning                                        | Section meaning                                             |
| --------- | ------------------------------------------------------ | ----------------------------------------------------------- |
| `project` | Value resolved from project config (wins on conflict). | All resolved entries came from project.                     |
| `global`  | Value resolved from global config only.                | All resolved entries came from global.                      |
| `merged`  | (Not used per-row.)                                    | Section contains entries from **both** axes.                |
| `default` | Scalar field is unset on both axes (kube / startup).   | No entries resolved at all (every scalar fell to default).  |

## Sensitive value redaction

Env keys whose name (case-insensitive) contains any of `TOKEN`, `SECRET`, `KEY`, `PASSWORD`, `PASSWD`, `CREDENTIAL` are displayed as `<redacted>`. The substring match is intentionally conservative — over-redacting is preferable to leaking a credential into a settings popup. The list is centralised in `effective.go` so the hook CLI sees the same rules.

## Project-wins verification

The unit test `TestMergeEffectiveProjectWinsConflicts` exercises the conflict path explicitly: a `DATABASE_URL` defined in both axes resolves to the project value with a `project` label, while non-conflicting keys (`EDITOR`, `GH_TOKEN`) keep their origin axis. The UI test `TestEffectiveMergeEntriesShowSourceLabels` then asserts the same outcome ends up in the rendered picker entries.

## Tests

- `go build ./...` clean
- `go test ./...` all packages green
- New tests:
  - `internal/integrations/hooks/effective_test.go` — engine: merge / project-wins / global-only / project-only / defaults / loader / redaction.
  - `internal/app/effective_merge_test.go` — UI: disabled-without-project, source labels in entries, redaction does not leak, missing global handled, dispatch routing.
  - `internal/app/settings_test.go` catalog regression: `settingsSectionEffectiveMerge` is `settingsAxisProject`.

## Test plan

- [ ] `make install` and open Settings popup from a project pane
- [ ] Switch to Project tab — confirm "Effective merge view" is now an open-able row
- [ ] Open it — confirm header info rows (Project context / Global config / Project config) and `[env]` / `[kube]` / `[startup]` sections render with per-row source labels
- [ ] Add a `GH_TOKEN` to project config — confirm value renders as `<redacted>`
- [ ] Add a global `~/.config/projmux/config.toml` with conflicting `EDITOR` — confirm project value wins, label is `project`

## Out of scope (per spec)

- `[hooks.*]` merge / source view → Hook maker Phase 4
- Trust prompts on the merge view (read-only page)
- Edit actions on the merge view (read-only by design; edits happen on the Project Config page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)