### PR TITLE
feat: add settings chip click and alt-shift chord

### DIFF
--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -194,9 +194,9 @@ func (c *settingsCommand) Run(args []string, stdout, stderr io.Writer) error {
 			ctx := c.resolveSettingsProjectContext()
 			if next == settingsRootTabProject && !ctx.hasProject() {
 				// Single-tab environment (no project context): the Project
-				// chip renders disabled and Alt-Left/Alt-Right is a no-op.
-				// We stay on the current tab rather than navigating into an
-				// empty Project scope.
+				// chip renders disabled and Alt-Shift-Left/Alt-Shift-Right
+				// (or a chip click) is a no-op. We stay on the current tab
+				// rather than navigating into an empty Project scope.
 				tab = settingsRootTabGlobal
 				continue
 			}
@@ -289,8 +289,8 @@ func (c *settingsCommand) rootOptions(tab settingsRootTab) intpickercompat.Optio
 		TitleChips: settingsRootTabChips(tab, ctx.hasProject()),
 		Prompt:     settingsRootPrompt(tab),
 		Header:     settingsRootContextHeader(tab, ctx),
-		Footer:     projmuxFooter("Enter: open  |  Alt-Left/Alt-Right: switch tab  |  Esc/Alt+5/Ctrl+Alt+S: close"),
-		ExpectKeys: []string{"enter", "ctrl-g", "ctrl-p", "alt-left", "alt-right"},
+		Footer:     projmuxFooter("Enter: open  |  Alt-Shift-Left/Alt-Shift-Right or click chip: switch tab  |  Esc/Alt+5/Ctrl+Alt+S: close"),
+		ExpectKeys: []string{"enter", "ctrl-g", "ctrl-p", "alt-shift-left", "alt-shift-right"},
 		Bindings:   settingsCloseBindings(),
 	}
 }
@@ -299,16 +299,21 @@ func (c *settingsCommand) rootOptions(tab settingsRootTab) intpickercompat.Optio
 // titlebar so the active scope reads as a real tab metaphor instead of an
 // inline list entry. When no project context is available, the Project
 // chip renders as disabled so the user still sees that the tab exists.
+// ClickValue mirrors the sentinel emitted by Alt-Shift-Left/Right chord
+// handling so a primary-button click on the chip resolves through the
+// same tab-resolution path as the keyboard chord.
 func settingsRootTabChips(active settingsRootTab, hasProject bool) []projmuxpicker.Chip {
 	return []projmuxpicker.Chip{
 		{
-			Label:  "Global",
-			Active: active == settingsRootTabGlobal,
+			Label:      "Global",
+			Active:     active == settingsRootTabGlobal,
+			ClickValue: settingsRootTabGlobalValue,
 		},
 		{
-			Label:    "Project",
-			Active:   active == settingsRootTabProject,
-			Disabled: !hasProject,
+			Label:      "Project",
+			Active:     active == settingsRootTabProject,
+			Disabled:   !hasProject,
+			ClickValue: settingsRootTabProjectValue,
 		},
 	}
 }
@@ -335,16 +340,18 @@ func settingsRootTabFromResult(result intpickercompat.Result) (settingsRootTab, 
 }
 
 // settingsRootTabFromResultWithCurrent resolves which tab the popup should
-// show next. Alt-Left and Alt-Right cycle between Global and Project,
-// while the legacy Ctrl-G / Ctrl-P bindings remain as direct selectors so
-// muscle memory does not regress.
+// show next. Alt-Shift-Left and Alt-Shift-Right cycle between Global and
+// Project, while the legacy Ctrl-G / Ctrl-P bindings remain as direct
+// selectors so muscle memory does not regress. Primary-button chip clicks
+// resolve through the Value sentinels emitted by the chip strip so click
+// and chord follow the same tab-resolution path.
 func settingsRootTabFromResultWithCurrent(result intpickercompat.Result, current settingsRootTab) (settingsRootTab, bool) {
 	switch strings.TrimSpace(result.Key) {
 	case "ctrl-g":
 		return settingsRootTabGlobal, true
 	case "ctrl-p":
 		return settingsRootTabProject, true
-	case "alt-left", "alt-right":
+	case "alt-shift-left", "alt-shift-right":
 		return settingsRootTabToggle(current), true
 	}
 	switch strings.TrimSpace(result.Value) {
@@ -429,11 +436,11 @@ func (ctx settingsProjectContext) hasProject() bool {
 func (c *settingsCommand) projectTabEntries() []intpickercompat.Entry {
 	ctx := c.resolveSettingsProjectContext()
 	if !ctx.hasProject() {
+		// The titlebar chip strip already advertises the active Project
+		// scope (and the popup header carries the "no project" hint), so
+		// the picker entry list skips the redundant "Project context"
+		// placeholder row that lived above the search bar in Phase 1/2.
 		return []intpickercompat.Entry{
-			{
-				Label: settingsLabelDim("Project context", "no project - open Settings from a project pane or set PROJMUX_CWD"),
-				Value: settingsNoopValue,
-			},
 			{
 				Label: settingsLabelDim("Trust", "disabled - no project context"),
 				Value: settingsNoopValue,
@@ -453,11 +460,9 @@ func (c *settingsCommand) projectTabEntries() []intpickercompat.Entry {
 		}
 	}
 
+	// The project context label is conveyed by the chip strip plus the
+	// popup header — keep the picker entries focused on actionable rows.
 	return []intpickercompat.Entry{
-		{
-			Label: settingsLabelInfo("Project context", ctx.Path, ctx.Source),
-			Value: settingsNoopValue,
-		},
 		{
 			Label: settingsLabelDim("Trust", "read-only preview arrives in Phase 4"),
 			Value: settingsNoopValue,

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -70,16 +70,16 @@ func TestSettingsRootOptionsDefaultGlobalTab(t *testing.T) {
 		t.Fatalf("root settings header = %q, want plain project context header %q", got, want)
 	}
 	wantChips := []projmuxpicker.Chip{
-		{Label: "Global", Active: true},
-		{Label: "Project", Disabled: true},
+		{Label: "Global", Active: true, ClickValue: settingsRootTabGlobalValue},
+		{Label: "Project", Disabled: true, ClickValue: settingsRootTabProjectValue},
 	}
 	if got := options.TitleChips; !reflect.DeepEqual(got, wantChips) {
 		t.Fatalf("root settings title chips = %#v, want %#v", got, wantChips)
 	}
-	if got, want := options.Footer, "Enter: open  |  Alt-Left/Alt-Right: switch tab  |  Esc/Alt+5/Ctrl+Alt+S: close"; got != want {
+	if got, want := options.Footer, "Enter: open  |  Alt-Shift-Left/Alt-Shift-Right or click chip: switch tab  |  Esc/Alt+5/Ctrl+Alt+S: close"; got != want {
 		t.Fatalf("root settings footer = %q, want %q", got, want)
 	}
-	if got, want := options.ExpectKeys, []string{"enter", "ctrl-g", "ctrl-p", "alt-left", "alt-right"}; !reflect.DeepEqual(got, want) {
+	if got, want := options.ExpectKeys, []string{"enter", "ctrl-g", "ctrl-p", "alt-shift-left", "alt-shift-right"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("root settings expect keys = %#v, want %#v", got, want)
 	}
 	if got, want := options.Bindings, []string{"esc:abort", "ctrl-c:abort", "alt-5:abort", "ctrl-alt-s:abort"}; !reflect.DeepEqual(got, want) {
@@ -151,7 +151,7 @@ func TestSettingsRootAltArrowTogglesTabsWhenProjectAvailable(t *testing.T) {
 		calls++
 		switch calls {
 		case 1:
-			return intpickercompat.Result{Key: "alt-right"}, nil
+			return intpickercompat.Result{Key: "alt-shift-right"}, nil
 		case 2:
 			projectOptions = options
 			return intpickercompat.Result{}, nil
@@ -174,10 +174,10 @@ func TestSettingsRootAltArrowTogglesTabsWhenProjectAvailable(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	if got, want := projectOptions.Prompt, "Settings > Project > "; got != want {
-		t.Fatalf("project tab prompt = %q, want %q after alt-right", got, want)
+		t.Fatalf("project tab prompt = %q, want %q after alt-shift-right", got, want)
 	}
 	if got := projectOptions.TitleChips; len(got) < 2 || got[0].Active || !got[1].Active || got[1].Disabled {
-		t.Fatalf("project tab chips after alt-right = %#v, want Project active and not disabled", got)
+		t.Fatalf("project tab chips after alt-shift-right = %#v, want Project active and not disabled", got)
 	}
 }
 
@@ -195,10 +195,10 @@ func TestSettingsRootAltArrowToggleInvariantWithProjectContext(t *testing.T) {
 		switch calls {
 		case 1:
 			// Global tab — pivot right.
-			return intpickercompat.Result{Key: "alt-right"}, nil
+			return intpickercompat.Result{Key: "alt-shift-right"}, nil
 		case 2:
 			// Project tab — pivot back left.
-			return intpickercompat.Result{Key: "alt-left"}, nil
+			return intpickercompat.Result{Key: "alt-shift-left"}, nil
 		case 3:
 			third = options
 			return intpickercompat.Result{}, nil
@@ -224,23 +224,27 @@ func TestSettingsRootAltArrowToggleInvariantWithProjectContext(t *testing.T) {
 		t.Fatalf("toggled-back prompt = %q, want %q", got, want)
 	}
 	if got := third.TitleChips; len(got) < 2 || !got[0].Active || got[1].Active {
-		t.Fatalf("toggled-back chips = %#v, want Global active after alt-right then alt-left", got)
+		t.Fatalf("toggled-back chips = %#v, want Global active after alt-shift-right then alt-shift-left", got)
 	}
 }
 
 func TestSettingsRootAltArrowDoesNotShadowGlobalSelectPaneChords(t *testing.T) {
 	t.Parallel()
 
-	// The settings popup binds Alt-Left/Alt-Right for tab navigation while
-	// global tmux select-pane chords keep the same physical keys. This is
-	// safe because tmux popups consume their own stdin and the popup is the
-	// active terminal client when Alt-Left/Right is pressed — the global
-	// chord only fires outside the popup. Verify the catalog still ships
-	// M-Left / M-Right so the global behaviour does not regress.
+	// The settings popup binds Alt-Shift-Left/Alt-Shift-Right for tab
+	// navigation while global tmux next/prev-window chords keep the same
+	// physical keys. This is safe because tmux popups consume their own
+	// stdin and the popup is the active terminal client when
+	// Alt-Shift-Left/Right is pressed — the global chord only fires
+	// outside the popup. Verify the catalog still ships M-S-Left /
+	// M-S-Right (and M-Left / M-Right select-pane) so the global behaviour
+	// does not regress.
 	catalog := defaultKeyBindingCatalog()
 	wantChords := map[string]string{
 		"select-pane-left":  "M-Left",
 		"select-pane-right": "M-Right",
+		"previous-window":   "M-S-Left",
+		"next-window":       "M-S-Right",
 	}
 	for id, chord := range wantChords {
 		var got string
@@ -260,9 +264,16 @@ func TestSettingsRootAltArrowDoesNotShadowGlobalSelectPaneChords(t *testing.T) {
 	for _, key := range rootOpts.ExpectKeys {
 		popupKeys[key] = true
 	}
-	for _, key := range []string{"alt-left", "alt-right"} {
+	for _, key := range []string{"alt-shift-left", "alt-shift-right"} {
 		if !popupKeys[key] {
 			t.Fatalf("settings popup expect keys = %#v, want %q", rootOpts.ExpectKeys, key)
+		}
+	}
+	// The legacy Alt-Left/Alt-Right chord no longer toggles tabs so
+	// muscle-memory holders of the new Alt-Shift chord do not double-bind.
+	for _, key := range []string{"alt-left", "alt-right"} {
+		if popupKeys[key] {
+			t.Fatalf("settings popup expect keys = %#v, want %q removed (Phase 2.6 chord changed to alt-shift)", rootOpts.ExpectKeys, key)
 		}
 	}
 }
@@ -276,7 +287,7 @@ func TestSettingsRootAltArrowIsNoopWithoutProjectContext(t *testing.T) {
 		calls++
 		switch calls {
 		case 1:
-			return intpickercompat.Result{Key: "alt-right"}, nil
+			return intpickercompat.Result{Key: "alt-shift-right"}, nil
 		case 2:
 			secondOptions = options
 			return intpickercompat.Result{}, nil
@@ -294,10 +305,82 @@ func TestSettingsRootAltArrowIsNoopWithoutProjectContext(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	if got, want := secondOptions.Prompt, "Settings > "; got != want {
-		t.Fatalf("alt-right with no project context = %q, want still on Global tab %q", got, want)
+		t.Fatalf("alt-shift-right with no project context = %q, want still on Global tab %q", got, want)
 	}
 	if got := secondOptions.TitleChips; len(got) < 2 || !got[0].Active || got[1].Active || !got[1].Disabled {
-		t.Fatalf("alt-right chips = %#v, want Global active and Project disabled (single-tab no-op)", got)
+		t.Fatalf("alt-shift-right chips = %#v, want Global active and Project disabled (single-tab no-op)", got)
+	}
+}
+
+func TestSettingsRootChipClickSwitchesToProjectTab(t *testing.T) {
+	t.Parallel()
+
+	// Phase 2.6: chip click resolves through Value sentinels so the
+	// settings loop can treat keyboard chord (Alt-Shift-Right) and mouse
+	// click on the chip strip as equivalent tab transitions.
+	home := t.TempDir()
+	project := filepath.Join(home, "app")
+	mkdirAll(t, filepath.Join(project, ".git"))
+
+	var calls int
+	var projectOptions intpickercompat.Options
+	runner := switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
+		calls++
+		switch calls {
+		case 1:
+			return intpickercompat.Result{Key: "chip", Value: settingsRootTabProjectValue}, nil
+		case 2:
+			projectOptions = options
+			return intpickercompat.Result{}, nil
+		default:
+			return intpickercompat.Result{}, nil
+		}
+	})
+	cmd := &settingsCommand{
+		runner:       runner,
+		nativePicker: nativePickerFromCompatRunner(runner),
+		lookupEnv: func(name string) string {
+			if name == "PROJMUX_CWD" {
+				return project
+			}
+			return ""
+		},
+	}
+
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got, want := projectOptions.Prompt, "Settings > Project > "; got != want {
+		t.Fatalf("project tab prompt after chip click = %q, want %q", got, want)
+	}
+}
+
+func TestSettingsRootChipClickOnDisabledProjectChipIsNoop(t *testing.T) {
+	t.Parallel()
+
+	// Without a project context the Project chip is disabled — picker
+	// suppresses the click at hit detection time so the settings loop
+	// never sees a chip Result for the Project tab. Mimic that behaviour
+	// in the runner stub by returning an empty result on the first call;
+	// the loop should fall through to "close picker" rather than toggle.
+	var calls int
+	runner := switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
+		calls++
+		// First call: Global tab. Return Closed result (Key empty, Value
+		// empty) so the loop exits cleanly. If chip click on a disabled
+		// chip were emitted as a Value we'd loop forever.
+		return intpickercompat.Result{}, nil
+	})
+	cmd := &settingsCommand{
+		runner:       runner,
+		nativePicker: nativePickerFromCompatRunner(runner),
+		lookupEnv:    func(string) string { return "" },
+	}
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("runner calls = %d, want exactly one picker invocation when disabled chip click is suppressed", calls)
 	}
 }
 
@@ -318,10 +401,16 @@ func TestSettingsProjectTabNoProjectShowsDisabledState(t *testing.T) {
 			t.Fatalf("project tab entry values = %#v, want disabled/noop rows only without inline tab toggle", entryValues(options.Entries))
 		}
 	}
-	for _, label := range []string{"no project", "Trust", "Hooks (project)", "config.toml", "Effective merge view"} {
+	for _, label := range []string{"Trust", "Hooks (project)", "config.toml", "Effective merge view"} {
 		if !hasEntryLabelContaining(options.Entries, label) {
 			t.Fatalf("project tab entries = %#v, want label containing %q", options.Entries, label)
 		}
+	}
+	// Phase 2.6: the chip strip plus popup header already announce the
+	// active scope, so the entry list drops the redundant "Project
+	// context" placeholder row that lived above the search bar.
+	if hasEntryLabelContaining(options.Entries, "Project context") {
+		t.Fatalf("project tab entries = %#v, want no \"Project context\" placeholder row", options.Entries)
 	}
 }
 
@@ -580,7 +669,7 @@ func TestSettingsHubSetsAIDefaultMode(t *testing.T) {
 	if got := rootOptions.TitleChips; len(got) < 1 || !got[0].Active {
 		t.Fatalf("root settings chips = %#v, want Global active", got)
 	}
-	if got, want := rootOptions.Footer, "Enter: open  |  Alt-Left/Alt-Right: switch tab  |  Esc/Alt+5/Ctrl+Alt+S: close"; got != want {
+	if got, want := rootOptions.Footer, "Enter: open  |  Alt-Shift-Left/Alt-Shift-Right or click chip: switch tab  |  Esc/Alt+5/Ctrl+Alt+S: close"; got != want {
 		t.Fatalf("root settings footer = %q, want %q", got, want)
 	}
 	if got, want := entryValues(rootOptions.Entries), []string{

--- a/internal/ui/picker/backend.go
+++ b/internal/ui/picker/backend.go
@@ -451,6 +451,18 @@ func runNativeInteractive(in io.Reader, out io.Writer, options Options) (Result,
 				}
 				continue
 			}
+			if nativeMouseIsPrimaryButton(key.Mouse.Button) {
+				// Chip click takes priority over list hit detection: chips
+				// live on the titlebar row above the content area so the
+				// regions never overlap, but resolving the chip first
+				// keeps the precedence explicit and matches the tab-style
+				// metaphor where the strip is its own click target.
+				if chipResult, ok := nativeMouseChipResult(options, layout, key.Mouse.X, key.Mouse.Y, query); ok {
+					primaryMouseDown = false
+					nativeDebugLogf("interactive ui=%q result=chip mouse=press value=%q query=%q", options.UI, chipResult.Value, chipResult.Query)
+					return chipResult, nil
+				}
+			}
 			if primaryMouseDown && nativeMouseIsPrimaryDrag(key.Mouse.Button) {
 				if nextSelected, ok := nativeMouseItemIndex(options, items, selected, layout, key.Mouse.X, key.Mouse.Y); ok {
 					selected = nextSelected
@@ -711,6 +723,38 @@ func nativeMouseSelection(options Options, items []Item, selected int, layout na
 	}
 }
 
+// nativeMouseChipResult resolves a primary-button press into a chip click
+// result. It returns ok=false when no chip strip is rendered, when the
+// click lands outside any chip's hit region, or when the chip has no
+// ClickValue (chord-only chip). Disabled chips still match the row but
+// resolve to ok=false so the press becomes a no-op — chord and click
+// behaviour stay in lockstep.
+func nativeMouseChipResult(options Options, layout nativeLayout, x, y int, query string) (Result, bool) {
+	if len(options.TitleChips) == 0 {
+		return Result{}, false
+	}
+	if y != projmuxpicker.ChipsTitlebarRow() {
+		return Result{}, false
+	}
+	innerWidth := layout.Cols - 2
+	if innerWidth < 4 {
+		return Result{}, false
+	}
+	for _, hit := range projmuxpicker.ChipsHitRegions(options.TitleChips, innerWidth) {
+		if x < hit.ColStart || x > hit.ColEnd {
+			continue
+		}
+		if hit.Disabled {
+			return Result{}, false
+		}
+		if strings.TrimSpace(hit.Value) == "" {
+			return Result{}, false
+		}
+		return Result{Key: "chip", Value: hit.Value, Query: query}, true
+	}
+	return Result{}, false
+}
+
 func nativeMouseIsPrimaryButton(button int) bool {
 	return button&32 == 0 && button&3 == 0
 }
@@ -910,8 +954,20 @@ func nativeKeyFromCSI(seq []byte) nativeKey {
 		return nativeKey{Name: "shift-" + name}
 	case "3":
 		return nativeKey{Name: "alt-" + name}
+	case "4":
+		// CSI modifier 4 = Shift+Alt. xterm encodes Alt-Shift-Left as
+		// "\x1b[1;4D" — normalize to alt-shift-<name> so popup chord
+		// matching uses the same surface form as keyboard chord catalog
+		// entries.
+		return nativeKey{Name: "alt-shift-" + name}
 	case "5":
 		return nativeKey{Name: "ctrl-" + name}
+	case "6":
+		return nativeKey{Name: "ctrl-shift-" + name}
+	case "7":
+		return nativeKey{Name: "ctrl-alt-" + name}
+	case "8":
+		return nativeKey{Name: "ctrl-alt-shift-" + name}
 	default:
 		return nativeKey{Name: name}
 	}

--- a/internal/ui/picker/backend_test.go
+++ b/internal/ui/picker/backend_test.go
@@ -1032,6 +1032,129 @@ func TestNativeInteractiveConsumesShiftCSIKeys(t *testing.T) {
 	}
 }
 
+func TestNativeInteractiveNormalizesAltShiftArrowCSIKeys(t *testing.T) {
+	t.Parallel()
+
+	// xterm encodes Alt-Shift-Left/Right as CSI 1;4D / 1;4C — modifier 4 is
+	// Shift+Alt. Settings popup Phase 2.6 binds Alt-Shift-Left/Right for
+	// tab navigation so the picker must surface them in their compound
+	// normalized form rather than dropping the modifier.
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "alt-shift-left", in: "\x1b[1;4D", want: "alt-shift-left"},
+		{name: "alt-shift-right", in: "\x1b[1;4C", want: "alt-shift-right"},
+		{name: "alt-shift-up", in: "\x1b[1;4A", want: "alt-shift-up"},
+		{name: "alt-shift-down", in: "\x1b[1;4B", want: "alt-shift-down"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			key, err := readNativeKey(strings.NewReader(tc.in))
+			if err != nil {
+				t.Fatalf("readNativeKey() error = %v", err)
+			}
+			if key.Name != tc.want || key.Text != "" {
+				t.Fatalf("key = %#v, want %q", key, tc.want)
+			}
+		})
+	}
+}
+
+func TestNativeInteractiveChipClickEmitsClickValueResult(t *testing.T) {
+	t.Parallel()
+
+	// Frame layout: outer 40x10, top border on row 1, chip strip on row 2.
+	// Chip "Global" starts at column 3 ([ G l o b a l ] occupies 3..10),
+	// gap at col 11, chip "Project" at cols 12..20. Click in the middle of
+	// the Project chip (col 16) should emit a chip result carrying the
+	// chip's ClickValue so the caller can resolve the tab transition.
+	in := "\x1b[<0;16;2M\x1b[<0;16;2m"
+	result, err := runNativeInteractive(strings.NewReader(in), io.Discard, Options{
+		UI: "settings",
+		TitleChips: []projmuxpicker.Chip{
+			{Label: "Global", Active: true, ClickValue: "__settings_tab_global__"},
+			{Label: "Project", ClickValue: "__settings_tab_project__"},
+		},
+		Items: []Item{
+			{Title: "Section A", Value: "section:a"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runNativeInteractive() error = %v", err)
+	}
+	if result.Key != "chip" || result.Value != "__settings_tab_project__" {
+		t.Fatalf("result = %#v, want chip click resolved to Project ClickValue", result)
+	}
+}
+
+func TestNativeInteractiveChipClickOnActiveChipResolves(t *testing.T) {
+	t.Parallel()
+
+	// Clicking the active chip still resolves through ClickValue — caller
+	// can interpret "click active tab" as either a no-op or a soft refresh.
+	in := "\x1b[<0;5;2M\x1b[<0;5;2m"
+	result, err := runNativeInteractive(strings.NewReader(in), io.Discard, Options{
+		UI: "settings",
+		TitleChips: []projmuxpicker.Chip{
+			{Label: "Global", Active: true, ClickValue: "__settings_tab_global__"},
+			{Label: "Project", ClickValue: "__settings_tab_project__"},
+		},
+		Items: []Item{{Title: "Section A", Value: "section:a"}},
+	})
+	if err != nil {
+		t.Fatalf("runNativeInteractive() error = %v", err)
+	}
+	if result.Key != "chip" || result.Value != "__settings_tab_global__" {
+		t.Fatalf("result = %#v, want chip click on active chip resolved to Global ClickValue", result)
+	}
+}
+
+func TestNativeInteractiveChipClickOnDisabledChipIsNoop(t *testing.T) {
+	t.Parallel()
+
+	// Disabled chip click is a no-op (matches chord behaviour). After the
+	// click we send Enter to select the only item — verify the result is
+	// the item, not a chip transition.
+	in := "\x1b[<0;16;2M\x1b[<0;16;2m\r"
+	result, err := runNativeInteractive(strings.NewReader(in), io.Discard, Options{
+		UI: "settings",
+		TitleChips: []projmuxpicker.Chip{
+			{Label: "Global", Active: true, ClickValue: "__settings_tab_global__"},
+			{Label: "Project", Disabled: true, ClickValue: "__settings_tab_project__"},
+		},
+		Items: []Item{{Title: "Section A", Value: "section:a"}},
+	})
+	if err != nil {
+		t.Fatalf("runNativeInteractive() error = %v", err)
+	}
+	if result.Key != "enter" || result.Value != "section:a" {
+		t.Fatalf("result = %#v, want disabled chip click ignored, enter selecting section:a", result)
+	}
+}
+
+func TestNativeInteractiveChipClickOutsideStripDoesNotEmitChipResult(t *testing.T) {
+	t.Parallel()
+
+	// A click on a row that is not the chip strip must not be hijacked by
+	// the chip-click handler. We check the result directly by calling the
+	// chip resolver — the integration-style test above already exercises
+	// row==2 clicks, so here we just need to assert "row==3 returns no
+	// chip" so future refactors of the row-2 invariant surface as a
+	// regression in this guard.
+	if _, ok := nativeMouseChipResult(Options{
+		TitleChips: []projmuxpicker.Chip{
+			{Label: "Global", Active: true, ClickValue: "tab:global"},
+			{Label: "Project", ClickValue: "tab:project"},
+		},
+	}, nativeLayout{Rows: 24, Cols: 40}, 16, 3, ""); ok {
+		t.Fatalf("nativeMouseChipResult(row=3) ok=true, want false because chip strip lives on row 2")
+	}
+}
+
 func TestNativeInteractiveWaitsForSplitEscapeSequences(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/projmuxpicker/frame.go
+++ b/internal/ui/projmuxpicker/frame.go
@@ -86,10 +86,92 @@ func RenderFullFrameUpdate(w io.Writer, frame string) {
 // chips with the inactive tone, so the popup tab metaphor visually matches
 // the tmux window list. Disabled chips render dim and convey "tab exists
 // but is not selectable" without breaking the chip row geometry.
+//
+// ClickValue is the picker Result.Value emitted when the chip is clicked
+// with the primary mouse button. Empty ClickValue or a Disabled chip make
+// the click a no-op so the picker keeps the keyboard chord and mouse
+// click metaphors in lockstep.
 type Chip struct {
-	Label    string
-	Active   bool
+	Label      string
+	Active     bool
+	Disabled   bool
+	ClickValue string
+}
+
+// ChipHit reports the visible column range a chip occupies in the rendered
+// chip strip. Columns are 1-based outer-frame coordinates so callers can
+// match mouse SGR events directly (the leftmost border column is 1).
+type ChipHit struct {
+	Index    int
 	Disabled bool
+	ColStart int
+	ColEnd   int
+	Value    string
+}
+
+// ChipsTitlebarRow returns the 1-based outer-frame row on which the chip
+// strip is rendered. The chip strip always sits on row 2 (top border is
+// row 1) so callers can collapse the entire layout calculation into a
+// single constant — kept as a function so the relation stays explicit and
+// is easy to extend if the frame grows additional decoration rows.
+func ChipsTitlebarRow() int {
+	return 2
+}
+
+// ChipsHitRegions returns the click-target columns each non-blank chip
+// occupies for the supplied innerWidth (frame inner width, i.e. outer
+// width minus the two border cells). The layout mirrors
+// frameTitlebarChipsLine: a single leading cell after the left border
+// followed by each chip body (" Label ") separated by one-cell gaps. The
+// caller is responsible for skipping disabled chips when matching, but
+// disabled chips still appear in the slice so geometry stays stable.
+func ChipsHitRegions(chips []Chip, innerWidth int) []ChipHit {
+	if innerWidth < 4 || len(chips) == 0 {
+		return nil
+	}
+	hits := make([]ChipHit, 0, len(chips))
+	// Column 1 is the left border, column 2 is the chip-strip leading
+	// padding cell, so the first chip body starts at column 3.
+	cursor := 3
+	maxBody := innerWidth - 1
+	used := 0
+	first := true
+	for index, chip := range chips {
+		label := strings.TrimSpace(chip.Label)
+		if label == "" {
+			continue
+		}
+		if !first {
+			gapWidth := 1
+			if used+gapWidth > maxBody {
+				break
+			}
+			cursor += gapWidth
+			used += gapWidth
+		}
+		first = false
+		remaining := maxBody - used
+		if remaining <= 2 {
+			break
+		}
+		labelBudget := remaining - 2
+		labelWidth := VisibleLen(label)
+		if labelWidth > labelBudget {
+			label = TruncateANSI(label, labelBudget)
+			labelWidth = VisibleLen(label)
+		}
+		chipWidth := labelWidth + 2
+		hits = append(hits, ChipHit{
+			Index:    index,
+			Disabled: chip.Disabled,
+			ColStart: cursor,
+			ColEnd:   cursor + chipWidth - 1,
+			Value:    chip.ClickValue,
+		})
+		cursor += chipWidth
+		used += chipWidth
+	}
+	return hits
 }
 
 func (r Renderer) ContentLayout(layout Layout) Layout {

--- a/internal/ui/projmuxpicker/frame_test.go
+++ b/internal/ui/projmuxpicker/frame_test.go
@@ -320,6 +320,64 @@ func TestRendererRenderFrameWithEmptyChipsHasNoTitlebar(t *testing.T) {
 	}
 }
 
+func TestChipsHitRegionsReportsClickColumnRangesPerChip(t *testing.T) {
+	t.Parallel()
+
+	// Outer width 40 → innerWidth 38. Chip strip layout starts at outer
+	// column 3 (border + leading cell), each chip body is " Label ", and
+	// chips are separated by one gap cell. " Global " spans 8 cells, then
+	// gap, then " Project " spans 9 cells.
+	hits := ChipsHitRegions([]Chip{
+		{Label: "Global", Active: true, ClickValue: "tab:global"},
+		{Label: "Project", Disabled: true, ClickValue: "tab:project"},
+	}, 38)
+
+	want := []ChipHit{
+		{Index: 0, Disabled: false, ColStart: 3, ColEnd: 10, Value: "tab:global"},
+		{Index: 1, Disabled: true, ColStart: 12, ColEnd: 20, Value: "tab:project"},
+	}
+	if len(hits) != len(want) {
+		t.Fatalf("ChipsHitRegions() length = %d, want %d (hits=%#v)", len(hits), len(want), hits)
+	}
+	for i := range want {
+		if hits[i] != want[i] {
+			t.Fatalf("ChipsHitRegions()[%d] = %#v, want %#v", i, hits[i], want[i])
+		}
+	}
+}
+
+func TestChipsHitRegionsSkipsBlankChips(t *testing.T) {
+	t.Parallel()
+
+	hits := ChipsHitRegions([]Chip{
+		{Label: "", ClickValue: ""},
+		{Label: "Project", ClickValue: "tab:project"},
+	}, 38)
+	if len(hits) != 1 {
+		t.Fatalf("ChipsHitRegions() = %#v, want one hit skipping blank chip", hits)
+	}
+	if hits[0].ColStart != 3 {
+		t.Fatalf("ChipsHitRegions()[0].ColStart = %d, want 3 (no leading gap before first visible chip)", hits[0].ColStart)
+	}
+}
+
+func TestChipsHitRegionsReturnsNilWhenInnerWidthTooSmall(t *testing.T) {
+	t.Parallel()
+
+	hits := ChipsHitRegions([]Chip{{Label: "Global"}}, 3)
+	if hits != nil {
+		t.Fatalf("ChipsHitRegions(small width) = %#v, want nil", hits)
+	}
+}
+
+func TestChipsTitlebarRowIsRowTwo(t *testing.T) {
+	t.Parallel()
+
+	if got, want := ChipsTitlebarRow(), 2; got != want {
+		t.Fatalf("ChipsTitlebarRow() = %d, want %d (top border on row 1, chip strip on row 2)", got, want)
+	}
+}
+
 func TestChipANSIGoldenMatchesTmuxWindowStatusPalette(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Background corrections

Phase 2.5 (#161) shipped the chip strip but user validation surfaced three follow-up corrections that Phase 2.6 addresses together:

1. **Chip click missing.** Window-tab UI metaphors are click-driven by default; the chord-only chip never felt like a real tab. Primary mouse-button clicks on the chip area now switch tabs.
2. **Chord muscle-memory mismatch.** `Alt-Left/Alt-Right` conflicted with users' muscle memory and shadows the global `M-Left/M-Right` select-pane intent linguistically. Tab navigation moves to `Alt-Shift-Left/Alt-Shift-Right`.
3. **Search-bar redundancy.** The Project tab opened with a "Project context" placeholder row above the search bar that was already conveyed by the chip strip and popup header. The picker entries drop it.

## Chip click implementation

- `projmuxpicker.Chip` gains `ClickValue` — the picker `Result.Value` to emit when the chip is clicked. Empty `ClickValue` or `Disabled: true` make the click a no-op so chord and click stay in lockstep.
- `projmuxpicker.ChipsHitRegions(chips, innerWidth)` returns per-chip `(ColStart, ColEnd)` ranges in 1-based outer-frame columns. Layout mirrors `frameTitlebarChipsLine`: column 1 is left border, column 2 is leading padding, first chip body starts at column 3, " Label " chips with one-cell gap separators. `ChipsTitlebarRow()` reports the row (always row 2 today) as a function for symmetry.
- `internal/ui/picker/backend.go` adds `nativeMouseChipResult`. On a primary-button press, the handler checks `y == ChipsTitlebarRow()`, walks the hit regions, suppresses disabled and value-less chips, and returns `Result{Key: "chip", Value: chip.ClickValue}`. Chip resolution runs before list hit detection so the chip strip is its own click target.
- `internal/app/settings.go` populates `ClickValue` with the existing `settingsRootTabGlobalValue` / `settingsRootTabProjectValue` sentinels. `settingsRootTabFromResultWithCurrent` already branches on those values, so the same code path handles chord and click.

## Alt-Shift CSI normalization

xterm encodes Alt-Shift-arrow as `CSI 1;4D` / `CSI 1;4C` (modifier `4` = Shift+Alt). `nativeKeyFromCSI` now maps modifier `4` to `alt-shift-` and also fills in the previously-unhandled `6`/`7`/`8` cases (`ctrl-shift-`, `ctrl-alt-`, `ctrl-alt-shift-`) for completeness so the same modifier table covers the full standard set. Settings popup `ExpectKeys` registers `alt-shift-left` / `alt-shift-right`; the legacy `alt-left` / `alt-right` entries are removed.

## Search-bar redundancy removal

`projectTabEntries` no longer emits the "Project context" placeholder row for either the no-project or the project-present case. The chip strip already labels the active scope, and the popup header still carries the "no project — open Settings from a project pane or set PROJMUX_CWD" hint for the empty case.

## Global chord regression guard

Global tmux `M-S-Left` / `M-S-Right` are bound to `previous-window` / `next-window` in `keybinding_catalog.go`. `TestSettingsRootAltArrowDoesNotShadowGlobalSelectPaneChords` now asserts both pairs (`M-Left/M-Right` for select-pane and `M-S-Left/M-S-Right` for prev/next-window) remain in the catalog, and that the popup `ExpectKeys` advertise the new `alt-shift-` chord while the legacy `alt-` chord is removed. The popup-vs-global separation is structural: tmux popups consume their own stdin while open, so the global plain-chord only fires outside the popup.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] New: `TestChipsHitRegionsReportsClickColumnRangesPerChip` (frame layout coordinates)
- [x] New: `TestChipsHitRegionsSkipsBlankChips` / `TestChipsHitRegionsReturnsNilWhenInnerWidthTooSmall` (degenerate inputs)
- [x] New: `TestNativeInteractiveNormalizesAltShiftArrowCSIKeys` (CSI modifier 4 mapping)
- [x] New: `TestNativeInteractiveChipClickEmitsClickValueResult` (click on Project chip → tab transition)
- [x] New: `TestNativeInteractiveChipClickOnActiveChipResolves` (click on active chip still resolves)
- [x] New: `TestNativeInteractiveChipClickOnDisabledChipIsNoop` (disabled chip click ignored, falls through to enter)
- [x] New: `TestNativeInteractiveChipClickOutsideStripDoesNotEmitChipResult` (row-2 invariant guard)
- [x] New: `TestSettingsRootChipClickSwitchesToProjectTab` (Run-level chip click → next tab options)
- [x] Updated: `TestSettingsRootOptionsDefaultGlobalTab` / `TestSettingsRootAltArrowTogglesTabsWhenProjectAvailable` / `TestSettingsRootAltArrowToggleInvariantWithProjectContext` / `TestSettingsRootAltArrowIsNoopWithoutProjectContext` / `TestSettingsRootAltArrowDoesNotShadowGlobalSelectPaneChords` / `TestSettingsHubSetsAIDefaultMode` to use `alt-shift-left/right`
- [x] Updated: `TestSettingsProjectTabNoProjectShowsDisabledState` asserts the "Project context" placeholder row is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)