### PR TITLE
feat: drop script hook branch for declarative-only

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,9 +4,30 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"sync"
 
+	"github.com/crevissepartners/projmux/internal/integrations/hooks"
 	"github.com/crevissepartners/projmux/internal/version"
 )
+
+// legacyHookMigrationOnce ensures the best-effort declarative migration only
+// runs once per process invocation. Settings UI entry points still trigger
+// migration directly so users who never set PROJMUX_CWD still see the
+// converted entries.
+var legacyHookMigrationOnce sync.Once
+
+func runLegacyHookMigrations() {
+	legacyHookMigrationOnce.Do(func() {
+		// Project migration only fires when PROJMUX_CWD is set; otherwise
+		// the caller invoked projmux outside any project context and we
+		// have nothing to migrate.
+		if cwd := os.Getenv("PROJMUX_CWD"); cwd != "" {
+			_, _ = hooks.MigrateProjectLegacyScripts(cwd, "", os.Stderr)
+		}
+		_, _ = hooks.MigrateGlobalLegacyScripts(os.Getenv, os.UserHomeDir, "", os.Stderr)
+	})
+}
 
 // Run is the current CLI bootstrap. Feature commands will grow from here.
 func Run(args []string, stdout, stderr io.Writer) error {
@@ -101,6 +122,7 @@ func New() *App {
 
 // Run dispatches the configured application commands.
 func (a *App) Run(args []string, stdout, stderr io.Writer) error {
+	runLegacyHookMigrations()
 	if len(args) == 0 {
 		printUsage(stdout)
 		return nil

--- a/internal/app/hookmaker.go
+++ b/internal/app/hookmaker.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -26,60 +25,71 @@ var settingsHookEvents = []settingsHookEvent{
 	{Name: string(hooks.EventPostAttach)},
 }
 
-// Hook maker action prefixes. Each action follows the shape
+// Hook maker action prefixes. Phase 2.6 dropped the script/declarative
+// distinction, so each action is now just
 //
-//	hook-<op>:<source>:<scope>:<event>
+//	hook-<op>:<scope>:<event>
 //
-// where source is "script" or "declarative", scope is "global" or "project",
-// and op is one of add, edit, remove. add does not have a leading source — the
-// branch picker that follows the add selection chooses script vs declarative.
+// where scope is "global" or "project" and op is one of add, edit, remove.
+// The [+ Add] picker always opens the declarative one-line editor.
 const (
 	settingsActionPrefixHookAdd    = "hook-add:"
 	settingsActionPrefixHookEdit   = "hook-edit:"
 	settingsActionPrefixHookRemove = "hook-remove:"
 
-	hookSourceScript      = "script"
-	hookSourceDeclarative = "declarative"
-
 	hookScopeGlobal  = "global"
 	hookScopeProject = "project"
 )
 
-type settingsHookPathState struct {
-	status string
-	path   string
-	note   string
-}
-
-// settingsHookRow describes the two hook sources (script file and declarative
-// config.toml entry) for a single lifecycle event. Empty fields are valid —
-// only populated sources are rendered as live rows.
+// settingsHookRow describes one lifecycle event's declarative entry plus any
+// legacy script file that the migrator could not flatten. Empty fields render
+// as a missing row with a [+ Add] button.
 type settingsHookRow struct {
 	Event      string
 	Scope      string
-	Script     settingsHookPathState
-	HasScript  bool
 	Declared   string
 	ConfigPath string
+	// Legacy is set when a multi-line script remains in the historical
+	// location after migration. The runner does not execute it; the row
+	// exists to nudge the user toward manual cleanup.
+	Legacy settingsLegacyScript
+}
+
+type settingsLegacyScript struct {
+	Path  string
+	Lines int
+	// Symlink is true when Path resolves to a symbolic link via Lstat. The
+	// migrator never touches symlinks (they typically come from a dotfiles
+	// repo), and the UI surfaces a dedicated message so the user knows to
+	// clean it up at the source instead of expecting projmux to rename it.
+	Symlink bool
 }
 
 func (c *settingsCommand) globalHookEntries() []intpickercompat.Entry {
 	entries := []intpickercompat.Entry{settingsBackEntry()}
 
-	paths, err := pickerBackendConfigPaths(c.homeDir, c.lookupEnv)
+	configPath, err := c.globalConfigPath()
 	if err != nil {
 		return append(entries, intpickercompat.Entry{
 			Label: settingsLabelDim("Hooks", err.Error()),
 			Value: settingsNoopValue,
 		})
 	}
+	entries = append(entries, intpickercompat.Entry{
+		Label: settingsLabelInfo("Global config", configPath, "[hooks.<event>]"),
+		Value: settingsNoopValue,
+	})
+
+	cfg, _ := hooks.LoadGlobalConfig(configPath)
+	legacy := globalLegacyScriptMap(c.homeDir, c.lookupEnv)
 
 	for _, event := range settingsHookEvents {
 		row := settingsHookRow{
-			Event:     event.Name,
-			Scope:     hookScopeGlobal,
-			Script:    settingsHookPathStateFor(paths.HookPath(event.Name)),
-			HasScript: true,
+			Event:      event.Name,
+			Scope:      hookScopeGlobal,
+			Declared:   declaredHookRun(cfg, event.Name),
+			ConfigPath: configPath,
+			Legacy:     legacy[event.Name],
 		}
 		entries = append(entries, renderHookRowEntries(row)...)
 	}
@@ -108,15 +118,15 @@ func (c *settingsCommand) projectHookEntries(ctx settingsProjectContext) []intpi
 
 	configPath := filepath.Join(ctx.Path, ".projmux", "config.toml")
 	cfg, _ := loadProjectConfigForRead(configPath)
+	legacy := projectLegacyScriptMap(ctx.Path)
 
 	for _, event := range settingsHookEvents {
 		row := settingsHookRow{
 			Event:      event.Name,
 			Scope:      hookScopeProject,
-			Script:     settingsProjectHookPathState(ctx.Path, event.Name),
-			HasScript:  true,
 			Declared:   declaredHookRun(cfg, event.Name),
 			ConfigPath: configPath,
+			Legacy:     legacy[event.Name],
 		}
 		entries = append(entries, renderHookRowEntries(row)...)
 	}
@@ -124,6 +134,11 @@ func (c *settingsCommand) projectHookEntries(ctx settingsProjectContext) []intpi
 }
 
 func (c *settingsCommand) runProjectHooksSection(stdout, stderr io.Writer) error {
+	// Best-effort migration on first entry so users on Phase 2.5 see their
+	// existing single-line scripts as declarative entries immediately.
+	if ctx := c.resolveSettingsProjectContext(); ctx.hasProject() {
+		_, _ = hooks.MigrateProjectLegacyScripts(ctx.Path, "", stderr)
+	}
 	for {
 		ctx := c.resolveSettingsProjectContext()
 		options, err := c.sectionOptions(settingsSectionProjectHooks)
@@ -160,6 +175,8 @@ func (c *settingsCommand) runProjectHooksSection(stdout, stderr io.Writer) error
 }
 
 func (c *settingsCommand) runGlobalHooksSection(stdout, stderr io.Writer) error {
+	// Same best-effort migration for the global hooks dir.
+	_, _ = hooks.MigrateGlobalLegacyScripts(c.lookupEnv, c.homeDir, "", stderr)
 	for {
 		options, err := c.sectionOptions(settingsSectionGlobalHooks)
 		if err != nil {
@@ -190,157 +207,147 @@ func (c *settingsCommand) runGlobalHooksSection(stdout, stderr io.Writer) error 
 	}
 }
 
-func settingsProjectHookPathState(projectPath, event string) settingsHookPathState {
-	candidates := []string{
-		filepath.Join(projectPath, ".projmux", event),
-		filepath.Join(projectPath, ".projmux", config.HooksDirName, event),
-	}
-	var inactive settingsHookPathState
-	for _, path := range candidates {
-		state := settingsHookPathStateFor(path)
-		if state.status == "active" {
-			return state
-		}
-		if state.status == "inactive" && inactive.path == "" {
-			inactive = state
-		}
-	}
-	if inactive.path != "" {
-		return inactive
-	}
-	return settingsHookPathState{
-		status: "missing",
-		// Display both candidate paths so the user can see where projmux will
-		// look. The canonical creation path is .projmux/hooks/<event>; the
-		// legacy .projmux/<event> location is still resolved by the runner.
-		path: strings.Join(candidates, " or "),
-	}
-}
-
-func settingsHookPathStateFor(path string) settingsHookPathState {
-	state := settingsHookPathState{status: "missing", path: path}
-	info, err := osStat(path)
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			state.status = "unreadable"
-			state.note = err.Error()
-		}
-		return state
-	}
-	if info.IsDir() {
-		state.status = "inactive"
-		state.note = "directory"
-		return state
-	}
-	if info.Mode().Perm()&0o100 == 0 {
-		state.status = "inactive"
-		state.note = "not executable"
-		return state
-	}
-	state.status = "active"
-	return state
-}
-
-// renderHookRowEntries emits picker rows for a single lifecycle event,
-// covering script + declarative sources. Active sources always get their own
-// edit row. When at least one source is already active, the missing
-// complement gets a source-specific [+ Add] row (no branch picker — the user
-// already chose). When BOTH sources are missing, a single [+ Add] row is
-// emitted that opens a declarative-vs-script branch picker.
+// renderHookRowEntries emits picker rows for a single lifecycle event using
+// the Phase 2.6 declarative-only model. The row is one of:
+//   - active: a single edit row whose label includes the run line
+//   - missing: a single [+ Add] row that opens the inline editor
+//
+// When a legacy multi-line script remains in the historical location, an
+// additional dim "(legacy script)" row is appended below to nudge the user
+// toward manual cleanup.
 func renderHookRowEntries(row settingsHookRow) []intpickercompat.Entry {
-	entries := make([]intpickercompat.Entry, 0, 4)
-
-	scriptActive := row.HasScript && (row.Script.status == "active" || row.Script.status == "inactive")
-	declarativeActive := row.Scope == hookScopeProject && strings.TrimSpace(row.Declared) != ""
-
-	// Global scope: only script is supported; collapse to a single row.
-	if row.Scope != hookScopeProject {
-		if scriptActive {
-			entries = append(entries, settingsHookScriptEntry(row))
-		} else {
-			entries = append(entries, settingsHookAddRow(row))
-		}
-		return entries
-	}
-
-	// Project scope.
-	switch {
-	case scriptActive && declarativeActive:
-		entries = append(entries, settingsHookScriptEntry(row), settingsHookDeclarativeEntry(row))
-	case scriptActive && !declarativeActive:
-		// Script is set; offer to add the missing declarative complement.
-		entries = append(entries,
-			settingsHookScriptEntry(row),
-			settingsHookAddDeclarativeRow(row),
-		)
-	case !scriptActive && declarativeActive:
-		// Declarative is set; offer to add a script complement.
-		entries = append(entries,
-			settingsHookDeclarativeEntry(row),
-			settingsHookAddScriptRow(row),
-		)
-	default:
-		// Both missing — one combined [+ Add] row that triggers branch picker.
+	entries := make([]intpickercompat.Entry, 0, 2)
+	if strings.TrimSpace(row.Declared) != "" {
+		entries = append(entries, settingsHookActiveEntry(row))
+	} else {
 		entries = append(entries, settingsHookAddRow(row))
+	}
+	if row.Legacy.Path != "" {
+		entries = append(entries, settingsHookLegacyEntry(row))
 	}
 	return entries
 }
 
 func settingsHookAddRow(row settingsHookRow) intpickercompat.Entry {
-	desc := "missing - " + row.Script.path + " [+ Add] declarative or script"
+	desc := "missing - " + row.ConfigPath + " [hooks." + row.Event + "] [+ Add]"
 	return intpickercompat.Entry{
 		Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, row.Event, desc),
 		Value: settingsActionPrefixHookAdd + row.Scope + ":" + row.Event,
 	}
 }
 
-func settingsHookAddScriptRow(row settingsHookRow) intpickercompat.Entry {
-	desc := "[+ Add] script - " + row.Script.path
-	return intpickercompat.Entry{
-		Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, row.Event, desc),
-		Value: settingsActionPrefixHookAdd + row.Scope + ":" + row.Event + ":" + hookSourceScript,
-	}
-}
-
-func settingsHookAddDeclarativeRow(row settingsHookRow) intpickercompat.Entry {
-	desc := "[+ Add] declarative - " + row.ConfigPath + " [hooks." + row.Event + "]"
-	return intpickercompat.Entry{
-		Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, row.Event, desc),
-		Value: settingsActionPrefixHookAdd + row.Scope + ":" + row.Event + ":" + hookSourceDeclarative,
-	}
-}
-
-func settingsHookScriptEntry(row settingsHookRow) intpickercompat.Entry {
-	glyph := settingsGlyphInactive
-	color := settingsColorDim
-	if row.Script.status == "active" {
-		glyph = settingsGlyphToggle
-		color = settingsColorAdd
-	}
-	desc := row.Script.status + " - " + row.Script.path + " (script)"
-	if row.Script.note != "" {
-		desc += " (" + row.Script.note + ")"
-	}
-	return intpickercompat.Entry{
-		Label: settingsLabel(glyph, color, row.Event, desc),
-		Value: settingsActionPrefixHookEdit + hookSourceScript + ":" + row.Scope + ":" + row.Event,
-	}
-}
-
-func settingsHookDeclarativeEntry(row settingsHookRow) intpickercompat.Entry {
-	desc := "active - run = " + row.Declared + " (declarative)"
+func settingsHookActiveEntry(row settingsHookRow) intpickercompat.Entry {
+	desc := "active - run = " + row.Declared
 	return intpickercompat.Entry{
 		Label: settingsLabel(settingsGlyphToggle, settingsColorAdd, row.Event, desc),
-		Value: settingsActionPrefixHookEdit + hookSourceDeclarative + ":" + row.Scope + ":" + row.Event,
+		Value: settingsActionPrefixHookEdit + row.Scope + ":" + row.Event,
 	}
 }
 
-// settingsHookEntry is preserved for tests that still rely on the simpler
-// single-source rendering. The hook maker page itself uses
-// renderHookRowEntries which emits the same label shape per source.
-func settingsHookEntry(event string, state settingsHookPathState) intpickercompat.Entry {
-	row := settingsHookRow{Event: event, Scope: hookScopeGlobal, Script: state, HasScript: true}
-	return settingsHookScriptEntry(row)
+// settingsHookLegacyEntry surfaces a multi-line or symlinked script left
+// behind after migration. The runner does not execute it; the row is
+// informational and non-interactive. Single-line regular files are migrated
+// automatically and never produce this row.
+func settingsHookLegacyEntry(row settingsHookRow) intpickercompat.Entry {
+	var (
+		title string
+		desc  string
+	)
+	if row.Legacy.Symlink {
+		title = row.Event + " (legacy script: symlink)"
+		desc = fmt.Sprintf("legacy script - %s (symlink, not executed; clean up via the source dotfiles repo)", row.Legacy.Path)
+	} else {
+		title = row.Event + " (legacy script)"
+		desc = fmt.Sprintf("legacy script - %s (%d lines, not executed)", row.Legacy.Path, row.Legacy.Lines)
+	}
+	return intpickercompat.Entry{
+		Label: settingsLabelDim(title, desc),
+		Value: settingsNoopValue,
+	}
+}
+
+// projectLegacyScriptMap collects legacy scripts that remain in the historical
+// `.projmux/<event>` / `.projmux/hooks/<event>` locations after migration.
+// Single-line regular files are migrated to declarative entries and renamed
+// to `<path>.bak`; they never show up here. Symlinks are always surfaced
+// because the migrator refuses to rename them (the source-of-truth lives
+// outside the projmux config dir, typically a dotfiles repo).
+func projectLegacyScriptMap(projectPath string) map[string]settingsLegacyScript {
+	result := map[string]settingsLegacyScript{}
+	for _, event := range settingsHookEvents {
+		for _, candidate := range []string{
+			filepath.Join(projectPath, ".projmux", event.Name),
+			filepath.Join(projectPath, ".projmux", config.HooksDirName, event.Name),
+		} {
+			if entry, ok := inspectLegacyScript(candidate); ok {
+				result[event.Name] = entry
+				break
+			}
+		}
+	}
+	return result
+}
+
+func globalLegacyScriptMap(homeDir func() (string, error), lookupEnv func(string) string) map[string]settingsLegacyScript {
+	result := map[string]settingsLegacyScript{}
+	paths, err := pickerBackendConfigPaths(homeDir, lookupEnv)
+	if err != nil {
+		return result
+	}
+	for _, event := range settingsHookEvents {
+		candidate := paths.HookPath(event.Name)
+		if entry, ok := inspectLegacyScript(candidate); ok {
+			result[event.Name] = entry
+		}
+	}
+	return result
+}
+
+// inspectLegacyScript returns a populated settingsLegacyScript when the
+// candidate path is a legacy artifact the UI should surface. Symlinks always
+// qualify (regardless of target line count) so dotfiles-managed hooks get a
+// dedicated cleanup nudge. Regular files only qualify when they have two or
+// more non-trivial lines — single-line scripts are migrated automatically.
+func inspectLegacyScript(path string) (settingsLegacyScript, bool) {
+	linfo, err := osLstat(path)
+	if err != nil {
+		return settingsLegacyScript{}, false
+	}
+	if linfo.Mode()&os.ModeSymlink != 0 {
+		return settingsLegacyScript{Path: path, Symlink: true}, true
+	}
+	info, err := osStat(path)
+	if err != nil || info.IsDir() {
+		return settingsLegacyScript{}, false
+	}
+	lines := countLegacyScriptLines(path)
+	if lines <= 1 {
+		return settingsLegacyScript{}, false
+	}
+	return settingsLegacyScript{Path: path, Lines: lines}, true
+}
+
+// countLegacyScriptLines counts non-empty, non-comment lines so the UI can
+// echo the same metric the migrator uses to decide whether a script qualifies
+// for automatic conversion.
+func countLegacyScriptLines(path string) int {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	count := 0
+	for _, raw := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+func (c *settingsCommand) globalConfigPath() (string, error) {
+	return hooks.GlobalConfigPath(c.lookupEnv, c.homeDir)
 }
 
 func settingsProjectConfigEntry(projectPath string) intpickercompat.Entry {
@@ -413,35 +420,47 @@ func (c *settingsCommand) runHookMakerAction(ctx settingsProjectContext, action 
 	switch {
 	case strings.HasPrefix(action, settingsActionPrefixHookAdd):
 		body := strings.TrimPrefix(action, settingsActionPrefixHookAdd)
-		return c.runHookMakerAdd(ctx, body, stdout, stderr)
+		scope, event, ok := parseHookActionBody(body)
+		if !ok {
+			return fmt.Errorf("invalid hook add action: %s", body)
+		}
+		return c.hookMakerEditDeclarative(ctx, scope, event, stdout, stderr)
 	case strings.HasPrefix(action, settingsActionPrefixHookEdit):
 		body := strings.TrimPrefix(action, settingsActionPrefixHookEdit)
-		return c.runHookMakerEdit(ctx, body, stdout, stderr)
+		scope, event, ok := parseHookActionBody(body)
+		if !ok {
+			return fmt.Errorf("invalid hook edit action: %s", body)
+		}
+		return c.hookMakerEditDeclarative(ctx, scope, event, stdout, stderr)
 	case strings.HasPrefix(action, settingsActionPrefixHookRemove):
 		body := strings.TrimPrefix(action, settingsActionPrefixHookRemove)
-		return c.runHookMakerRemove(ctx, body, stdout, stderr)
+		scope, event, ok := parseHookActionBody(body)
+		if !ok {
+			return fmt.Errorf("invalid hook remove action: %s", body)
+		}
+		return c.hookMakerRemoveDeclarative(ctx, scope, event, stdout)
 	default:
 		return fmt.Errorf("unknown hook maker action: %s", action)
 	}
 }
 
-func parseHookActionBody(body string) (scope, event, source string, ok bool) {
-	parts := strings.SplitN(body, ":", 3)
-	if len(parts) < 2 {
-		return "", "", "", false
+// parseHookActionBody parses "<scope>:<event>" payloads. Phase 2.6 collapsed
+// the scope/event/source triple to scope/event since there is only one source
+// (declarative).
+func parseHookActionBody(body string) (scope, event string, ok bool) {
+	parts := strings.SplitN(body, ":", 2)
+	if len(parts) != 2 {
+		return "", "", false
 	}
 	scope = parts[0]
 	event = parts[1]
-	if len(parts) == 3 {
-		source = parts[2]
-	}
 	if scope != hookScopeGlobal && scope != hookScopeProject {
-		return "", "", "", false
+		return "", "", false
 	}
-	if hooks.Event(event) == "" || !isSettingsSupportedHookEvent(event) {
-		return "", "", "", false
+	if !isSettingsSupportedHookEvent(event) {
+		return "", "", false
 	}
-	return scope, event, source, true
+	return scope, event, true
 }
 
 func isSettingsSupportedHookEvent(event string) bool {
@@ -453,265 +472,48 @@ func isSettingsSupportedHookEvent(event string) bool {
 	return false
 }
 
-func parseEditActionBody(body string) (source, scope, event string, ok bool) {
-	parts := strings.SplitN(body, ":", 3)
-	if len(parts) != 3 {
-		return "", "", "", false
+// --- declarative branch ----------------------------------------------------
+
+func (c *settingsCommand) hookMakerEditDeclarative(ctx settingsProjectContext, scope, event string, stdout, stderr io.Writer) error {
+	switch scope {
+	case hookScopeProject:
+		return c.hookMakerEditProjectDeclarative(ctx, event, stdout, stderr)
+	case hookScopeGlobal:
+		return c.hookMakerEditGlobalDeclarative(event, stdout, stderr)
+	default:
+		return fmt.Errorf("unknown hook scope: %s", scope)
 	}
-	source = parts[0]
-	scope = parts[1]
-	event = parts[2]
-	if source != hookSourceScript && source != hookSourceDeclarative {
-		return "", "", "", false
-	}
-	if scope != hookScopeGlobal && scope != hookScopeProject {
-		return "", "", "", false
-	}
-	if !isSettingsSupportedHookEvent(event) {
-		return "", "", "", false
-	}
-	return source, scope, event, true
 }
 
-func (c *settingsCommand) runHookMakerAdd(ctx settingsProjectContext, body string, stdout, stderr io.Writer) error {
-	scope, event, source, ok := parseHookActionBody(body)
-	if !ok {
-		return fmt.Errorf("invalid hook add action: %s", body)
-	}
-	if source == "" {
-		// Branch picker: declarative vs script. Adds a small help row that
-		// explains the trade-off.
-		entries := []intpickercompat.Entry{
-			settingsBackEntry(),
-			{
-				Label: settingsLabelDim("How to choose", "one-line command -> declarative; complex script -> $EDITOR"),
-				Value: settingsNoopValue,
-			},
-			{
-				Label: settingsLabel(settingsGlyphType, settingsColorType, "Declarative (one-liner)", "write run = \"...\" to .projmux/config.toml"),
-				Value: settingsActionPrefixHookAdd + scope + ":" + event + ":" + hookSourceDeclarative,
-			},
-			{
-				Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Script ($EDITOR)", "create .projmux/hooks/<event> and open $EDITOR"),
-				Value: settingsActionPrefixHookAdd + scope + ":" + event + ":" + hookSourceScript,
-			},
+func (c *settingsCommand) hookMakerRemoveDeclarative(ctx settingsProjectContext, scope, event string, stdout io.Writer) error {
+	switch scope {
+	case hookScopeProject:
+		if !ctx.hasProject() {
+			return nil
 		}
-		// Project scope only supports declarative. Surface that constraint.
-		if scope == hookScopeGlobal {
-			entries[2] = intpickercompat.Entry{
-				Label: settingsLabelDim("Declarative", "config.toml is project-only"),
-				Value: settingsNoopValue,
-			}
-		}
-		result, err := c.runPicker(intpickercompat.Options{
-			UI:         "settings-hook-maker-add",
-			Entries:    entries,
-			Title:      "Hook " + event + " - add",
-			Prompt:     "Settings > Hooks > " + event + " > Add > ",
-			Footer:     projmuxFooter("Enter: choose  |  Back: parent  |  Esc/Alt+5/Ctrl+Alt+S: close"),
-			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+		return c.saveProjectConfig(ctx, stdout, func(cfg *hooks.ProjectConfig) error {
+			delete(cfg.Hooks, hooks.Event(event))
+			return nil
 		})
+	case hookScopeGlobal:
+		path, err := c.globalConfigPath()
 		if err != nil {
 			return err
 		}
-		next := strings.TrimSpace(result.Value)
-		if result.Key != "enter" || next == "" || next == settingsNoopValue {
+		if _, err := hooks.UpdateGlobalConfig(path, func(cfg *hooks.ProjectConfig) error {
+			delete(cfg.Hooks, hooks.Event(event))
 			return nil
+		}); err != nil {
+			return err
 		}
-		if next == settingsBackValue {
-			return nil
-		}
-		// Recurse with the resolved source.
-		return c.runHookMakerAction(ctx, next, stdout, stderr)
-	}
-
-	switch source {
-	case hookSourceScript:
-		return c.hookMakerAddScript(ctx, scope, event, stdout, stderr)
-	case hookSourceDeclarative:
-		if scope == hookScopeGlobal {
-			fmt.Fprintln(stderr, "declarative hooks are only supported for project scope")
-			return nil
-		}
-		return c.hookMakerEditDeclarative(ctx, event, stdout, stderr)
+		_, err = fmt.Fprintf(stdout, "wrote %s\n", path)
+		return err
 	default:
-		return fmt.Errorf("unknown hook source: %s", source)
+		return fmt.Errorf("unknown hook scope: %s", scope)
 	}
 }
 
-func (c *settingsCommand) runHookMakerEdit(ctx settingsProjectContext, body string, stdout, stderr io.Writer) error {
-	source, scope, event, ok := parseEditActionBody(body)
-	if !ok {
-		return fmt.Errorf("invalid hook edit action: %s", body)
-	}
-	switch source {
-	case hookSourceScript:
-		return c.hookMakerEditScript(ctx, scope, event, stdout, stderr)
-	case hookSourceDeclarative:
-		if scope == hookScopeGlobal {
-			fmt.Fprintln(stderr, "declarative hooks are only supported for project scope")
-			return nil
-		}
-		return c.hookMakerEditDeclarative(ctx, event, stdout, stderr)
-	default:
-		return fmt.Errorf("unknown hook source: %s", source)
-	}
-}
-
-func (c *settingsCommand) runHookMakerRemove(ctx settingsProjectContext, body string, stdout, stderr io.Writer) error {
-	source, scope, event, ok := parseEditActionBody(body)
-	if !ok {
-		return fmt.Errorf("invalid hook remove action: %s", body)
-	}
-	switch source {
-	case hookSourceScript:
-		return c.hookMakerRemoveScript(ctx, scope, event, stdout)
-	case hookSourceDeclarative:
-		if scope == hookScopeGlobal {
-			return nil
-		}
-		return c.hookMakerRemoveDeclarative(ctx, event, stdout)
-	default:
-		return fmt.Errorf("unknown hook source: %s", source)
-	}
-}
-
-// --- script branch ---------------------------------------------------------
-
-func (c *settingsCommand) hookMakerScriptPath(ctx settingsProjectContext, scope, event string) (string, string, error) {
-	switch scope {
-	case hookScopeGlobal:
-		paths, err := pickerBackendConfigPaths(c.homeDir, c.lookupEnv)
-		if err != nil {
-			return "", "", err
-		}
-		return paths.HookPath(event), "", nil
-	case hookScopeProject:
-		if !ctx.hasProject() {
-			return "", "", errors.New("project hook requires a project context")
-		}
-		state := settingsProjectHookPathState(ctx.Path, event)
-		path := state.path
-		// state.path may be a " or "-joined list when both candidates are
-		// missing; pick the canonical hooks/ location for new files.
-		if state.status == "missing" {
-			path = filepath.Join(ctx.Path, ".projmux", config.HooksDirName, event)
-		}
-		rel, err := filepath.Rel(ctx.Path, path)
-		if err != nil {
-			return "", "", err
-		}
-		return path, filepath.ToSlash(rel), nil
-	default:
-		return "", "", fmt.Errorf("unknown hook scope: %s", scope)
-	}
-}
-
-func (c *settingsCommand) hookMakerAddScript(ctx settingsProjectContext, scope, event string, stdout, stderr io.Writer) error {
-	path, rel, err := c.hookMakerScriptPath(ctx, scope, event)
-	if err != nil {
-		return err
-	}
-	if _, err := os.Stat(path); err == nil {
-		// Already exists; treat add as edit.
-		return c.hookMakerOpenScript(ctx, scope, event, path, rel, stdout, stderr)
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	body := "#!/bin/sh\n# projmux " + event + " hook for " + scope + "\n"
-	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(stdout, "created %s\n", path); err != nil {
-		return err
-	}
-	return c.hookMakerOpenScript(ctx, scope, event, path, rel, stdout, stderr)
-}
-
-func (c *settingsCommand) hookMakerEditScript(ctx settingsProjectContext, scope, event string, stdout, stderr io.Writer) error {
-	path, rel, err := c.hookMakerScriptPath(ctx, scope, event)
-	if err != nil {
-		return err
-	}
-	if _, err := os.Stat(path); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			fmt.Fprintf(stderr, "hook script %s does not exist; creating now\n", path)
-			return c.hookMakerAddScript(ctx, scope, event, stdout, stderr)
-		}
-		return err
-	}
-	return c.hookMakerOpenScript(ctx, scope, event, path, rel, stdout, stderr)
-}
-
-func (c *settingsCommand) hookMakerOpenScript(ctx settingsProjectContext, scope, event, path, rel string, stdout, stderr io.Writer) error {
-	editor := c.resolveEditor()
-	if err := c.openEditor(editor, path); err != nil {
-		fmt.Fprintf(stderr, "editor %s exited with error: %v\n", editor, err)
-		// Continue — the file may still be edited and trusted.
-	}
-	if err := ensureExecutableScript(path); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(stdout, "edited %s\n", path); err != nil {
-		return err
-	}
-	if scope == hookScopeProject && ctx.hasProject() {
-		return c.recordProjectScriptTrust(ctx, rel, stdout, stderr)
-	}
-	return nil
-}
-
-func (c *settingsCommand) hookMakerRemoveScript(ctx settingsProjectContext, scope, event string, stdout io.Writer) error {
-	path, _, err := c.hookMakerScriptPath(ctx, scope, event)
-	if err != nil {
-		return err
-	}
-	if err := os.Remove(path); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		return err
-	}
-	_, err = fmt.Fprintf(stdout, "removed %s\n", path)
-	return err
-}
-
-func ensureExecutableScript(path string) error {
-	info, err := os.Stat(path)
-	if err != nil {
-		return err
-	}
-	if info.IsDir() {
-		return fmt.Errorf("hook %q is a directory", path)
-	}
-	mode := info.Mode().Perm()
-	if mode&0o111 != 0 {
-		return nil
-	}
-	return os.Chmod(path, mode|0o755)
-}
-
-func (c *settingsCommand) recordProjectScriptTrust(ctx settingsProjectContext, rel string, stdout, stderr io.Writer) error {
-	if rel == "" {
-		return nil
-	}
-	trustPath, err := c.projectConfigTrustStorePath()
-	if err != nil {
-		return err
-	}
-	if _, err := hooks.TrustProjectFile(ctx.Path, rel, trustPath); err != nil {
-		fmt.Fprintf(stderr, "trust %s: %v\n", rel, err)
-		return nil
-	}
-	_, err = fmt.Fprintf(stdout, "trusted %s\n", filepath.Join(ctx.Path, rel))
-	return err
-}
-
-// --- declarative branch ----------------------------------------------------
-
-func (c *settingsCommand) hookMakerEditDeclarative(ctx settingsProjectContext, event string, stdout, stderr io.Writer) error {
+func (c *settingsCommand) hookMakerEditProjectDeclarative(ctx settingsProjectContext, event string, stdout, stderr io.Writer) error {
 	if !ctx.hasProject() {
 		return errors.New("declarative hook requires a project context")
 	}
@@ -742,51 +544,44 @@ func (c *settingsCommand) hookMakerEditDeclarative(ctx settingsProjectContext, e
 	})
 }
 
-func (c *settingsCommand) hookMakerRemoveDeclarative(ctx settingsProjectContext, event string, stdout io.Writer) error {
-	if !ctx.hasProject() {
-		return nil
+// hookMakerEditGlobalDeclarative reads and writes the global
+// `${XDG_CONFIG_HOME}/projmux/config.toml` entry for event. Global declarative
+// hooks bypass the trust prompt — they are considered authoritative for the
+// user that runs projmux.
+func (c *settingsCommand) hookMakerEditGlobalDeclarative(event string, stdout, stderr io.Writer) error {
+	path, err := c.globalConfigPath()
+	if err != nil {
+		return err
 	}
-	return c.saveProjectConfig(ctx, stdout, func(cfg *hooks.ProjectConfig) error {
-		delete(cfg.Hooks, hooks.Event(event))
-		return nil
-	})
-}
-
-// --- editor ---------------------------------------------------------------
-
-func (c *settingsCommand) resolveEditor() string {
-	env := c.lookupEnv
-	if env == nil {
-		env = os.Getenv
+	cfg, err := hooks.LoadGlobalConfig(path)
+	if err != nil {
+		return err
 	}
-	for _, key := range []string{"VISUAL", "EDITOR"} {
-		if v := strings.TrimSpace(env(key)); v != "" {
-			return v
+	current := ""
+	if cfg.Hooks != nil {
+		current = cfg.Hooks[hooks.Event(event)]
+	}
+	value, ok, err := c.runProjectConfigTyped("Global Hook "+event+" - run",
+		"Type [hooks."+event+"] run > ", current)
+	if err != nil || !ok {
+		return err
+	}
+	value = strings.TrimSpace(value)
+	if _, err := hooks.UpdateGlobalConfig(path, func(cfg *hooks.ProjectConfig) error {
+		if cfg.Hooks == nil {
+			cfg.Hooks = map[hooks.Event]string{}
 		}
+		if value == "" {
+			delete(cfg.Hooks, hooks.Event(event))
+		} else {
+			cfg.Hooks[hooks.Event(event)] = value
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
-	return "vi"
-}
-
-func (c *settingsCommand) openEditor(editor, path string) error {
-	editor = strings.TrimSpace(editor)
-	if editor == "" {
-		editor = "vi"
-	}
-	if c.runCommand != nil {
-		// Split editor on whitespace so VISUAL="code -w" works.
-		fields := strings.Fields(editor)
-		name := fields[0]
-		args := append(append([]string{}, fields[1:]...), path)
-		return c.runCommand(name, args...)
-	}
-	fields := strings.Fields(editor)
-	name := fields[0]
-	args := append(append([]string{}, fields[1:]...), path)
-	cmd := exec.Command(name, args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	_, err = fmt.Fprintf(stdout, "wrote %s\n", path)
+	return err
 }
 
 // --- project config section ------------------------------------------------

--- a/internal/app/hookmaker_test.go
+++ b/internal/app/hookmaker_test.go
@@ -10,16 +10,13 @@ import (
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
 
-func TestSettingsGlobalHooksListShowsActiveAndMissingPaths(t *testing.T) {
+// --- Page-render tests ------------------------------------------------------
+
+func TestSettingsGlobalHooksListShowsConfigPathAndAddRows(t *testing.T) {
 	t.Parallel()
 
 	home := t.TempDir()
 	configHome := t.TempDir()
-	active := filepath.Join(configHome, "projmux", "hooks", "post-create")
-	mkdirAll(t, filepath.Dir(active))
-	if err := os.WriteFile(active, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 
 	cmd := &settingsCommand{
 		homeDir: func() (string, error) { return home, nil },
@@ -32,24 +29,81 @@ func TestSettingsGlobalHooksListShowsActiveAndMissingPaths(t *testing.T) {
 	}
 
 	entries := cmd.globalHookEntries()
-	assertEntryLabelContainsAll(t, entries, "post-create", "active", active)
-	assertEntryLabelContainsAll(t, entries, "pane-startup", "missing", filepath.Join(configHome, "projmux", "hooks", "pane-startup"))
+	wantConfig := filepath.Join(configHome, "projmux", "config.toml")
+	assertEntryLabelContainsAll(t, entries, "Global config", wantConfig)
+	assertEntryLabelContainsAll(t, entries, "post-create", "missing", "[+ Add]")
 }
 
-func TestSettingsProjectHooksListWithContext(t *testing.T) {
+func TestSettingsGlobalHooksListShowsActiveDeclarativeEntry(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := t.TempDir()
+	configPath := filepath.Join(configHome, "projmux", "config.toml")
+	mkdirAll(t, filepath.Dir(configPath))
+	if err := os.WriteFile(configPath, []byte(`
+[hooks.post-create]
+run = "echo global-active"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &settingsCommand{
+		homeDir: func() (string, error) { return home, nil },
+		lookupEnv: func(name string) string {
+			if name == "XDG_CONFIG_HOME" {
+				return configHome
+			}
+			return ""
+		},
+	}
+	entries := cmd.globalHookEntries()
+	assertEntryLabelContainsAll(t, entries, "post-create", "active", "echo global-active")
+}
+
+func TestSettingsProjectHooksListAllMissingRendersAddRows(t *testing.T) {
 	t.Parallel()
 
 	repo := t.TempDir()
-	postCreate := filepath.Join(repo, ".projmux", "post-create")
-	paneStartup := filepath.Join(repo, ".projmux", "hooks", "pane-startup")
-	mkdirAll(t, filepath.Dir(paneStartup))
-	if err := os.WriteFile(postCreate, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
+	cmd := &settingsCommand{
+		lookupEnv: func(name string) string {
+			if name == "PROJMUX_CWD" {
+				return repo
+			}
+			return ""
+		},
 	}
-	if err := os.WriteFile(paneStartup, []byte("#!/bin/sh\n"), 0o755); err != nil {
+	entries := cmd.projectHookEntries(cmd.resolveSettingsProjectContext())
+	for _, event := range []string{"pre-create", "post-create", "pane-startup", "post-attach"} {
+		assertEntryLabelContainsAll(t, entries, event, "missing", "[+ Add]")
+	}
+}
+
+func TestSettingsProjectHooksListNoProjectUsesDisabledState(t *testing.T) {
+	t.Parallel()
+
+	cmd := &settingsCommand{lookupEnv: func(string) string { return "" }}
+	options, err := cmd.sectionOptions(settingsSectionProjectHooks)
+	if err != nil {
+		t.Fatalf("sectionOptions(project hooks) error = %v", err)
+	}
+	assertEntryLabelContainsAll(t, options.Entries, "Hooks (project)", "disabled", "no project context")
+	if hasEntryLabelContaining(options.Entries, "post-create") {
+		t.Fatalf("project hooks entries = %#v, want no hook event rows without project context", options.Entries)
+	}
+}
+
+func TestSettingsProjectHooksListWithDeclarativeContext(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".projmux"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(repo, ".projmux", "config.toml"), []byte(`
+[hooks.post-create]
+run = "echo declared-post"
+
 [startup]
 run = "codex"
 `), 0o644); err != nil {
@@ -64,44 +118,95 @@ run = "codex"
 			return ""
 		},
 	}
-
-	options := cmd.rootOptions(settingsRootTabProject)
-	if !hasEntryValue(options.Entries, settingsSectionProjectHooks) {
-		t.Fatalf("project tab entries = %#v, want project Hooks page row", options.Entries)
-	}
-
 	hookOptions, err := cmd.sectionOptions(settingsSectionProjectHooks)
 	if err != nil {
 		t.Fatalf("sectionOptions(project hooks) error = %v", err)
 	}
-	assertEntryLabelContainsAll(t, hookOptions.Entries, "post-create", "active", postCreate)
-	assertEntryLabelContainsAll(t, hookOptions.Entries, "pane-startup", "active", paneStartup)
-	assertEntryLabelContainsAll(t, hookOptions.Entries, "pre-create", "missing", filepath.Join(repo, ".projmux", "pre-create"))
+	assertEntryLabelContainsAll(t, hookOptions.Entries, "post-create", "active", "echo declared-post")
+	assertEntryLabelContainsAll(t, hookOptions.Entries, "pre-create", "missing", "[+ Add]")
 	assertEntryLabelContainsAll(t, hookOptions.Entries, "config.toml", "present", "startup")
 }
 
-func TestSettingsProjectHooksNoProjectUsesDisabledState(t *testing.T) {
-	t.Parallel()
-
-	cmd := &settingsCommand{lookupEnv: func(string) string { return "" }}
-	options, err := cmd.sectionOptions(settingsSectionProjectHooks)
-	if err != nil {
-		t.Fatalf("sectionOptions(project hooks) error = %v", err)
-	}
-	assertEntryLabelContainsAll(t, options.Entries, "Hooks (project)", "disabled", "no project context")
-	if hasEntryLabelContaining(options.Entries, "post-create") {
-		t.Fatalf("project hooks entries = %#v, want no hook event rows without project context", options.Entries)
-	}
-}
-
-func TestSettingsHookMakerExcludesInternalTmuxHooks(t *testing.T) {
+func TestSettingsProjectHooksAddPickerHasNoBranch(t *testing.T) {
 	t.Parallel()
 
 	repo := t.TempDir()
-	internalHook := filepath.Join(repo, ".projmux", "hooks", "after-select-pane")
-	mkdirAll(t, filepath.Dir(internalHook))
-	if err := os.WriteFile(internalHook, []byte("#!/bin/sh\n"), 0o755); err != nil {
+	cmd := &settingsCommand{
+		lookupEnv: func(name string) string {
+			if name == "PROJMUX_CWD" {
+				return repo
+			}
+			return ""
+		},
+	}
+	entries := cmd.projectHookEntries(cmd.resolveSettingsProjectContext())
+	for _, entry := range entries {
+		if strings.Contains(entry.Value, ":script") || strings.Contains(entry.Value, ":declarative") {
+			t.Fatalf("entry %#v still encodes a script/declarative branch", entry)
+		}
+	}
+}
+
+func TestSettingsHookMakerExcludesInternalEvents(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	cmd := &settingsCommand{
+		lookupEnv: func(name string) string {
+			if name == "PROJMUX_CWD" {
+				return repo
+			}
+			return ""
+		},
+	}
+	entries := cmd.projectHookEntries(cmd.resolveSettingsProjectContext())
+	for _, banned := range []string{"after-select-pane", "pane-focus-in", "pane-focus-out"} {
+		for _, entry := range entries {
+			if strings.Contains(entry.Value, banned) {
+				t.Fatalf("entry %#v exposes internal event %q", entry, banned)
+			}
+		}
+	}
+}
+
+func TestSettingsHookMakerLegacyMultiLineScriptRendersLegacyRow(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	scriptPath := filepath.Join(repo, ".projmux", "post-create")
+	mkdirAll(t, filepath.Dir(scriptPath))
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho one\necho two\n"), 0o755); err != nil {
 		t.Fatal(err)
+	}
+	cmd := &settingsCommand{
+		lookupEnv: func(name string) string {
+			if name == "PROJMUX_CWD" {
+				return repo
+			}
+			return ""
+		},
+	}
+	entries := cmd.projectHookEntries(cmd.resolveSettingsProjectContext())
+	assertEntryLabelContainsAll(t, entries, "legacy script", scriptPath, "not executed")
+}
+
+func TestSettingsHookMakerLegacySymlinkRendersDotfilesNotice(t *testing.T) {
+	t.Parallel()
+
+	// A dotfiles-managed global hook arrives as a symlink whose source lives
+	// outside the projmux config dir. The UI must (a) surface a dedicated
+	// "symlink" message, (b) not pretend to count lines, and (c) leave the
+	// link untouched after rendering.
+	repo := t.TempDir()
+	external := t.TempDir()
+	target := filepath.Join(external, "post-create-source.sh")
+	if err := os.WriteFile(target, []byte("#!/bin/sh\necho dotfiles\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(repo, ".projmux", "post-create")
+	mkdirAll(t, filepath.Dir(scriptPath))
+	if err := os.Symlink(target, scriptPath); err != nil {
+		t.Fatalf("symlink: %v", err)
 	}
 
 	cmd := &settingsCommand{
@@ -113,25 +218,22 @@ func TestSettingsHookMakerExcludesInternalTmuxHooks(t *testing.T) {
 		},
 	}
 	entries := cmd.projectHookEntries(cmd.resolveSettingsProjectContext())
-	for _, label := range []string{"after-select-pane", "pane-focus-in", "pane-focus-out"} {
-		if hasEntryLabelContaining(entries, label) {
-			t.Fatalf("project hook entries = %#v, want no internal tmux hook %q", entries, label)
-		}
+	assertEntryLabelContainsAll(t, entries, "post-create", "legacy script: symlink", scriptPath)
+	assertEntryLabelContainsAll(t, entries, "post-create", "dotfiles repo")
+
+	// Link untouched.
+	if got, err := os.Readlink(scriptPath); err != nil || got != target {
+		t.Fatalf("readlink got=%q err=%v, want %q", got, err, target)
 	}
 }
 
-func TestSettingsHookMakerDoesNotMutateTrustStore(t *testing.T) {
+func TestSettingsHookMakerHooksPageDoesNotMutateTrustStore(t *testing.T) {
 	t.Parallel()
 
 	home := t.TempDir()
 	configHome := t.TempDir()
 	stateHome := t.TempDir()
 	repo := t.TempDir()
-	active := filepath.Join(repo, ".projmux", "hooks", "post-create")
-	mkdirAll(t, filepath.Dir(active))
-	if err := os.WriteFile(active, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 	trustStore := filepath.Join(stateHome, "projmux", "trusted-projects.json")
 	mkdirAll(t, filepath.Dir(trustStore))
 	const sentinel = `{"sentinel":true}`
@@ -171,6 +273,149 @@ func TestSettingsHookMakerDoesNotMutateTrustStore(t *testing.T) {
 	}
 }
 
+// --- Interactive add/edit/remove flows -------------------------------------
+
+func TestSettingsHookMakerProjectAddDeclarativeOpensInlineForm(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := t.TempDir()
+	stateHome := t.TempDir()
+	repo := t.TempDir()
+
+	var calls int
+	cmd := hookMakerTestSettings(t, home, configHome, stateHome, repo, func(options intpickercompat.Options) (intpickercompat.Result, error) {
+		calls++
+		switch calls {
+		case 1:
+			// Page render: declarative add row only (no branch picker).
+			if !hasEntryValue(options.Entries, settingsActionPrefixHookAdd+"project:post-create") {
+				t.Fatalf("entries = %#v, want post-create add row", options.Entries)
+			}
+			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixHookAdd + "project:post-create"}, nil
+		case 2:
+			// Inline typed form, NOT a branch picker.
+			if options.UI != "settings-project-config-typed" {
+				t.Fatalf("UI = %q, want settings-project-config-typed (branch picker removed)", options.UI)
+			}
+			return intpickercompat.Result{Key: "enter", Query: "echo from-declarative"}, nil
+		case 3:
+			if !hasEntryLabelContaining(options.Entries, "echo from-declarative") {
+				t.Fatalf("refreshed entries missing declarative: %#v", options.Entries)
+			}
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		default:
+			t.Fatalf("unexpected runner call %d", calls)
+			return intpickercompat.Result{}, nil
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	if err := cmd.runProjectHooksSection(&stdout, &stderr); err != nil {
+		t.Fatalf("runProjectHooksSection: %v", err)
+	}
+	configPath := filepath.Join(repo, ".projmux", "config.toml")
+	body := readFile(t, configPath)
+	if !strings.Contains(body, "[hooks.post-create]") || !strings.Contains(body, `run = "echo from-declarative"`) {
+		t.Fatalf("config.toml =\n%s\nwant [hooks.post-create] run line", body)
+	}
+	trustStore := readFile(t, filepath.Join(stateHome, "projmux", "trusted-projects.json"))
+	if !strings.Contains(trustStore, ".projmux/config.toml") {
+		t.Fatalf("trust store = %s, want config.toml trust", trustStore)
+	}
+}
+
+func TestSettingsHookMakerProjectEditDeclarativeUpdatesEntry(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := t.TempDir()
+	stateHome := t.TempDir()
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".projmux"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(repo, ".projmux", "config.toml")
+	writeFile(t, configPath, `
+[hooks.post-create]
+run = "echo original"
+`)
+
+	var calls int
+	cmd := hookMakerTestSettings(t, home, configHome, stateHome, repo, func(options intpickercompat.Options) (intpickercompat.Result, error) {
+		calls++
+		switch calls {
+		case 1:
+			if !hasEntryValue(options.Entries, settingsActionPrefixHookEdit+"project:post-create") {
+				t.Fatalf("entries = %#v, want post-create edit row", options.Entries)
+			}
+			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixHookEdit + "project:post-create"}, nil
+		case 2:
+			return intpickercompat.Result{Key: "enter", Query: "echo updated"}, nil
+		case 3:
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		default:
+			t.Fatalf("unexpected runner call %d", calls)
+			return intpickercompat.Result{}, nil
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	if err := cmd.runProjectHooksSection(&stdout, &stderr); err != nil {
+		t.Fatalf("runProjectHooksSection: %v", err)
+	}
+	body := readFile(t, configPath)
+	if !strings.Contains(body, `run = "echo updated"`) {
+		t.Fatalf("config.toml =\n%s\nwant updated run", body)
+	}
+}
+
+func TestSettingsHookMakerGlobalAddDeclarativeWritesGlobalConfig(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := t.TempDir()
+	stateHome := t.TempDir()
+
+	var calls int
+	cmd := hookMakerTestSettings(t, home, configHome, stateHome, "", func(options intpickercompat.Options) (intpickercompat.Result, error) {
+		calls++
+		switch calls {
+		case 1:
+			if !hasEntryValue(options.Entries, settingsActionPrefixHookAdd+"global:post-create") {
+				t.Fatalf("entries = %#v, want global post-create add row", options.Entries)
+			}
+			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixHookAdd + "global:post-create"}, nil
+		case 2:
+			if options.UI != "settings-project-config-typed" {
+				t.Fatalf("UI = %q, want typed editor (no branch picker)", options.UI)
+			}
+			return intpickercompat.Result{Key: "enter", Query: "echo global-declarative"}, nil
+		case 3:
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		default:
+			t.Fatalf("unexpected runner call %d", calls)
+			return intpickercompat.Result{}, nil
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	if err := cmd.runGlobalHooksSection(&stdout, &stderr); err != nil {
+		t.Fatalf("runGlobalHooksSection: %v", err)
+	}
+	configPath := filepath.Join(configHome, "projmux", "config.toml")
+	body := readFile(t, configPath)
+	if !strings.Contains(body, "[hooks.post-create]") || !strings.Contains(body, `run = "echo global-declarative"`) {
+		t.Fatalf("global config.toml =\n%s\nwant declarative entry", body)
+	}
+	// Global hooks must not touch the trust store.
+	if _, err := os.Stat(filepath.Join(stateHome, "projmux", "trusted-projects.json")); !os.IsNotExist(err) {
+		t.Fatalf("trust store stat = %v, want missing (global hooks bypass trust)", err)
+	}
+}
+
+// --- Project config section tests preserved from Phase 2.5 -----------------
+
 func TestSettingsProjectConfigEditorWritesAndTrustsConfig(t *testing.T) {
 	t.Parallel()
 
@@ -202,10 +447,6 @@ run = "echo post"
 			if !hasEntryValue(options.Entries, settingsActionPrefixProjectConfig+"startup:set") {
 				t.Fatalf("project config entries = %#v, want startup set action", options.Entries)
 			}
-			// Phase 2.5 (A): hook commands are authored from the Hooks page,
-			// so the config.toml section must not advertise them. The labels
-			// "Hook commands" / "preserved" only appear when the legacy row
-			// is rendered.
 			if hasEntryLabelContaining(options.Entries, "Hook commands") {
 				t.Fatalf("project config entries = %#v, want no hook commands row", options.Entries)
 			}
@@ -332,355 +573,6 @@ func TestSettingsProjectConfigEditorRejectsInvalidEnvKey(t *testing.T) {
 	}
 }
 
-func assertEntryLabelContainsAll(t *testing.T, entries []intpickercompat.Entry, parts ...string) {
-	t.Helper()
-	for _, entry := range entries {
-		matches := true
-		for _, part := range parts {
-			if !strings.Contains(entry.Label, part) {
-				matches = false
-				break
-			}
-		}
-		if matches {
-			return
-		}
-	}
-	t.Fatalf("entries = %#v, want one label containing all %#v", entries, parts)
-}
-
-// --- Phase 2.5 hook maker tests -------------------------------------------
-
-// hookMakerTestSettings builds a settingsCommand wired so it can drive the
-// project hook page using a scripted runner. The runner is the same one
-// returned, so callers can mutate it between calls if needed.
-func hookMakerTestSettings(t *testing.T, home, configHome, stateHome, repo string, run func(intpickercompat.Options) (intpickercompat.Result, error)) *settingsCommand {
-	t.Helper()
-	runner := switchRunnerFunc(run)
-	return &settingsCommand{
-		homeDir: func() (string, error) { return home, nil },
-		lookupEnv: func(name string) string {
-			switch name {
-			case "PROJMUX_CWD":
-				return repo
-			case "XDG_CONFIG_HOME":
-				return configHome
-			case "XDG_STATE_HOME":
-				return stateHome
-			default:
-				return ""
-			}
-		},
-		runner:       runner,
-		nativePicker: nativePickerFromCompatRunner(runner),
-	}
-}
-
-func TestSettingsHookMakerProjectAddDeclarativeWritesConfigAndTrusts(t *testing.T) {
-	t.Parallel()
-
-	home := t.TempDir()
-	configHome := t.TempDir()
-	stateHome := t.TempDir()
-	repo := t.TempDir()
-
-	var calls int
-	cmd := hookMakerTestSettings(t, home, configHome, stateHome, repo, func(options intpickercompat.Options) (intpickercompat.Result, error) {
-		calls++
-		switch calls {
-		case 1:
-			// Page render: expect [+ Add] declarative row for post-create.
-			if !hasEntryValue(options.Entries, settingsActionPrefixHookAdd+"project:post-create") {
-				t.Fatalf("hook entries = %#v, want declarative add for post-create", options.Entries)
-			}
-			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixHookAdd + "project:post-create"}, nil
-		case 2:
-			// Add branch picker.
-			if !hasEntryValue(options.Entries, settingsActionPrefixHookAdd+"project:post-create:declarative") {
-				t.Fatalf("add picker = %#v, want declarative branch", options.Entries)
-			}
-			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixHookAdd + "project:post-create:declarative"}, nil
-		case 3:
-			// Typed field for [hooks.post-create] run.
-			if options.UI != "settings-project-config-typed" {
-				t.Fatalf("typed UI = %q", options.UI)
-			}
-			return intpickercompat.Result{Key: "enter", Query: "echo from-declarative"}, nil
-		case 4:
-			// Page refresh — declarative row is now active.
-			if !hasEntryLabelContaining(options.Entries, "echo from-declarative") {
-				t.Fatalf("refreshed entries = %#v, want declarative active", options.Entries)
-			}
-			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
-		default:
-			t.Fatalf("unexpected runner call %d", calls)
-			return intpickercompat.Result{}, nil
-		}
-	})
-
-	var stdout, stderr bytes.Buffer
-	if err := cmd.runProjectHooksSection(&stdout, &stderr); err != nil {
-		t.Fatalf("runProjectHooksSection: %v", err)
-	}
-	configPath := filepath.Join(repo, ".projmux", "config.toml")
-	body := readFile(t, configPath)
-	if !strings.Contains(body, "[hooks.post-create]") || !strings.Contains(body, `run = "echo from-declarative"`) {
-		t.Fatalf("config.toml =\n%s\nwant [hooks.post-create] run line", body)
-	}
-	trustStore := readFile(t, filepath.Join(stateHome, "projmux", "trusted-projects.json"))
-	if !strings.Contains(trustStore, ".projmux/config.toml") {
-		t.Fatalf("trust store = %s, want config.toml trust", trustStore)
-	}
-}
-
-func TestSettingsHookMakerProjectAddScriptCreatesAndTrusts(t *testing.T) {
-	t.Parallel()
-
-	home := t.TempDir()
-	configHome := t.TempDir()
-	stateHome := t.TempDir()
-	repo := t.TempDir()
-
-	var editedPath string
-	var calls int
-	cmd := hookMakerTestSettings(t, home, configHome, stateHome, repo, func(options intpickercompat.Options) (intpickercompat.Result, error) {
-		calls++
-		switch calls {
-		case 1:
-			if !hasEntryValue(options.Entries, settingsActionPrefixHookAdd+"project:post-create") {
-				t.Fatalf("page entries = %#v, want post-create add", options.Entries)
-			}
-			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixHookAdd + "project:post-create"}, nil
-		case 2:
-			if !hasEntryValue(options.Entries, settingsActionPrefixHookAdd+"project:post-create:script") {
-				t.Fatalf("add picker = %#v, want script branch", options.Entries)
-			}
-			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixHookAdd + "project:post-create:script"}, nil
-		case 3:
-			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
-		default:
-			t.Fatalf("unexpected runner call %d", calls)
-			return intpickercompat.Result{}, nil
-		}
-	})
-	cmd.runCommand = func(name string, args ...string) error {
-		if len(args) == 0 {
-			t.Fatalf("editor invoked without path: %s", name)
-		}
-		editedPath = args[len(args)-1]
-		// Simulate a user save: append a comment line.
-		body, err := os.ReadFile(editedPath)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(editedPath, append(body, []byte("# edited by test\n")...), 0o755)
-	}
-
-	var stdout, stderr bytes.Buffer
-	if err := cmd.runProjectHooksSection(&stdout, &stderr); err != nil {
-		t.Fatalf("runProjectHooksSection: %v", err)
-	}
-	wantPath := filepath.Join(repo, ".projmux", "hooks", "post-create")
-	if editedPath != wantPath {
-		t.Fatalf("editor opened %q, want %q", editedPath, wantPath)
-	}
-	info, err := os.Stat(wantPath)
-	if err != nil {
-		t.Fatalf("stat hook: %v", err)
-	}
-	if info.Mode().Perm()&0o111 == 0 {
-		t.Fatalf("hook %s not executable: %v", wantPath, info.Mode())
-	}
-	trustStore := readFile(t, filepath.Join(stateHome, "projmux", "trusted-projects.json"))
-	if !strings.Contains(trustStore, ".projmux/hooks/post-create") {
-		t.Fatalf("trust store = %s, want hook script trusted", trustStore)
-	}
-	if !strings.Contains(trustStore, repo) {
-		t.Fatalf("trust store = %s, want repo entry", trustStore)
-	}
-}
-
-func TestSettingsHookMakerEditScriptUpdatesTrustHash(t *testing.T) {
-	t.Parallel()
-
-	home := t.TempDir()
-	configHome := t.TempDir()
-	stateHome := t.TempDir()
-	repo := t.TempDir()
-
-	hookPath := filepath.Join(repo, ".projmux", "hooks", "post-create")
-	mkdirAll(t, filepath.Dir(hookPath))
-	if err := os.WriteFile(hookPath, []byte("#!/bin/sh\necho original\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	// Pre-seed trust with an outdated hash so we can verify the edit updates it.
-	trustPath := filepath.Join(stateHome, "projmux", "trusted-projects.json")
-	mkdirAll(t, filepath.Dir(trustPath))
-	const staleHash = "0000000000000000000000000000000000000000000000000000000000000000"
-	staleTrust := `{"` + repo + `":{"trusted_at":"2024-01-01T00:00:00Z","files":{".projmux/hooks/post-create":{"sha256":"` + staleHash + `","trusted_at":"2024-01-01T00:00:00Z"}}}}`
-	if err := os.WriteFile(trustPath, []byte(staleTrust), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	var calls int
-	cmd := hookMakerTestSettings(t, home, configHome, stateHome, repo, func(options intpickercompat.Options) (intpickercompat.Result, error) {
-		calls++
-		switch calls {
-		case 1:
-			if !hasEntryValue(options.Entries, settingsActionPrefixHookEdit+"script:project:post-create") {
-				t.Fatalf("entries = %#v, want script edit row", options.Entries)
-			}
-			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixHookEdit + "script:project:post-create"}, nil
-		case 2:
-			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
-		default:
-			t.Fatalf("unexpected runner call %d", calls)
-			return intpickercompat.Result{}, nil
-		}
-	})
-	cmd.runCommand = func(name string, args ...string) error {
-		if len(args) == 0 {
-			return nil
-		}
-		path := args[len(args)-1]
-		return os.WriteFile(path, []byte("#!/bin/sh\necho updated\n"), 0o755)
-	}
-
-	var stdout, stderr bytes.Buffer
-	if err := cmd.runProjectHooksSection(&stdout, &stderr); err != nil {
-		t.Fatalf("runProjectHooksSection: %v", err)
-	}
-	trustBody := readFile(t, trustPath)
-	if strings.Contains(trustBody, staleHash) {
-		t.Fatalf("trust store still has stale hash:\n%s", trustBody)
-	}
-	if !strings.Contains(trustBody, ".projmux/hooks/post-create") {
-		t.Fatalf("trust store missing entry:\n%s", trustBody)
-	}
-}
-
-func TestSettingsHookMakerHooksPageRendersBothSources(t *testing.T) {
-	t.Parallel()
-
-	repo := t.TempDir()
-	// Active script hook.
-	scriptPath := filepath.Join(repo, ".projmux", "hooks", "post-create")
-	mkdirAll(t, filepath.Dir(scriptPath))
-	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	// Declarative hook for the same event.
-	cfgPath := filepath.Join(repo, ".projmux", "config.toml")
-	if err := os.WriteFile(cfgPath, []byte(`
-[hooks.post-create]
-run = "echo declared"
-`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	cmd := &settingsCommand{
-		lookupEnv: func(name string) string {
-			if name == "PROJMUX_CWD" {
-				return repo
-			}
-			return ""
-		},
-	}
-	entries := cmd.projectHookEntries(cmd.resolveSettingsProjectContext())
-	// Expect a script row (active) and a declarative row (active) for
-	// post-create — distinguishable by their source label suffixes.
-	if !hasEntryValue(entries, settingsActionPrefixHookEdit+"script:project:post-create") {
-		t.Fatalf("entries missing script edit row: %#v", entries)
-	}
-	if !hasEntryValue(entries, settingsActionPrefixHookEdit+"declarative:project:post-create") {
-		t.Fatalf("entries missing declarative edit row: %#v", entries)
-	}
-	assertEntryLabelContainsAll(t, entries, "post-create", "(script)")
-	assertEntryLabelContainsAll(t, entries, "post-create", "(declarative)", "echo declared")
-}
-
-func TestSettingsHookMakerGlobalPageSkipsTrust(t *testing.T) {
-	t.Parallel()
-
-	home := t.TempDir()
-	configHome := t.TempDir()
-	stateHome := t.TempDir()
-
-	var editedPath string
-	var calls int
-	cmd := hookMakerTestSettings(t, home, configHome, stateHome, "", func(options intpickercompat.Options) (intpickercompat.Result, error) {
-		calls++
-		switch calls {
-		case 1:
-			if !hasEntryValue(options.Entries, settingsActionPrefixHookAdd+"global:post-create") {
-				t.Fatalf("global hook entries = %#v, want add row", options.Entries)
-			}
-			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixHookAdd + "global:post-create"}, nil
-		case 2:
-			// Branch picker still appears, but declarative is disabled for
-			// global. Pick script.
-			if !hasEntryValue(options.Entries, settingsActionPrefixHookAdd+"global:post-create:script") {
-				t.Fatalf("branch picker = %#v, want script", options.Entries)
-			}
-			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixHookAdd + "global:post-create:script"}, nil
-		case 3:
-			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
-		default:
-			t.Fatalf("unexpected runner call %d", calls)
-			return intpickercompat.Result{}, nil
-		}
-	})
-	cmd.runCommand = func(name string, args ...string) error {
-		if len(args) == 0 {
-			return nil
-		}
-		editedPath = args[len(args)-1]
-		return nil
-	}
-
-	var stdout, stderr bytes.Buffer
-	if err := cmd.runGlobalHooksSection(&stdout, &stderr); err != nil {
-		t.Fatalf("runGlobalHooksSection: %v", err)
-	}
-	wantPath := filepath.Join(configHome, "projmux", "hooks", "post-create")
-	if editedPath != wantPath {
-		t.Fatalf("editor opened %q, want %q", editedPath, wantPath)
-	}
-	info, err := os.Stat(wantPath)
-	if err != nil {
-		t.Fatalf("stat global hook: %v", err)
-	}
-	if info.Mode().Perm()&0o111 == 0 {
-		t.Fatalf("global hook not executable: %v", info.Mode())
-	}
-	// Global edits must not write a trust store entry.
-	if _, err := os.Stat(filepath.Join(stateHome, "projmux", "trusted-projects.json")); !os.IsNotExist(err) {
-		t.Fatalf("trust store stat = %v, want missing (global hooks bypass trust)", err)
-	}
-}
-
-func TestSettingsHookMakerExcludesInternalEventsFromAdd(t *testing.T) {
-	t.Parallel()
-
-	repo := t.TempDir()
-	cmd := &settingsCommand{
-		lookupEnv: func(name string) string {
-			if name == "PROJMUX_CWD" {
-				return repo
-			}
-			return ""
-		},
-	}
-	entries := cmd.projectHookEntries(cmd.resolveSettingsProjectContext())
-	for _, banned := range []string{"after-select-pane", "pane-focus-in", "pane-focus-out"} {
-		for _, entry := range entries {
-			if strings.Contains(entry.Value, banned) {
-				t.Fatalf("entry %#v exposes internal event %q", entry, banned)
-			}
-		}
-	}
-}
-
 func TestSettingsHookMakerConfigSectionHasNoHookCommandsRow(t *testing.T) {
 	t.Parallel()
 
@@ -707,5 +599,49 @@ run = "echo b"
 		if strings.Contains(entry.Label, "Hook commands") {
 			t.Fatalf("config.toml section still renders hook commands row: %#v", entry)
 		}
+	}
+}
+
+// --- helpers ----------------------------------------------------------------
+
+func assertEntryLabelContainsAll(t *testing.T, entries []intpickercompat.Entry, parts ...string) {
+	t.Helper()
+	for _, entry := range entries {
+		matches := true
+		for _, part := range parts {
+			if !strings.Contains(entry.Label, part) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return
+		}
+	}
+	t.Fatalf("entries = %#v, want one label containing all %#v", entries, parts)
+}
+
+// hookMakerTestSettings builds a settingsCommand wired so it can drive the
+// project hook page using a scripted runner. The runner is the same one
+// returned, so callers can mutate it between calls if needed.
+func hookMakerTestSettings(t *testing.T, home, configHome, stateHome, repo string, run func(intpickercompat.Options) (intpickercompat.Result, error)) *settingsCommand {
+	t.Helper()
+	runner := switchRunnerFunc(run)
+	return &settingsCommand{
+		homeDir: func() (string, error) { return home, nil },
+		lookupEnv: func(name string) string {
+			switch name {
+			case "PROJMUX_CWD":
+				return repo
+			case "XDG_CONFIG_HOME":
+				return configHome
+			case "XDG_STATE_HOME":
+				return stateHome
+			default:
+				return ""
+			}
+		},
+		runner:       runner,
+		nativePicker: nativePickerFromCompatRunner(runner),
 	}
 }

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -21,6 +21,10 @@ import (
 // osStat is a package-level indirection so tests can stub filesystem checks.
 var osStat = os.Stat
 
+// osLstat mirrors osStat for symlink-aware checks (e.g. the hook maker has
+// to distinguish a dotfiles-managed symlink from a regular legacy script).
+var osLstat = os.Lstat
+
 type settingsCommand struct {
 	ai                 *aiCommand
 	switcher           *switchCommand

--- a/internal/app/tmux_client.go
+++ b/internal/app/tmux_client.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/integrations/hooks"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 	"github.com/crevissepartners/projmux/internal/version"
@@ -23,33 +22,21 @@ func defaultTmuxClient() *inttmux.Client {
 }
 
 func defaultLifecycleHookRunner() *hooks.Runner {
-	paths, err := config.DefaultPathsFromEnv()
+	globalConfigPath, err := hooks.GlobalConfigPath(os.Getenv, os.UserHomeDir)
 	if err != nil {
 		return nil
 	}
+
 	prompt := hooks.ProjectHookPrompt(nil)
 	if strings.TrimSpace(os.Getenv("TMUX")) != "" && strings.TrimSpace(os.Getenv(hookTrustInlineEnv)) == "" {
 		prompt = tmuxProjectHookPrompt(os.Getenv, os.Executable, inttmux.ExecRunner{})
 	}
 	return &hooks.Runner{
-		GlobalHookPaths: map[hooks.Event][]string{
-			hooks.EventPreCreate:   {paths.HookPath(config.PreCreateHookFileName)},
-			hooks.EventPostCreate:  {paths.HookPath(config.PostCreateHookFileName)},
-			hooks.EventPaneStartup: {paths.HookPath(config.PaneStartupHookFileName)},
-			hooks.EventPostAttach:  {paths.HookPath(config.PostAttachHookFileName)},
-		},
+		GlobalConfigPath:     globalConfigPath,
 		DiscoverProjectHooks: true,
 		ProjectHookPrompt:    prompt,
 		Logger:               os.Stderr,
 		Timeout:              hooks.DefaultPostCreateTimeout,
 		Version:              version.String(),
 	}
-}
-
-func defaultPostCreateHookPath() string {
-	paths, err := config.DefaultPathsFromEnv()
-	if err != nil {
-		return ""
-	}
-	return paths.PostCreateHookPath()
 }

--- a/internal/app/tmux_client_test.go
+++ b/internal/app/tmux_client_test.go
@@ -3,12 +3,9 @@ package app
 import (
 	"path/filepath"
 	"testing"
-
-	"github.com/crevissepartners/projmux/internal/config"
-	"github.com/crevissepartners/projmux/internal/integrations/hooks"
 )
 
-func TestDefaultLifecycleHookRunnerWiresGlobalEventPaths(t *testing.T) {
+func TestDefaultLifecycleHookRunnerWiresGlobalConfigPath(t *testing.T) {
 	home := t.TempDir()
 	configHome := filepath.Join(home, ".config")
 	stateHome := filepath.Join(home, ".local", "state")
@@ -22,17 +19,9 @@ func TestDefaultLifecycleHookRunnerWiresGlobalEventPaths(t *testing.T) {
 		t.Fatal("defaultLifecycleHookRunner() = nil")
 	}
 
-	want := map[hooks.Event]string{
-		hooks.EventPreCreate:   filepath.Join(configHome, "projmux", config.HooksDirName, config.PreCreateHookFileName),
-		hooks.EventPostCreate:  filepath.Join(configHome, "projmux", config.HooksDirName, config.PostCreateHookFileName),
-		hooks.EventPaneStartup: filepath.Join(configHome, "projmux", config.HooksDirName, config.PaneStartupHookFileName),
-		hooks.EventPostAttach:  filepath.Join(configHome, "projmux", config.HooksDirName, config.PostAttachHookFileName),
-	}
-	for event, path := range want {
-		got := runner.GlobalHookPaths[event]
-		if len(got) != 1 || got[0] != path {
-			t.Fatalf("GlobalHookPaths[%s] = %#v, want [%q]", event, got, path)
-		}
+	want := filepath.Join(configHome, "projmux", "config.toml")
+	if runner.GlobalConfigPath != want {
+		t.Fatalf("GlobalConfigPath = %q, want %q", runner.GlobalConfigPath, want)
 	}
 	if !runner.DiscoverProjectHooks {
 		t.Fatal("DiscoverProjectHooks = false, want true")

--- a/internal/integrations/hooks/global_config.go
+++ b/internal/integrations/hooks/global_config.go
@@ -1,0 +1,99 @@
+package hooks
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// GlobalConfigRelativePath is the path inside the projmux config directory at
+// which global lifecycle declarations live. The same TOML schema as the
+// project-local config.toml is reused so the parser can be shared.
+const GlobalConfigRelativePath = "projmux/config.toml"
+
+// resolveGlobalConfigDir returns the directory that contains the global
+// config.toml file. It prefers XDG_CONFIG_HOME (consistent with the rest of
+// projmux) and falls back to $HOME/.config.
+func resolveGlobalConfigDir(getenv func(string) string, homeDir func() (string, error)) (string, error) {
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+	if homeDir == nil {
+		homeDir = os.UserHomeDir
+	}
+	configHome := strings.TrimSpace(getenv("XDG_CONFIG_HOME"))
+	if configHome == "" {
+		home, err := homeDir()
+		if err != nil {
+			return "", err
+		}
+		if strings.TrimSpace(home) == "" {
+			return "", errors.New("home directory is required to resolve global config path")
+		}
+		configHome = filepath.Join(home, ".config")
+	}
+	return configHome, nil
+}
+
+// GlobalConfigPath returns the absolute path to the global projmux config.toml
+// file. The file may or may not exist; callers should treat ENOENT as an empty
+// configuration.
+func GlobalConfigPath(getenv func(string) string, homeDir func() (string, error)) (string, error) {
+	dir, err := resolveGlobalConfigDir(getenv, homeDir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, GlobalConfigRelativePath), nil
+}
+
+// LoadGlobalConfig reads the global config.toml at path. A missing file
+// returns a zero-value ProjectConfig and no error. Parse errors propagate.
+func LoadGlobalConfig(path string) (ProjectConfig, error) {
+	if strings.TrimSpace(path) == "" {
+		return ProjectConfig{}, nil
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ProjectConfig{}, nil
+		}
+		return ProjectConfig{}, err
+	}
+	return ParseProjectConfig(string(content))
+}
+
+// UpdateGlobalConfig loads the global config.toml at path, applies update,
+// validates the result, and writes it back atomically. A nil update is
+// treated as a no-op load + normalize + rewrite, which is handy for tests.
+// Unlike UpdateProjectConfig, the result is not trusted because global hooks
+// are always considered authoritative (they live alongside the projmux
+// binary's own config dir).
+func UpdateGlobalConfig(path string, update func(*ProjectConfig) error) (ProjectConfig, error) {
+	if strings.TrimSpace(path) == "" {
+		return ProjectConfig{}, errors.New("global config path is required")
+	}
+	cfg, err := LoadGlobalConfig(path)
+	if err != nil {
+		return ProjectConfig{}, err
+	}
+	if cfg.Hooks == nil {
+		cfg.Hooks = map[Event]string{}
+	}
+	if cfg.Env == nil {
+		cfg.Env = map[string]string{}
+	}
+	if update != nil {
+		if err := update(&cfg); err != nil {
+			return ProjectConfig{}, err
+		}
+	}
+	if err := validateProjectConfig(cfg); err != nil {
+		return ProjectConfig{}, err
+	}
+	normalizeProjectConfig(&cfg)
+	if err := writeProjectConfigFile(path, cfg); err != nil {
+		return ProjectConfig{}, err
+	}
+	return cfg, nil
+}

--- a/internal/integrations/hooks/global_config_test.go
+++ b/internal/integrations/hooks/global_config_test.go
@@ -1,0 +1,98 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGlobalConfigPathPrefersXdg(t *testing.T) {
+	t.Parallel()
+
+	configHome := t.TempDir()
+	getenv := func(name string) string {
+		if name == "XDG_CONFIG_HOME" {
+			return configHome
+		}
+		return ""
+	}
+	got, err := GlobalConfigPath(getenv, func() (string, error) { return "/should/not/be/used", nil })
+	if err != nil {
+		t.Fatalf("GlobalConfigPath() error = %v", err)
+	}
+	want := filepath.Join(configHome, "projmux", "config.toml")
+	if got != want {
+		t.Fatalf("GlobalConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestGlobalConfigPathFallsBackToHome(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	getenv := func(string) string { return "" }
+	got, err := GlobalConfigPath(getenv, func() (string, error) { return home, nil })
+	if err != nil {
+		t.Fatalf("GlobalConfigPath() error = %v", err)
+	}
+	want := filepath.Join(home, ".config", "projmux", "config.toml")
+	if got != want {
+		t.Fatalf("GlobalConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestLoadGlobalConfigMissingFileReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := LoadGlobalConfig(filepath.Join(t.TempDir(), "missing", "config.toml"))
+	if err != nil {
+		t.Fatalf("LoadGlobalConfig() error = %v", err)
+	}
+	if len(cfg.Hooks) != 0 || len(cfg.Env) != 0 || cfg.StartupRun != "" {
+		t.Fatalf("LoadGlobalConfig() = %#v, want empty", cfg)
+	}
+}
+
+func TestUpdateGlobalConfigWritesAndReadsBack(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "projmux", "config.toml")
+	_, err := UpdateGlobalConfig(path, func(cfg *ProjectConfig) error {
+		if cfg.Hooks == nil {
+			cfg.Hooks = map[Event]string{}
+		}
+		cfg.Hooks[EventPostCreate] = "echo global-post"
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("UpdateGlobalConfig() error = %v", err)
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(body), "[hooks.post-create]") {
+		t.Fatalf("config.toml missing section:\n%s", body)
+	}
+	if !strings.Contains(string(body), `run = "echo global-post"`) {
+		t.Fatalf("config.toml missing run line:\n%s", body)
+	}
+
+	cfg, err := LoadGlobalConfig(path)
+	if err != nil {
+		t.Fatalf("LoadGlobalConfig() error = %v", err)
+	}
+	if cfg.Hooks[EventPostCreate] != "echo global-post" {
+		t.Fatalf("Hooks[post-create] = %q, want %q", cfg.Hooks[EventPostCreate], "echo global-post")
+	}
+}
+
+func TestUpdateGlobalConfigEmptyPathErrors(t *testing.T) {
+	t.Parallel()
+
+	if _, err := UpdateGlobalConfig("", nil); err == nil {
+		t.Fatal("UpdateGlobalConfig(empty path) should error")
+	}
+}

--- a/internal/integrations/hooks/hooks.go
+++ b/internal/integrations/hooks/hooks.go
@@ -1,5 +1,11 @@
-// Package hooks runs optional user-supplied hook scripts at projmux
-// lifecycle points (e.g. tmux session creation).
+// Package hooks runs optional user-supplied lifecycle hooks at projmux
+// lifecycle points (e.g. tmux session creation). Hooks are sourced exclusively
+// from declarative [hooks.<event>] run = "..." entries in either the global
+// `${XDG_CONFIG_HOME}/projmux/config.toml` or the project-local
+// `<repo>/.projmux/config.toml`. Legacy script files in the historical
+// `.projmux/<event>` / `.projmux/hooks/<event>` layout are no longer executed;
+// MigrateProjectLegacyScripts / MigrateGlobalLegacyScripts handle the
+// transition.
 package hooks
 
 import (
@@ -10,7 +16,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -38,7 +43,7 @@ var SupportedEvents = []Event{
 // post-create public API.
 const DefaultPostCreateTimeout = 5 * time.Second
 
-// Context describes the tmux lifecycle point and is passed to hook scripts as
+// Context describes the tmux lifecycle point and is passed to hook commands as
 // PROJMUX_* environment variables.
 type Context struct {
 	SessionName string
@@ -52,7 +57,7 @@ type Context struct {
 }
 
 // PostCreateContext describes the tmux session that was just created and is
-// passed to the post-create hook script as PROJMUX_* environment variables.
+// passed to the post-create hook command as PROJMUX_* environment variables.
 type PostCreateContext = Context
 
 // RunResult is the observable hook output returned for events that consume
@@ -61,10 +66,15 @@ type RunResult struct {
 	Stdout string
 }
 
-// Runner runs optional global and project-local lifecycle hooks. Missing,
-// non-executable, or empty paths degrade to no-ops.
+// Runner runs optional global and project-local lifecycle hooks. Missing or
+// empty entries degrade to no-ops. Global hooks live in GlobalConfigPath
+// (defaults to `${XDG_CONFIG_HOME}/projmux/config.toml`) and are always
+// trusted; project-local hooks live in `<cwd>/.projmux/config.toml` and are
+// gated by the trust store.
 type Runner struct {
-	GlobalHookPaths      map[Event][]string
+	// GlobalConfigPath is the global declarative config file. Empty disables
+	// global hooks. A missing file is also treated as empty (no error).
+	GlobalConfigPath     string
 	DiscoverProjectHooks bool
 	ProjectHooksFilePath string
 	TrustStorePath       string
@@ -81,12 +91,11 @@ type Runner struct {
 // RunnerByEvent is the event-oriented lifecycle hook runner surface.
 type RunnerByEvent = Runner
 
-// PostCreateRunner runs the optional global post-create hook at HookPath, then
-// an optional project-local post-create hook when DiscoverProjectHooks is set.
-// A nil receiver, empty paths, and missing/non-executable files all degrade to
-// silent no-ops so the caller can always invoke Run unconditionally.
+// PostCreateRunner is a backwards-compatible shim that delegates to Runner
+// for the post-create lifecycle point. It is intentionally thin: callers that
+// want full event coverage should construct *Runner directly.
 type PostCreateRunner struct {
-	HookPath             string
+	GlobalConfigPath     string
 	DiscoverProjectHooks bool
 	ProjectHooksFilePath string
 	TrustStorePath       string
@@ -110,13 +119,16 @@ func (r *Runner) Run(ctx context.Context, event Event, c Context) (RunResult, er
 		return RunResult{}, nil
 	}
 
-	paths := r.hookPaths(event, c.CWD)
-	hasFileHooks := len(paths.global) > 0 || paths.project.path != ""
-	projectConfig, hasProjectConfig := r.projectConfigForEvent(event, paths.config, hasFileHooks)
-	if hasProjectConfig {
-		c.Env = mergeConfigEnv(c.Env, projectConfig.SessionEnv())
+	globalCfg, hasGlobalCfg := r.globalConfigForEvent(event)
+	projectFile := r.discoverProjectConfigFile(event, c.CWD)
+	projectCfg, hasProjectCfg := r.projectConfigForEvent(event, projectFile)
+	if hasGlobalCfg {
+		c.Env = mergeConfigEnv(c.Env, globalCfg.SessionEnv())
 	}
-	if len(paths.global) == 0 && paths.project.path == "" && !hasProjectConfig {
+	if hasProjectCfg {
+		c.Env = mergeConfigEnv(c.Env, projectCfg.SessionEnv())
+	}
+	if !hasGlobalCfg && !hasProjectCfg {
 		return RunResult{}, nil
 	}
 
@@ -126,40 +138,29 @@ func (r *Runner) Run(ctx context.Context, event Event, c Context) (RunResult, er
 	}
 
 	var result RunResult
-	for _, path := range paths.global {
-		hookResult, err := r.runHook(ctx, event, c, path, timeout, hookOutputMode(event))
+	if hasGlobalCfg {
+		hookResult, err := r.runConfigHook(ctx, event, c, globalCfg, "global", timeout, hookOutputMode(event))
 		if err != nil {
 			if event == EventPreCreate {
 				return result, err
 			}
-			r.warnf(event, "hook %q: %v", path, err)
-			continue
+			r.warnf(event, "global config hook: %v", err)
+		} else {
+			result = mergeResult(event, result, hookResult)
 		}
-		result = mergeResult(event, result, hookResult)
 	}
-	if paths.project.path != "" && r.authorizeProjectHook(paths.project) {
-		hookResult, err := r.runHook(ctx, event, c, paths.project.path, timeout, hookOutputMode(event))
+	if hasProjectCfg {
+		hookResult, err := r.runConfigHook(ctx, event, c, projectCfg, "project", timeout, hookOutputMode(event))
 		if err != nil {
 			if event == EventPreCreate {
 				return result, err
 			}
-			r.warnf(event, "hook %q: %v", paths.project.path, err)
-			return result, nil
+			r.warnf(event, "project config %q: %v", projectFile.rel, err)
+		} else {
+			result = mergeResult(event, result, hookResult)
 		}
-		result = mergeResult(event, result, hookResult)
-	}
-	if hasProjectConfig {
-		hookResult, err := r.runProjectConfigHook(ctx, event, c, projectConfig, timeout, hookOutputMode(event))
-		if err != nil {
-			if event == EventPreCreate {
-				return result, err
-			}
-			r.warnf(event, "config %q: %v", paths.config.rel, err)
-			return result, nil
-		}
-		result = mergeResult(event, result, hookResult)
 		if event == EventPaneStartup {
-			result = mergeResult(event, result, RunResult{Stdout: projectConfig.StartupRun})
+			result = mergeResult(event, result, RunResult{Stdout: projectCfg.StartupRun})
 		}
 	}
 	return result, nil
@@ -186,7 +187,7 @@ func (r *Runner) ProjectSessionEnv(cwd string) map[string]string {
 	return cfg.SessionEnv()
 }
 
-// HasHooks reports whether an executable global or project-local hook exists
+// HasHooks reports whether a declarative global or project-local hook exists
 // for event. It does not perform project trust prompting.
 func (r *Runner) HasHooks(event Event, cwd string) bool {
 	if r == nil {
@@ -196,24 +197,29 @@ func (r *Runner) HasHooks(event Event, cwd string) bool {
 	if event == "" {
 		return false
 	}
-	paths := r.hookPaths(event, cwd)
-	if len(paths.global) > 0 || paths.project.path != "" {
-		return true
+	if globalCfg, err := LoadGlobalConfig(r.GlobalConfigPath); err == nil {
+		if globalCfg.hasEventSurface(event) {
+			return true
+		}
 	}
-	if paths.config.path == "" {
+	if !r.DiscoverProjectHooks || projectHooksDisabled(event, r.ProjectHooksFilePath, r.Logger) {
 		return false
 	}
-	cfg, err := loadProjectConfig(paths.config.path)
+	configFile := discoverProjectConfig(cwd)
+	if configFile.path == "" {
+		return false
+	}
+	cfg, err := loadProjectConfig(configFile.path)
 	if err != nil {
-		r.warnf(event, "project config %q could not be parsed: %v", paths.config.rel, err)
+		r.warnf(event, "project config %q could not be parsed: %v", configFile.rel, err)
 		return false
 	}
 	return cfg.hasEventSurface(event)
 }
 
 // Run executes configured post-create hooks for c. Hook failures
-// (missing file, non-executable, non-zero exit, exec error, timeout) are
-// recorded as a single warning line on Logger and never returned.
+// (non-zero exit, exec error, timeout) are recorded as a single warning line
+// on Logger and never returned.
 func (r *PostCreateRunner) Run(ctx context.Context, c PostCreateContext) {
 	if r == nil {
 		return
@@ -221,24 +227,9 @@ func (r *PostCreateRunner) Run(ctx context.Context, c PostCreateContext) {
 	_, _ = r.runner().Run(ctx, EventPostCreate, c)
 }
 
-type hookPaths struct {
-	global  []string
-	project projectHook
-	config  projectConfigFile
-}
-
-type projectHook struct {
-	event Event
-	repo  string
-	rel   string
-	path  string
-}
-
 func (r *PostCreateRunner) runner() *Runner {
 	return &Runner{
-		GlobalHookPaths: map[Event][]string{
-			EventPostCreate: {r.HookPath},
-		},
+		GlobalConfigPath:     r.GlobalConfigPath,
 		DiscoverProjectHooks: r.DiscoverProjectHooks,
 		ProjectHooksFilePath: r.ProjectHooksFilePath,
 		TrustStorePath:       r.TrustStorePath,
@@ -249,68 +240,6 @@ func (r *PostCreateRunner) runner() *Runner {
 		Timeout:              r.Timeout,
 		Version:              r.Version,
 	}
-}
-
-func (r *Runner) hookPaths(event Event, cwd string) hookPaths {
-	var paths hookPaths
-	for _, path := range r.GlobalHookPaths[event] {
-		if path = strings.TrimSpace(path); isExecutableHook(path) {
-			paths.global = append(paths.global, path)
-		}
-	}
-	if r.DiscoverProjectHooks && !projectHooksDisabled(event, r.ProjectHooksFilePath, r.Logger) {
-		paths.project = discoverProjectHook(event, cwd)
-		paths.config = discoverProjectConfig(cwd)
-	}
-	return paths
-}
-
-func discoverProjectHook(event Event, cwd string) projectHook {
-	cwd = strings.TrimSpace(cwd)
-	if cwd == "" {
-		return projectHook{}
-	}
-	repo, err := filepath.Abs(cwd)
-	if err != nil {
-		return projectHook{}
-	}
-	for _, candidate := range projectHookCandidates(event) {
-		path := filepath.Join(repo, candidate)
-		if isExecutableHook(path) {
-			return projectHook{
-				event: event,
-				repo:  repo,
-				rel:   filepath.ToSlash(candidate),
-				path:  path,
-			}
-		}
-	}
-	return projectHook{}
-}
-
-func projectHookCandidates(event Event) []string {
-	name := string(normalizeEvent(event))
-	if name == "" {
-		return nil
-	}
-	return []string{
-		filepath.Join(".projmux", name),
-		filepath.Join(".projmux", "hooks", name),
-	}
-}
-
-func isExecutableHook(path string) bool {
-	if strings.TrimSpace(path) == "" {
-		return false
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	if info.IsDir() {
-		return false
-	}
-	return info.Mode().Perm()&0o100 != 0
 }
 
 type outputMode int
@@ -337,7 +266,26 @@ func mergeResult(event Event, current, next RunResult) RunResult {
 	return current
 }
 
-func (r *Runner) projectConfigForEvent(event Event, configFile projectConfigFile, hasHooks bool) (ProjectConfig, bool) {
+func (r *Runner) globalConfigForEvent(event Event) (ProjectConfig, bool) {
+	cfg, err := LoadGlobalConfig(r.GlobalConfigPath)
+	if err != nil {
+		r.warnf(event, "global config %q could not be parsed: %v", r.GlobalConfigPath, err)
+		return ProjectConfig{}, false
+	}
+	if !cfg.hasEventSurface(event) {
+		return ProjectConfig{}, false
+	}
+	return cfg, true
+}
+
+func (r *Runner) discoverProjectConfigFile(event Event, cwd string) projectConfigFile {
+	if !r.DiscoverProjectHooks || projectHooksDisabled(event, r.ProjectHooksFilePath, r.Logger) {
+		return projectConfigFile{}
+	}
+	return discoverProjectConfig(cwd)
+}
+
+func (r *Runner) projectConfigForEvent(event Event, configFile projectConfigFile) (ProjectConfig, bool) {
 	if configFile.path == "" {
 		return ProjectConfig{}, false
 	}
@@ -346,7 +294,7 @@ func (r *Runner) projectConfigForEvent(event Event, configFile projectConfigFile
 		r.warnf(event, "project config %q could not be parsed: %v", configFile.rel, err)
 		return ProjectConfig{}, false
 	}
-	if !cfg.relevantForEvent(event, hasHooks) {
+	if !cfg.relevantForEvent(event) {
 		return ProjectConfig{}, false
 	}
 	if !r.authorizeProjectConfig(event, configFile) {
@@ -355,19 +303,15 @@ func (r *Runner) projectConfigForEvent(event Event, configFile projectConfigFile
 	return cfg, true
 }
 
-func (r *Runner) runHook(ctx context.Context, event Event, c Context, path string, timeout time.Duration, mode outputMode) (RunResult, error) {
-	return r.runCommand(ctx, event, c, path, nil, timeout, mode)
-}
-
-func (r *Runner) runProjectConfigHook(ctx context.Context, event Event, c Context, cfg ProjectConfig, timeout time.Duration, mode outputMode) (RunResult, error) {
+func (r *Runner) runConfigHook(ctx context.Context, event Event, c Context, cfg ProjectConfig, label string, timeout time.Duration, mode outputMode) (RunResult, error) {
 	command := cfg.hookRun(event)
 	if strings.TrimSpace(command) == "" {
 		return RunResult{}, nil
 	}
-	return r.runCommand(ctx, event, c, "sh", []string{"-c", command}, timeout, mode)
+	return r.runCommand(ctx, event, c, "sh", []string{"-c", command}, label, timeout, mode)
 }
 
-func (r *Runner) runCommand(ctx context.Context, event Event, c Context, name string, args []string, timeout time.Duration, mode outputMode) (RunResult, error) {
+func (r *Runner) runCommand(ctx context.Context, event Event, c Context, name string, args []string, label string, timeout time.Duration, mode outputMode) (RunResult, error) {
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	cmd := exec.CommandContext(runCtx, name, args...)
@@ -381,7 +325,13 @@ func (r *Runner) runCommand(ctx context.Context, event Event, c Context, name st
 	cmd.WaitDelay = 250 * time.Millisecond
 
 	logger := r.Logger
-	prefixed := newLinePrefixer(logger, "["+string(event)+"] ")
+	// Note: label (e.g. "global"/"project") is intentionally NOT embedded in
+	// the line prefix so existing log scrapers and tests that anchor on the
+	// "[event]" shape keep working. Pass label as a contextual hint via the
+	// warning text instead.
+	_ = label
+	prefix := "[" + string(event) + "] "
+	prefixed := newLinePrefixer(logger, prefix)
 	var stdout bytes.Buffer
 	if mode == outputCaptureStdout {
 		cmd.Stdout = &stdout

--- a/internal/integrations/hooks/hooks_test.go
+++ b/internal/integrations/hooks/hooks_test.go
@@ -12,7 +12,16 @@ import (
 	"time"
 )
 
-func TestPostCreateRunnerEmptyHookPathIsNoOp(t *testing.T) {
+// --- PostCreateRunner shim coverage ---------------------------------------
+
+func TestPostCreateRunnerNilReceiverIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	var runner *PostCreateRunner
+	runner.Run(context.Background(), PostCreateContext{SessionName: "workspace"})
+}
+
+func TestPostCreateRunnerEmptyConfigIsNoOp(t *testing.T) {
 	t.Parallel()
 
 	var logger bytes.Buffer
@@ -24,129 +33,20 @@ func TestPostCreateRunnerEmptyHookPathIsNoOp(t *testing.T) {
 	}
 }
 
-func TestPostCreateRunnerNilReceiverIsNoOp(t *testing.T) {
-	t.Parallel()
-
-	var runner *PostCreateRunner
-	runner.Run(context.Background(), PostCreateContext{SessionName: "workspace"})
-}
-
-func TestPostCreateRunnerMissingHookIsNoOp(t *testing.T) {
-	t.Parallel()
-
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{
-		HookPath: filepath.Join(t.TempDir(), "missing"),
-		Logger:   &logger,
-	}
-	runner.Run(context.Background(), PostCreateContext{SessionName: "workspace"})
-
-	if logger.Len() != 0 {
-		t.Fatalf("logger output = %q, want empty", logger.String())
-	}
-}
-
-func TestPostCreateRunnerNonExecutableHookIsNoOp(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	dir := t.TempDir()
-	path := filepath.Join(dir, "hook")
-	if err := os.WriteFile(path, []byte("#!/usr/bin/env bash\nexit 0\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{HookPath: path, Logger: &logger}
-	runner.Run(context.Background(), PostCreateContext{SessionName: "workspace"})
-
-	if logger.Len() != 0 {
-		t.Fatalf("logger output = %q, want empty (non-executable should be silent)", logger.String())
-	}
-}
-
-func TestPostCreateRunnerDirectoryAtHookPathIsNoOp(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{HookPath: dir, Logger: &logger}
-	runner.Run(context.Background(), PostCreateContext{SessionName: "workspace"})
-
-	if logger.Len() != 0 {
-		t.Fatalf("logger output = %q, want empty", logger.String())
-	}
-}
-
-func TestPostCreateRunnerProjectLocalOnlyDiscoversShortPath(t *testing.T) {
+func TestPostCreateRunnerProjectConfigRunsWithTrust(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("bash fixtures require POSIX")
 	}
 	t.Parallel()
 
 	cwd := t.TempDir()
-	writeHook(t, filepath.Join(cwd, ".projmux", "post-create"), "echo local-short\n", 0o755)
-
-	var logger bytes.Buffer
-	runner := testProjectHookRunner(t, &logger, ProjectHookAllowOnce)
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         cwd,
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-
-	got := logger.String()
-	if !strings.Contains(got, "[post-create] local-short") {
-		t.Fatalf("logger output missing project hook output:\n%s", got)
-	}
-}
-
-func TestPostCreateRunnerProjectLocalDiscoversHooksSubdirFallback(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	cwd := t.TempDir()
-	writeHook(t, filepath.Join(cwd, ".projmux", "post-create"), "echo nonexec\n", 0o644)
-	writeHook(t, filepath.Join(cwd, ".projmux", "hooks", "post-create"), "echo local-hooks-dir\n", 0o755)
-
-	var logger bytes.Buffer
-	runner := testProjectHookRunner(t, &logger, ProjectHookAllowOnce)
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         cwd,
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-
-	got := logger.String()
-	if strings.Contains(got, "nonexec") {
-		t.Fatalf("non-executable project hook should be skipped:\n%s", got)
-	}
-	if !strings.Contains(got, "[post-create] local-hooks-dir") {
-		t.Fatalf("logger output missing hooks-dir fallback output:\n%s", got)
-	}
-}
-
-func TestPostCreateRunnerGlobalAndProjectHooksRunInOrder(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	dir := t.TempDir()
-	globalPath := filepath.Join(dir, "global-post-create")
-	cwd := filepath.Join(dir, "repo")
-	writeHook(t, globalPath, "echo global\n", 0o755)
-	writeHook(t, filepath.Join(cwd, ".projmux", "post-create"), "echo project\n", 0o755)
+	writeProjectConfig(t, cwd, `
+[hooks.post-create]
+run = "echo from-project"
+`)
 
 	var logger bytes.Buffer
 	runner := &PostCreateRunner{
-		HookPath:             globalPath,
 		DiscoverProjectHooks: true,
 		ProjectHooksFilePath: testProjectHooksFilePath(t),
 		TrustStorePath:       testTrustStorePath(t),
@@ -161,601 +61,110 @@ func TestPostCreateRunnerGlobalAndProjectHooksRunInOrder(t *testing.T) {
 	})
 
 	got := logger.String()
-	globalIdx := strings.Index(got, "[post-create] global")
-	projectIdx := strings.Index(got, "[post-create] project")
+	if !strings.Contains(got, "from-project") {
+		t.Fatalf("logger output missing declarative project hook stdout:\n%s", got)
+	}
+}
+
+// --- Runner declarative behaviour -----------------------------------------
+
+func TestRunnerNoConfigIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	var logger bytes.Buffer
+	runner := &Runner{Logger: &logger}
+	result, err := runner.Run(context.Background(), EventPostCreate, Context{CWD: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.Stdout != "" {
+		t.Fatalf("result.Stdout = %q, want empty", result.Stdout)
+	}
+	if logger.Len() != 0 {
+		t.Fatalf("logger output = %q, want empty", logger.String())
+	}
+}
+
+func TestRunnerGlobalAndProjectDeclarativeBothRun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash fixtures require POSIX")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	globalConfigPath := filepath.Join(dir, "global", "config.toml")
+	writeFileEnsuringDir(t, globalConfigPath, `
+[hooks.post-create]
+run = "echo global"
+`)
+	cwd := filepath.Join(dir, "repo")
+	writeProjectConfig(t, cwd, `
+[hooks.post-create]
+run = "echo project"
+`)
+
+	var logger bytes.Buffer
+	runner := &Runner{
+		GlobalConfigPath:     globalConfigPath,
+		DiscoverProjectHooks: true,
+		ProjectHooksFilePath: testProjectHooksFilePath(t),
+		TrustStorePath:       testTrustStorePath(t),
+		ProjectHookPrompt:    func(ProjectHookPromptRequest) ProjectHookDecision { return ProjectHookAllowOnce },
+		Logger:               &logger,
+	}
+	_, err := runner.Run(context.Background(), EventPostCreate, Context{
+		SessionName: "workspace",
+		CWD:         cwd,
+		Kind:        "persistent",
+		Version:     "0.0.0-test",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	got := logger.String()
+	globalIdx := strings.Index(got, "global")
+	projectIdx := strings.Index(got, "project")
 	if globalIdx < 0 || projectIdx < 0 {
-		t.Fatalf("logger output missing hook output:\n%s", got)
+		t.Fatalf("logger output missing hook stdout:\n%s", got)
 	}
 	if globalIdx > projectIdx {
 		t.Fatalf("hooks ran out of order:\n%s", got)
 	}
 }
 
-func TestPostCreateRunnerMissingProjectHookIsNoOp(t *testing.T) {
-	t.Parallel()
-
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{
-		DiscoverProjectHooks: true,
-		ProjectHooksFilePath: testProjectHooksFilePath(t),
-		Logger:               &logger,
-	}
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         t.TempDir(),
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-
-	if logger.Len() != 0 {
-		t.Fatalf("logger output = %q, want empty", logger.String())
-	}
-}
-
-func TestPostCreateRunnerNonExecutableProjectHookIsNoOp(t *testing.T) {
+func TestRunnerDoesNotExecuteScriptFiles(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("bash fixtures require POSIX")
 	}
 	t.Parallel()
 
 	cwd := t.TempDir()
-	writeHook(t, filepath.Join(cwd, ".projmux", "post-create"), "echo skipped\n", 0o644)
-
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{
-		DiscoverProjectHooks: true,
-		ProjectHooksFilePath: testProjectHooksFilePath(t),
-		Logger:               &logger,
-	}
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         cwd,
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-
-	if logger.Len() != 0 {
-		t.Fatalf("logger output = %q, want empty", logger.String())
-	}
-}
-
-func TestPostCreateRunnerGlobalFailureDoesNotSkipProjectHook(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	dir := t.TempDir()
-	globalPath := filepath.Join(dir, "global-post-create")
-	cwd := filepath.Join(dir, "repo")
-	writeHook(t, globalPath, "echo global-failed\nexit 7\n", 0o755)
-	writeHook(t, filepath.Join(cwd, ".projmux", "post-create"), "echo project-still-ran\n", 0o755)
-
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{
-		HookPath:             globalPath,
-		DiscoverProjectHooks: true,
-		ProjectHooksFilePath: testProjectHooksFilePath(t),
-		TrustStorePath:       testTrustStorePath(t),
-		ProjectHookPrompt:    func(ProjectHookPromptRequest) ProjectHookDecision { return ProjectHookAllowOnce },
-		Logger:               &logger,
-	}
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         cwd,
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-
-	got := logger.String()
-	if !strings.Contains(got, "exited with status 7") {
-		t.Fatalf("expected global failure warning, got:\n%s", got)
-	}
-	if !strings.Contains(got, "[post-create] project-still-ran") {
-		t.Fatalf("project hook did not run after global failure:\n%s", got)
-	}
-}
-
-func TestPostCreateRunnerProjectHookTimeoutWarnsAndReturns(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	cwd := t.TempDir()
-	writeHook(t, filepath.Join(cwd, ".projmux", "post-create"), "sleep 5\n", 0o755)
-
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{
-		DiscoverProjectHooks: true,
-		ProjectHooksFilePath: testProjectHooksFilePath(t),
-		TrustStorePath:       testTrustStorePath(t),
-		ProjectHookPrompt:    func(ProjectHookPromptRequest) ProjectHookDecision { return ProjectHookAllowOnce },
-		Logger:               &logger,
-		Timeout:              200 * time.Millisecond,
-	}
-
-	start := time.Now()
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         cwd,
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-	elapsed := time.Since(start)
-
-	if elapsed > 3*time.Second {
-		t.Fatalf("timeout did not fire in time: elapsed=%s", elapsed)
-	}
-	got := logger.String()
-	if !strings.Contains(got, "timed out") {
-		t.Fatalf("expected timeout warning, got:\n%s", got)
-	}
-}
-
-func TestPostCreateRunnerProjectHookRequiresTrustInNonInteractiveContext(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	cwd := t.TempDir()
-	writeHook(t, filepath.Join(cwd, ".projmux", "post-create"), "echo should-not-run\n", 0o755)
-
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{
-		DiscoverProjectHooks: true,
-		ProjectHooksFilePath: testProjectHooksFilePath(t),
-		TrustStorePath:       testTrustStorePath(t),
-		PromptReader:         strings.NewReader(""),
-		Logger:               &logger,
-	}
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         cwd,
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-
-	got := logger.String()
-	if strings.Contains(got, "should-not-run") {
-		t.Fatalf("untrusted project hook ran:\n%s", got)
-	}
-	if !strings.Contains(got, "requires trust") || !strings.Contains(got, "non-interactive") {
-		t.Fatalf("logger output missing trust warning:\n%s", got)
-	}
-}
-
-func TestPostCreateRunnerProjectHookAllowAlwaysPersistsAndHashMatchSkipsPrompt(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	cwd := t.TempDir()
-	writeHook(t, filepath.Join(cwd, ".projmux", "post-create"), "echo trusted\n", 0o755)
-	trustPath := testTrustStorePath(t)
-	promptCalls := 0
-
-	var firstLogger bytes.Buffer
-	first := &PostCreateRunner{
-		DiscoverProjectHooks: true,
-		ProjectHooksFilePath: testProjectHooksFilePath(t),
-		TrustStorePath:       trustPath,
-		ProjectHookPrompt: func(req ProjectHookPromptRequest) ProjectHookDecision {
-			promptCalls++
-			if req.RepoPath == "" || req.RelativePath != ".projmux/post-create" || req.SHA256 == "" {
-				t.Fatalf("prompt request = %#v", req)
-			}
-			return ProjectHookAllowAlways
-		},
-		Logger: &firstLogger,
-	}
-	first.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         cwd,
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-	if !strings.Contains(firstLogger.String(), "[post-create] trusted") {
-		t.Fatalf("first run logger output missing hook output:\n%s", firstLogger.String())
-	}
-	if promptCalls != 1 {
-		t.Fatalf("prompt calls after first run = %d, want 1", promptCalls)
-	}
-
-	var secondLogger bytes.Buffer
-	second := &PostCreateRunner{
-		DiscoverProjectHooks: true,
-		ProjectHooksFilePath: testProjectHooksFilePath(t),
-		TrustStorePath:       trustPath,
-		ProjectHookPrompt: func(ProjectHookPromptRequest) ProjectHookDecision {
-			t.Fatal("prompt should not be called when hash matches trust store")
-			return ProjectHookDeny
-		},
-		Logger: &secondLogger,
-	}
-	second.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         cwd,
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-	if !strings.Contains(secondLogger.String(), "[post-create] trusted") {
-		t.Fatalf("second run logger output missing hook output:\n%s", secondLogger.String())
-	}
-}
-
-func TestPostCreateRunnerProjectHookHashMismatchPromptsWithOldAndNewHash(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	cwd := t.TempDir()
-	hookPath := filepath.Join(cwd, ".projmux", "post-create")
-	writeHook(t, hookPath, "echo old\n", 0o755)
-	oldHash, _, err := hashHookFile(hookPath)
-	if err != nil {
-		t.Fatalf("hashHookFile old: %v", err)
-	}
-	trustPath := testTrustStorePath(t)
-	store := trustedProjects{}
-	store.trust(cwd, ".projmux/post-create", oldHash, time.Unix(1, 0).UTC())
-	if err := store.save(trustPath); err != nil {
-		t.Fatalf("save trust store: %v", err)
-	}
-
-	writeHook(t, hookPath, "echo new\n", 0o755)
-	newHash, _, err := hashHookFile(hookPath)
-	if err != nil {
-		t.Fatalf("hashHookFile new: %v", err)
-	}
-
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{
-		DiscoverProjectHooks: true,
-		ProjectHooksFilePath: testProjectHooksFilePath(t),
-		TrustStorePath:       trustPath,
-		ProjectHookPrompt: func(req ProjectHookPromptRequest) ProjectHookDecision {
-			if req.PreviousSHA256 != oldHash {
-				t.Fatalf("PreviousSHA256 = %q, want %q", req.PreviousSHA256, oldHash)
-			}
-			if req.SHA256 != newHash {
-				t.Fatalf("SHA256 = %q, want %q", req.SHA256, newHash)
-			}
-			if !strings.Contains(req.Preview, "echo new") {
-				t.Fatalf("Preview = %q, want new hook content", req.Preview)
-			}
-			return ProjectHookAllowAlways
-		},
-		Logger: &logger,
-	}
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         cwd,
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-
-	if !strings.Contains(logger.String(), "[post-create] new") {
-		t.Fatalf("logger output missing updated hook output:\n%s", logger.String())
-	}
-	reloaded, err := loadTrustedProjects(trustPath)
-	if err != nil {
-		t.Fatalf("loadTrustedProjects: %v", err)
-	}
-	file, ok := reloaded.trustedFile(cwd, ".projmux/post-create")
-	if !ok {
-		t.Fatalf("trusted file missing after mismatch approval: %#v", reloaded)
-	}
-	if file.SHA256 != newHash {
-		t.Fatalf("stored sha256 = %q, want %q", file.SHA256, newHash)
-	}
-}
-
-func TestPostCreateRunnerProjectHooksKillSwitchKeepsGlobalHook(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-
-	t.Setenv("PROJMUX_PROJECT_HOOKS", "off")
-	dir := t.TempDir()
-	globalPath := filepath.Join(dir, "global-post-create")
-	cwd := filepath.Join(dir, "repo")
-	writeHook(t, globalPath, "echo global\n", 0o755)
-	writeHook(t, filepath.Join(cwd, ".projmux", "post-create"), "echo project\n", 0o755)
-
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{
-		HookPath:             globalPath,
-		DiscoverProjectHooks: true,
-		ProjectHooksFilePath: testProjectHooksFilePath(t),
-		TrustStorePath:       testTrustStorePath(t),
-		ProjectHookPrompt: func(ProjectHookPromptRequest) ProjectHookDecision {
-			t.Fatal("project hook prompt should not be called when kill switch is off")
-			return ProjectHookDeny
-		},
-		Logger: &logger,
-	}
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         cwd,
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-
-	got := logger.String()
-	if !strings.Contains(got, "[post-create] global") {
-		t.Fatalf("global hook did not run with kill switch:\n%s", got)
-	}
-	if strings.Contains(got, "[post-create] project") {
-		t.Fatalf("project hook ran with kill switch:\n%s", got)
-	}
-}
-
-func TestPostCreateRunnerProjectHooksSettingsOffKeepsGlobalHook(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-
-	home := t.TempDir()
-	configHome := filepath.Join(home, ".config")
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", configHome)
-	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
-	if err := os.MkdirAll(filepath.Join(configHome, "projmux"), 0o755); err != nil {
-		t.Fatalf("MkdirAll config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(configHome, "projmux", "project-hooks"), []byte("off\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile project-hooks: %v", err)
-	}
-
-	dir := t.TempDir()
-	globalPath := filepath.Join(dir, "global-post-create")
-	cwd := filepath.Join(dir, "repo")
-	writeHook(t, globalPath, "echo global\n", 0o755)
-	writeHook(t, filepath.Join(cwd, ".projmux", "post-create"), "echo project\n", 0o755)
-
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{
-		HookPath:             globalPath,
-		DiscoverProjectHooks: true,
-		ProjectHooksFilePath: filepath.Join(configHome, "projmux", "project-hooks"),
-		TrustStorePath:       testTrustStorePath(t),
-		ProjectHookPrompt: func(ProjectHookPromptRequest) ProjectHookDecision {
-			t.Fatal("project hook prompt should not be called when settings toggle is off")
-			return ProjectHookDeny
-		},
-		Logger: &logger,
-	}
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         cwd,
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-
-	got := logger.String()
-	if !strings.Contains(got, "[post-create] global") {
-		t.Fatalf("global hook did not run with settings toggle off:\n%s", got)
-	}
-	if strings.Contains(got, "[post-create] project") {
-		t.Fatalf("project hook ran with settings toggle off:\n%s", got)
-	}
-}
-
-func TestTrustedProjectsStoreRoundTrip(t *testing.T) {
-	t.Parallel()
-
-	path := testTrustStorePath(t)
-	store := trustedProjects{}
-	at := time.Date(2026, 5, 10, 1, 2, 3, 0, time.UTC)
-	store.trust("/repo", ".projmux/post-create", "abc123", at)
-	if err := store.save(path); err != nil {
-		t.Fatalf("save: %v", err)
-	}
-
-	got, err := loadTrustedProjects(path)
-	if err != nil {
-		t.Fatalf("loadTrustedProjects: %v", err)
-	}
-	file, ok := got.trustedFile("/repo", ".projmux/post-create")
-	if !ok {
-		t.Fatalf("trusted file missing: %#v", got)
-	}
-	if file.SHA256 != "abc123" {
-		t.Fatalf("SHA256 = %q, want abc123", file.SHA256)
-	}
-	if !file.TrustedAt.Equal(at) {
-		t.Fatalf("TrustedAt = %s, want %s", file.TrustedAt, at)
-	}
-	if project := got["/repo"]; !project.TrustedAt.Equal(at) {
-		t.Fatalf("project TrustedAt = %s, want %s", project.TrustedAt, at)
-	}
-}
-
-func TestPostCreateRunnerHappyPathInjectsEnvAndPrefixesOutput(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	hookPath := absFixture(t, "echo-env.sh")
-	cwd := t.TempDir()
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{HookPath: hookPath, Logger: &logger}
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         cwd,
-		Kind:        "persistent",
-		Socket:      "projmux",
-		Version:     "0.0.0-test",
-	})
-
-	got := logger.String()
-	want := []string{
-		"[post-create] session=workspace",
-		"[post-create] cwd=" + cwd,
-		"[post-create] kind=persistent",
-		"[post-create] socket=projmux",
-		"[post-create] version=0.0.0-test",
-		"[post-create] stderr-line",
-	}
-	for _, line := range want {
-		if !strings.Contains(got, line) {
-			t.Fatalf("logger output missing %q\nfull output:\n%s", line, got)
-		}
-	}
-	if strings.Contains(got, "projmux: post-create hook:") {
-		t.Fatalf("happy path should not emit warning: %q", got)
-	}
-}
-
-func TestPostCreateRunnerOmitsSocketWhenEmpty(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	hookPath := absFixture(t, "echo-env.sh")
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{HookPath: hookPath, Logger: &logger}
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         t.TempDir(),
-		Kind:        "ephemeral",
-		Version:     "0.0.0-test",
-	})
-
-	got := logger.String()
-	if !strings.Contains(got, "[post-create] socket=unset") {
-		t.Fatalf("expected socket env to be unset, got:\n%s", got)
-	}
-}
-
-func TestPostCreateRunnerNonZeroExitWritesWarning(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	hookPath := absFixture(t, "fail.sh")
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{HookPath: hookPath, Logger: &logger}
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         t.TempDir(),
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-
-	got := logger.String()
-	if !strings.Contains(got, "projmux: post-create hook:") {
-		t.Fatalf("expected warning line, got:\n%s", got)
-	}
-	if !strings.Contains(got, "exited with status 7") {
-		t.Fatalf("expected exit status 7 in warning, got:\n%s", got)
-	}
-}
-
-func TestPostCreateRunnerTimeoutKillsHookAndWarns(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	hookPath := absFixture(t, "slow.sh")
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{
-		HookPath: hookPath,
-		Logger:   &logger,
-		Timeout:  200 * time.Millisecond,
-	}
-
-	start := time.Now()
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         t.TempDir(),
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-	elapsed := time.Since(start)
-
-	if elapsed > 3*time.Second {
-		t.Fatalf("timeout did not fire in time: elapsed=%s", elapsed)
-	}
-	got := logger.String()
-	if !strings.Contains(got, "timed out") {
-		t.Fatalf("expected timeout warning, got:\n%s", got)
-	}
-}
-
-func TestRunnerPaneStartupCapturesLastNonEmptyCommand(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	dir := t.TempDir()
-	globalPath := filepath.Join(dir, "global-pane-startup")
-	cwd := filepath.Join(dir, "repo")
-	writeHook(t, globalPath, "echo global-command\n", 0o755)
-	writeHook(t, filepath.Join(cwd, ".projmux", "pane-startup"), "echo project-command\n", 0o755)
+	writeHook(t, filepath.Join(cwd, ".projmux", "post-create"), "echo legacy-script\n", 0o755)
+	writeHook(t, filepath.Join(cwd, ".projmux", "hooks", "post-create"), "echo legacy-script-hooks-dir\n", 0o755)
 
 	var logger bytes.Buffer
 	runner := &Runner{
-		GlobalHookPaths: map[Event][]string{
-			EventPaneStartup: {globalPath},
-		},
 		DiscoverProjectHooks: true,
 		ProjectHooksFilePath: testProjectHooksFilePath(t),
 		TrustStorePath:       testTrustStorePath(t),
-		ProjectHookPrompt:    func(ProjectHookPromptRequest) ProjectHookDecision { return ProjectHookAllowOnce },
-		Logger:               &logger,
+		ProjectHookPrompt: func(ProjectHookPromptRequest) ProjectHookDecision {
+			t.Fatal("script files should never trigger a trust prompt")
+			return ProjectHookDeny
+		},
+		Logger: &logger,
 	}
-
-	result, err := runner.Run(context.Background(), EventPaneStartup, Context{
+	_, err := runner.Run(context.Background(), EventPostCreate, Context{
 		SessionName: "workspace",
 		CWD:         cwd,
 		Kind:        "persistent",
-		PaneID:      "%7",
 		Version:     "0.0.0-test",
 	})
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if result.Stdout != "project-command" {
-		t.Fatalf("pane-startup stdout = %q, want project-command", result.Stdout)
-	}
-	if logger.Len() != 0 {
-		t.Fatalf("pane-startup stdout should not be logged, got:\n%s", logger.String())
-	}
-}
-
-func TestRunnerPaneStartupProjectHookUsesHooksSubdirFallback(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	cwd := t.TempDir()
-	writeHook(t, filepath.Join(cwd, ".projmux", "pane-startup"), "echo skipped\n", 0o644)
-	writeHook(t, filepath.Join(cwd, ".projmux", "hooks", "pane-startup"), "echo hooks-dir-command\n", 0o755)
-
-	runner := &Runner{
-		DiscoverProjectHooks: true,
-		ProjectHooksFilePath: testProjectHooksFilePath(t),
-		TrustStorePath:       testTrustStorePath(t),
-		ProjectHookPrompt:    func(ProjectHookPromptRequest) ProjectHookDecision { return ProjectHookAllowOnce },
-	}
-
-	result, err := runner.Run(context.Background(), EventPaneStartup, Context{CWD: cwd})
-	if err != nil {
-		t.Fatalf("Run() error = %v", err)
-	}
-	if result.Stdout != "hooks-dir-command" {
-		t.Fatalf("pane-startup stdout = %q, want hooks-dir-command", result.Stdout)
+	if strings.Contains(logger.String(), "legacy-script") {
+		t.Fatalf("runner executed legacy script file:\n%s", logger.String())
 	}
 }
 
@@ -765,42 +174,118 @@ func TestRunnerPreCreateNonZeroExitAborts(t *testing.T) {
 	}
 	t.Parallel()
 
-	dir := t.TempDir()
-	hookPath := filepath.Join(dir, "pre-create")
-	writeHook(t, hookPath, "echo before-abort\nexit 12\n", 0o755)
+	cwd := t.TempDir()
+	writeProjectConfig(t, cwd, `
+[hooks.pre-create]
+run = "echo before-abort; exit 9"
+`)
 
 	var logger bytes.Buffer
 	runner := &Runner{
-		GlobalHookPaths: map[Event][]string{
-			EventPreCreate: {hookPath},
-		},
-		Logger: &logger,
+		DiscoverProjectHooks: true,
+		ProjectHooksFilePath: testProjectHooksFilePath(t),
+		TrustStorePath:       testTrustStorePath(t),
+		ProjectHookPrompt:    func(ProjectHookPromptRequest) ProjectHookDecision { return ProjectHookAllowOnce },
+		Logger:               &logger,
 	}
 
 	_, err := runner.Run(context.Background(), EventPreCreate, Context{
 		SessionName: "workspace",
-		CWD:         t.TempDir(),
+		CWD:         cwd,
 		Kind:        "persistent",
 	})
 	if err == nil {
 		t.Fatal("expected pre-create error")
 	}
-	if !strings.Contains(err.Error(), "exited with status 12") {
-		t.Fatalf("pre-create error = %v, want exit status", err)
+	if !strings.Contains(err.Error(), "exited with status 9") {
+		t.Fatalf("pre-create error = %v, want exit status 9", err)
 	}
-	if !strings.Contains(logger.String(), "[pre-create] before-abort") {
+	if !strings.Contains(logger.String(), "before-abort") {
 		t.Fatalf("pre-create output missing from logger:\n%s", logger.String())
 	}
 }
 
-func TestRunnerProjectHooksKillSwitchAppliesToPaneStartup(t *testing.T) {
+func TestRunnerPostCreateFailureIsLoggedNotReturned(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash fixtures require POSIX")
+	}
+	t.Parallel()
+
+	cwd := t.TempDir()
+	writeProjectConfig(t, cwd, `
+[hooks.post-create]
+run = "exit 7"
+`)
+
+	var logger bytes.Buffer
+	runner := &Runner{
+		DiscoverProjectHooks: true,
+		ProjectHooksFilePath: testProjectHooksFilePath(t),
+		TrustStorePath:       testTrustStorePath(t),
+		ProjectHookPrompt:    func(ProjectHookPromptRequest) ProjectHookDecision { return ProjectHookAllowOnce },
+		Logger:               &logger,
+	}
+	_, err := runner.Run(context.Background(), EventPostCreate, Context{
+		SessionName: "workspace",
+		CWD:         cwd,
+		Kind:        "persistent",
+	})
+	if err != nil {
+		t.Fatalf("post-create error should be swallowed, got %v", err)
+	}
+	if !strings.Contains(logger.String(), "exited with status 7") {
+		t.Fatalf("logger should record failure warning, got:\n%s", logger.String())
+	}
+}
+
+func TestRunnerTimeoutKillsHookAndWarns(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash fixtures require POSIX")
+	}
+	t.Parallel()
+
+	cwd := t.TempDir()
+	writeProjectConfig(t, cwd, `
+[hooks.post-create]
+run = "sleep 5"
+`)
+
+	var logger bytes.Buffer
+	runner := &Runner{
+		DiscoverProjectHooks: true,
+		ProjectHooksFilePath: testProjectHooksFilePath(t),
+		TrustStorePath:       testTrustStorePath(t),
+		ProjectHookPrompt:    func(ProjectHookPromptRequest) ProjectHookDecision { return ProjectHookAllowOnce },
+		Logger:               &logger,
+		Timeout:              200 * time.Millisecond,
+	}
+
+	start := time.Now()
+	_, err := runner.Run(context.Background(), EventPostCreate, Context{CWD: cwd})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed > 3*time.Second {
+		t.Fatalf("timeout did not fire in time: elapsed=%s", elapsed)
+	}
+	if !strings.Contains(logger.String(), "timed out") {
+		t.Fatalf("expected timeout warning, got:\n%s", logger.String())
+	}
+}
+
+func TestRunnerHooksKillSwitchDisablesProjectConfig(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("bash fixtures require POSIX")
 	}
 
 	t.Setenv("PROJMUX_PROJECT_HOOKS", "off")
 	cwd := t.TempDir()
-	writeHook(t, filepath.Join(cwd, ".projmux", "pane-startup"), "echo should-not-run\n", 0o755)
+	writeProjectConfig(t, cwd, `
+[hooks.post-create]
+run = "echo should-not-run"
+`)
 
 	var logger bytes.Buffer
 	runner := &Runner{
@@ -808,44 +293,166 @@ func TestRunnerProjectHooksKillSwitchAppliesToPaneStartup(t *testing.T) {
 		ProjectHooksFilePath: testProjectHooksFilePath(t),
 		TrustStorePath:       testTrustStorePath(t),
 		ProjectHookPrompt: func(ProjectHookPromptRequest) ProjectHookDecision {
-			t.Fatal("project hook prompt should not be called when kill switch is off")
+			t.Fatal("kill switch should suppress trust prompts")
 			return ProjectHookDeny
 		},
 		Logger: &logger,
 	}
-
-	result, err := runner.Run(context.Background(), EventPaneStartup, Context{CWD: cwd})
+	_, err := runner.Run(context.Background(), EventPostCreate, Context{CWD: cwd})
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
-	}
-	if result.Stdout != "" {
-		t.Fatalf("pane-startup stdout = %q, want empty", result.Stdout)
 	}
 	if strings.Contains(logger.String(), "should-not-run") {
 		t.Fatalf("project hook ran with kill switch:\n%s", logger.String())
 	}
 }
 
-func absFixture(t *testing.T, name string) string {
-	t.Helper()
-	abs, err := filepath.Abs(filepath.Join("testdata", name))
-	if err != nil {
-		t.Fatalf("filepath.Abs: %v", err)
+func TestRunnerHooksKillSwitchKeepsGlobalConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash fixtures require POSIX")
 	}
-	info, err := os.Stat(abs)
-	if err != nil {
-		t.Fatalf("stat fixture %s: %v", abs, err)
+
+	t.Setenv("PROJMUX_PROJECT_HOOKS", "off")
+	dir := t.TempDir()
+	globalConfigPath := filepath.Join(dir, "global", "config.toml")
+	writeFileEnsuringDir(t, globalConfigPath, `
+[hooks.post-create]
+run = "echo global"
+`)
+	cwd := filepath.Join(dir, "repo")
+	writeProjectConfig(t, cwd, `
+[hooks.post-create]
+run = "echo project-should-not-run"
+`)
+
+	var logger bytes.Buffer
+	runner := &Runner{
+		GlobalConfigPath:     globalConfigPath,
+		DiscoverProjectHooks: true,
+		ProjectHooksFilePath: testProjectHooksFilePath(t),
+		TrustStorePath:       testTrustStorePath(t),
+		Logger:               &logger,
 	}
-	if info.Mode().Perm()&0o100 == 0 {
-		// Repo restore did not preserve the execute bit; restore it for this run
-		// so we still exercise the happy path locally. CI checks that the bit is
-		// committed via git update-index --chmod=+x.
-		if err := os.Chmod(abs, 0o755); err != nil {
-			t.Fatalf("chmod fixture %s: %v", abs, err)
+	_, err := runner.Run(context.Background(), EventPostCreate, Context{CWD: cwd})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got := logger.String()
+	if !strings.Contains(got, "global") {
+		t.Fatalf("global hook missing:\n%s", got)
+	}
+	if strings.Contains(got, "project-should-not-run") {
+		t.Fatalf("project hook ran with kill switch:\n%s", got)
+	}
+}
+
+func TestRunnerHasHooksReadsGlobalAndProject(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	globalConfigPath := filepath.Join(dir, "global", "config.toml")
+	writeFileEnsuringDir(t, globalConfigPath, `
+[hooks.post-attach]
+run = "echo on-attach"
+`)
+	cwd := filepath.Join(dir, "repo")
+	writeProjectConfig(t, cwd, `
+[hooks.pre-create]
+run = "true"
+`)
+
+	runner := &Runner{
+		GlobalConfigPath:     globalConfigPath,
+		DiscoverProjectHooks: true,
+		ProjectHooksFilePath: testProjectHooksFilePath(t),
+		TrustStorePath:       testTrustStorePath(t),
+	}
+	if !runner.HasHooks(EventPostAttach, cwd) {
+		t.Fatal("HasHooks(post-attach) = false, want true (global)")
+	}
+	if !runner.HasHooks(EventPreCreate, cwd) {
+		t.Fatal("HasHooks(pre-create) = false, want true (project)")
+	}
+	if runner.HasHooks(EventPostCreate, cwd) {
+		t.Fatal("HasHooks(post-create) = true, want false")
+	}
+}
+
+// --- buildHookEnv coverage -------------------------------------------------
+
+func TestBuildHookEnvIncludesProjmuxVars(t *testing.T) {
+	t.Parallel()
+
+	env := buildHookEnv(Context{
+		SessionName: "workspace",
+		CWD:         "/tmp/repo",
+		Kind:        "persistent",
+		Socket:      "projmux",
+		PaneID:      "%7",
+		Env:         map[string]string{"FOO": "bar"},
+	}, "0.0.0-test")
+
+	want := []string{
+		"FOO=bar",
+		"PROJMUX_SESSION=workspace",
+		"PROJMUX_CWD=/tmp/repo",
+		"PROJMUX_SESSION_KIND=persistent",
+		"PROJMUX_VERSION=0.0.0-test",
+		"PROJMUX_SOCKET=projmux",
+		"PROJMUX_PANE=%7",
+	}
+	joined := strings.Join(env, "\n")
+	for _, line := range want {
+		if !strings.Contains(joined, line) {
+			t.Fatalf("env missing %q in:\n%s", line, joined)
 		}
 	}
-	return abs
 }
+
+func TestBuildHookEnvOmitsSocketWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	env := buildHookEnv(Context{
+		SessionName: "workspace",
+		CWD:         "/tmp/repo",
+		Kind:        "ephemeral",
+	}, "0.0.0-test")
+	joined := strings.Join(env, "\n")
+	if strings.Contains(joined, "PROJMUX_SOCKET") {
+		t.Fatalf("env should not include PROJMUX_SOCKET when empty:\n%s", joined)
+	}
+}
+
+// --- trust store roundtrip -------------------------------------------------
+
+func TestTrustedProjectsStoreRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := testTrustStorePath(t)
+	store := trustedProjects{}
+	at := time.Date(2026, 5, 10, 1, 2, 3, 0, time.UTC)
+	store.trust("/repo", ".projmux/config.toml", "abc123", at)
+	if err := store.save(path); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, err := loadTrustedProjects(path)
+	if err != nil {
+		t.Fatalf("loadTrustedProjects: %v", err)
+	}
+	file, ok := got.trustedFile("/repo", ".projmux/config.toml")
+	if !ok {
+		t.Fatalf("trusted file missing: %#v", got)
+	}
+	if file.SHA256 != "abc123" {
+		t.Fatalf("SHA256 = %q, want abc123", file.SHA256)
+	}
+	if !file.TrustedAt.Equal(at) {
+		t.Fatalf("TrustedAt = %s, want %s", file.TrustedAt, at)
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
 
 func writeHook(t *testing.T, path, body string, perm os.FileMode) {
 	t.Helper()
@@ -858,14 +465,13 @@ func writeHook(t *testing.T, path, body string, perm os.FileMode) {
 	}
 }
 
-func testProjectHookRunner(t *testing.T, logger io.Writer, decision ProjectHookDecision) *PostCreateRunner {
+func writeFileEnsuringDir(t *testing.T, path, body string) {
 	t.Helper()
-	return &PostCreateRunner{
-		DiscoverProjectHooks: true,
-		ProjectHooksFilePath: testProjectHooksFilePath(t),
-		TrustStorePath:       testTrustStorePath(t),
-		ProjectHookPrompt:    func(ProjectHookPromptRequest) ProjectHookDecision { return decision },
-		Logger:               logger,
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimSpace(body)+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
 }
 
@@ -878,3 +484,6 @@ func testTrustStorePath(t *testing.T) string {
 	t.Helper()
 	return filepath.Join(t.TempDir(), "trusted-projects.json")
 }
+
+// Silence unused warning when running selective tests.
+var _ = io.Discard

--- a/internal/integrations/hooks/migration.go
+++ b/internal/integrations/hooks/migration.go
@@ -1,0 +1,300 @@
+// Migration of legacy lifecycle script files into the declarative
+// [hooks.<event>] config.toml entry. The runner no longer executes script
+// files directly; this code path drains the historical layout so users do not
+// silently lose hook behaviour after upgrading.
+package hooks
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/crevissepartners/projmux/internal/config"
+)
+
+// LegacyScope identifies which legacy script layout to scan during migration.
+type LegacyScope string
+
+const (
+	// LegacyScopeProject scans `<repo>/.projmux/<event>` and
+	// `<repo>/.projmux/hooks/<event>` for each supported lifecycle event.
+	LegacyScopeProject LegacyScope = "project"
+	// LegacyScopeGlobal scans `${XDG_CONFIG_HOME}/projmux/hooks/<event>`.
+	LegacyScopeGlobal LegacyScope = "global"
+)
+
+// MigrationResult summarises which legacy script files were converted into
+// declarative entries and which were skipped because they contain too many
+// active lines to safely flatten.
+type MigrationResult struct {
+	Scope LegacyScope
+	// Migrated lists events whose script was converted to a [hooks.<event>]
+	// run = "..." entry. The original script is renamed to `<path>.bak` so
+	// the user can recover the source if needed.
+	Migrated []MigratedHook
+	// Skipped lists scripts that contain two or more meaningful lines.
+	// These are surfaced verbatim in the Settings UI as a "legacy script"
+	// row alongside the manual-cleanup advice; the runner does NOT execute
+	// them.
+	Skipped []SkippedHook
+}
+
+// MigratedHook describes a single converted script.
+type MigratedHook struct {
+	Event      Event
+	ScriptPath string
+	BackupPath string
+	Command    string
+}
+
+// SkippedHook describes a legacy script that was left in place because the
+// migrator does not know how to flatten it into a single declarative line,
+// or because it is a symlink (e.g. dotfiles-managed) that the migrator must
+// not rename out from under the user.
+type SkippedHook struct {
+	Event      Event
+	ScriptPath string
+	Lines      int
+	Reason     string
+	// Symlink is true when ScriptPath resolved to a symbolic link via Lstat.
+	// The migrator never reads, rewrites, or backs up symlinks regardless of
+	// whether the target appears to be single-line, because the source-of-truth
+	// for the file lives outside the projmux config directory.
+	Symlink bool
+}
+
+// SkipReasonSymlink is the canonical Reason value used when a legacy script
+// is skipped because Lstat reported a symbolic link.
+const SkipReasonSymlink = "symlink"
+
+// MigrateProjectLegacyScripts inspects `<repo>/.projmux/` for legacy script
+// files. The result is non-fatal: callers should log a warning and continue
+// even on partial failure. configPath is the target config.toml that picks
+// up converted entries; pass "" to compute the default `<repo>/.projmux/config.toml`.
+func MigrateProjectLegacyScripts(repoPath, configPath string, logger io.Writer) (MigrationResult, error) {
+	repoPath = strings.TrimSpace(repoPath)
+	if repoPath == "" {
+		return MigrationResult{Scope: LegacyScopeProject}, nil
+	}
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		return MigrationResult{Scope: LegacyScopeProject}, err
+	}
+	if configPath == "" {
+		configPath = filepath.Join(abs, projectConfigRelativePath)
+	}
+	candidates := func(event Event) []string {
+		name := string(event)
+		return []string{
+			filepath.Join(abs, ".projmux", name),
+			filepath.Join(abs, ".projmux", config.HooksDirName, name),
+		}
+	}
+	return migrateLegacyScripts(LegacyScopeProject, configPath, candidates, logger)
+}
+
+// MigrateGlobalLegacyScripts inspects the legacy global hooks directory
+// `${XDG_CONFIG_HOME}/projmux/hooks/`. configPath is the target global
+// config.toml; pass "" to resolve the default location.
+func MigrateGlobalLegacyScripts(getenv func(string) string, homeDir func() (string, error), configPath string, logger io.Writer) (MigrationResult, error) {
+	dir, err := resolveGlobalConfigDir(getenv, homeDir)
+	if err != nil {
+		return MigrationResult{Scope: LegacyScopeGlobal}, err
+	}
+	if configPath == "" {
+		configPath = filepath.Join(dir, GlobalConfigRelativePath)
+	}
+	candidates := func(event Event) []string {
+		return []string{
+			filepath.Join(dir, config.AppName, config.HooksDirName, string(event)),
+		}
+	}
+	return migrateLegacyScripts(LegacyScopeGlobal, configPath, candidates, logger)
+}
+
+func migrateLegacyScripts(scope LegacyScope, configPath string, candidates func(Event) []string, logger io.Writer) (MigrationResult, error) {
+	result := MigrationResult{Scope: scope}
+	pending := map[Event]MigratedHook{}
+	for _, event := range SupportedEvents {
+		for _, path := range candidates(event) {
+			// Lstat first so we can detect symlinks before os.Stat follows
+			// them. Dotfiles repos (e.g. github.com/es5h/dotfiles) deploy
+			// global hook files as symlinks; renaming the link to .bak would
+			// silently break the user's source-of-truth.
+			linfo, err := os.Lstat(path)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					continue
+				}
+				warnMigration(logger, scope, "lstat %q: %v", path, err)
+				continue
+			}
+			if linfo.Mode()&os.ModeSymlink != 0 {
+				result.Skipped = append(result.Skipped, SkippedHook{
+					Event:      event,
+					ScriptPath: path,
+					Lines:      0,
+					Reason:     SkipReasonSymlink,
+					Symlink:    true,
+				})
+				continue
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					continue
+				}
+				warnMigration(logger, scope, "stat %q: %v", path, err)
+				continue
+			}
+			if info.IsDir() {
+				continue
+			}
+			command, lineCount, err := analyzeLegacyScript(path)
+			if err != nil {
+				warnMigration(logger, scope, "read %q: %v", path, err)
+				continue
+			}
+			if lineCount > 1 {
+				result.Skipped = append(result.Skipped, SkippedHook{
+					Event:      event,
+					ScriptPath: path,
+					Lines:      lineCount,
+					Reason:     "multi-line scripts are no longer executed; rewrite manually as run = \"bash -c '...'\" or run = \"./scripts/foo.sh\"",
+				})
+				continue
+			}
+			if strings.TrimSpace(command) == "" {
+				// Empty file — nothing to migrate but rename so it does not
+				// keep tripping the scan.
+				if err := backupScript(path); err != nil {
+					warnMigration(logger, scope, "backup %q: %v", path, err)
+				}
+				continue
+			}
+			pending[event] = MigratedHook{
+				Event:      event,
+				ScriptPath: path,
+				BackupPath: path + ".bak",
+				Command:    command,
+			}
+		}
+	}
+	if len(pending) == 0 {
+		// Even without migration work we still surface skipped multi-line
+		// scripts so callers can warn the user.
+		logSkipped(logger, scope, result.Skipped)
+		return result, nil
+	}
+
+	_, err := UpdateProjectConfig(configPath, func(cfg *ProjectConfig) error {
+		if cfg.Hooks == nil {
+			cfg.Hooks = map[Event]string{}
+		}
+		for event, hook := range pending {
+			// Do not overwrite an existing declarative entry; the user has
+			// already authored one and the legacy script must lose. We still
+			// rename the script so the duplicate row stops showing up.
+			if existing := strings.TrimSpace(cfg.Hooks[event]); existing != "" {
+				continue
+			}
+			cfg.Hooks[event] = hook.Command
+		}
+		return nil
+	})
+	if err != nil {
+		return result, fmt.Errorf("write %s: %w", configPath, err)
+	}
+	for event, hook := range pending {
+		if err := backupScript(hook.ScriptPath); err != nil {
+			warnMigration(logger, scope, "backup %q: %v", hook.ScriptPath, err)
+			continue
+		}
+		result.Migrated = append(result.Migrated, MigratedHook{
+			Event:      event,
+			ScriptPath: hook.ScriptPath,
+			BackupPath: hook.BackupPath,
+			Command:    hook.Command,
+		})
+		if logger != nil {
+			fmt.Fprintf(logger, "projmux: migrated legacy %s hook %s -> [hooks.%s] run; original kept at %s\n", scope, hook.ScriptPath, event, hook.BackupPath)
+		}
+	}
+	logSkipped(logger, scope, result.Skipped)
+	return result, nil
+}
+
+func logSkipped(logger io.Writer, scope LegacyScope, skipped []SkippedHook) {
+	if logger == nil || len(skipped) == 0 {
+		return
+	}
+	for _, s := range skipped {
+		if s.Symlink {
+			fmt.Fprintf(logger, "projmux: legacy %s hook %s is a symlink; declarative migration skipped (clean up via the source dotfiles repo)\n", scope, s.ScriptPath)
+			continue
+		}
+		fmt.Fprintf(logger, "projmux: legacy %s hook %s has %d non-trivial lines; declarative migration skipped (%s)\n", scope, s.ScriptPath, s.Lines, s.Reason)
+	}
+}
+
+// analyzeLegacyScript reads the file at path and returns (command, lineCount, error).
+//   - lineCount counts all non-empty, non-comment, non-shebang lines.
+//   - command is the single command suitable for a declarative run = "..." entry
+//     when lineCount == 1, otherwise empty.
+func analyzeLegacyScript(path string) (string, int, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), 256*1024)
+	var (
+		count int
+		line  string
+	)
+	for scanner.Scan() {
+		raw := strings.TrimRight(scanner.Text(), "\r")
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		count++
+		if count == 1 {
+			line = trimmed
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", 0, err
+	}
+	if count != 1 {
+		return "", count, nil
+	}
+	return line, 1, nil
+}
+
+func backupScript(path string) error {
+	backup := path + ".bak"
+	// Remove any prior .bak so rename does not surprise on Windows.
+	if _, err := os.Stat(backup); err == nil {
+		if err := os.Remove(backup); err != nil {
+			return err
+		}
+	}
+	return os.Rename(path, backup)
+}
+
+func warnMigration(logger io.Writer, scope LegacyScope, format string, args ...any) {
+	if logger == nil {
+		return
+	}
+	fmt.Fprintf(logger, "projmux: %s hook migration: "+format+"\n", append([]any{scope}, args...)...)
+}

--- a/internal/integrations/hooks/migration_test.go
+++ b/internal/integrations/hooks/migration_test.go
@@ -1,0 +1,304 @@
+package hooks
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMigrateProjectLegacyScriptsSingleLineConvertsAndBackups(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	scriptPath := filepath.Join(repo, ".projmux", "post-create")
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho hello\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var logger bytes.Buffer
+	result, err := MigrateProjectLegacyScripts(repo, "", &logger)
+	if err != nil {
+		t.Fatalf("MigrateProjectLegacyScripts() error = %v", err)
+	}
+	if len(result.Migrated) != 1 || result.Migrated[0].Event != EventPostCreate {
+		t.Fatalf("Migrated = %#v, want post-create entry", result.Migrated)
+	}
+	if result.Migrated[0].Command != "echo hello" {
+		t.Fatalf("Command = %q, want echo hello", result.Migrated[0].Command)
+	}
+	if len(result.Skipped) != 0 {
+		t.Fatalf("Skipped = %#v, want none", result.Skipped)
+	}
+
+	configBody, err := os.ReadFile(filepath.Join(repo, ".projmux", "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(configBody), "[hooks.post-create]") {
+		t.Fatalf("config.toml missing migrated entry:\n%s", configBody)
+	}
+	if !strings.Contains(string(configBody), `run = "echo hello"`) {
+		t.Fatalf("config.toml missing run line:\n%s", configBody)
+	}
+
+	if _, err := os.Stat(scriptPath); !os.IsNotExist(err) {
+		t.Fatalf("original script still present, stat err = %v", err)
+	}
+	if _, err := os.Stat(scriptPath + ".bak"); err != nil {
+		t.Fatalf("backup file missing: %v", err)
+	}
+	if !strings.Contains(logger.String(), "migrated legacy project hook") {
+		t.Fatalf("logger missing migration line:\n%s", logger.String())
+	}
+}
+
+func TestMigrateProjectLegacyScriptsMultiLineSkippedAndLogged(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	scriptPath := filepath.Join(repo, ".projmux", "hooks", "post-create")
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "#!/bin/sh\necho one\necho two\n"
+	if err := os.WriteFile(scriptPath, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var logger bytes.Buffer
+	result, err := MigrateProjectLegacyScripts(repo, "", &logger)
+	if err != nil {
+		t.Fatalf("MigrateProjectLegacyScripts() error = %v", err)
+	}
+	if len(result.Migrated) != 0 {
+		t.Fatalf("Migrated = %#v, want none for multi-line", result.Migrated)
+	}
+	if len(result.Skipped) != 1 || result.Skipped[0].Event != EventPostCreate {
+		t.Fatalf("Skipped = %#v, want post-create entry", result.Skipped)
+	}
+	if result.Skipped[0].Lines != 2 {
+		t.Fatalf("Skipped[0].Lines = %d, want 2", result.Skipped[0].Lines)
+	}
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("multi-line script should remain in place: %v", err)
+	}
+	if _, err := os.Stat(scriptPath + ".bak"); !os.IsNotExist(err) {
+		t.Fatalf("multi-line script must not be backed up automatically: stat = %v", err)
+	}
+	if !strings.Contains(logger.String(), "declarative migration skipped") {
+		t.Fatalf("logger missing skip warning:\n%s", logger.String())
+	}
+}
+
+func TestMigrateProjectLegacyScriptsPreservesExistingDeclarativeEntry(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".projmux"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(repo, ".projmux", "config.toml")
+	if err := os.WriteFile(configPath, []byte(`[hooks.post-create]
+run = "echo declared-wins"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(repo, ".projmux", "post-create")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho legacy-loses\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := MigrateProjectLegacyScripts(repo, "", nil); err != nil {
+		t.Fatalf("MigrateProjectLegacyScripts() error = %v", err)
+	}
+
+	got, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), `run = "echo declared-wins"`) {
+		t.Fatalf("declarative entry should win, config:\n%s", got)
+	}
+	if strings.Contains(string(got), "echo legacy-loses") {
+		t.Fatalf("legacy script should not overwrite declarative entry, config:\n%s", got)
+	}
+	// Script still gets backed up so the duplicate row stops showing in the UI.
+	if _, err := os.Stat(scriptPath + ".bak"); err != nil {
+		t.Fatalf("script backup missing: %v", err)
+	}
+}
+
+func TestMigrateGlobalLegacyScriptsConvertsSingleLine(t *testing.T) {
+	t.Parallel()
+
+	configHome := t.TempDir()
+	scriptPath := filepath.Join(configHome, "projmux", "hooks", "post-create")
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho global-hello\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	getenv := func(name string) string {
+		if name == "XDG_CONFIG_HOME" {
+			return configHome
+		}
+		return ""
+	}
+
+	result, err := MigrateGlobalLegacyScripts(getenv, nil, "", nil)
+	if err != nil {
+		t.Fatalf("MigrateGlobalLegacyScripts() error = %v", err)
+	}
+	if len(result.Migrated) != 1 {
+		t.Fatalf("Migrated = %#v, want one entry", result.Migrated)
+	}
+	configPath := filepath.Join(configHome, "projmux", "config.toml")
+	body, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read global config: %v", err)
+	}
+	if !strings.Contains(string(body), `run = "echo global-hello"`) {
+		t.Fatalf("global config missing migrated run line:\n%s", body)
+	}
+	if _, err := os.Stat(scriptPath + ".bak"); err != nil {
+		t.Fatalf("backup missing: %v", err)
+	}
+}
+
+func TestMigrateProjectLegacyScriptsSymlinkIsNeverMigrated(t *testing.T) {
+	t.Parallel()
+
+	// Cover both link targets that *would* qualify for migration (single
+	// line) and ones that wouldn't (multi line) — neither should ever be
+	// renamed or written to the declarative config, because dotfiles repos
+	// commonly deploy these as symlinks and the migrator must not surprise
+	// the source-of-truth on disk.
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "single-line target", body: "#!/bin/sh\necho hello\n"},
+		{name: "multi-line target", body: "#!/bin/sh\necho one\necho two\n"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := t.TempDir()
+			external := t.TempDir()
+			target := filepath.Join(external, "post-create-source.sh")
+			if err := os.WriteFile(target, []byte(tc.body), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			scriptPath := filepath.Join(repo, ".projmux", "post-create")
+			if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, scriptPath); err != nil {
+				t.Fatalf("symlink: %v", err)
+			}
+
+			var logger bytes.Buffer
+			result, err := MigrateProjectLegacyScripts(repo, "", &logger)
+			if err != nil {
+				t.Fatalf("MigrateProjectLegacyScripts() error = %v", err)
+			}
+			if len(result.Migrated) != 0 {
+				t.Fatalf("Migrated = %#v, want none for symlink", result.Migrated)
+			}
+			if len(result.Skipped) != 1 {
+				t.Fatalf("Skipped = %#v, want exactly one entry", result.Skipped)
+			}
+			skip := result.Skipped[0]
+			if !skip.Symlink {
+				t.Fatalf("Skipped[0].Symlink = false, want true (%#v)", skip)
+			}
+			if skip.Reason != SkipReasonSymlink {
+				t.Fatalf("Skipped[0].Reason = %q, want %q", skip.Reason, SkipReasonSymlink)
+			}
+			if skip.Event != EventPostCreate {
+				t.Fatalf("Skipped[0].Event = %q, want post-create", skip.Event)
+			}
+
+			// Link must still point at the original target, unrenamed.
+			if got, err := os.Readlink(scriptPath); err != nil || got != target {
+				t.Fatalf("readlink got=%q err=%v, want %q (link must not be renamed)", got, err, target)
+			}
+			if _, err := os.Lstat(scriptPath + ".bak"); !os.IsNotExist(err) {
+				t.Fatalf("symlink must not be backed up: stat err = %v", err)
+			}
+			// Underlying target untouched.
+			if body, err := os.ReadFile(target); err != nil || string(body) != tc.body {
+				t.Fatalf("target file mutated: body=%q err=%v", body, err)
+			}
+			// Config must not have been created (no declarative entry).
+			if _, err := os.Stat(filepath.Join(repo, ".projmux", "config.toml")); !os.IsNotExist(err) {
+				t.Fatalf("config.toml unexpectedly created: stat err = %v", err)
+			}
+			if !strings.Contains(logger.String(), "symlink") {
+				t.Fatalf("logger missing symlink notice:\n%s", logger.String())
+			}
+		})
+	}
+}
+
+func TestMigrateGlobalLegacyScriptsSymlinkIsNeverMigrated(t *testing.T) {
+	t.Parallel()
+
+	configHome := t.TempDir()
+	external := t.TempDir()
+	target := filepath.Join(external, "post-create-source.sh")
+	if err := os.WriteFile(target, []byte("#!/bin/sh\necho dotfiles\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(configHome, "projmux", "hooks", "post-create")
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, scriptPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	getenv := func(name string) string {
+		if name == "XDG_CONFIG_HOME" {
+			return configHome
+		}
+		return ""
+	}
+
+	result, err := MigrateGlobalLegacyScripts(getenv, nil, "", nil)
+	if err != nil {
+		t.Fatalf("MigrateGlobalLegacyScripts() error = %v", err)
+	}
+	if len(result.Migrated) != 0 {
+		t.Fatalf("Migrated = %#v, want none", result.Migrated)
+	}
+	if len(result.Skipped) != 1 || !result.Skipped[0].Symlink {
+		t.Fatalf("Skipped = %#v, want one symlink entry", result.Skipped)
+	}
+	if _, err := os.Lstat(scriptPath); err != nil {
+		t.Fatalf("symlink should remain in place: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(configHome, "projmux", "config.toml")); !os.IsNotExist(err) {
+		t.Fatalf("global config.toml unexpectedly created: stat err = %v", err)
+	}
+}
+
+func TestMigrateProjectLegacyScriptsEmptyDirIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	result, err := MigrateProjectLegacyScripts(repo, "", nil)
+	if err != nil {
+		t.Fatalf("MigrateProjectLegacyScripts() error = %v", err)
+	}
+	if len(result.Migrated) != 0 || len(result.Skipped) != 0 {
+		t.Fatalf("Result = %#v, want empty", result)
+	}
+}

--- a/internal/integrations/hooks/project_config.go
+++ b/internal/integrations/hooks/project_config.go
@@ -62,8 +62,8 @@ func (c ProjectConfig) hasSessionEnv() bool {
 	return len(c.SessionEnv()) > 0
 }
 
-func (c ProjectConfig) relevantForEvent(event Event, hasHooks bool) bool {
-	return c.hasEventSurface(event) || hasHooks && c.hasSessionEnv()
+func (c ProjectConfig) relevantForEvent(event Event) bool {
+	return c.hasEventSurface(event)
 }
 
 func ParseProjectConfig(content string) (ProjectConfig, error) {

--- a/internal/integrations/hooks/project_config_test.go
+++ b/internal/integrations/hooks/project_config_test.go
@@ -177,17 +177,27 @@ run = "git status --short"
 	}
 }
 
-func TestRunnerPaneStartupConfigPrecedenceAfterHookFiles(t *testing.T) {
+func TestRunnerPaneStartupConfigPrecedenceStartupOverHook(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("bash fixtures require POSIX")
 	}
 	t.Parallel()
 
 	dir := t.TempDir()
-	globalPath := filepath.Join(dir, "global-pane-startup")
+	globalConfigPath := filepath.Join(dir, "global", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(globalConfigPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll global: %v", err)
+	}
+	if err := os.WriteFile(globalConfigPath, []byte(`
+[hooks.pane-startup]
+run = "echo global-command"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile global: %v", err)
+	}
+	// Legacy script files in the historical layout must be silently ignored
+	// by the runner; only declarative entries execute.
 	cwd := filepath.Join(dir, "repo")
-	writeHook(t, globalPath, "echo global-command\n", 0o755)
-	writeHook(t, filepath.Join(cwd, ".projmux", "pane-startup"), "echo project-file-command\n", 0o755)
+	writeHook(t, filepath.Join(cwd, ".projmux", "pane-startup"), "echo legacy-script-should-not-run\n", 0o755)
 	writeProjectConfig(t, cwd, `
 [hooks.pane-startup]
 run = "echo config-hook-command"
@@ -197,9 +207,7 @@ run = "startup-direct-command"
 `)
 
 	runner := &Runner{
-		GlobalHookPaths: map[Event][]string{
-			EventPaneStartup: {globalPath},
-		},
+		GlobalConfigPath:     globalConfigPath,
 		DiscoverProjectHooks: true,
 		ProjectHooksFilePath: testProjectHooksFilePath(t),
 		TrustStorePath:       testTrustStorePath(t),

--- a/internal/integrations/hooks/testdata/echo-env.sh
+++ b/internal/integrations/hooks/testdata/echo-env.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-echo "session=${PROJMUX_SESSION}"
-echo "cwd=${PROJMUX_CWD}"
-echo "kind=${PROJMUX_SESSION_KIND}"
-echo "socket=${PROJMUX_SOCKET-unset}"
-echo "version=${PROJMUX_VERSION}"
-echo "stderr-line" >&2
-exit 0

--- a/internal/integrations/hooks/testdata/fail.sh
+++ b/internal/integrations/hooks/testdata/fail.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-echo "boom" >&2
-exit 7

--- a/internal/integrations/hooks/testdata/slow.sh
+++ b/internal/integrations/hooks/testdata/slow.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-sleep 10
-exit 0

--- a/internal/integrations/hooks/trust.go
+++ b/internal/integrations/hooks/trust.go
@@ -58,10 +58,6 @@ type trustedFile struct {
 	TrustedAt time.Time `json:"trusted_at"`
 }
 
-func (r *Runner) authorizeProjectHook(h projectHook) bool {
-	return r.authorizeProjectFile(h.event, h.repo, h.rel, h.path, "project hook")
-}
-
 func (r *Runner) authorizeProjectConfig(event Event, h projectConfigFile) bool {
 	return r.authorizeProjectFile(event, h.repo, h.rel, h.path, "project config")
 }
@@ -176,12 +172,17 @@ func defaultTrustStorePath() string {
 	return filepath.Join(paths.StateDir, trustedProjectsFileName)
 }
 
-// TrustProjectFile hashes the file at repoPath/relPath and records the hash
+// trustProjectFile hashes the file at repoPath/relPath and records the hash
 // in the trust store so the runner will accept it on the next invocation.
 // relPath must be a slash-separated path relative to the repo root (e.g.
-// ".projmux/config.toml" or ".projmux/hooks/post-create"). An empty relPath is
-// rejected to keep callers explicit about which surface they trust.
-func TrustProjectFile(repoPath, relPath, trustStorePath string) (string, error) {
+// ".projmux/config.toml"). An empty relPath is rejected to keep callers
+// explicit about which surface they trust.
+//
+// This is an internal helper. The only public surface is TrustProjectConfig,
+// which targets the well-known .projmux/config.toml file. Script files are no
+// longer a trust surface — the runner refuses to execute them and the
+// migrator flips them to declarative entries instead.
+func trustProjectFile(repoPath, relPath, trustStorePath string) (string, error) {
 	repoPath = strings.TrimSpace(repoPath)
 	if repoPath == "" {
 		return "", errors.New("repo path is required")
@@ -217,10 +218,10 @@ func TrustProjectFile(repoPath, relPath, trustStorePath string) (string, error) 
 	return sum, nil
 }
 
-// TrustProjectConfig is a thin wrapper around TrustProjectFile that targets
-// the well-known .projmux/config.toml file.
+// TrustProjectConfig hashes the project-local .projmux/config.toml file and
+// records the hash so the runner will accept it on the next invocation.
 func TrustProjectConfig(repoPath, trustStorePath string) (string, error) {
-	return TrustProjectFile(repoPath, projectConfigRelativePath, trustStorePath)
+	return trustProjectFile(repoPath, projectConfigRelativePath, trustStorePath)
 }
 
 func loadTrustedProjects(path string) (trustedProjects, error) {


### PR DESCRIPTION
## Background

Phase 2.5 (#160) shipped script + declarative hook coexistence in the Settings hook maker. Post-merge user validation showed the file-form hook surface was unnecessary friction — every realistic project hook is a one-liner that belongs in `[hooks.<event>] run = \"...\"`. Phase 2.6 removes the script branch entirely, collapses the UI to a single declarative form, and auto-migrates the legacy layout so users do not silently lose hook behaviour.

## What changes

### Global `config.toml` support (new)
`internal/integrations/hooks/global_config.go` adds `GlobalConfigPath`, `LoadGlobalConfig`, and `UpdateGlobalConfig`. The global file lives at `${XDG_CONFIG_HOME:-$HOME/.config}/projmux/config.toml` and reuses the project parser. Previously global hooks were script-only.

### Script branch removed
`internal/app/hookmaker.go`:
- Drop `hook-add` / `hook-edit` / `hook-remove` `:script:` / `:declarative:` action variants — payload is now just `<scope>:<event>`.
- Drop the `[+ Add]` branch picker; the row opens the inline typed editor directly.
- Drop `(script)` / `(declarative)` row labels; collapse to a single \"active - run = ...\" row per event.
- Drop `hookMakerAddScript`, `hookMakerEditScript`, `hookMakerOpenScript`, `hookMakerRemoveScript`, `ensureExecutableScript`, `recordProjectScriptTrust`, `resolveEditor`, `openEditor`.
- Add `hookMakerEditGlobalDeclarative` that round-trips the global config.toml.

`internal/integrations/hooks/hooks.go`:
- `Runner` field `GlobalHookPaths map[Event][]string` → replaced by `GlobalConfigPath string`.
- Runtime drops `discoverProjectHook`, `projectHookCandidates`, `isExecutableHook`, `runHook`, `hookPaths`.
- Runner executes global declarative hooks first, then project declarative hooks (global → project order preserved).
- `PostCreateRunner` shim shape preserved (now backed by `GlobalConfigPath`).

### Auto-migration
`internal/integrations/hooks/migration.go` adds `MigrateProjectLegacyScripts` and `MigrateGlobalLegacyScripts`:
- **Single-line** (counting non-empty, non-comment lines, shebang stripped) → moved to `[hooks.<event>] run = \"<line>\"`, original renamed to `<path>.bak`. Existing declarative entries always win — the legacy script never overwrites.
- **Two+ lines** → skipped + warning logged + surfaced in the Settings UI as a `(legacy script)` non-interactive row pointing users to `run = \"bash -c '...'\"` or `run = \"./scripts/foo.sh\"` rewrites.
- Triggered from `App.Run` (sync.Once) plus on entry to the Settings hooks page so the migration is visible immediately.
- `.bak` files are NOT auto-cleaned (spec non-goal).

### Trust API simplification
`internal/integrations/hooks/trust.go`:
- `TrustProjectFile` → lowercase `trustProjectFile` (internal helper).
- `TrustProjectConfig` is the single public entry. Global hooks bypass trust entirely.
- `authorizeProjectHook` (script-file authorizer) removed; only `authorizeProjectConfig` remains.

### Misc
- `internal/app/tmux_client.go`: `defaultLifecycleHookRunner` now wires `GlobalConfigPath` instead of `GlobalHookPaths`. Test updated to assert the new field.
- Lifecycle catalogue unchanged: `pre-create` / `post-create` / `pane-startup` / `post-attach`. Internal-only tmux hooks (`after-select-pane`, `pane-focus-in/out`) remain hidden.

## Test results

```
$ go build ./...   # clean
$ go vet ./...     # clean
$ go test ./...    # all packages pass
ok  internal/app
ok  internal/integrations/hooks
ok  internal/integrations/tmux
... (full suite green)
```

Spec test cases all covered:
- `TestSettingsHookMakerProjectAddDeclarativeOpensInlineForm` — branch picker removed regression guard
- `TestMigrateProjectLegacyScriptsSingleLineConvertsAndBackups` — single-line migration + `.bak`
- `TestMigrateProjectLegacyScriptsMultiLineSkippedAndLogged` + `TestSettingsHookMakerLegacyMultiLineScriptRendersLegacyRow` — multi-line skip + UI row + warning
- `TestUpdateGlobalConfigWritesAndReadsBack` + `TestSettingsHookMakerGlobalAddDeclarativeWritesGlobalConfig` — global config read/write
- `TestRunnerDoesNotExecuteScriptFiles` — runner no longer touches script files
- `TestTrustProjectConfigPersistsHash` (preserved) — TrustProjectConfig as the only public surface

## Compatibility / migration

- Users on Phase 2.5 with a single-line script hook will see it converted on first run; original is preserved at `<path>.bak`.
- Users with multi-line scripts will see a `(legacy script)` row in Settings and a stderr warning on launch; they must manually rewrite as `run = \"bash -c '...'\"` or `run = \"./scripts/foo.sh\"`.
- Global script hooks at `${XDG_CONFIG_HOME}/projmux/hooks/<event>` get the same treatment.

## Test plan

- [ ] Open Settings > Global > Hooks on a config-less host → verify `[+ Add]` rows show `missing - <global config.toml>` and Enter opens inline typed editor (not branch picker).
- [ ] Add a global post-create hook through Settings → verify `${XDG_CONFIG_HOME}/projmux/config.toml` gets `[hooks.post-create] run = \"...\"`.
- [ ] Drop a single-line `.projmux/post-create` script in a repo, launch projmux → verify it auto-migrates to `[hooks.post-create]` and original renames to `.bak`.
- [ ] Drop a two-line `.projmux/post-create` script, open Settings > Project > Hooks → verify the `(legacy script)` row appears with `not executed` annotation.
- [ ] Create a tmux session in a repo with `[hooks.pre-create] run = \"exit 9\"` → verify session creation aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)