### PR TITLE
feat: extend effective merge view with hook entries

### DIFF
--- a/internal/app/effective_merge.go
+++ b/internal/app/effective_merge.go
@@ -95,7 +95,50 @@ func (c *settingsCommand) effectiveMergeEntries(ctx settingsProjectContext) []in
 	entries = append(entries, renderEffectiveSection(merged.Env)...)
 	entries = append(entries, renderEffectiveSection(merged.Kube)...)
 	entries = append(entries, renderEffectiveSection(merged.Startup)...)
+	entries = append(entries, renderEffectiveHooksSection(merged.Hooks)...)
 	return entries
+}
+
+// renderEffectiveHooksSection mirrors renderEffectiveSection but tailors the
+// "no entries" copy for the hooks axis: rather than the section-name +
+// "(no entries)" wording used elsewhere, an empty hooks section reads as
+// "no hooks configured" so the user understands the absence is intentional
+// (no lifecycle wiring is set on either axis) and not an error. Hook `run`
+// values are user-supplied commands rather than credentials, so they are
+// rendered verbatim — IsSensitiveEnvKey only applies to env values.
+func renderEffectiveHooksSection(section hooks.EffectiveSection) []intpickercompat.Entry {
+	header := intpickercompat.Entry{
+		Label: settingsLabelInfo("["+section.Name+"]", "", string(section.Source)),
+		Value: settingsNoopValue,
+	}
+	entries := []intpickercompat.Entry{header}
+	if len(section.Entries) == 0 {
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabelDim("  (no hooks configured)", string(hooks.EffectiveSourceDefault)),
+			Value: settingsNoopValue,
+		})
+		return entries
+	}
+	for _, entry := range section.Entries {
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabelInfo("  "+entry.Key, hookRunDisplayValue(entry.Value), string(entry.Source)),
+			Value: settingsNoopValue,
+		})
+	}
+	return entries
+}
+
+// hookRunDisplayValue formats a hook command for the popup. The value is the
+// user's own shell command — projmux does not redact it (unlike env values
+// flagged by IsSensitiveEnvKey) because the user wrote it deliberately and
+// hiding it would obscure what runs at the lifecycle point. An empty string
+// can only appear if a future code path produces it; the (unset) sentinel
+// keeps the row readable.
+func hookRunDisplayValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "(unset)"
+	}
+	return value
 }
 
 // renderEffectiveSection emits one section header row plus one row per

--- a/internal/app/effective_merge_test.go
+++ b/internal/app/effective_merge_test.go
@@ -216,6 +216,138 @@ func TestRunSectionDispatchesEffectiveMerge(t *testing.T) {
 	}
 }
 
+// TestEffectiveMergeEntriesHooksProjectWins covers the Phase 4 spec: a hook
+// defined on both axes resolves to the project value with a (project) label;
+// non-conflicting events keep their origin axis label; the section header
+// reads (merged) when both axes contributed.
+func TestEffectiveMergeEntriesHooksProjectWins(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := filepath.Join(home, ".config")
+	mustMkdirAll(t, filepath.Join(configHome, "projmux"))
+	if err := os.WriteFile(filepath.Join(configHome, "projmux", "config.toml"), []byte(strings.Join([]string{
+		`[hooks.pre-create]`,
+		`run = "echo global-pre"`,
+		`[hooks.post-create]`,
+		`run = "echo global-post"`,
+	}, "\n")), 0o644); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+
+	project := filepath.Join(home, "repo")
+	mustMkdirAll(t, filepath.Join(project, ".projmux"))
+	if err := os.WriteFile(filepath.Join(project, ".projmux", "config.toml"), []byte(strings.Join([]string{
+		`[hooks.post-create]`,
+		`run = "echo project-post"`,
+		`[hooks.pane-startup]`,
+		`run = "echo project-pane"`,
+	}, "\n")), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+
+	cmd := &settingsCommand{
+		homeDir: func() (string, error) { return home, nil },
+		lookupEnv: func(name string) string {
+			if name == "XDG_CONFIG_HOME" {
+				return configHome
+			}
+			return ""
+		},
+	}
+	ctx := newSettingsProjectContext(project, "test")
+	entries := cmd.effectiveMergeEntries(ctx)
+
+	// Section header — both axes contributed hook entries → merged.
+	requireEntryLabelContains(t, entries, "[hooks]", "(merged)")
+	// pre-create only on global axis → global label, value rendered verbatim.
+	requireEntryLabelContains(t, entries, "pre-create", "(global)")
+	requireEntryLabelContains(t, entries, "pre-create", "echo global-pre")
+	// post-create defined on both → project wins; row label reads project.
+	requireEntryLabelContains(t, entries, "post-create", "(project)")
+	requireEntryLabelContains(t, entries, "post-create", "echo project-post")
+	// pane-startup only in project → project label.
+	requireEntryLabelContains(t, entries, "pane-startup", "(project)")
+	requireEntryLabelContains(t, entries, "pane-startup", "echo project-pane")
+	// post-attach defined nowhere — confirm omission so the popup stays
+	// uncluttered for unused lifecycle events.
+	for _, entry := range entries {
+		if strings.Contains(entry.Label, "post-attach") {
+			t.Fatalf("entries leaked an undefined post-attach hook row: %q", entry.Label)
+		}
+	}
+}
+
+// TestEffectiveMergeEntriesHooksEmpty pins the Phase 4 display decision: when
+// neither axis defines any hook, the section still renders a header row plus
+// a single dim "(no hooks configured)" row, labelled as default.
+func TestEffectiveMergeEntriesHooksEmpty(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	project := filepath.Join(home, "repo")
+	mustMkdirAll(t, filepath.Join(project, ".projmux"))
+	if err := os.WriteFile(filepath.Join(project, ".projmux", "config.toml"), []byte(`[env]
+EDITOR = "vim"
+`), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+	cmd := &settingsCommand{
+		homeDir:   func() (string, error) { return home, nil },
+		lookupEnv: func(string) string { return "" },
+	}
+	ctx := newSettingsProjectContext(project, "test")
+	entries := cmd.effectiveMergeEntries(ctx)
+
+	requireEntryLabelContains(t, entries, "[hooks]", "(default)")
+	// The empty-row uses settingsLabelDim, which renders the source slot as
+	// a bare token (no parens). Match that shape so we pin the actual UX.
+	requireEntryLabelContains(t, entries, "no hooks configured", "default")
+}
+
+// TestEffectiveMergeEntriesHooksDoesNotRedactRunCommand documents the
+// Phase 4 decision: hook `run` strings are user-authored commands and are
+// rendered verbatim, even when they contain tokens or other secrets. Only
+// env values flagged by IsSensitiveEnvKey are redacted.
+func TestEffectiveMergeEntriesHooksDoesNotRedactRunCommand(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	project := filepath.Join(home, "repo")
+	mustMkdirAll(t, filepath.Join(project, ".projmux"))
+	if err := os.WriteFile(filepath.Join(project, ".projmux", "config.toml"), []byte(strings.Join([]string{
+		`[hooks.post-create]`,
+		// Intentionally embed a credential-shaped value in the user's
+		// shell command. The user wrote this on purpose; we surface it.
+		`run = "curl -H 'Authorization: Bearer ghp_xxx' https://example.com"`,
+	}, "\n")), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+	cmd := &settingsCommand{
+		homeDir:   func() (string, error) { return home, nil },
+		lookupEnv: func(string) string { return "" },
+	}
+	ctx := newSettingsProjectContext(project, "test")
+	entries := cmd.effectiveMergeEntries(ctx)
+
+	requireEntryLabelContains(t, entries, "post-create", "ghp_xxx")
+	requireEntryLabelContains(t, entries, "post-create", "(project)")
+}
+
+// TestHookRunDisplayValueHandlesEmpty pins the small display helper. The
+// merge engine omits unset events entirely, but the helper still has to
+// handle the empty case (e.g. a future caller passes through raw values).
+func TestHookRunDisplayValueHandlesEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := hookRunDisplayValue("echo hi"); got != "echo hi" {
+		t.Fatalf("hookRunDisplayValue plain = %q, want echo hi", got)
+	}
+	if got := hookRunDisplayValue("   "); got != "(unset)" {
+		t.Fatalf("hookRunDisplayValue whitespace = %q, want (unset)", got)
+	}
+}
+
 // --- helpers --------------------------------------------------------------
 
 func mustMkdirAll(t *testing.T, path string) {

--- a/internal/integrations/hooks/effective.go
+++ b/internal/integrations/hooks/effective.go
@@ -46,18 +46,20 @@ type EffectiveSection struct {
 	Entries []EffectiveEntry
 }
 
-// EffectiveConfig is the full merged view of the data-only config sections
-// ([env] / [kube] / [startup]). Hook entries ([hooks.*]) are intentionally
-// out of scope — the dedicated Hooks page surfaces those.
+// EffectiveConfig is the full merged view of the declarative config sections
+// ([env] / [kube] / [startup] / [hooks.*]). Phase 4 of the Hook maker roadmap
+// adds the Hooks section so the Effective merge view popup can surface the
+// resolved lifecycle hook command and the axis it was sourced from.
 type EffectiveConfig struct {
 	Env     EffectiveSection
 	Kube    EffectiveSection
 	Startup EffectiveSection
+	Hooks   EffectiveSection
 }
 
 // Sections returns the merged sections in stable display order.
 func (c EffectiveConfig) Sections() []EffectiveSection {
-	return []EffectiveSection{c.Env, c.Kube, c.Startup}
+	return []EffectiveSection{c.Env, c.Kube, c.Startup, c.Hooks}
 }
 
 // MergeEffective merges global + project config into a single effective view
@@ -70,6 +72,7 @@ func MergeEffective(global, project ProjectConfig) EffectiveConfig {
 		Env:     mergeEffectiveEnv(global, project),
 		Kube:    mergeEffectiveKube(global, project),
 		Startup: mergeEffectiveStartup(global, project),
+		Hooks:   mergeEffectiveHooks(global, project),
 	}
 }
 
@@ -125,6 +128,43 @@ func mergeEffectiveStartup(global, project ProjectConfig) EffectiveSection {
 	section.Entries = append(section.Entries,
 		resolveScalarEntry("run", project.StartupRun, global.StartupRun),
 	)
+	section.Source = summarizeSectionSource(section.Entries)
+	return section
+}
+
+// mergeEffectiveHooks resolves each supported lifecycle event with the same
+// project-wins policy as the data sections. Unlike [env] / [kube] / [startup],
+// each event resolves to a single `run` value sourced from exactly one axis —
+// so only EffectiveSourceProject and EffectiveSourceGlobal labels appear at
+// the row level. Events that are unset on both axes are omitted entirely to
+// keep the popup focused on active hooks (the popup is already information
+// dense). The section-level label still uses summarizeSectionSource so the
+// header reads (project), (global), or (merged) when both axes contribute
+// hook entries for different events.
+func mergeEffectiveHooks(global, project ProjectConfig) EffectiveSection {
+	section := EffectiveSection{Name: "hooks"}
+	for _, event := range SupportedEvents {
+		projectRun := strings.TrimSpace(project.hookRun(event))
+		globalRun := strings.TrimSpace(global.hookRun(event))
+		switch {
+		case projectRun != "":
+			// Project wins on conflict — the row is unambiguously sourced from
+			// the project config even if the global config also defines it.
+			section.Entries = append(section.Entries, EffectiveEntry{
+				Key:    string(event),
+				Value:  projectRun,
+				Source: EffectiveSourceProject,
+			})
+		case globalRun != "":
+			section.Entries = append(section.Entries, EffectiveEntry{
+				Key:    string(event),
+				Value:  globalRun,
+				Source: EffectiveSourceGlobal,
+			})
+		}
+		// Both axes empty → row omitted (declarative absence; the lifecycle
+		// is simply not wired up).
+	}
 	section.Source = summarizeSectionSource(section.Entries)
 	return section
 }

--- a/internal/integrations/hooks/effective_test.go
+++ b/internal/integrations/hooks/effective_test.go
@@ -208,3 +208,171 @@ func TestDisplayEnvValueRedactsSensitive(t *testing.T) {
 		t.Fatalf("DisplayEnvValue empty = %q, want (unset)", got)
 	}
 }
+
+// TestMergeEffectiveHooksProjectWinsOnConflict covers the Phase 4 merge
+// engine: when both axes define a [hooks.<event>] entry for the same event,
+// the project value wins and the row is labelled project.
+func TestMergeEffectiveHooksProjectWinsOnConflict(t *testing.T) {
+	t.Parallel()
+
+	global := ProjectConfig{
+		Hooks: map[Event]string{
+			EventPostCreate: "echo global-post",
+		},
+	}
+	project := ProjectConfig{
+		Hooks: map[Event]string{
+			EventPostCreate: "echo project-post",
+		},
+	}
+	got := MergeEffective(global, project).Hooks
+	want := []EffectiveEntry{
+		{Key: string(EventPostCreate), Value: "echo project-post", Source: EffectiveSourceProject},
+	}
+	if !reflect.DeepEqual(got.Entries, want) {
+		t.Fatalf("hooks entries = %+v, want %+v", got.Entries, want)
+	}
+	if got.Source != EffectiveSourceProject {
+		t.Fatalf("hooks section source = %q, want project", got.Source)
+	}
+}
+
+// TestMergeEffectiveHooksGlobalOnlySourceLabel covers the case where a hook
+// is defined only in the global config — the row reports the global axis and
+// the section header summarizes the same single axis.
+func TestMergeEffectiveHooksGlobalOnlySourceLabel(t *testing.T) {
+	t.Parallel()
+
+	global := ProjectConfig{
+		Hooks: map[Event]string{
+			EventPreCreate: "echo global-pre",
+		},
+	}
+	got := MergeEffective(global, ProjectConfig{}).Hooks
+	want := []EffectiveEntry{
+		{Key: string(EventPreCreate), Value: "echo global-pre", Source: EffectiveSourceGlobal},
+	}
+	if !reflect.DeepEqual(got.Entries, want) {
+		t.Fatalf("hooks entries = %+v, want %+v", got.Entries, want)
+	}
+	if got.Source != EffectiveSourceGlobal {
+		t.Fatalf("hooks section source = %q, want global", got.Source)
+	}
+}
+
+// TestMergeEffectiveHooksProjectOnlySourceLabel covers the symmetric case:
+// only the project config defines a hook, so both row and section label
+// resolve to project.
+func TestMergeEffectiveHooksProjectOnlySourceLabel(t *testing.T) {
+	t.Parallel()
+
+	project := ProjectConfig{
+		Hooks: map[Event]string{
+			EventPostAttach: "echo project-attach",
+		},
+	}
+	got := MergeEffective(ProjectConfig{}, project).Hooks
+	want := []EffectiveEntry{
+		{Key: string(EventPostAttach), Value: "echo project-attach", Source: EffectiveSourceProject},
+	}
+	if !reflect.DeepEqual(got.Entries, want) {
+		t.Fatalf("hooks entries = %+v, want %+v", got.Entries, want)
+	}
+	if got.Source != EffectiveSourceProject {
+		t.Fatalf("hooks section source = %q, want project", got.Source)
+	}
+}
+
+// TestMergeEffectiveHooksMixedAxesSectionLabel covers the case where each
+// axis contributes a hook for a *different* event — neither row alone is
+// ambiguous, but the section header should summarize as merged because both
+// axes contributed entries.
+func TestMergeEffectiveHooksMixedAxesSectionLabel(t *testing.T) {
+	t.Parallel()
+
+	global := ProjectConfig{
+		Hooks: map[Event]string{
+			EventPreCreate: "echo global-pre",
+		},
+	}
+	project := ProjectConfig{
+		Hooks: map[Event]string{
+			EventPostCreate: "echo project-post",
+		},
+	}
+	got := MergeEffective(global, project).Hooks
+	if got.Source != EffectiveSourceMerged {
+		t.Fatalf("hooks section source = %q, want merged (project + global contributed)", got.Source)
+	}
+	// Stable display order follows SupportedEvents (pre-create before
+	// post-create), so the per-axis order is global-then-project here.
+	if len(got.Entries) != 2 {
+		t.Fatalf("hooks entries len = %d, want 2: %+v", len(got.Entries), got.Entries)
+	}
+	if got.Entries[0].Key != string(EventPreCreate) || got.Entries[0].Source != EffectiveSourceGlobal {
+		t.Fatalf("entries[0] = %+v, want pre-create/global", got.Entries[0])
+	}
+	if got.Entries[1].Key != string(EventPostCreate) || got.Entries[1].Source != EffectiveSourceProject {
+		t.Fatalf("entries[1] = %+v, want post-create/project", got.Entries[1])
+	}
+}
+
+// TestMergeEffectiveHooksOmitsUndefinedEvents documents the Phase 4 display
+// decision: events that are unset on both axes are not emitted as rows. The
+// section is allowed to be entirely empty, which keeps the popup uncluttered
+// when no lifecycle is wired up.
+func TestMergeEffectiveHooksOmitsUndefinedEvents(t *testing.T) {
+	t.Parallel()
+
+	got := MergeEffective(ProjectConfig{}, ProjectConfig{}).Hooks
+	if len(got.Entries) != 0 {
+		t.Fatalf("hooks entries = %+v, want empty (no events defined)", got.Entries)
+	}
+	if got.Source != EffectiveSourceDefault {
+		t.Fatalf("hooks section source = %q, want default when both axes empty", got.Source)
+	}
+}
+
+// TestMergeEffectiveHooksRowOrderFollowsSupportedEvents pins the row order so
+// the popup renders lifecycle events in the same order Phase 2.6's hooks
+// catalog defines them — pre-create, post-create, pane-startup, post-attach.
+func TestMergeEffectiveHooksRowOrderFollowsSupportedEvents(t *testing.T) {
+	t.Parallel()
+
+	project := ProjectConfig{
+		Hooks: map[Event]string{
+			EventPostAttach:  "echo attach",
+			EventPreCreate:   "echo pre",
+			EventPaneStartup: "echo pane",
+			EventPostCreate:  "echo post",
+		},
+	}
+	got := MergeEffective(ProjectConfig{}, project).Hooks
+	wantOrder := []Event{EventPreCreate, EventPostCreate, EventPaneStartup, EventPostAttach}
+	if len(got.Entries) != len(wantOrder) {
+		t.Fatalf("hooks entries len = %d, want %d: %+v", len(got.Entries), len(wantOrder), got.Entries)
+	}
+	for i, want := range wantOrder {
+		if got.Entries[i].Key != string(want) {
+			t.Fatalf("entries[%d].Key = %q, want %q", i, got.Entries[i].Key, want)
+		}
+	}
+}
+
+// TestEffectiveConfigSectionsIncludesHooks pins the Sections() display order:
+// env, kube, startup, then hooks. The settings popup depends on this order
+// to lay out the page.
+func TestEffectiveConfigSectionsIncludesHooks(t *testing.T) {
+	t.Parallel()
+
+	got := MergeEffective(ProjectConfig{}, ProjectConfig{}).Sections()
+	wantNames := []string{"env", "kube", "startup", "hooks"}
+	if len(got) != len(wantNames) {
+		t.Fatalf("Sections() len = %d, want %d: %+v", len(got), len(wantNames), got)
+	}
+	for i, name := range wantNames {
+		if got[i].Name != name {
+			t.Fatalf("Sections()[%d].Name = %q, want %q", i, got[i].Name, name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Hook maker roadmap **Phase 4 — Effective merge view 내 hook 영역**. Extends
the Settings > Project > Effective merge view popup so the resolved
`[hooks.<event>]` entries surface alongside `[env]` / `[kube]` / `[startup]`
with the same source labels.

## Changes

- `hooks.MergeEffective` now emits a fourth `Hooks` section. Per-event
  merge follows the existing **project-wins** policy: on conflict the row
  is labelled `(project)`; otherwise the row carries `(project)` or
  `(global)` depending on the axis that defined the `run` value.
- `hooks.EffectiveConfig.Sections()` returns env → kube → startup → hooks
  in stable display order (used by the popup layout).
- `effective_merge.go` renders the new section under a dedicated
  `renderEffectiveHooksSection` helper that handles the "no hooks
  configured" empty state.
- Section-level label uses the existing `summarizeSectionSource`, so the
  header reads `(merged)` when both axes contributed entries (for
  different events) and `(default)` when neither did.

## Display decisions

- **Empty section**: when no hook is defined on either axis the section
  still renders a header row plus a single dim `(no hooks configured)`
  row. Undefined individual events (e.g. only `post-create` is wired and
  `pre-create` is not) are omitted entirely to keep the popup focused on
  active hooks.
- **Sensitive values**: hook `run` strings are user-authored shell code
  and are rendered verbatim — `IsSensitiveEnvKey` only applies to env
  values. Hiding the user's own command would obscure what runs at the
  lifecycle point. Documented inline in `hookRunDisplayValue`.

## Test results

`go test ./...` → all packages pass. New tests added:

- `internal/integrations/hooks/effective_test.go`
  - `TestMergeEffectiveHooksProjectWinsOnConflict`
  - `TestMergeEffectiveHooksGlobalOnlySourceLabel`
  - `TestMergeEffectiveHooksProjectOnlySourceLabel`
  - `TestMergeEffectiveHooksMixedAxesSectionLabel`
  - `TestMergeEffectiveHooksOmitsUndefinedEvents`
  - `TestMergeEffectiveHooksRowOrderFollowsSupportedEvents`
  - `TestEffectiveConfigSectionsIncludesHooks`
- `internal/app/effective_merge_test.go`
  - `TestEffectiveMergeEntriesHooksProjectWins`
  - `TestEffectiveMergeEntriesHooksEmpty`
  - `TestEffectiveMergeEntriesHooksDoesNotRedactRunCommand`
  - `TestHookRunDisplayValueHandlesEmpty`

## Test plan

- [ ] Open Settings > Project tab > Effective merge view in a repo that
  has hooks on both axes and confirm the new `[hooks]` section appears
  with correct source labels.
- [ ] Repeat with a repo that has no hooks anywhere — confirm the section
  renders `(no hooks configured)`.
- [ ] Define an event on both axes and confirm the row reads project
  value + `(project)` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)