### PR TITLE
feat: integrate trust badge into project settings tab

### DIFF
--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -70,6 +70,7 @@ var settingsEntryCatalog = map[string]settingsEntryMeta{
 	settingsSectionGlobalHooks:    {Name: "Hooks", Axis: settingsAxisGlobal},
 	settingsSectionProjectHooks:   {Name: "Hooks", Axis: settingsAxisProject},
 	settingsSectionProjectConfig:  {Name: "Project Config", Axis: settingsAxisProject},
+	settingsSectionProjectTrust:   {Name: "Trust", Axis: settingsAxisProject},
 	settingsSectionEffectiveMerge: {Name: "Effective merge view", Axis: settingsAxisProject},
 	settingsSectionAI:             {Name: "AI Settings", Axis: settingsAxisGlobal},
 	settingsSectionStatusbar:      {Name: "Appearance", Axis: settingsAxisGlobal},
@@ -103,6 +104,7 @@ var settingsEntryPrefixCatalog = []struct {
 	{settingsActionPrefixLabKeymap, settingsEntryMeta{Name: "Keybinding diagnostics", Axis: settingsAxisGlobal}},
 	{settingsActionPrefixPicker, settingsEntryMeta{Name: "Picker backend", Axis: settingsAxisGlobal}},
 	{settingsActionPrefixProjectConfig, settingsEntryMeta{Name: "Project Config", Axis: settingsAxisProject}},
+	{settingsActionPrefixTrust, settingsEntryMeta{Name: "Trust", Axis: settingsAxisProject}},
 	{settingsActionPrefixProjdir, settingsEntryMeta{Name: "Project Root", Axis: settingsAxisGlobal}},
 	{settingsActionPrefixStatusbar, settingsEntryMeta{Name: "Appearance", Axis: settingsAxisGlobal}},
 	{settingsActionPrefixSwitch, settingsEntryMeta{Name: "Pinned Projects", Axis: settingsAxisGlobal}},
@@ -131,6 +133,7 @@ const (
 	settingsSectionGlobalHooks        = "section:hooks-global"
 	settingsSectionProjectHooks       = "section:hooks-project"
 	settingsSectionProjectConfig      = "section:project-config"
+	settingsSectionProjectTrust       = "section:project-trust"
 	settingsSectionEffectiveMerge     = "section:effective-merge"
 	settingsSectionKeybindings        = "section:keybindings"
 	settingsSectionProject            = "section:project-picker"
@@ -143,6 +146,7 @@ const (
 	settingsActionPrefixLabKeymap     = "lab-keymap:"
 	settingsActionPrefixPicker        = "picker-backend:"
 	settingsActionPrefixProjectConfig = "project-config:"
+	settingsActionPrefixTrust         = "trust:"
 	settingsActionPrefixProjdir       = "projdir:"
 	settingsActionPrefixStatusbar     = "statusbar-decoration:"
 	settingsActionPrefixSwitch        = "switch:"
@@ -238,6 +242,9 @@ func (c *settingsCommand) runSection(section string, stdout, stderr io.Writer) e
 	}
 	if section == settingsSectionProjectConfig {
 		return c.runProjectConfigSection(stdout, stderr)
+	}
+	if section == settingsSectionProjectTrust {
+		return c.runProjectTrustSection(stdout, stderr)
 	}
 	if section == settingsSectionEffectiveMerge {
 		return c.runEffectiveMergeSection(stdout, stderr)
@@ -471,11 +478,12 @@ func (c *settingsCommand) projectTabEntries() []intpickercompat.Entry {
 
 	// The project context label is conveyed by the chip strip plus the
 	// popup header — keep the picker entries focused on actionable rows.
+	// The Trust row is rendered with state-aware tone (untrusted /
+	// trusted / stale / absent) and routes Enter into the trust subsection
+	// that decides whether to register, refresh, or untrust the
+	// project-local .projmux/config.toml hash.
 	return []intpickercompat.Entry{
-		{
-			Label: settingsLabelDim("Trust", "read-only preview arrives in Phase 4"),
-			Value: settingsNoopValue,
-		},
+		c.projectTrustEntry(ctx),
 		{
 			Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Hooks (project)", filepath.Join(ctx.Path, ".projmux")),
 			Value: settingsSectionProjectHooks,

--- a/internal/app/trust.go
+++ b/internal/app/trust.go
@@ -1,0 +1,325 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/crevissepartners/projmux/internal/integrations/hooks"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
+)
+
+// trust.go implements the Settings popup "Trust" badge + subsection used
+// by the Project tab. The Project tab's first picker row renders the
+// current trust standing of the project-local .projmux/config.toml file:
+//
+//   - absent    → no .projmux/config.toml on disk; trust is moot.
+//   - untrusted → file exists, no trust-store entry yet.
+//   - trusted   → trust-store hash matches the file on disk.
+//   - stale     → trust-store entry exists but the file hash changed.
+//
+// Enter on the Trust row opens this subsection so the user can confirm
+// the side-effecting action (trust / refresh / untrust). The subsection
+// reuses the standard picker chrome so it inherits the same back/close
+// behaviour as the other Project tab pages. The Global tab is exempt
+// from the Trust surface because the trust policy only governs
+// project-local configs — see hooks.InspectProjectConfigTrust for the
+// state machine.
+
+// projectTrustEntry builds the first row of the Project tab. It surfaces
+// the current trust standing and routes Enter into the Trust subsection
+// which decides whether to register, refresh, or untrust the project
+// config.
+func (c *settingsCommand) projectTrustEntry(ctx settingsProjectContext) intpickercompat.Entry {
+	report, err := c.inspectProjectTrust(ctx)
+	if err != nil {
+		// A read-only failure (e.g. the trust store is unreadable) keeps
+		// the badge dim so the rest of the Project tab stays usable.
+		// We still route Enter into the subsection so the user sees the
+		// error message in a dedicated page instead of losing it on the
+		// background log.
+		return intpickercompat.Entry{
+			Label: settingsLabelDim("Trust", "trust state unavailable - "+err.Error()),
+			Value: settingsSectionProjectTrust,
+		}
+	}
+	glyph, color, summary := trustBadgeAppearance(report.State)
+	return intpickercompat.Entry{
+		Label: settingsLabel(glyph, color, "Trust", summary),
+		Value: settingsSectionProjectTrust,
+	}
+}
+
+// trustBadgeAppearance maps a trust state to the picker row glyph,
+// colour, and dim summary used by the Project tab badge. The glyphs
+// reuse the existing settings palette so the Trust row reads as part of
+// the same design system as the other rows.
+func trustBadgeAppearance(state hooks.ProjectConfigTrustState) (string, string, string) {
+	switch state {
+	case hooks.ProjectConfigTrustTrusted:
+		return settingsGlyphToggle, settingsColorActive, "trusted - hash matches stored entry"
+	case hooks.ProjectConfigTrustStale:
+		return settingsGlyphInactive, settingsColorTrustStale, "stale - file changed since trust"
+	case hooks.ProjectConfigTrustUntrusted:
+		return settingsGlyphInfo, settingsColorRemove, "untrusted - registration required"
+	case hooks.ProjectConfigTrustAbsent:
+		return settingsGlyphInfo, settingsColorDim, "no .projmux/config.toml on disk"
+	default:
+		return settingsGlyphInfo, settingsColorDim, "unknown trust state"
+	}
+}
+
+// settingsColorTrustStale is amber-ish so the stale state reads as a
+// warning without colliding with the destructive red used for the
+// untrusted state. Kept here (rather than settings_render.go) because it
+// is the only colour that is trust-specific.
+const settingsColorTrustStale = "\x1b[33m"
+
+// inspectProjectTrust resolves the trust store path and asks the hooks
+// package to inspect the project config trust standing.
+func (c *settingsCommand) inspectProjectTrust(ctx settingsProjectContext) (hooks.ProjectConfigTrustReport, error) {
+	if !ctx.hasProject() {
+		return hooks.ProjectConfigTrustReport{}, errors.New("project context is required")
+	}
+	trustPath, err := c.projectConfigTrustStorePath()
+	if err != nil {
+		return hooks.ProjectConfigTrustReport{}, err
+	}
+	return hooks.InspectProjectConfigTrust(ctx.Path, trustPath)
+}
+
+// runProjectTrustSection drives the Trust subsection picker. The page
+// shows the project path, the resolved config path, the current trust
+// state, and one actionable row whose meaning depends on the state. A
+// destructive Untrust action goes through an extra confirmation page so
+// the user does not accidentally invalidate trust with a single Enter.
+func (c *settingsCommand) runProjectTrustSection(stdout, stderr io.Writer) error {
+	for {
+		ctx := c.resolveSettingsProjectContext()
+		options := c.projectTrustOptions(ctx)
+		result, err := c.runPicker(options)
+		if err != nil {
+			return err
+		}
+		action := strings.TrimSpace(result.Value)
+		if result.Key != "enter" || action == "" {
+			return errSettingsClosed
+		}
+		switch action {
+		case settingsBackValue:
+			return nil
+		case settingsNoopValue:
+			continue
+		case settingsTrustApply:
+			if err := c.runProjectTrustApply(ctx, stdout, stderr); err != nil {
+				return err
+			}
+		case settingsTrustRefresh:
+			// Refresh is the same call as apply — TrustProjectConfig is
+			// idempotent and just rewrites the stored hash so the runner
+			// accepts the updated file on its next invocation.
+			if err := c.runProjectTrustApply(ctx, stdout, stderr); err != nil {
+				return err
+			}
+		case settingsTrustUntrust:
+			confirmed, err := c.confirmProjectTrustUntrust(ctx)
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				continue
+			}
+			if err := c.runProjectTrustUntrust(ctx, stdout, stderr); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown trust action: %s", action)
+		}
+	}
+}
+
+// projectTrustOptions builds the Trust subsection picker. Layout mirrors
+// the Effective merge view page so the two project-scope pages feel
+// consistent (info rows + a small set of actionable rows).
+func (c *settingsCommand) projectTrustOptions(ctx settingsProjectContext) intpickercompat.Options {
+	return intpickercompat.Options{
+		UI:         "settings-project-trust",
+		Entries:    c.projectTrustEntries(ctx),
+		Title:      "Trust - Project config hash",
+		Prompt:     "Settings > Project > Trust > ",
+		Footer:     projmuxFooter("Enter: apply  |  Back row: parent  |  Esc/Alt+5/Ctrl+Alt+S: close"),
+		ExpectKeys: []string{"enter"},
+		Bindings:   settingsCloseBindings(),
+	}
+}
+
+func (c *settingsCommand) projectTrustEntries(ctx settingsProjectContext) []intpickercompat.Entry {
+	entries := []intpickercompat.Entry{settingsBackEntry()}
+	if !ctx.hasProject() {
+		return append(entries, intpickercompat.Entry{
+			Label: settingsLabelDim("Trust", "disabled - no project context"),
+			Value: settingsNoopValue,
+		})
+	}
+
+	configPath := settingsProjectConfigPath(ctx)
+	entries = append(entries,
+		intpickercompat.Entry{
+			Label: settingsLabelInfo("Project context", ctx.Path, ctx.Source),
+			Value: settingsNoopValue,
+		},
+		intpickercompat.Entry{
+			Label: settingsLabelInfo("Project config", configPath, "trust target"),
+			Value: settingsNoopValue,
+		},
+	)
+
+	report, err := c.inspectProjectTrust(ctx)
+	if err != nil {
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabelDim("Trust state error", err.Error()),
+			Value: settingsNoopValue,
+		})
+		return entries
+	}
+
+	glyph, color, summary := trustBadgeAppearance(report.State)
+	entries = append(entries, intpickercompat.Entry{
+		Label: settingsLabel(glyph, color, "State", summary),
+		Value: settingsNoopValue,
+	})
+
+	if report.StoredHash != "" {
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabelInfo("Stored hash", report.StoredHash, "trust-store"),
+			Value: settingsNoopValue,
+		})
+	}
+	if report.CurrentHash != "" {
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabelInfo("Current hash", report.CurrentHash, "on-disk"),
+			Value: settingsNoopValue,
+		})
+	}
+
+	switch report.State {
+	case hooks.ProjectConfigTrustUntrusted:
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabel(settingsGlyphAdd, settingsColorAdd, "Trust this config", "record current hash"),
+			Value: settingsTrustApply,
+		})
+	case hooks.ProjectConfigTrustStale:
+		entries = append(entries,
+			intpickercompat.Entry{
+				Label: settingsLabel(settingsGlyphType, settingsColorType, "Refresh trust", "rewrite stored hash to match current file"),
+				Value: settingsTrustRefresh,
+			},
+			intpickercompat.Entry{
+				Label: settingsLabel(settingsGlyphRemove, settingsColorRemove, "Untrust", "remove trust-store entry"),
+				Value: settingsTrustUntrust,
+			},
+		)
+	case hooks.ProjectConfigTrustTrusted:
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabel(settingsGlyphRemove, settingsColorRemove, "Untrust", "remove trust-store entry"),
+			Value: settingsTrustUntrust,
+		})
+	case hooks.ProjectConfigTrustAbsent:
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabelDim("No actions", "create "+filepath.Base(configPath)+" first via config.toml row"),
+			Value: settingsNoopValue,
+		})
+	}
+	return entries
+}
+
+func (c *settingsCommand) runProjectTrustApply(ctx settingsProjectContext, stdout, stderr io.Writer) error {
+	if !ctx.hasProject() {
+		return errors.New("trust requires a project context")
+	}
+	trustPath, err := c.projectConfigTrustStorePath()
+	if err != nil {
+		return err
+	}
+	sum, err := hooks.TrustProjectConfig(ctx.Path, trustPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "trust failed: %v\n", err)
+		return nil
+	}
+	configPath := settingsProjectConfigPath(ctx)
+	_, _ = fmt.Fprintf(stdout, "trusted %s\n", configPath)
+	_, _ = fmt.Fprintf(stdout, "sha256 %s\n", sum)
+	return nil
+}
+
+func (c *settingsCommand) runProjectTrustUntrust(ctx settingsProjectContext, stdout, stderr io.Writer) error {
+	if !ctx.hasProject() {
+		return errors.New("untrust requires a project context")
+	}
+	trustPath, err := c.projectConfigTrustStorePath()
+	if err != nil {
+		return err
+	}
+	if err := hooks.UntrustProjectConfig(ctx.Path, trustPath); err != nil {
+		fmt.Fprintf(stderr, "untrust failed: %v\n", err)
+		return nil
+	}
+	configPath := settingsProjectConfigPath(ctx)
+	_, _ = fmt.Fprintf(stdout, "untrusted %s\n", configPath)
+	return nil
+}
+
+// confirmProjectTrustUntrust shows a dedicated Yes/No picker so an
+// accidental Enter on the destructive Untrust row does not silently
+// invalidate the trust-store entry. Cancel (Esc/close) is treated the
+// same as No so the popup-toggle invariant is preserved.
+func (c *settingsCommand) confirmProjectTrustUntrust(ctx settingsProjectContext) (bool, error) {
+	configPath := settingsProjectConfigPath(ctx)
+	options := intpickercompat.Options{
+		UI: "settings-project-trust-confirm",
+		Entries: []intpickercompat.Entry{
+			{
+				Label: settingsLabelInfo("Untrust", configPath, "destructive"),
+				Value: settingsNoopValue,
+			},
+			{
+				Label: settingsLabel(settingsGlyphBack, settingsColorBack, "Cancel", "keep current trust"),
+				Value: settingsTrustConfirmNo,
+			},
+			{
+				Label: settingsLabel(settingsGlyphRemove, settingsColorRemove, "Yes, untrust", "remove trust-store entry"),
+				Value: settingsTrustConfirmYes,
+			},
+		},
+		Title:      "Untrust project config - confirm",
+		Prompt:     "Settings > Project > Trust > Untrust > ",
+		Footer:     projmuxFooter("Enter: confirm  |  Esc/Alt+5/Ctrl+Alt+S: cancel"),
+		ExpectKeys: []string{"enter"},
+		Bindings:   settingsCloseBindings(),
+	}
+	result, err := c.runPicker(options)
+	if err != nil {
+		if errors.Is(err, errSettingsClosed) {
+			return false, nil
+		}
+		return false, err
+	}
+	value := strings.TrimSpace(result.Value)
+	if result.Key != "enter" || value == "" {
+		return false, nil
+	}
+	return value == settingsTrustConfirmYes, nil
+}
+
+// Trust subsection action values. Each one lives in the trust: prefix
+// namespace so settingsEntryMetaForValue can resolve their telemetry meta
+// through the catalog rather than hard-coding a per-row entry.
+const (
+	settingsTrustApply      = "trust:apply"
+	settingsTrustRefresh    = "trust:refresh"
+	settingsTrustUntrust    = "trust:untrust"
+	settingsTrustConfirmYes = "trust:confirm-yes"
+	settingsTrustConfirmNo  = "trust:confirm-no"
+)

--- a/internal/app/trust_test.go
+++ b/internal/app/trust_test.go
@@ -1,0 +1,495 @@
+package app
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/integrations/hooks"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
+)
+
+// TestProjectTrustEntryAbsentWhenConfigMissing confirms the Trust row on
+// the Project tab reports the absent state (no config.toml on disk) and
+// still routes Enter into the Trust subsection so the user can read the
+// hint instead of losing it on a no-op row.
+func TestProjectTrustEntryAbsentWhenConfigMissing(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := t.TempDir()
+	stateHome := t.TempDir()
+	repo := t.TempDir()
+
+	cmd := trustTestSettings(t, home, configHome, stateHome, repo, nil)
+	entry := cmd.projectTrustEntry(cmd.resolveSettingsProjectContext())
+
+	if entry.Value != settingsSectionProjectTrust {
+		t.Fatalf("entry.Value = %q, want %q", entry.Value, settingsSectionProjectTrust)
+	}
+	if !strings.Contains(entry.Label, "Trust") || !strings.Contains(entry.Label, "no .projmux/config.toml") {
+		t.Fatalf("entry.Label = %q, want absent summary", entry.Label)
+	}
+}
+
+// TestProjectTrustEntryUntrustedAfterCreatingConfig verifies the badge
+// flips to "untrusted" tone once a config.toml is on disk but no trust
+// store entry exists yet.
+func TestProjectTrustEntryUntrustedAfterCreatingConfig(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := t.TempDir()
+	stateHome := t.TempDir()
+	repo := t.TempDir()
+	mkdirAll(t, filepath.Join(repo, ".projmux"))
+	writeFile(t, filepath.Join(repo, ".projmux", "config.toml"), `
+[startup]
+run = "echo ready"
+`)
+
+	cmd := trustTestSettings(t, home, configHome, stateHome, repo, nil)
+	entry := cmd.projectTrustEntry(cmd.resolveSettingsProjectContext())
+
+	if !strings.Contains(entry.Label, "untrusted") || !strings.Contains(entry.Label, "registration required") {
+		t.Fatalf("entry.Label = %q, want untrusted summary", entry.Label)
+	}
+	// Red tone for untrusted so users notice the registration gap.
+	if !strings.Contains(entry.Label, settingsColorRemove) {
+		t.Fatalf("entry.Label = %q, want red tone (%q) for untrusted", entry.Label, settingsColorRemove)
+	}
+}
+
+// TestProjectTrustEntryTrustedAfterTrust verifies the badge picks up
+// the bold/active tone and "hash matches" summary once the trust store
+// records the config hash.
+func TestProjectTrustEntryTrustedAfterTrust(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := t.TempDir()
+	stateHome := t.TempDir()
+	repo := t.TempDir()
+	mkdirAll(t, filepath.Join(repo, ".projmux"))
+	writeFile(t, filepath.Join(repo, ".projmux", "config.toml"), `
+[startup]
+run = "echo ready"
+`)
+	cmd := trustTestSettings(t, home, configHome, stateHome, repo, nil)
+
+	trustPath, err := cmd.projectConfigTrustStorePath()
+	if err != nil {
+		t.Fatalf("projectConfigTrustStorePath: %v", err)
+	}
+	if _, err := hooks.TrustProjectConfig(repo, trustPath); err != nil {
+		t.Fatalf("TrustProjectConfig: %v", err)
+	}
+
+	entry := cmd.projectTrustEntry(cmd.resolveSettingsProjectContext())
+	if !strings.Contains(entry.Label, "trusted") || !strings.Contains(entry.Label, "hash matches") {
+		t.Fatalf("entry.Label = %q, want trusted summary", entry.Label)
+	}
+	if !strings.Contains(entry.Label, settingsColorActive) {
+		t.Fatalf("entry.Label = %q, want active tone (%q) for trusted", entry.Label, settingsColorActive)
+	}
+}
+
+// TestProjectTrustEntryStaleAfterEdit verifies the badge moves to a
+// warning amber tone once the on-disk config hash diverges from the
+// stored hash.
+func TestProjectTrustEntryStaleAfterEdit(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := t.TempDir()
+	stateHome := t.TempDir()
+	repo := t.TempDir()
+	mkdirAll(t, filepath.Join(repo, ".projmux"))
+	writeFile(t, filepath.Join(repo, ".projmux", "config.toml"), `
+[startup]
+run = "echo ready"
+`)
+	cmd := trustTestSettings(t, home, configHome, stateHome, repo, nil)
+	trustPath, err := cmd.projectConfigTrustStorePath()
+	if err != nil {
+		t.Fatalf("projectConfigTrustStorePath: %v", err)
+	}
+	if _, err := hooks.TrustProjectConfig(repo, trustPath); err != nil {
+		t.Fatalf("TrustProjectConfig: %v", err)
+	}
+
+	// Mutate the on-disk config so its hash diverges from the stored one.
+	writeFile(t, filepath.Join(repo, ".projmux", "config.toml"), `
+[startup]
+run = "echo updated"
+`)
+
+	entry := cmd.projectTrustEntry(cmd.resolveSettingsProjectContext())
+	if !strings.Contains(entry.Label, "stale") || !strings.Contains(entry.Label, "file changed") {
+		t.Fatalf("entry.Label = %q, want stale summary", entry.Label)
+	}
+	if !strings.Contains(entry.Label, settingsColorTrustStale) {
+		t.Fatalf("entry.Label = %q, want stale tone (%q)", entry.Label, settingsColorTrustStale)
+	}
+}
+
+// TestProjectTrustEntriesShowActionsForEachState verifies the picker
+// rows on the Trust subsection match the current state: untrusted → Trust
+// row, stale → Refresh + Untrust rows, trusted → Untrust row, absent →
+// no actionable row.
+func TestProjectTrustEntriesShowActionsForEachState(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		setup      func(t *testing.T, repo string, cmd *settingsCommand)
+		wantValues []string
+		wantAbsent []string
+	}{
+		{
+			name:       "absent",
+			setup:      func(t *testing.T, repo string, cmd *settingsCommand) {},
+			wantValues: nil,
+			wantAbsent: []string{settingsTrustApply, settingsTrustRefresh, settingsTrustUntrust},
+		},
+		{
+			name: "untrusted",
+			setup: func(t *testing.T, repo string, cmd *settingsCommand) {
+				mkdirAll(t, filepath.Join(repo, ".projmux"))
+				writeFile(t, filepath.Join(repo, ".projmux", "config.toml"), `
+[startup]
+run = "echo ready"
+`)
+			},
+			wantValues: []string{settingsTrustApply},
+			wantAbsent: []string{settingsTrustRefresh, settingsTrustUntrust},
+		},
+		{
+			name: "trusted",
+			setup: func(t *testing.T, repo string, cmd *settingsCommand) {
+				mkdirAll(t, filepath.Join(repo, ".projmux"))
+				writeFile(t, filepath.Join(repo, ".projmux", "config.toml"), `
+[startup]
+run = "echo ready"
+`)
+				trustPath, err := cmd.projectConfigTrustStorePath()
+				if err != nil {
+					t.Fatalf("projectConfigTrustStorePath: %v", err)
+				}
+				if _, err := hooks.TrustProjectConfig(repo, trustPath); err != nil {
+					t.Fatalf("TrustProjectConfig: %v", err)
+				}
+			},
+			wantValues: []string{settingsTrustUntrust},
+			wantAbsent: []string{settingsTrustApply, settingsTrustRefresh},
+		},
+		{
+			name: "stale",
+			setup: func(t *testing.T, repo string, cmd *settingsCommand) {
+				mkdirAll(t, filepath.Join(repo, ".projmux"))
+				writeFile(t, filepath.Join(repo, ".projmux", "config.toml"), `
+[startup]
+run = "echo ready"
+`)
+				trustPath, err := cmd.projectConfigTrustStorePath()
+				if err != nil {
+					t.Fatalf("projectConfigTrustStorePath: %v", err)
+				}
+				if _, err := hooks.TrustProjectConfig(repo, trustPath); err != nil {
+					t.Fatalf("TrustProjectConfig: %v", err)
+				}
+				writeFile(t, filepath.Join(repo, ".projmux", "config.toml"), `
+[startup]
+run = "echo updated"
+`)
+			},
+			wantValues: []string{settingsTrustRefresh, settingsTrustUntrust},
+			wantAbsent: []string{settingsTrustApply},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			home := t.TempDir()
+			configHome := t.TempDir()
+			stateHome := t.TempDir()
+			repo := t.TempDir()
+			cmd := trustTestSettings(t, home, configHome, stateHome, repo, nil)
+			tc.setup(t, repo, cmd)
+
+			entries := cmd.projectTrustEntries(cmd.resolveSettingsProjectContext())
+			if !hasEntryValue(entries, settingsBackValue) {
+				t.Fatalf("entries missing Back row: %#v", entries)
+			}
+			for _, value := range tc.wantValues {
+				if !hasEntryValue(entries, value) {
+					t.Fatalf("entries missing expected action %q: %#v", value, entries)
+				}
+			}
+			for _, value := range tc.wantAbsent {
+				if hasEntryValue(entries, value) {
+					t.Fatalf("entries should not include %q for state %s: %#v", value, tc.name, entries)
+				}
+			}
+		})
+	}
+}
+
+// TestGlobalTabExcludesTrust enforces the spec exemption: the Trust
+// surface only exists on the Project tab — the Global tab must not
+// surface it (trust policy is project-scoped).
+func TestGlobalTabExcludesTrust(t *testing.T) {
+	t.Parallel()
+
+	cmd := &settingsCommand{lookupEnv: func(string) string { return "" }}
+	entries := cmd.rootEntriesForAxis(settingsAxisGlobal)
+	for _, entry := range entries {
+		if strings.Contains(stripAnsi(entry.Label), "Trust") {
+			t.Fatalf("global tab leaked Trust row: %q", entry.Label)
+		}
+		if entry.Value == settingsSectionProjectTrust {
+			t.Fatalf("global tab leaked Trust section value")
+		}
+	}
+}
+
+// TestRunSectionDispatchesProjectTrust verifies the new section value is
+// wired through runSection — guards against the dispatch table drifting
+// from the catalog.
+func TestRunSectionDispatchesProjectTrust(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := t.TempDir()
+	stateHome := t.TempDir()
+	repo := t.TempDir()
+
+	var calls int
+	runner := switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
+		calls++
+		if calls == 1 {
+			if got, want := options.UI, "settings-project-trust"; got != want {
+				t.Fatalf("first picker UI = %q, want %q", got, want)
+			}
+		}
+		return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+	})
+
+	cmd := trustTestSettings(t, home, configHome, stateHome, repo, runner)
+	var stdout, stderr bytes.Buffer
+	if err := cmd.runSection(settingsSectionProjectTrust, &stdout, &stderr); err != nil {
+		t.Fatalf("runSection: %v", err)
+	}
+	if calls < 1 {
+		t.Fatalf("runSection did not invoke picker (calls = %d)", calls)
+	}
+}
+
+// TestProjectTrustApplyWritesTrustStore drives the trust:apply action
+// through the subsection runner and confirms a fresh trust-store entry
+// is written. It exercises the same code path the user invokes when they
+// press Enter on the "Trust this config" row.
+func TestProjectTrustApplyWritesTrustStore(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := t.TempDir()
+	stateHome := t.TempDir()
+	repo := t.TempDir()
+	mkdirAll(t, filepath.Join(repo, ".projmux"))
+	writeFile(t, filepath.Join(repo, ".projmux", "config.toml"), `
+[startup]
+run = "echo ready"
+`)
+
+	var calls int
+	runner := switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
+		calls++
+		switch calls {
+		case 1:
+			return intpickercompat.Result{Key: "enter", Value: settingsTrustApply}, nil
+		case 2:
+			// After applying, the page should rerender and surface the
+			// trusted state — Back out so the loop terminates.
+			if !hasEntryLabelContaining(options.Entries, "trusted") {
+				t.Fatalf("refreshed entries missing trusted state: %#v", options.Entries)
+			}
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		default:
+			t.Fatalf("unexpected runner call %d", calls)
+			return intpickercompat.Result{}, nil
+		}
+	})
+
+	cmd := trustTestSettings(t, home, configHome, stateHome, repo, runner)
+	var stdout, stderr bytes.Buffer
+	if err := cmd.runProjectTrustSection(&stdout, &stderr); err != nil {
+		t.Fatalf("runProjectTrustSection: %v", err)
+	}
+
+	trustStorePath := filepath.Join(stateHome, "projmux", "trusted-projects.json")
+	contents, err := os.ReadFile(trustStorePath)
+	if err != nil {
+		t.Fatalf("trust store not written: %v", err)
+	}
+	if !strings.Contains(string(contents), ".projmux/config.toml") {
+		t.Fatalf("trust store = %s, want config.toml entry", contents)
+	}
+}
+
+// TestProjectTrustUntrustRequiresConfirmation confirms the destructive
+// Untrust row goes through a Yes/No confirmation page — a single Enter
+// on the Untrust row plus a Cancel must NOT mutate the trust store.
+func TestProjectTrustUntrustRequiresConfirmation(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := t.TempDir()
+	stateHome := t.TempDir()
+	repo := t.TempDir()
+	mkdirAll(t, filepath.Join(repo, ".projmux"))
+	writeFile(t, filepath.Join(repo, ".projmux", "config.toml"), `
+[startup]
+run = "echo ready"
+`)
+
+	// Pre-trust so the page surfaces an Untrust row.
+	tmpCmd := trustTestSettings(t, home, configHome, stateHome, repo, nil)
+	trustPath, err := tmpCmd.projectConfigTrustStorePath()
+	if err != nil {
+		t.Fatalf("projectConfigTrustStorePath: %v", err)
+	}
+	if _, err := hooks.TrustProjectConfig(repo, trustPath); err != nil {
+		t.Fatalf("TrustProjectConfig: %v", err)
+	}
+	storeBefore, err := os.ReadFile(trustPath)
+	if err != nil {
+		t.Fatalf("read trust store before: %v", err)
+	}
+
+	var calls int
+	runner := switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
+		calls++
+		switch calls {
+		case 1:
+			return intpickercompat.Result{Key: "enter", Value: settingsTrustUntrust}, nil
+		case 2:
+			// Confirmation page — pick Cancel.
+			if got, want := options.UI, "settings-project-trust-confirm"; got != want {
+				t.Fatalf("confirmation UI = %q, want %q", got, want)
+			}
+			return intpickercompat.Result{Key: "enter", Value: settingsTrustConfirmNo}, nil
+		case 3:
+			// Back to the page — exit.
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		default:
+			t.Fatalf("unexpected runner call %d", calls)
+			return intpickercompat.Result{}, nil
+		}
+	})
+
+	cmd := trustTestSettings(t, home, configHome, stateHome, repo, runner)
+	var stdout, stderr bytes.Buffer
+	if err := cmd.runProjectTrustSection(&stdout, &stderr); err != nil {
+		t.Fatalf("runProjectTrustSection: %v", err)
+	}
+
+	storeAfter, err := os.ReadFile(trustPath)
+	if err != nil {
+		t.Fatalf("read trust store after: %v", err)
+	}
+	if string(storeBefore) != string(storeAfter) {
+		t.Fatalf("trust store mutated after Cancel\nbefore=%s\nafter=%s", storeBefore, storeAfter)
+	}
+}
+
+// TestProjectTrustUntrustConfirmedRemovesEntry drives the Untrust flow
+// with a Yes confirmation and verifies the trust store entry is
+// removed.
+func TestProjectTrustUntrustConfirmedRemovesEntry(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	configHome := t.TempDir()
+	stateHome := t.TempDir()
+	repo := t.TempDir()
+	mkdirAll(t, filepath.Join(repo, ".projmux"))
+	writeFile(t, filepath.Join(repo, ".projmux", "config.toml"), `
+[startup]
+run = "echo ready"
+`)
+
+	tmpCmd := trustTestSettings(t, home, configHome, stateHome, repo, nil)
+	trustPath, err := tmpCmd.projectConfigTrustStorePath()
+	if err != nil {
+		t.Fatalf("projectConfigTrustStorePath: %v", err)
+	}
+	if _, err := hooks.TrustProjectConfig(repo, trustPath); err != nil {
+		t.Fatalf("TrustProjectConfig: %v", err)
+	}
+
+	var calls int
+	runner := switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
+		calls++
+		switch calls {
+		case 1:
+			return intpickercompat.Result{Key: "enter", Value: settingsTrustUntrust}, nil
+		case 2:
+			return intpickercompat.Result{Key: "enter", Value: settingsTrustConfirmYes}, nil
+		case 3:
+			if !hasEntryLabelContaining(options.Entries, "untrusted") {
+				t.Fatalf("refreshed entries missing untrusted state: %#v", options.Entries)
+			}
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		default:
+			t.Fatalf("unexpected runner call %d", calls)
+			return intpickercompat.Result{}, nil
+		}
+	})
+
+	cmd := trustTestSettings(t, home, configHome, stateHome, repo, runner)
+	var stdout, stderr bytes.Buffer
+	if err := cmd.runProjectTrustSection(&stdout, &stderr); err != nil {
+		t.Fatalf("runProjectTrustSection: %v", err)
+	}
+
+	report, err := hooks.InspectProjectConfigTrust(repo, trustPath)
+	if err != nil {
+		t.Fatalf("InspectProjectConfigTrust: %v", err)
+	}
+	if report.State != hooks.ProjectConfigTrustUntrusted {
+		t.Fatalf("State = %q, want %q after Untrust confirmation", report.State, hooks.ProjectConfigTrustUntrusted)
+	}
+}
+
+// trustTestSettings builds a settingsCommand wired so it can drive the
+// Trust subsection using a scripted runner. Passing a nil runner returns
+// a command that is only valid for read-only entry-building helpers.
+func trustTestSettings(t *testing.T, home, configHome, stateHome, repo string, runner switchRunnerFunc) *settingsCommand {
+	t.Helper()
+	cmd := &settingsCommand{
+		homeDir: func() (string, error) { return home, nil },
+		lookupEnv: func(name string) string {
+			switch name {
+			case "PROJMUX_CWD":
+				return repo
+			case "XDG_CONFIG_HOME":
+				return configHome
+			case "XDG_STATE_HOME":
+				return stateHome
+			default:
+				return ""
+			}
+		},
+	}
+	if runner != nil {
+		cmd.runner = runner
+		cmd.nativePicker = nativePickerFromCompatRunner(runner)
+	}
+	return cmd
+}

--- a/internal/integrations/hooks/trust.go
+++ b/internal/integrations/hooks/trust.go
@@ -224,6 +224,135 @@ func TrustProjectConfig(repoPath, trustStorePath string) (string, error) {
 	return trustProjectFile(repoPath, projectConfigRelativePath, trustStorePath)
 }
 
+// ProjectConfigTrustState classifies the trust standing of a project's
+// .projmux/config.toml file relative to the trust store.
+type ProjectConfigTrustState string
+
+const (
+	// ProjectConfigTrustAbsent means the project does not have a
+	// .projmux/config.toml file on disk, so trust is moot.
+	ProjectConfigTrustAbsent ProjectConfigTrustState = "absent"
+	// ProjectConfigTrustUntrusted means a config.toml exists but the trust
+	// store has no entry for it (or the store could not be opened in a way
+	// that would let a stored hash exist).
+	ProjectConfigTrustUntrusted ProjectConfigTrustState = "untrusted"
+	// ProjectConfigTrustTrusted means the stored hash matches the current
+	// file contents — the runner will accept the config without prompting.
+	ProjectConfigTrustTrusted ProjectConfigTrustState = "trusted"
+	// ProjectConfigTrustStale means an entry exists but the on-disk file
+	// hash differs from the stored hash; the runner will prompt before
+	// running anything declared in the changed file.
+	ProjectConfigTrustStale ProjectConfigTrustState = "stale"
+)
+
+// ProjectConfigTrustReport bundles the trust verdict together with the
+// hashes a caller needs to render meaningful UI (e.g. previous-vs-current
+// in a Settings badge).
+type ProjectConfigTrustReport struct {
+	State       ProjectConfigTrustState
+	CurrentHash string
+	StoredHash  string
+}
+
+// InspectProjectConfigTrust reports whether the project-local
+// .projmux/config.toml file is registered in the trust store and whether
+// the recorded hash still matches the file on disk. It does not mutate
+// the trust store. The function is read-only on purpose so a UI surface
+// (Settings Project tab) can render a "Trust" badge without side effects.
+func InspectProjectConfigTrust(repoPath, trustStorePath string) (ProjectConfigTrustReport, error) {
+	repoPath = strings.TrimSpace(repoPath)
+	if repoPath == "" {
+		return ProjectConfigTrustReport{}, errors.New("repo path is required")
+	}
+	repo, err := filepath.Abs(repoPath)
+	if err != nil {
+		return ProjectConfigTrustReport{}, err
+	}
+	rel := projectConfigRelativePath
+	path := filepath.Join(repo, filepath.FromSlash(rel))
+
+	info, statErr := os.Stat(path)
+	if errors.Is(statErr, os.ErrNotExist) || (statErr == nil && info.IsDir()) {
+		return ProjectConfigTrustReport{State: ProjectConfigTrustAbsent}, nil
+	}
+	if statErr != nil {
+		return ProjectConfigTrustReport{}, statErr
+	}
+
+	currentHash, _, err := hashHookFile(path)
+	if err != nil {
+		return ProjectConfigTrustReport{}, err
+	}
+
+	storePath := strings.TrimSpace(trustStorePath)
+	if storePath == "" {
+		storePath = defaultTrustStorePath()
+	}
+	if storePath == "" {
+		// No trust store available — treat the config as untrusted so the
+		// caller surfaces a "register required" badge instead of silently
+		// claiming trust.
+		return ProjectConfigTrustReport{
+			State:       ProjectConfigTrustUntrusted,
+			CurrentHash: currentHash,
+		}, nil
+	}
+	store, err := loadTrustedProjects(storePath)
+	if err != nil {
+		return ProjectConfigTrustReport{}, err
+	}
+	stored, ok := store.trustedFile(repo, rel)
+	if !ok {
+		return ProjectConfigTrustReport{
+			State:       ProjectConfigTrustUntrusted,
+			CurrentHash: currentHash,
+		}, nil
+	}
+	if stored.SHA256 == currentHash {
+		return ProjectConfigTrustReport{
+			State:       ProjectConfigTrustTrusted,
+			CurrentHash: currentHash,
+			StoredHash:  stored.SHA256,
+		}, nil
+	}
+	return ProjectConfigTrustReport{
+		State:       ProjectConfigTrustStale,
+		CurrentHash: currentHash,
+		StoredHash:  stored.SHA256,
+	}, nil
+}
+
+// UntrustProjectConfig removes the trust store entry for the project's
+// .projmux/config.toml file. If the trust store does not exist, or the
+// entry is already absent, the call is a no-op and returns nil so a UI
+// surface can render an idempotent "untrust" action.
+func UntrustProjectConfig(repoPath, trustStorePath string) error {
+	repoPath = strings.TrimSpace(repoPath)
+	if repoPath == "" {
+		return errors.New("repo path is required")
+	}
+	repo, err := filepath.Abs(repoPath)
+	if err != nil {
+		return err
+	}
+	rel := projectConfigRelativePath
+	storePath := strings.TrimSpace(trustStorePath)
+	if storePath == "" {
+		storePath = defaultTrustStorePath()
+	}
+	if storePath == "" {
+		return errors.New("trust store path could not be resolved")
+	}
+	store, err := loadTrustedProjects(storePath)
+	if err != nil {
+		return err
+	}
+	if !store.forget(repo, rel) {
+		return nil
+	}
+	return store.save(storePath)
+}
+
 func loadTrustedProjects(path string) (trustedProjects, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -292,6 +421,27 @@ func (s trustedProjects) previousHash(repo, rel string) string {
 		return ""
 	}
 	return file.SHA256
+}
+
+// forget removes the (repo, rel) entry from the trust store and reports
+// whether anything was actually removed. The project entry itself is
+// dropped when its last file is forgotten so save() doesn't leak empty
+// project keys into the on-disk JSON.
+func (s trustedProjects) forget(repo, rel string) bool {
+	project, ok := s[repo]
+	if !ok || project.Files == nil {
+		return false
+	}
+	if _, ok := project.Files[rel]; !ok {
+		return false
+	}
+	delete(project.Files, rel)
+	if len(project.Files) == 0 {
+		delete(s, repo)
+		return true
+	}
+	s[repo] = project
+	return true
 }
 
 func (s trustedProjects) trust(repo, rel, sum string, at time.Time) {

--- a/internal/integrations/hooks/trust_test.go
+++ b/internal/integrations/hooks/trust_test.go
@@ -1,0 +1,189 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInspectProjectConfigTrustReportsAbsentWithoutConfig(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	trustPath := testTrustStorePath(t)
+
+	report, err := InspectProjectConfigTrust(cwd, trustPath)
+	if err != nil {
+		t.Fatalf("InspectProjectConfigTrust() error = %v", err)
+	}
+	if report.State != ProjectConfigTrustAbsent {
+		t.Fatalf("State = %q, want %q", report.State, ProjectConfigTrustAbsent)
+	}
+	if report.CurrentHash != "" || report.StoredHash != "" {
+		t.Fatalf("hashes should be empty for absent config, got %+v", report)
+	}
+}
+
+func TestInspectProjectConfigTrustReportsUntrustedWithFreshConfig(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	writeProjectConfig(t, cwd, `
+[startup]
+run = "echo ready"
+`)
+	trustPath := testTrustStorePath(t)
+
+	report, err := InspectProjectConfigTrust(cwd, trustPath)
+	if err != nil {
+		t.Fatalf("InspectProjectConfigTrust() error = %v", err)
+	}
+	if report.State != ProjectConfigTrustUntrusted {
+		t.Fatalf("State = %q, want %q", report.State, ProjectConfigTrustUntrusted)
+	}
+	if report.CurrentHash == "" {
+		t.Fatalf("CurrentHash should be populated, got empty")
+	}
+	if report.StoredHash != "" {
+		t.Fatalf("StoredHash should be empty before trust, got %q", report.StoredHash)
+	}
+}
+
+func TestInspectProjectConfigTrustReportsTrustedAfterTrust(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	writeProjectConfig(t, cwd, `
+[startup]
+run = "echo ready"
+`)
+	trustPath := testTrustStorePath(t)
+
+	sum, err := TrustProjectConfig(cwd, trustPath)
+	if err != nil {
+		t.Fatalf("TrustProjectConfig() error = %v", err)
+	}
+	report, err := InspectProjectConfigTrust(cwd, trustPath)
+	if err != nil {
+		t.Fatalf("InspectProjectConfigTrust() error = %v", err)
+	}
+	if report.State != ProjectConfigTrustTrusted {
+		t.Fatalf("State = %q, want %q", report.State, ProjectConfigTrustTrusted)
+	}
+	if report.CurrentHash != sum || report.StoredHash != sum {
+		t.Fatalf("hashes = %+v, want both %q", report, sum)
+	}
+}
+
+func TestInspectProjectConfigTrustReportsStaleAfterChange(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	writeProjectConfig(t, cwd, `
+[startup]
+run = "echo ready"
+`)
+	trustPath := testTrustStorePath(t)
+
+	if _, err := TrustProjectConfig(cwd, trustPath); err != nil {
+		t.Fatalf("TrustProjectConfig() error = %v", err)
+	}
+
+	// Mutate the on-disk config so its hash diverges from the stored hash.
+	writeProjectConfig(t, cwd, `
+[startup]
+run = "echo updated"
+`)
+
+	report, err := InspectProjectConfigTrust(cwd, trustPath)
+	if err != nil {
+		t.Fatalf("InspectProjectConfigTrust() error = %v", err)
+	}
+	if report.State != ProjectConfigTrustStale {
+		t.Fatalf("State = %q, want %q", report.State, ProjectConfigTrustStale)
+	}
+	if report.CurrentHash == "" || report.StoredHash == "" {
+		t.Fatalf("stale report should carry both hashes, got %+v", report)
+	}
+	if report.CurrentHash == report.StoredHash {
+		t.Fatalf("stale hashes should differ, got equal %q", report.CurrentHash)
+	}
+}
+
+func TestUntrustProjectConfigRemovesEntry(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	writeProjectConfig(t, cwd, `
+[startup]
+run = "echo ready"
+`)
+	trustPath := testTrustStorePath(t)
+
+	if _, err := TrustProjectConfig(cwd, trustPath); err != nil {
+		t.Fatalf("TrustProjectConfig() error = %v", err)
+	}
+	if err := UntrustProjectConfig(cwd, trustPath); err != nil {
+		t.Fatalf("UntrustProjectConfig() error = %v", err)
+	}
+	report, err := InspectProjectConfigTrust(cwd, trustPath)
+	if err != nil {
+		t.Fatalf("InspectProjectConfigTrust() error = %v", err)
+	}
+	if report.State != ProjectConfigTrustUntrusted {
+		t.Fatalf("State = %q, want %q", report.State, ProjectConfigTrustUntrusted)
+	}
+
+	// Calling untrust again is a no-op rather than an error so the UI can
+	// stay idempotent.
+	if err := UntrustProjectConfig(cwd, trustPath); err != nil {
+		t.Fatalf("idempotent UntrustProjectConfig() error = %v", err)
+	}
+}
+
+func TestUntrustProjectConfigDropsEmptyProjectEntry(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	writeProjectConfig(t, cwd, `
+[startup]
+run = "echo ready"
+`)
+	trustPath := testTrustStorePath(t)
+
+	if _, err := TrustProjectConfig(cwd, trustPath); err != nil {
+		t.Fatalf("TrustProjectConfig() error = %v", err)
+	}
+	if err := UntrustProjectConfig(cwd, trustPath); err != nil {
+		t.Fatalf("UntrustProjectConfig() error = %v", err)
+	}
+	store, err := loadTrustedProjects(trustPath)
+	if err != nil {
+		t.Fatalf("loadTrustedProjects() error = %v", err)
+	}
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	if _, ok := store[abs]; ok {
+		t.Fatalf("project entry should be removed when last file is forgotten, store = %+v", store)
+	}
+}
+
+func TestUntrustProjectConfigWithoutStoreIsNoop(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	writeProjectConfig(t, cwd, `
+[startup]
+run = "echo ready"
+`)
+	trustPath := filepath.Join(t.TempDir(), "missing-trusted-projects.json")
+
+	if err := UntrustProjectConfig(cwd, trustPath); err != nil {
+		t.Fatalf("UntrustProjectConfig() error = %v", err)
+	}
+	if _, err := os.Stat(trustPath); !os.IsNotExist(err) {
+		t.Fatalf("trust store should not have been created, stat err = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Settings Phase 4 — wire the project-config trust state into the Settings popup so users can see and manage the `.projmux/config.toml` hash without leaving the tab.

- **Trust badge location / tone** — first row of the Project tab. State-aware glyph + colour: bold/active for `trusted` (hash matches), amber for `stale` (file changed since trust), red for `untrusted` (no store entry yet), dim for `absent` (no `.projmux/config.toml` on disk). Read-only — never mutates anything when the page renders.
- **3 → 4 state machine** — `hooks.InspectProjectConfigTrust` returns `absent` / `untrusted` / `trusted` / `stale` together with current + stored hashes. Pure read; never touches the trust store.
- **Click branch** — Enter on the Trust row opens the new `section:project-trust` subsection. Its actionable rows depend on the state:
  - `untrusted` → *Trust this config* (record current hash).
  - `stale`     → *Refresh trust* (rewrite stored hash) + *Untrust*.
  - `trusted`   → *Untrust*.
  - `absent`    → no action row, just a hint to create config.toml from the existing config.toml page.
- **Untrust confirmation** — destructive *Untrust* goes through a dedicated Yes/No page (`settings-project-trust-confirm`) so a single Enter cannot silently invalidate trust. Cancel / close = No (popup-toggle invariant preserved).
- **Global tab exemption** — Trust only appears under `settingsAxisProject`, so `rootEntriesForAxis(Global)` never emits a Trust row. Verified by `TestGlobalTabExcludesTrust`.
- **Hook 2.6 hash-flow integration** — `saveProjectConfig` already calls `hooks.TrustProjectConfig` on every config.toml write, so editing kube / env / startup / hook rows keeps the trust hash fresh. The new Trust UI calls the same `TrustProjectConfig` for *Trust* / *Refresh*, and the new `hooks.UntrustProjectConfig` (also idempotent / no-op when the entry is absent) for *Untrust*. Trust model (#139) is **not** redefined — only read + forget helpers were added.
- **Rebase** — clean. Rebased onto `origin/main` past #165 (Hook 4 effective.go Hooks section); no conflicts in `internal/integrations/hooks/trust.go` since #165 only touched `effective.go`.

## Files

- `internal/integrations/hooks/trust.go` — adds `ProjectConfigTrustState` + `ProjectConfigTrustReport`, `InspectProjectConfigTrust` (read-only), `UntrustProjectConfig`, and `trustedProjects.forget` (drops empty project keys).
- `internal/integrations/hooks/trust_test.go` — new. Covers all four states, idempotent untrust, empty-project cleanup, no-op when store missing.
- `internal/app/trust.go` — new. Settings UI: `projectTrustEntry` for the Project tab badge, `trustBadgeAppearance` palette, `runProjectTrustSection` loop, `confirmProjectTrustUntrust` guard, and the action constants (`trust:apply`, `trust:refresh`, `trust:untrust`, `trust:confirm-yes`, `trust:confirm-no`).
- `internal/app/trust_test.go` — new. Asserts badge tone per state, action-row matrix, global-tab exemption, runSection dispatch, apply / cancel / confirm flows on the runner.
- `internal/app/settings.go` — registers `settingsSectionProjectTrust` + `settingsActionPrefixTrust` in the entry/prefix catalogs (both `settingsAxisProject`), routes the section in `runSection`, and replaces the Phase 1 placeholder Trust row with `c.projectTrustEntry(ctx)`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass, including new `internal/app` + `internal/integrations/hooks` trust tests)
- [ ] Manual: open Settings → Project tab on a repo with `.projmux/config.toml`, observe state-aware badge; edit config.toml externally → badge flips to stale; Refresh → bold/trusted; Untrust → confirm Yes → untrusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)