### PR TITLE
feat: drop redundant project context header and info rows

### DIFF
--- a/internal/app/effective_merge.go
+++ b/internal/app/effective_merge.go
@@ -63,11 +63,9 @@ func (c *settingsCommand) effectiveMergeEntries(ctx settingsProjectContext) []in
 	globalCfg, globalPath, globalErr := c.loadGlobalConfigForMerge()
 	projectCfg, projectPath, projectErr := c.loadProjectConfigForMerge(ctx)
 
+	// Phase 2.7: drop the redundant "Project context" info row — the
+	// frame title chip strip already conveys the active project scope.
 	entries = append(entries,
-		intpickercompat.Entry{
-			Label: settingsLabelInfo("Project context", ctx.Path, ctx.Source),
-			Value: settingsNoopValue,
-		},
 		intpickercompat.Entry{
 			Label: settingsLabelInfo("Global config", globalPath, sourceFileState(globalCfg, globalErr, globalPath)),
 			Value: settingsNoopValue,

--- a/internal/app/effective_merge_test.go
+++ b/internal/app/effective_merge_test.go
@@ -30,6 +30,29 @@ func TestEffectiveMergeEntriesDisabledWithoutProject(t *testing.T) {
 	}
 }
 
+// TestEffectiveMergeEntriesOmitsProjectContextRow is a Phase 2.7 regression
+// guard: the redundant "Project context" info row that lived above the
+// Global/Project config rows is removed because the frame title chip
+// strip (Phase 2.5) already announces the active scope.
+func TestEffectiveMergeEntriesOmitsProjectContextRow(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	project := filepath.Join(home, "repo")
+	mustMkdirAll(t, filepath.Join(project, ".projmux"))
+
+	cmd := &settingsCommand{
+		homeDir:   func() (string, error) { return home, nil },
+		lookupEnv: func(string) string { return "" },
+	}
+	ctx := newSettingsProjectContext(project, "test")
+	entries := cmd.effectiveMergeEntries(ctx)
+
+	if hasEntryLabelContaining(entries, "Project context") {
+		t.Fatalf("effective merge entries = %#v, want no \"Project context\" info row", entries)
+	}
+}
+
 // TestEffectiveMergeEntriesShowSourceLabels verifies the spec requirement:
 // each merged row carries one of the four source labels (project / global /
 // merged / default), and the project-wins policy applies on conflict.

--- a/internal/app/hookmaker.go
+++ b/internal/app/hookmaker.go
@@ -99,22 +99,16 @@ func (c *settingsCommand) globalHookEntries() []intpickercompat.Entry {
 func (c *settingsCommand) projectHookEntries(ctx settingsProjectContext) []intpickercompat.Entry {
 	entries := []intpickercompat.Entry{settingsBackEntry()}
 	if !ctx.hasProject() {
-		return append(entries,
-			intpickercompat.Entry{
-				Label: settingsLabelDim("Project context", "no project - open Settings from a project pane or set PROJMUX_CWD"),
-				Value: settingsNoopValue,
-			},
-			intpickercompat.Entry{
-				Label: settingsLabelDim("Hooks (project)", "disabled - no project context"),
-				Value: settingsNoopValue,
-			},
-		)
+		// Phase 2.7: the frame title chip strip already announces the
+		// active scope, so drop the redundant "Project context" row.
+		return append(entries, intpickercompat.Entry{
+			Label: settingsLabelDim("Hooks (project)", "disabled - no project context"),
+			Value: settingsNoopValue,
+		})
 	}
 
-	entries = append(entries, intpickercompat.Entry{
-		Label: settingsLabelInfo("Project context", ctx.Path, ctx.Source),
-		Value: settingsNoopValue,
-	})
+	// Phase 2.7: drop the "Project context" info row — chip strip is the
+	// source of truth.
 
 	configPath := filepath.Join(ctx.Path, ".projmux", "config.toml")
 	cfg, _ := loadProjectConfigForRead(configPath)
@@ -677,16 +671,12 @@ func (c *settingsCommand) projectConfigEntries(ctx settingsProjectContext) []int
 		})
 	}
 	path := settingsProjectConfigPath(ctx)
-	entries = append(entries,
-		intpickercompat.Entry{
-			Label: settingsLabelInfo("Project context", ctx.Path, ctx.Source),
-			Value: settingsNoopValue,
-		},
-		intpickercompat.Entry{
-			Label: settingsLabelInfo("Path", path, settingsProjectConfigState(path)),
-			Value: settingsNoopValue,
-		},
-	)
+	// Phase 2.7: drop the redundant "Project context" info row — the
+	// frame title chip strip already announces the active scope.
+	entries = append(entries, intpickercompat.Entry{
+		Label: settingsLabelInfo("Path", path, settingsProjectConfigState(path)),
+		Value: settingsNoopValue,
+	})
 	cfg, err := c.loadProjectConfigForEdit(ctx)
 	if err != nil {
 		return append(entries, intpickercompat.Entry{

--- a/internal/app/hookmaker_test.go
+++ b/internal/app/hookmaker_test.go
@@ -93,6 +93,73 @@ func TestSettingsProjectHooksListNoProjectUsesDisabledState(t *testing.T) {
 	}
 }
 
+// TestSettingsProjectHooksListOmitsProjectContextRow is a Phase 2.7
+// regression guard: the Hooks (project) page used to render a "Project
+// context" info row both with and without a project. The frame title
+// chip strip (Phase 2.5) is now the source of truth, so the redundant
+// row is dropped on both branches.
+func TestSettingsProjectHooksListOmitsProjectContextRow(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no project", func(t *testing.T) {
+		cmd := &settingsCommand{lookupEnv: func(string) string { return "" }}
+		options, err := cmd.sectionOptions(settingsSectionProjectHooks)
+		if err != nil {
+			t.Fatalf("sectionOptions(project hooks) error = %v", err)
+		}
+		if hasEntryLabelContaining(options.Entries, "Project context") {
+			t.Fatalf("project hooks entries (no project) = %#v, want no \"Project context\" row", options.Entries)
+		}
+	})
+
+	t.Run("with project", func(t *testing.T) {
+		repo := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repo, ".projmux"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cmd := &settingsCommand{
+			lookupEnv: func(name string) string {
+				if name == "PROJMUX_CWD" {
+					return repo
+				}
+				return ""
+			},
+		}
+		options, err := cmd.sectionOptions(settingsSectionProjectHooks)
+		if err != nil {
+			t.Fatalf("sectionOptions(project hooks) error = %v", err)
+		}
+		if hasEntryLabelContaining(options.Entries, "Project context") {
+			t.Fatalf("project hooks entries (with project) = %#v, want no \"Project context\" info row", options.Entries)
+		}
+	})
+}
+
+// TestSettingsProjectConfigOmitsProjectContextRow is a Phase 2.7
+// regression guard for the config.toml subpage — same reasoning as the
+// Hooks page guard above.
+func TestSettingsProjectConfigOmitsProjectContextRow(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".projmux"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &settingsCommand{
+		lookupEnv: func(name string) string {
+			if name == "PROJMUX_CWD" {
+				return repo
+			}
+			return ""
+		},
+	}
+	ctx := cmd.resolveSettingsProjectContext()
+	entries := cmd.projectConfigEntries(ctx)
+	if hasEntryLabelContaining(entries, "Project context") {
+		t.Fatalf("project config entries = %#v, want no \"Project context\" info row", entries)
+	}
+}
+
 func TestSettingsProjectHooksListWithDeclarativeContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -334,14 +334,17 @@ func settingsRootTabChips(active settingsRootTab, hasProject bool) []projmuxpick
 	}
 }
 
+// settingsRootContextHeader returns the popup header text above the
+// search bar. Phase 2.5 ships the titlebar chip strip whose labels (and
+// the Project chip's disabled/active state) already announce the active
+// scope and whether a project context exists. The dedicated
+// "Project context: (...)" header line was redundant with that chip
+// metaphor, so Phase 2.7 drops it entirely and returns the empty string
+// — the chip strip is the source of truth.
 func settingsRootContextHeader(tab settingsRootTab, ctx settingsProjectContext) string {
-	if !ctx.hasProject() {
-		if tab == settingsRootTabProject {
-			return "Project context: (none) - open Settings from a project pane or set PROJMUX_CWD"
-		}
-		return "Project context: (none)"
-	}
-	return "Project context: (" + ctx.Name + ")"
+	_ = tab
+	_ = ctx
+	return ""
 }
 
 func settingsRootPrompt(tab settingsRootTab) string {

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -66,8 +66,12 @@ func TestSettingsRootOptionsDefaultGlobalTab(t *testing.T) {
 	if got, want := options.Title, "Settings"; got != want {
 		t.Fatalf("root settings title = %q, want %q", got, want)
 	}
-	if got, want := options.Header, "Project context: (none)"; got != want {
-		t.Fatalf("root settings header = %q, want plain project context header %q", got, want)
+	// Phase 2.7: the popup header is intentionally empty — the titlebar
+	// chip strip is the source of truth for the active scope, so the
+	// redundant "Project context: (...)" line above the search bar is
+	// dropped on every page.
+	if got := options.Header; got != "" {
+		t.Fatalf("root settings header = %q, want empty (chip strip is source of truth)", got)
 	}
 	wantChips := []projmuxpicker.Chip{
 		{Label: "Global", Active: true, ClickValue: settingsRootTabGlobalValue},
@@ -390,8 +394,11 @@ func TestSettingsProjectTabNoProjectShowsDisabledState(t *testing.T) {
 	cmd := &settingsCommand{lookupEnv: func(string) string { return "" }}
 	options := cmd.rootOptions(settingsRootTabProject)
 
-	if got, want := options.Header, "Project context: (none) - open Settings from a project pane or set PROJMUX_CWD"; got != want {
-		t.Fatalf("project tab header = %q, want %q", got, want)
+	// Phase 2.7: the dedicated "Project context: (none) - open
+	// Settings..." header line is dropped. The Project chip rendering
+	// (active + disabled) below already conveys the no-project state.
+	if got := options.Header; got != "" {
+		t.Fatalf("project tab header = %q, want empty (chip strip carries the no-project hint)", got)
 	}
 	if got := options.TitleChips; len(got) < 2 || got[0].Active || !got[1].Active || !got[1].Disabled {
 		t.Fatalf("project tab chips (no project) = %#v, want Project chip active+disabled", got)


### PR DESCRIPTION
## Summary

Phase 2.7 of the Settings scope split roadmap. Phase 2.5 (#161) shipped the frame title chip strip whose labels already announce the active Global/Project scope (with disabled state when no project context exists). The legacy `Project context: (...)` header above the search bar — plus the matching info rows on Effective merge view, Hooks (project), and config.toml subpages — duplicated that signal, so this PR removes them and lets the chip strip be the single source of truth.

User-validated request: "Settings Search 탭에 Project context: (projectname) 문구 이건 필요없으니까 날려줘"

## Removal sites

- `internal/app/settings.go` — `settingsRootContextHeader()` now returns the empty string on both Global/Project tabs, regardless of whether a project context is resolved.
- `internal/app/effective_merge.go` — drop the `Project context` info row above the `Global config` / `Project config` rows in `effectiveMergeEntries`.
- `internal/app/hookmaker.go` — drop the `Project context` rows in `projectHookEntries` (no-project branch + with-project branch) and in `projectConfigEntries`.

Design choice for the empty header: option (a) — the user simply wanted the redundant line gone, not replaced with a different hint. The chip strip already conveys both the active tab and the no-project disabled state, so leaving the header empty is the minimal change.

## Regression guards

- `internal/app/settings_test.go`: `TestSettingsRootOptions` and `TestSettingsProjectTabNoProjectShowsDisabledState` now assert `options.Header == ""` instead of the old `Project context: (...)` strings.
- `internal/app/effective_merge_test.go`: new `TestEffectiveMergeEntriesOmitsProjectContextRow` locks the merge view info row removal.
- `internal/app/hookmaker_test.go`: new `TestSettingsProjectHooksListOmitsProjectContextRow` (no-project + with-project subtests) and `TestSettingsProjectConfigOmitsProjectContextRow` lock the Hooks page and config.toml subpage removals.

## Out of scope

- The frame title chip strip (Phase 2.5) is unchanged — it remains the source of truth.
- `internal/app/trust.go:170` still renders a `Project context` info row; it was not in the spec's removal list for this phase and is left untouched.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all packages pass (`internal/app` includes the new regression guards)
- [x] `make fmt-check` clean
- [ ] Manual: open Settings popup from a project pane — confirm the area above the search bar is empty and the chip strip still shows `Project (projname)` as active.
- [ ] Manual: open Settings popup from a non-project shell (no `PROJMUX_CWD`) — confirm no header row, and the Project chip renders disabled.
- [ ] Manual: navigate to Effective merge view, Hooks (project), and config.toml subpages — confirm no `Project context: ...` info row above the actionable rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)