### PR TITLE
feat: align alt-shift-arrow chord with xterm standard (Settings 2.8)

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -284,11 +284,15 @@ action fires.
 | `ESC [ 9006 u` | `User5` | AI split picker |
 | `ESC [ 9007 u` | `User6` | Settings |
 | `ESC [ 9008 u` | `User7` | New tmux window in the current pane directory |
-| `ESC [ 9009 u` | `User8` | Previous tmux window |
-| `ESC [ 9010 u` | `User9` | Next tmux window |
 | `ESC [ 9011 u` | `User10` | Rename the current tmux window |
 | `ESC [ 9012 u` | `User11` | Rename the current tmux pane label |
 | `ESC [ 9013 u` | `User12` | Project switcher popup |
+
+> Previous/Next window (Alt-Shift-Left/Right) intentionally **do not** use a
+> CSI-u detour — both projmux and modern terminals already agree on the
+> xterm-standard modifier sequence (`\x1b[1;4D` / `\x1b[1;4C`), so tmux binds
+> directly to `M-S-Left` / `M-S-Right`. This keeps the popup-side chord
+> handler and the tmux root binding consuming the same sequence.
 
 ### Ghostty (manual)
 
@@ -312,9 +316,13 @@ keybind = ctrl+shift+l=csi:9002u
 keybind = ctrl+shift+n=csi:9008u
 keybind = ctrl+m=csi:9011u
 keybind = ctrl+shift+m=csi:9012u
-keybind = alt+shift+left=csi:9009u
-keybind = alt+shift+right=csi:9010u
 ```
+
+`Alt-Shift-Left` and `Alt-Shift-Right` are intentionally absent: Ghostty
+already emits the xterm-standard `\x1b[1;4D` / `\x1b[1;4C` sequences for
+those chords, which tmux now binds directly. Adding a `csi:9009u` /
+`csi:9010u` override would re-introduce the detour that hid the chord from
+projmux popup handlers.
 
 Reload Ghostty or restart the terminal after changing the config.
 

--- a/internal/app/keybinding_catalog.go
+++ b/internal/app/keybinding_catalog.go
@@ -328,48 +328,52 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			ProbePlain:     "\x0e",
 		},
 		{
+			// Phase 2.8: dropped UserSlot/CSIu (9009u) detour — tmux now
+			// listens directly for the xterm-standard `M-S-Left` chord that
+			// Ghostty and Windows Terminal emit out of the box. Keeping
+			// `WTInput` ensures Windows Terminal explicitly sends the same
+			// `\x1b[1;4D` sequence (it does not always forward modifier-arrow
+			// chords unless mapped). Ghostty drops the explicit keybind
+			// entirely because its default behaviour already emits the
+			// xterm sequence.
 			ID:             "previous-window",
 			Description:    "Previous tmux window",
 			Scope:          keyBindingScopeApp,
 			PlainChord:     "M-S-Left",
-			UserSlot:       8,
-			CSIu:           "9009",
+			UserSlot:       noUserSlot,
 			TmuxKind:       tmuxBindingCommand,
 			TmuxBody:       "previous-window",
 			PlainBindOrder: 60,
-			UserBindOrder:  20,
-			GhosttyTrigger: "alt+shift+left",
-			GhosttyOrder:   120,
 			WTID:           "User.projmuxPrevWindow",
 			WTKeys:         "alt+shift+left",
 			WTInput:        "\x1b[1;4D",
 			WTOrder:        100,
 			ProbeOrder:     120,
 			ProbeLabel:     "Alt-Shift-Left",
-			ProbeAction:    "Previous window (User8)",
+			ProbeAction:    "Previous window (M-S-Left)",
 			ProbePlain:     "\x1b[1;4D",
+			ProbeCSIu:      "-",
 		},
 		{
+			// See `previous-window` above — the same reasoning applies to the
+			// next-window chord (xterm sequence `\x1b[1;4C`).
 			ID:             "next-window",
 			Description:    "Next tmux window",
 			Scope:          keyBindingScopeApp,
 			PlainChord:     "M-S-Right",
-			UserSlot:       9,
-			CSIu:           "9010",
+			UserSlot:       noUserSlot,
 			TmuxKind:       tmuxBindingCommand,
 			TmuxBody:       "next-window",
 			PlainBindOrder: 70,
-			UserBindOrder:  30,
-			GhosttyTrigger: "alt+shift+right",
-			GhosttyOrder:   130,
 			WTID:           "User.projmuxNextWindow",
 			WTKeys:         "alt+shift+right",
 			WTInput:        "\x1b[1;4C",
 			WTOrder:        110,
 			ProbeOrder:     130,
 			ProbeLabel:     "Alt-Shift-Right",
-			ProbeAction:    "Next window (User9)",
+			ProbeAction:    "Next window (M-S-Right)",
 			ProbePlain:     "\x1b[1;4C",
+			ProbeCSIu:      "-",
 		},
 		{
 			ID:             "select-pane-left",

--- a/internal/app/shell_test.go
+++ b/internal/app/shell_test.go
@@ -61,8 +61,8 @@ func TestShellWritesAppConfigAndRunsIsolatedTmux(t *testing.T) {
 		"set -s user-keys[7] \"\\033[9008u\"",
 		"bind-key -n C-n new-window -c \"#{pane_current_path}\"",
 		"bind-key -n M-r command-prompt",
-		"bind-key -n User8 previous-window",
-		"bind-key -n User9 next-window",
+		"bind-key -n M-S-Left previous-window",
+		"bind-key -n M-S-Right next-window",
 		"bind-key -n User10 command-prompt",
 		"bind-key -n User11 command-prompt",
 		"set -g status-left-length 20",
@@ -87,6 +87,16 @@ func TestShellWritesAppConfigAndRunsIsolatedTmux(t *testing.T) {
 	for _, banned := range []string{
 		"set -g status 3",
 		"set -g status-format[2] \"",
+		// Phase 2.8 regression guard: alt-shift-arrow chords now bind to the
+		// xterm-standard `M-S-Left/Right` form. Their `User8`/`User9` detour
+		// is gone; if the generator regresses, popup-inside chords break in
+		// Ghostty (the original bug).
+		"set -s user-keys[8]",
+		"set -s user-keys[9]",
+		"\\033[9009u",
+		"\\033[9010u",
+		"bind-key -n User8",
+		"bind-key -n User9",
 	} {
 		if strings.Contains(config, banned) {
 			t.Fatalf("config = %q, did not expect substring %q", config, banned)

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -1226,8 +1226,6 @@ func TestTmuxPrintAppConfigUsesIsolatedAppSettings(t *testing.T) {
 		"#{@projmux_ai_topic}",
 		"#{pane_current_command},#{pane_title}",
 		"set -s user-keys[7] \"\\033[9008u\"",
-		"set -s user-keys[8] \"\\033[9009u\"",
-		"set -s user-keys[9] \"\\033[9010u\"",
 		"set -s user-keys[10] \"\\033[9011u\"",
 		"bind-key -n User11 command-prompt",
 		"select-pane -T '%1'",
@@ -1242,8 +1240,6 @@ func TestTmuxPrintAppConfigUsesIsolatedAppSettings(t *testing.T) {
 		"bind-key -n M-S-Right next-window",
 		"bind-key -n M-r command-prompt",
 		"bind-key -n User7 new-window -c \"#{pane_current_path}\"",
-		"bind-key -n User8 previous-window",
-		"bind-key -n User9 next-window",
 		"bind-key -n User10 command-prompt",
 		"bind-key R command-prompt",
 		"bind-key M if -F \"#{mouse}\"",
@@ -1271,6 +1267,17 @@ func TestTmuxPrintAppConfigUsesIsolatedAppSettings(t *testing.T) {
 	for _, banned := range []string{
 		"set -g status 3",
 		"set -g status-format[2] \"",
+		// Phase 2.8 regression guard: prev/next window must rely on the
+		// xterm-standard M-S-Left/Right chord — the legacy `User8`/`User9`
+		// detour and its `9009u`/`9010u` user-keys CSI form are gone so
+		// Ghostty (which emits the xterm sequence by default) can drive
+		// the popup chord through the same parser as the rest of the app.
+		"set -s user-keys[8]",
+		"set -s user-keys[9]",
+		"\\033[9009u",
+		"\\033[9010u",
+		"bind-key -n User8",
+		"bind-key -n User9",
 	} {
 		if strings.Contains(output, banned) {
 			t.Fatalf("print-app-config output = %q, did not expect substring %q", output, banned)


### PR DESCRIPTION
## 원인 chain

사용자 검증: Ghostty 환경에서 popup 내부 `Alt-Shift-Left/Right` 가 작동 안 함.

1. projmux 가 `~/.config/projmux/tmux.conf` 에서 `set -s user-keys[8] \"\033[9009u\"` / `user-keys[9] \"\033[9010u\"` 를 약속.
2. dotfiles 의 Ghostty `keybind = alt+shift+left=csi:9009u` 가 그 약속에 맞춰 시퀀스를 보냄. tmux **root** binding (`User8 previous-window` / `User9 next-window`) 은 정상 작동.
3. 그러나 projmux **popup** 의 `nativeKeyFromCSI` 는 xterm 표준 modifier form (`\x1b[1;4D` = alt-shift-left) 만 normalize. user-keys CSI form (`\x1b[9009u`) 은 `nativeKeyFromCSIu` 의 switch 에 없어 `esc` 로 떨어짐 → popup 내부에서 chord 가 안 잡힘.

요컨대 외부 단말 → tmux 까지는 OK 였지만, popup 진입 후엔 user-keys 우회가 vis 보이지 않아 chord 가 죽었다.

## 수정 방향: xterm 표준으로 통일

`previous-window` / `next-window` 두 chord 는 xterm 표준 modifier-arrow 시퀀스 (`\x1b[1;4D` / `\x1b[1;4C`) 가 이미 존재한다. user-keys 우회를 제거하면 모든 레이어 (Ghostty/WT → tmux root → popup parser) 가 동일한 xterm 표준 시퀀스를 본다.

### 변경 위치

- `internal/app/keybinding_catalog.go` — `previous-window` / `next-window` 엔트리에서 `UserSlot`/`CSIu`/`UserBindOrder` 제거. `PlainChord = M-S-Left/Right` 는 그대로. `WTInput = \x1b[1;4D/C` 도 그대로 (WT 가 xterm 표준 시퀀스를 명시적으로 보내도록).
  - `ghosttyBindingsFromCatalog` 는 `CSIu == \"\"` 면 skip → Ghostty managed 블록에서 `alt+shift+left/right` 줄이 자동으로 빠짐 (Ghostty 기본 동작이 xterm 시퀀스를 보냄).
  - `windowsTerminalBindingsFromCatalog` 는 `WTID != \"\"` 만 보므로 WT 바인딩은 유지.
  - `tmuxUserKeyLines` / `tmuxBindLines` 의 user-keys 분기는 `UserSlot == noUserSlot` 인 엔트리를 자동 제외.
- `internal/app/tmux.go` — 별도 수정 없음. catalog 변경이 자동 반영됨 (`tmuxUserKeyLines(appKeyBindings)` 가 `UserSlot != noUserSlot` 만 emit).

### `nativeKeyFromCSI` (popup parser)

변경 **없음**. Settings 2.6 (#163) 에서 이미 CSI modifier 4 → `alt-shift-<name>` 정규화를 추가해 둠. 외부 단말이 xterm 표준 시퀀스를 보내므로 popup parser 가 그대로 처리.

### 다른 user-keys 보존

`9001/9002` (Ctrl-Shift-R/L), `9007` (alt-5), `9008` (Ctrl-Shift-N), `9011` (Ctrl-M), `9012` (Ctrl-Shift-M), `9003-9006/9013` (alt-숫자) 는 그대로. 이들은 xterm 표준 시퀀스가 없거나 (Ctrl-Shift-letter 의 modifyOtherKeys) 단말 호환성 이슈가 있어 CSI-u 우회가 합리적.

## 회귀 가드

- `internal/app/tmux_test.go::TestTmuxPrintAppConfig` — substring 화이트리스트에서 `user-keys[8]/[9]` 와 `User8/User9` 줄 제거, banned 목록에 `\\033[9009u` / `\\033[9010u` / `bind-key -n User8/User9` 추가 (회귀 발생 시 즉시 실패).
- `internal/app/shell_test.go::TestShellAppConfig` — 동일하게 화이트리스트 갱신 + banned 가드 추가. `bind-key -n M-S-Left/M-S-Right previous/next-window` 가 emit 되는지 검증.
- 기존 `bind-key -n M-S-Left previous-window` / `M-S-Right next-window` substring 검증은 그대로 — Plain chord 만으로 tmux root binding 이 emit 되어야 한다는 사양 확인.
- Popup parser 의 `alt-shift-left/right` 회귀 (`internal/ui/picker/backend_test.go:1047-1050`) 는 손 안 댐 (이미 통과).

## dotfiles 후속 PR

dotfiles 의 Ghostty config 에 남아 있는

```
keybind = alt+shift+left=csi:9009u
keybind = alt+shift+right=csi:9010u
```

두 줄은 이 PR 이후 불필요. Ghostty 기본 동작이 `\x1b[1;4D/C` 를 보내므로 두 줄을 제거하면 됨. (별도 PR 로 진행.)

## 테스트

- `go build ./...` 통과.
- `go test ./...` 전체 패키지 통과 (app/picker 포함).
- `make fmt-check` 통과.

## Spec 차이 / 빠진 부분

없음. 사양 그대로 진행:

- tmux.go user-keys 제거 (catalog 기반이라 keybinding_catalog.go 한 곳 수정으로 반영)
- root binding 은 이미 `M-S-Left/Right` PlainChord 가 catalog 에 있어 자동 emit
- nativeKeyFromCSI 변경 없음 (modifier 4 분기 이미 존재)
- 다른 user-keys 보존
- docs/keybindings.md 의 CSI-u Map + Ghostty manual 블록도 정리 (9009/9010 줄 제거, 의도 주석 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)