### PR TITLE
fix(notify): use client-visible check for auto-ack, not pane_active

### DIFF
--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -172,7 +172,7 @@ func (c *aiCommand) applyAIStatus(state, paneID string) error {
 	case "waiting":
 		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneStateOption, "waiting")
 		_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionAckOption)
-		if c.readTrimmed("tmux", "display-message", "-p", "-t", paneID, "#{pane_active}") == "1" {
+		if c.paneVisibleToClient(paneID) {
 			_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionStateOption)
 			_ = c.run("tmux", "set-option", "-p", "-t", paneID, attentionAckOption, "1")
 			_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionFocusArmedOption)
@@ -1192,6 +1192,23 @@ func (c *aiCommand) readTrimmed(name string, args ...string) string {
 
 func (c *aiCommand) readTmuxPaneOption(paneID, option string) string {
 	return c.readTrimmed("tmux", "display-message", "-p", "-t", paneID, "#{"+option+"}")
+}
+
+// paneVisibleToClient mirrors attentionCommand.paneVisibleToClient: a pane is
+// only "visible" when some attached client's #{client_active_pane} matches it.
+// pane_active alone is true even when every client has moved to a different
+// window or session, which made the auto-ack silently swallow reply pings.
+func (c *aiCommand) paneVisibleToClient(paneID string) bool {
+	output, err := c.read("tmux", "list-clients", "-F", "#{client_active_pane}")
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(output), "\r\n"), "\n") {
+		if strings.TrimSpace(line) == paneID {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *aiCommand) duplicateAINotificationRecent(paneID, key string) bool {

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -489,8 +489,8 @@ func TestAIStatusSetWaitingMarksPaneReplyAndNotifies(t *testing.T) {
 			return []byte("dev\n"), nil
 		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%2", "#{pane_current_path}"}):
 			return []byte(work + "\n"), nil
-		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%2", "#{pane_active}"}):
-			return []byte("0\n"), nil
+		case reflect.DeepEqual(args, []string{"list-clients", "-F", "#{client_active_pane}"}):
+			return []byte("%99\n"), nil
 		}
 		return nil, os.ErrNotExist
 	}
@@ -575,8 +575,8 @@ func TestAIStatusSetWaitingUsesNotificationHook(t *testing.T) {
 			return []byte("dev\n"), nil
 		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%9", "#{pane_current_path}"}):
 			return []byte(work + "\n"), nil
-		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%9", "#{pane_active}"}):
-			return []byte("0\n"), nil
+		case reflect.DeepEqual(args, []string{"list-clients", "-F", "#{client_active_pane}"}):
+			return []byte("%99\n"), nil
 		}
 		return nil, os.ErrNotExist
 	}
@@ -668,8 +668,8 @@ func TestAIStatusSetWaitingInWSLRegistersToastAppIDAndDispatchesToast(t *testing
 			return []byte("dev\n"), nil
 		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%2", "#{pane_current_path}"}):
 			return []byte(work + "\n"), nil
-		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%2", "#{pane_active}"}):
-			return []byte("0\n"), nil
+		case reflect.DeepEqual(args, []string{"list-clients", "-F", "#{client_active_pane}"}):
+			return []byte("%99\n"), nil
 		}
 		return nil, os.ErrNotExist
 	}
@@ -725,12 +725,12 @@ func TestAIStatusSetWaitingInWSLRegistersToastAppIDAndDispatchesToast(t *testing
 	}
 }
 
-func TestAIStatusSetWaitingAcksActivePane(t *testing.T) {
+func TestAIStatusSetWaitingAcksVisiblePane(t *testing.T) {
 	home := t.TempDir()
 	cmd := testAICommand(home)
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
-		if name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%15", "#{pane_active}"}) {
-			return []byte("1\n"), nil
+		if name == "tmux" && reflect.DeepEqual(args, []string{"list-clients", "-F", "#{client_active_pane}"}) {
+			return []byte("%15\n"), nil
 		}
 		return []byte("\n"), nil
 	}
@@ -751,7 +751,36 @@ func TestAIStatusSetWaitingAcksActivePane(t *testing.T) {
 		t.Fatalf("command prefix = %#v, want %#v", commands, wantPrefix)
 	}
 	if containsAICommand(commands, "notify-send") {
-		t.Fatalf("commands = %#v, did not expect notify-send for active pane", commands)
+		t.Fatalf("commands = %#v, did not expect notify-send for visible pane", commands)
+	}
+}
+
+// Regression: pane_active=1 is not sufficient — when every client has moved to
+// a different window/session the pane is not visible and the reply must NOT be
+// auto-acked.
+func TestAIStatusSetWaitingDoesNotAckWhenNoClientViewingPane(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "tmux" && reflect.DeepEqual(args, []string{"list-clients", "-F", "#{client_active_pane}"}) {
+			return []byte("%99\n"), nil
+		}
+		return []byte("\n"), nil
+	}
+
+	if err := cmd.Run([]string{"status", "set", "waiting", "%15"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run status set waiting error = %v", err)
+	}
+
+	commands := cmdRecorder(cmd).commands
+	wantPrefix := []recordedAICommand{
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%15", "@projmux_ai_state", "waiting"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%15", "@projmux_attention_ack"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%15", "@projmux_attention_state", "reply"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%15", "@projmux_attention_focus_armed", "1"}},
+	}
+	if len(commands) < len(wantPrefix) || !reflect.DeepEqual(commands[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("command prefix = %#v, want %#v", commands, wantPrefix)
 	}
 }
 

--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -182,7 +182,7 @@ func (c *attentionCommand) runClear(args []string, stderr io.Writer) error {
 	if state == attentionStateBusy {
 		return nil
 	}
-	if state == attentionStateReply && c.paneOption(paneID, attentionFocusArmedOption) != "1" && !c.paneActive(paneID) {
+	if state == attentionStateReply && c.paneOption(paneID, attentionFocusArmedOption) != "1" && !c.paneVisibleToClient(paneID) {
 		return nil
 	}
 	c.unsetPaneOption(paneID, attentionStateOption)
@@ -281,8 +281,21 @@ func (c *attentionCommand) paneAttentionState(paneID string) string {
 	return c.paneOption(paneID, attentionStateOption)
 }
 
-func (c *attentionCommand) paneActive(paneID string) bool {
-	return c.paneOption(paneID, "pane_active") == "1"
+// paneVisibleToClient reports whether some attached tmux client is currently
+// viewing paneID. The naive #{pane_active} check is wrong here: a pane stays
+// pane_active=1 even when every client has switched to a different window or
+// session, which caused auto-ack to silently swallow reply notifications.
+func (c *attentionCommand) paneVisibleToClient(paneID string) bool {
+	output, err := c.run("tmux", "list-clients", "-F", "#{client_active_pane}")
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(output), "\r\n"), "\n") {
+		if strings.TrimSpace(line) == paneID {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *attentionCommand) paneOption(paneID, option string) string {

--- a/internal/app/attention_test.go
+++ b/internal/app/attention_test.go
@@ -119,7 +119,7 @@ func TestAttentionClearKeepsUnarmedReplyPane(t *testing.T) {
 		outputs: map[string][]byte{
 			"tmux display-message -p -t %5 #{@projmux_attention_state}":       []byte("reply\n"),
 			"tmux display-message -p -t %5 #{@projmux_attention_focus_armed}": []byte("\n"),
-			"tmux display-message -p -t %5 #{pane_active}":                    []byte("0\n"),
+			"tmux list-clients -F #{client_active_pane}":                      []byte("%99\n"),
 		},
 	}
 	cmd := &attentionCommand{runner: runner}
@@ -131,7 +131,7 @@ func TestAttentionClearKeepsUnarmedReplyPane(t *testing.T) {
 	want := []attentionCall{
 		{name: "tmux", args: []string{"display-message", "-p", "-t", "%5", "#{@projmux_attention_state}"}},
 		{name: "tmux", args: []string{"display-message", "-p", "-t", "%5", "#{@projmux_attention_focus_armed}"}},
-		{name: "tmux", args: []string{"display-message", "-p", "-t", "%5", "#{pane_active}"}},
+		{name: "tmux", args: []string{"list-clients", "-F", "#{client_active_pane}"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
@@ -145,7 +145,7 @@ func TestAttentionClearKeepsInactiveUnarmedReplyPaneWithTitleBadge(t *testing.T)
 		outputs: map[string][]byte{
 			"tmux display-message -p -t %8 #{@projmux_attention_state}":       []byte("reply\n"),
 			"tmux display-message -p -t %8 #{@projmux_attention_focus_armed}": []byte("\n"),
-			"tmux display-message -p -t %8 #{pane_active}":                    []byte("0\n"),
+			"tmux list-clients -F #{client_active_pane}":                      []byte("%99\n"),
 			"tmux display-message -p -t %8 #{pane_title}":                     []byte("✔ review\n"),
 		},
 	}
@@ -158,7 +158,7 @@ func TestAttentionClearKeepsInactiveUnarmedReplyPaneWithTitleBadge(t *testing.T)
 	want := []attentionCall{
 		{name: "tmux", args: []string{"display-message", "-p", "-t", "%8", "#{@projmux_attention_state}"}},
 		{name: "tmux", args: []string{"display-message", "-p", "-t", "%8", "#{@projmux_attention_focus_armed}"}},
-		{name: "tmux", args: []string{"display-message", "-p", "-t", "%8", "#{pane_active}"}},
+		{name: "tmux", args: []string{"list-clients", "-F", "#{client_active_pane}"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
@@ -172,7 +172,7 @@ func TestAttentionClearAcksActiveUnarmedReplyPane(t *testing.T) {
 		outputs: map[string][]byte{
 			"tmux display-message -p -t %7 #{@projmux_attention_state}":       []byte("reply\n"),
 			"tmux display-message -p -t %7 #{@projmux_attention_focus_armed}": []byte("\n"),
-			"tmux display-message -p -t %7 #{pane_active}":                    []byte("1\n"),
+			"tmux list-clients -F #{client_active_pane}":                      []byte("%7\n"),
 			"tmux display-message -p -t %7 #{pane_title}":                     []byte("repo\n"),
 		},
 	}
@@ -185,11 +185,39 @@ func TestAttentionClearAcksActiveUnarmedReplyPane(t *testing.T) {
 	want := []attentionCall{
 		{name: "tmux", args: []string{"display-message", "-p", "-t", "%7", "#{@projmux_attention_state}"}},
 		{name: "tmux", args: []string{"display-message", "-p", "-t", "%7", "#{@projmux_attention_focus_armed}"}},
-		{name: "tmux", args: []string{"display-message", "-p", "-t", "%7", "#{pane_active}"}},
+		{name: "tmux", args: []string{"list-clients", "-F", "#{client_active_pane}"}},
 		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%7", "@projmux_attention_state"}},
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", "@projmux_attention_ack", "1"}},
 		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%7", "@projmux_attention_focus_armed"}},
 		{name: "tmux", args: []string{"display-message", "-p", "-t", "%7", "#{pane_title}"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+// Regression: pane_active is true even when every client has switched to a
+// different window/session. The auto-ack must NOT fire in that case.
+func TestAttentionClearKeepsReplyPaneWhenClientOnDifferentWindow(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingAttentionRunner{
+		outputs: map[string][]byte{
+			"tmux display-message -p -t %7 #{@projmux_attention_state}":       []byte("reply\n"),
+			"tmux display-message -p -t %7 #{@projmux_attention_focus_armed}": []byte("\n"),
+			"tmux list-clients -F #{client_active_pane}":                      []byte("%42\n"),
+		},
+	}
+	cmd := &attentionCommand{runner: runner}
+
+	if err := cmd.Run([]string{"clear", "%7"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	want := []attentionCall{
+		{name: "tmux", args: []string{"display-message", "-p", "-t", "%7", "#{@projmux_attention_state}"}},
+		{name: "tmux", args: []string{"display-message", "-p", "-t", "%7", "#{@projmux_attention_focus_armed}"}},
+		{name: "tmux", args: []string{"list-clients", "-F", "#{client_active_pane}"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("calls = %#v, want %#v", runner.calls, want)


### PR DESCRIPTION
## Summary
- Auto-ack of AI reply notifications fired whenever `#{pane_active}` was 1 — but that's true even when every attached client has switched to a different window/session (or detached), so reply pings were silently swallowed.
- Replaces the `pane_active` check with `tmux list-clients -F '#{client_active_pane}'`: auto-ack only when *some* attached client is actually viewing the pane.
- Same fix applied to `attention clear` path (the "is the user looking?" branch).

## Test plan
- [x] `go build ./...`
- [x] `go test -count=1 ./...` (all packages green)
- [x] New regression tests:
  - `TestAIStatusSetWaitingDoesNotAckWhenNoClientViewingPane` — pane is `pane_active=1` but client is on a different pane → must NOT auto-ack
  - `TestAttentionClearKeepsReplyPaneWhenClientOnDifferentWindow` — same scenario through `attention clear`
- [ ] Manual: switch tmux window away before AI reply fires → notification sticks instead of self-acking