### PR TITLE
feat(notify): desktop notification on/off toggle + AppName branding

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,6 +150,12 @@ When the hook is set, projmux invokes it with positional arguments:
 summary body urgency app-name tag group icon-path
 ```
 
+The app-name argument is `com.crevisse.projmux` (reverse-domain id used as
+the Linux `--app-name`, the macOS sender label, and the Windows
+`AppUserModelID`). Earlier releases used `projmux.TmuxCodex`; the new id
+ships with a one-shot Windows cleanup that removes the legacy Start Menu
+shortcut and registry entry the first time projmux runs.
+
 OS desktop notifications can be silenced without touching the in-app notify
 queue. The resolution order is:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,7 @@ configured key opens and closes the popup.
 | `PROJMUX_MANAGED_ROOTS` | Search-root override. Uses the OS-native path-list separator and takes priority over the saved workdirs file and default weak probes. |
 | `TMUX_SESSIONIZER_ROOTS` | Legacy alias still honored at runtime for managed roots. |
 | `PROJMUX_NOTIFY_HOOK` | External executable that receives AI desktop notifications instead of the built-in Linux/WSL sender. |
+| `PROJMUX_DESKTOP_NOTIFY` | OS desktop notification on/off override. `on`/`off` (case insensitive). When set, this takes priority over the saved tmux option and the default. The in-app notify queue is not affected. |
 | `PROJMUX_WSL_TOAST_ICON_DIR` | Directory used when copying the WSL toast icon into a Windows-readable path. |
 | `PROJMUX_USAGE_STATE_DIR` | Override directory for AI usage snapshots. Defaults to `<state>/projmux/usage`. Point this at a synced directory to share authoritative usage across machines. |
 | `PROJMUX_USAGE_DEBUG` | When non-empty, prints adapter errors from `projmux status usage` to stderr. |
@@ -148,6 +149,17 @@ When the hook is set, projmux invokes it with positional arguments:
 ```text
 summary body urgency app-name tag group icon-path
 ```
+
+OS desktop notifications can be silenced without touching the in-app notify
+queue. The resolution order is:
+
+1. `PROJMUX_DESKTOP_NOTIFY` env (`on` / `off`).
+2. Tmux global option `@projmux_desktop_notify` (`1` / `0`).
+3. Default = on.
+
+Toggle from Settings > AI Settings > `Desktop notifications on/off`. The
+Settings info row labels the effective source as `env`, `setting`, or
+`default` so an env-pinned value is visible at a glance.
 
 Hook details for new-session lifecycle hooks and project-local
 `.projmux/config.toml` live in [Hooks](hooks.md).

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -278,7 +278,7 @@ func (c *aiCommand) notifyAIWithMode(paneID string, force bool) error {
 		Summary: aiSummaryForKind(replyKind, agentName, cleanTitle),
 		Body:    aiNotificationBody(cleanTitle, aiProjectName(panePath), c.gitBranchForPath(panePath), sessionName, windowName),
 		Urgency: aiUrgencyForKind(replyKind),
-		AppName: "projmux.TmuxCodex",
+		AppName: desktopAppID,
 		Icon:    c.notificationIcon(agentName),
 		Tag:     paneID,
 		Group:   sessionName,
@@ -1894,7 +1894,7 @@ Set-ItemProperty -Path $regPath -Name 'DisplayName' -Value '` + psEscape(display
 Set-ItemProperty -Path $regPath -Name 'ShowInSettings' -Value 1 -Type DWord
 ` + iconLine + `
 $shortcutDir = [Environment]::GetFolderPath('Programs')
-$shortcutPath = Join-Path $shortcutDir 'projmux Tmux Codex.lnk'
+$shortcutPath = Join-Path $shortcutDir 'projmux.lnk'
 $targetPath = [Environment]::ExpandEnvironmentVariables('%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe')
 $arguments = '-NoProfile -WindowStyle Hidden -Command exit'
 $description = 'projmux tmux AI notifications'
@@ -1903,6 +1903,39 @@ if ('` + psEscape(iconURI) + `' -ne '') {
   $iconLocation = '` + psEscape(iconURI) + `'
 }
 [ProjmuxToastShortcut]::Save($shortcutPath, $targetPath, $arguments, $description, $iconLocation, '` + psEscape(appID) + `')
+`
+}
+
+// buildLegacyToastCleanupPowerShell removes the Windows artifacts left over
+// from the `projmux.TmuxCodex` era. It is intentionally idempotent and
+// swallows every error: the script may run on machines that never had the
+// legacy registration (fresh installs after the rename), and we never want
+// the cleanup attempt itself to break notification dispatch.
+//
+// Two things are scrubbed:
+//  1. The legacy `projmux Tmux Codex.lnk` shortcut in the Start Menu's
+//     Programs folder (where `buildRegisterToastAppIDPowerShell` used to
+//     drop it). Get-StartApps confirms presence before delete so we don't
+//     touch unrelated shortcuts named similarly by users.
+//  2. The legacy `HKCU:\Software\Classes\AppUserModelId\projmux.TmuxCodex`
+//     registry key, which carried DisplayName / IconUri / ShowInSettings
+//     metadata for the old AppID.
+//
+// The cleanup is gated by the caller (see `ensureWSLLegacyAppIDCleaned` in
+// `notification.go`) with the `@projmux_legacy_appid_cleaned` tmux marker
+// so we attempt it at most once per tmux server.
+func buildLegacyToastCleanupPowerShell() string {
+	return `try {
+  $legacy = Get-StartApps | Where-Object Name -eq 'projmux Tmux Codex'
+  if ($legacy) {
+    $shortcutDir = [Environment]::GetFolderPath('Programs')
+    $shortcutPath = Join-Path $shortcutDir 'projmux Tmux Codex.lnk'
+    Remove-Item -Path $shortcutPath -Force -ErrorAction SilentlyContinue
+  }
+} catch { }
+try {
+  Remove-Item -Path 'HKCU:\Software\Classes\AppUserModelId\projmux.TmuxCodex' -Recurse -Force -ErrorAction SilentlyContinue
+} catch { }
 `
 }
 

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -561,8 +561,8 @@ func TestAIStatusSetWaitingMarksPaneReplyAndNotifies(t *testing.T) {
 		t.Fatalf("commands = %#v, want notify-send dispatch", commands)
 	}
 	for _, want := range []string{
-		"--app-name=projmux.TmuxCodex",
-		"projmux.TmuxCodex",
+		"--app-name=" + desktopAppID,
+		desktopAppID,
 		filepath.Join(home, ".local", "share", "projmux", "icons", "projmux.png"),
 		"Codex 승인 필요 · approval needed",
 		"검토 대기: approval needed · projmux/main",
@@ -638,7 +638,7 @@ func TestAIStatusSetWaitingUsesNotificationHook(t *testing.T) {
 		"Codex 입력 필요 · answer ready",
 		"검토 대기: answer ready · projmux/main",
 		"critical",
-		"projmux.TmuxCodex",
+		desktopAppID,
 		"%9",
 		"repo",
 		filepath.Join(home, ".local", "share", "projmux", "icons", "projmux.png"),
@@ -732,31 +732,47 @@ func TestAIStatusSetWaitingInWSLRegistersToastAppIDAndDispatchesToast(t *testing
 			powershellCommands = append(powershellCommands, command)
 		}
 	}
-	if got, want := len(powershellCommands), 2; got != want {
+	// One-shot legacy cleanup runs before the register + toast PS calls
+	// because the `@projmux_legacy_appid_cleaned` marker is unset for a
+	// fresh aiCommand fixture.
+	if got, want := len(powershellCommands), 3; got != want {
 		t.Fatalf("powershell commands len = %d, want %d, commands = %#v", got, want, cmdRecorder(cmd).commands)
 	}
-	registerScript := decodePowerShellEncodedCommand(t, powershellCommands[0])
-	if !strings.Contains(registerScript, `HKCU:\SOFTWARE\Classes\AppUserModelId\projmux.TmuxCodex`) {
-		t.Fatalf("register script = %q, want AppUserModelId registration", registerScript)
+	cleanupScript := decodePowerShellEncodedCommand(t, powershellCommands[0])
+	for _, want := range []string{
+		"Get-StartApps",
+		"projmux Tmux Codex",
+		`HKCU:\Software\Classes\AppUserModelId\projmux.TmuxCodex`,
+	} {
+		if !strings.Contains(cleanupScript, want) {
+			t.Fatalf("legacy cleanup script = %q, want substring %q", cleanupScript, want)
+		}
 	}
-	if !strings.Contains(registerScript, "Tmux Codex") {
-		t.Fatalf("register script = %q, want display name", registerScript)
+	if !containsAICommandArgs(cmdRecorder(cmd).commands, "tmux", []string{"set-option", "-g", legacyAppIDCleanedTmuxOption, "1"}) {
+		t.Fatalf("commands = %#v, want legacy cleanup marker write", cmdRecorder(cmd).commands)
+	}
+	registerScript := decodePowerShellEncodedCommand(t, powershellCommands[1])
+	if !strings.Contains(registerScript, `HKCU:\SOFTWARE\Classes\AppUserModelId\`+desktopAppID) {
+		t.Fatalf("register script = %q, want AppUserModelId registration for new id", registerScript)
+	}
+	if !strings.Contains(registerScript, desktopDisplayName) {
+		t.Fatalf("register script = %q, want display name %q", registerScript, desktopDisplayName)
 	}
 	if !strings.Contains(registerScript, iconWin) {
 		t.Fatalf("register script = %q, want icon uri", registerScript)
 	}
 	for _, want := range []string{
-		"projmux Tmux Codex.lnk",
-		"Save($shortcutPath, $targetPath, $arguments, $description, $iconLocation, 'projmux.TmuxCodex')",
+		"projmux.lnk",
+		"Save($shortcutPath, $targetPath, $arguments, $description, $iconLocation, '" + desktopAppID + "')",
 		"shellLink.SetPath(targetPath)",
 	} {
 		if !strings.Contains(registerScript, want) {
 			t.Fatalf("register script = %q, want substring %q", registerScript, want)
 		}
 	}
-	toastScript := decodePowerShellEncodedCommand(t, powershellCommands[1])
+	toastScript := decodePowerShellEncodedCommand(t, powershellCommands[2])
 	for _, want := range []string{
-		"CreateToastNotifier('projmux.TmuxCodex').Show($toast)",
+		"CreateToastNotifier('" + desktopAppID + "').Show($toast)",
 		"$toast.Tag = '%2'",
 		"$toast.Group = 'repo'",
 		"Codex 승인 필요 · approval needed",
@@ -981,7 +997,7 @@ func TestAINotifyUsesPaneMetadataBeforeMutableTitle(t *testing.T) {
 		t.Fatalf("commands = %#v, want notify-send dispatch", commands)
 	}
 	for _, want := range []string{
-		"projmux.TmuxCodex",
+		desktopAppID,
 		filepath.Join(home, ".local", "share", "projmux", "icons", "projmux.png"),
 		"Claude 승인 필요 · approval needed",
 	} {

--- a/internal/app/notification.go
+++ b/internal/app/notification.go
@@ -52,6 +52,14 @@ type aiDesktopNotifier struct {
 }
 
 func (n aiDesktopNotifier) Notify(notification aiNotification) error {
+	// Phase 1 desktop-notification gate. The in-app notify queue, the
+	// statusbar segment, and the attention badge are intentionally
+	// untouched — this only suppresses the OS-level dispatch so users
+	// can silence the popup/Toast/notify-send fan-out without losing
+	// the in-app surfaces.
+	if !n.command.desktopNotifyEnabled() {
+		return nil
+	}
 	if n.command.isWSL() {
 		_ = n.ensureWSLToastAppID(notification)
 		if err := n.dispatchWSLToast(notification); err == nil {

--- a/internal/app/notification.go
+++ b/internal/app/notification.go
@@ -61,6 +61,7 @@ func (n aiDesktopNotifier) Notify(notification aiNotification) error {
 		return nil
 	}
 	if n.command.isWSL() {
+		n.command.ensureWSLLegacyAppIDCleaned(notification)
 		_ = n.ensureWSLToastAppID(notification)
 		if err := n.dispatchWSLToast(notification); err == nil {
 			return nil
@@ -116,12 +117,55 @@ func (n aiDesktopNotifier) ensureWSLToastAppID(notification aiNotification) erro
 	if appID == "" {
 		return errors.New("toast app id is empty")
 	}
-	displayName := "Tmux Codex"
-	if appID != "projmux.TmuxCodex" {
+	// During the AppName migration we accept both the new reverse-domain
+	// id and the legacy `projmux.TmuxCodex` so users mid-migration keep
+	// getting toasts. New installs pick up `desktopDisplayName`; the
+	// legacy id still resolves to the old "Tmux Codex" label so we don't
+	// surprise users who somehow re-register the old AppID.
+	var displayName string
+	switch appID {
+	case desktopAppID:
+		displayName = desktopDisplayName
+	case legacyDesktopAppID:
+		displayName = "Tmux Codex"
+	default:
 		displayName = appID
 	}
 	script := buildRegisterToastAppIDPowerShell(appID, displayName, n.command.wslToastIconPath(notification.Icon))
 	return n.command.run(powerShell, "-NoProfile", "-NonInteractive", "-EncodedCommand", encodeUTF16LEBase64(script))
+}
+
+// ensureWSLLegacyAppIDCleaned removes the Start Menu shortcut and the
+// AppUserModelID registry key left over from the `projmux.TmuxCodex` era.
+// It runs at most once per tmux server, gated by the
+// `@projmux_legacy_appid_cleaned` user-option marker. The marker is set
+// even on failure so we don't keep retrying on a broken environment —
+// the registration helper still emits the new AppID artifacts each toast
+// so the user is never blocked.
+//
+// _ = notification: the cleanup script is self-contained and intentionally
+// does not depend on the inbound notification payload. Keeping the
+// parameter symmetric with `ensureWSLToastAppID` lets call sites pair them
+// without ceremony.
+func (c *aiCommand) ensureWSLLegacyAppIDCleaned(_ aiNotification) {
+	if !c.isWSL() {
+		return
+	}
+	if strings.TrimSpace(c.readTrimmed("tmux", "show-option", "-gqv", legacyAppIDCleanedTmuxOption)) == "1" {
+		return
+	}
+	powerShell := c.resolvePowerShell()
+	if powerShell == "" {
+		return
+	}
+	script := buildLegacyToastCleanupPowerShell()
+	// Best effort — the helper script itself swallows individual errors
+	// so a successful return here just means PowerShell launched. Any
+	// failure leaves the marker unset so a future Notify retries.
+	if err := c.run(powerShell, "-NoProfile", "-NonInteractive", "-EncodedCommand", encodeUTF16LEBase64(script)); err != nil {
+		return
+	}
+	_ = c.run("tmux", "set-option", "-g", legacyAppIDCleanedTmuxOption, "1")
 }
 
 func (c *aiCommand) notificationIcon(string) string {

--- a/internal/app/notification_appid.go
+++ b/internal/app/notification_appid.go
@@ -1,0 +1,27 @@
+package app
+
+// notification_appid.go centralizes the desktop notification AppID brand.
+// Phase 2 of the OS-알림 정리 roadmap migrated the historical
+// `projmux.TmuxCodex` label to a reverse-domain id that Windows
+// AppUserModelID rules accept natively and macOS / Linux render cleanly.
+//
+// `legacyDesktopAppID` is retained for two reasons:
+//  1. The WSL Toast register helper sanity-guards against unknown app
+//     ids; the legacy value stays whitelisted so users mid-migration
+//     keep getting toasts.
+//  2. The one-shot Windows cleanup helper removes the Start Menu
+//     shortcut and the AppUserModelID registry key tied to the legacy
+//     value. Keeping the constant alongside the new one makes the
+//     migration footprint discoverable in one place.
+
+const (
+	desktopAppID       = "com.crevisse.projmux"
+	desktopDisplayName = "projmux"
+	legacyDesktopAppID = "projmux.TmuxCodex"
+
+	// legacyAppIDCleanedTmuxOption marks that the one-shot Windows
+	// legacy AppID cleanup has already been attempted on this server.
+	// Stored as a global tmux user-option so the marker survives across
+	// sessions on the same tmux server.
+	legacyAppIDCleanedTmuxOption = "@projmux_legacy_appid_cleaned"
+)

--- a/internal/app/notification_appid_test.go
+++ b/internal/app/notification_appid_test.go
@@ -1,0 +1,21 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLegacyToastCleanupScriptScrubsBothArtifacts(t *testing.T) {
+	script := buildLegacyToastCleanupPowerShell()
+	for _, want := range []string{
+		"Get-StartApps",
+		"projmux Tmux Codex",
+		"projmux Tmux Codex.lnk",
+		`Remove-Item -Path 'HKCU:\Software\Classes\AppUserModelId\projmux.TmuxCodex'`,
+		"ErrorAction SilentlyContinue",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("cleanup script missing %q: %s", want, script)
+		}
+	}
+}

--- a/internal/app/notification_toggle.go
+++ b/internal/app/notification_toggle.go
@@ -1,0 +1,126 @@
+package app
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// notification_toggle.go owns the OS-desktop-notification on/off switch.
+// The toggle is intentionally orthogonal to the in-app notify queue,
+// statusbar segment, and attention badge — those keep working when the
+// desktop dispatch is silenced (loud-environment / screen-share use case).
+//
+// Resolution priority (highest first):
+//  1. env `PROJMUX_DESKTOP_NOTIFY=on|off` (case-insensitive)
+//  2. tmux global option `@projmux_desktop_notify` (`1` / `0`)
+//  3. default = on
+//
+// The Settings popup exposes a row whose info line surfaces the source
+// (`env` / `setting` / `default`) so users can see immediately why a
+// toggle press would be ineffective when env is set.
+
+const (
+	// desktopNotifyTmuxOption controls the OS desktop notification on/off
+	// toggle. tmux user-options carry the `@` prefix by convention.
+	// Settings writes "1" or "0"; absent means "default".
+	desktopNotifyTmuxOption = "@projmux_desktop_notify"
+
+	// desktopNotifyEnv is the env-level override. `on` / `off` (case
+	// insensitive). Any other value falls through to the tmux option.
+	desktopNotifyEnv = "PROJMUX_DESKTOP_NOTIFY"
+)
+
+// desktopNotifySource describes where the effective desktop-notify state
+// came from. Settings shows this label so the user understands why a
+// toggle press might be ineffective (e.g. an env override pins the value).
+type desktopNotifySource string
+
+const (
+	desktopNotifySourceEnv     desktopNotifySource = "env"
+	desktopNotifySourceSetting desktopNotifySource = "setting"
+	desktopNotifySourceDefault desktopNotifySource = "default"
+)
+
+// desktopNotifyResolver resolves the effective on/off state and reports the
+// source so the Settings row can render it. The lookups are injected as
+// function pointers so the resolution path stays testable without spawning
+// real tmux processes.
+type desktopNotifyResolver struct {
+	lookupEnv func(string) string
+	// readTmuxOption reads the global @projmux_desktop_notify user-option
+	// (`tmux show-option -gqv ...`). It must return the trimmed string,
+	// or empty when tmux is unavailable or the option is unset.
+	readTmuxOption func(name string) string
+}
+
+// resolve returns (enabled, source). enabled = true means desktop
+// notifications should fire.
+func (r desktopNotifyResolver) resolve() (bool, desktopNotifySource) {
+	if r.lookupEnv != nil {
+		raw := strings.TrimSpace(r.lookupEnv(desktopNotifyEnv))
+		switch strings.ToLower(raw) {
+		case "off", "0", "false", "no":
+			return false, desktopNotifySourceEnv
+		case "on", "1", "true", "yes":
+			return true, desktopNotifySourceEnv
+		}
+	}
+	if r.readTmuxOption != nil {
+		raw := strings.TrimSpace(r.readTmuxOption(desktopNotifyTmuxOption))
+		switch raw {
+		case "0":
+			return false, desktopNotifySourceSetting
+		case "1":
+			return true, desktopNotifySourceSetting
+		}
+	}
+	return true, desktopNotifySourceDefault
+}
+
+// desktopNotifyEnabled is a convenience wrapper used by the
+// `aiDesktopNotifier.Notify` gate. The gate only needs the bool — the
+// source is reserved for the Settings UI render path.
+func (c *aiCommand) desktopNotifyEnabled() bool {
+	enabled, _ := c.desktopNotifyResolution()
+	return enabled
+}
+
+// desktopNotifyResolution returns the effective on/off state plus the
+// source label. Splitting it out keeps the gate cheap (no source string
+// formatting) while letting future call sites (e.g. diagnostics) reuse the
+// same resolution path.
+func (c *aiCommand) desktopNotifyResolution() (bool, desktopNotifySource) {
+	resolver := desktopNotifyResolver{
+		lookupEnv: c.lookupEnv,
+		readTmuxOption: func(name string) string {
+			// tmux show-option only makes sense inside a tmux client
+			// (we follow the same TMUX gate used elsewhere in the
+			// codebase — see tmuxProjdirOption in switch.go).
+			if strings.TrimSpace(c.env("TMUX")) == "" {
+				return ""
+			}
+			return c.readTrimmed("tmux", "show-option", "-gqv", name)
+		},
+	}
+	return resolver.resolve()
+}
+
+// settingsDesktopNotifyResolver builds the same resolver from a
+// `settingsCommand`. settingsCommand uses raw `runCommand` / direct
+// `exec.Command` for its tmux reads, so we wire the lookup through
+// `exec.Command` directly (mirroring `tmuxProjdirOption`).
+func settingsDesktopNotifyResolver(lookupEnv func(string) string) desktopNotifyResolver {
+	return desktopNotifyResolver{
+		lookupEnv: lookupEnv,
+		readTmuxOption: func(name string) string {
+			if lookupEnv == nil || strings.TrimSpace(lookupEnv("TMUX")) == "" {
+				return ""
+			}
+			out, err := exec.Command("tmux", "show-option", "-gqv", name).Output()
+			if err != nil {
+				return ""
+			}
+			return strings.TrimSpace(string(out))
+		},
+	}
+}

--- a/internal/app/notification_toggle_test.go
+++ b/internal/app/notification_toggle_test.go
@@ -1,0 +1,141 @@
+package app
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestDesktopNotifyResolverPriority(t *testing.T) {
+	cases := []struct {
+		name       string
+		env        string
+		option     string
+		wantOn     bool
+		wantSource desktopNotifySource
+	}{
+		{name: "default when nothing set", env: "", option: "", wantOn: true, wantSource: desktopNotifySourceDefault},
+		{name: "tmux option off", env: "", option: "0", wantOn: false, wantSource: desktopNotifySourceSetting},
+		{name: "tmux option on", env: "", option: "1", wantOn: true, wantSource: desktopNotifySourceSetting},
+		{name: "env off wins over tmux on", env: "off", option: "1", wantOn: false, wantSource: desktopNotifySourceEnv},
+		{name: "env on wins over tmux off", env: "on", option: "0", wantOn: true, wantSource: desktopNotifySourceEnv},
+		{name: "env unknown falls through to tmux", env: "garbage", option: "0", wantOn: false, wantSource: desktopNotifySourceSetting},
+		{name: "env empty falls through to default", env: "", option: "", wantOn: true, wantSource: desktopNotifySourceDefault},
+		{name: "env OFF case-insensitive", env: "OFF", option: "1", wantOn: false, wantSource: desktopNotifySourceEnv},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolver := desktopNotifyResolver{
+				lookupEnv: func(name string) string {
+					if name == desktopNotifyEnv {
+						return tc.env
+					}
+					return ""
+				},
+				readTmuxOption: func(name string) string {
+					if name == desktopNotifyTmuxOption {
+						return tc.option
+					}
+					return ""
+				},
+			}
+			gotOn, gotSource := resolver.resolve()
+			if gotOn != tc.wantOn || gotSource != tc.wantSource {
+				t.Fatalf("resolve() = (%v, %q), want (%v, %q)", gotOn, gotSource, tc.wantOn, tc.wantSource)
+			}
+		})
+	}
+}
+
+func TestDesktopNotifyGateSilencesDispatchWhenOff(t *testing.T) {
+	home := t.TempDir()
+	work := home + "/repo"
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := testAICommand(home)
+	cmd.lookupEnv = func(name string) string {
+		switch name {
+		case "HOME":
+			return home
+		case "PROJMUX_DESKTOP_NOTIFY":
+			return "off"
+		default:
+			return ""
+		}
+	}
+	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		// notify-send is "available" but the gate should silence the
+		// dispatch anyway. We assert below that it's never called.
+		if name == "command" && len(args) == 2 && args[0] == "-v" && args[1] == "notify-send" {
+			return []byte("/usr/bin/notify-send\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	notifier := aiDesktopNotifier{command: cmd}
+	if err := notifier.Notify(aiNotification{
+		Summary: "Hello",
+		Body:    "World",
+		Urgency: "normal",
+		AppName: "projmux.TmuxCodex",
+		Icon:    "dialog-information",
+	}); err != nil {
+		t.Fatalf("Notify with desktop notifications off returned error: %v", err)
+	}
+
+	for _, command := range cmdRecorder(cmd).commands {
+		if command.name == "notify-send" {
+			t.Fatalf("commands = %#v, did not expect notify-send dispatch when gate is off", cmdRecorder(cmd).commands)
+		}
+	}
+}
+
+func TestDesktopNotifyGateAllowsDispatchWhenOn(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.lookupEnv = func(name string) string {
+		switch name {
+		case "HOME":
+			return home
+		case "PROJMUX_DESKTOP_NOTIFY":
+			return "on"
+		default:
+			return ""
+		}
+	}
+	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "command" && len(args) == 2 && args[0] == "-v" && args[1] == "notify-send" {
+			return []byte("/usr/bin/notify-send\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	notifier := aiDesktopNotifier{command: cmd}
+	if err := notifier.Notify(aiNotification{
+		Summary: "Hello",
+		Body:    "World",
+		Urgency: "normal",
+		AppName: "projmux.TmuxCodex",
+		Icon:    "dialog-information",
+	}); err != nil {
+		t.Fatalf("Notify with desktop notifications on returned error: %v", err)
+	}
+
+	var sawNotifySend bool
+	for _, command := range cmdRecorder(cmd).commands {
+		if command.name == "notify-send" {
+			sawNotifySend = true
+			wantPrefix := []string{
+				"--app-name=projmux.TmuxCodex",
+			}
+			if !reflect.DeepEqual(command.args[:len(wantPrefix)], wantPrefix) {
+				t.Fatalf("notify-send args = %#v, want first arg %q", command.args, wantPrefix[0])
+			}
+		}
+	}
+	if !sawNotifySend {
+		t.Fatalf("commands = %#v, want notify-send dispatch when gate is on", cmdRecorder(cmd).commands)
+	}
+}

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -96,6 +96,7 @@ var settingsEntryPrefixCatalog = []struct {
 	meta   settingsEntryMeta
 }{
 	{settingsActionPrefixAI, settingsEntryMeta{Name: "AI Settings", Axis: settingsAxisGlobal}},
+	{settingsActionPrefixDesktopNotify, settingsEntryMeta{Name: "Desktop notifications", Axis: settingsAxisGlobal}},
 	{settingsActionPrefixHooks, settingsEntryMeta{Name: "Project hook policy", Axis: settingsAxisGlobal}},
 	{settingsActionPrefixHookAdd, settingsEntryMeta{Name: "Hook maker - add", Axis: settingsAxisBoth}},
 	{settingsActionPrefixHookEdit, settingsEntryMeta{Name: "Hook maker - edit", Axis: settingsAxisBoth}},
@@ -141,6 +142,7 @@ const (
 	settingsSectionLabs               = "section:labs"
 	settingsSectionAbout              = "section:about"
 	settingsActionPrefixAI            = "ai:"
+	settingsActionPrefixDesktopNotify = "desktop-notify:"
 	settingsActionPrefixHooks         = "project-hooks:"
 	settingsActionPrefixKeymap        = "keymap:"
 	settingsActionPrefixLabKeymap     = "lab-keymap:"
@@ -1382,7 +1384,11 @@ func (c *settingsCommand) aiEntries() []intpickercompat.Entry {
 		{aiModeShell, "always open plain shell split"},
 	}
 
-	entries := make([]intpickercompat.Entry, 0, len(modes)+1)
+	notifyOn, notifySource := settingsDesktopNotifyResolver(c.lookupEnv).resolve()
+
+	// Reserve room for: back row + split modes + 1 info row + 2 toggle
+	// rows (on/off) for the desktop-notify switch.
+	entries := make([]intpickercompat.Entry, 0, len(modes)+4)
 	entries = append(entries, settingsBackEntry())
 	for _, item := range modes {
 		glyph := settingsGlyphInactive
@@ -1394,6 +1400,37 @@ func (c *settingsCommand) aiEntries() []intpickercompat.Entry {
 		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabel(glyph, color, item.mode, item.desc),
 			Value: settingsActionPrefixAI + item.mode,
+		})
+	}
+
+	// Phase 1: desktop notification on/off toggle. The info row shows the
+	// effective value plus where it came from (env / setting / default) so
+	// users mid-troubleshooting see immediately why a toggle press might
+	// not stick (env override pins the value).
+	notifyValue := "off"
+	if notifyOn {
+		notifyValue = "on"
+	}
+	entries = append(entries, intpickercompat.Entry{
+		Label: settingsLabelInfo("Desktop notifications", notifyValue, string(notifySource)),
+		Value: settingsNoopValue,
+	})
+	for _, item := range []struct {
+		state string
+		desc  string
+	}{
+		{"on", "fire OS desktop notifications for AI reply-ready"},
+		{"off", "silence OS notifications; in-app notify queue is unaffected"},
+	} {
+		glyph := settingsGlyphInactive
+		color := settingsColorDim
+		if (item.state == "on") == notifyOn {
+			glyph = settingsGlyphToggle
+			color = settingsColorAdd
+		}
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabel(glyph, color, "Desktop notifications "+item.state, item.desc),
+			Value: settingsActionPrefixDesktopNotify + item.state,
 		})
 	}
 	return entries
@@ -2091,6 +2128,47 @@ func (c *settingsCommand) currentStatusbarDecoration() config.StatusbarDecoratio
 	return loadStatusbarDecoration(c.homeDir, c.lookupEnv)
 }
 
+// setDesktopNotify writes the user-facing on/off choice into the
+// `@projmux_desktop_notify` global tmux user-option. The env variable
+// `PROJMUX_DESKTOP_NOTIFY` continues to take priority at resolve time,
+// so toggling here when env is set will appear to "do nothing" — the
+// Settings info row surfaces the source so users see why.
+//
+// When projmux runs outside tmux we silently skip the live update; the
+// gate at `aiDesktopNotifier.Notify` only reads the option inside tmux
+// anyway, so there's nothing to persist elsewhere.
+func (c *settingsCommand) setDesktopNotify(value string) error {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var optionValue string
+	switch value {
+	case "on", "1", "true", "yes":
+		optionValue = "1"
+	case "off", "0", "false", "no":
+		optionValue = "0"
+	default:
+		return fmt.Errorf("unknown desktop notification value: %s", value)
+	}
+	if c.lookupEnv == nil || strings.TrimSpace(c.lookupEnv("TMUX")) == "" {
+		// Outside tmux there is no server to persist to. The toggle is
+		// inherently a tmux-scoped surface (resolve order checks env
+		// first, then this option, then default) so this isn't an error
+		// — just a no-op with a friendly hint.
+		return nil
+	}
+	if c.runCommand == nil {
+		return errors.New("settings runner is not configured")
+	}
+	if err := c.runCommand("tmux", "set-option", "-g", desktopNotifyTmuxOption, optionValue); err != nil {
+		return fmt.Errorf("set live tmux desktop-notify option: %w", err)
+	}
+	stateLabel := "on"
+	if optionValue == "0" {
+		stateLabel = "off"
+	}
+	_ = c.runCommand("tmux", "display-message", "desktop notifications: "+stateLabel)
+	return nil
+}
+
 func (c *settingsCommand) setStatusbarDecoration(value string) error {
 	mode := config.NormalizeStatusbarDecoration(value)
 	paths, err := statusbarConfigPaths(c.homeDir, c.lookupEnv)
@@ -2297,6 +2375,8 @@ func (c *settingsCommand) execute(value string, stdout, stderr io.Writer) error 
 			return errors.New("ai settings are not configured")
 		}
 		return c.ai.setMode(mode)
+	case strings.HasPrefix(value, settingsActionPrefixDesktopNotify):
+		return c.setDesktopNotify(strings.TrimPrefix(value, settingsActionPrefixDesktopNotify))
 	case strings.HasPrefix(value, settingsActionPrefixHooks):
 		return c.setProjectHooksMode(strings.TrimPrefix(value, settingsActionPrefixHooks))
 	case strings.HasPrefix(value, settingsActionPrefixPicker):

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -976,6 +976,100 @@ func TestSettingsHubSetsStatusbarDecoration(t *testing.T) {
 	}
 }
 
+func TestSettingsSetDesktopNotifyWritesTmuxOption(t *testing.T) {
+	t.Parallel()
+
+	var tmuxCalls [][]string
+	cmd := &settingsCommand{
+		lookupEnv: func(name string) string {
+			if name == "TMUX" {
+				return "/tmp/tmux"
+			}
+			return ""
+		},
+		runCommand: func(name string, args ...string) error {
+			tmuxCalls = append(tmuxCalls, append([]string{name}, args...))
+			return nil
+		},
+	}
+	if err := cmd.setDesktopNotify("off"); err != nil {
+		t.Fatalf("setDesktopNotify(off) error = %v", err)
+	}
+	if !reflect.DeepEqual(tmuxCalls, [][]string{
+		{"tmux", "set-option", "-g", desktopNotifyTmuxOption, "0"},
+		{"tmux", "display-message", "desktop notifications: off"},
+	}) {
+		t.Fatalf("tmux calls = %#v", tmuxCalls)
+	}
+
+	tmuxCalls = nil
+	if err := cmd.setDesktopNotify("on"); err != nil {
+		t.Fatalf("setDesktopNotify(on) error = %v", err)
+	}
+	if !reflect.DeepEqual(tmuxCalls, [][]string{
+		{"tmux", "set-option", "-g", desktopNotifyTmuxOption, "1"},
+		{"tmux", "display-message", "desktop notifications: on"},
+	}) {
+		t.Fatalf("tmux calls = %#v", tmuxCalls)
+	}
+}
+
+func TestSettingsSetDesktopNotifyOutsideTmuxIsNoop(t *testing.T) {
+	t.Parallel()
+
+	var tmuxCalls [][]string
+	cmd := &settingsCommand{
+		lookupEnv: func(string) string { return "" },
+		runCommand: func(name string, args ...string) error {
+			tmuxCalls = append(tmuxCalls, append([]string{name}, args...))
+			return nil
+		},
+	}
+	if err := cmd.setDesktopNotify("off"); err != nil {
+		t.Fatalf("setDesktopNotify(off) outside tmux returned error: %v", err)
+	}
+	if len(tmuxCalls) != 0 {
+		t.Fatalf("outside tmux: tmux calls = %#v, want no live update", tmuxCalls)
+	}
+}
+
+func TestSettingsAIEntriesIncludesDesktopNotifyToggle(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cmd := &settingsCommand{
+		ai:      testAICommand(home),
+		homeDir: func() (string, error) { return home, nil },
+		lookupEnv: func(name string) string {
+			if name == "PROJMUX_DESKTOP_NOTIFY" {
+				return "off"
+			}
+			return ""
+		},
+	}
+	entries := cmd.aiEntries()
+	if !hasEntryValue(entries, settingsActionPrefixDesktopNotify+"on") {
+		t.Fatalf("ai entries = %#v, want desktop-notify on row", entries)
+	}
+	if !hasEntryValue(entries, settingsActionPrefixDesktopNotify+"off") {
+		t.Fatalf("ai entries = %#v, want desktop-notify off row", entries)
+	}
+	// Env override sets source = env and effective value = off; confirm
+	// the info row reflects that so users see why a toggle press might
+	// look like a no-op.
+	var sawInfo bool
+	for _, entry := range entries {
+		if strings.Contains(entry.Label, "Desktop notifications") &&
+			strings.Contains(entry.Label, "off") &&
+			strings.Contains(entry.Label, "env") {
+			sawInfo = true
+		}
+	}
+	if !sawInfo {
+		t.Fatalf("ai entries = %#v, want info row with off + env source", entries)
+	}
+}
+
 func TestSettingsHubRunsProjectPickerActions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Roadmap item "OS 알림 정리 (on/off 토글 + AppName 브랜딩)" — Phase 1 + Phase 2 bundled. Same code area, natural single PR per the roadmap detail design.

**Phase 1** — Desktop notification on/off toggle
- Resolution order: `PROJMUX_DESKTOP_NOTIFY` env → tmux option `@projmux_desktop_notify` → default `on`.
- Gate at `aiDesktopNotifier.Notify` entry. In-app notify queue, statusbar segment, attention badge are NOT affected.
- Settings row inside AI Settings popup; effective source shown as `env` / `setting` / `default`.

**Phase 2** — AppName branding `projmux.TmuxCodex` → `com.crevisse.projmux`
- All three hardcode sites (`ai.go:281` AppName, `ai.go` Windows shortcut name → `projmux.lnk`, `notification.go` display-name switch) replaced with constants in new `internal/app/notification_appid.go`.
- Sanity guard accepts both new and legacy AppID during migration window so users mid-upgrade keep getting toasts.
- One-shot Windows legacy cleanup `buildLegacyToastCleanupPowerShell` removes `projmux Tmux Codex.lnk` shortcut + `HKCU:\Software\Classes\AppUserModelId\projmux.TmuxCodex` registry key. Gated by `@projmux_legacy_appid_cleaned` tmux option marker (attempted at most once per tmux server).

## Notable decisions

- Settings row placed **inside existing AI Settings section** (not a new top-level Notifications section) — AI reply-ready is the only desktop-notification producer today; a one-row top-level section would look anemic.
- Legacy cleanup wired inside `n.command.isWSL()` branch right before `ensureWSLToastAppID` (per roadmap detail).
- Cleanup marker is set only when PowerShell launches successfully — silent script-internal failures don't poison the marker.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l internal/app/` empty
- [x] `go test ./...` all packages pass (full suite)
- [ ] Manual WSL: confirm Toast renders with new "projmux" label on first dispatch
- [ ] Manual WSL: confirm legacy `projmux.TmuxCodex` registry key + Start Menu shortcut gone after first dispatch
- [ ] Manual: confirm Settings toggle flips `@projmux_desktop_notify` and gates subsequent notifications
- [ ] Manual: confirm `PROJMUX_DESKTOP_NOTIFY=off` env pins the toggle even when setting=on

## References
- Roadmap detail: `로드맵 디테일 - OS 알림 on-off 토글` (in vault)
- Phase 1 commit: `9576d06`
- Phase 2 commit: `ee44465`

🤖 Generated with [Claude Code](https://claude.com/claude-code)