### PR TITLE
feat(osfocus): tier-1 adapter for Windows Terminal × WSL → Windows

### DIFF
--- a/docs/notify-os-focus-poc.md
+++ b/docs/notify-os-focus-poc.md
@@ -55,9 +55,11 @@ Two entry points are possible:
 
 Lock the decision once the matrix below is filled in:
 
-- [ ] Primary trigger mode confirmed as (b).
-- [ ] (a) shipped as opt-in only, or deferred entirely.
-- [ ] System notification daemon path adopted in place of (a), or deferred.
+- [x] Primary trigger mode confirmed as (b).
+- [x] (a) shipped as opt-in only, or deferred entirely. — **deferred**.
+- [x] System notification daemon path adopted in place of (a), or deferred. —
+  **deferred**; the WSL toast path already in place covers the (a) substitute
+  role for tier-1.
 
 ## Terminal × OS matrix
 
@@ -159,17 +161,33 @@ talk to and falls through to the next on detect failure.
 
 ## Decisions to lock after measurement
 
-- [ ] Tier-1 support matrix — which terminal × OS cells ship in the first
-  adapter PR.
-- [ ] Trigger mode — confirm (a), (b), or both (b primary + (a) opt-in).
-- [ ] System notification daemon integration — in scope for tier-1, or
-  deferred to a follow-on PR.
-- [ ] Adapter module path — proposed `internal/integrations/osfocus/`. Confirm
-  or pick alternative.
-- [ ] Adapter call style — synchronous from `projmux focus`, or background
-  (`tmux run-shell -b`-style) so the click → toast path stays responsive.
-- [ ] Failure policy — silent fallback (keep entry in queue, no error
-  surfaced) confirmed as the default.
+- [x] Tier-1 support matrix — which terminal × OS cells ship in the first
+  adapter PR. → **Windows Terminal × WSL → Windows only** (the single
+  combination measured this session). Other matrix rows stay pending tier-2
+  measurements.
+- [x] Trigger mode — confirm (a), (b), or both (b primary + (a) opt-in). →
+  **(b) on-click/keypress is primary; (a) on-push is deferred** (the WSL
+  toast already serves as the (a) substitute).
+- [x] System notification daemon integration — in scope for tier-1, or
+  deferred to a follow-on PR. → **deferred** (WSL toast path already in
+  place).
+- [x] Adapter module path — proposed `internal/integrations/osfocus/`. Confirm
+  or pick alternative. → confirmed `internal/integrations/osfocus/`.
+- [x] Adapter call style — synchronous from `projmux focus`, or background
+  (`tmux run-shell -b`-style) so the click → toast path stays responsive. →
+  **background goroutine, non-blocking** inside the adapter; the chain
+  itself returns immediately to the caller.
+- [x] Failure policy — silent fallback (keep entry in queue, no error
+  surfaced) confirmed as the default. → confirmed; the chain returns nil
+  even when an adapter's Focus errors.
+
+Locked 2026-05-11.
+
+### Tier-1 status
+
+Tier-1 adapter shipped: `internal/integrations/osfocus/` with
+`WindowsTerminalWSLAdapter`. Other matrix rows remain pending tier-2
+measurements.
 
 ## Out of scope
 

--- a/internal/app/focus.go
+++ b/internal/app/focus.go
@@ -41,6 +41,10 @@ type focusCommand struct {
 	stdout       io.Writer
 	stderr       io.Writer
 	notifierOnce func(stderr io.Writer) focusNotifier
+	// osFocusChain is the OS-window/terminal raise dispatcher invoked after
+	// the tmux pane focus succeeds. Tests stub it to avoid shelling out to
+	// adapters like wt.exe; production code defaults to defaultOSFocusChain.
+	osFocusChain osFocusDispatcher
 }
 
 type focusOptions struct {
@@ -205,6 +209,11 @@ func (c *focusCommand) execute(ctx context.Context, target corefocus.Target, soc
 		base.Reason = "switch-client-failed"
 		return base, err
 	}
+	// tmux pane focus succeeded — fire the OS-focus chain so the host
+	// terminal window is raised. Adapter dispatch is asynchronous and
+	// silent on failure (see internal/integrations/osfocus), so this never
+	// blocks the focus path or surfaces an error.
+	c.dispatchOSFocus(target, socket)
 
 	if target.HasWindow() {
 		windowTarget := fmt.Sprintf("%s:%s", resolution.Name, target.WindowSelector())

--- a/internal/app/osfocus.go
+++ b/internal/app/osfocus.go
@@ -1,0 +1,45 @@
+package app
+
+import (
+	"github.com/crevissepartners/projmux/internal/core/focus"
+	"github.com/crevissepartners/projmux/internal/integrations/osfocus"
+)
+
+// osFocusDispatcher abstracts the chain interface so tests can stub it out
+// (the dispatcher is invoked from execute() and we don't want unit tests to
+// shell out to wt.exe via the default adapter).
+type osFocusDispatcher interface {
+	Focus(target osfocus.Target) error
+}
+
+// defaultOSFocusChain returns the tier-1 chain. As of tier-1 it contains a
+// single adapter (Windows Terminal hosting WSL → Windows); tier-2 will add
+// more matrix entries here. The chain itself is cheap to construct on each
+// call — Detect() is what runs on the focus hot path.
+func defaultOSFocusChain() osFocusDispatcher {
+	return osfocus.NewChain(
+		osfocus.WindowsTerminalWSLAdapter{},
+	)
+}
+
+// dispatchOSFocus is the focus.go-side hook point. It is called from
+// execute() only after the tmux pane focus has succeeded — we don't want to
+// raise the host window when tmux failed, because the user would arrive at
+// the wrong place.
+//
+// The function is best-effort by contract: the chain swallows adapter
+// errors, and we ignore the chain's return value entirely. If no adapter
+// detects (the common case until the user is on a measured terminal × OS
+// combo), this is a no-op.
+func (c *focusCommand) dispatchOSFocus(target focus.Target, socket string) {
+	chain := c.osFocusChain
+	if chain == nil {
+		chain = defaultOSFocusChain()
+	}
+	_ = chain.Focus(osfocus.Target{
+		Socket:  socket,
+		Session: target.Session,
+		Window:  target.WindowSelector(),
+		Pane:    target.PaneSelector(),
+	})
+}

--- a/internal/app/osfocus_test.go
+++ b/internal/app/osfocus_test.go
@@ -1,0 +1,137 @@
+package app
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/integrations/osfocus"
+)
+
+// fakeOSFocusChain stubs out the production chain so unit tests don't shell
+// out to wt.exe and can assert when (and with what Target) the dispatcher
+// was invoked.
+type fakeOSFocusChain struct {
+	mu      sync.Mutex
+	calls   []osfocus.Target
+	respond error
+}
+
+func (f *fakeOSFocusChain) Focus(t osfocus.Target) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, t)
+	return f.respond
+}
+
+func (f *fakeOSFocusChain) snapshot() []osfocus.Target {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]osfocus.Target(nil), f.calls...)
+}
+
+func TestFocus_DispatchesOSFocusOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	listSessions := []byte("100\tworkspace\t1\n")
+	listClients := []byte("/dev/pts/0\tworkspace\n")
+
+	runner := &focusFakeRunner{
+		respond: func(args []string) ([]byte, error) {
+			switch {
+			case containsArg(args, "list-sessions"):
+				return listSessions, nil
+			case containsArg(args, "list-clients"):
+				return listClients, nil
+			}
+			return nil, nil
+		},
+	}
+	chain := &fakeOSFocusChain{}
+	cmd := newFocusTestCommand(runner, nil, nil)
+	cmd.osFocusChain = chain
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := cmd.Run([]string{"--target", "workspace:1.0"}, stdout, stderr); err != nil {
+		t.Fatalf("Run returned error: %v (stderr=%s)", err, stderr.String())
+	}
+
+	calls := chain.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly one os-focus dispatch, got %d (%v)", len(calls), calls)
+	}
+	got := calls[0]
+	if got.Session != "workspace" {
+		t.Errorf("dispatched Target.Session = %q, want %q", got.Session, "workspace")
+	}
+	if got.Window != "1" {
+		t.Errorf("dispatched Target.Window = %q, want %q", got.Window, "1")
+	}
+	if got.Pane != "0" {
+		t.Errorf("dispatched Target.Pane = %q, want %q", got.Pane, "0")
+	}
+}
+
+func TestFocus_DoesNotDispatchOSFocusWhenNoClientAttached(t *testing.T) {
+	t.Parallel()
+
+	// notify-only fallback: there is no attached client, so no tmux pane was
+	// actually focused. Raising the host window would land the user on the
+	// wrong place — the dispatcher must stay quiet.
+	listSessions := []byte("100\tworkspace\t0\n")
+
+	runner := &focusFakeRunner{
+		respond: func(args []string) ([]byte, error) {
+			switch {
+			case containsArg(args, "list-sessions"):
+				return listSessions, nil
+			case containsArg(args, "list-clients"):
+				return []byte(""), nil
+			}
+			return nil, nil
+		},
+	}
+	notifier := &focusFakeNotifier{}
+	chain := &fakeOSFocusChain{}
+	cmd := newFocusTestCommand(runner, nil, notifier)
+	cmd.osFocusChain = chain
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := cmd.Run([]string{"--target", "workspace:1.0"}, stdout, stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if calls := chain.snapshot(); len(calls) != 0 {
+		t.Fatalf("expected no os-focus dispatch on notify-only fallback, got %v", calls)
+	}
+}
+
+func TestFocus_DoesNotDispatchOSFocusOnUnresolvedSession(t *testing.T) {
+	t.Parallel()
+
+	// Session never resolves → no switch-client → no os-focus dispatch.
+	runner := &focusFakeRunner{
+		respond: func(args []string) ([]byte, error) {
+			switch {
+			case containsArg(args, "list-sessions"):
+				return []byte("100\tunrelated\t0\n"), nil
+			case containsArg(args, "list-clients"):
+				return []byte(""), nil
+			}
+			return nil, nil
+		},
+	}
+	chain := &fakeOSFocusChain{}
+	cmd := newFocusTestCommand(runner, nil, nil)
+	cmd.osFocusChain = chain
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	_ = cmd.Run([]string{"--target", "needle:1"}, stdout, stderr)
+
+	if calls := chain.snapshot(); len(calls) != 0 {
+		t.Fatalf("expected no os-focus dispatch when session unresolved, got %v", calls)
+	}
+}

--- a/internal/integrations/osfocus/osfocus.go
+++ b/internal/integrations/osfocus/osfocus.go
@@ -1,0 +1,92 @@
+// Package osfocus contains terminal/OS-window focus adapters that run after
+// the tmux pane focus dispatcher succeeds. Tier-1 ships exactly one adapter,
+// for Windows Terminal hosting WSL → Windows; other terminals listed in the
+// spike matrix (docs/notify-os-focus-poc.md) will land in tier-2 once they
+// are measured.
+//
+// Design notes:
+//
+//   - Detect() should be cheap (env lookups, optional binary existence checks)
+//     because it runs on every focus call.
+//   - Focus() is best-effort and must not block the caller; the adapter is
+//     responsible for any goroutine dispatch internally. The roadmap's risk
+//     section requires the call to stay snappy.
+//   - The Chain returns nil whenever no adapter detects, matching the
+//     documented "silent fallback" failure policy: the calling notify path
+//     still has the tmux pane focus and the in-app notify queue, so doing
+//     nothing on the OS-focus step is the correct no-op.
+//
+// TODO(tier-2): add an OS-level Windows `SetForegroundWindow` fallback adapter
+// for non-WT Windows hosts. Test 2 in the spike doc recorded that path as
+// Partial — it works with the `AttachThreadInput` + `BringWindowToTop` combo
+// but must `IsIconic`-guard `ShowWindow(SW_RESTORE)` so maximized windows
+// aren't restored to normal size. Same for the other matrix rows (Ghostty,
+// Kitty, WezTerm, iTerm2, …) once each environment is measured.
+package osfocus
+
+// Target identifies what the adapter should focus. Fields are advisory — an
+// adapter is free to ignore fields it does not need. Tier-1's
+// WindowsTerminalWSLAdapter ignores all of them because `wt.exe -w 0`
+// raises the active WT window, which is the right behavior when projmux
+// is doing focus from inside the tmux pane the user just clicked toward.
+type Target struct {
+	Socket  string // tmux socket name (-L) the target lives under
+	Session string // tmux session name
+	Window  string // tmux window index/id (rendered form, may be empty)
+	Pane    string // tmux pane index/id (rendered form, may be empty)
+}
+
+// Adapter is the per-environment focus implementation. Detect runs on every
+// focus call and should be cheap; Focus is best-effort and must return
+// without blocking the caller.
+type Adapter interface {
+	Name() string
+	Detect() bool
+	Focus(target Target) error
+}
+
+// Chain holds adapters in priority order. Focus runs the first Detect() that
+// returns true. If no adapter matches, Focus returns nil (treat the OS-focus
+// step as a no-op rather than a failure).
+type Chain struct {
+	adapters []Adapter
+}
+
+// NewChain returns a Chain populated with the supplied adapters in priority
+// order. Nil entries are filtered out defensively so callers can compose the
+// chain conditionally without panicking.
+func NewChain(adapters ...Adapter) *Chain {
+	out := make([]Adapter, 0, len(adapters))
+	for _, a := range adapters {
+		if a == nil {
+			continue
+		}
+		out = append(out, a)
+	}
+	return &Chain{adapters: out}
+}
+
+// Focus walks the chain in order and dispatches to the first adapter whose
+// Detect() returns true. The chain swallows the adapter's error so the
+// overall focus path stays silent on OS-focus failure; only the per-adapter
+// implementation observes the failure (for its own logging, if any). When no
+// adapter detects, Focus returns nil.
+func (c *Chain) Focus(target Target) error {
+	if c == nil {
+		return nil
+	}
+	for _, a := range c.adapters {
+		if a == nil {
+			continue
+		}
+		if !a.Detect() {
+			continue
+		}
+		// Silent fallback policy: the adapter's own error never propagates to
+		// the caller. The chain still stops at the first detect because
+		// further adapters would not match anyway.
+		_ = a.Focus(target)
+		return nil
+	}
+	return nil
+}

--- a/internal/integrations/osfocus/osfocus_test.go
+++ b/internal/integrations/osfocus/osfocus_test.go
@@ -1,0 +1,127 @@
+package osfocus
+
+import (
+	"errors"
+	"testing"
+)
+
+// fakeAdapter is a minimal Adapter used to exercise the Chain. It records
+// whether Focus was called so chain ordering and short-circuit behavior can
+// be asserted.
+type fakeAdapter struct {
+	name     string
+	detect   bool
+	focusErr error
+	focused  int
+	lastTgt  Target
+}
+
+func (a *fakeAdapter) Name() string { return a.name }
+func (a *fakeAdapter) Detect() bool { return a.detect }
+func (a *fakeAdapter) Focus(t Target) error {
+	a.focused++
+	a.lastTgt = t
+	return a.focusErr
+}
+
+func TestChain_EmptyChainReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	c := NewChain()
+	if err := c.Focus(Target{Session: "ws"}); err != nil {
+		t.Fatalf("Focus on empty chain returned %v, want nil", err)
+	}
+}
+
+func TestChain_NilReceiverReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	var c *Chain
+	if err := c.Focus(Target{}); err != nil {
+		t.Fatalf("Focus on nil chain returned %v, want nil", err)
+	}
+}
+
+func TestChain_NoAdapterDetectsReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	a := &fakeAdapter{name: "a", detect: false}
+	c := NewChain(a)
+
+	if err := c.Focus(Target{Session: "ws"}); err != nil {
+		t.Fatalf("Focus returned %v, want nil", err)
+	}
+	if a.focused != 0 {
+		t.Fatalf("Focus was called %d times on non-detecting adapter; want 0", a.focused)
+	}
+}
+
+func TestChain_FirstDetectingAdapterWins(t *testing.T) {
+	t.Parallel()
+
+	first := &fakeAdapter{name: "first", detect: true}
+	second := &fakeAdapter{name: "second", detect: true}
+	c := NewChain(first, second)
+
+	target := Target{Session: "ws", Window: "1", Pane: "0"}
+	if err := c.Focus(target); err != nil {
+		t.Fatalf("Focus returned %v, want nil", err)
+	}
+	if first.focused != 1 {
+		t.Fatalf("first.focused = %d, want 1", first.focused)
+	}
+	if second.focused != 0 {
+		t.Fatalf("second.focused = %d, want 0 (chain should short-circuit)", second.focused)
+	}
+	if first.lastTgt != target {
+		t.Fatalf("first.lastTgt = %#v, want %#v", first.lastTgt, target)
+	}
+}
+
+func TestChain_SkipsNonDetectingAdaptersUntilFirstMatch(t *testing.T) {
+	t.Parallel()
+
+	first := &fakeAdapter{name: "first", detect: false}
+	second := &fakeAdapter{name: "second", detect: true}
+	third := &fakeAdapter{name: "third", detect: true}
+	c := NewChain(first, second, third)
+
+	if err := c.Focus(Target{}); err != nil {
+		t.Fatalf("Focus returned %v, want nil", err)
+	}
+	if first.focused != 0 || third.focused != 0 {
+		t.Fatalf("only the first detecting adapter should run: first=%d third=%d", first.focused, third.focused)
+	}
+	if second.focused != 1 {
+		t.Fatalf("second.focused = %d, want 1", second.focused)
+	}
+}
+
+func TestChain_AdapterErrorIsSwallowed(t *testing.T) {
+	t.Parallel()
+
+	a := &fakeAdapter{name: "a", detect: true, focusErr: errors.New("boom")}
+	c := NewChain(a)
+
+	if err := c.Focus(Target{}); err != nil {
+		t.Fatalf("Focus returned %v, want nil (chain should swallow adapter errors)", err)
+	}
+	if a.focused != 1 {
+		t.Fatalf("a.focused = %d, want 1", a.focused)
+	}
+}
+
+func TestChain_NilEntriesAreSkipped(t *testing.T) {
+	t.Parallel()
+
+	a := &fakeAdapter{name: "a", detect: true}
+	// NewChain takes Adapter values; a typed-nil entry must be tolerated.
+	c := NewChain(nil, a, nil)
+
+	if err := c.Focus(Target{}); err != nil {
+		t.Fatalf("Focus returned %v, want nil", err)
+	}
+	if a.focused != 1 {
+		t.Fatalf("a.focused = %d, want 1", a.focused)
+	}
+}

--- a/internal/integrations/osfocus/wt_wsl.go
+++ b/internal/integrations/osfocus/wt_wsl.go
@@ -1,0 +1,97 @@
+package osfocus
+
+import (
+	"os"
+	"os/exec"
+)
+
+// WindowsTerminalWSLAdapter raises the Windows Terminal window when projmux
+// is running inside WSL and Windows Terminal is the host (the most common
+// projmux setup for Windows users).
+//
+// Detection follows the spike doc's "Notes for adapter authors": Windows
+// Terminal cannot be detected via TERM_PROGRAM inside tmux because tmux
+// rewrites that variable to "tmux"; instead `WT_SESSION` is forwarded into
+// WSL via `WSLENV`. The combination of `WT_SESSION` and `WSL_INTEROP`
+// identifies "Windows Terminal hosting a WSL session" specifically and lets
+// us safely shell out to `wt.exe` via WSL interop.
+//
+// Focus uses `wt.exe -w 0 focus-tab -t 0`. Test 1 in the spike measured
+// this as the no-side-effect raise call: it focuses the active WT window
+// without spawning a new tab (which is what the bare `wt.exe -w 0` form
+// does — see Test 3) and without un-maximizing the window (which the
+// `SetForegroundWindow` + `ShowWindow(SW_RESTORE)` combo can do — see
+// Test 2). The Target argument is ignored at tier-1 because `-w 0` means
+// "the currently active WT window," which matches the pane the user just
+// clicked toward.
+type WindowsTerminalWSLAdapter struct {
+	// LookupEnv is injected for tests. When nil it falls back to os.LookupEnv.
+	LookupEnv func(string) (string, bool)
+	// Run is injected for tests. When nil it spawns wt.exe in the background
+	// with stdout/stderr discarded so the caller is never blocked. The
+	// adapter does not wait on the spawned process.
+	Run func(name string, args ...string) error
+}
+
+// Name returns the adapter's identifier used for logging/telemetry.
+func (a WindowsTerminalWSLAdapter) Name() string { return "windows-terminal-wsl" }
+
+// Detect returns true only when we are inside a WSL distro hosted by Windows
+// Terminal. Both env vars must be non-empty:
+//
+//   - WT_SESSION  → Windows Terminal forwarded its session GUID into WSL
+//     (the user has WSLENV configured the standard way, or WT inherits it).
+//   - WSL_INTEROP → we can spawn Windows-side executables via the WSL
+//     interop bridge (which is how we reach wt.exe).
+func (a WindowsTerminalWSLAdapter) Detect() bool {
+	lookup := a.LookupEnv
+	if lookup == nil {
+		lookup = os.LookupEnv
+	}
+	wt, _ := lookup("WT_SESSION")
+	if wt == "" {
+		return false
+	}
+	interop, _ := lookup("WSL_INTEROP")
+	return interop != ""
+}
+
+// Focus spawns `wt.exe -w 0 focus-tab -t 0` in a goroutine and returns
+// immediately. The call is best-effort: if the spawn fails (wt.exe missing
+// from $PATH, interop misconfigured, etc.) the error is dropped because the
+// chain documents silent fallback as the failure policy. The Target argument
+// is accepted for forward compatibility with tier-2 adapters but not
+// consumed here.
+func (a WindowsTerminalWSLAdapter) Focus(_ Target) error {
+	runner := a.Run
+	if runner == nil {
+		runner = defaultWTRun
+	}
+	// Background dispatch keeps Focus non-blocking — the caller is on the
+	// focus hot path and must not wait on an external process. We discard
+	// the runner's error intentionally; the chain's contract is silent
+	// fallback on adapter failure.
+	go func() {
+		_ = runner("wt.exe", "-w", "0", "focus-tab", "-t", "0")
+	}()
+	return nil
+}
+
+// defaultWTRun spawns the command without waiting on it. stdout/stderr are
+// discarded so the spawn cannot leak handles into the projmux process.
+func defaultWTRun(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Stdin = nil
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	// Reap the child in a goroutine so we don't leave a zombie behind. We
+	// don't surface Wait's error because Focus already returned to the
+	// caller — silent fallback policy.
+	go func() {
+		_ = cmd.Wait()
+	}()
+	return nil
+}

--- a/internal/integrations/osfocus/wt_wsl_test.go
+++ b/internal/integrations/osfocus/wt_wsl_test.go
@@ -1,0 +1,205 @@
+package osfocus
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func envLookup(values map[string]string) func(string) (string, bool) {
+	return func(key string) (string, bool) {
+		v, ok := values[key]
+		return v, ok
+	}
+}
+
+func TestWindowsTerminalWSLAdapter_Name(t *testing.T) {
+	t.Parallel()
+
+	if got := (WindowsTerminalWSLAdapter{}).Name(); got != "windows-terminal-wsl" {
+		t.Fatalf("Name() = %q, want %q", got, "windows-terminal-wsl")
+	}
+}
+
+func TestWindowsTerminalWSLAdapter_Detect(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{
+			name: "both present",
+			env:  map[string]string{"WT_SESSION": "abc", "WSL_INTEROP": "/run/WSL/1_interop"},
+			want: true,
+		},
+		{
+			name: "only WT_SESSION",
+			env:  map[string]string{"WT_SESSION": "abc"},
+			want: false,
+		},
+		{
+			name: "only WSL_INTEROP",
+			env:  map[string]string{"WSL_INTEROP": "/run/WSL/1_interop"},
+			want: false,
+		},
+		{
+			name: "neither",
+			env:  map[string]string{},
+			want: false,
+		},
+		{
+			name: "both empty strings",
+			env:  map[string]string{"WT_SESSION": "", "WSL_INTEROP": ""},
+			want: false,
+		},
+		{
+			name: "WT_SESSION set, WSL_INTEROP empty string",
+			env:  map[string]string{"WT_SESSION": "abc", "WSL_INTEROP": ""},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := WindowsTerminalWSLAdapter{LookupEnv: envLookup(tc.env)}
+			if got := a.Detect(); got != tc.want {
+				t.Fatalf("Detect() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// recordedRun captures the args passed to the injected runner so the test can
+// assert the adapter shells out with the exact spike-measured arguments.
+type recordedRun struct {
+	mu     sync.Mutex
+	calls  [][]string
+	err    error
+	delay  time.Duration
+	signal chan struct{}
+}
+
+func (r *recordedRun) run(name string, args ...string) error {
+	if r.delay > 0 {
+		time.Sleep(r.delay)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, append([]string{name}, args...))
+	if r.signal != nil {
+		close(r.signal)
+		r.signal = nil
+	}
+	return r.err
+}
+
+func (r *recordedRun) snapshot() [][]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([][]string, len(r.calls))
+	for i, c := range r.calls {
+		out[i] = append([]string(nil), c...)
+	}
+	return out
+}
+
+func TestWindowsTerminalWSLAdapter_Focus_ShellsOutWithSpikeArgs(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordedRun{signal: make(chan struct{})}
+	signal := rec.signal
+	a := WindowsTerminalWSLAdapter{Run: rec.run}
+
+	if err := a.Focus(Target{Session: "ws", Window: "1", Pane: "0"}); err != nil {
+		t.Fatalf("Focus returned error: %v", err)
+	}
+
+	// Focus dispatches to a goroutine; wait for the runner to be called.
+	select {
+	case <-signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("runner was not invoked within timeout; calls=%v", rec.snapshot())
+	}
+
+	calls := rec.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly one run, got %d (%v)", len(calls), calls)
+	}
+	want := []string{"wt.exe", "-w", "0", "focus-tab", "-t", "0"}
+	if !equalStrings(calls[0], want) {
+		t.Fatalf("run args = %v, want %v", calls[0], want)
+	}
+}
+
+func TestWindowsTerminalWSLAdapter_Focus_SilentOnRunnerError(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordedRun{
+		err:    errors.New("wt.exe boom"),
+		signal: make(chan struct{}),
+	}
+	signal := rec.signal
+	a := WindowsTerminalWSLAdapter{Run: rec.run}
+
+	if err := a.Focus(Target{}); err != nil {
+		t.Fatalf("Focus returned error despite runner failure: %v", err)
+	}
+	select {
+	case <-signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("runner was not invoked within timeout")
+	}
+}
+
+func TestWindowsTerminalWSLAdapter_Focus_NonBlocking(t *testing.T) {
+	t.Parallel()
+
+	// The runner sleeps for a noticeable interval. If Focus were synchronous
+	// it would block for at least that long; the non-blocking contract says
+	// Focus returns well before the runner completes.
+	const runnerDelay = 250 * time.Millisecond
+	rec := &recordedRun{
+		delay:  runnerDelay,
+		signal: make(chan struct{}),
+	}
+	signal := rec.signal
+	a := WindowsTerminalWSLAdapter{Run: rec.run}
+
+	start := time.Now()
+	if err := a.Focus(Target{}); err != nil {
+		t.Fatalf("Focus returned error: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	// Allow generous slack for scheduling jitter on CI. The point is that
+	// Focus returns far faster than the runner's own delay.
+	if elapsed > runnerDelay/2 {
+		t.Fatalf("Focus blocked for %v, want < %v", elapsed, runnerDelay/2)
+	}
+
+	// The runner still completes asynchronously; verify it eventually fires
+	// so we know dispatch actually happened (not silently dropped).
+	select {
+	case <-signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("runner was never invoked after async dispatch")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Tier-1 implementation of the "Notify 시 터미널 OS 포커스" roadmap item, scoped to the **single terminal × OS combination measured in PR #176**: Windows Terminal hosting WSL → Windows.

## What lands

**New package** `internal/integrations/osfocus/`
- `Adapter` interface + `Chain` dispatcher (priority order, first-match wins, silent on adapter failure, returns nil when nothing matches).
- `WindowsTerminalWSLAdapter` — detects via `WT_SESSION` + `WSL_INTEROP` env (per spike doc note that `TERM_PROGRAM` is masked by tmux). Focus spawns `wt.exe -w 0 focus-tab -t 0` in a background goroutine so the call returns immediately. Silent on launch failure.
- Test coverage for Detect cases (both env / one env / neither), Focus (records args, tolerates injected error), non-blocking dispatch (Focus returns before slow injected runner completes), Chain semantics (empty / no-match / first-match-only / nil-entry).

**Wiring** — `internal/app/focus.go` + new `internal/app/osfocus.go`
- After tmux pane focus succeeds (`switch-client`), the helper builds a `Target` from the resolved socket/session/window/pane and calls `Chain.Focus`. Failures are silent; the in-app notify path is unaffected.
- Hooked ONLY on success — we don't raise the host window if the tmux focus failed (user would arrive at the wrong place).
- Adapter ignores Target for tier-1 (`wt.exe -w 0` always raises the active WT window), but plumbing is in place so tier-2 adapters can consume window/pane selectors without touching the call site again.

**Spike doc close-out** — `docs/notify-os-focus-poc.md`
- All six decisions checkboxes locked with rationale (tier-1: WT × WSL→Windows; trigger mode: (b) on-click; daemon integration deferred; module path `internal/integrations/osfocus/`; call style: background goroutine; failure policy: silent fallback).
- "Locked 2026-05-11" timestamp added.
- New "Tier-1 status" subsection records what shipped and what stays pending.
- `// TODO(tier-2)` left in the package doc for the `SetForegroundWindow` combo (Test 2 finding — non-WT Windows fallback).

## Out of scope (tier-2 candidates)

- Other terminals (Ghostty / Kitty / WezTerm / iTerm2 / Alacritty / VS Code embedded) — pending measurement in those environments.
- `SetForegroundWindow` AttachThreadInput combo for non-WT Windows apps.
- On-push (a) trigger mode; system notification daemon integration.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` empty
- [x] `go test ./internal/integrations/osfocus/... -count=1` PASS
- [x] `go test ./internal/app/... -count=1 -timeout 120s` PASS
- [ ] Manual: WT raise verified on real environment (already confirmed on the lead's box via PR #176 Test 1 measurement; same `wt.exe -w 0 focus-tab -t 0` invocation is the adapter's Focus body).

## References
- Spike doc: `docs/notify-os-focus-poc.md` (post-merge)
- Detail design: `로드맵 디테일 - Notify 시 터미널 OS 포커스` (vault)
- Locked decisions: see the doc's "Decisions to lock" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)