### PR TITLE
feat(notify): Toast click → projmux focus via projmux:// URI (Tier 1.5, Windows scope)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -116,8 +116,10 @@ does not diagnose terminal key delivery; use `projmux setup` for that.
 
 ```
 projmux focus --target SESSION[:WINDOW[.PANE]] [--socket <path>]
-              [--source ai|status-bar|external|os-notification]
-              [--kind reply-ready|busy-cleared|segment-click|custom]
+              [--source ai|status-bar|external|os-notification|toast]
+              [--kind reply-ready|busy-cleared|segment-click|toast-click|custom]
+              [--json]
+projmux focus --uri "projmux://focus?pane_id=%N&socket=<path>&source=toast"
               [--json]
 ```
 
@@ -127,6 +129,13 @@ client on the selected socket. It never force-detaches other clients. If no
 client is attached on that socket, it emits the configured desktop
 notification instead. `--socket` is explicit; when omitted, the socket is
 derived from `$TMUX`.
+
+`--uri` is the entry point used by the WSL Toast click handler (see
+[configuration.md](configuration.md#toast-click-handler-wsl--windows-terminal)).
+The pane id from the URI is resolved to a `SESSION:WINDOW.%paneID` target
+via `tmux display-message`, and the URI's `socket` overrides any
+`--socket` flag so the click round-trips back to the right tmux server.
+`--uri` and `--target` are mutually exclusive.
 
 Exit codes:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,6 +170,38 @@ Settings info row labels the effective source as `env`, `setting`, or
 Hook details for new-session lifecycle hooks and project-local
 `.projmux/config.toml` live in [Hooks](hooks.md).
 
+### Toast click handler (WSL + Windows Terminal)
+
+On WSL, projmux registers a `projmux://` URL scheme on the Windows side the
+first time a Toast is dispatched on each tmux server. Clicking the Toast
+hands control back to projmux inside WSL via the registered command:
+
+```text
+wsl.exe -d $WSL_DISTRO_NAME -- projmux focus --uri "%1"
+```
+
+The URI carries the originating pane id and tmux socket so the click
+round-trips back to the exact pane that fired the notification, which
+the `projmux focus` path then redirects via `tmux switch-client`.
+
+Registration markers and the writes involved:
+
+- Registry keys (HKCU): `SOFTWARE\Classes\projmux\(Default)`,
+  `SOFTWARE\Classes\projmux\URL Protocol`, and
+  `SOFTWARE\Classes\projmux\shell\open\command\(Default)`.
+- tmux user-option marker `@projmux_uri_protocol_registered` records that
+  registration has been attempted on this server so the script runs at most
+  once per server boot.
+
+Limitations:
+
+- The handler captures the user's current `WSL_DISTRO_NAME` at registration
+  time. Users running multiple WSL distros get one handler bound to the
+  first distro that fired a toast — clicks from a different distro's toast
+  will route back through the first distro. Tier-2 follow-up.
+- WSL2 cold-start latency: the first click after a long idle goes through
+  WSL boot and typically takes 2-3s to surface the focus on the pane.
+
 ## Usage Tracking
 
 `projmux usage` and the status-bar usage segment store snapshots under:

--- a/docs/notify-os-focus-poc.md
+++ b/docs/notify-os-focus-poc.md
@@ -169,8 +169,13 @@ talk to and falls through to the next on detect failure.
   **(b) on-click/keypress is primary; (a) on-push is deferred** (the WSL
   toast already serves as the (a) substitute).
 - [x] System notification daemon integration — in scope for tier-1, or
-  deferred to a follow-on PR. → **deferred** (WSL toast path already in
-  place).
+  deferred to a follow-on PR. → **shipped (Windows scope only)**. The WSL
+  toast now carries a `projmux://focus?pane_id=…&socket=…&source=toast`
+  launch URI; a one-shot HKCU registration on first dispatch wires
+  `wsl.exe -d <distro> -- projmux focus --uri "%1"` so the click
+  round-trips back into the (b) focus path. Tier-2 covers
+  non-WSL/non-Windows daemons (libnotify, UNUserNotificationCenter) and
+  the multi-distro handler.
 - [x] Adapter module path — proposed `internal/integrations/osfocus/`. Confirm
   or pick alternative. → confirmed `internal/integrations/osfocus/`.
 - [x] Adapter call style — synchronous from `projmux focus`, or background
@@ -188,6 +193,25 @@ Locked 2026-05-11.
 Tier-1 adapter shipped: `internal/integrations/osfocus/` with
 `WindowsTerminalWSLAdapter`. Other matrix rows remain pending tier-2
 measurements.
+
+### Tier-1.5 shipped — Toast click handler (WSL + Windows Terminal)
+
+The Toast notification produced by `aiDesktopNotifier.Notify` on WSL now
+carries a `launch="projmux://focus?..." activationType="protocol"` attribute,
+and the first dispatch of a tmux server boot registers the `projmux://`
+scheme in `HKCU\SOFTWARE\Classes\projmux\…` so Windows routes the click
+to `wsl.exe -d <distro> -- projmux focus --uri "%1"`. Inside WSL,
+`projmux focus --uri` parses the URI, resolves the pane id to its
+`session:window.%paneID` target via `tmux display-message`, and reuses the
+existing focus dispatch. This closes the previously-deferred (a) on-push
+trigger mode in the Windows-only scope: the Toast becomes the (a)
+surface and its click drops into the (b) `projmux focus` path.
+
+Multi-distro dispatch (one handler per distro, or a distro-selector
+arg) is a known tier-2 follow-up — current registration captures the
+first distro to fire a toast and pins the handler to it. See
+docs/configuration.md → "Toast click handler" for the limitation
+summary.
 
 ## Out of scope
 

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -1726,7 +1726,23 @@ func aiAttentionMismatch(nextState, attentionState string) bool {
 	}
 }
 
-func buildToastPowerShell(summary, body, appName, tag, group, iconPath string) string {
+// buildToastPowerShell composes the PowerShell snippet that Windows runs to
+// surface a Toast notification.
+//
+// When launchURI is non-empty the root <toast> element gains a
+// `launch="<uri>" activationType="protocol"` pair. Windows then hands the
+// URI to the registered scheme handler on click — for the WSL scope shipped
+// today that is `wsl.exe -d <distro> -- projmux focus --uri "%1"`, wired
+// from buildRegisterURIProtocolPowerShell. The URI itself is produced by
+// buildFocusURI (already URL-encoded once); we xml-escape it for the
+// attribute so the two layers compose without double-decoding.
+//
+// When launchURI is empty the launch attribute is omitted entirely and the
+// toast behaves as a passive notification — the existing pre-protocol path.
+// This lets the WSL hook short-circuit cleanly when the inbound
+// notification has no pane id (`aiNotification.Tag` empty) without breaking
+// non-WSL notify paths that never compute a URI.
+func buildToastPowerShell(summary, body, appName, tag, group, iconPath, launchURI string) string {
 	tagLine := ""
 	if tag != "" {
 		tagLine = "$toast.Tag = '" + psEscape(truncate64(tag)) + "'"
@@ -1739,10 +1755,14 @@ func buildToastPowerShell(summary, body, appName, tag, group, iconPath string) s
 	if iconPath != "" {
 		iconXML = "\n      <image placement=\"appLogoOverride\" hint-crop=\"circle\" src=\"" + xmlEscape(iconPath) + "\"/>"
 	}
+	toastAttrs := ""
+	if launchURI != "" {
+		toastAttrs = ` launch="` + xmlEscape(launchURI) + `" activationType="protocol"`
+	}
 	return `[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType=WindowsRuntime] | Out-Null
 [Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType=WindowsRuntime] | Out-Null
 $xml = @'
-<toast>
+<toast` + toastAttrs + `>
   <visual>
     <binding template="ToastGeneric">` + iconXML + `
       <text>` + xmlEscape(summary) + `</text>
@@ -1757,6 +1777,45 @@ $toast = [Windows.UI.Notifications.ToastNotification]::new($tpl)
 ` + tagLine + `
 ` + groupLine + `
 [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('` + psEscape(appName) + `').Show($toast)
+`
+}
+
+// buildRegisterURIProtocolPowerShell emits an idempotent PowerShell script
+// that registers the `projmux://` URI scheme in the user's HKCU registry so
+// a Toast click can hand control back to projmux running inside WSL.
+//
+// Registry layout (HKCU\SOFTWARE\Classes\<scheme>):
+//
+//	(Default)                          = "URL:projmux"
+//	URL Protocol                       = ""
+//	shell\open\command\(Default)       = wsl.exe -d <distro> -- projmux focus --uri "%1"
+//
+// The handler captures the user's *current* WSL_DISTRO_NAME because the
+// click is received on the Windows side with no knowledge of which distro
+// produced the notification. This is the documented limitation: users with
+// multiple WSL distros only get the handler bound to whichever distro fired
+// the first toast on this tmux server. The follow-up roadmap entry covers
+// multi-distro dispatch.
+//
+// The script is safe to re-run — every Set-ItemProperty is overwriting
+// idempotently, and the New-Item is gated on Test-Path. Caller gates the
+// invocation behind a tmux user-option marker so this runs at most once per
+// server boot anyway (see ensureWSLURIProtocol).
+func buildRegisterURIProtocolPowerShell(scheme, distro string) string {
+	return `$regPath = "HKCU:\SOFTWARE\Classes\` + psEscape(scheme) + `"
+$cmdPath = "$regPath\shell\open\command"
+try {
+  if (-not (Test-Path $regPath)) {
+    New-Item -Path $regPath -Force | Out-Null
+  }
+  if (-not (Test-Path $cmdPath)) {
+    New-Item -Path $cmdPath -Force | Out-Null
+  }
+  Set-ItemProperty -Path $regPath -Name '(Default)' -Value 'URL:` + psEscape(scheme) + `' -Type String
+  Set-ItemProperty -Path $regPath -Name 'URL Protocol' -Value '' -Type String
+  $launchCmd = 'wsl.exe -d ` + psEscape(distro) + ` -- projmux focus --uri "%1"'
+  Set-ItemProperty -Path $cmdPath -Name '(Default)' -Value $launchCmd -Type String
+} catch { }
 `
 }
 

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -732,10 +732,15 @@ func TestAIStatusSetWaitingInWSLRegistersToastAppIDAndDispatchesToast(t *testing
 			powershellCommands = append(powershellCommands, command)
 		}
 	}
-	// One-shot legacy cleanup runs before the register + toast PS calls
-	// because the `@projmux_legacy_appid_cleaned` marker is unset for a
-	// fresh aiCommand fixture.
-	if got, want := len(powershellCommands), 3; got != want {
+	// Notify wiring (notification.go) runs PowerShell in this order on the
+	// first WSL toast of a fresh tmux server:
+	//   [0] legacy AppID cleanup    (ensureWSLLegacyAppIDCleaned)
+	//   [1] projmux:// URI register (ensureWSLURIProtocol)
+	//   [2] new AppID register      (ensureWSLToastAppID)
+	//   [3] toast XML show          (dispatchWSLToast)
+	// The legacy + URI registration markers are then written to tmux so
+	// subsequent notifications skip the one-shots.
+	if got, want := len(powershellCommands), 4; got != want {
 		t.Fatalf("powershell commands len = %d, want %d, commands = %#v", got, want, cmdRecorder(cmd).commands)
 	}
 	cleanupScript := decodePowerShellEncodedCommand(t, powershellCommands[0])
@@ -751,7 +756,22 @@ func TestAIStatusSetWaitingInWSLRegistersToastAppIDAndDispatchesToast(t *testing
 	if !containsAICommandArgs(cmdRecorder(cmd).commands, "tmux", []string{"set-option", "-g", legacyAppIDCleanedTmuxOption, "1"}) {
 		t.Fatalf("commands = %#v, want legacy cleanup marker write", cmdRecorder(cmd).commands)
 	}
-	registerScript := decodePowerShellEncodedCommand(t, powershellCommands[1])
+	uriScript := decodePowerShellEncodedCommand(t, powershellCommands[1])
+	for _, want := range []string{
+		`HKCU:\SOFTWARE\Classes\` + desktopURIScheme,
+		`URL:` + desktopURIScheme,
+		"URL Protocol",
+		"shell\\open\\command",
+		`wsl.exe -d Ubuntu-24.04 -- projmux focus --uri "%1"`,
+	} {
+		if !strings.Contains(uriScript, want) {
+			t.Fatalf("uri register script = %q, want substring %q", uriScript, want)
+		}
+	}
+	if !containsAICommandArgs(cmdRecorder(cmd).commands, "tmux", []string{"set-option", "-g", uriProtocolRegisteredTmuxOption, "1"}) {
+		t.Fatalf("commands = %#v, want uri protocol marker write", cmdRecorder(cmd).commands)
+	}
+	registerScript := decodePowerShellEncodedCommand(t, powershellCommands[2])
 	if !strings.Contains(registerScript, `HKCU:\SOFTWARE\Classes\AppUserModelId\`+desktopAppID) {
 		t.Fatalf("register script = %q, want AppUserModelId registration for new id", registerScript)
 	}
@@ -770,7 +790,7 @@ func TestAIStatusSetWaitingInWSLRegistersToastAppIDAndDispatchesToast(t *testing
 			t.Fatalf("register script = %q, want substring %q", registerScript, want)
 		}
 	}
-	toastScript := decodePowerShellEncodedCommand(t, powershellCommands[2])
+	toastScript := decodePowerShellEncodedCommand(t, powershellCommands[3])
 	for _, want := range []string{
 		"CreateToastNotifier('" + desktopAppID + "').Show($toast)",
 		"$toast.Tag = '%2'",
@@ -779,6 +799,11 @@ func TestAIStatusSetWaitingInWSLRegistersToastAppIDAndDispatchesToast(t *testing
 		"검토 대기: approval needed · projmux/main",
 		iconWin,
 		"appLogoOverride",
+		// The toast now carries the projmux:// click target so a desktop
+		// click round-trips back into `projmux focus --uri`.
+		`activationType="protocol"`,
+		"projmux://focus?",
+		"pane_id=%252",
 	} {
 		if !strings.Contains(toastScript, want) {
 			t.Fatalf("toast script = %q, want substring %q", toastScript, want)

--- a/internal/app/focus.go
+++ b/internal/app/focus.go
@@ -52,6 +52,7 @@ type focusOptions struct {
 	Socket string
 	Source string
 	Kind   string
+	URI    string
 	JSON   bool
 }
 
@@ -89,6 +90,10 @@ func (c *focusCommand) Run(args []string, stdout, stderr io.Writer) error {
 
 	opts, err := parseFocusArgs(args, stderr)
 	if err != nil {
+		return err
+	}
+
+	if err := c.resolveURIOption(&opts); err != nil {
 		return err
 	}
 
@@ -139,10 +144,11 @@ func parseFocusArgs(args []string, stderr io.Writer) (focusOptions, error) {
 	fs.SetOutput(stderr)
 
 	opts := focusOptions{}
-	fs.StringVar(&opts.Target, "target", "", "Focus target SESSION[:WINDOW[.PANE]] (required)")
+	fs.StringVar(&opts.Target, "target", "", "Focus target SESSION[:WINDOW[.PANE]] (mutually exclusive with --uri)")
 	fs.StringVar(&opts.Socket, "socket", "", "tmux socket path (overrides $TMUX)")
-	fs.StringVar(&opts.Source, "source", "", "Telemetry label: ai|status-bar|external|os-notification")
-	fs.StringVar(&opts.Kind, "kind", "", "Telemetry label: reply-ready|busy-cleared|segment-click|custom")
+	fs.StringVar(&opts.Source, "source", "", "Telemetry label: ai|status-bar|external|os-notification|toast")
+	fs.StringVar(&opts.Kind, "kind", "", "Telemetry label: reply-ready|busy-cleared|segment-click|toast-click|custom")
+	fs.StringVar(&opts.URI, "uri", "", "projmux:// URI from a Toast click (resolves to --target via tmux)")
 	fs.BoolVar(&opts.JSON, "json", false, "Emit a single-line JSON result")
 
 	if err := fs.Parse(args); err != nil {
@@ -151,8 +157,15 @@ func parseFocusArgs(args []string, stderr io.Writer) (focusOptions, error) {
 	if fs.NArg() != 0 {
 		return focusOptions{}, fmt.Errorf("focus does not accept positional arguments")
 	}
-	if strings.TrimSpace(opts.Target) == "" {
-		return focusOptions{}, fmt.Errorf("--target is required")
+	// --uri and --target are alternative entry points and must not be
+	// combined: --uri carries everything --target+--socket+--source would
+	// have carried, so accepting both would silently let the URI override
+	// (or be overridden by) explicit flags in ways callers can't predict.
+	if strings.TrimSpace(opts.URI) != "" && strings.TrimSpace(opts.Target) != "" {
+		return focusOptions{}, fmt.Errorf("--uri and --target are mutually exclusive")
+	}
+	if strings.TrimSpace(opts.URI) == "" && strings.TrimSpace(opts.Target) == "" {
+		return focusOptions{}, fmt.Errorf("one of --target or --uri is required")
 	}
 	return opts, nil
 }
@@ -266,6 +279,93 @@ func focusSessionState(resolution corefocus.Resolution) string {
 		return "fallback"
 	}
 	return "exact"
+}
+
+// resolveURIOption inflates a `--uri` invocation into the existing
+// `--target`/`--socket`/`--source` shape so the rest of focus dispatch is
+// unchanged.
+//
+// A toast click hands us a tmux pane id like `%8` plus the originating tmux
+// socket. corefocus.Target requires a SESSION[:WINDOW[.PANE]] coordinate,
+// so we resolve the pane id to its enclosing session + window via
+// `tmux display-message -p -t %N '#S__SEP__#I'` against the URI's socket.
+// The translated target preserves the explicit pane id (`session:window.%8`)
+// so the pane-level focus stays exact even if a layout change shifts pane
+// indices between toast emission and click.
+//
+// Telemetry default: `--kind toast-click` is applied when the caller hasn't
+// already set it. `--source` follows the URI's hint (defaults to `toast`).
+func (c *focusCommand) resolveURIOption(opts *focusOptions) error {
+	raw := strings.TrimSpace(opts.URI)
+	if raw == "" {
+		return nil
+	}
+	parsed, err := parseFocusURI(raw)
+	if err != nil {
+		return err
+	}
+	// URI's socket wins over an explicit --socket (the toast click path
+	// carried the socket from the producer side; an additional --socket
+	// flag would generally be a misuse and we surface that by overriding).
+	if strings.TrimSpace(parsed.Socket) != "" {
+		opts.Socket = parsed.Socket
+	}
+	// URI's source wins over --source — the click path is the canonical
+	// telemetry source for this invocation.
+	if strings.TrimSpace(parsed.Source) != "" {
+		opts.Source = parsed.Source
+	}
+	if strings.TrimSpace(opts.Kind) == "" && opts.Source == focusURISourceDef {
+		opts.Kind = "toast-click"
+	}
+
+	socket := c.resolveSocket(opts.Socket)
+	target, err := c.translatePaneIDToTarget(context.Background(), socket, parsed.PaneID)
+	if err != nil {
+		return err
+	}
+	opts.Target = target
+	return nil
+}
+
+// translatePaneIDToTarget resolves a tmux pane id (`%N`) to the
+// `SESSION[:WINDOW.%N]` coordinate corefocus.Target expects. The pane id is
+// preserved on both ends — we read only the session and window index/id —
+// so that the resulting target still pins down the exact pane the toast
+// referenced.
+func (c *focusCommand) translatePaneIDToTarget(ctx context.Context, socket, paneID string) (string, error) {
+	paneID = strings.TrimSpace(paneID)
+	if paneID == "" {
+		return "", errors.New("focus: uri pane_id is empty")
+	}
+	format := "#S" + focusFieldSeparator + "#I"
+	args := c.tmuxArgs(socket, "display-message", "-p", "-t", paneID, format)
+	out, err := c.runner.Run(ctx, "tmux", args...)
+	if err != nil {
+		return "", fmt.Errorf("focus: resolve uri pane %q via tmux: %w", paneID, err)
+	}
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		return "", fmt.Errorf("focus: tmux returned no metadata for pane %q", paneID)
+	}
+	fields := strings.SplitN(line, focusFieldSeparator, 2)
+	if len(fields) != 2 {
+		// Be tolerant of users whose tmux drops our separator and falls
+		// back to tab (rare but documented in the test fixtures).
+		fields = strings.SplitN(line, "\t", 2)
+	}
+	if len(fields) != 2 {
+		return "", fmt.Errorf("focus: parse pane metadata %q", line)
+	}
+	session := strings.TrimSpace(fields[0])
+	window := strings.TrimSpace(fields[1])
+	if session == "" {
+		return "", fmt.Errorf("focus: pane %q has no session", paneID)
+	}
+	if window == "" {
+		return session + ":" + paneID, nil
+	}
+	return session + ":" + window + "." + paneID, nil
 }
 
 func (c *focusCommand) resolveSocket(explicit string) string {

--- a/internal/app/focus_test.go
+++ b/internal/app/focus_test.go
@@ -435,6 +435,193 @@ func TestFocus_AppDispatcherRoutesFocus(t *testing.T) {
 	}
 }
 
+func TestFocus_URIResolvesToSwitchClient(t *testing.T) {
+	t.Parallel()
+
+	// Build a URI as the Toast XML would carry it. Round-tripping through
+	// buildFocusURI guarantees this test stays aligned with the encoder.
+	uri := buildFocusURI("%8", "/tmp/projmux.sock")
+
+	var displayArgs []string
+	runner := &focusFakeRunner{
+		respond: func(args []string) ([]byte, error) {
+			switch {
+			case containsArg(args, "display-message"):
+				// Record so we can assert the pane-id query was sent against
+				// the URI's socket.
+				displayArgs = append([]string(nil), args...)
+				return []byte("workspace" + focusFieldSeparator + "1\n"), nil
+			case containsArg(args, "list-sessions"):
+				return []byte("100\tworkspace\t1\n"), nil
+			case containsArg(args, "list-clients"):
+				return []byte("/dev/pts/0\tworkspace\n"), nil
+			}
+			return nil, nil
+		},
+	}
+	cmd := newFocusTestCommand(runner, nil, nil)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := cmd.Run([]string{"--uri", uri, "--json"}, stdout, stderr); err != nil {
+		t.Fatalf("Run returned error: %v (stderr=%s)", err, stderr.String())
+	}
+
+	var res focusResult
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &res); err != nil {
+		t.Fatalf("decode JSON: %v (raw=%q)", err, stdout.String())
+	}
+	if !res.OK {
+		t.Fatalf("result = %#v, want ok=true", res)
+	}
+	if res.Target != "workspace:1.%8" {
+		t.Fatalf("Target = %q, want workspace:1.%%8", res.Target)
+	}
+	if res.Socket != "/tmp/projmux.sock" {
+		t.Fatalf("Socket = %q, want /tmp/projmux.sock (uri override)", res.Socket)
+	}
+	for _, sub := range []string{"display-message", "list-sessions", "list-clients", "switch-client", "select-window", "select-pane"} {
+		if !sawSubcommand(runner.calls, sub) {
+			t.Errorf("expected tmux call with %q, got %#v", sub, runner.calls)
+		}
+	}
+	// display-message must be addressed at the pane id and run against the
+	// uri's socket (-S /tmp/projmux.sock display-message -p -t %8 #S__SEP__#I).
+	wantInDisplay := []string{"-S", "/tmp/projmux.sock", "display-message", "-p", "-t", "%8"}
+	for _, w := range wantInDisplay {
+		if !slices.Contains(displayArgs, w) {
+			t.Fatalf("display-message args missing %q: %v", w, displayArgs)
+		}
+	}
+}
+
+func TestFocus_URITakesPrecedenceOverSocketFlag(t *testing.T) {
+	t.Parallel()
+
+	uri := buildFocusURI("%4", "/from/uri.sock")
+	runner := &focusFakeRunner{
+		respond: func(args []string) ([]byte, error) {
+			switch {
+			case containsArg(args, "display-message"):
+				return []byte("ws" + focusFieldSeparator + "0\n"), nil
+			case containsArg(args, "list-sessions"):
+				return []byte("100\tws\t1\n"), nil
+			case containsArg(args, "list-clients"):
+				return []byte("/dev/pts/0\tws\n"), nil
+			}
+			return nil, nil
+		},
+	}
+	cmd := newFocusTestCommand(runner, nil, nil)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := cmd.Run([]string{"--uri", uri, "--socket", "/from/flag.sock", "--json"}, stdout, stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	for _, c := range runner.calls {
+		if slices.Contains(c.args, "/from/flag.sock") {
+			t.Fatalf("URI socket should override --socket flag, but saw call with /from/flag.sock: %#v", c.args)
+		}
+	}
+}
+
+func TestFocus_URIRejectsCombinedWithTarget(t *testing.T) {
+	t.Parallel()
+
+	cmd := newFocusTestCommand(&focusFakeRunner{}, nil, nil)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	err := cmd.Run([]string{"--uri", "projmux://focus?pane_id=%251", "--target", "ws"}, stdout, stderr)
+	if err == nil {
+		t.Fatal("expected --uri + --target combination to error, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("err = %v, want mutually-exclusive message", err)
+	}
+}
+
+func TestFocus_URIRejectsMalformedURI(t *testing.T) {
+	t.Parallel()
+
+	cmd := newFocusTestCommand(&focusFakeRunner{}, nil, nil)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	err := cmd.Run([]string{"--uri", "http://focus?pane_id=%251"}, stdout, stderr)
+	if err == nil {
+		t.Fatal("expected wrong-scheme URI to error")
+	}
+}
+
+func TestFocus_URISetsToastClickTelemetryKind(t *testing.T) {
+	t.Parallel()
+
+	uri := buildFocusURI("%2", "/sock")
+	runner := &focusFakeRunner{
+		respond: func(args []string) ([]byte, error) {
+			switch {
+			case containsArg(args, "display-message"):
+				return []byte("ws" + focusFieldSeparator + "0\n"), nil
+			case containsArg(args, "list-sessions"):
+				return []byte("100\tws\t1\n"), nil
+			case containsArg(args, "list-clients"):
+				return []byte("/dev/pts/0\tws\n"), nil
+			}
+			return nil, nil
+		},
+	}
+	cmd := newFocusTestCommand(runner, map[string]string{"PROJMUX_FOCUS_DEBUG": "1"}, nil)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := cmd.Run([]string{"--uri", uri, "--json"}, stdout, stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	// Telemetry line is human-readable and contains `source=` + `kind=`
+	// fields; uri-mode should surface source=toast kind=toast-click so
+	// downstream debugging can distinguish click-driven focus.
+	if !strings.Contains(stderr.String(), "source=toast") {
+		t.Fatalf("stderr = %q, want source=toast", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "kind=toast-click") {
+		t.Fatalf("stderr = %q, want kind=toast-click", stderr.String())
+	}
+}
+
+func TestFocus_URITargetWindowAtIndexZero(t *testing.T) {
+	t.Parallel()
+
+	// Pane that belongs to window index 0 should still produce a
+	// session:0.%paneID target rather than collapsing to session:%paneID.
+	uri := buildFocusURI("%99", "/sock")
+	runner := &focusFakeRunner{
+		respond: func(args []string) ([]byte, error) {
+			switch {
+			case containsArg(args, "display-message"):
+				return []byte("only-session" + focusFieldSeparator + "0\n"), nil
+			case containsArg(args, "list-sessions"):
+				return []byte("100\tonly-session\t1\n"), nil
+			case containsArg(args, "list-clients"):
+				return []byte("/dev/pts/0\tonly-session\n"), nil
+			}
+			return nil, nil
+		},
+	}
+	cmd := newFocusTestCommand(runner, nil, nil)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := cmd.Run([]string{"--uri", uri, "--json"}, stdout, stderr); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	var res focusResult
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &res); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if res.Target != "only-session:0.%99" {
+		t.Fatalf("Target = %q, want only-session:0.%%99", res.Target)
+	}
+}
+
 func containsArg(args []string, needle string) bool {
 	return slices.Contains(args, needle)
 }

--- a/internal/app/notification.go
+++ b/internal/app/notification.go
@@ -62,6 +62,7 @@ func (n aiDesktopNotifier) Notify(notification aiNotification) error {
 	}
 	if n.command.isWSL() {
 		n.command.ensureWSLLegacyAppIDCleaned(notification)
+		n.command.ensureWSLURIProtocol()
 		_ = n.ensureWSLToastAppID(notification)
 		if err := n.dispatchWSLToast(notification); err == nil {
 			return nil
@@ -97,6 +98,17 @@ func (n aiDesktopNotifier) dispatchWSLToast(notification aiNotification) error {
 	if powerShell == "" {
 		return errors.New("powershell.exe is unavailable")
 	}
+	// `notification.Tag` carries the originating pane id (e.g. `%8`); the
+	// Toast click handler needs that plus the live tmux socket path so it
+	// can route back to the right server. Reading `#{socket_path}` here
+	// (rather than threading it through the producer) keeps the existing
+	// notify call sites unchanged and naturally tracks the user's
+	// current tmux server, which is what we want for click round-trip.
+	socket := ""
+	if strings.TrimSpace(notification.Tag) != "" {
+		socket = n.command.readTrimmed("tmux", "display-message", "-p", "#{socket_path}")
+	}
+	launchURI := buildFocusURI(notification.Tag, socket)
 	script := buildToastPowerShell(
 		notification.Summary,
 		notification.Body,
@@ -104,6 +116,7 @@ func (n aiDesktopNotifier) dispatchWSLToast(notification aiNotification) error {
 		notification.Tag,
 		notification.Group,
 		n.command.wslToastIconPath(notification.Icon),
+		launchURI,
 	)
 	return n.command.run(powerShell, "-NoProfile", "-NonInteractive", "-EncodedCommand", encodeUTF16LEBase64(script))
 }
@@ -133,6 +146,47 @@ func (n aiDesktopNotifier) ensureWSLToastAppID(notification aiNotification) erro
 	}
 	script := buildRegisterToastAppIDPowerShell(appID, displayName, n.command.wslToastIconPath(notification.Icon))
 	return n.command.run(powerShell, "-NoProfile", "-NonInteractive", "-EncodedCommand", encodeUTF16LEBase64(script))
+}
+
+// ensureWSLURIProtocol registers the `projmux://` URL scheme in the user's
+// HKCU registry so a Toast click is routed back into `projmux focus --uri`
+// running inside the same WSL distro that produced the notification. It
+// runs at most once per tmux server, gated by
+// `@projmux_uri_protocol_registered`.
+//
+// The handler command binds to the *current* WSL_DISTRO_NAME at
+// registration time — users who switch distros mid-server keep the
+// originally-registered handler. This is the documented multi-distro
+// limitation captured in docs/configuration.md.
+//
+// The marker is only set on a successful PowerShell launch. Failure cases
+// (missing distro env, no PowerShell available, run error) leave the
+// marker unset so a later Notify call retries. The registration script
+// itself swallows individual errors so even a partial registry write
+// doesn't break the notification dispatch.
+func (c *aiCommand) ensureWSLURIProtocol() {
+	if !c.isWSL() {
+		return
+	}
+	if strings.TrimSpace(c.readTrimmed("tmux", "show-option", "-gqv", uriProtocolRegisteredTmuxOption)) == "1" {
+		return
+	}
+	distro := strings.TrimSpace(c.env("WSL_DISTRO_NAME"))
+	if distro == "" {
+		// We don't know which distro the click should target — skipping
+		// without setting the marker lets a later call (after WSLENV is
+		// populated) retry the registration.
+		return
+	}
+	powerShell := c.resolvePowerShell()
+	if powerShell == "" {
+		return
+	}
+	script := buildRegisterURIProtocolPowerShell(desktopURIScheme, distro)
+	if err := c.run(powerShell, "-NoProfile", "-NonInteractive", "-EncodedCommand", encodeUTF16LEBase64(script)); err != nil {
+		return
+	}
+	_ = c.run("tmux", "set-option", "-g", uriProtocolRegisteredTmuxOption, "1")
 }
 
 // ensureWSLLegacyAppIDCleaned removes the Start Menu shortcut and the

--- a/internal/app/notification_appid.go
+++ b/internal/app/notification_appid.go
@@ -24,4 +24,24 @@ const (
 	// Stored as a global tmux user-option so the marker survives across
 	// sessions on the same tmux server.
 	legacyAppIDCleanedTmuxOption = "@projmux_legacy_appid_cleaned"
+
+	// desktopURIScheme is the custom URI scheme the Windows side registers
+	// so that a Toast click can hand control back to projmux running inside
+	// WSL. The scheme is shared across all environments — only WSL +
+	// Windows Terminal users actually register the handler today (other
+	// platforms keep the in-app focus path). The handler command we register
+	// looks like `wsl.exe -d <distro> -- projmux focus --uri "%1"`.
+	//
+	// This implements the "(a) on-push (자동)" trigger mode from the
+	// roadmap detail (Notify 시 터미널 OS 포커스) by piping the user's
+	// click on the system notification through the existing (b)
+	// `projmux focus` path. See docs/notify-os-focus-poc.md for the spike
+	// trail.
+	desktopURIScheme = "projmux"
+
+	// uriProtocolRegisteredTmuxOption marks that the one-shot URI protocol
+	// registration has already been attempted on this server. Same shape
+	// and rationale as legacyAppIDCleanedTmuxOption: we register at most
+	// once per tmux server lifetime to keep the notify path fast.
+	uriProtocolRegisteredTmuxOption = "@projmux_uri_protocol_registered"
 )

--- a/internal/app/notification_toast_launch_test.go
+++ b/internal/app/notification_toast_launch_test.go
@@ -1,0 +1,76 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildToastPowerShell_OmitsLaunchWhenURIEmpty(t *testing.T) {
+	t.Parallel()
+
+	script := buildToastPowerShell("hello", "world", "com.crevisse.projmux", "%8", "session", "", "")
+	if strings.Contains(script, "launch=") {
+		t.Fatalf("expected launch attribute absent when launchURI is empty; got:\n%s", script)
+	}
+	if strings.Contains(script, "activationType=") {
+		t.Fatalf("expected activationType attribute absent when launchURI is empty; got:\n%s", script)
+	}
+	if !strings.Contains(script, "<toast>") {
+		t.Fatalf("expected bare <toast> open tag without launch URI; got:\n%s", script)
+	}
+}
+
+func TestBuildToastPowerShell_InjectsLaunchAndProtocolActivation(t *testing.T) {
+	t.Parallel()
+
+	uri := buildFocusURI("%8", "/tmp/tmux-1000/projmux")
+	script := buildToastPowerShell("hello", "world", "com.crevisse.projmux", "%8", "session", "", uri)
+	if !strings.Contains(script, `activationType="protocol"`) {
+		t.Fatalf("expected activationType=\"protocol\"; got:\n%s", script)
+	}
+	if !strings.Contains(script, `launch="`) {
+		t.Fatalf("expected launch attribute present; got:\n%s", script)
+	}
+	// The URI is URL-encoded once by buildFocusURI; the XML layer then
+	// xml-escapes `&` to `&amp;`. The two encodings compose, so the raw
+	// URI's `&` must appear in the script as `&amp;`.
+	if !strings.Contains(script, "&amp;") {
+		t.Fatalf("expected `&` in URI to be xml-escaped to `&amp;`; got:\n%s", script)
+	}
+	if strings.Contains(script, "?pane_id=%8&socket=") {
+		t.Fatalf("raw `&` leaked into XML attribute (broken double-encoding); got:\n%s", script)
+	}
+}
+
+func TestBuildRegisterURIProtocolPowerShell_WritesAllRegistryKeys(t *testing.T) {
+	t.Parallel()
+
+	script := buildRegisterURIProtocolPowerShell("projmux", "Ubuntu-24.04")
+	wantSubstrings := []string{
+		`$regPath = "HKCU:\SOFTWARE\Classes\projmux"`,
+		`$cmdPath = "$regPath\shell\open\command"`,
+		"New-Item -Path $regPath -Force",
+		"New-Item -Path $cmdPath -Force",
+		`Set-ItemProperty -Path $regPath -Name '(Default)' -Value 'URL:projmux'`,
+		"Set-ItemProperty -Path $regPath -Name 'URL Protocol' -Value ''",
+		`wsl.exe -d Ubuntu-24.04 -- projmux focus --uri "%1"`,
+		`Set-ItemProperty -Path $cmdPath -Name '(Default)'`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(script, want) {
+			t.Fatalf("register script missing %q:\n%s", want, script)
+		}
+	}
+}
+
+func TestBuildRegisterURIProtocolPowerShell_PSEscapesDistro(t *testing.T) {
+	t.Parallel()
+
+	// Distro names with single quotes (unusual but technically allowed in
+	// WSL distro registration) must be PowerShell-escaped to keep the
+	// quoted string literal balanced.
+	script := buildRegisterURIProtocolPowerShell("projmux", "weird's-distro")
+	if !strings.Contains(script, `wsl.exe -d weird''s-distro -- projmux focus --uri "%1"`) {
+		t.Fatalf("expected single-quote-escaped distro in launch command; got:\n%s", script)
+	}
+}

--- a/internal/app/notification_uri.go
+++ b/internal/app/notification_uri.go
@@ -1,0 +1,114 @@
+package app
+
+// notification_uri.go encodes and decodes the `projmux://` URI that the
+// WSL → Windows Toast click handler shuttles between the Windows shell and
+// the in-WSL `projmux focus --uri` invocation.
+//
+// The URI shape is:
+//
+//	projmux://focus?pane_id=<%paneID>&socket=<socketPath>&source=toast
+//
+// `pane_id` is the tmux pane id (e.g. `%8`) — the same identifier the Toast
+// already carries in its `Tag`. `socket` is the tmux socket path the
+// notification was produced from (we read `#{socket_path}` at notify time
+// so the click round-trips back to the right server even when the user runs
+// multiple tmux servers). `source` defaults to `toast` and is surfaced in
+// focus telemetry so the click path is distinguishable from a status-bar or
+// notify-sidebar click.
+//
+// Both encodings are URL-encoded once; the toast XML attribute layer then
+// xml-escapes the result. The two encodings compose without ambiguity (URL
+// reserved chars and XML reserved chars do not overlap on the producer
+// side after `&` → `%26`).
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const (
+	focusURIHost      = "focus"
+	focusURIParamPane = "pane_id"
+	focusURIParamSock = "socket"
+	focusURIParamSrc  = "source"
+	focusURISourceDef = "toast"
+)
+
+// buildFocusURI assembles a `projmux://focus?...` URI from a tmux pane id
+// and a tmux socket path. `paneID` is required; an empty pane id returns
+// an empty string so callers can use the result as a "no launch attribute"
+// signal (the Toast XML omits the launch attribute when this is empty).
+// `socket` is optional — at click time the receiving `projmux focus --uri`
+// falls back to $TMUX when the query param is absent.
+func buildFocusURI(paneID, socket string) string {
+	paneID = strings.TrimSpace(paneID)
+	if paneID == "" {
+		return ""
+	}
+	values := url.Values{}
+	values.Set(focusURIParamPane, paneID)
+	if s := strings.TrimSpace(socket); s != "" {
+		values.Set(focusURIParamSock, s)
+	}
+	values.Set(focusURIParamSrc, focusURISourceDef)
+	// url.Values.Encode sorts keys, which keeps the output stable for tests.
+	return desktopURIScheme + "://" + focusURIHost + "?" + values.Encode()
+}
+
+// focusURI is the parsed shape of a `projmux://focus?...` URI.
+type focusURI struct {
+	PaneID string
+	Socket string
+	Source string
+}
+
+// parseFocusURI inverts buildFocusURI. Unknown query parameters are ignored
+// so future extensions stay backward-compatible. Source defaults to
+// `toast` when the parameter is absent (the click invariably comes from a
+// Toast in the WSL scope shipping today, and the explicit default makes
+// telemetry stable when older Toast XML is encountered).
+func parseFocusURI(raw string) (focusURI, error) {
+	if strings.TrimSpace(raw) == "" {
+		return focusURI{}, errors.New("focus uri: empty")
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return focusURI{}, fmt.Errorf("focus uri: parse %q: %w", raw, err)
+	}
+	if parsed.Scheme != desktopURIScheme {
+		return focusURI{}, fmt.Errorf("focus uri: scheme %q is not %q", parsed.Scheme, desktopURIScheme)
+	}
+	// `projmux://focus?...` parses with Host=="focus". Some shells may
+	// pass `projmux:focus?...` (opaque form); accept both. RawPath /
+	// Opaque cover the corner case where Windows hands us the URL with
+	// extra encoding around the host segment.
+	host := strings.ToLower(parsed.Host)
+	if host == "" {
+		// Opaque form: `projmux:focus?...` ends up in Opaque without `//`.
+		opaque := parsed.Opaque
+		if i := strings.Index(opaque, "?"); i >= 0 {
+			opaque = opaque[:i]
+		}
+		host = strings.ToLower(strings.Trim(opaque, "/"))
+	}
+	if host != focusURIHost {
+		return focusURI{}, fmt.Errorf("focus uri: host %q is not %q", host, focusURIHost)
+	}
+
+	values, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return focusURI{}, fmt.Errorf("focus uri: query %q: %w", parsed.RawQuery, err)
+	}
+	pane := strings.TrimSpace(values.Get(focusURIParamPane))
+	if pane == "" {
+		return focusURI{}, errors.New("focus uri: missing pane_id")
+	}
+	socket := strings.TrimSpace(values.Get(focusURIParamSock))
+	source := strings.TrimSpace(values.Get(focusURIParamSrc))
+	if source == "" {
+		source = focusURISourceDef
+	}
+	return focusURI{PaneID: pane, Socket: socket, Source: source}, nil
+}

--- a/internal/app/notification_uri_test.go
+++ b/internal/app/notification_uri_test.go
@@ -1,0 +1,186 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildFocusURI_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		pane   string
+		socket string
+	}{
+		{"basic", "%8", "/tmp/tmux-1000/projmux"},
+		{"no socket", "%12", ""},
+		{"socket with spaces", "%3", "/tmp/tmux 1000/default"},
+		{"unicode socket", "%5", "/tmp/tmux-한글/소켓"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			uri := buildFocusURI(tc.pane, tc.socket)
+			if uri == "" {
+				t.Fatalf("buildFocusURI returned empty for pane=%q socket=%q", tc.pane, tc.socket)
+			}
+			parsed, err := parseFocusURI(uri)
+			if err != nil {
+				t.Fatalf("parseFocusURI(%q) error: %v", uri, err)
+			}
+			if parsed.PaneID != tc.pane {
+				t.Fatalf("PaneID = %q, want %q", parsed.PaneID, tc.pane)
+			}
+			if parsed.Socket != tc.socket {
+				t.Fatalf("Socket = %q, want %q", parsed.Socket, tc.socket)
+			}
+			if parsed.Source != focusURISourceDef {
+				t.Fatalf("Source = %q, want %q", parsed.Source, focusURISourceDef)
+			}
+		})
+	}
+}
+
+func TestBuildFocusURI_EmptyPaneReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := buildFocusURI("", "/sock"); got != "" {
+		t.Fatalf("buildFocusURI with empty pane = %q, want empty", got)
+	}
+	if got := buildFocusURI("   ", "/sock"); got != "" {
+		t.Fatalf("buildFocusURI with whitespace pane = %q, want empty", got)
+	}
+}
+
+func TestBuildFocusURI_SchemeAndHost(t *testing.T) {
+	t.Parallel()
+
+	uri := buildFocusURI("%1", "/s")
+	if !strings.HasPrefix(uri, "projmux://focus?") {
+		t.Fatalf("uri = %q, want projmux://focus? prefix", uri)
+	}
+}
+
+func TestParseFocusURI_RejectsWrongScheme(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		"http://focus?pane_id=%251",
+		"https://focus?pane_id=%251",
+		"vscode://focus?pane_id=%251",
+		"projmuxx://focus?pane_id=%251",
+	} {
+		if _, err := parseFocusURI(raw); err == nil {
+			t.Fatalf("parseFocusURI(%q) accepted wrong scheme", raw)
+		}
+	}
+}
+
+func TestParseFocusURI_RejectsWrongHost(t *testing.T) {
+	t.Parallel()
+
+	if _, err := parseFocusURI("projmux://launch?pane_id=%251"); err == nil {
+		t.Fatal("parseFocusURI accepted non-focus host")
+	}
+}
+
+func TestParseFocusURI_RejectsMissingPaneID(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		"projmux://focus",
+		"projmux://focus?",
+		"projmux://focus?socket=/tmp/sock",
+		"projmux://focus?pane_id=",
+		"projmux://focus?pane_id=%20%20",
+	} {
+		if _, err := parseFocusURI(raw); err == nil {
+			t.Fatalf("parseFocusURI(%q) accepted missing pane_id", raw)
+		}
+	}
+}
+
+func TestParseFocusURI_DecodesURLEncodedSocket(t *testing.T) {
+	t.Parallel()
+
+	uri := "projmux://focus?pane_id=%258&socket=%2Ftmp%2Ftmux-1000%2Fprojmux"
+	got, err := parseFocusURI(uri)
+	if err != nil {
+		t.Fatalf("parseFocusURI: %v", err)
+	}
+	if got.PaneID != "%8" {
+		t.Fatalf("PaneID = %q, want %q", got.PaneID, "%8")
+	}
+	if got.Socket != "/tmp/tmux-1000/projmux" {
+		t.Fatalf("Socket = %q, want /tmp/tmux-1000/projmux", got.Socket)
+	}
+	if got.Source != focusURISourceDef {
+		t.Fatalf("Source = %q, want %q", got.Source, focusURISourceDef)
+	}
+}
+
+func TestParseFocusURI_DefaultSourceWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseFocusURI("projmux://focus?pane_id=%251")
+	if err != nil {
+		t.Fatalf("parseFocusURI: %v", err)
+	}
+	if got.Source != focusURISourceDef {
+		t.Fatalf("Source = %q, want default %q", got.Source, focusURISourceDef)
+	}
+}
+
+func TestParseFocusURI_IgnoresUnknownParams(t *testing.T) {
+	t.Parallel()
+
+	uri := "projmux://focus?pane_id=%251&socket=/s&future=hello&another=world"
+	got, err := parseFocusURI(uri)
+	if err != nil {
+		t.Fatalf("parseFocusURI rejected extra params: %v", err)
+	}
+	if got.PaneID != "%1" || got.Socket != "/s" {
+		t.Fatalf("got = %#v, want pane=%%1 socket=/s", got)
+	}
+}
+
+func TestParseFocusURI_CustomSourcePreserved(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseFocusURI("projmux://focus?pane_id=%251&source=custom-handler")
+	if err != nil {
+		t.Fatalf("parseFocusURI: %v", err)
+	}
+	if got.Source != "custom-handler" {
+		t.Fatalf("Source = %q, want custom-handler", got.Source)
+	}
+}
+
+func TestParseFocusURI_OpaqueFormAccepted(t *testing.T) {
+	t.Parallel()
+
+	// Some Windows shells hand us `projmux:focus?...` without the `//`
+	// authority delimiter; net/url parses this as opaque. Accept it so we
+	// don't reject a click just because of an authority-stripping shell.
+	got, err := parseFocusURI("projmux:focus?pane_id=%251&socket=/s")
+	if err != nil {
+		t.Fatalf("parseFocusURI(opaque) error: %v", err)
+	}
+	if got.PaneID != "%1" || got.Socket != "/s" {
+		t.Fatalf("got = %#v, want pane=%%1 socket=/s", got)
+	}
+}
+
+func TestParseFocusURI_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	if _, err := parseFocusURI(""); err == nil {
+		t.Fatal("parseFocusURI(\"\") accepted empty input")
+	}
+	if _, err := parseFocusURI("   "); err == nil {
+		t.Fatal("parseFocusURI whitespace accepted empty input")
+	}
+}


### PR DESCRIPTION
## Summary

Adopts the deferred (a) on-push trigger mode **for Windows + Windows Terminal only**. When projmux fires a desktop Toast and the user clicks it from Windows side, control routes back into WSL → `projmux focus` → existing tmux pane-focus + osfocus chain.

This is the **Tier 1.5** entry from the roadmap hub doc — bridges the gap between (a) (on-push automatic) and (b) (on-click in tmux), giving Windows users a way to act on a notification while they're elsewhere in the OS.

## Design — `projmux://` URI protocol

- Scheme: `projmux:` registered in HKCU on the Windows side.
- Handler: `wsl.exe -d <distro> -- projmux focus --uri "%1"`.
- URI shape: `projmux://focus?pane_id=<%paneID>&socket=<socketPath>&source=toast` (URL-encoded once; Toast XML attribute then xml-escapes — encodings compose).
- Toast XML gains `launch="..."` + `activationType="protocol"` on the root `<toast>`. Click → Windows resolves protocol → spawns wsl.exe → in-WSL projmux focus dispatches.

## What lands

**Constants** (`internal/app/notification_appid.go`)
- `desktopURIScheme = "projmux"`, `uriProtocolRegisteredTmuxOption = "@projmux_uri_protocol_registered"`.

**URI builder + parser** (`internal/app/notification_uri.go` + tests)
- `buildFocusURI(paneID, socket)`, `parseFocusURI(raw)` with round-trip semantics.
- Accepts both `projmux://focus?...` (authority form) and `projmux:focus?...` (opaque form) — Windows shell occasionally mangles URLs and we'd lose clicks if we rejected the opaque form.

**One-shot registration** (`internal/app/notification.go`)
- `ensureWSLURIProtocol()` mirrors `ensureWSLLegacyAppIDCleaned` / `ensureWSLToastAppID`. Gated by tmux user option `@projmux_uri_protocol_registered`. Skips silently when `WSL_DISTRO_NAME` is empty or PowerShell unreachable. Wired in `aiDesktopNotifier.Notify` right after the legacy cleanup.
- `buildRegisterURIProtocolPowerShell(scheme, distro)` writes the HKCU keys.

**Toast XML** (`internal/app/ai.go`)
- `buildToastPowerShell` signature gains `launchURI`. Non-empty launchURI → `<toast launch="..." activationType="protocol">`. Empty → no attribute (back-compat for non-WSL paths).

**Focus CLI** (`internal/app/focus.go`)
- `--uri <url>` flag mutually exclusive with `--target`.
- URI socket/source override the corresponding flags (URI wins).
- Pane id → target translation preserves the pane id in the target string (`session:1.%8`) so layout shifts between toast emission and click don't desync the focus.

**Docs** — `docs/cli.md`, `docs/configuration.md`, `docs/notify-os-focus-poc.md` updated.

## Limits (recorded as Tier-2 followups in roadmap)

- Single WSL distro registered (current `WSL_DISTRO_NAME`). Multi-distro users get clicks routed through the registration distro only.
- WSL2 cold-start latency ~2-3s between click and pane focus.
- `wsl.exe -d <distro> -- projmux focus --uri "%1"` assumes `projmux` is on PATH inside the distro. Standard install satisfies this.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` empty
- [x] `go test ./... -count=1 -timeout 180s` — 23 packages PASS
- [ ] Manual: install on lead box; trigger a real toast; click; verify the toast dismisses, projmux focus runs, and the pane is selected.
- [ ] Manual: verify the registry was written: `HKCU:\SOFTWARE\Classes\projmux\shell\open\command` contains `wsl.exe ... projmux focus --uri "%1"`.
- [ ] Manual: verify tmux marker `@projmux_uri_protocol_registered = 1` is set after first dispatch.

## References
- Hub doc: vault `로드맵 디테일 - Notify 시 터미널 OS 포커스` (Tier 1.5 section)
- Spike data: `docs/notify-os-focus-poc.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)