### PR TITLE
fix(notify): correct projmux:// registry command to bypass zsh shell

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,8 +177,15 @@ first time a Toast is dispatched on each tmux server. Clicking the Toast
 hands control back to projmux inside WSL via the registered command:
 
 ```text
-wsl.exe -d $WSL_DISTRO_NAME -- projmux focus --uri "%1"
+wsl.exe -d $WSL_DISTRO_NAME --exec <absolute-path-to-projmux> focus --uri "%1"
 ```
+
+`--exec` (rather than `--`) is required so the URI bypasses the user's
+default login shell — `wsl.exe -- <cmd>` routes its tail through that shell,
+which then parses `&` query-string separators as background-job operators
+(zsh emits `parse error near '&'`). The absolute WSL filesystem path to the
+binary is captured at registration time so the launch doesn't depend on
+PATH being set under `--exec`.
 
 The URI carries the originating pane id and tmux socket so the click
 round-trips back to the exact pane that fired the notification, which
@@ -189,9 +196,12 @@ Registration markers and the writes involved:
 - Registry keys (HKCU): `SOFTWARE\Classes\projmux\(Default)`,
   `SOFTWARE\Classes\projmux\URL Protocol`, and
   `SOFTWARE\Classes\projmux\shell\open\command\(Default)`.
-- tmux user-option marker `@projmux_uri_protocol_registered` records that
+- tmux user-option marker `@projmux_uri_protocol_registered_v2` records that
   registration has been attempted on this server so the script runs at most
-  once per server boot.
+  once per server boot. (The v1 marker `@projmux_uri_protocol_registered`
+  was bumped when the registry command switched to `--exec`; existing v1
+  users re-register transparently on the next Notify after upgrade and the
+  orphaned v1 key requires no cleanup.)
 
 Limitations:
 

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -1732,8 +1732,8 @@ func aiAttentionMismatch(nextState, attentionState string) bool {
 // When launchURI is non-empty the root <toast> element gains a
 // `launch="<uri>" activationType="protocol"` pair. Windows then hands the
 // URI to the registered scheme handler on click — for the WSL scope shipped
-// today that is `wsl.exe -d <distro> -- projmux focus --uri "%1"`, wired
-// from buildRegisterURIProtocolPowerShell. The URI itself is produced by
+// today that is `wsl.exe -d <distro> --exec <abs-binary-path> focus --uri "%1"`,
+// wired from buildRegisterURIProtocolPowerShell. The URI itself is produced by
 // buildFocusURI (already URL-encoded once); we xml-escape it for the
 // attribute so the two layers compose without double-decoding.
 //
@@ -1788,7 +1788,17 @@ $toast = [Windows.UI.Notifications.ToastNotification]::new($tpl)
 //
 //	(Default)                          = "URL:projmux"
 //	URL Protocol                       = ""
-//	shell\open\command\(Default)       = wsl.exe -d <distro> -- projmux focus --uri "%1"
+//	shell\open\command\(Default)       = wsl.exe -d <distro> --exec <binaryPath> focus --uri "%1"
+//
+// `--exec` instead of `--` is load-bearing: `wsl.exe -- <cmd> <args>` routes
+// `<cmd> <args>` through the user's default login shell (zsh/bash). The
+// `projmux://` URI carries `&` characters as query-parameter separators, and
+// zsh parses `&` as a background-job operator before projmux ever runs,
+// emitting `zsh:1: parse error near '&'`. `--exec` skips the shell and
+// invokes the binary directly with the args verbatim. Because `--exec`
+// doesn't load shell init files, PATH may be empty, so we register the
+// absolute WSL filesystem path to the projmux binary captured at
+// registration time (whichever binary actually wrote the registry key).
 //
 // The handler captures the user's *current* WSL_DISTRO_NAME because the
 // click is received on the Windows side with no knowledge of which distro
@@ -1801,7 +1811,7 @@ $toast = [Windows.UI.Notifications.ToastNotification]::new($tpl)
 // idempotently, and the New-Item is gated on Test-Path. Caller gates the
 // invocation behind a tmux user-option marker so this runs at most once per
 // server boot anyway (see ensureWSLURIProtocol).
-func buildRegisterURIProtocolPowerShell(scheme, distro string) string {
+func buildRegisterURIProtocolPowerShell(scheme, distro, binaryPath string) string {
 	return `$regPath = "HKCU:\SOFTWARE\Classes\` + psEscape(scheme) + `"
 $cmdPath = "$regPath\shell\open\command"
 try {
@@ -1813,7 +1823,7 @@ try {
   }
   Set-ItemProperty -Path $regPath -Name '(Default)' -Value 'URL:` + psEscape(scheme) + `' -Type String
   Set-ItemProperty -Path $regPath -Name 'URL Protocol' -Value '' -Type String
-  $launchCmd = 'wsl.exe -d ` + psEscape(distro) + ` -- projmux focus --uri "%1"'
+  $launchCmd = 'wsl.exe -d ` + psEscape(distro) + ` --exec ` + psEscape(binaryPath) + ` focus --uri "%1"'
   Set-ItemProperty -Path $cmdPath -Name '(Default)' -Value $launchCmd -Type String
 } catch { }
 `

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -762,7 +762,10 @@ func TestAIStatusSetWaitingInWSLRegistersToastAppIDAndDispatchesToast(t *testing
 		`URL:` + desktopURIScheme,
 		"URL Protocol",
 		"shell\\open\\command",
-		`wsl.exe -d Ubuntu-24.04 -- projmux focus --uri "%1"`,
+		// `--exec <abs-path>` (no shell, no PATH dependency) — see the
+		// hot-fix note on buildRegisterURIProtocolPowerShell. The binary
+		// path comes from testAICommand's fake executable resolver.
+		`wsl.exe -d Ubuntu-24.04 --exec /tmp/projmux focus --uri "%1"`,
 	} {
 		if !strings.Contains(uriScript, want) {
 			t.Fatalf("uri register script = %q, want substring %q", uriScript, want)

--- a/internal/app/notification.go
+++ b/internal/app/notification.go
@@ -178,11 +178,23 @@ func (c *aiCommand) ensureWSLURIProtocol() {
 		// populated) retry the registration.
 		return
 	}
+	// Resolve the absolute WSL path to this projmux binary so the registry
+	// command can use `wsl.exe --exec <abs-path>` (no shell, no PATH
+	// dependency). If we can't resolve the path, skip without setting the
+	// marker so a later Notify retries with a healthier environment.
+	binaryPath, err := c.binaryPath()
+	if err != nil {
+		return
+	}
+	binaryPath = strings.TrimSpace(binaryPath)
+	if binaryPath == "" {
+		return
+	}
 	powerShell := c.resolvePowerShell()
 	if powerShell == "" {
 		return
 	}
-	script := buildRegisterURIProtocolPowerShell(desktopURIScheme, distro)
+	script := buildRegisterURIProtocolPowerShell(desktopURIScheme, distro, binaryPath)
 	if err := c.run(powerShell, "-NoProfile", "-NonInteractive", "-EncodedCommand", encodeUTF16LEBase64(script)); err != nil {
 		return
 	}

--- a/internal/app/notification_appid.go
+++ b/internal/app/notification_appid.go
@@ -30,7 +30,9 @@ const (
 	// WSL. The scheme is shared across all environments — only WSL +
 	// Windows Terminal users actually register the handler today (other
 	// platforms keep the in-app focus path). The handler command we register
-	// looks like `wsl.exe -d <distro> -- projmux focus --uri "%1"`.
+	// looks like `wsl.exe -d <distro> --exec <abs-binary-path> focus --uri "%1"`
+	// — `--exec` bypasses the user's login shell so URI query separators
+	// (`&`) don't get parsed as background-job operators by zsh/bash.
 	//
 	// This implements the "(a) on-push (자동)" trigger mode from the
 	// roadmap detail (Notify 시 터미널 OS 포커스) by piping the user's
@@ -43,5 +45,12 @@ const (
 	// registration has already been attempted on this server. Same shape
 	// and rationale as legacyAppIDCleanedTmuxOption: we register at most
 	// once per tmux server lifetime to keep the notify path fast.
-	uriProtocolRegisteredTmuxOption = "@projmux_uri_protocol_registered"
+	//
+	// v2 — incremented after the hot-fix that switched the registry command
+	// from `wsl.exe -- projmux ...` (broke on `&` due to shell
+	// interpretation) to `wsl.exe --exec <abs-path> ...`. Existing v1 marker
+	// users get a fresh registration on their next Notify dispatch; the v1
+	// key (`@projmux_uri_protocol_registered`) is left orphaned —
+	// re-registration is idempotent so no cleanup is needed.
+	uriProtocolRegisteredTmuxOption = "@projmux_uri_protocol_registered_v2"
 )

--- a/internal/app/notification_toast_launch_test.go
+++ b/internal/app/notification_toast_launch_test.go
@@ -45,7 +45,7 @@ func TestBuildToastPowerShell_InjectsLaunchAndProtocolActivation(t *testing.T) {
 func TestBuildRegisterURIProtocolPowerShell_WritesAllRegistryKeys(t *testing.T) {
 	t.Parallel()
 
-	script := buildRegisterURIProtocolPowerShell("projmux", "Ubuntu-24.04")
+	script := buildRegisterURIProtocolPowerShell("projmux", "Ubuntu-24.04", "/home/me/go/bin/projmux")
 	wantSubstrings := []string{
 		`$regPath = "HKCU:\SOFTWARE\Classes\projmux"`,
 		`$cmdPath = "$regPath\shell\open\command"`,
@@ -53,7 +53,7 @@ func TestBuildRegisterURIProtocolPowerShell_WritesAllRegistryKeys(t *testing.T) 
 		"New-Item -Path $cmdPath -Force",
 		`Set-ItemProperty -Path $regPath -Name '(Default)' -Value 'URL:projmux'`,
 		"Set-ItemProperty -Path $regPath -Name 'URL Protocol' -Value ''",
-		`wsl.exe -d Ubuntu-24.04 -- projmux focus --uri "%1"`,
+		`wsl.exe -d Ubuntu-24.04 --exec /home/me/go/bin/projmux focus --uri "%1"`,
 		`Set-ItemProperty -Path $cmdPath -Name '(Default)'`,
 	}
 	for _, want := range wantSubstrings {
@@ -63,14 +63,49 @@ func TestBuildRegisterURIProtocolPowerShell_WritesAllRegistryKeys(t *testing.T) 
 	}
 }
 
+func TestBuildRegisterURIProtocolPowerShell_BypassesShellWithExecAndAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	// Regression guard: the registered launch command must use `--exec`
+	// (skips the user's login shell so URI query `&` separators don't get
+	// parsed as background-job operators by zsh/bash) and must point at the
+	// absolute WSL filesystem path to the projmux binary (because `--exec`
+	// doesn't load shell init files, so PATH is unreliable). The bare
+	// `-- projmux focus` form shipped in PR #178 broke on the very first
+	// `&`-bearing toast click; do not let it come back.
+	script := buildRegisterURIProtocolPowerShell("projmux", "Ubuntu-24.04", "/home/me/go/bin/projmux")
+	wantLaunch := `wsl.exe -d Ubuntu-24.04 --exec /home/me/go/bin/projmux focus --uri "%1"`
+	if !strings.Contains(script, wantLaunch) {
+		t.Fatalf("expected launch command %q in script:\n%s", wantLaunch, script)
+	}
+	if strings.Contains(script, `-- projmux focus`) {
+		t.Fatalf("script must not use the legacy `-- projmux focus` form (shell-interpreted, breaks on `&`):\n%s", script)
+	}
+	if !strings.Contains(script, "--exec ") {
+		t.Fatalf("script must use `--exec` to bypass the login shell:\n%s", script)
+	}
+}
+
 func TestBuildRegisterURIProtocolPowerShell_PSEscapesDistro(t *testing.T) {
 	t.Parallel()
 
 	// Distro names with single quotes (unusual but technically allowed in
 	// WSL distro registration) must be PowerShell-escaped to keep the
 	// quoted string literal balanced.
-	script := buildRegisterURIProtocolPowerShell("projmux", "weird's-distro")
-	if !strings.Contains(script, `wsl.exe -d weird''s-distro -- projmux focus --uri "%1"`) {
+	script := buildRegisterURIProtocolPowerShell("projmux", "weird's-distro", "/home/me/go/bin/projmux")
+	if !strings.Contains(script, `wsl.exe -d weird''s-distro --exec /home/me/go/bin/projmux focus --uri "%1"`) {
 		t.Fatalf("expected single-quote-escaped distro in launch command; got:\n%s", script)
+	}
+}
+
+func TestBuildRegisterURIProtocolPowerShell_PSEscapesBinaryPath(t *testing.T) {
+	t.Parallel()
+
+	// Binary paths shouldn't contain single quotes in practice, but defend
+	// the quoted PowerShell literal so a pathological install location can't
+	// break the registration script.
+	script := buildRegisterURIProtocolPowerShell("projmux", "Ubuntu-24.04", "/home/o'brien/bin/projmux")
+	if !strings.Contains(script, `--exec /home/o''brien/bin/projmux focus`) {
+		t.Fatalf("expected single-quote-escaped binary path in launch command; got:\n%s", script)
 	}
 }


### PR DESCRIPTION
## Bug

PR #178 shipped \`projmux://\` URI registration but the toast click path was a silent no-op end-to-end. Root cause: the registered command line ran the URI through the user's login shell.

\`wsl.exe -d <distro> -- <cmd> <args>\` joins args with spaces and routes them through the user's default shell (zsh in our env). The URI has \`&\` separators between query params, which zsh interprets as background-job operators:

\`\`\`
zsh:1: parse error near '&'
\`\`\`

Switching to \`--exec\` bypasses the shell, but \`--exec\` doesn't load shell init files so PATH is empty:

\`\`\`
execvpe(projmux) failed: No such file or directory
\`\`\`

## Fix

Register the absolute binary path captured at registration time:

\`\`\`
wsl.exe -d <distro> --exec <absolute-path> focus --uri "%1"
\`\`\`

- bypasses the shell entirely (no \`&\` interpretation)
- doesn't depend on PATH being set
- uses the exact binary that registered the protocol

Bumped registration marker to \`@projmux_uri_protocol_registered_v2\` so existing users transparently re-register on next dispatch.

## Verification

In-WSL → Windows resolution chain traced step-by-step in the lead session before the dispatch:

1. \`projmux focus --uri "projmux://focus?..."\` works in-WSL ✓ (PR #178 logic is sound)
2. \`Start-Process projmux://...\` from PowerShell — Windows resolves the protocol ✓ (registry layout correct)
3. \`wsl.exe -d <distro> -- ...\` — fails with zsh parse error on \`&\` ✗ (root cause)
4. \`wsl.exe -d <distro> --exec /usr/local/bin/projmux ...\` — works ✓ (this PR's fix)

## Test plan

- [x] \`go build / vet / fmt / test\` all green (24 packages PASS)
- [x] Defense-in-depth tests:
  - \`_BypassesShellWithExecAndAbsolutePath\` — locks in \`--exec\` + binary path, prevents regression to \`-- projmux\` form
  - \`_PSEscapesBinaryPath\` — guards single-quote escaping in PowerShell
- [ ] Manual: click a fresh toast, verify focus actually moves to the source pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)