### PR TITLE
feat(notify): 3-way desktop notification mode (none/notify/raise) + Defender-safe shortcut + on-push auto-raise

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,7 +108,8 @@ configured key opens and closes the popup.
 | `PROJMUX_MANAGED_ROOTS` | Search-root override. Uses the OS-native path-list separator and takes priority over the saved workdirs file and default weak probes. |
 | `TMUX_SESSIONIZER_ROOTS` | Legacy alias still honored at runtime for managed roots. |
 | `PROJMUX_NOTIFY_HOOK` | External executable that receives AI desktop notifications instead of the built-in Linux/WSL sender. |
-| `PROJMUX_DESKTOP_NOTIFY` | OS desktop notification on/off override. `on`/`off` (case insensitive). When set, this takes priority over the saved tmux option and the default. The in-app notify queue is not affected. |
+| `PROJMUX_DESKTOP_NOTIFY_MODE` | OS desktop notification mode override. `none` / `notify` / `raise` (case insensitive). When set, this takes priority over every other resolution rung. The in-app notify queue is not affected. |
+| `PROJMUX_DESKTOP_NOTIFY` | Legacy on/off override kept for backward compatibility. `on` maps to `notify`, `off` maps to `none`. Honored only when `PROJMUX_DESKTOP_NOTIFY_MODE` is unset. |
 | `PROJMUX_WSL_TOAST_ICON_DIR` | Directory used when copying the WSL toast icon into a Windows-readable path. |
 | `PROJMUX_USAGE_STATE_DIR` | Override directory for AI usage snapshots. Defaults to `<state>/projmux/usage`. Point this at a synced directory to share authoritative usage across machines. |
 | `PROJMUX_USAGE_DEBUG` | When non-empty, prints adapter errors from `projmux status usage` to stderr. |
@@ -156,36 +157,87 @@ the Linux `--app-name`, the macOS sender label, and the Windows
 ships with a one-shot Windows cleanup that removes the legacy Start Menu
 shortcut and registry entry the first time projmux runs.
 
-OS desktop notifications can be silenced without touching the in-app notify
-queue. The resolution order is:
+### Desktop notification mode
 
-1. `PROJMUX_DESKTOP_NOTIFY` env (`on` / `off`).
-2. Tmux global option `@projmux_desktop_notify` (`1` / `0`).
-3. Default = on.
+The OS-level dispatch carries three modes. The in-app notify queue, the
+statusbar segment, and the attention badge stay live regardless of which
+mode is active — only the toast / notify-send / auto-raise fan-out is
+gated here.
 
-Toggle from Settings > AI Settings > `Desktop notifications on/off`. The
-Settings info row labels the effective source as `env`, `setting`, or
-`default` so an env-pinned value is visible at a glance.
+| Mode | On push | On click |
+| --- | --- | --- |
+| `none` | no toast | n/a |
+| `notify` | toast / notify-send fires | toast click invokes `projmux focus --uri` via the `projmux://` handler |
+| `raise` | toast / notify-send fires AND the host terminal is auto-raised via the osfocus chain | same as `notify` — click is always available |
+
+Click activation is always wired. The `projmux://` URI handler is
+registered on the first Notify of each tmux server (gated by the
+`@projmux_uri_protocol_registered_v2` marker) regardless of mode. The
+mode only controls whether a toast fires at all and whether to follow it
+up with an on-push auto-raise.
+
+Resolution order (highest priority first):
+
+1. `PROJMUX_DESKTOP_NOTIFY_MODE` env (`none` / `notify` / `raise`).
+2. `PROJMUX_DESKTOP_NOTIFY` env (legacy `on` / `off`; `on` → `notify`,
+   `off` → `none`).
+3. Tmux global option `@projmux_desktop_notify_mode`.
+4. Tmux global option `@projmux_desktop_notify` (legacy `1` / `0`, same
+   mapping as the env above).
+5. Default = `raise` when running inside WSL with `$WT_SESSION` set
+   (Windows Terminal × WSL is the measured-working cell for osfocus
+   raise today); otherwise `notify`.
+
+Migration is intentionally read-time. Users with the previous legacy
+toggle set keep their behavior — `@projmux_desktop_notify=0` resolves to
+`none`, `@projmux_desktop_notify=1` resolves to `notify`. The first
+Settings press through the new row writes the new key and the legacy key
+goes unused. No eager rewrite of tmux state.
+
+Toggle from Settings > AI Settings > `Desktop notifications`. The
+Settings info row labels the effective source as `env`, `env (legacy)`,
+`setting`, `setting (legacy)`, or `default` so users see which rung of
+the cascade pinned the value.
 
 Hook details for new-session lifecycle hooks and project-local
 `.projmux/config.toml` live in [Hooks](hooks.md).
 
 ### Toast click handler (WSL + Windows Terminal)
 
-On WSL, projmux registers a `projmux://` URL scheme on the Windows side the
-first time a Toast is dispatched on each tmux server. Clicking the Toast
-hands control back to projmux inside WSL via the registered command:
+On WSL, projmux registers a `projmux://` URL scheme on the Windows side
+the first time a Toast is dispatched on each tmux server. Clicking the
+toast hands control back to projmux inside WSL via the registered command:
 
 ```text
 wsl.exe -d $WSL_DISTRO_NAME --exec <absolute-path-to-projmux> focus --uri "%1"
 ```
 
-`--exec` (rather than `--`) is required so the URI bypasses the user's
-default login shell — `wsl.exe -- <cmd>` routes its tail through that shell,
-which then parses `&` query-string separators as background-job operators
-(zsh emits `parse error near '&'`). The absolute WSL filesystem path to the
-binary is captured at registration time so the launch doesn't depend on
-PATH being set under `--exec`.
+For click activation to work in our unpackaged Win32 setup, four
+conditions must hold simultaneously — all of them are arranged by the
+notify path so users do not configure anything:
+
+1. No COM Toast Activator is registered. The shortcut writes only
+   `PKEY_AppUserModel_ID` (pid=5) and intentionally omits
+   `PKEY_AppUserModel_ToastActivatorCLSID` (pid=26). When a COM activator
+   is registered alongside the AppID, Windows tries COM first, silently
+   fails for unpackaged exes, and does *not* fall through to the launch
+   URI. Stripping the COM side makes Windows ShellExecute the launch URI
+   on click.
+2. The Start Menu shortcut exists with the AppID set. The shortcut is
+   never launched — it is a property bag so the toast can route under
+   the right DisplayName + icon.
+3. The shortcut target is `cmd.exe /c exit`. Earlier code used
+   `powershell.exe -WindowStyle Hidden -Command exit`; Windows Defender
+   silently quarantines such shortcuts moments after creation, which
+   leaves no AppID-tagged shortcut and breaks both the routing and the
+   click path. `cmd.exe /c exit` is treated as benign and survives.
+4. The WSL handler command uses `--exec`, not `--`. `wsl.exe -- <cmd>`
+   routes its tail through the user's login shell, which parses `&`
+   query-string separators as background-job operators (zsh emits
+   `parse error near '&'`). `--exec` skips the shell and invokes the
+   binary directly. The absolute WSL filesystem path to the binary is
+   captured at registration so PATH does not need to be populated under
+   `--exec`.
 
 The URI carries the originating pane id and tmux socket so the click
 round-trips back to the exact pane that fired the notification, which

--- a/docs/notify-os-focus-poc.md
+++ b/docs/notify-os-focus-poc.md
@@ -196,16 +196,81 @@ measurements.
 
 ### Tier-1.5 shipped — Toast click handler (WSL + Windows Terminal)
 
-The Toast notification produced by `aiDesktopNotifier.Notify` on WSL now
-carries a `launch="projmux://focus?..." activationType="protocol"` attribute,
-and the first dispatch of a tmux server boot registers the `projmux://`
-scheme in `HKCU\SOFTWARE\Classes\projmux\…` so Windows routes the click
-to `wsl.exe -d <distro> -- projmux focus --uri "%1"`. Inside WSL,
+The toast notification produced by `aiDesktopNotifier.Notify` on WSL
+carries a `launch="projmux://focus?..." activationType="protocol"`
+attribute, and the first dispatch of a tmux server boot registers the
+`projmux://` scheme in `HKCU\SOFTWARE\Classes\projmux\…` so Windows
+routes the click to
+`wsl.exe -d <distro> --exec <abs-path> focus --uri "%1"`. Inside WSL,
 `projmux focus --uri` parses the URI, resolves the pane id to its
-`session:window.%paneID` target via `tmux display-message`, and reuses the
-existing focus dispatch. This closes the previously-deferred (a) on-push
-trigger mode in the Windows-only scope: the Toast becomes the (a)
-surface and its click drops into the (b) `projmux focus` path.
+`session:window.%paneID` target via `tmux display-message`, and reuses
+the existing focus dispatch. This closes the previously-deferred (a)
+on-push trigger mode in the Windows-only scope: the toast becomes the
+(a) surface and its click drops into the (b) `projmux focus` path.
+
+Trigger mode is a 3-way selector now (Settings > AI Settings > Desktop
+notifications, tmux option `@projmux_desktop_notify_mode`):
+
+| Mode | On push | On click |
+|---|---|---|
+| `none` | no toast | n/a |
+| `notify` | show toast | toast click → `projmux focus` via URI handler |
+| `raise` | show toast + raise host terminal via osfocus chain | toast click → `projmux focus` via URI handler |
+
+Click handling is always wired regardless of mode — the URI handler
+registration is gated on its own one-shot marker, not on the mode.
+
+#### Retrospective — what the working configuration is
+
+An earlier Tier-1.5 spike explored a COM Toast Activator path (PR-H
+tree: the `feat/toast-com-activator` branch and tooling under
+`tools/win-toast-activator`). That path is **abandoned**: an unpackaged
+Win32 binary running under WSL cannot reliably take a
+`INotificationActivationCallback` dispatch even with a fully-wired
+registry chain. The configuration that works in live testing on this
+machine is:
+
+1. **No COM activator** at all. The shortcut writes only
+   `PKEY_AppUserModel_ID` (pid=5) and intentionally omits
+   `PKEY_AppUserModel_ToastActivatorCLSID` (pid=26). When a COM activator
+   is registered, Windows tries COM first and silently fails — it does
+   not fall through to the launch URI. Stripping the COM side makes
+   Windows ShellExecute the URI on click.
+2. **AppID-tagged shortcut present** (`projmux.lnk` in the Start Menu's
+   Programs folder, target `cmd.exe /c exit`). The toast platform
+   requires an AppID-tagged shortcut to be discoverable for the toast to
+   route under the right DisplayName + icon. The target is never
+   launched — it is a property bag.
+3. **Shortcut target = `cmd.exe /c exit`**. Earlier code used
+   `powershell.exe -WindowStyle Hidden -Command exit`. Windows Defender
+   silently quarantines such shortcuts within seconds of creation, which
+   leaves no AppID-tagged shortcut at all and breaks both the toast
+   routing and (since the AppID has to be live when the toast fires) the
+   click path. `cmd.exe /c exit` is benign and survives.
+4. **WSL handler command uses `--exec` not `--`**. `wsl.exe -- <cmd>`
+   routes its tail through the user's default login shell, which parses
+   `&` query-string separators as background-job operators (zsh emits
+   `parse error near '&'`). `--exec` skips the shell and invokes the
+   binary directly. PATH is empty under `--exec`, so the registry
+   command uses the absolute WSL filesystem path captured at registration
+   time.
+
+#### Lessons (so future readers don't repeat them)
+
+- Do not "fix" the shortcut target back to `powershell.exe -WindowStyle
+  Hidden -Command exit`. It triggers Defender quarantine and breaks
+  every routing path that depends on the AppID shortcut existing.
+- Do not add `PKEY_AppUserModel_ToastActivatorCLSID` (pid=26) thinking
+  it would "unlock click activation". For unpackaged binaries it does
+  the opposite — Windows routes through the COM path, the COM call
+  silently fails, and the launch URI is never invoked.
+- Do not use `wsl.exe -- projmux ...` in the registry handler.
+  Re-introducing the login-shell hop will surface as `parse error near
+  '&'` from the user's shell at click time.
+- The `@projmux_uri_protocol_registered_v2` marker exists because the
+  v1 marker came before the `--exec` fix. Re-registration is idempotent
+  so upgrades from v1 transparently install the new handler — the old
+  marker key just goes orphaned.
 
 Multi-distro dispatch (one handler per distro, or a distro-selector
 arg) is a known tier-2 follow-up — current registration captures the

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -1964,8 +1964,30 @@ Set-ItemProperty -Path $regPath -Name 'ShowInSettings' -Value 1 -Type DWord
 ` + iconLine + `
 $shortcutDir = [Environment]::GetFolderPath('Programs')
 $shortcutPath = Join-Path $shortcutDir 'projmux.lnk'
-$targetPath = [Environment]::ExpandEnvironmentVariables('%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe')
-$arguments = '-NoProfile -WindowStyle Hidden -Command exit'
+# The shortcut target is intentionally cmd.exe /c exit (a no-op). The
+# shortcut is never actually launched — it exists solely as a property bag
+# so the Windows toast platform can attach the
+# PKEY_AppUserModel_ID (pid=5) value via IPropertyStore.SetValue in
+# ProjmuxToastShortcut::Save. That AppUserModelID is what routes the toast
+# under our DisplayName + icon.
+#
+# DO NOT change this target back to
+#   powershell.exe -WindowStyle Hidden -Command exit
+# Windows Defender silently quarantines Start Menu shortcuts whose target
+# is "powershell.exe -WindowStyle Hidden ..." within seconds of creation,
+# which leaves no shortcut at all and silently breaks the AppID routing
+# (and, since the URI-launch click handler depends on the AppID being live
+# when the toast fires, breaks click activation too). cmd.exe /c exit
+# is treated as benign and survives Defender's heuristics.
+#
+# Note: PKEY_AppUserModel_ToastActivatorCLSID (pid=26) is intentionally
+# NOT set on this shortcut. The Win32 unpackaged toast click path falls
+# back to ShellExecute on the launch URI ONLY when no COM Toast Activator
+# is registered alongside the AppID. Setting ToastActivatorCLSID would
+# route Windows down the COM activator path first, which silently fails
+# in our unpackaged setup and does not fall through to the URI handler.
+$targetPath = [Environment]::ExpandEnvironmentVariables('%SystemRoot%\System32\cmd.exe')
+$arguments = '/c exit'
 $description = 'projmux tmux AI notifications'
 $iconLocation = ''
 if ('` + psEscape(iconURI) + `' -ne '') {

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -1721,3 +1721,84 @@ func TestAITopicErrorsWhenNoPaneAvailable(t *testing.T) {
 		t.Fatalf("expected no tmux set-option commands, got %#v", cmdRecorder(cmd).commands)
 	}
 }
+
+// TestBuildRegisterToastAppIDShortcutTargetIsCmdExe pins the Start Menu
+// shortcut target produced by buildRegisterToastAppIDPowerShell to
+// `cmd.exe /c exit`. The shortcut is a property bag for PKEY_AppUserModel_ID
+// (pid=5) so the toast routes under our DisplayName; its target is never
+// actually launched. We do NOT want `powershell.exe -WindowStyle Hidden ...`
+// here — Windows Defender quarantines such shortcuts moments after creation,
+// which silently breaks toast AppID routing and (because the click path
+// depends on the AppID being live) silently breaks click activation.
+func TestBuildRegisterToastAppIDShortcutTargetIsCmdExe(t *testing.T) {
+	script := buildRegisterToastAppIDPowerShell(desktopAppID, desktopDisplayName, "")
+	for _, want := range []string{
+		`$targetPath = [Environment]::ExpandEnvironmentVariables('%SystemRoot%\System32\cmd.exe')`,
+		`$arguments = '/c exit'`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("register script missing %q: %s", want, script)
+		}
+	}
+	// Strip PS `#` comment lines before scanning for forbidden tokens —
+	// the source-level guidance comment mentions the historical
+	// powershell.exe target by name and we don't want the assertion to
+	// flag its own do-not-do-this commentary.
+	var noComments strings.Builder
+	for _, line := range strings.Split(script, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		noComments.WriteString(line)
+		noComments.WriteByte('\n')
+	}
+	effective := noComments.String()
+	for _, forbidden := range []string{
+		`WindowsPowerShell\v1.0\powershell.exe`,
+		`-WindowStyle Hidden`,
+	} {
+		if strings.Contains(effective, forbidden) {
+			t.Fatalf("register script contains forbidden token %q (Defender quarantines such shortcuts): %s", forbidden, effective)
+		}
+	}
+}
+
+// TestBuildRegisterToastAppIDDoesNotSetToastActivatorCLSID guards against a
+// well-meaning "fix" that adds PKEY_AppUserModel_ToastActivatorCLSID
+// (pid=26) to the shortcut. Setting that property routes Windows toast
+// activation down the COM path first; in our unpackaged Win32 setup the
+// COM call silently fails and Windows does NOT fall through to the
+// ShellExecute(launch URI) path — i.e. click activation breaks. The
+// shortcut intentionally carries only the AppUserModelID (pid=5) so the
+// URI launch path is taken on click.
+//
+// We strip PowerShell comment lines before scanning so the source-level
+// guidance comment that mentions ToastActivatorCLSID by name doesn't
+// trigger the substring assertion. The check intentionally targets
+// executable PS lines only.
+func TestBuildRegisterToastAppIDDoesNotSetToastActivatorCLSID(t *testing.T) {
+	script := buildRegisterToastAppIDPowerShell(desktopAppID, desktopDisplayName, "")
+	var noComments strings.Builder
+	for _, line := range strings.Split(script, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		noComments.WriteString(line)
+		noComments.WriteByte('\n')
+	}
+	effective := noComments.String()
+	for _, forbidden := range []string{
+		"ToastActivatorCLSID",
+		// pid=26 is the property id for ToastActivatorCLSID. The shortcut's
+		// only property write is the AppUserModel_ID (pid=5) — any pid=26
+		// PROPERTYKEY introduction would be a regression.
+		`PROPERTYKEY("9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3", 26)`,
+		// Cover the PROPERTYKEY constructor by raw pid form too.
+		", 26)",
+	} {
+		if strings.Contains(effective, forbidden) {
+			t.Fatalf("register script must not configure ToastActivatorCLSID (%q): %s", forbidden, effective)
+		}
+	}
+}

--- a/internal/app/notification.go
+++ b/internal/app/notification.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/crevissepartners/projmux/internal/integrations/osfocus"
 )
 
 type aiNotification struct {
@@ -49,15 +51,28 @@ func (n aiHookNotifier) Notify(notification aiNotification) error {
 
 type aiDesktopNotifier struct {
 	command *aiCommand
+	// osFocusChain is an optional injection seam for the auto-raise hook
+	// fired when the resolved mode is `raise`. When nil, defaultOSFocusChain()
+	// builds the production tier-1 chain (Windows Terminal × WSL adapter
+	// today). Tests inject a stub so they don't shell out to wt.exe.
+	osFocusChain osFocusDispatcher
 }
 
 func (n aiDesktopNotifier) Notify(notification aiNotification) error {
-	// Phase 1 desktop-notification gate. The in-app notify queue, the
-	// statusbar segment, and the attention badge are intentionally
-	// untouched — this only suppresses the OS-level dispatch so users
-	// can silence the popup/Toast/notify-send fan-out without losing
-	// the in-app surfaces.
-	if !n.command.desktopNotifyEnabled() {
+	// 3-way mode gate. The in-app notify queue, the statusbar segment,
+	// and the attention badge are intentionally untouched — this only
+	// suppresses the OS-level dispatch so users can silence the
+	// popup/Toast/notify-send fan-out without losing the in-app
+	// surfaces.
+	//
+	// `mode=none` skips dispatch entirely. `mode=notify` dispatches the
+	// toast / notify-send but does not auto-raise; click-to-focus is
+	// still wired via the projmux:// URI handler regardless of mode (the
+	// handler registration is gated on its own marker, not the mode).
+	// `mode=raise` dispatches and follows up with an osfocus chain call
+	// to bring the host terminal to the foreground.
+	mode := n.command.desktopNotifyMode()
+	if mode == desktopNotifyModeNone {
 		return nil
 	}
 	if n.command.isWSL() {
@@ -65,6 +80,7 @@ func (n aiDesktopNotifier) Notify(notification aiNotification) error {
 		n.command.ensureWSLURIProtocol()
 		_ = n.ensureWSLToastAppID(notification)
 		if err := n.dispatchWSLToast(notification); err == nil {
+			n.maybeRaiseHostTerminal(mode, notification)
 			return nil
 		}
 		if n.command.readTrimmed("command", "-v", "wsl-notify-send.exe") != "" {
@@ -73,6 +89,7 @@ func (n aiDesktopNotifier) Notify(notification aiNotification) error {
 				message += "\n" + notification.Body
 			}
 			if err := n.command.run("wsl-notify-send.exe", "--category", notification.AppName, message); err == nil {
+				n.maybeRaiseHostTerminal(mode, notification)
 				return nil
 			}
 		}
@@ -84,13 +101,43 @@ func (n aiDesktopNotifier) Notify(notification aiNotification) error {
 	if n.command.readTrimmed("command", "-v", "notify-send") == "" {
 		return errors.New("notify-send is unavailable")
 	}
-	return n.command.run("notify-send",
+	if err := n.command.run("notify-send",
 		"--app-name="+notification.AppName,
 		"--icon="+icon,
 		"--urgency="+notification.Urgency,
 		notification.Summary,
 		notification.Body,
-	)
+	); err != nil {
+		return err
+	}
+	n.maybeRaiseHostTerminal(mode, notification)
+	return nil
+}
+
+// maybeRaiseHostTerminal fires the osfocus chain to bring the host
+// terminal to the foreground when mode=raise. The call is intentionally
+// best-effort:
+//
+//   - The chain swallows adapter errors and returns nil when no adapter
+//     detects (the silent-fallback policy documented on osfocus.Chain).
+//   - The dispatch is paired with a *successful* notification dispatch,
+//     so the user always sees both the toast and the raised terminal as
+//     a pair — we never raise without an accompanying notification.
+//
+// The Target's Pane is set to the originating pane id (aiNotification.Tag);
+// other Target fields stay empty because the tier-1
+// WindowsTerminalWSLAdapter ignores everything but `wt.exe -w 0
+// focus-tab` semantics. Tier-2 adapters that route to specific
+// windows/tabs can use Pane as a hint without changing the call site.
+func (n aiDesktopNotifier) maybeRaiseHostTerminal(mode desktopNotifyMode, notification aiNotification) {
+	if mode != desktopNotifyModeRaise {
+		return
+	}
+	chain := n.osFocusChain
+	if chain == nil {
+		chain = defaultOSFocusChain()
+	}
+	_ = chain.Focus(osfocus.Target{Pane: strings.TrimSpace(notification.Tag)})
 }
 
 func (n aiDesktopNotifier) dispatchWSLToast(notification aiNotification) error {

--- a/internal/app/notification_raise_test.go
+++ b/internal/app/notification_raise_test.go
@@ -1,0 +1,197 @@
+package app
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/integrations/osfocus"
+)
+
+// recordingOSFocusChain is the test stub plugged into
+// `aiDesktopNotifier.osFocusChain` so the mode=raise auto-raise hook can
+// be observed without shelling out to the production WT × WSL adapter.
+type recordingOSFocusChain struct {
+	mu    sync.Mutex
+	calls []osfocus.Target
+	err   error
+}
+
+func (c *recordingOSFocusChain) Focus(target osfocus.Target) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls = append(c.calls, target)
+	return c.err
+}
+
+func (c *recordingOSFocusChain) snapshot() []osfocus.Target {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]osfocus.Target, len(c.calls))
+	copy(out, c.calls)
+	return out
+}
+
+func notifySendIsAvailable(_ context.Context, name string, args ...string) ([]byte, error) {
+	if name == "command" && len(args) == 2 && args[0] == "-v" && args[1] == "notify-send" {
+		return []byte("/usr/bin/notify-send\n"), nil
+	}
+	return nil, os.ErrNotExist
+}
+
+// TestNotifyMode_NoneSuppressesDispatchAndRaise pins the mode=none path:
+// no toast, no notify-send, no auto-raise. The in-app surfaces are
+// orthogonal (not the concern of this test) so we just assert the OS
+// side stays silent.
+func TestNotifyMode_NoneSuppressesDispatchAndRaise(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.lookupEnv = func(name string) string {
+		switch name {
+		case "HOME":
+			return home
+		case desktopNotifyModeEnv:
+			return "none"
+		}
+		return ""
+	}
+	cmd.readCommand = notifySendIsAvailable
+
+	chain := &recordingOSFocusChain{}
+	notifier := aiDesktopNotifier{command: cmd, osFocusChain: chain}
+	if err := notifier.Notify(aiNotification{
+		Summary: "Hello", Body: "World", Urgency: "normal",
+		AppName: desktopAppID, Icon: "dialog-information", Tag: "%8",
+	}); err != nil {
+		t.Fatalf("Notify(mode=none) error = %v", err)
+	}
+	for _, command := range cmdRecorder(cmd).commands {
+		if command.name == "notify-send" {
+			t.Fatalf("commands = %#v, did not expect notify-send dispatch when mode=none", cmdRecorder(cmd).commands)
+		}
+	}
+	if got := chain.snapshot(); len(got) != 0 {
+		t.Fatalf("osfocus chain calls = %#v, did not expect a raise when mode=none", got)
+	}
+}
+
+// TestNotifyMode_NotifyDispatchesButDoesNotRaise pins the mode=notify
+// path: notify-send fires, but the osfocus chain is NOT invoked.
+func TestNotifyMode_NotifyDispatchesButDoesNotRaise(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.lookupEnv = func(name string) string {
+		switch name {
+		case "HOME":
+			return home
+		case desktopNotifyModeEnv:
+			return "notify"
+		}
+		return ""
+	}
+	cmd.readCommand = notifySendIsAvailable
+
+	chain := &recordingOSFocusChain{}
+	notifier := aiDesktopNotifier{command: cmd, osFocusChain: chain}
+	if err := notifier.Notify(aiNotification{
+		Summary: "Hello", Body: "World", Urgency: "normal",
+		AppName: desktopAppID, Icon: "dialog-information", Tag: "%8",
+	}); err != nil {
+		t.Fatalf("Notify(mode=notify) error = %v", err)
+	}
+	var sawNotifySend bool
+	for _, command := range cmdRecorder(cmd).commands {
+		if command.name == "notify-send" {
+			sawNotifySend = true
+			break
+		}
+	}
+	if !sawNotifySend {
+		t.Fatalf("commands = %#v, want notify-send dispatch when mode=notify", cmdRecorder(cmd).commands)
+	}
+	if got := chain.snapshot(); len(got) != 0 {
+		t.Fatalf("osfocus chain calls = %#v, did not expect a raise when mode=notify", got)
+	}
+}
+
+// TestNotifyMode_RaiseDispatchesAndRaises pins the mode=raise path:
+// notify-send fires AND the osfocus chain receives a Focus() call with
+// the originating pane id threaded through. Tier-1 adapters ignore the
+// pane field; tier-2 adapters that target specific windows/tabs can use
+// it as a hint.
+func TestNotifyMode_RaiseDispatchesAndRaises(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.lookupEnv = func(name string) string {
+		switch name {
+		case "HOME":
+			return home
+		case desktopNotifyModeEnv:
+			return "raise"
+		}
+		return ""
+	}
+	cmd.readCommand = notifySendIsAvailable
+
+	chain := &recordingOSFocusChain{}
+	notifier := aiDesktopNotifier{command: cmd, osFocusChain: chain}
+	if err := notifier.Notify(aiNotification{
+		Summary: "Hello", Body: "World", Urgency: "normal",
+		AppName: desktopAppID, Icon: "dialog-information", Tag: "%8",
+	}); err != nil {
+		t.Fatalf("Notify(mode=raise) error = %v", err)
+	}
+	var sawNotifySend bool
+	for _, command := range cmdRecorder(cmd).commands {
+		if command.name == "notify-send" {
+			sawNotifySend = true
+			break
+		}
+	}
+	if !sawNotifySend {
+		t.Fatalf("commands = %#v, want notify-send dispatch when mode=raise", cmdRecorder(cmd).commands)
+	}
+	calls := chain.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("osfocus chain calls = %#v, want exactly one Focus() when mode=raise", calls)
+	}
+	if got, want := calls[0].Pane, "%8"; got != want {
+		t.Fatalf("osfocus.Target.Pane = %q, want %q (originating pane id should be threaded through)", got, want)
+	}
+}
+
+// TestNotifyMode_RaiseSkippedWhenDispatchFails confirms the raise call
+// is gated on a *successful* notification dispatch. If notify-send is
+// unavailable, the user would see a raised terminal with no message
+// explaining why — we explicitly avoid that surprise.
+func TestNotifyMode_RaiseSkippedWhenDispatchFails(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.lookupEnv = func(name string) string {
+		switch name {
+		case "HOME":
+			return home
+		case desktopNotifyModeEnv:
+			return "raise"
+		}
+		return ""
+	}
+	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		// notify-send is NOT available — `command -v notify-send` fails.
+		return nil, os.ErrNotExist
+	}
+
+	chain := &recordingOSFocusChain{}
+	notifier := aiDesktopNotifier{command: cmd, osFocusChain: chain}
+	err := notifier.Notify(aiNotification{
+		Summary: "Hello", Body: "World", Urgency: "normal",
+		AppName: desktopAppID, Icon: "dialog-information", Tag: "%8",
+	})
+	if err == nil {
+		t.Fatalf("Notify(mode=raise) with notify-send unavailable should return error, got nil")
+	}
+	if got := chain.snapshot(); len(got) != 0 {
+		t.Fatalf("osfocus chain calls = %#v, raise must NOT fire when dispatch failed", got)
+	}
+}

--- a/internal/app/notification_toggle.go
+++ b/internal/app/notification_toggle.go
@@ -172,16 +172,6 @@ func (r desktopNotifyResolver) resolveMode() (desktopNotifyMode, desktopNotifySo
 	return desktopNotifyModeNotify, desktopNotifySourceDefault
 }
 
-// resolve is a transitional shim mirroring the legacy 2-state API
-// (enabled bool + source) on top of the 3-way resolver. Kept so the
-// Settings catalog row left over from the old on/off toggle keeps
-// building until the follow-up commit replaces that render with the
-// 3-way selector.
-func (r desktopNotifyResolver) resolve() (bool, desktopNotifySource) {
-	mode, source := r.resolveMode()
-	return mode != desktopNotifyModeNone, source
-}
-
 // desktopNotifyMode is the convenience accessor used by the
 // `aiDesktopNotifier.Notify` gate. The gate uses the mode directly to
 // decide whether to dispatch the toast and whether to follow it up with

--- a/internal/app/notification_toggle.go
+++ b/internal/app/notification_toggle.go
@@ -5,91 +5,198 @@ import (
 	"strings"
 )
 
-// notification_toggle.go owns the OS-desktop-notification on/off switch.
-// The toggle is intentionally orthogonal to the in-app notify queue,
-// statusbar segment, and attention badge — those keep working when the
-// desktop dispatch is silenced (loud-environment / screen-share use case).
+// notification_toggle.go owns the OS-desktop-notification mode selector.
+// The selector is intentionally orthogonal to the in-app notify queue,
+// statusbar segment, and attention badge — those keep working regardless
+// of which desktop dispatch mode is active (loud-environment / screen-share
+// use case).
+//
+// The setting carries three values:
+//
+//	none    — no toast, no auto-raise
+//	notify  — toast only (click → projmux focus via URI handler)
+//	raise   — toast + auto-raise host terminal via osfocus chain
+//
+// Click handling is always enabled — the URI handler is registered on
+// first dispatch and does not depend on the mode. The mode only gates
+// whether to fire a toast at all and whether to auto-raise on push.
 //
 // Resolution priority (highest first):
-//  1. env `PROJMUX_DESKTOP_NOTIFY=on|off` (case-insensitive)
-//  2. tmux global option `@projmux_desktop_notify` (`1` / `0`)
-//  3. default = on
+//  1. env `PROJMUX_DESKTOP_NOTIFY_MODE=none|notify|raise` (case-insensitive)
+//  2. env `PROJMUX_DESKTOP_NOTIFY` (legacy on/off, mapped: off→none, on→notify)
+//  3. tmux global option `@projmux_desktop_notify_mode`
+//  4. tmux global option `@projmux_desktop_notify` (legacy `1`/`0`, same mapping)
+//  5. default = `raise` if (isWSL && $WT_SESSION present), else `notify`
 //
 // The Settings popup exposes a row whose info line surfaces the source
-// (`env` / `setting` / `default`) so users can see immediately why a
-// toggle press would be ineffective when env is set.
+// (`env` / `env (legacy)` / `setting` / `setting (legacy)` / `default`)
+// so users see immediately which rung of the resolution cascade pinned
+// the value.
+//
+// Legacy migration is intentionally read-time only. Users who set
+// `@projmux_desktop_notify=0` on the previous toggle keep getting their
+// "no desktop dispatch" behavior (mapped to mode=none) without any eager
+// rewrite of their tmux state. The first Settings toggle through the new
+// row writes the new key and orphans the legacy one (legacy reads still
+// hit on machines that never touched Settings).
 
 const (
-	// desktopNotifyTmuxOption controls the OS desktop notification on/off
-	// toggle. tmux user-options carry the `@` prefix by convention.
-	// Settings writes "1" or "0"; absent means "default".
+	// desktopNotifyTmuxOption is the legacy on/off toggle. Kept for the
+	// migration read path — users with `0`/`1` set here see their old
+	// preference honored until they touch the new selector. Settings no
+	// longer writes here.
 	desktopNotifyTmuxOption = "@projmux_desktop_notify"
 
-	// desktopNotifyEnv is the env-level override. `on` / `off` (case
-	// insensitive). Any other value falls through to the tmux option.
+	// desktopNotifyEnv is the legacy on/off env override. Same migration
+	// shape as the tmux option above.
 	desktopNotifyEnv = "PROJMUX_DESKTOP_NOTIFY"
+
+	// desktopNotifyModeTmuxOption is the 3-way mode user-option that
+	// Settings writes. Values: `none` / `notify` / `raise`.
+	desktopNotifyModeTmuxOption = "@projmux_desktop_notify_mode"
+
+	// desktopNotifyModeEnv is the 3-way env override. Same values as the
+	// tmux option, case insensitive.
+	desktopNotifyModeEnv = "PROJMUX_DESKTOP_NOTIFY_MODE"
 )
 
-// desktopNotifySource describes where the effective desktop-notify state
-// came from. Settings shows this label so the user understands why a
-// toggle press might be ineffective (e.g. an env override pins the value).
+// desktopNotifyMode is the effective dispatch behavior.
+type desktopNotifyMode string
+
+const (
+	// desktopNotifyModeNone disables the OS-level dispatch entirely. The
+	// in-app notify queue / statusbar / attention badge still fire — only
+	// the toast / notify-send / osfocus raise are suppressed.
+	desktopNotifyModeNone desktopNotifyMode = "none"
+
+	// desktopNotifyModeNotify dispatches the OS notification (toast on
+	// WSL, notify-send on Linux). Click is always enabled via the URI
+	// handler; on-push auto-raise is OFF.
+	desktopNotifyModeNotify desktopNotifyMode = "notify"
+
+	// desktopNotifyModeRaise dispatches the OS notification AND
+	// auto-raises the host terminal via the osfocus chain after a
+	// successful dispatch.
+	desktopNotifyModeRaise desktopNotifyMode = "raise"
+)
+
+// desktopNotifySource describes where the effective mode came from. The
+// Settings info row renders this so the user can tell which rung of the
+// resolution cascade pinned the value.
 type desktopNotifySource string
 
 const (
-	desktopNotifySourceEnv     desktopNotifySource = "env"
-	desktopNotifySourceSetting desktopNotifySource = "setting"
-	desktopNotifySourceDefault desktopNotifySource = "default"
+	desktopNotifySourceEnv           desktopNotifySource = "env"
+	desktopNotifySourceEnvLegacy     desktopNotifySource = "env (legacy)"
+	desktopNotifySourceSetting       desktopNotifySource = "setting"
+	desktopNotifySourceSettingLegacy desktopNotifySource = "setting (legacy)"
+	desktopNotifySourceDefault       desktopNotifySource = "default"
 )
 
-// desktopNotifyResolver resolves the effective on/off state and reports the
-// source so the Settings row can render it. The lookups are injected as
-// function pointers so the resolution path stays testable without spawning
-// real tmux processes.
+// desktopNotifyResolver resolves the effective 3-way mode. The lookups
+// and the WSL/WT-host signals are injected as function pointers / fields
+// so the resolution path stays testable without spawning real tmux
+// processes or touching `/proc`.
 type desktopNotifyResolver struct {
 	lookupEnv func(string) string
-	// readTmuxOption reads the global @projmux_desktop_notify user-option
-	// (`tmux show-option -gqv ...`). It must return the trimmed string,
-	// or empty when tmux is unavailable or the option is unset.
+	// readTmuxOption reads a global user-option (`tmux show-option -gqv …`).
+	// Must return the trimmed string, or empty when tmux is unavailable or
+	// the option is unset.
 	readTmuxOption func(name string) string
+	// isWSL tells the default branch whether we are inside WSL. Combined
+	// with `wtPresent`, this decides whether the unset-everything default
+	// is `raise` or `notify`.
+	isWSL bool
+	// wtPresent indicates `$WT_SESSION` is set — the only signal that
+	// reliably survives the tmux env rewrite. The two-pronged default
+	// matches the WSL+Windows-Terminal cell where osfocus raise actually
+	// works today; everything else falls back to `notify` (toast only).
+	wtPresent bool
 }
 
-// resolve returns (enabled, source). enabled = true means desktop
-// notifications should fire.
-func (r desktopNotifyResolver) resolve() (bool, desktopNotifySource) {
+// parseDesktopNotifyMode maps a raw 3-way value to a desktopNotifyMode.
+// Returns (mode, true) on a known value; (_, false) when the input is
+// unknown or empty so the caller can fall through to the next rung.
+func parseDesktopNotifyMode(raw string) (desktopNotifyMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "none", "off", "disabled":
+		return desktopNotifyModeNone, true
+	case "notify", "toast":
+		return desktopNotifyModeNotify, true
+	case "raise", "auto-raise", "autoraise":
+		return desktopNotifyModeRaise, true
+	}
+	return "", false
+}
+
+// parseLegacyDesktopNotify maps the legacy boolean values to a 3-way
+// mode. Migration policy: legacy off → none, legacy on → notify. Users
+// who previously had auto-raise behavior didn't have it on the legacy
+// toggle (it didn't exist), so notify is the closest faithful migration.
+func parseLegacyDesktopNotify(raw string) (desktopNotifyMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "off", "0", "false", "no":
+		return desktopNotifyModeNone, true
+	case "on", "1", "true", "yes":
+		return desktopNotifyModeNotify, true
+	}
+	return "", false
+}
+
+// resolveMode returns (mode, source). The cascade is:
+//
+//	new env → legacy env → new tmux option → legacy tmux option → default
+//
+// The default rung uses `isWSL && wtPresent` to decide between `raise`
+// and `notify`.
+func (r desktopNotifyResolver) resolveMode() (desktopNotifyMode, desktopNotifySource) {
 	if r.lookupEnv != nil {
-		raw := strings.TrimSpace(r.lookupEnv(desktopNotifyEnv))
-		switch strings.ToLower(raw) {
-		case "off", "0", "false", "no":
-			return false, desktopNotifySourceEnv
-		case "on", "1", "true", "yes":
-			return true, desktopNotifySourceEnv
+		if mode, ok := parseDesktopNotifyMode(r.lookupEnv(desktopNotifyModeEnv)); ok {
+			return mode, desktopNotifySourceEnv
+		}
+		if mode, ok := parseLegacyDesktopNotify(r.lookupEnv(desktopNotifyEnv)); ok {
+			return mode, desktopNotifySourceEnvLegacy
 		}
 	}
 	if r.readTmuxOption != nil {
-		raw := strings.TrimSpace(r.readTmuxOption(desktopNotifyTmuxOption))
-		switch raw {
-		case "0":
-			return false, desktopNotifySourceSetting
-		case "1":
-			return true, desktopNotifySourceSetting
+		if mode, ok := parseDesktopNotifyMode(r.readTmuxOption(desktopNotifyModeTmuxOption)); ok {
+			return mode, desktopNotifySourceSetting
+		}
+		if mode, ok := parseLegacyDesktopNotify(r.readTmuxOption(desktopNotifyTmuxOption)); ok {
+			return mode, desktopNotifySourceSettingLegacy
 		}
 	}
-	return true, desktopNotifySourceDefault
+	if r.isWSL && r.wtPresent {
+		return desktopNotifyModeRaise, desktopNotifySourceDefault
+	}
+	return desktopNotifyModeNotify, desktopNotifySourceDefault
 }
 
-// desktopNotifyEnabled is a convenience wrapper used by the
-// `aiDesktopNotifier.Notify` gate. The gate only needs the bool — the
-// source is reserved for the Settings UI render path.
-func (c *aiCommand) desktopNotifyEnabled() bool {
-	enabled, _ := c.desktopNotifyResolution()
-	return enabled
+// resolve is a transitional shim mirroring the legacy 2-state API
+// (enabled bool + source) on top of the 3-way resolver. Kept so the
+// Settings catalog row left over from the old on/off toggle keeps
+// building until the follow-up commit replaces that render with the
+// 3-way selector.
+func (r desktopNotifyResolver) resolve() (bool, desktopNotifySource) {
+	mode, source := r.resolveMode()
+	return mode != desktopNotifyModeNone, source
 }
 
-// desktopNotifyResolution returns the effective on/off state plus the
-// source label. Splitting it out keeps the gate cheap (no source string
-// formatting) while letting future call sites (e.g. diagnostics) reuse the
-// same resolution path.
-func (c *aiCommand) desktopNotifyResolution() (bool, desktopNotifySource) {
+// desktopNotifyMode is the convenience accessor used by the
+// `aiDesktopNotifier.Notify` gate. The gate uses the mode directly to
+// decide whether to dispatch the toast and whether to follow it up with
+// an auto-raise; the source label is reserved for the Settings UI render
+// path.
+func (c *aiCommand) desktopNotifyMode() desktopNotifyMode {
+	mode, _ := c.desktopNotifyModeResolution()
+	return mode
+}
+
+// desktopNotifyModeResolution returns the effective mode plus the source
+// label. Splitting it out keeps the gate cheap (no source string
+// formatting) while letting future call sites (e.g. diagnostics) reuse
+// the same resolution path.
+func (c *aiCommand) desktopNotifyModeResolution() (desktopNotifyMode, desktopNotifySource) {
 	resolver := desktopNotifyResolver{
 		lookupEnv: c.lookupEnv,
 		readTmuxOption: func(name string) string {
@@ -101,15 +208,34 @@ func (c *aiCommand) desktopNotifyResolution() (bool, desktopNotifySource) {
 			}
 			return c.readTrimmed("tmux", "show-option", "-gqv", name)
 		},
+		isWSL:     c.isWSL(),
+		wtPresent: strings.TrimSpace(c.env("WT_SESSION")) != "",
 	}
-	return resolver.resolve()
+	return resolver.resolveMode()
+}
+
+// desktopNotifyEnabled is a transitional shim mapping the new 3-way
+// mode back to the legacy boolean gate so the existing call site in
+// `aiDesktopNotifier.Notify` keeps building. The follow-up commit
+// replaces the call site with a direct mode read and drops this shim.
+func (c *aiCommand) desktopNotifyEnabled() bool {
+	return c.desktopNotifyMode() != desktopNotifyModeNone
 }
 
 // settingsDesktopNotifyResolver builds the same resolver from a
 // `settingsCommand`. settingsCommand uses raw `runCommand` / direct
 // `exec.Command` for its tmux reads, so we wire the lookup through
 // `exec.Command` directly (mirroring `tmuxProjdirOption`).
+//
+// isWSL and wtPresent are derived from the env lookup so the Settings
+// render path computes the same default as the runtime gate.
 func settingsDesktopNotifyResolver(lookupEnv func(string) string) desktopNotifyResolver {
+	wsl := false
+	wt := false
+	if lookupEnv != nil {
+		wsl = strings.TrimSpace(lookupEnv("WSL_DISTRO_NAME")) != ""
+		wt = strings.TrimSpace(lookupEnv("WT_SESSION")) != ""
+	}
 	return desktopNotifyResolver{
 		lookupEnv: lookupEnv,
 		readTmuxOption: func(name string) string {
@@ -122,5 +248,7 @@ func settingsDesktopNotifyResolver(lookupEnv func(string) string) desktopNotifyR
 			}
 			return strings.TrimSpace(string(out))
 		},
+		isWSL:     wsl,
+		wtPresent: wt,
 	}
 }

--- a/internal/app/notification_toggle.go
+++ b/internal/app/notification_toggle.go
@@ -214,14 +214,6 @@ func (c *aiCommand) desktopNotifyModeResolution() (desktopNotifyMode, desktopNot
 	return resolver.resolveMode()
 }
 
-// desktopNotifyEnabled is a transitional shim mapping the new 3-way
-// mode back to the legacy boolean gate so the existing call site in
-// `aiDesktopNotifier.Notify` keeps building. The follow-up commit
-// replaces the call site with a direct mode read and drops this shim.
-func (c *aiCommand) desktopNotifyEnabled() bool {
-	return c.desktopNotifyMode() != desktopNotifyModeNone
-}
-
 // settingsDesktopNotifyResolver builds the same resolver from a
 // `settingsCommand`. settingsCommand uses raw `runCommand` / direct
 // `exec.Command` for its tmux reads, so we wire the lookup through

--- a/internal/app/notification_toggle_test.go
+++ b/internal/app/notification_toggle_test.go
@@ -3,52 +3,161 @@ package app
 import (
 	"context"
 	"os"
-	"reflect"
 	"testing"
 )
 
-func TestDesktopNotifyResolverPriority(t *testing.T) {
+func TestDesktopNotifyResolverModeCascade(t *testing.T) {
 	cases := []struct {
 		name       string
-		env        string
-		option     string
-		wantOn     bool
+		envMode    string
+		envLegacy  string
+		optMode    string
+		optLegacy  string
+		isWSL      bool
+		wtPresent  bool
+		wantMode   desktopNotifyMode
 		wantSource desktopNotifySource
 	}{
-		{name: "default when nothing set", env: "", option: "", wantOn: true, wantSource: desktopNotifySourceDefault},
-		{name: "tmux option off", env: "", option: "0", wantOn: false, wantSource: desktopNotifySourceSetting},
-		{name: "tmux option on", env: "", option: "1", wantOn: true, wantSource: desktopNotifySourceSetting},
-		{name: "env off wins over tmux on", env: "off", option: "1", wantOn: false, wantSource: desktopNotifySourceEnv},
-		{name: "env on wins over tmux off", env: "on", option: "0", wantOn: true, wantSource: desktopNotifySourceEnv},
-		{name: "env unknown falls through to tmux", env: "garbage", option: "0", wantOn: false, wantSource: desktopNotifySourceSetting},
-		{name: "env empty falls through to default", env: "", option: "", wantOn: true, wantSource: desktopNotifySourceDefault},
-		{name: "env OFF case-insensitive", env: "OFF", option: "1", wantOn: false, wantSource: desktopNotifySourceEnv},
+		{
+			name: "default in WSL with WT",
+			isWSL: true, wtPresent: true,
+			wantMode: desktopNotifyModeRaise, wantSource: desktopNotifySourceDefault,
+		},
+		{
+			name: "default in WSL without WT", isWSL: true,
+			wantMode: desktopNotifyModeNotify, wantSource: desktopNotifySourceDefault,
+		},
+		{
+			name: "default outside WSL with WT", wtPresent: true,
+			wantMode: desktopNotifyModeNotify, wantSource: desktopNotifySourceDefault,
+		},
+		{
+			name:     "default linux",
+			wantMode: desktopNotifyModeNotify, wantSource: desktopNotifySourceDefault,
+		},
+		{
+			name: "new tmux option none beats default raise", isWSL: true, wtPresent: true, optMode: "none",
+			wantMode: desktopNotifyModeNone, wantSource: desktopNotifySourceSetting,
+		},
+		{
+			name: "new tmux option raise beats default notify", optMode: "raise",
+			wantMode: desktopNotifyModeRaise, wantSource: desktopNotifySourceSetting,
+		},
+		{
+			name: "new tmux option notify pinned", optMode: "notify",
+			wantMode: desktopNotifyModeNotify, wantSource: desktopNotifySourceSetting,
+		},
+		{
+			name: "legacy tmux 0 fallback maps to none", optLegacy: "0",
+			wantMode: desktopNotifyModeNone, wantSource: desktopNotifySourceSettingLegacy,
+		},
+		{
+			name: "legacy tmux 1 fallback maps to notify", optLegacy: "1",
+			wantMode: desktopNotifyModeNotify, wantSource: desktopNotifySourceSettingLegacy,
+		},
+		{
+			name: "new tmux overrides legacy tmux", optMode: "raise", optLegacy: "0",
+			wantMode: desktopNotifyModeRaise, wantSource: desktopNotifySourceSetting,
+		},
+		{
+			name: "new env beats new tmux", envMode: "none", optMode: "raise",
+			wantMode: desktopNotifyModeNone, wantSource: desktopNotifySourceEnv,
+		},
+		{
+			name: "legacy env beats new tmux when new env unset", envLegacy: "off", optMode: "raise",
+			wantMode: desktopNotifyModeNone, wantSource: desktopNotifySourceEnvLegacy,
+		},
+		{
+			name: "new env beats legacy env", envMode: "raise", envLegacy: "off",
+			wantMode: desktopNotifyModeRaise, wantSource: desktopNotifySourceEnv,
+		},
+		{
+			name: "unknown new env falls through to legacy env", envMode: "garbage", envLegacy: "on",
+			wantMode: desktopNotifyModeNotify, wantSource: desktopNotifySourceEnvLegacy,
+		},
+		{
+			name: "unknown new env, unknown legacy env, falls through to tmux", envMode: "garbage", envLegacy: "garbage", optMode: "raise",
+			wantMode: desktopNotifyModeRaise, wantSource: desktopNotifySourceSetting,
+		},
+		{
+			name: "env mode case insensitive", envMode: "RAISE",
+			wantMode: desktopNotifyModeRaise, wantSource: desktopNotifySourceEnv,
+		},
+		{
+			name: "env mode off alias maps to none", envMode: "OFF",
+			wantMode: desktopNotifyModeNone, wantSource: desktopNotifySourceEnv,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			resolver := desktopNotifyResolver{
 				lookupEnv: func(name string) string {
-					if name == desktopNotifyEnv {
-						return tc.env
+					switch name {
+					case desktopNotifyModeEnv:
+						return tc.envMode
+					case desktopNotifyEnv:
+						return tc.envLegacy
 					}
 					return ""
 				},
 				readTmuxOption: func(name string) string {
-					if name == desktopNotifyTmuxOption {
-						return tc.option
+					switch name {
+					case desktopNotifyModeTmuxOption:
+						return tc.optMode
+					case desktopNotifyTmuxOption:
+						return tc.optLegacy
 					}
 					return ""
 				},
+				isWSL:     tc.isWSL,
+				wtPresent: tc.wtPresent,
 			}
-			gotOn, gotSource := resolver.resolve()
-			if gotOn != tc.wantOn || gotSource != tc.wantSource {
-				t.Fatalf("resolve() = (%v, %q), want (%v, %q)", gotOn, gotSource, tc.wantOn, tc.wantSource)
+			gotMode, gotSource := resolver.resolveMode()
+			if gotMode != tc.wantMode || gotSource != tc.wantSource {
+				t.Fatalf("resolveMode() = (%q, %q), want (%q, %q)", gotMode, gotSource, tc.wantMode, tc.wantSource)
 			}
 		})
 	}
 }
 
-func TestDesktopNotifyGateSilencesDispatchWhenOff(t *testing.T) {
+func TestParseDesktopNotifyModeAccepts(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want desktopNotifyMode
+	}{
+		{"none", desktopNotifyModeNone},
+		{"NONE", desktopNotifyModeNone},
+		{"off", desktopNotifyModeNone},
+		{"disabled", desktopNotifyModeNone},
+		{"notify", desktopNotifyModeNotify},
+		{"toast", desktopNotifyModeNotify},
+		{"raise", desktopNotifyModeRaise},
+		{"AUTO-RAISE", desktopNotifyModeRaise},
+		{"autoraise", desktopNotifyModeRaise},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			got, ok := parseDesktopNotifyMode(tc.in)
+			if !ok || got != tc.want {
+				t.Fatalf("parseDesktopNotifyMode(%q) = (%q, %v), want (%q, true)", tc.in, got, ok, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseDesktopNotifyModeRejects(t *testing.T) {
+	for _, tc := range []string{"", "garbage", "1", "0", "true", "yes"} {
+		t.Run(tc, func(t *testing.T) {
+			if _, ok := parseDesktopNotifyMode(tc); ok {
+				t.Fatalf("parseDesktopNotifyMode(%q) should not match", tc)
+			}
+		})
+	}
+}
+
+// TestDesktopNotifyGateSilencesDispatchWhenNone confirms the boolean
+// shim (still wired into aiDesktopNotifier.Notify in this commit) maps
+// mode=none to false and silences the notify-send dispatch.
+func TestDesktopNotifyGateSilencesDispatchWhenNone(t *testing.T) {
 	home := t.TempDir()
 	work := home + "/repo"
 	if err := os.MkdirAll(work, 0o755); err != nil {
@@ -59,15 +168,12 @@ func TestDesktopNotifyGateSilencesDispatchWhenOff(t *testing.T) {
 		switch name {
 		case "HOME":
 			return home
-		case "PROJMUX_DESKTOP_NOTIFY":
-			return "off"
-		default:
-			return ""
+		case desktopNotifyModeEnv:
+			return "none"
 		}
+		return ""
 	}
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
-		// notify-send is "available" but the gate should silence the
-		// dispatch anyway. We assert below that it's never called.
 		if name == "command" && len(args) == 2 && args[0] == "-v" && args[1] == "notify-send" {
 			return []byte("/usr/bin/notify-send\n"), nil
 		}
@@ -79,31 +185,32 @@ func TestDesktopNotifyGateSilencesDispatchWhenOff(t *testing.T) {
 		Summary: "Hello",
 		Body:    "World",
 		Urgency: "normal",
-		AppName: "projmux.TmuxCodex",
+		AppName: desktopAppID,
 		Icon:    "dialog-information",
 	}); err != nil {
-		t.Fatalf("Notify with desktop notifications off returned error: %v", err)
+		t.Fatalf("Notify with mode=none returned error: %v", err)
 	}
 
 	for _, command := range cmdRecorder(cmd).commands {
 		if command.name == "notify-send" {
-			t.Fatalf("commands = %#v, did not expect notify-send dispatch when gate is off", cmdRecorder(cmd).commands)
+			t.Fatalf("commands = %#v, did not expect notify-send dispatch when mode=none", cmdRecorder(cmd).commands)
 		}
 	}
 }
 
-func TestDesktopNotifyGateAllowsDispatchWhenOn(t *testing.T) {
+// TestDesktopNotifyGateAllowsDispatchWhenNotify confirms the boolean
+// shim treats mode=notify as on so notify-send fires.
+func TestDesktopNotifyGateAllowsDispatchWhenNotify(t *testing.T) {
 	home := t.TempDir()
 	cmd := testAICommand(home)
 	cmd.lookupEnv = func(name string) string {
 		switch name {
 		case "HOME":
 			return home
-		case "PROJMUX_DESKTOP_NOTIFY":
-			return "on"
-		default:
-			return ""
+		case desktopNotifyModeEnv:
+			return "notify"
 		}
+		return ""
 	}
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
 		if name == "command" && len(args) == 2 && args[0] == "-v" && args[1] == "notify-send" {
@@ -117,25 +224,63 @@ func TestDesktopNotifyGateAllowsDispatchWhenOn(t *testing.T) {
 		Summary: "Hello",
 		Body:    "World",
 		Urgency: "normal",
-		AppName: "projmux.TmuxCodex",
+		AppName: desktopAppID,
 		Icon:    "dialog-information",
 	}); err != nil {
-		t.Fatalf("Notify with desktop notifications on returned error: %v", err)
+		t.Fatalf("Notify with mode=notify returned error: %v", err)
 	}
 
 	var sawNotifySend bool
 	for _, command := range cmdRecorder(cmd).commands {
 		if command.name == "notify-send" {
 			sawNotifySend = true
-			wantPrefix := []string{
-				"--app-name=projmux.TmuxCodex",
-			}
-			if !reflect.DeepEqual(command.args[:len(wantPrefix)], wantPrefix) {
-				t.Fatalf("notify-send args = %#v, want first arg %q", command.args, wantPrefix[0])
-			}
+			break
 		}
 	}
 	if !sawNotifySend {
-		t.Fatalf("commands = %#v, want notify-send dispatch when gate is on", cmdRecorder(cmd).commands)
+		t.Fatalf("commands = %#v, want notify-send dispatch when mode=notify", cmdRecorder(cmd).commands)
+	}
+}
+
+// TestDesktopNotifyModeLegacyFallback exercises the migration read path:
+// a user with the legacy `PROJMUX_DESKTOP_NOTIFY=off` and no new-mode env
+// keeps the silenced behavior (mapped to none).
+func TestDesktopNotifyModeLegacyFallback(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.lookupEnv = func(name string) string {
+		switch name {
+		case "HOME":
+			return home
+		case desktopNotifyEnv:
+			return "off"
+		}
+		return ""
+	}
+	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "command" && len(args) == 2 && args[0] == "-v" && args[1] == "notify-send" {
+			return []byte("/usr/bin/notify-send\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	if got, src := cmd.desktopNotifyModeResolution(); got != desktopNotifyModeNone || src != desktopNotifySourceEnvLegacy {
+		t.Fatalf("legacy off env mapping = (%q, %q), want (none, env (legacy))", got, src)
+	}
+
+	notifier := aiDesktopNotifier{command: cmd}
+	if err := notifier.Notify(aiNotification{
+		Summary: "Hello",
+		Body:    "World",
+		Urgency: "normal",
+		AppName: desktopAppID,
+		Icon:    "dialog-information",
+	}); err != nil {
+		t.Fatalf("Notify legacy off returned error: %v", err)
+	}
+	for _, command := range cmdRecorder(cmd).commands {
+		if command.name == "notify-send" {
+			t.Fatalf("commands = %#v, did not expect notify-send dispatch when legacy off env is set", cmdRecorder(cmd).commands)
+		}
 	}
 }

--- a/internal/app/notification_toggle_test.go
+++ b/internal/app/notification_toggle_test.go
@@ -19,7 +19,7 @@ func TestDesktopNotifyResolverModeCascade(t *testing.T) {
 		wantSource desktopNotifySource
 	}{
 		{
-			name: "default in WSL with WT",
+			name:  "default in WSL with WT",
 			isWSL: true, wtPresent: true,
 			wantMode: desktopNotifyModeRaise, wantSource: desktopNotifySourceDefault,
 		},

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -96,7 +96,7 @@ var settingsEntryPrefixCatalog = []struct {
 	meta   settingsEntryMeta
 }{
 	{settingsActionPrefixAI, settingsEntryMeta{Name: "AI Settings", Axis: settingsAxisGlobal}},
-	{settingsActionPrefixDesktopNotify, settingsEntryMeta{Name: "Desktop notifications", Axis: settingsAxisGlobal}},
+	{settingsActionPrefixDesktopNotifyMode, settingsEntryMeta{Name: "Desktop notifications", Axis: settingsAxisGlobal}},
 	{settingsActionPrefixHooks, settingsEntryMeta{Name: "Project hook policy", Axis: settingsAxisGlobal}},
 	{settingsActionPrefixHookAdd, settingsEntryMeta{Name: "Hook maker - add", Axis: settingsAxisBoth}},
 	{settingsActionPrefixHookEdit, settingsEntryMeta{Name: "Hook maker - edit", Axis: settingsAxisBoth}},
@@ -126,48 +126,48 @@ func settingsEntryMetaForValue(value string) (settingsEntryMeta, bool) {
 }
 
 const (
-	settingsBackValue                 = "__settings_back__"
-	settingsNoopValue                 = "__settings_noop__"
-	settingsRootTabGlobalValue        = "__settings_tab_global__"
-	settingsRootTabProjectValue       = "__settings_tab_project__"
-	settingsSectionAI                 = "section:ai"
-	settingsSectionGlobalHooks        = "section:hooks-global"
-	settingsSectionProjectHooks       = "section:hooks-project"
-	settingsSectionProjectConfig      = "section:project-config"
-	settingsSectionProjectTrust       = "section:project-trust"
-	settingsSectionEffectiveMerge     = "section:effective-merge"
-	settingsSectionKeybindings        = "section:keybindings"
-	settingsSectionProject            = "section:project-picker"
-	settingsSectionStatusbar          = "section:statusbar"
-	settingsSectionLabs               = "section:labs"
-	settingsSectionAbout              = "section:about"
-	settingsActionPrefixAI            = "ai:"
-	settingsActionPrefixDesktopNotify = "desktop-notify:"
-	settingsActionPrefixHooks         = "project-hooks:"
-	settingsActionPrefixKeymap        = "keymap:"
-	settingsActionPrefixLabKeymap     = "lab-keymap:"
-	settingsActionPrefixPicker        = "picker-backend:"
-	settingsActionPrefixProjectConfig = "project-config:"
-	settingsActionPrefixTrust         = "trust:"
-	settingsActionPrefixProjdir       = "projdir:"
-	settingsActionPrefixStatusbar     = "statusbar-decoration:"
-	settingsActionPrefixSwitch        = "switch:"
-	settingsActionPrefixUpdate        = "update:"
-	settingsActionPrefixWorkdir       = "workdir:"
-	settingsProjectAdd                = "project:add"
-	settingsProjectPins               = "project:pins"
-	settingsProjectRootManage         = "project-root:manage"
-	settingsProjdirClear              = "projdir:clear"
-	settingsProjdirSetCurrent         = "projdir:set-current"
-	settingsProjdirSetTyped           = "projdir:set-typed"
-	settingsUpdateApply               = "update:apply"
-	settingsUpdateCheck               = "update:check"
-	settingsWorkdirAdd                = "workdir:add"
-	settingsWorkdirList               = "workdir:list"
-	settingsWorkdirTyped              = "workdir:typed"
-	settingsLabKeybindings            = "labs:keybindings"
-	settingsKeymapFieldPlain          = "plain"
-	settingsKeymapFieldPrefix         = "prefix"
+	settingsBackValue                     = "__settings_back__"
+	settingsNoopValue                     = "__settings_noop__"
+	settingsRootTabGlobalValue            = "__settings_tab_global__"
+	settingsRootTabProjectValue           = "__settings_tab_project__"
+	settingsSectionAI                     = "section:ai"
+	settingsSectionGlobalHooks            = "section:hooks-global"
+	settingsSectionProjectHooks           = "section:hooks-project"
+	settingsSectionProjectConfig          = "section:project-config"
+	settingsSectionProjectTrust           = "section:project-trust"
+	settingsSectionEffectiveMerge         = "section:effective-merge"
+	settingsSectionKeybindings            = "section:keybindings"
+	settingsSectionProject                = "section:project-picker"
+	settingsSectionStatusbar              = "section:statusbar"
+	settingsSectionLabs                   = "section:labs"
+	settingsSectionAbout                  = "section:about"
+	settingsActionPrefixAI                = "ai:"
+	settingsActionPrefixDesktopNotifyMode = "desktop-notify-mode:"
+	settingsActionPrefixHooks             = "project-hooks:"
+	settingsActionPrefixKeymap            = "keymap:"
+	settingsActionPrefixLabKeymap         = "lab-keymap:"
+	settingsActionPrefixPicker            = "picker-backend:"
+	settingsActionPrefixProjectConfig     = "project-config:"
+	settingsActionPrefixTrust             = "trust:"
+	settingsActionPrefixProjdir           = "projdir:"
+	settingsActionPrefixStatusbar         = "statusbar-decoration:"
+	settingsActionPrefixSwitch            = "switch:"
+	settingsActionPrefixUpdate            = "update:"
+	settingsActionPrefixWorkdir           = "workdir:"
+	settingsProjectAdd                    = "project:add"
+	settingsProjectPins                   = "project:pins"
+	settingsProjectRootManage             = "project-root:manage"
+	settingsProjdirClear                  = "projdir:clear"
+	settingsProjdirSetCurrent             = "projdir:set-current"
+	settingsProjdirSetTyped               = "projdir:set-typed"
+	settingsUpdateApply                   = "update:apply"
+	settingsUpdateCheck                   = "update:check"
+	settingsWorkdirAdd                    = "workdir:add"
+	settingsWorkdirList                   = "workdir:list"
+	settingsWorkdirTyped                  = "workdir:typed"
+	settingsLabKeybindings                = "labs:keybindings"
+	settingsKeymapFieldPlain              = "plain"
+	settingsKeymapFieldPrefix             = "prefix"
 )
 
 func newSettingsCommand(ai *aiCommand, switcher *switchCommand, update *updateCommand) *settingsCommand {
@@ -1384,11 +1384,11 @@ func (c *settingsCommand) aiEntries() []intpickercompat.Entry {
 		{aiModeShell, "always open plain shell split"},
 	}
 
-	notifyOn, notifySource := settingsDesktopNotifyResolver(c.lookupEnv).resolve()
+	notifyMode, notifySource := settingsDesktopNotifyResolver(c.lookupEnv).resolveMode()
 
-	// Reserve room for: back row + split modes + 1 info row + 2 toggle
-	// rows (on/off) for the desktop-notify switch.
-	entries := make([]intpickercompat.Entry, 0, len(modes)+4)
+	// Reserve room for: back row + split modes + 1 info row + 3 toggle
+	// rows (none/notify/raise) for the desktop-notify mode selector.
+	entries := make([]intpickercompat.Entry, 0, len(modes)+5)
 	entries = append(entries, settingsBackEntry())
 	for _, item := range modes {
 		glyph := settingsGlyphInactive
@@ -1403,34 +1403,31 @@ func (c *settingsCommand) aiEntries() []intpickercompat.Entry {
 		})
 	}
 
-	// Phase 1: desktop notification on/off toggle. The info row shows the
-	// effective value plus where it came from (env / setting / default) so
-	// users mid-troubleshooting see immediately why a toggle press might
-	// not stick (env override pins the value).
-	notifyValue := "off"
-	if notifyOn {
-		notifyValue = "on"
-	}
+	// Desktop notification mode selector. The info row shows the effective
+	// value plus where it came from (env / env (legacy) / setting / setting
+	// (legacy) / default) so users mid-troubleshooting see immediately why
+	// a toggle press might not stick (env override pins the value).
 	entries = append(entries, intpickercompat.Entry{
-		Label: settingsLabelInfo("Desktop notifications", notifyValue, string(notifySource)),
+		Label: settingsLabelInfo("Desktop notifications", string(notifyMode), string(notifySource)),
 		Value: settingsNoopValue,
 	})
 	for _, item := range []struct {
-		state string
-		desc  string
+		mode desktopNotifyMode
+		desc string
 	}{
-		{"on", "fire OS desktop notifications for AI reply-ready"},
-		{"off", "silence OS notifications; in-app notify queue is unaffected"},
+		{desktopNotifyModeNone, "silence OS notifications; in-app notify queue is unaffected"},
+		{desktopNotifyModeNotify, "fire toast / notify-send for AI reply-ready (click → focus via projmux://)"},
+		{desktopNotifyModeRaise, "fire toast and auto-raise host terminal via osfocus chain"},
 	} {
 		glyph := settingsGlyphInactive
 		color := settingsColorDim
-		if (item.state == "on") == notifyOn {
+		if item.mode == notifyMode {
 			glyph = settingsGlyphToggle
 			color = settingsColorAdd
 		}
 		entries = append(entries, intpickercompat.Entry{
-			Label: settingsLabel(glyph, color, "Desktop notifications "+item.state, item.desc),
-			Value: settingsActionPrefixDesktopNotify + item.state,
+			Label: settingsLabel(glyph, color, "Desktop notifications "+string(item.mode), item.desc),
+			Value: settingsActionPrefixDesktopNotifyMode + string(item.mode),
 		})
 	}
 	return entries
@@ -2128,44 +2125,41 @@ func (c *settingsCommand) currentStatusbarDecoration() config.StatusbarDecoratio
 	return loadStatusbarDecoration(c.homeDir, c.lookupEnv)
 }
 
-// setDesktopNotify writes the user-facing on/off choice into the
-// `@projmux_desktop_notify` global tmux user-option. The env variable
-// `PROJMUX_DESKTOP_NOTIFY` continues to take priority at resolve time,
-// so toggling here when env is set will appear to "do nothing" — the
+// setDesktopNotifyMode writes the user-facing 3-way choice into the
+// `@projmux_desktop_notify_mode` global tmux user-option. The env
+// variables (`PROJMUX_DESKTOP_NOTIFY_MODE`, plus the legacy
+// `PROJMUX_DESKTOP_NOTIFY`) continue to take priority at resolve time, so
+// toggling here when an env is set will appear to "do nothing" — the
 // Settings info row surfaces the source so users see why.
+//
+// The legacy `@projmux_desktop_notify` option is intentionally NOT
+// rewritten here. Read-time migration keeps honoring it for users who
+// never opened the Settings row; once they pick a value via this code
+// path the new option pins the resolution and the legacy one is
+// effectively orphaned.
 //
 // When projmux runs outside tmux we silently skip the live update; the
 // gate at `aiDesktopNotifier.Notify` only reads the option inside tmux
 // anyway, so there's nothing to persist elsewhere.
-func (c *settingsCommand) setDesktopNotify(value string) error {
-	value = strings.ToLower(strings.TrimSpace(value))
-	var optionValue string
-	switch value {
-	case "on", "1", "true", "yes":
-		optionValue = "1"
-	case "off", "0", "false", "no":
-		optionValue = "0"
-	default:
-		return fmt.Errorf("unknown desktop notification value: %s", value)
+func (c *settingsCommand) setDesktopNotifyMode(value string) error {
+	mode, ok := parseDesktopNotifyMode(value)
+	if !ok {
+		return fmt.Errorf("unknown desktop notification mode: %s", value)
 	}
 	if c.lookupEnv == nil || strings.TrimSpace(c.lookupEnv("TMUX")) == "" {
 		// Outside tmux there is no server to persist to. The toggle is
 		// inherently a tmux-scoped surface (resolve order checks env
-		// first, then this option, then default) so this isn't an error
-		// — just a no-op with a friendly hint.
+		// first, then this option, then default) so this isn't an
+		// error — just a no-op with a friendly hint.
 		return nil
 	}
 	if c.runCommand == nil {
 		return errors.New("settings runner is not configured")
 	}
-	if err := c.runCommand("tmux", "set-option", "-g", desktopNotifyTmuxOption, optionValue); err != nil {
-		return fmt.Errorf("set live tmux desktop-notify option: %w", err)
+	if err := c.runCommand("tmux", "set-option", "-g", desktopNotifyModeTmuxOption, string(mode)); err != nil {
+		return fmt.Errorf("set live tmux desktop-notify-mode option: %w", err)
 	}
-	stateLabel := "on"
-	if optionValue == "0" {
-		stateLabel = "off"
-	}
-	_ = c.runCommand("tmux", "display-message", "desktop notifications: "+stateLabel)
+	_ = c.runCommand("tmux", "display-message", "desktop notifications: "+string(mode))
 	return nil
 }
 
@@ -2375,8 +2369,8 @@ func (c *settingsCommand) execute(value string, stdout, stderr io.Writer) error 
 			return errors.New("ai settings are not configured")
 		}
 		return c.ai.setMode(mode)
-	case strings.HasPrefix(value, settingsActionPrefixDesktopNotify):
-		return c.setDesktopNotify(strings.TrimPrefix(value, settingsActionPrefixDesktopNotify))
+	case strings.HasPrefix(value, settingsActionPrefixDesktopNotifyMode):
+		return c.setDesktopNotifyMode(strings.TrimPrefix(value, settingsActionPrefixDesktopNotifyMode))
 	case strings.HasPrefix(value, settingsActionPrefixHooks):
 		return c.setProjectHooksMode(strings.TrimPrefix(value, settingsActionPrefixHooks))
 	case strings.HasPrefix(value, settingsActionPrefixPicker):

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -976,45 +976,48 @@ func TestSettingsHubSetsStatusbarDecoration(t *testing.T) {
 	}
 }
 
-func TestSettingsSetDesktopNotifyWritesTmuxOption(t *testing.T) {
+func TestSettingsSetDesktopNotifyModeWritesTmuxOption(t *testing.T) {
 	t.Parallel()
 
-	var tmuxCalls [][]string
-	cmd := &settingsCommand{
-		lookupEnv: func(name string) string {
-			if name == "TMUX" {
-				return "/tmp/tmux"
+	for _, tc := range []struct {
+		in       string
+		wantOpt  string
+		wantText string
+	}{
+		{"none", "none", "none"},
+		{"notify", "notify", "notify"},
+		{"raise", "raise", "raise"},
+		{"off", "none", "none"}, // alias accepted by parseDesktopNotifyMode
+		{"toast", "notify", "notify"},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			var tmuxCalls [][]string
+			cmd := &settingsCommand{
+				lookupEnv: func(name string) string {
+					if name == "TMUX" {
+						return "/tmp/tmux"
+					}
+					return ""
+				},
+				runCommand: func(name string, args ...string) error {
+					tmuxCalls = append(tmuxCalls, append([]string{name}, args...))
+					return nil
+				},
 			}
-			return ""
-		},
-		runCommand: func(name string, args ...string) error {
-			tmuxCalls = append(tmuxCalls, append([]string{name}, args...))
-			return nil
-		},
-	}
-	if err := cmd.setDesktopNotify("off"); err != nil {
-		t.Fatalf("setDesktopNotify(off) error = %v", err)
-	}
-	if !reflect.DeepEqual(tmuxCalls, [][]string{
-		{"tmux", "set-option", "-g", desktopNotifyTmuxOption, "0"},
-		{"tmux", "display-message", "desktop notifications: off"},
-	}) {
-		t.Fatalf("tmux calls = %#v", tmuxCalls)
-	}
-
-	tmuxCalls = nil
-	if err := cmd.setDesktopNotify("on"); err != nil {
-		t.Fatalf("setDesktopNotify(on) error = %v", err)
-	}
-	if !reflect.DeepEqual(tmuxCalls, [][]string{
-		{"tmux", "set-option", "-g", desktopNotifyTmuxOption, "1"},
-		{"tmux", "display-message", "desktop notifications: on"},
-	}) {
-		t.Fatalf("tmux calls = %#v", tmuxCalls)
+			if err := cmd.setDesktopNotifyMode(tc.in); err != nil {
+				t.Fatalf("setDesktopNotifyMode(%q) error = %v", tc.in, err)
+			}
+			if !reflect.DeepEqual(tmuxCalls, [][]string{
+				{"tmux", "set-option", "-g", desktopNotifyModeTmuxOption, tc.wantOpt},
+				{"tmux", "display-message", "desktop notifications: " + tc.wantText},
+			}) {
+				t.Fatalf("tmux calls = %#v", tmuxCalls)
+			}
+		})
 	}
 }
 
-func TestSettingsSetDesktopNotifyOutsideTmuxIsNoop(t *testing.T) {
+func TestSettingsSetDesktopNotifyModeOutsideTmuxIsNoop(t *testing.T) {
 	t.Parallel()
 
 	var tmuxCalls [][]string
@@ -1025,15 +1028,32 @@ func TestSettingsSetDesktopNotifyOutsideTmuxIsNoop(t *testing.T) {
 			return nil
 		},
 	}
-	if err := cmd.setDesktopNotify("off"); err != nil {
-		t.Fatalf("setDesktopNotify(off) outside tmux returned error: %v", err)
+	if err := cmd.setDesktopNotifyMode("none"); err != nil {
+		t.Fatalf("setDesktopNotifyMode(none) outside tmux returned error: %v", err)
 	}
 	if len(tmuxCalls) != 0 {
 		t.Fatalf("outside tmux: tmux calls = %#v, want no live update", tmuxCalls)
 	}
 }
 
-func TestSettingsAIEntriesIncludesDesktopNotifyToggle(t *testing.T) {
+func TestSettingsSetDesktopNotifyModeRejectsGarbage(t *testing.T) {
+	t.Parallel()
+
+	cmd := &settingsCommand{
+		lookupEnv: func(name string) string {
+			if name == "TMUX" {
+				return "/tmp/tmux"
+			}
+			return ""
+		},
+		runCommand: func(string, ...string) error { return nil },
+	}
+	if err := cmd.setDesktopNotifyMode("garbage"); err == nil {
+		t.Fatalf("setDesktopNotifyMode(garbage) expected error, got nil")
+	}
+}
+
+func TestSettingsAIEntriesIncludesDesktopNotifyModeRows(t *testing.T) {
 	t.Parallel()
 
 	home := t.TempDir()
@@ -1041,32 +1061,35 @@ func TestSettingsAIEntriesIncludesDesktopNotifyToggle(t *testing.T) {
 		ai:      testAICommand(home),
 		homeDir: func() (string, error) { return home, nil },
 		lookupEnv: func(name string) string {
-			if name == "PROJMUX_DESKTOP_NOTIFY" {
-				return "off"
+			if name == "PROJMUX_DESKTOP_NOTIFY_MODE" {
+				return "raise"
 			}
 			return ""
 		},
 	}
 	entries := cmd.aiEntries()
-	if !hasEntryValue(entries, settingsActionPrefixDesktopNotify+"on") {
-		t.Fatalf("ai entries = %#v, want desktop-notify on row", entries)
+	for _, want := range []string{
+		settingsActionPrefixDesktopNotifyMode + "none",
+		settingsActionPrefixDesktopNotifyMode + "notify",
+		settingsActionPrefixDesktopNotifyMode + "raise",
+	} {
+		if !hasEntryValue(entries, want) {
+			t.Fatalf("ai entries = %#v, want row %q", entries, want)
+		}
 	}
-	if !hasEntryValue(entries, settingsActionPrefixDesktopNotify+"off") {
-		t.Fatalf("ai entries = %#v, want desktop-notify off row", entries)
-	}
-	// Env override sets source = env and effective value = off; confirm
+	// Env override sets source = env and effective value = raise; confirm
 	// the info row reflects that so users see why a toggle press might
 	// look like a no-op.
 	var sawInfo bool
 	for _, entry := range entries {
 		if strings.Contains(entry.Label, "Desktop notifications") &&
-			strings.Contains(entry.Label, "off") &&
+			strings.Contains(entry.Label, "raise") &&
 			strings.Contains(entry.Label, "env") {
 			sawInfo = true
 		}
 	}
 	if !sawInfo {
-		t.Fatalf("ai entries = %#v, want info row with off + env source", entries)
+		t.Fatalf("ai entries = %#v, want info row with raise + env source", entries)
 	}
 }
 


### PR DESCRIPTION
## Summary

Refits the WSL+WT desktop notification path based on live-test findings during this session. The shipped behavior now lets users pick **one of three modes**:

| Mode | On push | On click |
|---|---|---|
| `none` | no toast | n/a |
| `notify` | show toast | click → projmux focus via URI handler |
| `raise` | show toast + auto-raise WT (osfocus chain) | click → projmux focus via URI handler |

Default: `raise` if `isWSL && WT_SESSION present`, else `notify`. Click handling is always-on (URI handler is registered independently of mode).

## Why this shape

URI infrastructure shipped in #178/#179 was originally thought to be display-only (toast click reportedly did nothing). Live testing this session showed click **does** invoke the registered `projmux://` URI handler, BUT only when no COM Toast Activator is configured alongside. Multiple gotchas were narrowed down:

1. Windows Defender silently quarantines `powershell.exe -WindowStyle Hidden -Command exit` Start Menu shortcuts seconds after creation, which kills the AppID routing — switched the shortcut target to `cmd.exe /c exit`.
2. Adding `PKEY_AppUserModel_ToastActivatorCLSID` to the shortcut routes Windows down the COM activator path; that path silently fails on unpackaged Win32 apps and Windows does NOT fall through to ShellExecute on the launch URI. Stripping the property restores the working path.
3. The `wsl.exe -- projmux ...` form routes through the user's login shell (zsh), which parses URI query separators `&` as background-job operators (\`zsh:1: parse error near '&'\`). PR-F's switch to `wsl.exe --exec <abs-path>` already fixed this.
4. COM Toast Activator implementation (PR-H prototype in \`tools/win-toast-activator/\` archive) launches and registers with COM but Windows never dispatches Activate — the unpackaged Win32 click activation path doesn't seem to work without MSIX packaging.

Lessons captured in \`docs/notify-os-focus-poc.md\` and the roadmap hub so a future implementer doesn't repeat them.

## Knobs

- env: \`PROJMUX_DESKTOP_NOTIFY_MODE\` — \`none\` / \`notify\` / \`raise\` (case-insensitive, plus aliases \`off\`, \`toast\`, \`auto-raise\`)
- env legacy fallback: \`PROJMUX_DESKTOP_NOTIFY\` — \`off\`→none, \`on\`→notify
- tmux option: \`@projmux_desktop_notify_mode\` — same canonical values
- tmux option legacy fallback: \`@projmux_desktop_notify\` — read-only, never written by Settings
- Settings UI: \`Desktop notifications\` selector with effective-source label (\`env\` / \`env (legacy)\` / \`setting\` / \`setting (legacy)\` / \`default\`)

## Changes

- \`internal/app/ai.go\` — shortcut target = \`cmd.exe /c exit\`, no ToastActivatorCLSID set
- \`internal/app/notification.go\` — mode gate + \`maybeRaiseHostTerminal\` (only on successful dispatch)
- \`internal/app/notification_toggle.go\` — 3-way resolver with legacy migration
- \`internal/app/settings.go\` — 3-way selector
- Tests + docs updated. Roadmap hub doc updated in vault separately.

URI infrastructure (\`notification_uri.go\`, \`buildToastPowerShell\` \`launch\` attr, \`ensureWSLURIProtocol\`, \`projmux focus --uri\`) is unchanged — promoted from deferred to shipped per the click-activation verification.

## Test plan
- [x] \`go build / vet / fmt / test\` all green
- [x] Click activation verified live (this session): toast click in 'home' session → switches /dev/pts/0 to 'repos-projmux' (target pane's session)
- [ ] Manual after merge+install: verify (i) toast click switches sessions, (ii) \`raise\` mode brings WT to foreground on dispatch, (iii) Settings selector toggles take effect, (iv) legacy \`@projmux_desktop_notify=0/1\` fallback honored

🤖 Generated with [Claude Code](https://claude.com/claude-code)