### PR TITLE
fix(osfocus): remove racing goroutine wrap so wt.exe actually spawns

### DIFF
--- a/internal/integrations/osfocus/wt_wsl.go
+++ b/internal/integrations/osfocus/wt_wsl.go
@@ -56,25 +56,28 @@ func (a WindowsTerminalWSLAdapter) Detect() bool {
 	return interop != ""
 }
 
-// Focus spawns `wt.exe -w 0 focus-tab -t 0` in a goroutine and returns
-// immediately. The call is best-effort: if the spawn fails (wt.exe missing
-// from $PATH, interop misconfigured, etc.) the error is dropped because the
-// chain documents silent fallback as the failure policy. The Target argument
-// is accepted for forward compatibility with tier-2 adapters but not
-// consumed here.
+// Focus shells out to `wt.exe -w 0 focus-tab -t 0` synchronously and returns
+// the runner's error verbatim. The Chain owns the silent-fallback policy and
+// discards adapter errors; the adapter just surfaces what the OS told it.
+// The Target argument is accepted for forward compatibility with tier-2
+// adapters but not consumed here.
+//
+// Synchronous on purpose: defaultWTRun uses cmd.Start() (which returns as soon
+// as the OS confirms the spawn — it does NOT block on wt.exe's own execution)
+// and reaps the child in its own goroutine, so the adapter is already
+// non-blocking enough for the focus hot path. Wrapping this call in an outer
+// `go func()` previously caused a race with short-lived callers: when
+// `projmux ai notify` (invoked from tmux hooks as a one-shot subprocess)
+// returned from Notify, main exited and the Go runtime tore the goroutine
+// down before it had a chance to call Start(), so wt.exe never spawned and
+// `mode=raise` did nothing visible. Calling synchronously guarantees the
+// spawn syscall completes before the parent process can exit.
 func (a WindowsTerminalWSLAdapter) Focus(_ Target) error {
 	runner := a.Run
 	if runner == nil {
 		runner = defaultWTRun
 	}
-	// Background dispatch keeps Focus non-blocking — the caller is on the
-	// focus hot path and must not wait on an external process. We discard
-	// the runner's error intentionally; the chain's contract is silent
-	// fallback on adapter failure.
-	go func() {
-		_ = runner("wt.exe", "-w", "0", "focus-tab", "-t", "0")
-	}()
-	return nil
+	return runner("wt.exe", "-w", "0", "focus-tab", "-t", "0")
 }
 
 // defaultWTRun spawns the command without waiting on it. stdout/stderr are

--- a/internal/integrations/osfocus/wt_wsl_test.go
+++ b/internal/integrations/osfocus/wt_wsl_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"sync"
 	"testing"
-	"time"
 )
 
 func envLookup(values map[string]string) func(string) (string, bool) {
@@ -78,24 +77,15 @@ func TestWindowsTerminalWSLAdapter_Detect(t *testing.T) {
 // recordedRun captures the args passed to the injected runner so the test can
 // assert the adapter shells out with the exact spike-measured arguments.
 type recordedRun struct {
-	mu     sync.Mutex
-	calls  [][]string
-	err    error
-	delay  time.Duration
-	signal chan struct{}
+	mu    sync.Mutex
+	calls [][]string
+	err   error
 }
 
 func (r *recordedRun) run(name string, args ...string) error {
-	if r.delay > 0 {
-		time.Sleep(r.delay)
-	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.calls = append(r.calls, append([]string{name}, args...))
-	if r.signal != nil {
-		close(r.signal)
-		r.signal = nil
-	}
 	return r.err
 }
 
@@ -112,19 +102,14 @@ func (r *recordedRun) snapshot() [][]string {
 func TestWindowsTerminalWSLAdapter_Focus_ShellsOutWithSpikeArgs(t *testing.T) {
 	t.Parallel()
 
-	rec := &recordedRun{signal: make(chan struct{})}
-	signal := rec.signal
+	rec := &recordedRun{}
 	a := WindowsTerminalWSLAdapter{Run: rec.run}
 
+	// Focus is synchronous — the runner must have been invoked by the time
+	// Focus returns. (See wt_wsl.go: the previous goroutine wrap raced
+	// short-lived callers like `projmux ai notify` and is removed.)
 	if err := a.Focus(Target{Session: "ws", Window: "1", Pane: "0"}); err != nil {
 		t.Fatalf("Focus returned error: %v", err)
-	}
-
-	// Focus dispatches to a goroutine; wait for the runner to be called.
-	select {
-	case <-signal:
-	case <-time.After(2 * time.Second):
-		t.Fatalf("runner was not invoked within timeout; calls=%v", rec.snapshot())
 	}
 
 	calls := rec.snapshot()
@@ -137,58 +122,32 @@ func TestWindowsTerminalWSLAdapter_Focus_ShellsOutWithSpikeArgs(t *testing.T) {
 	}
 }
 
-func TestWindowsTerminalWSLAdapter_Focus_SilentOnRunnerError(t *testing.T) {
+// TestWindowsTerminalWSLAdapter_Focus_SynchronousReturnsRunnerError asserts
+// the adapter surfaces the runner's error verbatim. The silent-fallback
+// policy lives in Chain.Focus (see TestChain_AdapterErrorIsSwallowed), not
+// at the adapter layer — the adapter just exposes the OS spawn result.
+func TestWindowsTerminalWSLAdapter_Focus_SynchronousReturnsRunnerError(t *testing.T) {
 	t.Parallel()
 
-	rec := &recordedRun{
-		err:    errors.New("wt.exe boom"),
-		signal: make(chan struct{}),
-	}
-	signal := rec.signal
+	boom := errors.New("wt.exe boom")
+	rec := &recordedRun{err: boom}
 	a := WindowsTerminalWSLAdapter{Run: rec.run}
 
-	if err := a.Focus(Target{}); err != nil {
-		t.Fatalf("Focus returned error despite runner failure: %v", err)
-	}
-	select {
-	case <-signal:
-	case <-time.After(2 * time.Second):
-		t.Fatalf("runner was not invoked within timeout")
-	}
-}
-
-func TestWindowsTerminalWSLAdapter_Focus_NonBlocking(t *testing.T) {
-	t.Parallel()
-
-	// The runner sleeps for a noticeable interval. If Focus were synchronous
-	// it would block for at least that long; the non-blocking contract says
-	// Focus returns well before the runner completes.
-	const runnerDelay = 250 * time.Millisecond
-	rec := &recordedRun{
-		delay:  runnerDelay,
-		signal: make(chan struct{}),
-	}
-	signal := rec.signal
-	a := WindowsTerminalWSLAdapter{Run: rec.run}
-
-	start := time.Now()
-	if err := a.Focus(Target{}); err != nil {
-		t.Fatalf("Focus returned error: %v", err)
-	}
-	elapsed := time.Since(start)
-
-	// Allow generous slack for scheduling jitter on CI. The point is that
-	// Focus returns far faster than the runner's own delay.
-	if elapsed > runnerDelay/2 {
-		t.Fatalf("Focus blocked for %v, want < %v", elapsed, runnerDelay/2)
+	err := a.Focus(Target{})
+	if !errors.Is(err, boom) {
+		t.Fatalf("Focus returned %v, want runner error %v", err, boom)
 	}
 
-	// The runner still completes asynchronously; verify it eventually fires
-	// so we know dispatch actually happened (not silently dropped).
-	select {
-	case <-signal:
-	case <-time.After(2 * time.Second):
-		t.Fatalf("runner was never invoked after async dispatch")
+	// Even on error, the runner must have actually been called — i.e. the
+	// adapter is synchronous so the spawn syscall has completed before
+	// Focus returns. This is the property short-lived callers depend on.
+	calls := rec.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly one synchronous run, got %d (%v)", len(calls), calls)
+	}
+	want := []string{"wt.exe", "-w", "0", "focus-tab", "-t", "0"}
+	if !equalStrings(calls[0], want) {
+		t.Fatalf("run args = %v, want %v", calls[0], want)
 	}
 }
 


### PR DESCRIPTION
## Bug

PR #180 shipped `mode=raise` which calls the osfocus chain → `WindowsTerminalWSLAdapter.Focus` to bring WT forward after toast dispatch. Live test on the lead's box showed the raise never fires.

Root cause: `Focus` wrapped the runner call in an outer `go func()`. Combined with `projmux ai notify` being a short-lived subprocess invoked from tmux hooks, the Go runtime tore down the goroutine before it could call `cmd.Start()` — `wt.exe` never spawned.

`defaultWTRun` already uses `cmd.Start()` (non-blocking on wt.exe execution itself, only blocking on the OS spawn confirmation ~10ms). The outer goroutine wrap was both redundant and harmful.

## Fix

Drop the outer goroutine in `Focus`. Call `runner(...)` synchronously; spawn confirmation completes before the short-lived parent exits.

## Test plan
- [x] go build / vet / fmt / test — green
- [ ] Manual after merge+install: fire notify in mode=raise, verify WT comes forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)