### PR TITLE
fix(osfocus): wrap wt.exe spawn through bash -c for WSL foreground rights

### DIFF
--- a/internal/integrations/osfocus/wt_wsl.go
+++ b/internal/integrations/osfocus/wt_wsl.go
@@ -3,6 +3,7 @@ package osfocus
 import (
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // WindowsTerminalWSLAdapter raises the Windows Terminal window when projmux
@@ -82,8 +83,17 @@ func (a WindowsTerminalWSLAdapter) Focus(_ Target) error {
 
 // defaultWTRun spawns the command without waiting on it. stdout/stderr are
 // discarded so the spawn cannot leak handles into the projmux process.
+//
+// WSL interop quirk: a direct Go exec of `wt.exe` (the binfmt_misc shim
+// routes us into Windows) spawns the resulting Windows process WITHOUT
+// foreground-window rights. wt.exe runs but cannot raise its window.
+// Wrapping through `bash -c` lets bash set up the process (controlling
+// tty / session) such that foreground rights propagate and the raise
+// actually fires. Verified empirically vs three alternatives during the
+// tier-1 ship.
 func defaultWTRun(name string, args ...string) error {
-	cmd := exec.Command(name, args...)
+	quoted := shellQuoteArgs(append([]string{name}, args...))
+	cmd := exec.Command("bash", "-c", quoted)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	cmd.Stdin = nil
@@ -97,4 +107,16 @@ func defaultWTRun(name string, args ...string) error {
 		_ = cmd.Wait()
 	}()
 	return nil
+}
+
+// shellQuoteArgs joins argv into a single bash command line, quoting each
+// arg with POSIX single-quote rules so embedded characters (including
+// none for the tier-1 path, but defensive for tier-2 adapters reusing
+// this helper) cannot reinterpret as shell metachars.
+func shellQuoteArgs(argv []string) string {
+	parts := make([]string, 0, len(argv))
+	for _, a := range argv {
+		parts = append(parts, "'"+strings.ReplaceAll(a, "'", "'\\''")+"'")
+	}
+	return strings.Join(parts, " ")
 }

--- a/internal/integrations/osfocus/wt_wsl_test.go
+++ b/internal/integrations/osfocus/wt_wsl_test.go
@@ -151,6 +151,22 @@ func TestWindowsTerminalWSLAdapter_Focus_SynchronousReturnsRunnerError(t *testin
 	}
 }
 
+func TestShellQuoteArgs_(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want string
+	}{
+		{[]string{"wt.exe", "-w", "0", "ft", "-t", "0"}, `'wt.exe' '-w' '0' 'ft' '-t' '0'`},
+		{[]string{"path with space"}, `'path with space'`},
+		{[]string{"x'y"}, `'x'\''y'`},
+	}
+	for _, c := range cases {
+		if got := shellQuoteArgs(c.in); got != c.want {
+			t.Errorf("shellQuoteArgs(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Bug

Tier-1 osfocus adapter shells out via `exec.Command("wt.exe", ...).Start()`. Live-test on lead's box after PR #181's goroutine fix: wt.exe runs but **does not raise** Windows Terminal.

Empirical comparison:
- `( sleep 5 && wt.exe -w 0 ft -t 0 ) &` from bash → ✅ raises
- Go `exec.Command("wt.exe", ...).Start()` direct → ❌ wt.exe runs but no raise
- Go `exec.Command("bash", "-c", "wt.exe -w 0 ft -t 0").Start()` → ✅ raises

Root cause: WSL2's binfmt_misc shim spawns Windows-side `wt.exe` without propagating foreground-window rights when the parent is a direct Go `exec`. Bash's wrapper layer sets up controlling-tty / session such that the spawn inherits foreground rights.

## Fix

`defaultWTRun` now wraps via `bash -c "<quoted argv>"`. Added a POSIX single-quote `shellQuoteArgs` helper so future tier-2 adapters can reuse safely.

## Test plan
- [x] go build / vet / fmt / test green
- [ ] Manual after merge+install: verify wt.exe actually raises WT now when mode=raise fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)