### PR TITLE
fix(osfocus): setsid bash subprocess so wt.exe survives parent exit

### DIFF
--- a/internal/integrations/osfocus/wt_wsl.go
+++ b/internal/integrations/osfocus/wt_wsl.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 )
 
 // WindowsTerminalWSLAdapter raises the Windows Terminal window when projmux
@@ -91,18 +92,31 @@ func (a WindowsTerminalWSLAdapter) Focus(_ Target) error {
 // tty / session) such that foreground rights propagate and the raise
 // actually fires. Verified empirically vs three alternatives during the
 // tier-1 ship.
+//
+// Setsid rationale: `projmux ai notify` is invoked from tmux hooks as a
+// one-shot subprocess; after Notify returns the projmux main goroutine
+// exits and the kernel sends SIGHUP to every member of the parent's
+// process group. cmd.Start("bash", "-c", "wt.exe ...") returns after the
+// fork(2) succeeds but BEFORE bash has exec'd wt.exe — so without
+// detaching, bash dies in the parent's pgroup before the exec can happen
+// and wt.exe never spawns. SysProcAttr{Setsid: true} makes bash a session
+// leader with its own pgroup, so the SIGHUP-on-parent-exit chain does not
+// reach it and the raise fires correctly.
 func defaultWTRun(name string, args ...string) error {
 	quoted := shellQuoteArgs(append([]string{name}, args...))
 	cmd := exec.Command("bash", "-c", quoted)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	cmd.Stdin = nil
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	if err := cmd.Start(); err != nil {
 		return err
 	}
 	// Reap the child in a goroutine so we don't leave a zombie behind. We
 	// don't surface Wait's error because Focus already returned to the
-	// caller — silent fallback policy.
+	// caller — silent fallback policy. If projmux exits first the goroutine
+	// dies too, but the bash child is now in its own session and continues
+	// running detached, so wt.exe still spawns.
 	go func() {
 		_ = cmd.Wait()
 	}()


### PR DESCRIPTION
## Bug

After PR #181 + #182, `projmux ai notify` (short-lived tmux-hook subprocess) still does not visibly raise WT in mode=raise. Verified by `ps -ef | grep wt.exe` during the call — no wt.exe process ever spawns.

Root cause: `cmd.Start("bash", "-c", "wt.exe ...")` returns after fork(2) but before bash has exec'd wt.exe. The new bash child is in projmux's process group; when projmux exits immediately after `Notify` returns, the kernel SIGHUPs the whole pgroup → bash dies before the wt.exe exec → no raise.

Verified by comparison: same `chain.Focus` from a standalone Go test that sleeps 3s after the call raises WT correctly (the sleep keeps the pgroup alive long enough for bash → wt.exe).

## Fix

`SysProcAttr{Setsid: true}` makes bash a session leader with its own pgroup. The parent-exit SIGHUP chain does not reach the new session, so bash survives long enough to exec wt.exe and the raise fires.

## Test plan
- [x] go build / vet / fmt / test green
- [ ] Manual after merge+install: mode=raise notify fires + WT visibly raises

🤖 Generated with [Claude Code](https://claude.com/claude-code)