### PR TITLE
feat(statusbar): polish display-only popups (any-key close, drop inline title)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -70,6 +70,7 @@ type App struct {
 	kill         *killCommand
 	notify       *notifyCommand
 	pin          *pinCommand
+	popupWaitKey *popupWaitKeyCommand
 	preview      *previewCommand
 	prune        *pruneCommand
 	sessions     *sessionsCommand
@@ -104,6 +105,7 @@ func New() *App {
 		kill:         newKillCommand(),
 		notify:       newNotifyCommand(),
 		pin:          newPinCommand(),
+		popupWaitKey: newPopupWaitKeyCommand(),
 		preview:      newPreviewCommand(),
 		prune:        newPruneCommand(),
 		sessions:     newSessionsCommand(),
@@ -153,6 +155,11 @@ func (a *App) Run(args []string, stdout, stderr io.Writer) error {
 		return a.notify.Run(args[1:], stdout, stderr)
 	case "pin":
 		return a.pin.Run(args[1:], stdout, stderr)
+	case "popup-wait-key":
+		// Hidden helper: invoked from statusbar display-only popup payloads to
+		// read a single key from /dev/tty and exit. Intentionally absent from
+		// printUsage so `projmux help` stays focused on user-facing commands.
+		return a.popupWaitKey.Run(args[1:], stdout, stderr)
 	case "preview":
 		return a.preview.Run(args[1:], stdout, stderr)
 	case "prune":

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -261,3 +261,30 @@ func (r *recordingCurrentSessionExecutor) OpenSession(_ context.Context, session
 func contains(haystack, needle string) bool {
 	return bytes.Contains([]byte(haystack), []byte(needle))
 }
+
+// TestAppRunDispatchesPopupWaitKey verifies the hidden helper subcommand is
+// wired into the top-level argv dispatch. The statusbar display-only popups
+// embed `<binary> popup-wait-key` into their payloads, so a missing dispatch
+// entry would silently turn every popup into an Enter-only surface.
+func TestAppRunDispatchesPopupWaitKey(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	app := &App{
+		popupWaitKey: &popupWaitKeyCommand{
+			openTTY: func() (popupTTY, error) {
+				called = true
+				return &fakePopupTTY{readBuf: []byte("k"), name: "/dev/tty"}, nil
+			},
+			setRawMode: func(_ popupTTY) (func(), error) {
+				return func() {}, nil
+			},
+		},
+	}
+	if err := app.Run([]string{"popup-wait-key"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !called {
+		t.Fatalf("popup-wait-key dispatch did not invoke handler")
+	}
+}

--- a/internal/app/popup_wait_key.go
+++ b/internal/app/popup_wait_key.go
@@ -1,0 +1,166 @@
+// Package app: popup-wait-key is a hidden helper used by the statusbar's
+// display-only popups (cwd, usage HUD). Those popups want any-key dismissal,
+// but the popup payload runs under whatever shell tmux happens to spawn for
+// `display-popup -E <command>`. Embedding a raw `read -n1` works in bash and
+// zsh but is non-portable (POSIX `sh` rejects `-n`, dash needs `dd`+`stty`
+// gymnastics, fish needs yet another form). Routing through a hidden projmux
+// subcommand removes that shell dependency: the popup payload just calls
+// `<projmux> popup-wait-key` and we handle the raw 1-byte read in Go.
+//
+// The command is intentionally absent from the top-level `printUsage` so it
+// doesn't pollute `projmux help` — it's an internal IPC surface, not a user
+// command.
+package app
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// popupWaitKeyCommand reads one byte from the controlling terminal in raw mode
+// and exits. Used as the close path for display-only statusbar popups.
+type popupWaitKeyCommand struct {
+	// openTTY lets tests substitute a stub instead of opening /dev/tty.
+	openTTY func() (popupTTY, error)
+	// setRawMode flips the tty into a min=1,time=0,no-echo,no-canon state so
+	// a single keystroke completes the read. Substitutable for tests.
+	setRawMode func(tty popupTTY) (restore func(), err error)
+}
+
+// popupTTY is the subset of *os.File popup-wait-key needs. Splitting it lets
+// tests avoid touching the real /dev/tty.
+type popupTTY interface {
+	io.Reader
+	io.Closer
+	Name() string
+}
+
+func newPopupWaitKeyCommand() *popupWaitKeyCommand {
+	return &popupWaitKeyCommand{
+		openTTY:    defaultPopupTTY,
+		setRawMode: defaultPopupRawMode,
+	}
+}
+
+func defaultPopupTTY() (popupTTY, error) {
+	// /dev/tty resolves to the controlling terminal of the calling process.
+	// Under `tmux display-popup -E <cmd>`, tmux assigns the popup pane as the
+	// controlling terminal of <cmd>, so /dev/tty is the popup's own input
+	// stream — exactly what we want to read a single key from.
+	f, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// defaultPopupRawMode shells out to `stty` against the supplied tty. We do
+// this rather than ioctl-via-syscall so the implementation stays
+// dependency-free (no x/sys/unix or x/term in go.mod). `stty` is POSIX and
+// present on every platform tmux already runs on.
+func defaultPopupRawMode(tty popupTTY) (func(), error) {
+	name := tty.Name()
+	if name == "" {
+		return func() {}, errors.New("popup-wait-key: tty has no name")
+	}
+	// Snapshot the current termios so we can restore it on exit.
+	saved, err := exec.Command("stty", "-g", "-F", name).Output()
+	if err != nil {
+		// Some older `stty` builds (notably macOS prior to a certain era)
+		// don't accept -F and expect the tty on stdin. Retry that shape.
+		saved, err = popupSttyStdinGet(name)
+		if err != nil {
+			return func() {}, err
+		}
+	}
+	settings := string(bytesTrimTrailingNewline(saved))
+
+	// Configure for any-key reads: disable echo + canonical mode, read at
+	// least one byte with no inter-byte timeout.
+	if err := popupSttyApply(name, "-echo", "-icanon", "min", "1", "time", "0"); err != nil {
+		return func() {}, err
+	}
+	restore := func() {
+		_ = popupSttyApply(name, settings)
+	}
+	return restore, nil
+}
+
+// popupSttyApply runs `stty <args>` against the supplied tty path, trying the
+// `-F <path>` shape first and falling back to stdin redirection so we cover
+// stty implementations on both Linux and the BSDs.
+func popupSttyApply(name string, args ...string) error {
+	full := append([]string{"-F", name}, args...)
+	if err := exec.Command("stty", full...).Run(); err == nil {
+		return nil
+	}
+	// BSD-style fallback: stty reads termios from its stdin.
+	f, err := os.OpenFile(name, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	cmd := exec.Command("stty", args...)
+	cmd.Stdin = f
+	return cmd.Run()
+}
+
+func popupSttyStdinGet(name string) ([]byte, error) {
+	f, err := os.OpenFile(name, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	cmd := exec.Command("stty", "-g")
+	cmd.Stdin = f
+	return cmd.Output()
+}
+
+func bytesTrimTrailingNewline(b []byte) []byte {
+	for len(b) > 0 && (b[len(b)-1] == '\n' || b[len(b)-1] == '\r') {
+		b = b[:len(b)-1]
+	}
+	return b
+}
+
+// Run reads exactly one byte from /dev/tty in raw mode and returns. Errors
+// are intentionally swallowed at the popup level: from the popup's
+// perspective, the only observable behavior is "the wait ended", and printing
+// a stack trace into the popup body on a failed terminal probe would be
+// worse than just closing.
+func (c *popupWaitKeyCommand) Run(_ []string, _ io.Writer, _ io.Writer) error {
+	if c == nil || c.openTTY == nil {
+		return errors.New("popup-wait-key: not configured")
+	}
+	tty, err := c.openTTY()
+	if err != nil {
+		// Best effort: if we can't open /dev/tty (e.g. the popup payload was
+		// invoked without a controlling terminal during a test substrate),
+		// fall back to a read from stdin so the popup still has *some* close
+		// affordance. The Enter-only behavior we are replacing was strictly
+		// worse than this fallback.
+		return popupWaitKeyReadStdin()
+	}
+	defer tty.Close()
+
+	if c.setRawMode != nil {
+		if restore, err := c.setRawMode(tty); err == nil {
+			defer restore()
+		}
+		// If raw-mode setup failed we still attempt the read; the worst
+		// case (canonical mode) means the user has to press Enter, which is
+		// no worse than the prior behavior we are replacing.
+	}
+
+	var buf [1]byte
+	_, _ = tty.Read(buf[:])
+	return nil
+}
+
+func popupWaitKeyReadStdin() error {
+	var buf [1]byte
+	_, _ = os.Stdin.Read(buf[:])
+	return nil
+}

--- a/internal/app/popup_wait_key_test.go
+++ b/internal/app/popup_wait_key_test.go
@@ -1,0 +1,126 @@
+package app
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// fakePopupTTY is a no-op popupTTY that records whether Read was called and
+// returns the configured byte stream. It lets tests exercise popupWaitKey
+// without depending on /dev/tty.
+type fakePopupTTY struct {
+	io.Reader
+	closed   bool
+	name     string
+	readErr  error
+	readN    int
+	readBuf  []byte
+	readDone chan struct{}
+}
+
+func (f *fakePopupTTY) Close() error {
+	f.closed = true
+	return nil
+}
+
+func (f *fakePopupTTY) Name() string { return f.name }
+
+func (f *fakePopupTTY) Read(p []byte) (int, error) {
+	if f.readDone != nil {
+		defer close(f.readDone)
+	}
+	if f.readErr != nil {
+		return 0, f.readErr
+	}
+	if len(f.readBuf) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(p, f.readBuf)
+	f.readN += n
+	return n, nil
+}
+
+func TestPopupWaitKeyConsumesOneByte(t *testing.T) {
+	t.Parallel()
+
+	tty := &fakePopupTTY{readBuf: []byte("a"), name: "/dev/tty"}
+	restored := false
+	cmd := &popupWaitKeyCommand{
+		openTTY: func() (popupTTY, error) { return tty, nil },
+		setRawMode: func(_ popupTTY) (func(), error) {
+			return func() { restored = true }, nil
+		},
+	}
+
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if tty.readN != 1 {
+		t.Fatalf("Read bytes = %d, want 1", tty.readN)
+	}
+	if !tty.closed {
+		t.Fatalf("Close() not called on tty")
+	}
+	if !restored {
+		t.Fatalf("setRawMode restore func not invoked")
+	}
+}
+
+func TestPopupWaitKeyRecoversWhenTTYOpenFails(t *testing.T) {
+	t.Parallel()
+
+	// Even when /dev/tty cannot be opened (e.g. some container substrates
+	// without a controlling terminal), Run must succeed so the popup
+	// payload still has a clean exit. The fallback path reads from stdin;
+	// for the test we only assert the error contract — not the byte read.
+	cmd := &popupWaitKeyCommand{
+		openTTY: func() (popupTTY, error) { return nil, errors.New("no tty") },
+		setRawMode: func(_ popupTTY) (func(), error) {
+			return func() {}, nil
+		},
+	}
+	// Use a goroutine + closed stdin sentinel: os.Stdin in `go test` is
+	// typically /dev/null, so Read returns 0, io.EOF immediately. That's
+	// the behavior we want — fallback returns nil without hanging.
+	done := make(chan error, 1)
+	go func() { done <- cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	}
+}
+
+func TestPopupWaitKeyTolerantOfSetRawModeFailure(t *testing.T) {
+	t.Parallel()
+
+	tty := &fakePopupTTY{readBuf: []byte("x"), name: "/dev/tty"}
+	cmd := &popupWaitKeyCommand{
+		openTTY: func() (popupTTY, error) { return tty, nil },
+		setRawMode: func(_ popupTTY) (func(), error) {
+			return func() {}, errors.New("stty unavailable")
+		},
+	}
+
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if tty.readN != 1 {
+		t.Fatalf("Read bytes = %d, want 1", tty.readN)
+	}
+}
+
+func TestPopupWaitKeyNotConfiguredReturnsError(t *testing.T) {
+	t.Parallel()
+
+	cmd := &popupWaitKeyCommand{}
+	err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Fatalf("Run() error = %v, want not-configured error", err)
+	}
+}

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -377,7 +377,15 @@ func (c *statusbarCommand) handlePwd(_ statusbarClickOptions, _, stderr io.Write
 	}
 
 	metadata := c.statusbarPathMetadata(ctx, path)
-	popup := statusbarPathPopup(path, metadata)
+	// Binary path is best-effort: a failure here only loses the any-key
+	// close path; the popup itself can still render and falls back to the
+	// Enter-only close shape inside statusbarPopupCommand.
+	binaryPath, binErr := c.resolveBinary()
+	if binErr != nil {
+		fmt.Fprintf(stderr, "statusbar pwd: resolve projmux binary for any-key close: %v\n", binErr)
+		binaryPath = ""
+	}
+	popup := statusbarPathPopup(path, metadata, binaryPath)
 	if err := c.runTmuxNoFallback(stderr,
 		"display-popup",
 		"-E",
@@ -445,7 +453,12 @@ func (c *statusbarCommand) handleUsage(_ statusbarClickOptions, _, stderr io.Wri
 		fmt.Fprintf(stderr, "statusbar usage: load usage state: %v\n", err)
 		state.LoadError = err
 	}
-	popup := statusbarUsagePopup(state, c.nowTime())
+	binaryPath, binErr := c.resolveBinary()
+	if binErr != nil {
+		fmt.Fprintf(stderr, "statusbar usage: resolve projmux binary for any-key close: %v\n", binErr)
+		binaryPath = ""
+	}
+	popup := statusbarUsagePopup(state, c.nowTime(), binaryPath)
 	if err := c.runTmuxNoFallback(stderr,
 		"display-popup",
 		"-E",
@@ -713,14 +726,14 @@ type statusbarUsagePopupView struct {
 
 const statusbarUsageSyncStaleAfter = time.Minute
 
-func statusbarUsagePopup(state statusbarUsageState, now time.Time) statusbarUsagePopupView {
+func statusbarUsagePopup(state statusbarUsageState, now time.Time, binaryPath string) statusbarUsagePopupView {
 	const width = 96
 	title := "Usage"
 	lines := statusbarUsagePopupLines(state, now, width-2)
 	content := strings.Join(lines, "\n")
 	height := projmuxpicker.RenderedTextLineCount(content) + 2
 	payload := strings.TrimRight(content, "\n") + "\n"
-	command := "printf %s " + tmuxShellQuote(payload) + "; IFS= read -r _"
+	command := statusbarPopupCommand(payload, binaryPath)
 	return statusbarUsagePopupView{
 		Title:   title,
 		Toast:   statusbarUsageToast(state),
@@ -732,8 +745,13 @@ func statusbarUsagePopup(state statusbarUsageState, now time.Time) statusbarUsag
 
 func statusbarUsagePopupLines(state statusbarUsageState, now time.Time, cols int) []string {
 	rows := statusbarUsageRows(state.Snapshots)
+	// The popup border title chrome (`display-popup -T "Usage"`) already
+	// communicates which view this is; an inline title here would duplicate
+	// that and — because the picker-style highlight ANSI it used to wear
+	// reads as "this row is selected" — also misrepresent a non-input popup
+	// as an active row in a picker. So the body opens with just the
+	// subdued subtitle.
 	lines := []string{
-		statusbarPopupTitleLine("Usage HUD"),
 		dimANSI("AI token usage windows from the local cache."),
 		"",
 		statusbarUsageSyncLine(state, now),
@@ -996,13 +1014,15 @@ type statusbarPathPopupView struct {
 	Height  int
 }
 
-func statusbarPathPopup(path string, metadata statusbarPathMetadata) statusbarPathPopupView {
+func statusbarPathPopup(path string, metadata statusbarPathMetadata, binaryPath string) statusbarPathPopupView {
 	title := "Current path"
 
 	const width = 84
 	contentWidth := width - 2
+	// Border title `-T "Current path"` already labels the popup; the body
+	// opens with a quiet subtitle instead of a duplicate inline title so we
+	// don't borrow picker-active-row styling for a non-input surface.
 	lines := []string{
-		statusbarPopupTitleLine("Current path"),
 		dimANSI("Active pane working directory."),
 		"",
 	}
@@ -1021,7 +1041,7 @@ func statusbarPathPopup(path string, metadata statusbarPathMetadata) statusbarPa
 	content := strings.Join(lines, "\n")
 	height := projmuxpicker.RenderedTextLineCount(content) + 2
 	payload := strings.TrimRight(content, "\n") + "\n"
-	command := "printf %s " + tmuxShellQuote(payload) + "; IFS= read -r _"
+	command := statusbarPopupCommand(payload, binaryPath)
 	return statusbarPathPopupView{
 		Title:   title,
 		Toast:   "path",
@@ -1031,15 +1051,26 @@ func statusbarPathPopup(path string, metadata statusbarPathMetadata) statusbarPa
 	}
 }
 
-func statusbarPopupTitleLine(title string) string {
-	return projmuxpicker.CurrentStart + " " + strings.TrimSpace(title) + " " + projmuxpicker.Reset
+// statusbarPopupCommand renders a display-only popup payload plus its
+// any-key close path. The close path prefers the hidden `popup-wait-key`
+// subcommand so we don't depend on the popup's underlying shell supporting
+// `read -n1` / `stty` directly. When the binary path is empty (resolveBinary
+// failed) we fall back to the legacy Enter-only `IFS= read -r _` shape so
+// the popup at least remains dismissable.
+func statusbarPopupCommand(payload, binaryPath string) string {
+	prefix := "printf %s " + tmuxShellQuote(payload)
+	binaryPath = strings.TrimSpace(binaryPath)
+	if binaryPath == "" {
+		return prefix + "; IFS= read -r _"
+	}
+	return prefix + "; " + tmuxShellQuote(binaryPath) + " popup-wait-key"
 }
 
 func statusbarPopupFooterLines(cols int) []string {
 	return []string{
 		"",
 		projmuxpicker.SeparatorLine(cols),
-		projmuxpicker.MutedStart + "Enter closes this popup." + projmuxpicker.Reset,
+		projmuxpicker.MutedStart + "Press any key to close." + projmuxpicker.Reset,
 	}
 }
 

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -272,11 +272,18 @@ func TestStatusbarClickPwdOpensPathPopupWithoutCopy(t *testing.T) {
 	if !strings.HasPrefix(command, "printf %s ") {
 		t.Fatalf("popup command = %q, want single-payload printf %%s", command)
 	}
-	if !strings.Contains(command, "Current path") || !strings.Contains(command, projmuxpicker.CurrentStart) {
-		t.Fatalf("path popup command = %q, want styled content title", command)
+	// Inline title removed: the popup border `-T "Current path"` already
+	// labels the surface, and the prior inline title borrowed the picker
+	// active-row ANSI which read as a selected row in a non-input popup.
+	if strings.Contains(command, projmuxpicker.CurrentStart) {
+		t.Fatalf("path popup must not embed picker active-row ANSI: %q", command)
 	}
-	if !strings.Contains(command, "; IFS= read -r _") {
-		t.Fatalf("popup command = %q, want simple Enter read", command)
+	// Any-key close: helper subcommand replaces the legacy Enter-only read.
+	if strings.Contains(command, "; IFS= read -r _") {
+		t.Fatalf("popup command = %q, must not use Enter-only read", command)
+	}
+	if !strings.Contains(command, "popup-wait-key") {
+		t.Fatalf("popup command = %q, want any-key helper invocation", command)
 	}
 	if strings.Contains(command, "printf '%s\\n'") || strings.Contains(command, "read -n1") {
 		t.Fatalf("popup command uses brittle output/read shape: %q", command)
@@ -469,8 +476,11 @@ func TestStatusbarClickUsageOpensNativeHUDPopup(t *testing.T) {
 	if !sawTmuxArgsContainInOrder(runner.calls, []string{"display-popup", "-T", "Usage"}) {
 		t.Fatalf("missing usage popup title; calls = %#v", runner.calls)
 	}
-	if !sawTmuxPopupCommandContaining(runner.calls, "Enter closes this popup.") {
-		t.Fatalf("missing enter-to-close prompt; calls = %#v", runner.calls)
+	if !sawTmuxPopupCommandContaining(runner.calls, "Press any key to close.") {
+		t.Fatalf("missing any-key-to-close prompt; calls = %#v", runner.calls)
+	}
+	if sawTmuxPopupCommandContaining(runner.calls, "Enter closes this popup.") {
+		t.Fatalf("legacy Enter-only prompt must be gone; calls = %#v", runner.calls)
 	}
 	if !sawTmuxPopupCommandContaining(runner.calls, "Claude") || !sawTmuxPopupCommandContaining(runner.calls, "Codex") {
 		t.Fatalf("missing model rows; calls = %#v", runner.calls)
@@ -481,7 +491,11 @@ func TestStatusbarClickUsageOpensNativeHUDPopup(t *testing.T) {
 	if !sawTmuxPopupCommandContaining(runner.calls, "80%") {
 		t.Fatalf("missing percentage value; calls = %#v", runner.calls)
 	}
-	if sawTmuxPopupCommandContaining(runner.calls, "/usr/local/bin/projmux") || sawTmuxPopupCommandContaining(runner.calls, "'usage'") {
+	// The popup body must render structured content rather than shelling
+	// out to `projmux usage`. We do however expect the binary path to appear
+	// in the close path (`<bin> popup-wait-key`) — so we forbid only the
+	// `usage` subcommand invocation, not the binary path itself.
+	if sawTmuxPopupCommandContaining(runner.calls, "'usage'") || sawTmuxPopupCommandContaining(runner.calls, " usage\n") {
 		t.Fatalf("usage popup should render structured content, not run raw projmux usage; calls = %#v", runner.calls)
 	}
 	if sawTmuxPopupCommandContaining(runner.calls, "read -n1 -s") {
@@ -494,11 +508,16 @@ func TestStatusbarClickUsageOpensNativeHUDPopup(t *testing.T) {
 	if !strings.HasPrefix(command, "printf %s ") || strings.Contains(command, "printf '%s\\n'") {
 		t.Fatalf("usage popup command = %q, want single-payload printf", command)
 	}
-	if !strings.Contains(command, "Usage HUD") || !strings.Contains(command, projmuxpicker.CurrentStart) {
-		t.Fatalf("usage popup command = %q, want styled content title", command)
+	// Inline `Usage HUD` title removed in favor of the tmux `-T "Usage"`
+	// border title; the popup body opens with the subdued subtitle.
+	if strings.Contains(command, projmuxpicker.CurrentStart) {
+		t.Fatalf("usage popup must not embed picker active-row ANSI: %q", command)
 	}
-	if !strings.Contains(command, "; IFS= read -r _") {
-		t.Fatalf("usage popup command = %q, want simple Enter read", command)
+	if strings.Contains(command, "; IFS= read -r _") {
+		t.Fatalf("usage popup command = %q, must not use Enter-only read", command)
+	}
+	if !strings.Contains(command, "popup-wait-key") {
+		t.Fatalf("usage popup command = %q, want any-key helper invocation", command)
 	}
 	if strings.ContainsAny(command, "╭╮╰╯│") {
 		t.Fatalf("usage popup must rely on tmux chrome, not an inner frame: %q", command)
@@ -521,7 +540,7 @@ func TestStatusbarUsagePopupColorsThresholdsAndStaleSync(t *testing.T) {
 			{Model: "claude", Window: coreusage.Window5h, Pct: 94.9, ResetsAt: now.Add(time.Hour)},
 			{Model: "codex", Window: coreusage.Window5h, Pct: 95, ResetsAt: now.Add(time.Hour)},
 		},
-	}, now)
+	}, now, "/usr/local/bin/projmux")
 
 	if !strings.Contains(popup.Command, "\x1b[38;5;214m") {
 		t.Fatalf("popup missing amber ANSI for stale sync / >=80%% usage: %q", popup.Command)
@@ -577,7 +596,7 @@ func TestStatusbarUsagePopupDimsUnavailableValues(t *testing.T) {
 		Snapshots: []coreusage.Snapshot{
 			{Model: "claude", Window: coreusage.WindowWeekly, Pct: 33},
 		},
-	}, now)
+	}, now, "/usr/local/bin/projmux")
 
 	if !strings.Contains(popup.Command, projmuxpicker.MutedStart) {
 		t.Fatalf("popup missing dim ANSI for unavailable values: %q", popup.Command)
@@ -1238,3 +1257,84 @@ type fakeExitError struct {
 
 func (e *fakeExitError) Error() string { return e.msg }
 func (e *fakeExitError) ExitCode() int { return e.code }
+
+// TestStatusbarPathPopupRemovesInlineTitle locks in that the path popup body
+// no longer borrows the picker active-row ANSI for an inline title. The
+// border title chrome (`display-popup -T "Current path"`) is the sole label
+// for this surface.
+func TestStatusbarPathPopupRemovesInlineTitle(t *testing.T) {
+	t.Parallel()
+
+	popup := statusbarPathPopup("/tmp/example", statusbarPathMetadata{}, "/usr/local/bin/projmux")
+	if strings.Contains(popup.Command, projmuxpicker.CurrentStart) {
+		t.Fatalf("path popup command must not contain picker active-row ANSI: %q", popup.Command)
+	}
+	if strings.Contains(popup.Command, "Current path") {
+		t.Fatalf("path popup body must not duplicate the border title: %q", popup.Command)
+	}
+}
+
+// TestStatusbarUsagePopupRemovesInlineTitle locks in that the usage popup
+// body no longer renders an inline `Usage HUD` row using picker active-row
+// ANSI. The tmux border `-T "Usage"` is the sole label.
+func TestStatusbarUsagePopupRemovesInlineTitle(t *testing.T) {
+	t.Parallel()
+
+	popup := statusbarUsagePopup(statusbarUsageState{}, time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC), "/usr/local/bin/projmux")
+	if strings.Contains(popup.Command, projmuxpicker.CurrentStart) {
+		t.Fatalf("usage popup command must not contain picker active-row ANSI: %q", popup.Command)
+	}
+	if strings.Contains(popup.Command, "Usage HUD") {
+		t.Fatalf("usage popup body must not contain inline `Usage HUD` title: %q", popup.Command)
+	}
+}
+
+// TestStatusbarPopupFooterReadsAsAnyKey locks in the updated footer prompt.
+// `Enter closes this popup.` was Enter-only and misled users about the new
+// any-key close behavior.
+func TestStatusbarPopupFooterReadsAsAnyKey(t *testing.T) {
+	t.Parallel()
+
+	footer := strings.Join(statusbarPopupFooterLines(60), "\n")
+	if !strings.Contains(footer, "Press any key to close.") {
+		t.Fatalf("footer missing any-key prompt: %q", footer)
+	}
+	if strings.Contains(footer, "Enter closes this popup.") {
+		t.Fatalf("footer still advertises legacy Enter-only prompt: %q", footer)
+	}
+}
+
+// TestStatusbarPopupCommandPrefersHelperSubcommand locks in that the popup
+// payload routes its close path through the hidden `popup-wait-key` helper
+// rather than `IFS= read -r _`, removing the popup shell's dependency on
+// bash/zsh-specific `read -n1` semantics.
+func TestStatusbarPopupCommandPrefersHelperSubcommand(t *testing.T) {
+	t.Parallel()
+
+	cmd := statusbarPopupCommand("hello", "/usr/local/bin/projmux")
+	if strings.Contains(cmd, "IFS= read -r _") {
+		t.Fatalf("popup command must not retain Enter-only read: %q", cmd)
+	}
+	if !strings.Contains(cmd, "popup-wait-key") {
+		t.Fatalf("popup command missing helper subcommand: %q", cmd)
+	}
+	if !strings.Contains(cmd, "'/usr/local/bin/projmux'") {
+		t.Fatalf("popup command missing quoted binary path: %q", cmd)
+	}
+}
+
+// TestStatusbarPopupCommandFallsBackWhenBinaryUnknown documents that the
+// helper invocation degrades to the legacy Enter-only read when the
+// projmux binary path could not be resolved — the popup still has *a*
+// close path even in that degraded state.
+func TestStatusbarPopupCommandFallsBackWhenBinaryUnknown(t *testing.T) {
+	t.Parallel()
+
+	cmd := statusbarPopupCommand("hello", "")
+	if !strings.Contains(cmd, "IFS= read -r _") {
+		t.Fatalf("popup command must retain Enter fallback when binary path is empty: %q", cmd)
+	}
+	if strings.Contains(cmd, "popup-wait-key") {
+		t.Fatalf("popup command must not reference helper when binary is unknown: %q", cmd)
+	}
+}


### PR DESCRIPTION
## Summary

Tidies the two display-only statusbar popups (`statusbarPathPopup` cwd,
`statusbarUsagePopup`):

- **Inline title removed.** Both popups had a body-first row that used
  `projmuxpicker.CurrentStart` — the native picker's *active row* ANSI
  — so non-input popups read like a selected row in a picker. tmux
  already draws the popup border title via `display-popup -T`, so the
  inline title was also a duplicate. Body now opens with the subdued
  subtitle.
- **Any-key close.** Close path moved from `IFS= read -r _` (Enter-only)
  to a new hidden subcommand `projmux popup-wait-key` that reads one
  byte from `/dev/tty` in raw mode. This removes the dependency on the
  popup shell supporting `read -n1` (fish, dash, posh reject it). When
  the projmux binary path can't be resolved the helper degrades to the
  legacy Enter-only read so the popup never becomes undismissable.
- **Footer text** updated to `Press any key to close.`
- Added `statusbarPopupCommand(payload, binaryPath)` so future
  display-only popups stay consistent.

Non-input popups (settings, sessionizer, picker, sidebar) are
**unchanged** — their Enter dismissal is the right shape for input
surfaces.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `make test-integration`
- [x] `make test-e2e`
- [x] Regression guards added: picker active-row ANSI absent from popup
      bodies, `popup-wait-key` token present in popup command, footer
      reads `Press any key to close.`, helper falls back to Enter when
      binary path is empty, `App.Run` dispatches `popup-wait-key`.

Manual cwd / usage popup smoke (any-key close, no inline title) is on
the lead session before merge — popup behavior under tmux is hard to
exercise inside the docker e2e substrate without spinning up a fake
display, and the integration tests already cover the close-path token
contract.

Detail note: `obsidian://open?file=30.Projects.Design/Projmux/10.Roadmap/%EB%A1%9C%EB%93%9C%EB%A7%B5%20%EB%94%94%ED%85%8C%EC%9D%BC%20-%20HUD-cwd%20popup%20UI%20%EB%8B%A4%EB%93%AC%EA%B8%B0.md`