### PR TITLE
fix(statusbar): wrap display-only popups in native picker frame chrome

### DIFF
--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -386,12 +386,17 @@ func (c *statusbarCommand) handlePwd(_ statusbarClickOptions, _, stderr io.Write
 		binaryPath = ""
 	}
 	popup := statusbarPathPopup(path, metadata, binaryPath)
+	// The frame chrome (outer box + titlebar + divider) is drawn inside the
+	// payload, so we suppress tmux's own popup border with `-B` and drop the
+	// `-T` border title — `frame.go` renders an identical title bar inline so
+	// duplicating it via tmux chrome would offset the visual header and
+	// double-decorate the surface.
 	if err := c.runTmuxNoFallback(stderr,
 		"display-popup",
 		"-E",
+		"-B",
 		"-w", strconv.Itoa(popup.Width),
 		"-h", strconv.Itoa(popup.Height),
-		"-T", popup.Title,
 		popup.Command,
 	); err == nil {
 		return nil
@@ -459,12 +464,16 @@ func (c *statusbarCommand) handleUsage(_ statusbarClickOptions, _, stderr io.Wri
 		binaryPath = ""
 	}
 	popup := statusbarUsagePopup(state, c.nowTime(), binaryPath)
+	// Same as `handlePwd`: the payload renders its own picker-style frame
+	// chrome (outer box + titlebar + divider) so we drop tmux's `-T` border
+	// title and pass `-B` to suppress tmux's popup border entirely. Mixing
+	// both would double-decorate the popup and offset the geometry.
 	if err := c.runTmuxNoFallback(stderr,
 		"display-popup",
 		"-E",
+		"-B",
 		"-w", strconv.Itoa(popup.Width),
 		"-h", strconv.Itoa(popup.Height),
-		"-T", popup.Title,
 		popup.Command,
 	); err == nil {
 		return nil
@@ -729,10 +738,30 @@ const statusbarUsageSyncStaleAfter = time.Minute
 func statusbarUsagePopup(state statusbarUsageState, now time.Time, binaryPath string) statusbarUsagePopupView {
 	const width = 96
 	title := "Usage"
-	lines := statusbarUsagePopupLines(state, now, width-2)
-	content := strings.Join(lines, "\n")
-	height := projmuxpicker.RenderedTextLineCount(content) + 2
-	payload := strings.TrimRight(content, "\n") + "\n"
+	// The popup wears the native picker frame chrome: outer box (top+bottom
+	// border = 2 rows), title bar + divider (2 rows), and the body content
+	// laid out within the inner column budget the renderer reserves. We
+	// derive the *inner* layout from ContentLayoutWithTitle so body wrap
+	// width matches the chrome the renderer will draw around it.
+	innerLayout := projmuxpicker.DefaultRenderer().ContentLayoutWithTitle(
+		projmuxpicker.Layout{Rows: 0, Cols: width}, title,
+	)
+	lines := statusbarUsagePopupLines(state, now, innerLayout.Cols)
+	bodyContent := strings.Join(lines, "\n")
+	// Outer rows = inner rows + 2 (top/bottom border) + 2 (titlebar +
+	// divider). RenderedTextLineCount strips trailing blank lines, so use
+	// the raw len(lines) as the row budget instead — that way the frame
+	// reserves a row for every body line we asked it to render.
+	innerRows := len(lines)
+	if innerRows < 1 {
+		innerRows = 1
+	}
+	height := innerRows + 4
+	outerLayout := projmuxpicker.Layout{Rows: height, Cols: width}
+
+	var framed strings.Builder
+	projmuxpicker.DefaultRenderer().RenderFrameWithTitle(&framed, bodyContent, title, outerLayout)
+	payload := strings.TrimRight(framed.String(), "\n") + "\n"
 	command := statusbarPopupCommand(payload, binaryPath)
 	return statusbarUsagePopupView{
 		Title:   title,
@@ -745,12 +774,10 @@ func statusbarUsagePopup(state statusbarUsageState, now time.Time, binaryPath st
 
 func statusbarUsagePopupLines(state statusbarUsageState, now time.Time, cols int) []string {
 	rows := statusbarUsageRows(state.Snapshots)
-	// The popup border title chrome (`display-popup -T "Usage"`) already
-	// communicates which view this is; an inline title here would duplicate
-	// that and — because the picker-style highlight ANSI it used to wear
-	// reads as "this row is selected" — also misrepresent a non-input popup
-	// as an active row in a picker. So the body opens with just the
-	// subdued subtitle.
+	// The native picker frame chrome wrapping this body already renders the
+	// `Usage` title bar (and the divider below it). Body opens with the
+	// subdued subtitle so the popup mirrors the picker layout one-to-one
+	// without duplicating the title or borrowing picker active-row ANSI.
 	lines := []string{
 		dimANSI("AI token usage windows from the local cache."),
 		"",
@@ -1018,10 +1045,16 @@ func statusbarPathPopup(path string, metadata statusbarPathMetadata, binaryPath 
 	title := "Current path"
 
 	const width = 84
-	contentWidth := width - 2
-	// Border title `-T "Current path"` already labels the popup; the body
-	// opens with a quiet subtitle instead of a duplicate inline title so we
-	// don't borrow picker-active-row styling for a non-input surface.
+	// Reserve the inner column budget the picker frame renderer will leave
+	// us after drawing the outer box + title bar. Body wraps to inner.Cols
+	// so right-edge characters never collide with the frame vertical bar.
+	innerLayout := projmuxpicker.DefaultRenderer().ContentLayoutWithTitle(
+		projmuxpicker.Layout{Rows: 0, Cols: width}, title,
+	)
+	contentWidth := innerLayout.Cols
+	// The frame chrome around this body renders the `Current path` title
+	// bar; the body opens with a subdued subtitle, identical layout to the
+	// native picker (description row right under the divider).
 	lines := []string{
 		dimANSI("Active pane working directory."),
 		"",
@@ -1038,9 +1071,20 @@ func statusbarPathPopup(path string, metadata statusbarPathMetadata, binaryPath 
 	}
 	lines = append(lines, statusbarPopupFooterLines(contentWidth)...)
 
-	content := strings.Join(lines, "\n")
-	height := projmuxpicker.RenderedTextLineCount(content) + 2
-	payload := strings.TrimRight(content, "\n") + "\n"
+	bodyContent := strings.Join(lines, "\n")
+	// Outer rows = inner rows + 2 (top/bottom border) + 2 (titlebar +
+	// divider). Use raw len(lines) — RenderedTextLineCount trims trailing
+	// blank lines and the footer would lose its leading separator row.
+	innerRows := len(lines)
+	if innerRows < 1 {
+		innerRows = 1
+	}
+	height := innerRows + 4
+	outerLayout := projmuxpicker.Layout{Rows: height, Cols: width}
+
+	var framed strings.Builder
+	projmuxpicker.DefaultRenderer().RenderFrameWithTitle(&framed, bodyContent, title, outerLayout)
+	payload := strings.TrimRight(framed.String(), "\n") + "\n"
 	command := statusbarPopupCommand(payload, binaryPath)
 	return statusbarPathPopupView{
 		Title:   title,

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -242,8 +242,22 @@ func TestStatusbarClickPwdOpensPathPopupWithoutCopy(t *testing.T) {
 	if !sawTmuxSubcommand(runner.calls, "display-popup") {
 		t.Fatalf("missing path display-popup; calls = %#v", runner.calls)
 	}
-	if !sawTmuxArgsContainInOrder(runner.calls, []string{"display-popup", "-T", "Current path"}) {
-		t.Fatalf("missing path popup title; calls = %#v", runner.calls)
+	// The popup payload now renders its own native picker frame chrome
+	// (outer box + title bar). tmux's `-T` border title was dropped to
+	// avoid double-decoration, and `-B` was added so tmux's own popup
+	// border doesn't compete with the inline chrome.
+	popupArgs, ok := firstTmuxPopupArgs(runner.calls)
+	if !ok {
+		t.Fatalf("missing display-popup invocation; calls = %#v", runner.calls)
+	}
+	if slices.Contains(popupArgs, "-T") {
+		t.Fatalf("path popup must not pass tmux `-T` (frame chrome owns the title); args = %#v", popupArgs)
+	}
+	if !slices.Contains(popupArgs, "-B") {
+		t.Fatalf("path popup must pass tmux `-B` to suppress tmux's popup border; args = %#v", popupArgs)
+	}
+	if !sawTmuxPopupCommandContaining(runner.calls, "Current path") {
+		t.Fatalf("missing inline frame title `Current path`; calls = %#v", runner.calls)
 	}
 	if !sawTmuxPopupCommandContaining(runner.calls, "/home/es5h/source/repos/projmux") {
 		t.Fatalf("missing full path in popup; calls = %#v", runner.calls)
@@ -288,8 +302,21 @@ func TestStatusbarClickPwdOpensPathPopupWithoutCopy(t *testing.T) {
 	if strings.Contains(command, "printf '%s\\n'") || strings.Contains(command, "read -n1") {
 		t.Fatalf("popup command uses brittle output/read shape: %q", command)
 	}
-	if strings.ContainsAny(command, "╭╮╰╯│") {
-		t.Fatalf("path popup must rely on tmux chrome, not an inner frame: %q", command)
+	// Frame chrome regression guard: the payload now renders the native
+	// picker frame so the outer box glyphs must appear, paired with the
+	// title bar (`TitlebarStart`) and divider (`TitlebarRule`) the picker
+	// uses for the input variants. Missing any of these means we lost
+	// alignment with the picker visual language.
+	for _, glyph := range []string{"╭", "╮", "╰", "╯", "│"} {
+		if !strings.Contains(command, glyph) {
+			t.Fatalf("path popup missing frame glyph %q: %q", glyph, command)
+		}
+	}
+	if !strings.Contains(command, projmuxpicker.TitlebarStart) {
+		t.Fatalf("path popup missing frame titlebar ANSI: %q", command)
+	}
+	if !strings.Contains(command, projmuxpicker.TitlebarRule) {
+		t.Fatalf("path popup missing frame divider ANSI: %q", command)
 	}
 }
 
@@ -473,8 +500,20 @@ func TestStatusbarClickUsageOpensNativeHUDPopup(t *testing.T) {
 	if !sawTmuxSubcommand(runner.calls, "display-popup") {
 		t.Fatalf("missing display-popup; calls = %#v", runner.calls)
 	}
-	if !sawTmuxArgsContainInOrder(runner.calls, []string{"display-popup", "-T", "Usage"}) {
-		t.Fatalf("missing usage popup title; calls = %#v", runner.calls)
+	// Frame chrome owns the title; tmux's `-T` is gone and `-B` is added
+	// so tmux's popup border doesn't double-decorate the surface.
+	popupArgs, ok := firstTmuxPopupArgs(runner.calls)
+	if !ok {
+		t.Fatalf("missing display-popup invocation; calls = %#v", runner.calls)
+	}
+	if slices.Contains(popupArgs, "-T") {
+		t.Fatalf("usage popup must not pass tmux `-T` (frame chrome owns the title); args = %#v", popupArgs)
+	}
+	if !slices.Contains(popupArgs, "-B") {
+		t.Fatalf("usage popup must pass tmux `-B` to suppress tmux's popup border; args = %#v", popupArgs)
+	}
+	if !sawTmuxPopupCommandContaining(runner.calls, "Usage") {
+		t.Fatalf("missing inline frame title `Usage`; calls = %#v", runner.calls)
 	}
 	if !sawTmuxPopupCommandContaining(runner.calls, "Press any key to close.") {
 		t.Fatalf("missing any-key-to-close prompt; calls = %#v", runner.calls)
@@ -519,8 +558,19 @@ func TestStatusbarClickUsageOpensNativeHUDPopup(t *testing.T) {
 	if !strings.Contains(command, "popup-wait-key") {
 		t.Fatalf("usage popup command = %q, want any-key helper invocation", command)
 	}
-	if strings.ContainsAny(command, "╭╮╰╯│") {
-		t.Fatalf("usage popup must rely on tmux chrome, not an inner frame: %q", command)
+	// Native picker frame chrome must wrap the body: outer glyphs, title
+	// bar ANSI, divider ANSI all required so the popup mirrors the picker
+	// surface one-to-one.
+	for _, glyph := range []string{"╭", "╮", "╰", "╯", "│"} {
+		if !strings.Contains(command, glyph) {
+			t.Fatalf("usage popup missing frame glyph %q: %q", glyph, command)
+		}
+	}
+	if !strings.Contains(command, projmuxpicker.TitlebarStart) {
+		t.Fatalf("usage popup missing frame titlebar ANSI: %q", command)
+	}
+	if !strings.Contains(command, projmuxpicker.TitlebarRule) {
+		t.Fatalf("usage popup missing frame divider ANSI: %q", command)
 	}
 	for _, call := range runner.calls {
 		if call.name == "/usr/local/bin/projmux" || sawArgsContain(call.args, "popup-toggle") {
@@ -1196,6 +1246,16 @@ func firstTmuxPopupCommand(calls []statusbarFakeCall) (string, bool) {
 	return "", false
 }
 
+func firstTmuxPopupArgs(calls []statusbarFakeCall) ([]string, bool) {
+	for _, c := range calls {
+		if c.name != "tmux" || len(c.args) < 2 || c.args[0] != "display-popup" {
+			continue
+		}
+		return c.args, true
+	}
+	return nil, false
+}
+
 func lastDisplayMessage(calls []statusbarFakeCall) (string, bool) {
 	for i := len(calls) - 1; i >= 0; i-- {
 		c := calls[i]
@@ -1258,26 +1318,39 @@ type fakeExitError struct {
 func (e *fakeExitError) Error() string { return e.msg }
 func (e *fakeExitError) ExitCode() int { return e.code }
 
-// TestStatusbarPathPopupRemovesInlineTitle locks in that the path popup body
-// no longer borrows the picker active-row ANSI for an inline title. The
-// border title chrome (`display-popup -T "Current path"`) is the sole label
-// for this surface.
-func TestStatusbarPathPopupRemovesInlineTitle(t *testing.T) {
+// TestStatusbarPathPopupWearsFrameChrome locks in the picker frame chrome
+// wrap: the popup payload must include the native frame title bar (so the
+// surface reads as a picker, not a bare text dump) but must still not
+// borrow the picker active-row highlight ANSI for any body row (that would
+// misrepresent a non-input popup as a selected picker row).
+func TestStatusbarPathPopupWearsFrameChrome(t *testing.T) {
 	t.Parallel()
 
 	popup := statusbarPathPopup("/tmp/example", statusbarPathMetadata{}, "/usr/local/bin/projmux")
 	if strings.Contains(popup.Command, projmuxpicker.CurrentStart) {
 		t.Fatalf("path popup command must not contain picker active-row ANSI: %q", popup.Command)
 	}
-	if strings.Contains(popup.Command, "Current path") {
-		t.Fatalf("path popup body must not duplicate the border title: %q", popup.Command)
+	if !strings.Contains(popup.Command, "Current path") {
+		t.Fatalf("path popup body must render the frame title bar: %q", popup.Command)
+	}
+	if !strings.Contains(popup.Command, projmuxpicker.TitlebarStart) {
+		t.Fatalf("path popup missing frame titlebar ANSI: %q", popup.Command)
+	}
+	if !strings.Contains(popup.Command, projmuxpicker.TitlebarRule) {
+		t.Fatalf("path popup missing frame divider ANSI: %q", popup.Command)
+	}
+	for _, glyph := range []string{"╭", "╮", "╰", "╯", "│"} {
+		if !strings.Contains(popup.Command, glyph) {
+			t.Fatalf("path popup missing frame glyph %q: %q", glyph, popup.Command)
+		}
 	}
 }
 
-// TestStatusbarUsagePopupRemovesInlineTitle locks in that the usage popup
-// body no longer renders an inline `Usage HUD` row using picker active-row
-// ANSI. The tmux border `-T "Usage"` is the sole label.
-func TestStatusbarUsagePopupRemovesInlineTitle(t *testing.T) {
+// TestStatusbarUsagePopupWearsFrameChrome locks in the picker frame chrome
+// wrap: the native frame title bar is drawn inline, but no body row may
+// borrow the picker active-row highlight ANSI (display-only popup, not a
+// picker surface).
+func TestStatusbarUsagePopupWearsFrameChrome(t *testing.T) {
 	t.Parallel()
 
 	popup := statusbarUsagePopup(statusbarUsageState{}, time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC), "/usr/local/bin/projmux")
@@ -1286,6 +1359,20 @@ func TestStatusbarUsagePopupRemovesInlineTitle(t *testing.T) {
 	}
 	if strings.Contains(popup.Command, "Usage HUD") {
 		t.Fatalf("usage popup body must not contain inline `Usage HUD` title: %q", popup.Command)
+	}
+	if !strings.Contains(popup.Command, "Usage") {
+		t.Fatalf("usage popup body must render the frame title `Usage`: %q", popup.Command)
+	}
+	if !strings.Contains(popup.Command, projmuxpicker.TitlebarStart) {
+		t.Fatalf("usage popup missing frame titlebar ANSI: %q", popup.Command)
+	}
+	if !strings.Contains(popup.Command, projmuxpicker.TitlebarRule) {
+		t.Fatalf("usage popup missing frame divider ANSI: %q", popup.Command)
+	}
+	for _, glyph := range []string{"╭", "╮", "╰", "╯", "│"} {
+		if !strings.Contains(popup.Command, glyph) {
+			t.Fatalf("usage popup missing frame glyph %q: %q", glyph, popup.Command)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- PR #185 removed the inline picker-active-row title from the cwd / usage statusbar popups, but the resulting header was empty — only the tmux `-T` border title remained and that did not match the picker visual language users expect from projmux popups.
- This change wraps both `statusbarPathPopup` and `statusbarUsagePopup` payloads in the native `projmuxpicker.RenderFrameWithTitle` chrome (outer box + title bar + divider) so the display-only popups mirror the native picker surface one-to-one, minus the input/focus/select machinery. Body design (field rows, usage table, footer) is unchanged.
- `display-popup` argv: drop `-T <title>` (frame chrome owns the title bar now) and add `-B` so tmux's own popup border does not compete with the inline chrome.

### Before / After

Before (PR #185): tmux popup wore only the `-T "Current path"` / `-T "Usage"` tmux border title; the body opened straight into the subtitle with no inline header — read as "header missing".

After: payload includes the same `╭───╮ │ │ ╰───╯` frame and `│▌ Title ▌│` title bar the native picker renders, with the body content laid out in the inner area returned by `ContentLayoutWithTitle`.

Height math: outer rows = inner body line count + 4 (top/bottom border = 2 + title bar + divider = 2). Width: outer 84 / 96 unchanged; body wraps to `inner.Cols` (= width − 2).

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `make test-integration`
- [x] `make test-e2e`
- [x] `make fmt-check`
- [x] Manual visual aid: rendered path popup payload printed via a one-off test — frame chrome aligns, title bar + divider render with picker ANSI, body fits inner area without right-edge collisions.

## Notes for the lead session

- PR is ready (not draft) per the agent instructions; do not merge from this agent.
- No primary repo / other worktree touched.
- The two updated tests (`TestStatusbarClickPwdOpensPathPopupWithoutCopy`, `TestStatusbarClickUsageOpensNativeHUDPopup`) now positively assert the frame chrome glyphs / titlebar ANSI / divider ANSI and forbid `-T` while requiring `-B` — these are the regression guards for PR #185's drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)