### PR TITLE
fix: ack notify clicks for missing targets

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -33,8 +33,8 @@
 - `make test` also covers Settings IA regression guards for `send-noti` visibility in Hooks, no nested Project recipe inside Hooks, Project recipe/AI/Labs view-first detail rows, and Desktop notifications under Labs.
 - `make test` also now covers onboarding revisit and welcome wiring (`projmux welcome`, `Settings > About > Welcome`, `pending_attach_welcome`, attach-time `welcome --popup` one-time claim/env suppression/tmux popup payload, and generated `client-attached` app config wiring) via shell welcome tests.
 - Current focused unit coverage also includes strict notify SOT behavior
-  (TTL does not remove rows, focus success acks, reconcile reports stale
-  rows), `notify list --live` queue/live explanations, notify sidebar
+  (TTL does not remove rows, focus success and target-gone clicks ack,
+  reconcile reports stale rows), `notify list --live` queue/live explanations, notify sidebar
   two-line card rendering with age/project/window/pane metadata plus focus/ack/clear-all
   actions, and `focus` dispatch diagnostics for session fallback, unresolved
   targets, window fallback, pane fallback, explicit id failures, and

--- a/docs/notify-queue.md
+++ b/docs/notify-queue.md
@@ -183,8 +183,8 @@ Outcomes:
 
 - **Focus succeeded** — ack the entry. Focus is the single consume path for
   routed notification clicks.
-- **Focus exited 2 (target unresolved)** — keep the entry pending and toast
-  `notify target gone; ack to clear`.
+- **Focus exited 2 (target unresolved)** — ack the entry and toast
+  `notify target gone; cleared`.
 - **Other failure** — keep the entry, toast `focus failed: <reason>`
   so the user can retry without losing the row.
 

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -126,7 +126,7 @@ click. Each handler therefore swallows runtime failures and surfaces
 them as `display-message` toasts:
 
 - `notify` click whose focus dispatch exits 2 (target unresolved):
-  keep the entry pending, toast `notify target gone; ack to clear`.
+  ack the entry, toast `notify target gone; cleared`.
 - Any other focus failure: keep the entry, toast `focus failed:
   <reason>`.
 - `session`, `kube`, or `git` popup launch failure: toast

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -1211,7 +1211,7 @@ func (c *aiCommand) paneVisibleToClient(paneID string) bool {
 	if err != nil {
 		return false
 	}
-	for _, line := range strings.Split(strings.TrimRight(string(output), "\r\n"), "\n") {
+	for line := range strings.SplitSeq(strings.TrimRight(string(output), "\r\n"), "\n") {
 		if strings.TrimSpace(line) == paneID {
 			return true
 		}

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -1745,7 +1745,7 @@ func TestBuildRegisterToastAppIDShortcutTargetIsCmdExe(t *testing.T) {
 	// powershell.exe target by name and we don't want the assertion to
 	// flag its own do-not-do-this commentary.
 	var noComments strings.Builder
-	for _, line := range strings.Split(script, "\n") {
+	for line := range strings.SplitSeq(script, "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "#") {
 			continue
 		}
@@ -1779,7 +1779,7 @@ func TestBuildRegisterToastAppIDShortcutTargetIsCmdExe(t *testing.T) {
 func TestBuildRegisterToastAppIDDoesNotSetToastActivatorCLSID(t *testing.T) {
 	script := buildRegisterToastAppIDPowerShell(desktopAppID, desktopDisplayName, "")
 	var noComments strings.Builder
-	for _, line := range strings.Split(script, "\n") {
+	for line := range strings.SplitSeq(script, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "#") {
 			continue

--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -290,7 +290,7 @@ func (c *attentionCommand) paneVisibleToClient(paneID string) bool {
 	if err != nil {
 		return false
 	}
-	for _, line := range strings.Split(strings.TrimRight(string(output), "\r\n"), "\n") {
+	for line := range strings.SplitSeq(strings.TrimRight(string(output), "\r\n"), "\n") {
 		if strings.TrimSpace(line) == paneID {
 			return true
 		}

--- a/internal/app/hookmaker.go
+++ b/internal/app/hookmaker.go
@@ -357,7 +357,7 @@ func countLegacyScriptLines(path string) int {
 		return 0
 	}
 	count := 0
-	for _, raw := range strings.Split(string(data), "\n") {
+	for raw := range strings.SplitSeq(string(data), "\n") {
 		trimmed := strings.TrimSpace(raw)
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue

--- a/internal/app/notification_uri_test.go
+++ b/internal/app/notification_uri_test.go
@@ -20,7 +20,6 @@ func TestBuildFocusURI_RoundTrip(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			uri := buildFocusURI(tc.pane, tc.socket)

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -334,6 +334,12 @@ func (c *notifyCommand) runSidebar(entries []notify.Notification, stdout, stderr
 			return fmt.Errorf("focus notification: %w: %s", notify.ErrNotFound, id)
 		}
 		if err := c.focusNotification(entry, "notify-sidebar", "row-select"); err != nil {
+			if isFocusTargetUnresolved(err) {
+				if ackErr := store.Ack(id); ackErr != nil {
+					return fmt.Errorf("ack target-gone notification: %w", ackErr)
+				}
+				return nil
+			}
 			return err
 		}
 		if err := store.Ack(id); err != nil {

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -510,6 +510,44 @@ func TestNotifyListSidebarDoesNotAckWhenFocusFails(t *testing.T) {
 	}
 }
 
+func TestNotifyListSidebarTargetGoneAcksSelectedRow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	store := &stubNotifyStore{
+		listEntries: []notify.Notification{
+			{
+				ID:        "abc",
+				Text:      "deploy ok",
+				Severity:  notify.SeverityWarn,
+				Source:    notify.SourceAI,
+				Session:   "__gone",
+				Window:    "1",
+				Pane:      "0",
+				CreatedAt: now.Add(-30 * time.Second),
+				ExpiresAt: now.Add(time.Hour),
+			},
+		},
+	}
+	picker := &stubNotifyPicker{result: intpickercompat.Result{Value: "abc"}}
+	runner := &focusFakeRunner{respond: func([]string) ([]byte, error) {
+		return nil, &fakeExitError{code: focusExitNotResolved, msg: "target unresolved"}
+	}}
+	cmd := newCmd(store)
+	cmd.now = func() time.Time { return now }
+	cmd.picker = picker
+	cmd.native = nativePickerFromCompatRunner(picker)
+	cmd.runner = runner
+	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
+
+	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+	if store.ackedID != "abc" {
+		t.Fatalf("ackedID = %q, want abc", store.ackedID)
+	}
+}
+
 func TestNotifyListSidebarAcksSelectedRow(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -606,14 +606,17 @@ func (c *statusbarCommand) handleNotify(opts statusbarClickOptions, _, stderr io
 	if _, runErr := c.runner.Run(context.Background(), binaryPath, args...); runErr != nil {
 		// The focus subprocess exits with a deterministic code 2 when the
 		// target session/window/pane cannot be resolved (see focus.go's
-		// focusExitNotResolved). Under notify SOT semantics, even an
-		// unroutable row remains pending until explicit ack; show a toast
-		// instead of silently deleting it. Any other exit code is treated as
-		// transient (network hiccup, tmux server churn, etc.) — keep the entry
-		// so the user can retry, and surface the reason as a toast instead of a
-		// tmux error popup.
+		// focusExitNotResolved). A click on that row is still a consume signal:
+		// there is nowhere useful to focus, so clear the stuck notification
+		// instead of making every later click repeat the same toast. Any other
+		// exit code is treated as transient (tmux server churn, etc.) — keep the
+		// entry so the user can retry, and surface the reason as a toast instead
+		// of a tmux error popup.
 		if isFocusTargetUnresolved(runErr) {
-			return c.runTmux(stderr, "display-message", "notify target gone; ack to clear")
+			if err := store.Ack(head.ID); err != nil {
+				return c.runTmux(stderr, "display-message", fmt.Sprintf("notify target gone; ack failed: %s", focusFailureSummary(err)))
+			}
+			return c.runTmux(stderr, "display-message", "notify target gone; cleared")
 		}
 		return c.runTmux(stderr, "display-message", fmt.Sprintf("focus failed: %s", focusFailureSummary(runErr)))
 	}
@@ -752,10 +755,7 @@ func statusbarUsagePopup(state statusbarUsageState, now time.Time, binaryPath st
 	// divider). RenderedTextLineCount strips trailing blank lines, so use
 	// the raw len(lines) as the row budget instead — that way the frame
 	// reserves a row for every body line we asked it to render.
-	innerRows := len(lines)
-	if innerRows < 1 {
-		innerRows = 1
-	}
+	innerRows := max(len(lines), 1)
 	height := innerRows + 4
 	outerLayout := projmuxpicker.Layout{Rows: height, Cols: width}
 
@@ -1075,10 +1075,7 @@ func statusbarPathPopup(path string, metadata statusbarPathMetadata, binaryPath 
 	// Outer rows = inner rows + 2 (top/bottom border) + 2 (titlebar +
 	// divider). Use raw len(lines) — RenderedTextLineCount trims trailing
 	// blank lines and the footer would lose its leading separator row.
-	innerRows := len(lines)
-	if innerRows < 1 {
-		innerRows = 1
-	}
+	innerRows := max(len(lines), 1)
 	height := innerRows + 4
 	outerLayout := projmuxpicker.Layout{Rows: height, Cols: width}
 

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -825,7 +825,7 @@ func TestStatusbarClickNotifyTransientFocusFailureSurfacesToastAndKeepsEntry(t *
 	}
 }
 
-func TestStatusbarClickNotifyTargetGoneKeepsEntryAndShowsToast(t *testing.T) {
+func TestStatusbarClickNotifyTargetGoneAcksEntryAndShowsToast(t *testing.T) {
 	t.Parallel()
 
 	runner := &statusbarFakeRunner{
@@ -852,10 +852,10 @@ func TestStatusbarClickNotifyTargetGoneKeepsEntryAndShowsToast(t *testing.T) {
 	if err := cmd.Run([]string{"click", "notify"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v, want nil (target-gone must not surface as tmux error popup)", err)
 	}
-	if store.ackedID != "" {
-		t.Fatalf("store.ackedID = %q, want empty (target-gone must keep entry until explicit ack)", store.ackedID)
+	if store.ackedID != "abc" {
+		t.Fatalf("store.ackedID = %q, want abc (target-gone click should clear the stuck row)", store.ackedID)
 	}
-	if !sawTmuxDisplayMessage(runner.calls, "notify target gone; ack to clear") {
+	if !sawTmuxDisplayMessage(runner.calls, "notify target gone; cleared") {
 		t.Fatalf("missing 'notify target gone' display-message; calls = %#v", runner.calls)
 	}
 }
@@ -889,10 +889,10 @@ func TestStatusbarClickNotifyUsageErrorTreatedAsTargetGone(t *testing.T) {
 	if err := cmd.Run([]string{"click", "notify"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v, want nil", err)
 	}
-	if store.ackedID != "" {
-		t.Fatalf("store.ackedID = %q, want empty (UsageError should keep entry like target-gone)", store.ackedID)
+	if store.ackedID != "abc" {
+		t.Fatalf("store.ackedID = %q, want abc (UsageError should clear like target-gone)", store.ackedID)
 	}
-	if !sawTmuxDisplayMessage(runner.calls, "notify target gone; ack to clear") {
+	if !sawTmuxDisplayMessage(runner.calls, "notify target gone; cleared") {
 		t.Fatalf("missing target-gone display-message; calls = %#v", runner.calls)
 	}
 }

--- a/internal/app/trust_test.go
+++ b/internal/app/trust_test.go
@@ -211,7 +211,6 @@ run = "echo updated"
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/app/welcome_command.go
+++ b/internal/app/welcome_command.go
@@ -218,7 +218,7 @@ func welcomeCurrentVersion() string {
 
 func welcomePopupWidth(payload string) string {
 	width := 80
-	for _, line := range strings.Split(payload, "\n") {
+	for line := range strings.SplitSeq(payload, "\n") {
 		if visible := visibleWelcomeLineLen(line); visible > width {
 			width = visible
 		}
@@ -227,10 +227,7 @@ func welcomePopupWidth(payload string) string {
 }
 
 func welcomePopupHeight(payload string) string {
-	height := strings.Count(payload, "\n")
-	if height < 1 {
-		height = 1
-	}
+	height := max(strings.Count(payload, "\n"), 1)
 	return strconv.Itoa(height)
 }
 

--- a/internal/integrations/hooks/migration_test.go
+++ b/internal/integrations/hooks/migration_test.go
@@ -187,7 +187,6 @@ func TestMigrateProjectLegacyScriptsSymlinkIsNeverMigrated(t *testing.T) {
 		{name: "multi-line target", body: "#!/bin/sh\necho one\necho two\n"},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/integrations/osfocus/wt_wsl_test.go
+++ b/internal/integrations/osfocus/wt_wsl_test.go
@@ -62,7 +62,6 @@ func TestWindowsTerminalWSLAdapter_Detect(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
## Summary
- ack notify rows when a statusbar or sidebar click finds the focus target is already gone
- keep transient focus failures pending for retry
- update notify/statusbar docs and focused test coverage
- include make fix mechanical cleanups

## Validation
- make fix
- make fmt
- go test ./internal/app -run 'TestStatusbarClickNotify|TestNotifyListSidebar'
- git diff --check

## Local test note
- make test was attempted. In this local environment it still fails in internal/app hook context tests: TestHookList_ProjectOnlyDegradesWithoutContext and TestHookTrust_RejectsWhenContextMissing. Sandbox mode also blocks httptest socket creation unless run escalated; escalated execution removes the socket failure.