### PR TITLE
fix(hooks): ignore temp root project markers

### DIFF
--- a/internal/app/hook.go
+++ b/internal/app/hook.go
@@ -677,6 +677,8 @@ func (c *hookCommand) loadProject() (string, hooks.ProjectConfig, error, string)
 // resolution but trimmed for CLI use: PROJMUX_CWD wins (so tmux-launched
 // CLI invocations inherit the pane's project), otherwise we fall back to
 // `os.Getwd()` and walk upward to the nearest `.projmux` or `.git` marker.
+// The implicit walk stops before considering the system temp root itself so
+// temp fixtures and other scratch parents do not become project contexts.
 // Returning an empty string is not an error; downstream commands decide
 // whether the context is required.
 func (c *hookCommand) resolveProjectContext() (string, error) {
@@ -693,17 +695,24 @@ func (c *hookCommand) resolveProjectContext() (string, error) {
 		return "", err
 	}
 	wd = filepath.Clean(wd)
-	if root := nearestProjectMarker(wd); root != "" {
+	if root := nearestProjectMarker(wd, os.TempDir()); root != "" {
 		return root, nil
 	}
 	return "", nil
 }
 
 // nearestProjectMarker walks parent directories looking for a `.projmux` or
-// `.git` marker. Returns "" when the walk reaches the filesystem root with
-// nothing found.
-func nearestProjectMarker(path string) string {
+// `.git` marker. Boundary paths are not considered candidates. Returns "" when
+// the walk reaches a boundary or the filesystem root with nothing found.
+func nearestProjectMarker(path string, boundaries ...string) string {
+	path = filepath.Clean(path)
 	for {
+		for _, boundary := range boundaries {
+			boundary = filepath.Clean(strings.TrimSpace(boundary))
+			if boundary != "" && boundary != "." && path == boundary {
+				return ""
+			}
+		}
 		if hookMarkerExists(filepath.Join(path, ".projmux")) || hookMarkerExists(filepath.Join(path, ".git")) {
 			return path
 		}

--- a/internal/app/hook_test.go
+++ b/internal/app/hook_test.go
@@ -608,6 +608,75 @@ func TestHookTrust_RejectsWhenContextMissing(t *testing.T) {
 	}
 }
 
+func TestHookResolveProjectContextIgnoresTempRootMarker(t *testing.T) {
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+	mustMkdirAll(t, filepath.Join(tempRoot, ".git"))
+	wd := filepath.Join(tempRoot, "scratch", "leaf")
+	mustMkdirAll(t, wd)
+
+	cmd := &hookCommand{
+		lookupEnv: func(string) string { return "" },
+		getwd:     func() (string, error) { return wd, nil },
+	}
+
+	got, err := cmd.resolveProjectContext()
+	if err != nil {
+		t.Fatalf("resolveProjectContext() err = %v", err)
+	}
+	if got != "" {
+		t.Fatalf("resolveProjectContext() = %q, want no context from temp root marker", got)
+	}
+}
+
+func TestHookResolveProjectContextAllowsRepoUnderTempRoot(t *testing.T) {
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+	repo := filepath.Join(tempRoot, "repo")
+	wd := filepath.Join(repo, "nested")
+	mustMkdirAll(t, filepath.Join(repo, ".git"))
+	mustMkdirAll(t, wd)
+
+	cmd := &hookCommand{
+		lookupEnv: func(string) string { return "" },
+		getwd:     func() (string, error) { return wd, nil },
+	}
+
+	got, err := cmd.resolveProjectContext()
+	if err != nil {
+		t.Fatalf("resolveProjectContext() err = %v", err)
+	}
+	if got != repo {
+		t.Fatalf("resolveProjectContext() = %q, want %q", got, repo)
+	}
+}
+
+func TestHookResolveProjectContextExplicitEnvWinsUnderTempRoot(t *testing.T) {
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+	project := filepath.Join(tempRoot, "project")
+	wd := filepath.Join(tempRoot, "scratch")
+	mustMkdirAll(t, wd)
+
+	cmd := &hookCommand{
+		lookupEnv: func(name string) string {
+			if name == "PROJMUX_CWD" {
+				return project
+			}
+			return ""
+		},
+		getwd: func() (string, error) { return wd, nil },
+	}
+
+	got, err := cmd.resolveProjectContext()
+	if err != nil {
+		t.Fatalf("resolveProjectContext() err = %v", err)
+	}
+	if got != project {
+		t.Fatalf("resolveProjectContext() = %q, want explicit PROJMUX_CWD %q", got, project)
+	}
+}
+
 // --- small helpers --------------------------------------------------------
 
 // wrapLookupEnv returns a lookup function that overrides values for the


### PR DESCRIPTION
## Summary
- stop implicit hook project-context resolution before accepting markers exactly at the system temp root
- preserve explicit PROJMUX_CWD behavior and repos below the temp root
- add regression tests for no-context, temp-root, and explicit env cases

## Validation
- make fmt
- make fix
- make test
- make test-integration (blocked: docker not available in this WSL distro)
- make test-e2e (blocked: docker not available in this WSL distro)