### PR TITLE
feat(ai): ingest Codex notify events

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -299,6 +299,7 @@ projmux ai settings
 projmux ai status   set <thinking|waiting|idle> [--pane <id>]
 projmux ai notify   <reset|notify> [--pane <id>]
 projmux ai watch-title [--pane <id>]
+projmux ai ingest   codex-notify '<json>'
 projmux ai topic     ...
 ```
 
@@ -307,6 +308,13 @@ the `attention` badge, the `notify` queue producer, and the desktop
 notifier. `status set waiting` is the trigger that flips a pane to the
 reply-ready state — that transition pushes an `ai:<session>:<pane>`
 entry into the notify queue.
+
+`ingest codex-notify` is the hook-facing entrypoint for Codex legacy notify
+JSON. On `agent-turn-complete`, it matches a tmux pane by `$TMUX_PANE`,
+payload `cwd`, then cached thread/session pane options, marks the pane
+hook-active, sets AI state to waiting, and writes a metadata-bearing notify
+queue entry. Panes marked `@projmux_ai_hook_active=1` are skipped by the
+fallback title watcher.
 
 ## tmux
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -209,6 +209,9 @@ stdin receives one JSON object:
   "pane": "%9",
   "session": "main",
   "message": "claude: reply ready · worker loop",
+  "metadata": {
+    "agent": "claude"
+  },
   "created_at": "2026-05-12T02:03:04Z"
 }
 ```

--- a/docs/notify-queue.md
+++ b/docs/notify-queue.md
@@ -34,6 +34,7 @@ type Notification struct {
     Text      string    // capped at 80 runes
     Severity  string    // info | warn | critical
     Source    string    // ai | k8s | git | external
+    Metadata  map[string]string // optional producer metadata
     CreatedAt time.Time
     ExpiresAt time.Time
     Target            // session, window, pane, socket
@@ -52,6 +53,10 @@ freshness/display field, not a removal condition. `Severity` and
 `Source` are validated against the constants above; an invalid value
 returns `ErrInvalidSeverity` / `ErrInvalidSource` which the CLI maps to
 exit code 2.
+
+`Metadata` is optional and is omitted when empty. Hook producers use it for
+routing/debug context such as `agent`, `thread_id`, `turn_id`, `cwd`,
+`model`, and `client`; existing entries without metadata remain valid.
 
 ## CLI surface
 

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -33,6 +33,9 @@ const (
 	aiPaneStateOption       = "@projmux_ai_state"
 	aiPaneTopicOption       = "@projmux_ai_topic"
 	aiPaneTopicManualOption = "@projmux_ai_topic_manual"
+	aiPaneHookActiveOption  = "@projmux_ai_hook_active"
+	aiPaneThreadIDOption    = "@projmux_ai_thread_id"
+	aiPaneSessionIDOption   = "@projmux_ai_session_id"
 )
 
 type aiCommandRunner interface {
@@ -122,6 +125,8 @@ func (c *aiCommand) Run(args []string, stdout, stderr io.Writer) error {
 		return c.runNotify(args[1:], stderr)
 	case "watch-title":
 		return c.runWatchTitle(args[1:], stderr)
+	case "ingest":
+		return c.runIngest(args[1:], stderr)
 	case "topic":
 		return c.runTopic(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
@@ -159,9 +164,17 @@ func (c *aiCommand) runStatus(args []string, stderr io.Writer) error {
 }
 
 func (c *aiCommand) applyAIStatus(state, paneID string) error {
+	return c.applyAIStatusWithNotify(state, paneID, attentionNotifyInput{})
+}
+
+func (c *aiCommand) applyAIStatusWithNotify(state, paneID string, notifyIn attentionNotifyInput) error {
 	paneID = strings.TrimSpace(paneID)
 	if paneID == "" {
 		return nil
+	}
+	notifyIn.PaneID = paneID
+	if notifyIn.Lookup == nil {
+		notifyIn.Lookup = c.notifyLookup()
 	}
 
 	switch strings.TrimSpace(state) {
@@ -170,28 +183,28 @@ func (c *aiCommand) applyAIStatus(state, paneID string) error {
 		_ = c.run("tmux", "set-option", "-p", "-t", paneID, attentionStateOption, attentionStateBusy)
 		_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionAckOption)
 		_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionFocusArmedOption)
-		c.notifyProducer().AckReplyReady(attentionNotifyInput{PaneID: paneID, Lookup: c.notifyLookup()})
+		c.notifyProducer().AckReplyReady(notifyIn)
 	case "waiting":
 		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneStateOption, "waiting")
 		_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionAckOption)
-		if c.paneVisibleToClient(paneID) {
+		if !notifyIn.Force && c.paneVisibleToClient(paneID) {
 			_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionStateOption)
 			_ = c.run("tmux", "set-option", "-p", "-t", paneID, attentionAckOption, "1")
 			_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionFocusArmedOption)
 			// The pane is already active so no reply badge survives — clear
 			// any stale queue entry instead of pushing a new one.
-			c.notifyProducer().AckReplyReady(attentionNotifyInput{PaneID: paneID, Lookup: c.notifyLookup()})
+			c.notifyProducer().AckReplyReady(notifyIn)
 		} else {
 			_ = c.run("tmux", "set-option", "-p", "-t", paneID, attentionStateOption, attentionStateReply)
 			_ = c.run("tmux", "set-option", "-p", "-t", paneID, attentionFocusArmedOption, "1")
 			_ = c.notifyAI(paneID)
-			c.notifyProducer().PushReplyReady(attentionNotifyInput{PaneID: paneID, Lookup: c.notifyLookup()})
+			c.notifyProducer().PushReplyReady(notifyIn)
 		}
 	case "idle", "":
 		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneStateOption, "idle")
 		_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionStateOption)
 		_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionFocusArmedOption)
-		c.notifyProducer().AckReplyReady(attentionNotifyInput{PaneID: paneID, Lookup: c.notifyLookup()})
+		c.notifyProducer().AckReplyReady(notifyIn)
 	default:
 		return fmt.Errorf("unknown ai status state: %s", state)
 	}
@@ -302,6 +315,9 @@ func (c *aiCommand) runWatchTitle(args []string, stderr io.Writer) error {
 	if paneID == "" {
 		return nil
 	}
+	if isTruthyTmuxOption(c.readTmuxPaneOption(paneID, aiPaneHookActiveOption)) {
+		return nil
+	}
 
 	interval := c.watchInterval()
 	settleLimit := c.watchSettleLoops()
@@ -312,6 +328,9 @@ func (c *aiCommand) runWatchTitle(args []string, stderr io.Writer) error {
 	for {
 		currentPaneID, err := c.read("tmux", "display-message", "-p", "-t", paneID, "#{pane_id}")
 		if err != nil || strings.TrimSpace(string(currentPaneID)) != paneID {
+			return nil
+		}
+		if isTruthyTmuxOption(c.readTmuxPaneOption(paneID, aiPaneHookActiveOption)) {
 			return nil
 		}
 		snapshot := c.readAIWatchSnapshot(paneID)
@@ -2195,6 +2214,7 @@ func printAIUsage(w io.Writer) {
 	fmt.Fprintln(w, "  projmux ai status set <thinking|waiting|idle> [pane]")
 	fmt.Fprintln(w, "  projmux ai notify [notify|reset] [pane]")
 	fmt.Fprintln(w, "  projmux ai watch-title [pane]")
+	fmt.Fprintln(w, "  projmux ai ingest <codex-notify> <json>")
 	fmt.Fprintln(w, "  projmux ai topic set <text> [--pane <id>]")
 	fmt.Fprintln(w, "  projmux ai topic clear [--pane <id>]")
 	fmt.Fprintln(w, "  projmux ai topic get [--pane <id>]")

--- a/internal/app/ai_ingest.go
+++ b/internal/app/ai_ingest.go
@@ -1,0 +1,278 @@
+package app
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+)
+
+const aiIngestListPanesFormat = "#{pane_id}\x1f#{pane_current_path}\x1f#{" + aiPaneThreadIDOption + "}\x1f#{" + aiPaneSessionIDOption + "}"
+
+type codexNotifyPayload struct {
+	Type                 string
+	ThreadID             string
+	SessionID            string
+	TurnID               string
+	CWD                  string
+	Client               string
+	Model                string
+	InputMessages        []json.RawMessage
+	LastAssistantMessage string
+}
+
+type aiPaneMatchInput struct {
+	CWD       string
+	ThreadID  string
+	SessionID string
+}
+
+type aiPaneMatchRow struct {
+	PaneID    string
+	CWD       string
+	ThreadID  string
+	SessionID string
+}
+
+func (c *aiCommand) runIngest(args []string, stderr io.Writer) error {
+	if len(args) < 1 {
+		printAIUsage(stderr)
+		return errors.New("ai ingest requires <agent-kind>")
+	}
+	switch args[0] {
+	case "codex-notify":
+		if len(args) != 2 {
+			printAIUsage(stderr)
+			return errors.New("ai ingest codex-notify requires a JSON payload argument")
+		}
+		return c.ingestCodexNotify([]byte(args[1]))
+	case "help", "--help", "-h":
+		printAIUsage(stderr)
+		return nil
+	default:
+		printAIUsage(stderr)
+		return fmt.Errorf("unknown ai ingest agent-kind: %s", args[0])
+	}
+}
+
+func (c *aiCommand) ingestCodexNotify(data []byte) error {
+	payload, err := parseCodexNotifyPayload(data)
+	if err != nil {
+		return err
+	}
+	if payload.Type != "agent-turn-complete" {
+		return nil
+	}
+
+	paneID := c.matchAIPane(aiPaneMatchInput{
+		CWD:       payload.CWD,
+		ThreadID:  payload.ThreadID,
+		SessionID: payload.SessionID,
+	})
+	if paneID == "" {
+		return nil
+	}
+
+	metadata := payload.codexMetadata()
+	topic := truncateRunes(payload.LastAssistantMessage, 80)
+	_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneHookActiveOption, "1")
+	_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneManagedOption, "1")
+	_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneAgentOption, aiModeCodex)
+	if payload.CWD != "" {
+		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneContextOption, payload.CWD)
+	}
+	if payload.ThreadID != "" {
+		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneThreadIDOption, payload.ThreadID)
+	}
+	if payload.SessionID != "" {
+		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneSessionIDOption, payload.SessionID)
+	}
+	if topic != "" {
+		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneTopicOption, topic)
+	}
+
+	notifyInput := attentionNotifyInput{
+		ID:       codexNotifyID(payload),
+		Text:     codexNotifyText(payload.LastAssistantMessage),
+		Metadata: metadata,
+		Force:    true,
+	}
+	return c.applyAIStatusWithNotify("waiting", paneID, notifyInput)
+}
+
+func parseCodexNotifyPayload(data []byte) (codexNotifyPayload, error) {
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return codexNotifyPayload{}, fmt.Errorf("parse codex notify payload: %w", err)
+	}
+	payload := codexNotifyPayload{
+		Type:                 stringFromAny(raw["type"]),
+		ThreadID:             firstString(raw, "thread-id", "thread_id"),
+		SessionID:            firstString(raw, "session-id", "session_id"),
+		TurnID:               firstString(raw, "turn-id", "turn_id"),
+		CWD:                  stringFromAny(raw["cwd"]),
+		Model:                stringFromAny(raw["model"]),
+		LastAssistantMessage: stringFromAny(raw["last-assistant-message"]),
+	}
+	payload.Client = stringFromAny(raw["client"])
+	if payload.Client == "" {
+		payload.Client = firstNestedString(raw["client"], "name", "version")
+	}
+	if payload.Model == "" {
+		payload.Model = firstNestedString(raw["client"], "model")
+	}
+	if messages, ok := raw["input-messages"].([]any); ok {
+		payload.InputMessages = make([]json.RawMessage, 0, len(messages))
+		for _, message := range messages {
+			encoded, err := json.Marshal(message)
+			if err == nil {
+				payload.InputMessages = append(payload.InputMessages, encoded)
+			}
+		}
+	}
+	return payload, nil
+}
+
+func (p codexNotifyPayload) codexMetadata() map[string]string {
+	metadata := map[string]string{
+		"agent":      aiModeCodex,
+		"thread_id":  p.ThreadID,
+		"session_id": p.SessionID,
+		"turn_id":    p.TurnID,
+		"cwd":        p.CWD,
+		"model":      p.Model,
+		"client":     p.Client,
+	}
+	out := make(map[string]string, len(metadata))
+	for k, v := range metadata {
+		if value := strings.TrimSpace(v); value != "" {
+			out[k] = value
+		}
+	}
+	return out
+}
+
+func (c *aiCommand) matchAIPane(in aiPaneMatchInput) string {
+	if envPane := strings.TrimSpace(c.env("TMUX_PANE")); envPane != "" {
+		return envPane
+	}
+	rows := c.listAIPaneMatchRows()
+	if cwd := cleanMatchPath(in.CWD); cwd != "" {
+		for _, row := range rows {
+			if cleanMatchPath(row.CWD) == cwd {
+				return row.PaneID
+			}
+		}
+	}
+	threadID := strings.TrimSpace(in.ThreadID)
+	sessionID := strings.TrimSpace(in.SessionID)
+	if threadID == "" && sessionID == "" {
+		return ""
+	}
+	for _, row := range rows {
+		if threadID != "" && strings.TrimSpace(row.ThreadID) == threadID {
+			return row.PaneID
+		}
+		if sessionID != "" && strings.TrimSpace(row.SessionID) == sessionID {
+			return row.PaneID
+		}
+	}
+	return ""
+}
+
+func (c *aiCommand) listAIPaneMatchRows() []aiPaneMatchRow {
+	out, err := c.read("tmux", "list-panes", "-a", "-F", aiIngestListPanesFormat)
+	if err != nil {
+		return nil
+	}
+	rows := strings.Split(strings.TrimSpace(string(out)), "\n")
+	matches := make([]aiPaneMatchRow, 0, len(rows))
+	for _, raw := range rows {
+		fields := strings.Split(raw, "\x1f")
+		if len(fields) != 4 {
+			continue
+		}
+		paneID := strings.TrimSpace(fields[0])
+		if paneID == "" {
+			continue
+		}
+		matches = append(matches, aiPaneMatchRow{
+			PaneID:    paneID,
+			CWD:       strings.TrimSpace(fields[1]),
+			ThreadID:  strings.TrimSpace(fields[2]),
+			SessionID: strings.TrimSpace(fields[3]),
+		})
+	}
+	return matches
+}
+
+func cleanMatchPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	return filepath.Clean(path)
+}
+
+func codexNotifyID(p codexNotifyPayload) string {
+	threadID := strings.TrimSpace(p.ThreadID)
+	turnID := strings.TrimSpace(p.TurnID)
+	switch {
+	case threadID != "" && turnID != "":
+		return "ai:codex:" + threadID + ":" + turnID
+	case threadID != "":
+		return "ai:codex:" + threadID
+	default:
+		return ""
+	}
+}
+
+func codexNotifyText(message string) string {
+	text := "Codex · 응답 완료"
+	if msg := truncateRunes(message, 80); msg != "" {
+		text += " · " + msg
+	}
+	return text
+}
+
+func firstString(raw map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value := stringFromAny(raw[key]); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstNestedString(value any, keys ...string) string {
+	nested, ok := value.(map[string]any)
+	if !ok {
+		return ""
+	}
+	return firstString(nested, keys...)
+}
+
+func stringFromAny(value any) string {
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case fmt.Stringer:
+		return strings.TrimSpace(v.String())
+	default:
+		return ""
+	}
+}
+
+func truncateRunes(value string, max int) string {
+	value = strings.TrimSpace(value)
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= max {
+		return value
+	}
+	return string(runes[:max])
+}

--- a/internal/app/ai_ingest_test.go
+++ b/internal/app/ai_ingest_test.go
@@ -1,0 +1,177 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestParseCodexNotifyPayload(t *testing.T) {
+	t.Parallel()
+
+	payload, err := parseCodexNotifyPayload([]byte(`{
+		"type": "agent-turn-complete",
+		"thread-id": "thread-123",
+		"turn-id": "turn-456",
+		"cwd": "/repo/projmux",
+		"client": {"name": "codex-cli", "model": "gpt-5.1-codex"},
+		"input-messages": [{"role": "user", "content": "run tests"}],
+		"last-assistant-message": "Tests passed."
+	}`))
+	if err != nil {
+		t.Fatalf("parseCodexNotifyPayload() error = %v", err)
+	}
+	if payload.Type != "agent-turn-complete" || payload.ThreadID != "thread-123" || payload.TurnID != "turn-456" || payload.CWD != "/repo/projmux" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if payload.Client != "codex-cli" || payload.Model != "gpt-5.1-codex" {
+		t.Fatalf("client/model = %q/%q", payload.Client, payload.Model)
+	}
+	if len(payload.InputMessages) != 1 {
+		t.Fatalf("InputMessages len = %d, want 1", len(payload.InputMessages))
+	}
+	if payload.LastAssistantMessage != "Tests passed." {
+		t.Fatalf("LastAssistantMessage = %q", payload.LastAssistantMessage)
+	}
+}
+
+func TestMatchAIPanePriority(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.lookupEnv = func(name string) string {
+		if name == "TMUX_PANE" {
+			return "%env"
+		}
+		return ""
+	}
+	if got := cmd.matchAIPane(aiPaneMatchInput{CWD: "/repo/projmux", ThreadID: "thread-2"}); got != "%env" {
+		t.Fatalf("env match = %q, want %%env", got)
+	}
+
+	cmd.lookupEnv = func(string) string { return "" }
+	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "tmux" && reflect.DeepEqual(args, []string{"list-panes", "-a", "-F", aiIngestListPanesFormat}) {
+			return []byte("%cwd\x1f/repo/projmux\x1fthread-1\x1fsession-1\n%thread\x1f/repo/other\x1fthread-2\x1fsession-2\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+	if got := cmd.matchAIPane(aiPaneMatchInput{CWD: "/repo/projmux", ThreadID: "thread-2"}); got != "%cwd" {
+		t.Fatalf("cwd match = %q, want %%cwd", got)
+	}
+	if got := cmd.matchAIPane(aiPaneMatchInput{ThreadID: "thread-2"}); got != "%thread" {
+		t.Fatalf("thread match = %q, want %%thread", got)
+	}
+	if got := cmd.matchAIPane(aiPaneMatchInput{SessionID: "session-2"}); got != "%thread" {
+		t.Fatalf("session match = %q, want %%thread", got)
+	}
+}
+
+func TestIngestCodexNotifyPushesWaitingStatusAndMetadata(t *testing.T) {
+	home := t.TempDir()
+	store := &stubNotifyStore{}
+	cmd := testAICommand(home)
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name != "tmux" {
+			return nil, os.ErrNotExist
+		}
+		switch {
+		case reflect.DeepEqual(args, []string{"list-panes", "-a", "-F", aiIngestListPanesFormat}):
+			return []byte("%7\x1f/repo/projmux\x1f\x1f\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%7", "#{@projmux_ai_agent}"}):
+			return []byte("codex\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%7", "#S"}):
+			return []byte("workspace\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%7", "#{window_id}"}):
+			return []byte("@1\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%7", "#{pane_id}"}):
+			return []byte("%7\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%7", "#{socket_path}"}):
+			return []byte("/tmp/tmux-1000/projmux\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	err := cmd.Run([]string{"ingest", "codex-notify", `{
+		"type": "agent-turn-complete",
+		"thread-id": "thread-123",
+		"turn-id": "turn-456",
+		"cwd": "/repo/projmux",
+		"model": "gpt-5.1-codex",
+		"client": "codex-cli",
+		"last-assistant-message": "Implemented hook notify ingest."
+	}`}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("Run ingest codex-notify error = %v", err)
+	}
+
+	for _, want := range []recordedAICommand{
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiPaneHookActiveOption, "1"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiPaneStateOption, "waiting"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", attentionStateOption, attentionStateReply}},
+	} {
+		if !hasRecordedAICommand(cmdRecorder(cmd).commands, want) {
+			t.Fatalf("commands = %#v, missing %#v", cmdRecorder(cmd).commands, want)
+		}
+	}
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1", len(store.pushed))
+	}
+	got := store.pushed[0]
+	if got.ID != "ai:codex:thread-123:turn-456" {
+		t.Fatalf("ID = %q", got.ID)
+	}
+	if got.Text != "Codex · 응답 완료 · Implemented hook notify ingest." {
+		t.Fatalf("Text = %q", got.Text)
+	}
+	if got.Metadata["agent"] != "codex" || got.Metadata["thread_id"] != "thread-123" || got.Metadata["turn_id"] != "turn-456" || got.Metadata["cwd"] != "/repo/projmux" || got.Metadata["model"] != "gpt-5.1-codex" || got.Metadata["client"] != "codex-cli" {
+		t.Fatalf("Metadata = %#v", got.Metadata)
+	}
+	if got.Target.Session != "workspace" || got.Target.Window != "@1" || got.Target.Pane != "%7" {
+		t.Fatalf("Target = %+v", got.Target)
+	}
+}
+
+func TestAIWatchTitleSkipsHookActivePane(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	paneIDReads := 0
+	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name != "tmux" {
+			return nil, os.ErrNotExist
+		}
+		switch {
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%5", "#{" + aiPaneHookActiveOption + "}"}):
+			return []byte("1\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%5", "#{pane_id}"}):
+			paneIDReads++
+			return []byte("%5\n"), nil
+		default:
+			return nil, os.ErrNotExist
+		}
+	}
+
+	if err := cmd.Run([]string{"watch-title", "%5"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run watch-title error = %v", err)
+	}
+	if paneIDReads != 0 {
+		t.Fatalf("paneIDReads = %d, want 0", paneIDReads)
+	}
+	if len(cmdRecorder(cmd).commands) != 0 {
+		t.Fatalf("commands = %#v, want no writes for hook-active pane", cmdRecorder(cmd).commands)
+	}
+}
+
+func hasRecordedAICommand(commands []recordedAICommand, want recordedAICommand) bool {
+	for _, got := range commands {
+		if got.name == want.name && reflect.DeepEqual(got.args, want.args) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/notify_hook.go
+++ b/internal/app/notify_hook.go
@@ -26,15 +26,16 @@ type notifyHookMeta struct {
 }
 
 type notifyHookPayload struct {
-	Event     string    `json:"event"`
-	ID        string    `json:"id"`
-	Type      string    `json:"type"`
-	Agent     string    `json:"agent"`
-	Topic     string    `json:"topic"`
-	Pane      string    `json:"pane"`
-	Session   string    `json:"session"`
-	Message   string    `json:"message"`
-	CreatedAt time.Time `json:"created_at"`
+	Event     string            `json:"event"`
+	ID        string            `json:"id"`
+	Type      string            `json:"type"`
+	Agent     string            `json:"agent"`
+	Topic     string            `json:"topic"`
+	Pane      string            `json:"pane"`
+	Session   string            `json:"session"`
+	Message   string            `json:"message"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	CreatedAt time.Time         `json:"created_at"`
 }
 
 type sendNotiHookDispatcher struct {
@@ -69,6 +70,7 @@ func (d *sendNotiHookDispatcher) Dispatch(entry notify.Notification, meta notify
 		Pane:      strings.TrimSpace(entry.Pane),
 		Session:   strings.TrimSpace(entry.Session),
 		Message:   strings.TrimSpace(meta.Message),
+		Metadata:  entry.Metadata,
 		CreatedAt: entry.CreatedAt,
 	}
 	if payload.Type == "" {

--- a/internal/app/notify_producer.go
+++ b/internal/app/notify_producer.go
@@ -28,8 +28,12 @@ type attentionNotifyProducer interface {
 // the only mandatory field; the producer reads everything else off tmux via
 // Lookup.
 type attentionNotifyInput struct {
-	PaneID string
-	Lookup attentionNotifyLookup
+	PaneID   string
+	Lookup   attentionNotifyLookup
+	ID       string
+	Text     string
+	Metadata map[string]string
+	Force    bool
 }
 
 // attentionNotifyLookup is the minimal tmux read surface the producer needs.
@@ -105,6 +109,14 @@ func (p *storeAttentionNotifyProducer) PushReplyReady(in attentionNotifyInput) {
 	socket := strings.TrimSpace(in.Lookup.PaneFormat(paneID, "#{socket_path}"))
 
 	topic := strings.TrimSpace(in.Lookup.PaneOption(paneID, aiPaneTopicOption))
+	text := strings.TrimSpace(in.Text)
+	if text == "" {
+		text = composeAttentionReplyText(agent, topic)
+	}
+	id := strings.TrimSpace(in.ID)
+	if id == "" {
+		id = buildAttentionNotifyID(session, resolvedPane)
+	}
 
 	ttl := p.ttl
 	if ttl <= 0 {
@@ -112,10 +124,11 @@ func (p *storeAttentionNotifyProducer) PushReplyReady(in attentionNotifyInput) {
 	}
 
 	entry, _, err := p.store.Push(notify.PushInput{
-		ID:       buildAttentionNotifyID(session, resolvedPane),
-		Text:     composeAttentionReplyText(agent, topic),
+		ID:       id,
+		Text:     text,
 		Severity: notify.SeverityInfo,
 		Source:   notify.SourceAI,
+		Metadata: in.Metadata,
 		TTL:      ttl,
 		Target: notify.Target{
 			Socket:  socket,

--- a/internal/app/notify_producer_test.go
+++ b/internal/app/notify_producer_test.go
@@ -99,6 +99,42 @@ func TestStoreAttentionNotifyProducerPushReplyReadyWithTopic(t *testing.T) {
 	}
 }
 
+func TestStoreAttentionNotifyProducerPushReplyReadyWithOverrides(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{}
+	producer := &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+
+	lookup := newFakeAttentionLookup(map[string]string{
+		"%2|@projmux_ai_agent": "Codex",
+		"%2|#S":                "feat-notify-producer-attention",
+		"%2|#{window_id}":      "@1",
+		"%2|#{pane_id}":        "%2",
+	})
+
+	producer.PushReplyReady(attentionNotifyInput{
+		PaneID: "%2",
+		Lookup: lookup,
+		ID:     "ai:codex:thread:turn",
+		Text:   "Codex · 응답 완료 · done",
+		Metadata: map[string]string{
+			"agent":     "codex",
+			"thread_id": "thread",
+		},
+	})
+
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1", len(store.pushed))
+	}
+	got := store.pushed[0]
+	if got.ID != "ai:codex:thread:turn" || got.Text != "Codex · 응답 완료 · done" {
+		t.Fatalf("PushInput = %+v", got)
+	}
+	if got.Metadata["agent"] != "codex" || got.Metadata["thread_id"] != "thread" {
+		t.Fatalf("Metadata = %#v", got.Metadata)
+	}
+}
+
 func TestStoreAttentionNotifyProducerPushReplyReadyDispatchesSendNotiHook(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/notify/notification.go
+++ b/internal/core/notify/notification.go
@@ -40,16 +40,17 @@ const MaxTextLength = 80
 
 // Notification is a single queued status-bar entry.
 type Notification struct {
-	ID        string    `json:"id"`
-	Text      string    `json:"text"`
-	Severity  string    `json:"severity"`
-	Socket    string    `json:"socket,omitempty"`
-	Session   string    `json:"session"`
-	Window    string    `json:"window,omitempty"`
-	Pane      string    `json:"pane,omitempty"`
-	Source    string    `json:"source"`
-	CreatedAt time.Time `json:"created_at"`
-	ExpiresAt time.Time `json:"expires_at"`
+	ID        string            `json:"id"`
+	Text      string            `json:"text"`
+	Severity  string            `json:"severity"`
+	Socket    string            `json:"socket,omitempty"`
+	Session   string            `json:"session"`
+	Window    string            `json:"window,omitempty"`
+	Pane      string            `json:"pane,omitempty"`
+	Source    string            `json:"source"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	CreatedAt time.Time         `json:"created_at"`
+	ExpiresAt time.Time         `json:"expires_at"`
 }
 
 // Target groups the routing fields of a notification.
@@ -67,6 +68,7 @@ type PushInput struct {
 	Text     string
 	Severity string
 	Source   string
+	Metadata map[string]string
 	TTL      time.Duration
 	Target   Target
 }

--- a/internal/core/notify/store.go
+++ b/internal/core/notify/store.go
@@ -135,6 +135,7 @@ func (s *Store) Push(in PushInput) (Notification, PushResult, error) {
 		Window:    strings.TrimSpace(in.Target.Window),
 		Pane:      strings.TrimSpace(in.Target.Pane),
 		Source:    source,
+		Metadata:  sanitizeMetadata(in.Metadata),
 		CreatedAt: now,
 		ExpiresAt: now.Add(ttl),
 	}
@@ -166,6 +167,25 @@ func (s *Store) Push(in PushInput) (Notification, PushResult, error) {
 		return Notification{}, PushResult{}, err
 	}
 	return entry, result, nil
+}
+
+func sanitizeMetadata(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		key := strings.TrimSpace(k)
+		value := strings.TrimSpace(v)
+		if key == "" || value == "" {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // List returns all pending entries in recency-desc order. Expiration metadata

--- a/internal/core/notify/store_test.go
+++ b/internal/core/notify/store_test.go
@@ -64,6 +64,34 @@ func TestPushRoundTrip(t *testing.T) {
 	}
 }
 
+func TestPushRoundTripMetadataSanitizesAndCopies(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	metadata := map[string]string{
+		" agent ": " codex ",
+		"empty":   "",
+		"":        "ignored",
+	}
+	if _, _, err := store.Push(PushInput{
+		Text:     "Codex ready",
+		Source:   SourceAI,
+		Metadata: metadata,
+		Target:   Target{Session: "s"},
+	}); err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+	metadata[" agent "] = "mutated"
+
+	entries, err := store.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if got := entries[0].Metadata; len(got) != 1 || got["agent"] != "codex" {
+		t.Fatalf("Metadata = %#v, want sanitized copy", got)
+	}
+}
+
 func TestPushDefaults(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add `projmux ai ingest codex-notify <json>` for legacy Codex notify payloads
- add pane matching by TMUX_PANE, cwd, and cached thread/session options
- persist notify metadata and force queue entries for Codex turn completion
- mark hook-active panes so watch-title polling skips them

## Deferred
- `projmux ai integrate codex`
- `ai/codex` source enum split; this slice uses source `ai` with metadata
- Claude and bell ingest paths

## Validation
- make fmt
- make fix
- make test
- make test-integration (blocked locally: docker not available in this WSL distro)
- make test-e2e (blocked locally: docker not available in this WSL distro)