### PR TITLE
feat(layout): list project presets

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -33,6 +33,7 @@
 - `make test` also covers Settings IA regression guards for `send-noti` visibility in Hooks, no nested Project recipe inside Hooks, Project recipe/AI/Labs view-first detail rows, and Desktop notifications under Labs.
 - `make test` also covers Settings > Session State view-first rows, auto-save/auto-restore toggles, current-session snapshot summary/delete behavior, autosave disabled gate, user-facing `projmux session-state` status/save/delete/restore dry-run actions including explicit manual save bypass of disabled autosave, and `projmux shell` auto-restore gating for enabled/disabled/missing-snapshot/existing-session/replay-failure paths including nested `TMUX` env stripping.
 - `make test` also covers the statusbar Session State popup entrypoint, manual save-now and restore dry-run preview actions, missing-snapshot messaging, and `projmux tmux sessionstate-status` helper wiring.
+- `make test` also covers project layout preset schema/discovery for `.projmux/layouts/*.toml`, supported interpolation validation, malformed-file list warnings, and user-facing `projmux layout list|show` behavior.
 - `make test` also now covers onboarding revisit and welcome wiring (`projmux welcome`, `Settings > About > Welcome`, `pending_attach_welcome`, attach-time `welcome --popup` one-time claim/env suppression/tmux popup payload, and generated `client-attached` app config wiring) via shell welcome tests.
 - Current focused unit coverage also includes strict notify SOT behavior
   (TTL does not remove rows, focus success and target-gone clicks ack,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,7 @@ projmux <command> [args...]
 | `focus` | Switch the active client to a session/window/pane target. |
 | `init` | Apply supported terminal keybinding fallbacks. |
 | `kill` | Terminate tagged tmux sessions. |
+| `layout` | List and inspect project layout presets. |
 | `notify` | Manage the pending AI notify queue (push/list/ack/reconcile). |
 | `pin` | Manage pinned project directories. |
 | `preview` | Manage persisted tmux preview selection. |
@@ -63,6 +64,24 @@ the active session in sync).
 
 Settings > Labs remains available for experimental settings, but picker backend
 selection has been retired. The native picker is always used.
+
+## layout
+
+```
+projmux layout list [--json]
+projmux layout show <name>
+```
+
+Project layout presets are read from `<project>/.projmux/layouts/*.toml`,
+where the project context is `PROJMUX_CWD` when set, otherwise the nearest
+parent with `.projmux` or `.git`.
+
+`layout list` prints valid presets and skips malformed files with a warning on
+stderr. `--json` emits an array of `{name,path,description,mode,windows,panes}`.
+`layout show <name>` prints the raw preset file content.
+
+`layout save`, `layout remove`, and `layout apply` are intentionally deferred in
+this release.
 
 ## setup
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,48 @@ The saved workdir file is:
 It stores one absolute path per line. Lines beginning with `#` are comments.
 The file is read only when no env root list is set.
 
+## Project Layout Presets
+
+Projects may keep reusable tmux layout seeds in:
+
+```text
+<project>/.projmux/layouts/<name>.toml
+```
+
+The project context comes from `PROJMUX_CWD` when set, otherwise projmux walks
+upward from the current directory to the nearest `.projmux` or `.git` marker.
+Files outside that project tree are not discovered.
+
+The Phase 1 schema is intentionally close to the session-state snapshot shape:
+
+```toml
+schema_version = 1
+description = "Daily dev"
+mode = "inherit-autosave" # default; or "fresh-each-time"
+default_cwd = "${PROJMUX_CWD}"
+
+[[windows]]
+index = 0
+name = "main"
+layout = "..."
+active_pane_index = 0
+
+[[windows.panes]]
+index = 0
+cwd = "${PROJMUX_CWD}"
+command = "make watch"
+```
+
+`command` records a startup recipe, matching the supported session-state replay
+recipe. Panes without `command` may use `recipe = "shell"`. Supported
+interpolation placeholders are limited to `${PROJMUX_CWD}` and
+`${PROJMUX_SESSION}`; other `${...}` values are rejected during load.
+
+Unknown fields and unknown sections are ignored so future schema additions do
+not break older `layout list` and `layout show` flows. The built-in parser only
+accepts quoted strings and integer values for the known fields above; it does
+not implement the full TOML language.
+
 ## Keymap File
 
 Settings > Keybindings is the normal in-app editor for action keys. It lists

--- a/docs/session-restore.md
+++ b/docs/session-restore.md
@@ -22,3 +22,9 @@ the same read model and CLI behavior:
 Delete, auto-save/auto-restore toggles, and restore execution remain in Settings
 or CLI for now. Destructive restore execution stays deferred until the popup has
 a dedicated safe policy for existing or non-empty live sessions.
+
+Project layout presets in `<project>/.projmux/layouts/*.toml` reuse the same
+window, pane, cwd, and startup recipe concepts as session snapshots. In this
+release they are discoverable with `projmux layout list` and inspectable with
+`projmux layout show <name>`; applying presets to live tmux sessions remains
+deferred.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -68,6 +68,7 @@ type App struct {
 	hook         *hookCommand
 	initCmd      *initCommand
 	kill         *killCommand
+	layout       *layoutCommand
 	notify       *notifyCommand
 	pin          *pinCommand
 	popupWaitKey *popupWaitKeyCommand
@@ -105,6 +106,7 @@ func New() *App {
 		hook:         newHookCommand(),
 		initCmd:      newInitCommand(),
 		kill:         newKillCommand(),
+		layout:       newLayoutCommand(),
 		notify:       newNotifyCommand(),
 		pin:          newPinCommand(),
 		popupWaitKey: newPopupWaitKeyCommand(),
@@ -155,6 +157,8 @@ func (a *App) Run(args []string, stdout, stderr io.Writer) error {
 		return a.initCmd.Run(args[1:], stdout, stderr)
 	case "kill":
 		return a.kill.Run(args[1:], stdout, stderr)
+	case "layout":
+		return a.layout.Run(args[1:], stdout, stderr)
 	case "notify":
 		return a.notify.Run(args[1:], stdout, stderr)
 	case "pin":
@@ -223,6 +227,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  hook      List, edit, validate, and trust lifecycle hook config")
 	fmt.Fprintln(w, "  init      Merge projmux keybindings into a terminal config")
 	fmt.Fprintln(w, "  kill      Terminate tagged tmux sessions")
+	fmt.Fprintln(w, "  layout    List and inspect project layout presets")
 	fmt.Fprintln(w, "  notify    Manage the pending AI notify queue (push/list/ack/reconcile)")
 	fmt.Fprintln(w, "  pin       Manage pinned project directories")
 	fmt.Fprintln(w, "  preview   Manage persisted tmux preview selection")

--- a/internal/app/layout.go
+++ b/internal/app/layout.go
@@ -1,0 +1,167 @@
+package app
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	corelayout "github.com/crevissepartners/projmux/internal/core/layout"
+)
+
+type layoutCommand struct {
+	lookupEnv func(string) string
+	getwd     func() (string, error)
+}
+
+func newLayoutCommand() *layoutCommand {
+	return &layoutCommand{
+		lookupEnv: os.Getenv,
+		getwd:     os.Getwd,
+	}
+}
+
+func (c *layoutCommand) Run(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("layout", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() == 0 {
+		printLayoutUsage(stderr)
+		return errors.New("layout requires a subcommand")
+	}
+
+	switch fs.Arg(0) {
+	case "list":
+		return c.runList(fs.Args()[1:], stdout, stderr)
+	case "show":
+		return c.runShow(fs.Args()[1:], stdout, stderr)
+	case "save", "remove", "apply":
+		return fmt.Errorf("layout %s is not implemented in this release", fs.Arg(0))
+	case "help", "--help", "-h":
+		printLayoutUsage(stdout)
+		return nil
+	default:
+		printLayoutUsage(stderr)
+		return fmt.Errorf("unknown layout subcommand: %s", fs.Arg(0))
+	}
+}
+
+func (c *layoutCommand) runList(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("layout list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	jsonOut := fs.Bool("json", false, "print layout presets as JSON")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		printLayoutUsage(stderr)
+		return fmt.Errorf("layout list does not accept positional arguments")
+	}
+	store, err := c.store()
+	if err != nil {
+		return err
+	}
+	entries, warnings, err := store.List()
+	if err != nil {
+		return err
+	}
+	printLayoutWarnings(stderr, warnings)
+	if *jsonOut {
+		data, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			return fmt.Errorf("encode layout list JSON: %w", err)
+		}
+		_, err = fmt.Fprintf(stdout, "%s\n", data)
+		return err
+	}
+	if len(entries) == 0 {
+		_, err := fmt.Fprintln(stdout, "no layout presets found")
+		return err
+	}
+	_, _ = fmt.Fprintln(stdout, "NAME\tMODE\tWINDOWS\tPANES\tDESCRIPTION")
+	for _, entry := range entries {
+		if _, err := fmt.Fprintf(stdout, "%s\t%s\t%d\t%d\t%s\n", entry.Name, entry.Mode, entry.Windows, entry.Panes, entry.Description); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *layoutCommand) runShow(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("layout show", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		printLayoutUsage(stderr)
+		return fmt.Errorf("layout show requires exactly 1 argument: <name>")
+	}
+	store, err := c.store()
+	if err != nil {
+		return err
+	}
+	body, err := store.Show(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	if !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	_, err = io.WriteString(stdout, body)
+	return err
+}
+
+func (c *layoutCommand) store() (corelayout.Store, error) {
+	projectRoot, err := c.resolveProjectContext()
+	if err != nil {
+		return corelayout.Store{}, err
+	}
+	if projectRoot == "" {
+		return corelayout.Store{}, errors.New("layout requires a project context; run inside a project tree or set PROJMUX_CWD")
+	}
+	return corelayout.NewStore(projectRoot), nil
+}
+
+func (c *layoutCommand) resolveProjectContext() (string, error) {
+	if c.lookupEnv != nil {
+		if raw := strings.TrimSpace(c.lookupEnv("PROJMUX_CWD")); raw != "" {
+			return filepath.Clean(raw), nil
+		}
+	}
+	if c.getwd == nil {
+		return "", nil
+	}
+	wd, err := c.getwd()
+	if err != nil {
+		return "", err
+	}
+	wd = filepath.Clean(wd)
+	if root := nearestProjectMarker(wd, os.TempDir()); root != "" {
+		return root, nil
+	}
+	return "", nil
+}
+
+func printLayoutWarnings(w io.Writer, warnings []corelayout.Warning) {
+	for _, warning := range warnings {
+		fmt.Fprintf(w, "warning: skip layout preset %s: %v\n", warning.Path, warning.Err)
+	}
+}
+
+func printLayoutUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  projmux layout list [--json]")
+	fmt.Fprintln(w, "  projmux layout show <name>")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Deferred:")
+	fmt.Fprintln(w, "  projmux layout save <name>")
+	fmt.Fprintln(w, "  projmux layout remove <name>")
+	fmt.Fprintln(w, "  projmux layout apply <name>")
+}

--- a/internal/app/layout_test.go
+++ b/internal/app/layout_test.go
@@ -1,0 +1,138 @@
+package app
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLayoutListPrintsProjectPresets(t *testing.T) {
+	t.Parallel()
+
+	project := t.TempDir()
+	writeLayoutTestFile(t, project, "dev", `
+schema_version = 1
+description = "Daily dev"
+
+[[windows]]
+index = 0
+active_pane_index = 0
+
+[[windows.panes]]
+index = 0
+cwd = "${PROJMUX_CWD}"
+recipe = "shell"
+`)
+	cmd := &layoutCommand{
+		lookupEnv: func(name string) string {
+			if name == "PROJMUX_CWD" {
+				return project
+			}
+			return ""
+		},
+	}
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"list"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	output := stdout.String()
+	for _, want := range []string{"NAME\tMODE\tWINDOWS\tPANES\tDESCRIPTION", "dev\tinherit-autosave\t1\t1\tDaily dev"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestLayoutListJSONSkipsMalformedWithWarning(t *testing.T) {
+	t.Parallel()
+
+	project := t.TempDir()
+	writeLayoutTestFile(t, project, "dev", `
+schema_version = 1
+
+[[windows]]
+index = 0
+active_pane_index = 0
+
+[[windows.panes]]
+index = 0
+cwd = "${PROJMUX_CWD}"
+recipe = "shell"
+`)
+	writeLayoutTestFile(t, project, "bad", `schema_version = "nope"`)
+	cmd := &layoutCommand{
+		lookupEnv: func(name string) string {
+			if name == "PROJMUX_CWD" {
+				return project
+			}
+			return ""
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := cmd.Run([]string{"list", "--json"}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"name": "dev"`) {
+		t.Fatalf("stdout = %s, want dev JSON entry", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "warning: skip layout preset") || !strings.Contains(stderr.String(), "bad.toml") {
+		t.Fatalf("stderr = %q, want malformed warning", stderr.String())
+	}
+}
+
+func TestLayoutShowPrintsPresetContent(t *testing.T) {
+	t.Parallel()
+
+	project := t.TempDir()
+	writeLayoutTestFile(t, project, "review", `
+schema_version = 1
+description = "Review"
+`)
+	cmd := &layoutCommand{
+		lookupEnv: func(name string) string {
+			if name == "PROJMUX_CWD" {
+				return project
+			}
+			return ""
+		},
+	}
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"show", "review"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, `description = "Review"`) {
+		t.Fatalf("stdout = %q, want raw preset content", got)
+	}
+}
+
+func TestLayoutRequiresProjectContext(t *testing.T) {
+	t.Parallel()
+
+	cmd := &layoutCommand{
+		lookupEnv: func(string) string { return "" },
+		getwd:     func() (string, error) { return t.TempDir(), nil },
+	}
+	err := cmd.Run([]string{"list"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "requires a project context") {
+		t.Fatalf("error = %v, want project context error", err)
+	}
+}
+
+func writeLayoutTestFile(t *testing.T, project, name, body string) {
+	t.Helper()
+	path := filepath.Join(project, ".projmux", "layouts", name+".toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(body, "\n")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/core/layout/layout.go
+++ b/internal/core/layout/layout.go
@@ -1,0 +1,808 @@
+// Package layout manages project-local tmux layout presets.
+package layout
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/integrations/sessionstate"
+)
+
+const (
+	// SchemaVersion is the current project layout preset TOML schema.
+	SchemaVersion = 1
+
+	ModeInheritAutosave = "inherit-autosave"
+	ModeFreshEachTime   = "fresh-each-time"
+
+	dirName  = ".projmux/layouts"
+	fileMode = 0o644
+)
+
+var (
+	ErrNotFound        = errors.New("layout preset not found")
+	ErrInvalidName     = errors.New("invalid layout preset name")
+	ErrInvalidPreset   = errors.New("invalid layout preset")
+	ErrUnsupportedMode = errors.New("unsupported layout preset mode")
+
+	placeholderPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
+)
+
+// Preset is a project-local layout seed stored as TOML.
+type Preset struct {
+	SchemaVersion int
+	Description   string
+	Mode          string
+	DefaultCWD    string
+	Windows       []Window
+}
+
+// Window mirrors the reusable tmux session-state window shape.
+type Window struct {
+	Index           int
+	Name            string
+	Layout          string
+	ActivePaneIndex int
+	Panes           []Pane
+}
+
+// Pane mirrors the reusable tmux session-state pane shape with a compact
+// command field for startup recipes.
+type Pane struct {
+	Index    int
+	CWD      string
+	Recipe   sessionstate.Recipe
+	Agent    string
+	ResumeID string
+	Topic    string
+	Command  string
+}
+
+// Entry is the compact list view for one preset file.
+type Entry struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Description string `json:"description,omitempty"`
+	Mode        string `json:"mode"`
+	Windows     int    `json:"windows"`
+	Panes       int    `json:"panes"`
+}
+
+// Warning records a preset file that discovery skipped.
+type Warning struct {
+	Path string
+	Err  error
+}
+
+// Store discovers and writes layouts below ProjectRoot/.projmux/layouts.
+type Store struct {
+	ProjectRoot string
+}
+
+func NewStore(projectRoot string) Store {
+	return Store{ProjectRoot: filepath.Clean(strings.TrimSpace(projectRoot))}
+}
+
+func (s Store) Dir() string {
+	return filepath.Join(s.ProjectRoot, dirName)
+}
+
+func (s Store) Path(name string) (string, error) {
+	if err := ValidateName(name); err != nil {
+		return "", err
+	}
+	return filepath.Join(s.Dir(), name+".toml"), nil
+}
+
+func (s Store) List() ([]Entry, []Warning, error) {
+	entries, err := os.ReadDir(s.Dir())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("layout: read presets dir %s: %w", s.Dir(), err)
+	}
+
+	var out []Entry
+	var warnings []Warning
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".toml" {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ".toml")
+		preset, err := s.Load(name)
+		path := filepath.Join(s.Dir(), entry.Name())
+		if err != nil {
+			warnings = append(warnings, Warning{Path: path, Err: err})
+			continue
+		}
+		out = append(out, presetEntry(name, path, preset))
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out, warnings, nil
+}
+
+func (s Store) Load(name string) (Preset, error) {
+	path, err := s.Path(name)
+	if err != nil {
+		return Preset{}, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Preset{}, fmt.Errorf("%w: %s", ErrNotFound, path)
+		}
+		return Preset{}, fmt.Errorf("layout: read preset %s: %w", path, err)
+	}
+	preset, err := Parse(string(data))
+	if err != nil {
+		return Preset{}, fmt.Errorf("layout: parse preset %s: %w", path, err)
+	}
+	if err := preset.Validate(); err != nil {
+		return Preset{}, fmt.Errorf("layout: validate preset %s: %w", path, err)
+	}
+	return preset.Normalize(), nil
+}
+
+func (s Store) Save(name string, preset Preset) error {
+	if err := ValidateName(name); err != nil {
+		return err
+	}
+	preset = preset.Normalize()
+	if err := preset.Validate(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(s.Dir(), 0o755); err != nil {
+		return fmt.Errorf("layout: create presets dir %s: %w", s.Dir(), err)
+	}
+	path, err := s.Path(name)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(s.Dir(), "."+name+".toml.tmp-*")
+	if err != nil {
+		return fmt.Errorf("layout: create temp preset: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if err := tmp.Chmod(fileMode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("layout: chmod temp preset: %w", err)
+	}
+	if _, err := tmp.WriteString(Render(preset)); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("layout: write temp preset: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("layout: close temp preset: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("layout: rename temp preset: %w", err)
+	}
+	cleanup = false
+	return nil
+}
+
+func (s Store) Remove(name string) error {
+	path, err := s.Path(name)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("%w: %s", ErrNotFound, path)
+		}
+		return fmt.Errorf("layout: remove preset %s: %w", path, err)
+	}
+	return nil
+}
+
+func (s Store) Show(name string) (string, error) {
+	path, err := s.Path(name)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("%w: %s", ErrNotFound, path)
+		}
+		return "", fmt.Errorf("layout: read preset %s: %w", path, err)
+	}
+	return string(data), nil
+}
+
+func FromSnapshot(snap sessionstate.Snapshot, projectRoot, description, mode string) Preset {
+	p := Preset{
+		SchemaVersion: SchemaVersion,
+		Description:   strings.TrimSpace(description),
+		Mode:          normalizeMode(mode),
+		DefaultCWD:    portablePath(snap.DefaultCWD, projectRoot),
+		Windows:       make([]Window, 0, len(snap.Windows)),
+	}
+	for _, window := range snap.Windows {
+		out := Window{
+			Index:           window.Index,
+			Name:            window.Name,
+			Layout:          window.Layout,
+			ActivePaneIndex: window.ActivePaneIndex,
+			Panes:           make([]Pane, 0, len(window.Panes)),
+		}
+		for _, pane := range window.Panes {
+			out.Panes = append(out.Panes, paneFromSnapshot(pane, projectRoot))
+		}
+		p.Windows = append(p.Windows, out)
+	}
+	return p.Normalize()
+}
+
+func (p Preset) Validate() error {
+	if p.SchemaVersion == 0 {
+		return fmt.Errorf("%w: schema_version is required", ErrInvalidPreset)
+	}
+	if p.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("%w: unsupported schema_version %d", ErrInvalidPreset, p.SchemaVersion)
+	}
+	if p.Mode != "" && p.Mode != ModeInheritAutosave && p.Mode != ModeFreshEachTime {
+		return fmt.Errorf("%w: %s", ErrUnsupportedMode, p.Mode)
+	}
+	if err := validatePlaceholders("description", p.Description); err != nil {
+		return err
+	}
+	if err := validatePath("default_cwd", p.DefaultCWD, true); err != nil {
+		return err
+	}
+	for wi, window := range p.Windows {
+		if window.Index < 0 {
+			return fmt.Errorf("%w: window %d index must be non-negative", ErrInvalidPreset, wi)
+		}
+		if window.ActivePaneIndex < 0 {
+			return fmt.Errorf("%w: window %d active_pane_index must be non-negative", ErrInvalidPreset, wi)
+		}
+		activePaneFound := len(window.Panes) == 0
+		for pi, pane := range window.Panes {
+			if pane.Index < 0 {
+				return fmt.Errorf("%w: window %d pane %d index must be non-negative", ErrInvalidPreset, wi, pi)
+			}
+			if pane.Index == window.ActivePaneIndex {
+				activePaneFound = true
+			}
+			if err := validatePath(fmt.Sprintf("window %d pane %d cwd", wi, pi), pane.CWD, false); err != nil {
+				return err
+			}
+			if err := validatePaneRecipe(wi, pi, pane); err != nil {
+				return err
+			}
+		}
+		if !activePaneFound {
+			return fmt.Errorf("%w: window %d active_pane_index %d does not match a pane index", ErrInvalidPreset, wi, window.ActivePaneIndex)
+		}
+	}
+	return nil
+}
+
+func (p Preset) Normalize() Preset {
+	p.SchemaVersion = SchemaVersion
+	p.Description = strings.TrimSpace(p.Description)
+	p.Mode = normalizeMode(p.Mode)
+	p.DefaultCWD = strings.TrimSpace(p.DefaultCWD)
+	for wi := range p.Windows {
+		p.Windows[wi].Name = strings.TrimSpace(p.Windows[wi].Name)
+		p.Windows[wi].Layout = strings.TrimSpace(p.Windows[wi].Layout)
+		for pi := range p.Windows[wi].Panes {
+			pane := &p.Windows[wi].Panes[pi]
+			pane.CWD = strings.TrimSpace(pane.CWD)
+			pane.Agent = strings.TrimSpace(pane.Agent)
+			pane.ResumeID = strings.TrimSpace(pane.ResumeID)
+			pane.Topic = strings.TrimSpace(pane.Topic)
+			pane.Command = strings.TrimSpace(pane.Command)
+			if pane.Command == "" && pane.Recipe.Kind == sessionstate.RecipeKindStartup {
+				pane.Command = strings.TrimSpace(pane.Recipe.Command)
+			}
+			if pane.Recipe.Kind == "" {
+				switch {
+				case pane.Command != "":
+					pane.Recipe = sessionstate.StartupRecipe(pane.Command)
+				case pane.Agent != "":
+					pane.Recipe = sessionstate.AgentRecipe(pane.Agent, pane.ResumeID, pane.Topic)
+				default:
+					pane.Recipe = sessionstate.ShellRecipe()
+				}
+			}
+			if pane.Recipe.Kind == sessionstate.RecipeKindAgent {
+				pane.Recipe = sessionstate.AgentRecipe(pane.Agent, pane.ResumeID, pane.Topic)
+			}
+			if pane.Recipe.Kind == sessionstate.RecipeKindStartup && pane.Command != "" {
+				pane.Recipe = sessionstate.StartupRecipe(pane.Command)
+			}
+			if pane.Recipe.Kind == sessionstate.RecipeKindStartup {
+				pane.Command = strings.TrimSpace(pane.Recipe.Command)
+			}
+			if pane.Recipe.Kind == sessionstate.RecipeKindAgent {
+				pane.Agent = strings.TrimSpace(pane.Recipe.Agent)
+				pane.ResumeID = strings.TrimSpace(pane.Recipe.ResumeID)
+				pane.Topic = strings.TrimSpace(pane.Recipe.Topic)
+			}
+		}
+	}
+	return p
+}
+
+func ValidateName(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" || name == "." || name == ".." || filepath.IsAbs(name) || strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("%w: %q", ErrInvalidName, name)
+	}
+	if strings.HasSuffix(name, ".toml") {
+		return fmt.Errorf("%w: omit .toml suffix in %q", ErrInvalidName, name)
+	}
+	return nil
+}
+
+func Parse(content string) (Preset, error) {
+	var p Preset
+	section := rootSection
+	currentWindow := -1
+	currentPane := -1
+	ignoredArray := false
+
+	for lineNo, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(stripComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[[") && strings.HasSuffix(line, "]]") {
+			name := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "[["), "]]"))
+			switch name {
+			case "windows":
+				p.Windows = append(p.Windows, Window{})
+				currentWindow = len(p.Windows) - 1
+				currentPane = -1
+				section = windowSection
+				ignoredArray = false
+			case "windows.panes":
+				if currentWindow < 0 {
+					return Preset{}, fmt.Errorf("line %d: windows.panes must follow a windows entry", lineNo+1)
+				}
+				p.Windows[currentWindow].Panes = append(p.Windows[currentWindow].Panes, Pane{})
+				currentPane = len(p.Windows[currentWindow].Panes) - 1
+				section = paneSection
+				ignoredArray = false
+			default:
+				section = ignoredSection
+				ignoredArray = true
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = ignoredSection
+			ignoredArray = true
+			continue
+		}
+		key, rawValue, ok := strings.Cut(line, "=")
+		if !ok {
+			return Preset{}, fmt.Errorf("line %d: expected key = value", lineNo+1)
+		}
+		if ignoredArray {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		rawValue = strings.TrimSpace(rawValue)
+		if key == "" {
+			return Preset{}, fmt.Errorf("line %d: empty key", lineNo+1)
+		}
+		if err := applyValue(&p, section, currentWindow, currentPane, key, rawValue, lineNo+1); err != nil {
+			return Preset{}, err
+		}
+	}
+	return p.Normalize(), nil
+}
+
+func Render(p Preset) string {
+	p = p.Normalize()
+	var b strings.Builder
+	b.WriteString("schema_version = ")
+	b.WriteString(strconv.Itoa(p.SchemaVersion))
+	b.WriteString("\n")
+	if p.Description != "" {
+		b.WriteString("description = ")
+		b.WriteString(strconv.Quote(p.Description))
+		b.WriteString("\n")
+	}
+	b.WriteString("mode = ")
+	b.WriteString(strconv.Quote(p.Mode))
+	b.WriteString("\n")
+	if p.DefaultCWD != "" {
+		b.WriteString("default_cwd = ")
+		b.WriteString(strconv.Quote(p.DefaultCWD))
+		b.WriteString("\n")
+	}
+	for _, window := range p.Windows {
+		b.WriteString("\n[[windows]]\n")
+		b.WriteString("index = ")
+		b.WriteString(strconv.Itoa(window.Index))
+		b.WriteString("\n")
+		if window.Name != "" {
+			b.WriteString("name = ")
+			b.WriteString(strconv.Quote(window.Name))
+			b.WriteString("\n")
+		}
+		if window.Layout != "" {
+			b.WriteString("layout = ")
+			b.WriteString(strconv.Quote(window.Layout))
+			b.WriteString("\n")
+		}
+		b.WriteString("active_pane_index = ")
+		b.WriteString(strconv.Itoa(window.ActivePaneIndex))
+		b.WriteString("\n")
+		for _, pane := range window.Panes {
+			b.WriteString("\n[[windows.panes]]\n")
+			b.WriteString("index = ")
+			b.WriteString(strconv.Itoa(pane.Index))
+			b.WriteString("\n")
+			b.WriteString("cwd = ")
+			b.WriteString(strconv.Quote(pane.CWD))
+			b.WriteString("\n")
+			switch pane.Recipe.Kind {
+			case sessionstate.RecipeKindStartup:
+				b.WriteString("command = ")
+				b.WriteString(strconv.Quote(strings.TrimSpace(pane.Recipe.Command)))
+				b.WriteString("\n")
+			case sessionstate.RecipeKindAgent:
+				b.WriteString("recipe = ")
+				b.WriteString(strconv.Quote(sessionstate.RecipeKindAgent))
+				b.WriteString("\n")
+				b.WriteString("agent = ")
+				b.WriteString(strconv.Quote(pane.Recipe.Agent))
+				b.WriteString("\n")
+				if pane.Recipe.ResumeID != "" {
+					b.WriteString("resume_id = ")
+					b.WriteString(strconv.Quote(pane.Recipe.ResumeID))
+					b.WriteString("\n")
+				}
+				if pane.Recipe.Topic != "" {
+					b.WriteString("topic = ")
+					b.WriteString(strconv.Quote(pane.Recipe.Topic))
+					b.WriteString("\n")
+				}
+			default:
+				b.WriteString("recipe = ")
+				b.WriteString(strconv.Quote(sessionstate.RecipeKindShell))
+				b.WriteString("\n")
+			}
+		}
+	}
+	return b.String()
+}
+
+func ToSnapshot(p Preset, session, projectRoot string, now time.Time) (sessionstate.Snapshot, error) {
+	p = p.Normalize()
+	if err := p.Validate(); err != nil {
+		return sessionstate.Snapshot{}, err
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	snap := sessionstate.Snapshot{
+		Version:    sessionstate.Version,
+		Session:    session,
+		DefaultCWD: expandPath(p.DefaultCWD, projectRoot, session),
+		SavedAt:    now,
+		Windows:    make([]sessionstate.Window, 0, len(p.Windows)),
+	}
+	for _, window := range p.Windows {
+		out := sessionstate.Window{
+			Index:           window.Index,
+			Name:            window.Name,
+			Layout:          window.Layout,
+			ActivePaneIndex: window.ActivePaneIndex,
+			Panes:           make([]sessionstate.Pane, 0, len(window.Panes)),
+		}
+		for _, pane := range window.Panes {
+			out.Panes = append(out.Panes, sessionstate.Pane{
+				Index:  pane.Index,
+				CWD:    expandPath(pane.CWD, projectRoot, session),
+				Recipe: pane.Recipe,
+			})
+		}
+		snap.Windows = append(snap.Windows, out)
+	}
+	if err := snap.Validate(); err != nil {
+		return sessionstate.Snapshot{}, err
+	}
+	return snap, nil
+}
+
+type parserSection int
+
+const (
+	rootSection parserSection = iota
+	windowSection
+	paneSection
+	ignoredSection
+)
+
+func applyValue(p *Preset, section parserSection, currentWindow, currentPane int, key, raw string, lineNo int) error {
+	switch section {
+	case rootSection:
+		switch key {
+		case "schema_version":
+			n, err := parseIntValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: schema_version: %w", lineNo, err)
+			}
+			p.SchemaVersion = n
+		case "description":
+			value, err := parseStringValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: description: %w", lineNo, err)
+			}
+			p.Description = value
+		case "mode":
+			value, err := parseStringValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: mode: %w", lineNo, err)
+			}
+			p.Mode = value
+		case "default_cwd":
+			value, err := parseStringValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: default_cwd: %w", lineNo, err)
+			}
+			p.DefaultCWD = value
+		}
+	case windowSection:
+		if currentWindow < 0 {
+			return fmt.Errorf("line %d: window field without window", lineNo)
+		}
+		window := &p.Windows[currentWindow]
+		switch key {
+		case "index":
+			n, err := parseIntValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: window index: %w", lineNo, err)
+			}
+			window.Index = n
+		case "name":
+			value, err := parseStringValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: window name: %w", lineNo, err)
+			}
+			window.Name = value
+		case "layout":
+			value, err := parseStringValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: window layout: %w", lineNo, err)
+			}
+			window.Layout = value
+		case "active_pane_index":
+			n, err := parseIntValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: window active_pane_index: %w", lineNo, err)
+			}
+			window.ActivePaneIndex = n
+		}
+	case paneSection:
+		if currentWindow < 0 || currentPane < 0 {
+			return fmt.Errorf("line %d: pane field without pane", lineNo)
+		}
+		pane := &p.Windows[currentWindow].Panes[currentPane]
+		switch key {
+		case "index":
+			n, err := parseIntValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: pane index: %w", lineNo, err)
+			}
+			pane.Index = n
+		case "cwd":
+			value, err := parseStringValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: pane cwd: %w", lineNo, err)
+			}
+			pane.CWD = value
+		case "recipe":
+			value, err := parseStringValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: pane recipe: %w", lineNo, err)
+			}
+			pane.Recipe.Kind = value
+		case "command":
+			value, err := parseStringValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: pane command: %w", lineNo, err)
+			}
+			pane.Command = value
+			pane.Recipe = sessionstate.StartupRecipe(value)
+		case "agent":
+			value, err := parseStringValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: pane agent: %w", lineNo, err)
+			}
+			pane.Agent = value
+		case "resume_id":
+			value, err := parseStringValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: pane resume_id: %w", lineNo, err)
+			}
+			pane.ResumeID = value
+		case "topic":
+			value, err := parseStringValue(raw)
+			if err != nil {
+				return fmt.Errorf("line %d: pane topic: %w", lineNo, err)
+			}
+			pane.Topic = value
+		}
+	}
+	return nil
+}
+
+func validatePaneRecipe(wi, pi int, pane Pane) error {
+	for label, value := range map[string]string{
+		"agent":     pane.Agent,
+		"resume_id": pane.ResumeID,
+		"topic":     pane.Topic,
+		"command":   pane.Command,
+	} {
+		if err := validatePlaceholders(fmt.Sprintf("window %d pane %d %s", wi, pi, label), value); err != nil {
+			return err
+		}
+	}
+	return pane.Recipe.Validate()
+}
+
+func validatePath(label, value string, optional bool) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		if optional {
+			return nil
+		}
+		return fmt.Errorf("%w: %s is required", ErrInvalidPreset, label)
+	}
+	if err := validatePlaceholders(label, value); err != nil {
+		return err
+	}
+	if strings.HasPrefix(value, "${PROJMUX_CWD}") {
+		return nil
+	}
+	if filepath.IsAbs(value) {
+		return nil
+	}
+	return fmt.Errorf("%w: %s must be absolute or start with ${PROJMUX_CWD}", ErrInvalidPreset, label)
+}
+
+func validatePlaceholders(label, value string) error {
+	for _, match := range placeholderPattern.FindAllStringSubmatch(value, -1) {
+		if len(match) != 2 {
+			continue
+		}
+		switch match[1] {
+		case "PROJMUX_CWD", "PROJMUX_SESSION":
+		default:
+			return fmt.Errorf("%w: %s uses unsupported placeholder ${%s}", ErrInvalidPreset, label, match[1])
+		}
+	}
+	return nil
+}
+
+func parseStringValue(value string) (string, error) {
+	if !strings.HasPrefix(value, `"`) {
+		return "", fmt.Errorf("value must be a quoted string")
+	}
+	decoded, err := strconv.Unquote(value)
+	if err != nil {
+		return "", fmt.Errorf("invalid quoted string: %w", err)
+	}
+	return decoded, nil
+}
+
+func parseIntValue(value string) (int, error) {
+	n, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil {
+		return 0, fmt.Errorf("value must be an integer")
+	}
+	return n, nil
+}
+
+func stripComment(line string) string {
+	inString := false
+	escaped := false
+	for i, r := range line {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inString && r == '\\' {
+			escaped = true
+			continue
+		}
+		if r == '"' {
+			inString = !inString
+			continue
+		}
+		if !inString && r == '#' {
+			return line[:i]
+		}
+	}
+	return line
+}
+
+func normalizeMode(mode string) string {
+	mode = strings.TrimSpace(mode)
+	if mode == "" {
+		return ModeInheritAutosave
+	}
+	return mode
+}
+
+func paneFromSnapshot(pane sessionstate.Pane, projectRoot string) Pane {
+	out := Pane{
+		Index:  pane.Index,
+		CWD:    portablePath(pane.CWD, projectRoot),
+		Recipe: pane.Recipe,
+	}
+	switch pane.Recipe.Kind {
+	case sessionstate.RecipeKindStartup:
+		out.Command = strings.TrimSpace(pane.Recipe.Command)
+	case sessionstate.RecipeKindAgent:
+		out.Agent = pane.Recipe.Agent
+		out.ResumeID = pane.Recipe.ResumeID
+		out.Topic = pane.Recipe.Topic
+	}
+	return out
+}
+
+func portablePath(path, projectRoot string) string {
+	path = filepath.Clean(strings.TrimSpace(path))
+	projectRoot = filepath.Clean(strings.TrimSpace(projectRoot))
+	if path == "" || projectRoot == "" {
+		return path
+	}
+	rel, err := filepath.Rel(projectRoot, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return path
+	}
+	if rel == "." {
+		return "${PROJMUX_CWD}"
+	}
+	return "${PROJMUX_CWD}/" + filepath.ToSlash(rel)
+}
+
+func expandPath(path, projectRoot, session string) string {
+	path = strings.ReplaceAll(path, "${PROJMUX_SESSION}", session)
+	if path == "${PROJMUX_CWD}" {
+		return filepath.Clean(projectRoot)
+	}
+	if after, ok := strings.CutPrefix(path, "${PROJMUX_CWD}/"); ok {
+		return filepath.Join(projectRoot, filepath.FromSlash(after))
+	}
+	return path
+}
+
+func presetEntry(name, path string, preset Preset) Entry {
+	panes := 0
+	for _, window := range preset.Windows {
+		panes += len(window.Panes)
+	}
+	return Entry{
+		Name:        name,
+		Path:        path,
+		Description: preset.Description,
+		Mode:        preset.Mode,
+		Windows:     len(preset.Windows),
+		Panes:       panes,
+	}
+}

--- a/internal/core/layout/layout_test.go
+++ b/internal/core/layout/layout_test.go
@@ -1,0 +1,151 @@
+package layout
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/integrations/sessionstate"
+)
+
+func TestStoreListDiscoversValidPresetsAndWarnsMalformed(t *testing.T) {
+	t.Parallel()
+
+	project := t.TempDir()
+	store := NewStore(project)
+	mustWrite(t, filepath.Join(store.Dir(), "dev.toml"), `
+schema_version = 1
+description = "Daily dev"
+mode = "fresh-each-time"
+unknown = "ignored"
+
+[[windows]]
+index = 0
+name = "main"
+layout = "layout"
+active_pane_index = 0
+extra = "ignored"
+
+[[windows.panes]]
+index = 0
+cwd = "${PROJMUX_CWD}"
+command = "make watch"
+`)
+	mustWrite(t, filepath.Join(store.Dir(), "broken.toml"), `
+schema_version = 1
+[[windows.panes]]
+index = 0
+cwd = "${PROJMUX_CWD}"
+`)
+
+	entries, warnings, err := store.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "dev" {
+		t.Fatalf("entries = %#v, want dev only", entries)
+	}
+	if entries[0].Mode != ModeFreshEachTime || entries[0].Windows != 1 || entries[0].Panes != 1 {
+		t.Fatalf("entry = %#v, want summarized preset", entries[0])
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0].Path, "broken.toml") {
+		t.Fatalf("warnings = %#v, want malformed warning", warnings)
+	}
+}
+
+func TestLoadDefaultsModeAndSupportsStartupCommand(t *testing.T) {
+	t.Parallel()
+
+	project := t.TempDir()
+	store := NewStore(project)
+	mustWrite(t, filepath.Join(store.Dir(), "review.toml"), `
+schema_version = 1
+
+[[windows]]
+index = 0
+active_pane_index = 0
+
+[[windows.panes]]
+index = 0
+cwd = "${PROJMUX_CWD}/service"
+command = "nvim ."
+`)
+
+	preset, err := store.Load("review")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if preset.Mode != ModeInheritAutosave {
+		t.Fatalf("Mode = %q, want default inherit", preset.Mode)
+	}
+	if got := preset.Windows[0].Panes[0].Recipe; got.Kind != sessionstate.RecipeKindStartup || got.Command != "nvim ." {
+		t.Fatalf("Recipe = %#v, want startup command", got)
+	}
+}
+
+func TestLoadRejectsUnsupportedPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	project := t.TempDir()
+	store := NewStore(project)
+	mustWrite(t, filepath.Join(store.Dir(), "bad.toml"), `
+schema_version = 1
+
+[[windows]]
+index = 0
+active_pane_index = 0
+
+[[windows.panes]]
+index = 0
+cwd = "${HOME}"
+recipe = "shell"
+`)
+
+	_, err := store.Load("bad")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrInvalidPreset) || !strings.Contains(err.Error(), "${HOME}") {
+		t.Fatalf("error = %v, want unsupported placeholder validation", err)
+	}
+}
+
+func TestToSnapshotInterpolatesAllowedPlaceholders(t *testing.T) {
+	t.Parallel()
+
+	preset, err := Parse(`
+schema_version = 1
+
+[[windows]]
+index = 0
+active_pane_index = 0
+
+[[windows.panes]]
+index = 0
+cwd = "${PROJMUX_CWD}/pkg"
+recipe = "shell"
+`)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	snap, err := ToSnapshot(preset, "workspace", "/repo", time.Time{})
+	if err != nil {
+		t.Fatalf("ToSnapshot() error = %v", err)
+	}
+	if got := snap.Windows[0].Panes[0].CWD; got != "/repo/pkg" {
+		t.Fatalf("CWD = %q, want interpolated project path", got)
+	}
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(body, "\n")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- add project layout preset schema/discovery for `.projmux/layouts/*.toml`
- validate supported placeholders `${PROJMUX_CWD}` and `${PROJMUX_SESSION}`
- add `projmux layout list [--json]` and `projmux layout show <name>`
- document deferred `save`, `remove`, and `apply` commands

## Deferred
- `projmux layout save`
- `projmux layout remove`
- `projmux layout apply`
- shell session picker

## Validation
- go test ./internal/core/layout
- go test ./internal/app -run "TestLayout|TestAppRunLayout"
- make fmt
- make fix
- make test
- git diff --check
- make test-integration (blocked locally: docker not available in this WSL distro)
- make test-e2e (blocked locally: docker not available in this WSL distro)