### PR TITLE
feat(ai): ingest Claude hook events

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -35,6 +35,7 @@
 - `make test` also covers the statusbar Session State popup entrypoint, manual save-now and restore dry-run preview actions, missing-snapshot messaging, and `projmux tmux sessionstate-status` helper wiring.
 - `make test` also covers project layout preset schema/discovery for `.projmux/layouts/*.toml`, supported interpolation validation, malformed-file list warnings, and user-facing `projmux layout list|show|save|remove|apply` behavior including portable save paths, `--description`, `--fresh`, `remove --force` safety, apply dry-run conversion to the session-state restore preview, missing current-session failure, and the deferred destructive `apply --force` error.
 - `make test` also covers `projmux ai integrate codex` legacy Codex notify config install/idempotence, dry-run preview, unmanaged `notify = ...` conflict refusal, and managed-block removal.
+- `make test` also covers `projmux ai ingest claude-hook` core Claude Code hook ingest for event parsing, transcript fallback, permission summary formatting, UserPromptSubmit busy/no-queue behavior, Notification severity/text mapping, and hook-active pane marking.
 - `make test` also now covers onboarding revisit and welcome wiring (`projmux welcome`, `Settings > About > Welcome`, `pending_attach_welcome`, attach-time `welcome --popup` one-time claim/env suppression/tmux popup payload, and generated `client-attached` app config wiring) via shell welcome tests.
 - Current focused unit coverage also includes strict notify SOT behavior
   (TTL does not remove rows, focus success and target-gone clicks ack,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -340,6 +340,7 @@ projmux ai status   set <thinking|waiting|idle> [--pane <id>]
 projmux ai notify   <reset|notify> [--pane <id>]
 projmux ai watch-title [--pane <id>]
 projmux ai ingest   codex-notify '<json>'
+projmux ai ingest   claude-hook < payload.json
 projmux ai integrate codex [--dry-run] [--remove]
 projmux ai topic     ...
 ```
@@ -357,6 +358,21 @@ hook-active, sets AI state to waiting, and writes a metadata-bearing notify
 queue entry. Panes marked `@projmux_ai_hook_active=1` are skipped by the
 title watcher.
 
+`ingest claude-hook` is the hook-facing entrypoint for Claude Code hooks. It
+reads one JSON payload from stdin and handles the core hook events:
+`Notification`, `Stop`, `UserPromptSubmit`, and `PermissionRequest`. It uses
+the same pane matching order as Codex ingest (`$TMUX_PANE`, payload `cwd`, then
+cached session id), marks matched panes hook-active, and writes
+metadata-bearing notify queue entries for reply-ready, input-ready, and
+approval-required events. `UserPromptSubmit` only moves the pane to
+thinking/busy and does not push a queue entry.
+
+For `Stop`, projmux reads `transcript_path` when present and extracts the last
+assistant text from the transcript tail; if that is unavailable, it falls back
+to a generic Claude completion row. `PermissionRequest` rows expose the tool
+name plus a concise input summary, preferring Bash commands, file paths, and
+URLs when those fields exist.
+
 `integrate codex` manages legacy Codex `notify` wiring in
 `~/.codex/config.toml`:
 
@@ -371,7 +387,8 @@ already contains an unmanaged `notify = ...` setting, projmux refuses to
 install over it and leaves the file untouched; use `--dry-run` to inspect the
 conflict and then edit the user-owned setting manually if needed.
 
-Claude Code hooks, Codex hooks-engine mode, and tmux bell integration are not
+Claude Code hook ingest is available through `ingest claude-hook`, but
+`integrate claude`, Codex hooks-engine mode, and tmux bell integration are not
 part of this command yet.
 
 ## tmux

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -252,6 +252,31 @@ notify has a single command slot.
 Codex hooks-engine mode, Claude Code hooks, and tmux bell fallback integration
 remain future slices.
 
+## Claude Code Hook Ingest
+
+`projmux ai ingest claude-hook` is the conservative core ingest path for
+Claude Code hooks. It reads a single JSON payload from stdin and currently
+handles these events:
+
+| Event | Behavior |
+| --- | --- |
+| `UserPromptSubmit` | marks the matched pane hook-active and sets AI state to thinking/busy; no notify queue entry is pushed |
+| `Notification` | pushes a Claude notify row for response-ready, approval-required, or input-ready based on `notification_type` |
+| `PermissionRequest` | pushes a critical approval row with the tool name and a concise tool input summary |
+| `Stop` | pushes a Claude completion row, using the last assistant transcript text when `transcript_path` is readable |
+
+Pane matching follows the shared AI ingest order: inherited `$TMUX_PANE`, then
+payload `cwd`, then cached session id pane options. A matched pane is marked
+with `@projmux_ai_hook_active=1`, so `projmux ai watch-title` skips the pane
+and hook payloads become the primary signal.
+
+The Claude hook payload is intentionally accepted directly at the ingest
+boundary; `projmux ai integrate claude` is still deferred, so users must wire
+Claude settings manually for now. Deferred Claude events include
+`StopFailure`, `SubagentStop`, and `TeammateIdle`. Dedupe across simultaneous
+Claude events is also deferred; the current slice keeps each supported hook
+event explicit.
+
 ## Pre Create Abort
 
 `pre-create` runs before `tmux new-session` on creation paths. A non-zero exit,

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -48,6 +48,7 @@ type aiCommand struct {
 	executable   func() (string, error)
 	lookupEnv    func(string) string
 	homeDir      func() (string, error)
+	stdin        io.Reader
 	readFile     func(string) ([]byte, error)
 	writeFile    func(string, []byte, os.FileMode) error
 	mkdirAll     func(string, os.FileMode) error
@@ -64,6 +65,7 @@ func newAICommand() *aiCommand {
 		executable:   os.Executable,
 		lookupEnv:    os.Getenv,
 		homeDir:      os.UserHomeDir,
+		stdin:        os.Stdin,
 		readFile:     os.ReadFile,
 		writeFile:    os.WriteFile,
 		mkdirAll:     os.MkdirAll,
@@ -2220,7 +2222,8 @@ func printAIUsage(w io.Writer) {
 	fmt.Fprintln(w, "  projmux ai status set <thinking|waiting|idle> [pane]")
 	fmt.Fprintln(w, "  projmux ai notify [notify|reset] [pane]")
 	fmt.Fprintln(w, "  projmux ai watch-title [pane]")
-	fmt.Fprintln(w, "  projmux ai ingest <codex-notify> <json>")
+	fmt.Fprintln(w, "  projmux ai ingest codex-notify <json>")
+	fmt.Fprintln(w, "  projmux ai ingest claude-hook < payload.json")
 	fmt.Fprintln(w, "  projmux ai integrate codex [--dry-run] [--remove]")
 	fmt.Fprintln(w, "  projmux ai topic set <text> [--pane <id>]")
 	fmt.Fprintln(w, "  projmux ai topic clear [--pane <id>]")

--- a/internal/app/ai_ingest.go
+++ b/internal/app/ai_ingest.go
@@ -5,11 +5,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
+	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/crevissepartners/projmux/internal/core/notify"
 )
 
 const aiIngestListPanesFormat = "#{pane_id}\x1f#{pane_current_path}\x1f#{" + aiPaneThreadIDOption + "}\x1f#{" + aiPaneSessionIDOption + "}"
+const claudeTranscriptTailLimit = 256 * 1024
 
 type codexNotifyPayload struct {
 	Type                 string
@@ -36,6 +41,19 @@ type aiPaneMatchRow struct {
 	SessionID string
 }
 
+type claudeHookPayload struct {
+	EventName        string
+	SessionID        string
+	CWD              string
+	TranscriptPath   string
+	NotificationType string
+	Message          string
+	Prompt           string
+	ToolName         string
+	ToolUseID        string
+	ToolInput        map[string]any
+}
+
 func (c *aiCommand) runIngest(args []string, stderr io.Writer) error {
 	if len(args) < 1 {
 		printAIUsage(stderr)
@@ -48,6 +66,23 @@ func (c *aiCommand) runIngest(args []string, stderr io.Writer) error {
 			return errors.New("ai ingest codex-notify requires a JSON payload argument")
 		}
 		return c.ingestCodexNotify([]byte(args[1]))
+	case "claude-hook":
+		if len(args) != 1 {
+			printAIUsage(stderr)
+			return errors.New("ai ingest claude-hook reads JSON from stdin and accepts no payload arguments")
+		}
+		reader := c.stdin
+		if reader == nil {
+			reader = os.Stdin
+		}
+		data, err := io.ReadAll(io.LimitReader(reader, 1024*1024+1))
+		if err != nil {
+			return fmt.Errorf("read claude hook payload: %w", err)
+		}
+		if len(data) > 1024*1024 {
+			return errors.New("claude hook payload exceeds 1 MiB")
+		}
+		return c.ingestClaudeHook(data)
 	case "help", "--help", "-h":
 		printAIUsage(stderr)
 		return nil
@@ -102,6 +137,62 @@ func (c *aiCommand) ingestCodexNotify(data []byte) error {
 	return c.applyAIStatusWithNotify("waiting", paneID, notifyInput)
 }
 
+func (c *aiCommand) ingestClaudeHook(data []byte) error {
+	payload, err := parseClaudeHookPayload(data)
+	if err != nil {
+		return err
+	}
+
+	paneID := c.matchAIPane(aiPaneMatchInput{
+		CWD:       payload.CWD,
+		SessionID: payload.SessionID,
+	})
+	if paneID == "" {
+		return nil
+	}
+
+	c.markAIHookPane(paneID, aiModeClaude, payload.CWD, "", payload.SessionID, "")
+	metadata := payload.claudeMetadata()
+
+	switch payload.EventName {
+	case "UserPromptSubmit":
+		if topic := truncateRunes(payload.Prompt, 80); topic != "" {
+			_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneTopicOption, topic)
+		}
+		return c.applyAIStatusWithNotify("thinking", paneID, attentionNotifyInput{
+			Metadata: metadata,
+		})
+	case "Notification":
+		label, severity := claudeNotificationLabelSeverity(payload.NotificationType)
+		return c.applyAIStatusWithNotify("waiting", paneID, attentionNotifyInput{
+			ID:       claudeNotifyID(payload),
+			Text:     claudeNotifyText(label, payload.Message),
+			Severity: severity,
+			Metadata: metadata,
+			Force:    true,
+		})
+	case "PermissionRequest":
+		return c.applyAIStatusWithNotify("waiting", paneID, attentionNotifyInput{
+			ID:       claudePermissionNotifyID(payload),
+			Text:     claudePermissionNotifyText(payload),
+			Severity: notify.SeverityCritical,
+			Metadata: metadata,
+			Force:    true,
+		})
+	case "Stop":
+		message := readClaudeTranscriptLastAssistantText(payload.TranscriptPath)
+		return c.applyAIStatusWithNotify("waiting", paneID, attentionNotifyInput{
+			ID:       claudeStopNotifyID(payload),
+			Text:     claudeStopNotifyText(message),
+			Severity: notify.SeverityInfo,
+			Metadata: metadata,
+			Force:    true,
+		})
+	default:
+		return nil
+	}
+}
+
 func parseCodexNotifyPayload(data []byte) (codexNotifyPayload, error) {
 	var raw map[string]any
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -135,6 +226,51 @@ func parseCodexNotifyPayload(data []byte) (codexNotifyPayload, error) {
 	return payload, nil
 }
 
+func parseClaudeHookPayload(data []byte) (claudeHookPayload, error) {
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return claudeHookPayload{}, fmt.Errorf("parse claude hook payload: %w", err)
+	}
+	payload := claudeHookPayload{
+		EventName:        firstString(raw, "hook_event_name", "event_name"),
+		SessionID:        firstString(raw, "session_id", "session-id"),
+		CWD:              firstString(raw, "cwd", "workspace", "project_dir"),
+		TranscriptPath:   firstString(raw, "transcript_path", "transcriptPath"),
+		NotificationType: firstString(raw, "notification_type", "notificationType"),
+		Message:          firstString(raw, "message", "text"),
+		Prompt:           firstString(raw, "prompt", "user_prompt"),
+		ToolName:         firstString(raw, "tool_name", "toolName"),
+		ToolUseID:        firstString(raw, "tool_use_id", "toolUseID", "id"),
+	}
+	if payload.CWD == "" {
+		payload.CWD = firstNestedString(raw["workspace"], "cwd", "path")
+	}
+	if payload.Message == "" {
+		payload.Message = firstNestedString(raw["notification"], "message", "text")
+	}
+	if payload.NotificationType == "" {
+		payload.NotificationType = firstNestedString(raw["notification"], "notification_type", "type")
+	}
+	if payload.ToolName == "" {
+		payload.ToolName = firstNestedString(raw["tool"], "name", "tool_name")
+	}
+	if payload.ToolUseID == "" {
+		payload.ToolUseID = firstNestedString(raw["tool"], "id", "tool_use_id")
+	}
+	payload.ToolInput = mapFromAny(raw["tool_input"])
+	if len(payload.ToolInput) == 0 {
+		payload.ToolInput = mapFromAny(raw["input"])
+	}
+	if len(payload.ToolInput) == 0 {
+		payload.ToolInput = mapFromAny(raw["tool"])
+		delete(payload.ToolInput, "name")
+		delete(payload.ToolInput, "tool_name")
+		delete(payload.ToolInput, "id")
+		delete(payload.ToolInput, "tool_use_id")
+	}
+	return payload, nil
+}
+
 func (p codexNotifyPayload) codexMetadata() map[string]string {
 	metadata := map[string]string{
 		"agent":      aiModeCodex,
@@ -152,6 +288,52 @@ func (p codexNotifyPayload) codexMetadata() map[string]string {
 		}
 	}
 	return out
+}
+
+func (p claudeHookPayload) claudeMetadata() map[string]string {
+	metadata := map[string]string{
+		"agent":             aiModeClaude,
+		"event":             p.EventName,
+		"session_id":        p.SessionID,
+		"cwd":               p.CWD,
+		"transcript_path":   p.TranscriptPath,
+		"notification_type": p.NotificationType,
+		"prompt":            truncateRunes(p.Prompt, 60),
+		"tool_name":         p.ToolName,
+		"tool_use_id":       p.ToolUseID,
+	}
+	for key, value := range p.ToolInput {
+		if text := stringFromAny(value); text != "" {
+			metadata["tool_input."+key] = truncateRunes(text, 160)
+		}
+	}
+	out := make(map[string]string, len(metadata))
+	for k, v := range metadata {
+		if value := strings.TrimSpace(v); value != "" {
+			out[k] = value
+		}
+	}
+	return out
+}
+
+func (c *aiCommand) markAIHookPane(paneID, agent, cwd, threadID, sessionID, topic string) {
+	_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneHookActiveOption, "1")
+	_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneManagedOption, "1")
+	if agent != "" {
+		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneAgentOption, agent)
+	}
+	if cwd != "" {
+		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneContextOption, cwd)
+	}
+	if threadID != "" {
+		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneThreadIDOption, threadID)
+	}
+	if sessionID != "" {
+		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneSessionIDOption, sessionID)
+	}
+	if topic != "" {
+		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneTopicOption, topic)
+	}
 }
 
 func (c *aiCommand) matchAIPane(in aiPaneMatchInput) string {
@@ -237,6 +419,172 @@ func codexNotifyText(message string) string {
 	return text
 }
 
+func claudeNotificationLabelSeverity(notificationType string) (string, string) {
+	switch strings.TrimSpace(notificationType) {
+	case "permission_prompt":
+		return "승인 필요", notify.SeverityCritical
+	case "elicitation_dialog":
+		return "입력 필요", notify.SeverityCritical
+	case "idle_prompt":
+		return "응답 완료", notify.SeverityInfo
+	default:
+		return "응답 완료", notify.SeverityInfo
+	}
+}
+
+func claudeNotifyID(p claudeHookPayload) string {
+	parts := []string{"ai", "claude", "notification"}
+	if value := strings.TrimSpace(p.SessionID); value != "" {
+		parts = append(parts, value)
+	}
+	if value := strings.TrimSpace(p.NotificationType); value != "" {
+		parts = append(parts, value)
+	}
+	if value := strings.TrimSpace(p.Message); value != "" {
+		parts = append(parts, truncateRunes(value, 40))
+	}
+	return strings.Join(parts, ":")
+}
+
+func claudeNotifyText(label, message string) string {
+	text := "Claude · " + strings.TrimSpace(label)
+	if msg := truncateRunes(message, 80); msg != "" {
+		text += " · " + msg
+	}
+	return text
+}
+
+func claudePermissionNotifyID(p claudeHookPayload) string {
+	sessionID := strings.TrimSpace(p.SessionID)
+	toolUseID := strings.TrimSpace(p.ToolUseID)
+	switch {
+	case sessionID != "" && toolUseID != "":
+		return "ai:claude:permission:" + sessionID + ":" + toolUseID
+	case toolUseID != "":
+		return "ai:claude:permission:" + toolUseID
+	default:
+		return ""
+	}
+}
+
+func claudePermissionNotifyText(p claudeHookPayload) string {
+	toolName := strings.TrimSpace(p.ToolName)
+	if toolName == "" {
+		toolName = "Tool"
+	}
+	text := "Claude · 승인 필요 · " + toolName
+	if summary := formatClaudeToolInputSummary(toolName, p.ToolInput, p.ToolUseID); summary != "" {
+		text += ": " + summary
+	}
+	return text
+}
+
+func formatClaudeToolInputSummary(toolName string, input map[string]any, fallbackID string) string {
+	keys := []string{"command", "file_path", "path", "url"}
+	switch strings.TrimSpace(toolName) {
+	case "Bash":
+		keys = []string{"command", "description"}
+	case "Write", "Edit", "MultiEdit", "Read":
+		keys = []string{"file_path", "path"}
+	case "WebFetch", "WebSearch":
+		keys = []string{"url", "query"}
+	}
+	for _, key := range keys {
+		if value := stringFromAny(input[key]); value != "" {
+			return truncateRunes(value, 80)
+		}
+	}
+	if fallback := strings.TrimSpace(fallbackID); fallback != "" {
+		return fallback
+	}
+	return ""
+}
+
+func claudeStopNotifyID(p claudeHookPayload) string {
+	if sessionID := strings.TrimSpace(p.SessionID); sessionID != "" {
+		return "ai:claude:stop:" + sessionID
+	}
+	return ""
+}
+
+func claudeStopNotifyText(message string) string {
+	text := "Claude · 응답 완료"
+	if msg := truncateRunes(message, 80); msg != "" {
+		text += " · " + msg
+	}
+	return text
+}
+
+func readClaudeTranscriptLastAssistantText(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return ""
+	}
+	size := info.Size()
+	if size <= 0 {
+		return ""
+	}
+	start := int64(0)
+	if size > claudeTranscriptTailLimit {
+		start = size - claudeTranscriptTailLimit
+	}
+	buf := make([]byte, size-start)
+	if _, err := file.ReadAt(buf, start); err != nil && !errors.Is(err, io.EOF) {
+		return ""
+	}
+	lines := strings.Split(strings.TrimSpace(string(buf)), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if text := claudeAssistantTextFromJSONLine(lines[i]); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func claudeAssistantTextFromJSONLine(line string) string {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		return ""
+	}
+	if strings.EqualFold(stringFromAny(raw["role"]), "assistant") {
+		return claudeContentText(raw["content"])
+	}
+	message := mapFromAny(raw["message"])
+	if strings.EqualFold(stringFromAny(message["role"]), "assistant") {
+		return claudeContentText(message["content"])
+	}
+	return ""
+}
+
+func claudeContentText(value any) string {
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case []any:
+		for _, item := range v {
+			if text := firstNestedString(item, "text"); text != "" {
+				return text
+			}
+			if text := stringFromAny(item); text != "" {
+				return text
+			}
+		}
+	case map[string]any:
+		return firstString(v, "text", "content")
+	}
+	return ""
+}
+
 func firstString(raw map[string]any, keys ...string) string {
 	for _, key := range keys {
 		if value := stringFromAny(raw[key]); value != "" {
@@ -252,6 +600,15 @@ func firstNestedString(value any, keys ...string) string {
 		return ""
 	}
 	return firstString(nested, keys...)
+}
+
+func mapFromAny(value any) map[string]any {
+	if raw, ok := value.(map[string]any); ok {
+		out := make(map[string]any, len(raw))
+		maps.Copy(out, raw)
+		return out
+	}
+	return map[string]any{}
 }
 
 func stringFromAny(value any) string {

--- a/internal/app/ai_ingest_test.go
+++ b/internal/app/ai_ingest_test.go
@@ -4,9 +4,13 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/notify"
 )
 
 func TestParseCodexNotifyPayload(t *testing.T) {
@@ -137,6 +141,224 @@ func TestIngestCodexNotifyPushesWaitingStatusAndMetadata(t *testing.T) {
 	}
 }
 
+func TestParseClaudeHookPayload(t *testing.T) {
+	t.Parallel()
+
+	payload, err := parseClaudeHookPayload([]byte(`{
+		"hook_event_name": "PermissionRequest",
+		"session_id": "claude-session",
+		"cwd": "/repo/projmux",
+		"transcript_path": "/tmp/transcript.jsonl",
+		"tool_name": "Bash",
+		"tool_use_id": "tool-123",
+		"tool_input": {"command": "go test ./internal/app", "description": "run focused tests"}
+	}`))
+	if err != nil {
+		t.Fatalf("parseClaudeHookPayload() error = %v", err)
+	}
+	if payload.EventName != "PermissionRequest" || payload.SessionID != "claude-session" || payload.CWD != "/repo/projmux" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if payload.TranscriptPath != "/tmp/transcript.jsonl" || payload.ToolName != "Bash" || payload.ToolUseID != "tool-123" {
+		t.Fatalf("tool fields = %+v", payload)
+	}
+	if got := stringFromAny(payload.ToolInput["command"]); got != "go test ./internal/app" {
+		t.Fatalf("tool input command = %q", got)
+	}
+}
+
+func TestClaudeTranscriptReaderReturnsLastAssistantText(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	content := strings.Join([]string{
+		`{"role":"assistant","content":[{"type":"text","text":"first assistant"}]}`,
+		`{"role":"user","content":"thanks"}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"last assistant"}]}}`,
+	}, "\n")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := readClaudeTranscriptLastAssistantText(path); got != "last assistant" {
+		t.Fatalf("readClaudeTranscriptLastAssistantText() = %q", got)
+	}
+	if got := readClaudeTranscriptLastAssistantText(filepath.Join(t.TempDir(), "missing.jsonl")); got != "" {
+		t.Fatalf("missing transcript text = %q, want empty fallback", got)
+	}
+}
+
+func TestClaudePermissionTextFormatting(t *testing.T) {
+	t.Parallel()
+
+	got := claudePermissionNotifyText(claudeHookPayload{
+		ToolName:  "Bash",
+		ToolUseID: "tool-123",
+		ToolInput: map[string]any{"command": "rm -rf /tmp/old-cache"},
+	})
+	if got != "Claude · 승인 필요 · Bash: rm -rf /tmp/old-cache" {
+		t.Fatalf("Bash text = %q", got)
+	}
+
+	got = claudePermissionNotifyText(claudeHookPayload{
+		ToolName:  "WebFetch",
+		ToolUseID: "tool-456",
+		ToolInput: map[string]any{"url": "https://example.com/docs"},
+	})
+	if got != "Claude · 승인 필요 · WebFetch: https://example.com/docs" {
+		t.Fatalf("WebFetch text = %q", got)
+	}
+}
+
+func TestIngestClaudeUserPromptSetsThinkingWithoutQueue(t *testing.T) {
+	home := t.TempDir()
+	store := &stubNotifyStore{}
+	cmd := testAICommand(home)
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+	cmd.stdin = strings.NewReader(`{
+		"hook_event_name": "UserPromptSubmit",
+		"session_id": "claude-session",
+		"cwd": "/repo/projmux",
+		"prompt": "implement claude hook ingest"
+	}`)
+	cmd.lookupEnv = func(name string) string {
+		if name == "TMUX_PANE" {
+			return "%9"
+		}
+		return ""
+	}
+
+	err := cmd.Run([]string{"ingest", "claude-hook"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("Run ingest claude-hook UserPromptSubmit error = %v", err)
+	}
+	if len(store.pushed) != 0 {
+		t.Fatalf("push count = %d, want 0", len(store.pushed))
+	}
+	for _, want := range []recordedAICommand{
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%9", aiPaneHookActiveOption, "1"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%9", aiPaneAgentOption, aiModeClaude}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%9", aiPaneStateOption, "thinking"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%9", attentionStateOption, attentionStateBusy}},
+	} {
+		if !hasRecordedAICommand(cmdRecorder(cmd).commands, want) {
+			t.Fatalf("commands = %#v, missing %#v", cmdRecorder(cmd).commands, want)
+		}
+	}
+}
+
+func TestIngestClaudePermissionPushesCriticalQueueEntryAndHookMarker(t *testing.T) {
+	home := t.TempDir()
+	store := &stubNotifyStore{}
+	cmd := testAICommand(home)
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+	cmd.stdin = strings.NewReader(`{
+		"hook_event_name": "PermissionRequest",
+		"session_id": "claude-session",
+		"cwd": "/repo/projmux",
+		"tool_name": "Bash",
+		"tool_use_id": "tool-123",
+		"tool_input": {"command": "go test ./internal/app"}
+	}`)
+	cmd.readCommand = claudeIngestReadCommand("%7")
+
+	err := cmd.Run([]string{"ingest", "claude-hook"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("Run ingest claude-hook PermissionRequest error = %v", err)
+	}
+	for _, want := range []recordedAICommand{
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiPaneHookActiveOption, "1"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiPaneSessionIDOption, "claude-session"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiPaneStateOption, "waiting"}},
+	} {
+		if !hasRecordedAICommand(cmdRecorder(cmd).commands, want) {
+			t.Fatalf("commands = %#v, missing %#v", cmdRecorder(cmd).commands, want)
+		}
+	}
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1", len(store.pushed))
+	}
+	got := store.pushed[0]
+	if got.ID != "ai:claude:permission:claude-session:tool-123" {
+		t.Fatalf("ID = %q", got.ID)
+	}
+	if got.Text != "Claude · 승인 필요 · Bash: go test ./internal/app" {
+		t.Fatalf("Text = %q", got.Text)
+	}
+	if got.Severity != notify.SeverityCritical {
+		t.Fatalf("Severity = %q", got.Severity)
+	}
+	if got.Metadata["agent"] != "claude" || got.Metadata["event"] != "PermissionRequest" || got.Metadata["tool_input.command"] != "go test ./internal/app" {
+		t.Fatalf("Metadata = %#v", got.Metadata)
+	}
+}
+
+func TestIngestClaudeStopUsesTranscriptOrGenericFallback(t *testing.T) {
+	home := t.TempDir()
+	transcript := filepath.Join(t.TempDir(), "transcript.jsonl")
+	if err := os.WriteFile(transcript, []byte(`{"role":"assistant","content":[{"type":"text","text":"implemented and verified"}]}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := &stubNotifyStore{}
+	cmd := testAICommand(home)
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+	cmd.stdin = strings.NewReader(`{
+		"hook_event_name": "Stop",
+		"session_id": "claude-session",
+		"cwd": "/repo/projmux",
+		"transcript_path": "` + transcript + `"
+	}`)
+	cmd.readCommand = claudeIngestReadCommand("%7")
+	if err := cmd.Run([]string{"ingest", "claude-hook"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run ingest claude-hook Stop error = %v", err)
+	}
+	if len(store.pushed) != 1 || store.pushed[0].Text != "Claude · 응답 완료 · implemented and verified" {
+		t.Fatalf("pushed = %#v", store.pushed)
+	}
+
+	store = &stubNotifyStore{}
+	cmd = testAICommand(home)
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+	cmd.stdin = strings.NewReader(`{
+		"hook_event_name": "Stop",
+		"session_id": "claude-session",
+		"cwd": "/repo/projmux"
+	}`)
+	cmd.readCommand = claudeIngestReadCommand("%7")
+	if err := cmd.Run([]string{"ingest", "claude-hook"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run ingest claude-hook Stop without transcript error = %v", err)
+	}
+	if len(store.pushed) != 1 || store.pushed[0].Text != "Claude · 응답 완료" {
+		t.Fatalf("fallback pushed = %#v", store.pushed)
+	}
+}
+
+func TestIngestClaudeNotificationMapsInputReady(t *testing.T) {
+	home := t.TempDir()
+	store := &stubNotifyStore{}
+	cmd := testAICommand(home)
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+	cmd.stdin = strings.NewReader(`{
+		"hook_event_name": "Notification",
+		"session_id": "claude-session",
+		"cwd": "/repo/projmux",
+		"notification_type": "elicitation_dialog",
+		"message": "Need deployment target"
+	}`)
+	cmd.readCommand = claudeIngestReadCommand("%7")
+
+	if err := cmd.Run([]string{"ingest", "claude-hook"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run ingest claude-hook Notification error = %v", err)
+	}
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1", len(store.pushed))
+	}
+	got := store.pushed[0]
+	if got.Text != "Claude · 입력 필요 · Need deployment target" || got.Severity != notify.SeverityCritical {
+		t.Fatalf("pushed = %#v", got)
+	}
+}
+
 func TestAIWatchTitleSkipsHookActivePane(t *testing.T) {
 	home := t.TempDir()
 	cmd := testAICommand(home)
@@ -164,6 +386,29 @@ func TestAIWatchTitleSkipsHookActivePane(t *testing.T) {
 	}
 	if len(cmdRecorder(cmd).commands) != 0 {
 		t.Fatalf("commands = %#v, want no writes for hook-active pane", cmdRecorder(cmd).commands)
+	}
+}
+
+func claudeIngestReadCommand(paneID string) func(context.Context, string, ...string) ([]byte, error) {
+	return func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name != "tmux" {
+			return nil, os.ErrNotExist
+		}
+		switch {
+		case reflect.DeepEqual(args, []string{"list-panes", "-a", "-F", aiIngestListPanesFormat}):
+			return []byte(paneID + "\x1f/repo/projmux\x1f\x1f\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", paneID, "#{@projmux_ai_agent}"}):
+			return []byte("claude\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", paneID, "#S"}):
+			return []byte("workspace\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", paneID, "#{window_id}"}):
+			return []byte("@1\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", paneID, "#{pane_id}"}):
+			return []byte(paneID + "\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", paneID, "#{socket_path}"}):
+			return []byte("/tmp/tmux-1000/projmux\n"), nil
+		}
+		return nil, os.ErrNotExist
 	}
 }
 

--- a/internal/app/notify_producer.go
+++ b/internal/app/notify_producer.go
@@ -32,6 +32,7 @@ type attentionNotifyInput struct {
 	Lookup   attentionNotifyLookup
 	ID       string
 	Text     string
+	Severity string
 	Metadata map[string]string
 	Force    bool
 }
@@ -113,6 +114,10 @@ func (p *storeAttentionNotifyProducer) PushReplyReady(in attentionNotifyInput) {
 	if text == "" {
 		text = composeAttentionReplyText(agent, topic)
 	}
+	severity := strings.TrimSpace(in.Severity)
+	if severity == "" {
+		severity = notify.SeverityInfo
+	}
 	id := strings.TrimSpace(in.ID)
 	if id == "" {
 		id = buildAttentionNotifyID(session, resolvedPane)
@@ -126,7 +131,7 @@ func (p *storeAttentionNotifyProducer) PushReplyReady(in attentionNotifyInput) {
 	entry, _, err := p.store.Push(notify.PushInput{
 		ID:       id,
 		Text:     text,
-		Severity: notify.SeverityInfo,
+		Severity: severity,
 		Source:   notify.SourceAI,
 		Metadata: in.Metadata,
 		TTL:      ttl,


### PR DESCRIPTION
## Summary
- add projmux ai ingest claude-hook, reading one Claude hook JSON payload from stdin
- handle Notification, Stop, UserPromptSubmit, and PermissionRequest with pane matching and hook-active markers
- push metadata-bearing notify rows for completion, input-ready, and approval-required events, including concise tool summaries

## Validation
- go test ./internal/app -run 'Test(ParseClaude|Claude|IngestClaude|AIWatchTitle|ParseCodex|IngestCodex|MatchAIPane)'
- git diff --check HEAD~1
- make fmt
- make fix
- make test

## Deferred
- projmux ai integrate claude
- StopFailure, SubagentStop, and TeammateIdle events
- dedupe/source enum split and Codex hooks-engine mode