### PR TITLE
fix(ai): append Codex hooks after config

### DIFF
--- a/internal/app/ai_integrate.go
+++ b/internal/app/ai_integrate.go
@@ -299,7 +299,7 @@ func (c *aiCommand) planCodexHooksIntegration(remove, removeAllManaged bool) (co
 	if !includeFeatureInBlock {
 		nextConfig = ensureCodexHooksFeatureEnabled(nextConfig)
 	}
-	next := codexHooksBlockForEvents(includeFeatureInBlock, hookEvents) + nextConfig
+	next := appendCodexHooksBlock(nextConfig, codexHooksBlockForEvents(includeFeatureInBlock, hookEvents))
 	plan.next = next
 	plan.changed = next != current
 	if plan.changed {
@@ -632,6 +632,14 @@ func codexNotifyBlock() string {
 
 func codexHooksBlock(includeFeature bool) string {
 	return codexHooksBlockForEvents(includeFeature, defaultAIHookInstallEvents(aiHookProviderCodex))
+}
+
+func appendCodexHooksBlock(content, block string) string {
+	if strings.TrimSpace(content) == "" {
+		return block
+	}
+	content = strings.TrimRight(content, "\r\n")
+	return content + "\n\n" + block
 }
 
 func codexHooksBlockForEvents(includeFeature bool, events []string) string {

--- a/internal/app/ai_integrate_test.go
+++ b/internal/app/ai_integrate_test.go
@@ -179,6 +179,9 @@ command = "echo keep"
 	if strings.Count(got, "[features]") != 1 {
 		t.Fatalf("config duplicated [features]:\n%s", got)
 	}
+	if strings.Index(got, `model = "gpt-5.1-codex"`) > strings.Index(got, codexHooksMarkerBegin) {
+		t.Fatalf("managed hooks block was inserted before root config, which would scope root keys into the last hook table:\n%s", got)
+	}
 	codexHookEvents := defaultAIHookInstallEvents(aiHookProviderCodex)
 	if len(codexHookEvents) != 8 {
 		t.Fatalf("default Codex hook catalog has %d events, want 8", len(codexHookEvents))


### PR DESCRIPTION
## Summary
- append the managed Codex hooks block after existing config instead of prepending it
- add a regression assertion that root Codex config keys remain before the managed hook tables

## Why
TOML table context does not return to root after [[hooks.*]] tables. Prepending the managed hooks block scoped following root keys such as model into the last hook table, which could surface as duplicate-key or malformed config errors.

## Verification
- GOCACHE=/tmp/projmux-go-cache make fmt
- GOCACHE=/tmp/projmux-go-cache make fix
- GOCACHE=/tmp/projmux-go-cache make test
- git diff --check