### PR TITLE
fix(ai): parse tmux escaped bell fields

### DIFF
--- a/internal/app/ai_ingest.go
+++ b/internal/app/ai_ingest.go
@@ -321,7 +321,7 @@ func (c *aiCommand) readBellPaneInfo(paneID string) (bellPaneInfo, bool) {
 	if out == "" {
 		return bellPaneInfo{}, false
 	}
-	fields := strings.Split(out, "\x1f")
+	fields := splitTmuxUnitFields(out)
 	if len(fields) < 7 {
 		return bellPaneInfo{}, false
 	}
@@ -1032,7 +1032,7 @@ func (c *aiCommand) listAIPaneMatchRows() []aiPaneMatchRow {
 	rows := strings.Split(strings.TrimSpace(string(out)), "\n")
 	matches := make([]aiPaneMatchRow, 0, len(rows))
 	for _, raw := range rows {
-		fields := strings.Split(raw, "\x1f")
+		fields := splitTmuxUnitFields(raw)
 		if len(fields) != 4 {
 			continue
 		}
@@ -1048,6 +1048,13 @@ func (c *aiCommand) listAIPaneMatchRows() []aiPaneMatchRow {
 		})
 	}
 	return matches
+}
+
+func splitTmuxUnitFields(raw string) []string {
+	if strings.Contains(raw, "\x1f") {
+		return strings.Split(raw, "\x1f")
+	}
+	return strings.Split(raw, "\\037")
 }
 
 func cleanMatchPath(path string) string {

--- a/internal/app/ai_ingest_test.go
+++ b/internal/app/ai_ingest_test.go
@@ -434,7 +434,7 @@ func TestIngestBellPushesQueueEntryAndDedupesPane(t *testing.T) {
 		}
 		switch {
 		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%7", aiBellPaneFormat}):
-			return []byte("workspace\x1f@1\x1feditor\x1f%7\x1fClaude CLI\x1fnode\x1f/tmp/tmux-1000/projmux\n"), nil
+			return []byte("workspace\\037@1\\037editor\\037%7\\037Claude CLI\\037node\\037/tmp/tmux-1000/projmux\n"), nil
 		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%7", "#{" + aiBellDedupeOption + "}"}):
 			return []byte(lastBellAt + "\n"), nil
 		}
@@ -469,6 +469,20 @@ func TestIngestBellPushesQueueEntryAndDedupesPane(t *testing.T) {
 	}
 	if !hasRecordedAICommand(cmdRecorder(cmd).commands, recordedAICommand{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiBellDedupeOption, "100"}}) {
 		t.Fatalf("commands = %#v, want bell dedupe timestamp", cmdRecorder(cmd).commands)
+	}
+}
+
+func TestSplitTmuxUnitFieldsAcceptsRawAndEscapedSeparators(t *testing.T) {
+	for name, raw := range map[string]string{
+		"raw":     "one\x1ftwo\x1fthree",
+		"escaped": "one\\037two\\037three",
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := splitTmuxUnitFields(raw)
+			if !reflect.DeepEqual(got, []string{"one", "two", "three"}) {
+				t.Fatalf("splitTmuxUnitFields(%q) = %#v", raw, got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- accept tmux \037-escaped unit separators when parsing AI ingest pane rows
- fix tmux bell pane info parsing so existing panes are not reported as missing
- add regression coverage for raw and escaped separator forms

## Verification
- `GOCACHE=/tmp/projmux-go-cache go test ./internal/app -run 'Test(IngestBell|SplitTmuxUnitFields|IngestCodexNotify|IngestCodexHook|IngestClaude)'`
- `GOCACHE=/tmp/projmux-go-cache go run ./cmd/projmux ai ingest bell --pane %63`
- `projmux notify list`
- `projmux ai ingest log --tail 10`
- `GOCACHE=/tmp/projmux-go-cache make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `git diff --check`