### PR TITLE
fix(ai): use pane id for tmux bell hook

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -563,9 +563,11 @@ reviewing or trusting the hook through its `/hooks` flow before commands run.
 `integrate tmux-bell` is opt-in server-level tmux wiring for arbitrary tools
 that emit BEL or OSC 9. It applies `allow-passthrough on`, `monitor-bell on`,
 `bell-action other`, and appends a marked `alert-bell` hook that invokes
-`projmux ai ingest bell --pane "#{hook_pane}"`. `--dry-run` prints the tmux
-commands. `--remove` unsets only hook entries carrying the projmux marker and
-leaves user-owned `alert-bell` hooks alone.
+`projmux ai ingest bell --pane "#{pane_id}"`. `--dry-run` prints the tmux
+commands. tmux `alert-bell` is a window alert and does not expose
+`#{hook_pane}` on tmux 3.4, so `#{pane_id}` is the best available pane context.
+`--remove` unsets only hook entries carrying the projmux marker and leaves
+user-owned `alert-bell` hooks alone.
 
 ## tmux
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -408,7 +408,7 @@ server settings and appends a marked `alert-bell` hook:
 tmux set-option -g allow-passthrough on
 tmux set-option -g monitor-bell on
 tmux set-option -g bell-action other
-tmux set-hook -ag alert-bell run-shell -b 'projmux ai ingest bell --pane "#{hook_pane}" >/dev/null 2>&1 || true # projmux-managed:tmux-bell:v1'
+tmux set-hook -ag alert-bell run-shell -b 'projmux ai ingest bell --pane "#{pane_id}" >/dev/null 2>&1 || true # projmux-managed:tmux-bell:v1'
 ```
 
 The hook calls `projmux ai ingest bell --pane <pane_id>`. Bell ingest resolves
@@ -416,7 +416,9 @@ the target pane through tmux and pushes an info notify queue row such as
 `bell · Claude CLI`, with metadata including `agent=bell`, `event=bell`,
 session/window/pane, pane title, command, and socket path when available. The
 pane does not need `@projmux_ai_agent` or any other AI-managed option because
-this path is for unknown tools.
+this path is for unknown tools. tmux `alert-bell` is a window alert; tmux 3.4
+does not expose `#{hook_pane}` there, so projmux uses `#{pane_id}` as the best
+available pane context.
 
 Repeated bells from the same pane are suppressed for 5 seconds using a
 pane-local tmux timestamp option. The notify row also uses a stable

--- a/internal/app/ai_integrate.go
+++ b/internal/app/ai_integrate.go
@@ -27,7 +27,7 @@ const (
 
 	tmuxBellManagedMarker = "projmux-managed:tmux-bell:v1"
 	tmuxBellHookName      = "alert-bell"
-	tmuxBellHookCommand   = `run-shell -b 'projmux ai ingest bell --pane "#{hook_pane}" >/dev/null 2>&1 || true # ` + tmuxBellManagedMarker + `'`
+	tmuxBellHookCommand   = `run-shell -b 'projmux ai ingest bell --pane "#{pane_id}" >/dev/null 2>&1 || true # ` + tmuxBellManagedMarker + `'`
 )
 
 type codexNotifyPlan struct {

--- a/internal/app/ai_integrate_test.go
+++ b/internal/app/ai_integrate_test.go
@@ -720,7 +720,7 @@ func TestAIIntegrateTmuxBellDryRunPlansInstallCommands(t *testing.T) {
 		"set-option -g monitor-bell on",
 		"set-option -g bell-action other",
 		"set-hook -ag alert-bell",
-		"#{hook_pane}",
+		"#{pane_id}",
 		tmuxBellManagedMarker,
 	} {
 		if !strings.Contains(out, want) {


### PR DESCRIPTION
## Summary
- change tmux bell fallback hook from unsupported `#{hook_pane}` to `#{pane_id}`
- document tmux 3.4 alert-bell pane context behavior
- update tmux bell integration test expectations

## Verification
- `GOCACHE=/tmp/projmux-go-cache go test ./internal/app -run TestAIIntegrateTmuxBell`
- `GOCACHE=/tmp/projmux-go-cache make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `git diff --check`