### PR TITLE
fix: separate settings views from actions

### DIFF
--- a/internal/app/sessionstate_settings.go
+++ b/internal/app/sessionstate_settings.go
@@ -62,17 +62,23 @@ func (c *settingsCommand) runSessionStateSection(stdout, stderr io.Writer) error
 		if action == settingsNoopValue {
 			continue
 		}
-		if action == settingsSessionStateDelete {
-			confirmed, err := c.confirmSessionStateDelete()
-			if err != nil {
+		switch action {
+		case settingsSessionStateAutosaveDetail:
+			if err := c.runSessionStateToggleDetail("Session State - Auto-save", "Settings > Session State > Auto-save > ", func() []intpickercompat.Entry {
+				autosave := c.currentSessionStateAutosave()
+				return c.sessionStateToggleDetailEntries("Auto-save", "autosave", autosave.Mode, autosave.Source)
+			}, stdout, stderr); err != nil {
 				return err
 			}
-			if !confirmed {
-				continue
+		case settingsSessionStateStartupPickerDetail:
+			if err := c.runSessionStateToggleDetail("Session State - Startup picker", "Settings > Session State > Startup picker > ", func() []intpickercompat.Entry {
+				autorestore := c.currentSessionStateAutorestore()
+				return c.sessionStateToggleDetailEntries("Startup picker", "autorestore", autorestore.Mode, autorestore.Source)
+			}, stdout, stderr); err != nil {
+				return err
 			}
-		}
-		if err := c.execute(action, stdout, stderr); err != nil {
-			return err
+		default:
+			return fmt.Errorf("unknown session state settings action: %s", action)
 		}
 	}
 }
@@ -97,7 +103,111 @@ func (c *settingsCommand) runProjectSessionStateSection(stdout, stderr io.Writer
 		if action == settingsNoopValue {
 			continue
 		}
-		if action == settingsProjectSessionStateDelete {
+		switch action {
+		case settingsProjectSessionStateAutosaveDetail:
+			if err := c.runProjectSessionStateAutosaveDetail(stdout, stderr); err != nil {
+				return err
+			}
+		case settingsProjectSessionStateActionsDetail:
+			if err := c.runProjectSessionStateActionsDetail(stdout, stderr); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown project session state settings action: %s", action)
+		}
+	}
+}
+
+func (c *settingsCommand) runSessionStateToggleDetail(title, prompt string, entries func() []intpickercompat.Entry, stdout, stderr io.Writer) error {
+	for {
+		result, err := c.runPicker(intpickercompat.Options{
+			UI:         "settings-sessionstate-detail",
+			Entries:    entries(),
+			Title:      title,
+			Prompt:     prompt,
+			Footer:     projmuxFooter("Enter: apply  |  Back row: parent  |  Esc/Alt+5/Ctrl+Alt+S: close"),
+			ExpectKeys: []string{"enter"},
+			Bindings:   settingsCloseBindings(),
+		})
+		if err != nil {
+			return err
+		}
+		action := strings.TrimSpace(result.Value)
+		if result.Key != "enter" || action == "" {
+			return errSettingsClosed
+		}
+		switch {
+		case action == settingsBackValue:
+			return nil
+		case action == settingsNoopValue:
+			continue
+		case strings.HasPrefix(action, settingsActionPrefixSessionState):
+			if err := c.execute(action, stdout, stderr); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown session state detail action: %s", action)
+		}
+	}
+}
+
+func (c *settingsCommand) runProjectSessionStateAutosaveDetail(stdout, stderr io.Writer) error {
+	for {
+		result, err := c.runPicker(intpickercompat.Options{
+			UI:         "settings-project-sessionstate-autosave",
+			Entries:    c.projectSessionStateAutosaveDetailEntries(),
+			Title:      "Session State - Project auto-save",
+			Prompt:     "Settings > Project > Session State > Auto-save > ",
+			Footer:     projmuxFooter("Enter: apply  |  Back row: parent  |  Esc/Alt+5/Ctrl+Alt+S: close"),
+			ExpectKeys: []string{"enter"},
+			Bindings:   settingsCloseBindings(),
+		})
+		if err != nil {
+			return err
+		}
+		action := strings.TrimSpace(result.Value)
+		if result.Key != "enter" || action == "" {
+			return errSettingsClosed
+		}
+		switch {
+		case action == settingsBackValue:
+			return nil
+		case action == settingsNoopValue:
+			continue
+		case strings.HasPrefix(action, settingsActionPrefixSessionState):
+			if err := c.execute(action, stdout, stderr); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown project session state auto-save action: %s", action)
+		}
+	}
+}
+
+func (c *settingsCommand) runProjectSessionStateActionsDetail(stdout, stderr io.Writer) error {
+	for {
+		result, err := c.runPicker(intpickercompat.Options{
+			UI:         "settings-project-sessionstate-actions",
+			Entries:    c.projectSessionStateActionsDetailEntries(),
+			Title:      "Session State - Project snapshot actions",
+			Prompt:     "Settings > Project > Session State > Snapshot actions > ",
+			Footer:     projmuxFooter("Enter: action  |  Back row: parent  |  Esc/Alt+5/Ctrl+Alt+S: close"),
+			ExpectKeys: []string{"enter"},
+			Bindings:   settingsCloseBindings(),
+		})
+		if err != nil {
+			return err
+		}
+		action := strings.TrimSpace(result.Value)
+		if result.Key != "enter" || action == "" {
+			return errSettingsClosed
+		}
+		switch {
+		case action == settingsBackValue:
+			return nil
+		case action == settingsNoopValue:
+			continue
+		case action == settingsProjectSessionStateDelete:
 			confirmed, err := c.confirmProjectSessionStateDelete()
 			if err != nil {
 				return err
@@ -105,9 +215,15 @@ func (c *settingsCommand) runProjectSessionStateSection(stdout, stderr io.Writer
 			if !confirmed {
 				continue
 			}
-		}
-		if err := c.execute(action, stdout, stderr); err != nil {
-			return err
+			if err := c.execute(action, stdout, stderr); err != nil {
+				return err
+			}
+		case strings.HasPrefix(action, settingsActionPrefixSessionState):
+			if err := c.execute(action, stdout, stderr); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown project session state snapshot action: %s", action)
 		}
 	}
 }
@@ -142,12 +258,12 @@ func (c *settingsCommand) sessionStateEntries() []intpickercompat.Entry {
 	entries := []intpickercompat.Entry{
 		settingsBackEntry(),
 		{
-			Label: settingsLabelInfo("Auto-save", string(autosave.Mode), autosave.Source),
-			Value: settingsNoopValue,
+			Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Auto-save", string(autosave.Mode)+" - "+autosave.Source),
+			Value: settingsSessionStateAutosaveDetail,
 		},
 		{
-			Label: settingsLabelInfo("Startup picker", string(autorestore.Mode), autorestore.Source),
-			Value: settingsNoopValue,
+			Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Startup picker", string(autorestore.Mode)+" - "+autorestore.Source),
+			Value: settingsSessionStateStartupPickerDetail,
 		},
 		{
 			Label: settingsLabelInfo("Storage", "latest snapshot store", "per-session JSON under XDG state"),
@@ -158,8 +274,6 @@ func (c *settingsCommand) sessionStateEntries() []intpickercompat.Entry {
 			Value: settingsNoopValue,
 		},
 	}
-	entries = append(entries, c.sessionStateToggleEntries("Auto-save", "autosave", autosave.Mode)...)
-	entries = append(entries, c.sessionStateToggleEntries("Startup picker", "autorestore", autorestore.Mode)...)
 	return entries
 }
 
@@ -192,8 +306,8 @@ func (c *settingsCommand) projectSessionStateEntries() []intpickercompat.Entry {
 			Value: settingsNoopValue,
 		},
 		{
-			Label: settingsLabelInfo("Project auto-save", string(autosave.ProjectMode), autosave.ProjectSource),
-			Value: settingsNoopValue,
+			Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Project auto-save", string(autosave.ProjectMode)+" - "+autosave.ProjectSource),
+			Value: settingsProjectSessionStateAutosaveDetail,
 		},
 		{
 			Label: settingsLabelInfo("Effective auto-save", string(autosave.Mode), autosave.Source),
@@ -207,10 +321,99 @@ func (c *settingsCommand) projectSessionStateEntries() []intpickercompat.Entry {
 			Label: settingsLabelInfo("Global startup picker", string(autorestore.Mode), autorestore.Source),
 			Value: settingsNoopValue,
 		},
+		{
+			Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Snapshot actions", c.projectSessionStateActionsSummary(identity)),
+			Value: settingsProjectSessionStateActionsDetail,
+		},
 	}
-	entries = append(entries, c.projectSessionStateActionEntries(identity)...)
+	return entries
+}
+
+func (c *settingsCommand) sessionStateToggleDetailEntries(label, key string, current config.SessionStateToggle, source string) []intpickercompat.Entry {
+	entries := []intpickercompat.Entry{
+		settingsBackEntry(),
+		{
+			Label: settingsLabelInfo(label, string(current), source),
+			Value: settingsNoopValue,
+		},
+	}
+	entries = append(entries, c.sessionStateToggleEntries(label, key, current)...)
+	return entries
+}
+
+func (c *settingsCommand) projectSessionStateAutosaveDetailEntries() []intpickercompat.Entry {
+	identity := c.projectSessionStateIdentity(c.resolveSettingsProjectContext())
+	if identity.Err != nil {
+		return []intpickercompat.Entry{
+			settingsBackEntry(),
+			{
+				Label: settingsLabelInfo("Project", "unavailable", identity.Err.Error()),
+				Value: settingsNoopValue,
+			},
+		}
+	}
+	autosave := c.currentProjectSessionStateAutosave(identity)
+	entries := []intpickercompat.Entry{
+		settingsBackEntry(),
+		{
+			Label: settingsLabelInfo("Project auto-save", string(autosave.ProjectMode), autosave.ProjectSource),
+			Value: settingsNoopValue,
+		},
+		{
+			Label: settingsLabelInfo("Effective auto-save", string(autosave.Mode), autosave.Source),
+			Value: settingsNoopValue,
+		},
+		{
+			Label: settingsLabelInfo("Global auto-save", string(autosave.Global.Mode), autosave.Global.Source),
+			Value: settingsNoopValue,
+		},
+	}
 	entries = append(entries, c.projectSessionStateAutosaveToggleEntries(autosave.ProjectMode)...)
 	return entries
+}
+
+func (c *settingsCommand) projectSessionStateActionsDetailEntries() []intpickercompat.Entry {
+	identity := c.projectSessionStateIdentity(c.resolveSettingsProjectContext())
+	if identity.Err != nil {
+		return []intpickercompat.Entry{
+			settingsBackEntry(),
+			{
+				Label: settingsLabelInfo("Project", "unavailable", identity.Err.Error()),
+				Value: settingsNoopValue,
+			},
+		}
+	}
+	entries := []intpickercompat.Entry{
+		settingsBackEntry(),
+		{
+			Label: settingsLabelInfo("Project", identity.Project.Name, identity.Project.Path),
+			Value: settingsNoopValue,
+		},
+		{
+			Label: settingsLabelInfo("Session identity", identity.Session, "derived from project path"),
+			Value: settingsNoopValue,
+		},
+	}
+	entries = append(entries, c.projectSessionStateActionEntries(identity)...)
+	return entries
+}
+
+func (c *settingsCommand) projectSessionStateActionsSummary(identity projectSessionStateIdentity) string {
+	parts := []string{"latest/named save"}
+	if ok, reason := c.projectSessionStateLiveSessionAvailable(identity.Session); !ok {
+		parts = append(parts, "save unavailable: "+reason)
+	}
+	store, err := c.settingsSessionStateStore()
+	if err != nil {
+		parts = append(parts, "snapshot unavailable")
+		return strings.Join(parts, " - ")
+	}
+	if _, err := store.Summary(identity.Session); err != nil {
+		parts = append(parts, "snapshot missing")
+	} else {
+		parts = append(parts, "preview/delete available")
+	}
+	return strings.Join(parts, " - ")
 }
 
 func (c *settingsCommand) projectSessionStateActionEntries(identity projectSessionStateIdentity) []intpickercompat.Entry {
@@ -981,11 +1184,15 @@ func sessionStateToggleEnabledDefault(homeDir func() (string, error), lookupEnv 
 }
 
 const (
-	settingsProjectSessionStateSaveLatest = settingsActionPrefixSessionState + "project-save-latest"
-	settingsProjectSessionStateSaveNamed  = settingsActionPrefixSessionState + "project-save-named"
-	settingsProjectSessionStateSave       = settingsActionPrefixSessionState + "project-save"
-	settingsProjectSessionStatePreview    = settingsActionPrefixSessionState + "project-preview"
-	settingsProjectSessionStateDelete     = settingsActionPrefixSessionState + "project-delete"
-	settingsSessionStateConfirmYes        = "sessionstate:confirm-yes"
-	settingsSessionStateConfirmNo         = "sessionstate:confirm-no"
+	settingsSessionStateAutosaveDetail        = settingsActionPrefixSessionState + "view-autosave"
+	settingsSessionStateStartupPickerDetail   = settingsActionPrefixSessionState + "view-startup-picker"
+	settingsProjectSessionStateAutosaveDetail = settingsActionPrefixSessionState + "project-view-autosave"
+	settingsProjectSessionStateActionsDetail  = settingsActionPrefixSessionState + "project-view-actions"
+	settingsProjectSessionStateSaveLatest     = settingsActionPrefixSessionState + "project-save-latest"
+	settingsProjectSessionStateSaveNamed      = settingsActionPrefixSessionState + "project-save-named"
+	settingsProjectSessionStateSave           = settingsActionPrefixSessionState + "project-save"
+	settingsProjectSessionStatePreview        = settingsActionPrefixSessionState + "project-preview"
+	settingsProjectSessionStateDelete         = settingsActionPrefixSessionState + "project-delete"
+	settingsSessionStateConfirmYes            = "sessionstate:confirm-yes"
+	settingsSessionStateConfirmNo             = "sessionstate:confirm-no"
 )

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -2441,8 +2441,8 @@ func (c *settingsCommand) runLabsSection(stdout, stderr io.Writer) error {
 			}
 		case action == settingsLabsProjectHooks:
 			return c.runLabsProjectHooksSection(stdout, stderr)
-		case strings.HasPrefix(action, settingsActionPrefixSessionState):
-			if err := c.execute(action, stdout, stderr); err != nil {
+		case action == settingsLabsSidebarStartupPicker:
+			if err := c.runLabsSidebarStartupPickerSection(stdout, stderr); err != nil {
 				return err
 			}
 		case strings.HasPrefix(action, settingsActionPrefixHooks):
@@ -2451,6 +2451,39 @@ func (c *settingsCommand) runLabsSection(stdout, stderr io.Writer) error {
 			}
 		default:
 			return fmt.Errorf("unknown labs settings action: %s", action)
+		}
+	}
+}
+
+func (c *settingsCommand) runLabsSidebarStartupPickerSection(stdout, stderr io.Writer) error {
+	for {
+		result, err := c.runPicker(intpickercompat.Options{
+			UI:         "settings-labs-sidebar-startup-picker",
+			Entries:    c.labsSidebarStartupPickerEntries(),
+			Title:      "Labs - Sidebar startup picker",
+			Prompt:     "Settings > Labs > Sidebar startup picker > ",
+			Footer:     projmuxFooter("Enter: apply  |  Back row: parent  |  Esc/Alt+5/Ctrl+Alt+S: close"),
+			ExpectKeys: []string{"enter"},
+			Bindings:   settingsCloseBindings(),
+		})
+		if err != nil {
+			return err
+		}
+		action := strings.TrimSpace(result.Value)
+		if result.Key != "enter" || action == "" {
+			return errSettingsClosed
+		}
+		switch {
+		case action == settingsBackValue:
+			return nil
+		case action == settingsNoopValue:
+			continue
+		case strings.HasPrefix(action, settingsActionPrefixSessionState):
+			if err := c.execute(action, stdout, stderr); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown sidebar startup picker action: %s", action)
 		}
 	}
 }
@@ -2911,13 +2944,36 @@ func (c *settingsCommand) labsEntries() []intpickercompat.Entry {
 	current, source := c.currentPickerBackend()
 	hookMode, hookSource := c.currentProjectHooksMode()
 	sidebarStartup := c.currentSidebarStartupPicker()
-	entries := make([]intpickercompat.Entry, 0, 6)
+	entries := make([]intpickercompat.Entry, 0, 4)
 	entries = append(entries, settingsBackEntry())
 	entries = append(entries, intpickercompat.Entry{
 		Label:     settingsLabel(settingsGlyphOpen, settingsColorType, "Project Hooks", string(hookMode)+" - "+hookSource),
 		Value:     settingsLabsProjectHooks,
 		SearchKey: "Project Hooks trusted local hooks on off",
 	})
+	entries = append(entries, intpickercompat.Entry{
+		Label:     settingsLabel(settingsGlyphOpen, settingsColorType, "Sidebar startup picker", string(sidebarStartup.Mode)+" - "+sidebarStartup.Source),
+		Value:     settingsLabsSidebarStartupPicker,
+		SearchKey: "Sidebar startup picker Start project empty session on off",
+	})
+	if source != "" {
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabelInfo("Picker source", string(current), source),
+			Value: settingsNoopValue,
+		})
+	}
+	return entries
+}
+
+func (c *settingsCommand) labsSidebarStartupPickerEntries() []intpickercompat.Entry {
+	sidebarStartup := c.currentSidebarStartupPicker()
+	entries := []intpickercompat.Entry{
+		settingsBackEntry(),
+		{
+			Label: settingsLabelInfo("Sidebar startup picker", string(sidebarStartup.Mode), sidebarStartup.Source),
+			Value: settingsNoopValue,
+		},
+	}
 	for _, item := range []struct {
 		mode config.SessionStateToggle
 		desc string
@@ -2935,12 +2991,6 @@ func (c *settingsCommand) labsEntries() []intpickercompat.Entry {
 			Label:     settingsLabel(glyph, color, "Sidebar startup picker "+string(item.mode), item.desc+" - "+sidebarStartup.Source),
 			Value:     settingsActionPrefixSessionState + "sidebar-startup:" + string(item.mode),
 			SearchKey: "Sidebar startup picker Start project empty session on off",
-		})
-	}
-	if source != "" {
-		entries = append(entries, intpickercompat.Entry{
-			Label: settingsLabelInfo("Picker source", string(current), source),
-			Value: settingsNoopValue,
 		})
 	}
 	return entries

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -842,10 +842,14 @@ func TestSettingsHubKeepsLabsSectionWithoutPickerBackendChoices(t *testing.T) {
 	if !hasEntryValue(labsOptions.Entries, settingsLabsProjectHooks) {
 		t.Fatalf("labs settings entries = %#v, want project hooks overview row", labsOptions.Entries)
 	}
-	if !hasEntryLabelContaining(labsOptions.Entries, "Sidebar startup picker off") ||
-		!hasEntryValue(labsOptions.Entries, settingsActionPrefixSessionState+"sidebar-startup:off") ||
-		!hasEntryValue(labsOptions.Entries, settingsActionPrefixSessionState+"sidebar-startup:on") {
-		t.Fatalf("labs settings entries = %#v, want sidebar startup picker default off toggle", labsOptions.Entries)
+	if !hasEntryLabelContaining(labsOptions.Entries, "Sidebar startup picker") ||
+		!hasEntryLabelContaining(labsOptions.Entries, "off") ||
+		!hasEntryValue(labsOptions.Entries, settingsLabsSidebarStartupPicker) {
+		t.Fatalf("labs settings entries = %#v, want sidebar startup picker overview row", labsOptions.Entries)
+	}
+	if hasEntryValue(labsOptions.Entries, settingsActionPrefixSessionState+"sidebar-startup:off") ||
+		hasEntryValue(labsOptions.Entries, settingsActionPrefixSessionState+"sidebar-startup:on") {
+		t.Fatalf("labs settings entries = %#v, want no direct sidebar startup picker mutation rows", labsOptions.Entries)
 	}
 	if hasEntryValue(labsOptions.Entries, settingsActionPrefixHooks+string(config.ProjectHooksOn)) ||
 		hasEntryValue(labsOptions.Entries, settingsActionPrefixHooks+string(config.ProjectHooksOff)) {
@@ -1653,13 +1657,21 @@ func TestSettingsSessionStateDetailRowsUseEnvAndSnapshotSummary(t *testing.T) {
 		}
 	}
 	for _, want := range []string{
+		settingsSessionStateAutosaveDetail,
+		settingsSessionStateStartupPickerDetail,
+	} {
+		if !hasEntryValue(entries, want) {
+			t.Fatalf("session state entries = %#v, want %q", entries, want)
+		}
+	}
+	for _, absent := range []string{
 		settingsActionPrefixSessionState + "autosave:on",
 		settingsActionPrefixSessionState + "autosave:off",
 		settingsActionPrefixSessionState + "autorestore:on",
 		settingsActionPrefixSessionState + "autorestore:off",
 	} {
-		if !hasEntryValue(entries, want) {
-			t.Fatalf("session state entries = %#v, want %q", entries, want)
+		if hasEntryValue(entries, absent) {
+			t.Fatalf("session state entries = %#v, want no direct mutation row %q", entries, absent)
 		}
 	}
 }
@@ -1741,12 +1753,8 @@ func TestSettingsProjectSessionStateUsesDerivedProjectIdentity(t *testing.T) {
 		"off",
 		"global default",
 		"Global auto-save",
-		"Save latest snapshot",
-		"capture live project session as latest",
-		"Save named snapshot",
-		"Preview restore",
-		"dry-run only",
-		"Delete snapshot",
+		"Snapshot actions",
+		"preview/delete available",
 	} {
 		if !hasEntryLabelContaining(options.Entries, want) {
 			t.Fatalf("project session state entries = %#v, want label containing %q", options.Entries, want)
@@ -1760,9 +1768,14 @@ func TestSettingsProjectSessionStateUsesDerivedProjectIdentity(t *testing.T) {
 	if hasEntryLabelContaining(options.Entries, "live-session") {
 		t.Fatalf("project session state entries = %#v, want derived identity instead of live tmux session", options.Entries)
 	}
-	for _, want := range []string{settingsProjectSessionStateSaveLatest, settingsProjectSessionStateSaveNamed, settingsProjectSessionStatePreview, settingsProjectSessionStateDelete} {
+	for _, want := range []string{settingsProjectSessionStateAutosaveDetail, settingsProjectSessionStateActionsDetail} {
 		if !hasEntryValue(options.Entries, want) {
 			t.Fatalf("project session state entries = %#v, want project action %q", options.Entries, want)
+		}
+	}
+	for _, absent := range []string{settingsProjectSessionStateSaveLatest, settingsProjectSessionStateSaveNamed, settingsProjectSessionStatePreview, settingsProjectSessionStateDelete} {
+		if hasEntryValue(options.Entries, absent) {
+			t.Fatalf("project session state entries = %#v, want no direct mutation action %q", options.Entries, absent)
 		}
 	}
 }
@@ -1863,7 +1876,7 @@ func TestSettingsProjectSessionStateShowsUnavailableMissingAndInvalidStates(t *t
 	if err != nil {
 		t.Fatalf("sectionOptions(missing) error = %v", err)
 	}
-	for _, want := range []string{"Project auto-save", "inherit", "Effective auto-save", "off", "Save latest snapshot", "Save named snapshot", "unavailable - live project session not found", "Preview restore", "unavailable without a valid snapshot", "Delete snapshot"} {
+	for _, want := range []string{"Project auto-save", "inherit", "Effective auto-save", "off", "Snapshot actions", "save unavailable: live project session not found", "snapshot missing"} {
 		if !hasEntryLabelContaining(missingOptions.Entries, want) {
 			t.Fatalf("missing snapshot entries = %#v, want %q", missingOptions.Entries, want)
 		}
@@ -1887,8 +1900,10 @@ func TestSettingsProjectSessionStateShowsUnavailableMissingAndInvalidStates(t *t
 	if err != nil {
 		t.Fatalf("sectionOptions(invalid) error = %v", err)
 	}
-	if hasEntryLabelContaining(invalidOptions.Entries, "Snapshot") || hasEntryLabelContaining(invalidOptions.Entries, "invalid") {
-		t.Fatalf("invalid snapshot entries = %#v, want no primary snapshot state in project settings", invalidOptions.Entries)
+	for _, absent := range []string{"Window", "Pane", "Save latest snapshot", "Delete snapshot"} {
+		if hasEntryLabelContaining(invalidOptions.Entries, absent) {
+			t.Fatalf("invalid snapshot entries = %#v, want no primary snapshot/action label %q", invalidOptions.Entries, absent)
+		}
 	}
 }
 
@@ -1980,12 +1995,18 @@ func TestSettingsSessionStateDeleteRequiresConfirmation(t *testing.T) {
 			if got, want := options.UI, "settings-sessionstate"; got != want {
 				t.Fatalf("session state UI = %q, want %q", got, want)
 			}
-			return intpickercompat.Result{Key: "enter", Value: settingsSessionStateDelete}, nil
-		case 2:
-			if got, want := options.UI, "settings-sessionstate-delete-confirm"; got != want {
-				t.Fatalf("confirm UI = %q, want %q", got, want)
+			if hasEntryValue(options.Entries, settingsSessionStateDelete) {
+				t.Fatalf("session state entries = %#v, want no direct delete action", options.Entries)
 			}
-			return intpickercompat.Result{Key: "enter", Value: settingsSessionStateConfirmNo}, nil
+			return intpickercompat.Result{Key: "enter", Value: settingsSessionStateAutosaveDetail}, nil
+		case 2:
+			if got, want := options.UI, "settings-sessionstate-detail"; got != want {
+				t.Fatalf("detail UI = %q, want %q", got, want)
+			}
+			if !hasEntryValue(options.Entries, settingsActionPrefixSessionState+"autosave:off") {
+				t.Fatalf("session state detail entries = %#v, want autosave mutation row", options.Entries)
+			}
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 		case 3:
 			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 		default:
@@ -2012,7 +2033,7 @@ func TestSettingsSessionStateDeleteRequiresConfirmation(t *testing.T) {
 		t.Fatalf("runSessionStateSection() error = %v", err)
 	}
 	if _, err := store.Load("workspace"); err != nil {
-		t.Fatalf("Load() after cancelled delete error = %v, want snapshot preserved", err)
+		t.Fatalf("Load() after view-first navigation error = %v, want snapshot preserved", err)
 	}
 }
 
@@ -2042,16 +2063,30 @@ func TestSettingsSessionStateDeleteConfirmedRemovesSnapshot(t *testing.T) {
 		calls++
 		switch calls {
 		case 1:
-			return intpickercompat.Result{Key: "enter", Value: settingsSessionStateDelete}, nil
-		case 2:
-			if got, want := options.UI, "settings-sessionstate-delete-confirm"; got != want {
-				t.Fatalf("confirm UI = %q, want %q", got, want)
+			if got, want := options.UI, "settings-sessionstate"; got != want {
+				t.Fatalf("session state UI = %q, want %q", got, want)
 			}
-			return intpickercompat.Result{Key: "enter", Value: settingsSessionStateConfirmYes}, nil
-		case 3:
 			if hasEntryValue(options.Entries, settingsSessionStateDelete) {
-				t.Fatalf("session state entries = %#v, want delete disabled after confirmed delete", options.Entries)
+				t.Fatalf("session state entries = %#v, want no direct delete action", options.Entries)
 			}
+			return intpickercompat.Result{Key: "enter", Value: settingsSessionStateStartupPickerDetail}, nil
+		case 2:
+			if got, want := options.UI, "settings-sessionstate-detail"; got != want {
+				t.Fatalf("detail UI = %q, want %q", got, want)
+			}
+			if !hasEntryValue(options.Entries, settingsActionPrefixSessionState+"autorestore:off") {
+				t.Fatalf("session state detail entries = %#v, want startup picker mutation row", options.Entries)
+			}
+			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixSessionState + "autorestore:off"}, nil
+		case 3:
+			if got, want := options.UI, "settings-sessionstate-detail"; got != want {
+				t.Fatalf("detail UI after apply = %q, want %q", got, want)
+			}
+			if !hasEntryLabelContaining(options.Entries, "off") {
+				t.Fatalf("session state detail entries = %#v, want applied off state", options.Entries)
+			}
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		case 4:
 			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 		default:
 			t.Fatalf("unexpected picker call %d", calls)
@@ -2076,8 +2111,15 @@ func TestSettingsSessionStateDeleteConfirmedRemovesSnapshot(t *testing.T) {
 	if err := cmd.runSessionStateSection(&bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("runSessionStateSection() error = %v", err)
 	}
-	if _, err := store.Load("workspace"); !errors.Is(err, sessionstate.ErrNotFound) {
-		t.Fatalf("Load() after confirmed delete error = %v, want %v", err, sessionstate.ErrNotFound)
+	paths, err := config.Homes{HomeDir: home, StateHome: xdgState}.Paths()
+	if err != nil {
+		t.Fatalf("Paths() error = %v", err)
+	}
+	if got, err := config.LoadSessionStateToggleFile(paths.SessionStateAutorestoreFile()); err != nil || got != config.SessionStateToggleOff {
+		t.Fatalf("autorestore file = %q, %v; want off, nil", got, err)
+	}
+	if _, err := store.Load("workspace"); err != nil {
+		t.Fatalf("Load() after startup picker detail change error = %v, want snapshot preserved", err)
 	}
 }
 
@@ -2275,13 +2317,23 @@ func TestSettingsProjectSessionStatePreviewAndDeleteAreProjectScopedAndConfirmed
 			if got, want := options.UI, "settings-project-sessionstate"; got != want {
 				t.Fatalf("project session state UI = %q, want %q", got, want)
 			}
-			return intpickercompat.Result{Key: "enter", Value: settingsProjectSessionStateDelete}, nil
+			if hasEntryValue(options.Entries, settingsProjectSessionStateDelete) {
+				t.Fatalf("project session state entries = %#v, want no direct delete action", options.Entries)
+			}
+			return intpickercompat.Result{Key: "enter", Value: settingsProjectSessionStateActionsDetail}, nil
 		case 2:
+			if got, want := options.UI, "settings-project-sessionstate-actions"; got != want {
+				t.Fatalf("project actions UI = %q, want %q", got, want)
+			}
+			return intpickercompat.Result{Key: "enter", Value: settingsProjectSessionStateDelete}, nil
+		case 3:
 			if got, want := options.UI, "settings-project-sessionstate-delete-confirm"; got != want {
 				t.Fatalf("confirm UI = %q, want %q", got, want)
 			}
 			return intpickercompat.Result{Key: "enter", Value: settingsSessionStateConfirmNo}, nil
-		case 3:
+		case 4:
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		case 5:
 			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 		default:
 			t.Fatalf("unexpected picker call %d", calls)
@@ -2300,10 +2352,14 @@ func TestSettingsProjectSessionStatePreviewAndDeleteAreProjectScopedAndConfirmed
 		calls++
 		switch calls {
 		case 1:
-			return intpickercompat.Result{Key: "enter", Value: settingsProjectSessionStateDelete}, nil
+			return intpickercompat.Result{Key: "enter", Value: settingsProjectSessionStateActionsDetail}, nil
 		case 2:
-			return intpickercompat.Result{Key: "enter", Value: settingsSessionStateConfirmYes}, nil
+			return intpickercompat.Result{Key: "enter", Value: settingsProjectSessionStateDelete}, nil
 		case 3:
+			return intpickercompat.Result{Key: "enter", Value: settingsSessionStateConfirmYes}, nil
+		case 4:
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		case 5:
 			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
 		default:
 			t.Fatalf("unexpected picker call %d", calls)


### PR DESCRIPTION
## Summary
- Move Settings > Session State edits behind detail views for Auto-save and Startup picker.
- Move Settings > Labs > Sidebar startup picker edits behind its own detail view.
- Move Settings > Project > Session State edits behind Project auto-save and Snapshot actions detail views.

## Validation
- `go test ./internal/app`
- `make fmt`
- `make fix`
- `make test`
- `git diff --check`
