### PR TITLE
fix: show sidebar trust prompt inline

### DIFF
--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -860,6 +860,7 @@ func buildPopupToggle(mode tmuxPopupToggleMode, binaryPath, marker string, ctx t
 }
 
 func addHookTrustPopupTargetEnv(env map[string]string, ctx tmuxPopupContext) {
+	env[hookTrustInlineEnv] = "1"
 	if strings.TrimSpace(ctx.TargetClient) != "" {
 		env[hookTrustPopupTargetClientEnv] = ctx.TargetClient
 	}

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -290,6 +290,7 @@ func TestAppRunTmuxPopupToggleOpensStandaloneSidebar(t *testing.T) {
 		"-E",
 		"-B",
 		"-d", "/tmp/work tree",
+		"-e", "PROJMUX_HOOK_TRUST_INLINE=1",
 		"-e", "PROJMUX_HOOK_TRUST_TARGET_CLIENT=/dev/pts/projmux-test-sidebar",
 		"-e", "PROJMUX_HOOK_TRUST_TARGET_PANE=%1",
 		"-e", "PROJMUX_NATIVE_LAUNCH_KEY=alt-1",
@@ -308,6 +309,7 @@ func TestAppRunTmuxPopupToggleOpensStandaloneSidebar(t *testing.T) {
 	command := got.args[len(got.args)-1]
 	for _, want := range []string{
 		"cd -- '/tmp/work tree'",
+		"PROJMUX_HOOK_TRUST_INLINE='1'",
 		"TMUX_SESSIONIZER_CONTEXT_SESSION='work'",
 		"TMUX_SESSIONIZER_CONTEXT_PANE='%1'",
 		"'/tmp/proj mux/bin/projmux' 'switch' '--ui=sidebar'",


### PR DESCRIPTION
## Summary
- pass inline trust mode into sessionizer popup flows
- keep existing trust target client/pane env propagation
- cover sidebar popup env propagation in tests

## Validation
- make fmt
- make fix
- make test
- make test-integration
- make test-e2e