### PR TITLE
fix: show sidebar trust as popup

### DIFF
--- a/internal/app/hook_trust_popup.go
+++ b/internal/app/hook_trust_popup.go
@@ -46,7 +46,6 @@ func tmuxProjectHookPrompt(lookupEnv func(string) string, executable func() (str
 			pane: firstNonEmpty(
 				lookupEnv(hookTrustPopupTargetPaneEnv),
 				lookupEnv("PROJMUX_POPUP_TARGET_PANE"),
-				lookupEnv("TMUX_SESSIONIZER_CONTEXT_PANE"),
 			),
 		})
 		if err != nil {

--- a/internal/app/hook_trust_popup_test.go
+++ b/internal/app/hook_trust_popup_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -18,7 +19,7 @@ func TestBuildHookTrustPopupArgsTargetsWidePopup(t *testing.T) {
 		"/tmp/proj mux/bin/projmux",
 		"/tmp/request file.json",
 		"/tmp/decision file.txt",
-		hookTrustPopupTarget{client: "/dev/pts/7", pane: "%3"},
+		hookTrustPopupTarget{client: "/dev/pts/7"},
 	)
 	if err != nil {
 		t.Fatalf("buildHookTrustPopupArgs() error = %v", err)
@@ -27,7 +28,6 @@ func TestBuildHookTrustPopupArgsTargetsWidePopup(t *testing.T) {
 	wantPrefix := []string{
 		"display-popup",
 		"-c", "/dev/pts/7",
-		"-t", "%3",
 		"-E",
 		"-w", hookTrustPopupWidth,
 		"-h", hookTrustPopupHeight,
@@ -99,8 +99,8 @@ func TestTmuxProjectHookPromptUsesDisplayPopupDecision(t *testing.T) {
 				return "/tmp/tmux/default,1,0"
 			case hookTrustPopupTargetClientEnv:
 				return "/dev/pts/9"
-			case hookTrustPopupTargetPaneEnv:
-				return "%9"
+			case "TMUX_SESSIONIZER_CONTEXT_PANE":
+				return "%hidden-behind-parent-popup"
 			default:
 				return ""
 			}
@@ -129,8 +129,14 @@ func TestTmuxProjectHookPromptUsesDisplayPopupDecision(t *testing.T) {
 	if !strings.Contains(command, "tmux hook-trust-prompt") {
 		t.Fatalf("popup command = %q, want hook trust prompt", command)
 	}
-	if !containsTmuxArgPair(call.args, "-c", "/dev/pts/9") || !containsTmuxArgPair(call.args, "-t", "%9") {
-		t.Fatalf("tmux call args = %#v, want target client and pane", call.args)
+	if !containsTmuxArgPair(call.args, "-c", "/dev/pts/9") {
+		t.Fatalf("tmux call args = %#v, want target client", call.args)
+	}
+	if containsTmuxArgPair(call.args, "-t", "%hidden-behind-parent-popup") {
+		t.Fatalf("tmux call args = %#v, want no fallback target pane from sessionizer context", call.args)
+	}
+	if containsTmuxArg(call.args, "-t") {
+		t.Fatalf("tmux call args = %#v, want client-scoped popup without target pane", call.args)
 	}
 }
 
@@ -161,4 +167,8 @@ func singleQuotedFlagValue(command, flag string) string {
 		return ""
 	}
 	return value
+}
+
+func containsTmuxArg(args []string, key string) bool {
+	return slices.Contains(args, key)
 }

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -864,12 +864,8 @@ func buildPopupToggle(mode tmuxPopupToggleMode, binaryPath, marker string, ctx t
 }
 
 func addHookTrustPopupTargetEnv(env map[string]string, ctx tmuxPopupContext) {
-	env[hookTrustInlineEnv] = "1"
 	if strings.TrimSpace(ctx.TargetClient) != "" {
 		env[hookTrustPopupTargetClientEnv] = ctx.TargetClient
-	}
-	if strings.TrimSpace(ctx.OriginPane) != "" {
-		env[hookTrustPopupTargetPaneEnv] = ctx.OriginPane
 	}
 }
 

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -290,9 +290,7 @@ func TestAppRunTmuxPopupToggleOpensStandaloneSidebar(t *testing.T) {
 		"-E",
 		"-B",
 		"-d", "/tmp/work tree",
-		"-e", "PROJMUX_HOOK_TRUST_INLINE=1",
 		"-e", "PROJMUX_HOOK_TRUST_TARGET_CLIENT=/dev/pts/projmux-test-sidebar",
-		"-e", "PROJMUX_HOOK_TRUST_TARGET_PANE=%1",
 		"-e", "PROJMUX_NATIVE_LAUNCH_KEY=alt-1",
 		"-e", "PROJMUX_PICKER_BACKEND=native",
 		"-e", "TMUX_SESSIONIZER_CONTEXT_DIR=/tmp/work tree",
@@ -309,13 +307,21 @@ func TestAppRunTmuxPopupToggleOpensStandaloneSidebar(t *testing.T) {
 	command := got.args[len(got.args)-1]
 	for _, want := range []string{
 		"cd -- '/tmp/work tree'",
-		"PROJMUX_HOOK_TRUST_INLINE='1'",
+		"PROJMUX_HOOK_TRUST_TARGET_CLIENT='/dev/pts/projmux-test-sidebar'",
 		"TMUX_SESSIONIZER_CONTEXT_SESSION='work'",
 		"TMUX_SESSIONIZER_CONTEXT_PANE='%1'",
 		"'/tmp/proj mux/bin/projmux' 'switch' '--ui=sidebar'",
 	} {
 		if !strings.Contains(command, want) {
 			t.Fatalf("popup command = %q, want substring %q", command, want)
+		}
+	}
+	for _, unwanted := range []string{
+		"PROJMUX_HOOK_TRUST_INLINE",
+		"PROJMUX_HOOK_TRUST_TARGET_PANE",
+	} {
+		if strings.Contains(command, unwanted) {
+			t.Fatalf("popup command = %q, unwanted substring %q", command, unwanted)
 		}
 	}
 	content, err := os.ReadFile(marker)
@@ -763,6 +769,7 @@ func TestBuildPopupTogglePropagatesPickerEnvironment(t *testing.T) {
 		"/tmp/marker",
 		tmuxPopupContext{
 			OriginPane:    "%1",
+			TargetClient:  "/dev/pts/7",
 			OriginSession: "main",
 			ContextDir:    "/workspace/projects/alpha-api",
 			ClientWidth:   200,
@@ -778,10 +785,15 @@ func TestBuildPopupTogglePropagatesPickerEnvironment(t *testing.T) {
 		"PROJMUX_NATIVE_TTY_FALLBACK='0'",
 		"PROJMUX_PROJDIR='/workspace/projects'",
 		"PROJMUX_MANAGED_ROOTS='/workspace/projects'",
-		hookTrustPopupTargetPaneEnv + "='%1'",
+		hookTrustPopupTargetClientEnv + "='/dev/pts/7'",
 	} {
 		if !strings.Contains(command, want) {
 			t.Fatalf("popup command = %q, want substring %q", command, want)
+		}
+	}
+	for _, unwanted := range []string{hookTrustInlineEnv, hookTrustPopupTargetPaneEnv} {
+		if strings.Contains(command, unwanted) {
+			t.Fatalf("popup command = %q, unwanted substring %q", command, unwanted)
 		}
 	}
 	for key, want := range map[string]string{
@@ -790,11 +802,51 @@ func TestBuildPopupTogglePropagatesPickerEnvironment(t *testing.T) {
 		"PROJMUX_NATIVE_TTY_FALLBACK": "0",
 		"PROJMUX_PROJDIR":             "/workspace/projects",
 		"PROJMUX_MANAGED_ROOTS":       "/workspace/projects",
-		hookTrustPopupTargetPaneEnv:   "%1",
+		hookTrustPopupTargetClientEnv: "/dev/pts/7",
 	} {
 		if got := options.Env[key]; got != want {
 			t.Fatalf("options.Env[%q] = %q, want %q", key, got, want)
 		}
+	}
+	for _, key := range []string{hookTrustInlineEnv, hookTrustPopupTargetPaneEnv} {
+		if value, ok := options.Env[key]; ok {
+			t.Fatalf("options.Env[%q] = %q, want absent", key, value)
+		}
+	}
+}
+
+func TestBuildPopupToggleSessionizerTrustEnvUsesClientOnly(t *testing.T) {
+	command, options, err := buildPopupToggleWithPickerBackend(
+		tmuxPopupToggleMode{Raw: "sessionizer", Canonical: "sessionizer"},
+		"/tmp/projmux",
+		"/tmp/marker",
+		tmuxPopupContext{
+			TargetClient:  "/dev/pts/8",
+			OriginPane:    "%2",
+			OriginSession: "main",
+			ContextDir:    "/workspace/projects/alpha-api",
+			ClientWidth:   200,
+			ClientHeight:  50,
+		},
+		intpicker.Backend("legacy"),
+		func(string) string { return "" },
+	)
+	if err != nil {
+		t.Fatalf("buildPopupToggleWithPickerBackend() error = %v", err)
+	}
+	if !strings.Contains(command, hookTrustPopupTargetClientEnv+"='/dev/pts/8'") {
+		t.Fatalf("popup command = %q, want target client env", command)
+	}
+	for _, unwanted := range []string{hookTrustInlineEnv, hookTrustPopupTargetPaneEnv} {
+		if strings.Contains(command, unwanted) {
+			t.Fatalf("popup command = %q, unwanted substring %q", command, unwanted)
+		}
+		if value, ok := options.Env[unwanted]; ok {
+			t.Fatalf("options.Env[%q] = %q, want absent", unwanted, value)
+		}
+	}
+	if got := options.Env[hookTrustPopupTargetClientEnv]; got != "/dev/pts/8" {
+		t.Fatalf("options.Env[%q] = %q, want target client", hookTrustPopupTargetClientEnv, got)
 	}
 }
 


### PR DESCRIPTION
Summary:
- stop forcing sidebar/sessionizer trust checks into inline mode
- target hook trust prompts by tmux client so the existing trust dialog appears as a separate popup after startup mode selection
- cover client-only trust env propagation and no hidden pane fallback

Validation:
- make fmt
- GOCACHE=/tmp/projmux-go-cache make fix
- GOCACHE=/tmp/projmux-go-cache make test
- GOCACHE=/tmp/projmux-go-cache make test-integration
- GOCACHE=/tmp/projmux-go-cache make test-e2e