### PR TITLE
fix: preserve statusbar popup client

### DIFF
--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -362,8 +362,8 @@ func (c *statusbarCommand) dispatchTable() map[statusbarRangeID]func(statusbarCl
 // handleSession opens the project sidebar. It uses the same
 // popup-toggle surface as the keyboard bindings so a second click/chord closes
 // the scoped popup instead of stacking another one.
-func (c *statusbarCommand) handleSession(_ statusbarClickOptions, _, stderr io.Writer) error {
-	return c.handlePopupToggle(stderr, "session", "sessionizer-sidebar")
+func (c *statusbarCommand) handleSession(opts statusbarClickOptions, _, stderr io.Writer) error {
+	return c.handlePopupToggleWithClient(stderr, "session", "sessionizer-sidebar", opts.ClientTTY)
 }
 
 // handlePwd shows the current pane's path in a small popup. A plain
@@ -416,23 +416,19 @@ func (c *statusbarCommand) handlePwd(_ statusbarClickOptions, _, stderr io.Write
 // handleKube opens the project switcher. There is no kube-specific filter
 // surface yet; the switch picker is the existing navigation surface that
 // already renders kube metadata for candidates.
-func (c *statusbarCommand) handleKube(_ statusbarClickOptions, _, stderr io.Writer) error {
-	return c.handlePopupToggle(stderr, "kube", "sessionizer")
+func (c *statusbarCommand) handleKube(opts statusbarClickOptions, _, stderr io.Writer) error {
+	return c.handlePopupToggleWithClient(stderr, "kube", "sessionizer", opts.ClientTTY)
 }
 
 // handleGit opens the project switcher. There is no git-specific filter
 // surface yet; the switch picker is the existing navigation surface that
 // already renders git metadata for candidates.
-func (c *statusbarCommand) handleGit(_ statusbarClickOptions, _, stderr io.Writer) error {
-	return c.handlePopupToggle(stderr, "git", "sessionizer")
+func (c *statusbarCommand) handleGit(opts statusbarClickOptions, _, stderr io.Writer) error {
+	return c.handlePopupToggleWithClient(stderr, "git", "sessionizer", opts.ClientTTY)
 }
 
 func (c *statusbarCommand) handleSettings(opts statusbarClickOptions, _, stderr io.Writer) error {
 	return c.handlePopupToggleWithClient(stderr, "settings", "ai-split-settings", opts.ClientTTY)
-}
-
-func (c *statusbarCommand) handlePopupToggle(stderr io.Writer, label, mode string) error {
-	return c.handlePopupToggleWithClient(stderr, label, mode, "")
 }
 
 func (c *statusbarCommand) handlePopupToggleWithClient(stderr io.Writer, label, mode, clientTTY string) error {

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -318,11 +318,11 @@ func TestStatusbarClickSessionOpensProjectSidebar(t *testing.T) {
 	runner := &statusbarFakeRunner{}
 	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
 
-	if err := cmd.Run([]string{"click", "session"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+	if err := cmd.Run([]string{"click", "session", "--client", "/dev/pts/7"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if !sawProjmuxArgs(runner.calls, []string{"tmux", "popup-toggle", "sessionizer-sidebar"}) {
-		t.Fatalf("missing sessionizer-sidebar popup-toggle; calls = %#v", runner.calls)
+	if !sawProjmuxArgs(runner.calls, []string{"tmux", "popup-toggle", "--client", "/dev/pts/7", "sessionizer-sidebar"}) {
+		t.Fatalf("missing client-scoped sessionizer-sidebar popup-toggle; calls = %#v", runner.calls)
 	}
 }
 
@@ -479,11 +479,11 @@ func TestStatusbarClickKubeOpensProjectSwitcher(t *testing.T) {
 	runner := &statusbarFakeRunner{}
 	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
 
-	if err := cmd.Run([]string{"click", "kube"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+	if err := cmd.Run([]string{"click", "kube", "--client", "/dev/pts/7"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if !sawProjmuxArgs(runner.calls, []string{"tmux", "popup-toggle", "sessionizer"}) {
-		t.Fatalf("missing project switcher popup-toggle; calls = %#v", runner.calls)
+	if !sawProjmuxArgs(runner.calls, []string{"tmux", "popup-toggle", "--client", "/dev/pts/7", "sessionizer"}) {
+		t.Fatalf("missing client-scoped project switcher popup-toggle; calls = %#v", runner.calls)
 	}
 }
 
@@ -493,11 +493,11 @@ func TestStatusbarClickGitOpensProjectSwitcher(t *testing.T) {
 	runner := &statusbarFakeRunner{}
 	cmd := newStatusbarTestCommand(runner, &stubNotifyStore{})
 
-	if err := cmd.Run([]string{"click", "git"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+	if err := cmd.Run([]string{"click", "git", "--client", "/dev/pts/7"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if !sawProjmuxArgs(runner.calls, []string{"tmux", "popup-toggle", "sessionizer"}) {
-		t.Fatalf("missing project switcher popup-toggle; calls = %#v", runner.calls)
+	if !sawProjmuxArgs(runner.calls, []string{"tmux", "popup-toggle", "--client", "/dev/pts/7", "sessionizer"}) {
+		t.Fatalf("missing client-scoped project switcher popup-toggle; calls = %#v", runner.calls)
 	}
 }
 


### PR DESCRIPTION
Summary:
- forward statusbar click client tty into session/kube/git popup-toggle actions
- keep sidebar trust popup target client when the project sidebar is opened from the statusbar
- update statusbar click tests for client-scoped popup-toggle calls

Validation:
- make fmt
- GOCACHE=/tmp/projmux-go-cache make fix
- GOCACHE=/tmp/projmux-go-cache make test
- GOCACHE=/tmp/projmux-go-cache make test-integration
- GOCACHE=/tmp/projmux-go-cache make test-e2e