### PR TITLE
fix: target client when opening sidebar project

### DIFF
--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -869,6 +869,12 @@ func addHookTrustPopupTargetEnv(env map[string]string, ctx tmuxPopupContext) {
 	}
 }
 
+func addSwitchTargetClientEnv(env map[string]string, ctx tmuxPopupContext) {
+	if strings.TrimSpace(ctx.TargetClient) != "" {
+		env[inttmux.SwitchTargetClientEnv] = ctx.TargetClient
+	}
+}
+
 func buildPopupToggleWithPickerBackend(mode tmuxPopupToggleMode, binaryPath, marker string, ctx tmuxPopupContext, backend intpicker.Backend, lookupEnv func(string) string) (string, inttmux.PopupOptions, error) {
 	options := inttmux.PopupOptions{
 		Target:        ctx.OriginPane,
@@ -888,6 +894,7 @@ func buildPopupToggleWithPickerBackend(mode tmuxPopupToggleMode, binaryPath, mar
 		options.Height = popupSize(ctx.ClientHeight, 70, 28)
 		cwd = ctx.ContextDir
 		addHookTrustPopupTargetEnv(env, ctx)
+		addSwitchTargetClientEnv(env, ctx)
 		env["TMUX_SESSIONIZER_CONTEXT_DIR"] = ctx.ContextDir
 		env["TMUX_SESSIONIZER_CONTEXT_SESSION"] = ctx.OriginSession
 		env["TMUX_SESSIONIZER_CONTEXT_PANE"] = ctx.OriginPane
@@ -899,6 +906,7 @@ func buildPopupToggleWithPickerBackend(mode tmuxPopupToggleMode, binaryPath, mar
 		options.Y = "0"
 		cwd = ctx.ContextDir
 		addHookTrustPopupTargetEnv(env, ctx)
+		addSwitchTargetClientEnv(env, ctx)
 		env["TMUX_SESSIONIZER_CONTEXT_DIR"] = ctx.ContextDir
 		env["TMUX_SESSIONIZER_CONTEXT_SESSION"] = ctx.OriginSession
 		env["TMUX_SESSIONIZER_CONTEXT_PANE"] = ctx.OriginPane

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -293,6 +293,7 @@ func TestAppRunTmuxPopupToggleOpensStandaloneSidebar(t *testing.T) {
 		"-e", "PROJMUX_HOOK_TRUST_TARGET_CLIENT=/dev/pts/projmux-test-sidebar",
 		"-e", "PROJMUX_NATIVE_LAUNCH_KEY=alt-1",
 		"-e", "PROJMUX_PICKER_BACKEND=native",
+		"-e", "PROJMUX_SWITCH_TARGET_CLIENT=/dev/pts/projmux-test-sidebar",
 		"-e", "TMUX_SESSIONIZER_CONTEXT_DIR=/tmp/work tree",
 		"-e", "TMUX_SESSIONIZER_CONTEXT_PANE=%1",
 		"-e", "TMUX_SESSIONIZER_CONTEXT_SESSION=work",
@@ -308,6 +309,7 @@ func TestAppRunTmuxPopupToggleOpensStandaloneSidebar(t *testing.T) {
 	for _, want := range []string{
 		"cd -- '/tmp/work tree'",
 		"PROJMUX_HOOK_TRUST_TARGET_CLIENT='/dev/pts/projmux-test-sidebar'",
+		"PROJMUX_SWITCH_TARGET_CLIENT='/dev/pts/projmux-test-sidebar'",
 		"TMUX_SESSIONIZER_CONTEXT_SESSION='work'",
 		"TMUX_SESSIONIZER_CONTEXT_PANE='%1'",
 		"'/tmp/proj mux/bin/projmux' 'switch' '--ui=sidebar'",
@@ -786,6 +788,7 @@ func TestBuildPopupTogglePropagatesPickerEnvironment(t *testing.T) {
 		"PROJMUX_PROJDIR='/workspace/projects'",
 		"PROJMUX_MANAGED_ROOTS='/workspace/projects'",
 		hookTrustPopupTargetClientEnv + "='/dev/pts/7'",
+		inttmux.SwitchTargetClientEnv + "='/dev/pts/7'",
 	} {
 		if !strings.Contains(command, want) {
 			t.Fatalf("popup command = %q, want substring %q", command, want)
@@ -803,6 +806,7 @@ func TestBuildPopupTogglePropagatesPickerEnvironment(t *testing.T) {
 		"PROJMUX_PROJDIR":             "/workspace/projects",
 		"PROJMUX_MANAGED_ROOTS":       "/workspace/projects",
 		hookTrustPopupTargetClientEnv: "/dev/pts/7",
+		inttmux.SwitchTargetClientEnv: "/dev/pts/7",
 	} {
 		if got := options.Env[key]; got != want {
 			t.Fatalf("options.Env[%q] = %q, want %q", key, got, want)
@@ -837,6 +841,9 @@ func TestBuildPopupToggleSessionizerTrustEnvUsesClientOnly(t *testing.T) {
 	if !strings.Contains(command, hookTrustPopupTargetClientEnv+"='/dev/pts/8'") {
 		t.Fatalf("popup command = %q, want target client env", command)
 	}
+	if !strings.Contains(command, inttmux.SwitchTargetClientEnv+"='/dev/pts/8'") {
+		t.Fatalf("popup command = %q, want switch target client env", command)
+	}
 	for _, unwanted := range []string{hookTrustInlineEnv, hookTrustPopupTargetPaneEnv} {
 		if strings.Contains(command, unwanted) {
 			t.Fatalf("popup command = %q, unwanted substring %q", command, unwanted)
@@ -847,6 +854,9 @@ func TestBuildPopupToggleSessionizerTrustEnvUsesClientOnly(t *testing.T) {
 	}
 	if got := options.Env[hookTrustPopupTargetClientEnv]; got != "/dev/pts/8" {
 		t.Fatalf("options.Env[%q] = %q, want target client", hookTrustPopupTargetClientEnv, got)
+	}
+	if got := options.Env[inttmux.SwitchTargetClientEnv]; got != "/dev/pts/8" {
+		t.Fatalf("options.Env[%q] = %q, want target client", inttmux.SwitchTargetClientEnv, got)
 	}
 }
 

--- a/internal/integrations/tmux/client.go
+++ b/internal/integrations/tmux/client.go
@@ -15,6 +15,8 @@ import (
 	"github.com/crevissepartners/projmux/internal/integrations/hooks"
 )
 
+const SwitchTargetClientEnv = "PROJMUX_SWITCH_TARGET_CLIENT"
+
 var (
 	errCurrentPanePathUnavailable = errors.New("tmux current pane path is unavailable")
 	errCurrentSessionUnavailable  = errors.New("tmux current session is unavailable")
@@ -659,7 +661,7 @@ func (c *Client) OpenSession(ctx context.Context, sessionName string) error {
 	action := "attach"
 	inside := c.InsideSession()
 	if inside {
-		command = []string{"switch-client", "-t", sessionName}
+		command = c.switchClientCommand(sessionName)
 		action = "switch"
 	}
 
@@ -695,7 +697,7 @@ func (c *Client) OpenSessionTarget(ctx context.Context, sessionName, windowIndex
 	if inside {
 		target = sessionPaneTarget(sessionName, windowIndex, paneIndex)
 		action = "switch"
-		command = []string{"switch-client", "-t", target}
+		command = c.switchClientCommand(target)
 	} else if windowIndex != "" {
 		target = sessionWindowTarget(sessionName, windowIndex)
 		command = []string{"attach-session", "-t", target}
@@ -709,6 +711,16 @@ func (c *Client) OpenSessionTarget(ctx context.Context, sessionName, windowIndex
 		c.runPostAttach(ctx, sessionName, target)
 	}
 	return nil
+}
+
+func (c *Client) switchClientCommand(target string) []string {
+	command := []string{"switch-client"}
+	if c.lookupEnv != nil {
+		if client := strings.TrimSpace(c.lookupEnv(SwitchTargetClientEnv)); client != "" {
+			command = append(command, "-c", client)
+		}
+	}
+	return append(command, "-t", target)
 }
 
 func (c *Client) runPostAttach(ctx context.Context, sessionName, target string) {

--- a/internal/integrations/tmux/client_test.go
+++ b/internal/integrations/tmux/client_test.go
@@ -1006,7 +1006,7 @@ func TestClientOpenSessionSwitchesInsideTmux(t *testing.T) {
 		t:     t,
 		steps: []scriptedStep{{}},
 	}
-	client := newClientWithEnv(runner, func(string) string { return "/tmp/tmux-sock" })
+	client := newClientWithEnv(runner, tmuxEnvOnly)
 
 	if err := client.OpenSession(context.Background(), "workspace"); err != nil {
 		t.Fatalf("OpenSession returned error: %v", err)
@@ -1014,6 +1014,36 @@ func TestClientOpenSessionSwitchesInsideTmux(t *testing.T) {
 
 	want := []commandCall{
 		{name: "tmux", args: []string{"switch-client", "-t", "workspace"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("unexpected calls %#v", runner.calls)
+	}
+}
+
+func TestClientOpenSessionTargetsClientInsideTmux(t *testing.T) {
+	t.Parallel()
+
+	runner := &scriptedRunner{
+		t:     t,
+		steps: []scriptedStep{{}},
+	}
+	client := newClientWithEnv(runner, func(name string) string {
+		switch name {
+		case "TMUX":
+			return "/tmp/tmux-sock"
+		case SwitchTargetClientEnv:
+			return "/dev/pts/7"
+		default:
+			return ""
+		}
+	})
+
+	if err := client.OpenSession(context.Background(), "workspace"); err != nil {
+		t.Fatalf("OpenSession returned error: %v", err)
+	}
+
+	want := []commandCall{
+		{name: "tmux", args: []string{"switch-client", "-c", "/dev/pts/7", "-t", "workspace"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("unexpected calls %#v", runner.calls)
@@ -1343,7 +1373,7 @@ func TestClientOpenSessionTargetSwitchesToPaneInsideTmux(t *testing.T) {
 		t:     t,
 		steps: []scriptedStep{{}},
 	}
-	client := newClientWithEnv(runner, func(string) string { return "/tmp/tmux-sock" })
+	client := newClientWithEnv(runner, tmuxEnvOnly)
 
 	if err := client.OpenSessionTarget(context.Background(), "workspace", "3", "8"); err != nil {
 		t.Fatalf("OpenSessionTarget returned error: %v", err)
@@ -1351,6 +1381,36 @@ func TestClientOpenSessionTargetSwitchesToPaneInsideTmux(t *testing.T) {
 
 	want := []commandCall{
 		{name: "tmux", args: []string{"switch-client", "-t", "workspace:3.8"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("unexpected calls %#v", runner.calls)
+	}
+}
+
+func TestClientOpenSessionTargetTargetsClientInsideTmux(t *testing.T) {
+	t.Parallel()
+
+	runner := &scriptedRunner{
+		t:     t,
+		steps: []scriptedStep{{}},
+	}
+	client := newClientWithEnv(runner, func(name string) string {
+		switch name {
+		case "TMUX":
+			return "/tmp/tmux-sock"
+		case SwitchTargetClientEnv:
+			return "/dev/pts/7"
+		default:
+			return ""
+		}
+	})
+
+	if err := client.OpenSessionTarget(context.Background(), "workspace", "3", "8"); err != nil {
+		t.Fatalf("OpenSessionTarget returned error: %v", err)
+	}
+
+	want := []commandCall{
+		{name: "tmux", args: []string{"switch-client", "-c", "/dev/pts/7", "-t", "workspace:3.8"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("unexpected calls %#v", runner.calls)
@@ -1368,7 +1428,7 @@ func TestClientOpenSessionTargetRunsPostAttachAfterInsideTmuxSwitch(t *testing.T
 		},
 	}
 	hook := &fakeLifecycleRunner{}
-	client := newClientWithEnv(runner, func(string) string { return "/tmp/tmux-sock" }, withLifecycleHookRunnerInterface(hook))
+	client := newClientWithEnv(runner, tmuxEnvOnly, withLifecycleHookRunnerInterface(hook))
 
 	if err := client.OpenSessionTarget(context.Background(), "workspace", "3", "8"); err != nil {
 		t.Fatalf("OpenSessionTarget returned error: %v", err)
@@ -2066,7 +2126,7 @@ func TestClientOpenSessionRunsPostAttachAfterInsideTmuxSwitch(t *testing.T) {
 		},
 	}
 	hook := &fakeLifecycleRunner{}
-	client := newClientWithEnv(runner, func(string) string { return "/tmp/tmux-sock" }, withLifecycleHookRunnerInterface(hook), WithSocketName("projmux"))
+	client := newClientWithEnv(runner, tmuxEnvOnly, withLifecycleHookRunnerInterface(hook), WithSocketName("projmux"))
 
 	if err := client.OpenSession(context.Background(), "workspace"); err != nil {
 		t.Fatalf("OpenSession returned error: %v", err)
@@ -2237,6 +2297,13 @@ func withLifecycleHookRunnerInterface(r lifecycleHookRunner) ClientOption {
 	return func(c *Client) {
 		c.lifecycle = r
 	}
+}
+
+func tmuxEnvOnly(name string) string {
+	if name == "TMUX" {
+		return "/tmp/tmux-sock"
+	}
+	return ""
 }
 
 func exitError(t *testing.T, code int) error {


### PR DESCRIPTION
Summary:
- pass the popup target client through sessionizer/sidebar switch commands
- make tmux OpenSession/OpenSessionTarget call switch-client with -c when PROJMUX_SWITCH_TARGET_CLIENT is present
- cover sidebar env propagation and client-scoped switch-client calls

Validation:
- make fmt
- GOCACHE=/tmp/projmux-go-cache make fix
- GOCACHE=/tmp/projmux-go-cache make test
- GOCACHE=/tmp/projmux-go-cache make test-integration
- GOCACHE=/tmp/projmux-go-cache make test-e2e