### PR TITLE
fix(switch): open empty session when project trust is denied

### DIFF
--- a/internal/app/project_startup.go
+++ b/internal/app/project_startup.go
@@ -56,10 +56,17 @@ func (c *switchCommand) openProjectTarget(ctx context.Context, target, sessionNa
 	if mode.Kind == projectStartupKindBack {
 		return errProjectStartupBack
 	}
-	if trusted, err := c.authorizeProjectOpen(ctx, target); err != nil {
+	trusted, err := c.authorizeProjectOpen(ctx, target)
+	if err != nil {
 		return err
-	} else if !trusted {
-		return nil
+	}
+	if !trusted {
+		// Trust was denied: skip snapshot replay (which would re-run
+		// previously-recorded startup recipes) and open a bare session at
+		// the project cwd instead of silently doing nothing. The internal
+		// trust gate inside runStartupCommand prevents the startup command
+		// from firing for an untrusted project.
+		return c.ensureAndOpenProjectSession(ctx, sessionName, target)
 	}
 	switch mode.Kind {
 	case projectStartupKindLatest:

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -906,7 +906,7 @@ func TestSwitchProjectOpenStartupPickerOffCreatesEmptyWithoutPicker(t *testing.T
 	}
 }
 
-func TestSwitchProjectOpenTrustDenyAfterStartupSelectionCreatesNoSession(t *testing.T) {
+func TestSwitchProjectOpenTrustDenyAfterStartupSelectionFallsBackToEmptySession(t *testing.T) {
 	t.Parallel()
 
 	home := t.TempDir()
@@ -942,8 +942,67 @@ func TestSwitchProjectOpenTrustDenyAfterStartupSelectionCreatesNoSession(t *test
 	if !pickerCalled {
 		t.Fatal("startup picker was not called before trust gate")
 	}
-	if executor.ensureSessionName != "" || executor.restoreSessionName != "" || executor.openSessionName != "" {
-		t.Fatalf("startup ran after deny: picker=%v ensure=%q restore=%q open=%q", pickerCalled, executor.ensureSessionName, executor.restoreSessionName, executor.openSessionName)
+	if executor.restoreSessionName != "" {
+		t.Fatalf("snapshot restore ran after deny: restore=%q", executor.restoreSessionName)
+	}
+	if got, want := executor.ensureSessionName, "workspace"; got != want {
+		t.Fatalf("ensure session = %q, want %q", got, want)
+	}
+	if got, want := executor.ensureCWD, "/tmp/workspace"; got != want {
+		t.Fatalf("ensure cwd = %q, want %q", got, want)
+	}
+	if got, want := executor.openSessionName, "workspace"; got != want {
+		t.Fatalf("open session = %q, want %q", got, want)
+	}
+	if got, want := executor.calls, []string{"authorize:/tmp/workspace", "ensure:workspace", "open:workspace"}; !equalStrings(got, want) {
+		t.Fatalf("calls = %q, want %q", got, want)
+	}
+}
+
+func TestSwitchProjectOpenTrustDenyWithLatestSnapshotSkipsRestoreAndOpensEmpty(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	enableSidebarStartupPickerForTest(t, home)
+	project := filepath.Join(home, "workspace")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := filepath.Join(home, "state", "projmux", "sessions")
+	store := sessionstate.NewStore(stateDir)
+	saveSwitchProjectStartupSnapshot(t, store, "workspace")
+
+	executor := &capturingSwitchSessionExecutor{authorizeSet: true, authorizeResult: false}
+	cmd := &switchCommand{
+		sessions: executor,
+		identity: stubSwitchIdentityResolver{name: "workspace"},
+		homeDir:  func() (string, error) { return home, nil },
+		lookupEnv: func(name string) string {
+			switch name {
+			case "XDG_STATE_HOME":
+				return filepath.Join(home, "state")
+			case "XDG_CONFIG_HOME":
+				return filepath.Join(home, "config")
+			default:
+				return ""
+			}
+		},
+		runner: switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+			return intpickercompat.Result{Value: projectStartupValueLatest}, nil
+		}),
+		nativePicker: nativePickerFromCompatRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+			return intpickercompat.Result{Value: projectStartupValueLatest}, nil
+		})),
+	}
+
+	if err := cmd.openProjectTarget(context.Background(), project, "workspace"); err != nil {
+		t.Fatalf("openProjectTarget() error = %v", err)
+	}
+	if executor.restoreSessionName != "" {
+		t.Fatalf("snapshot restore ran after trust deny: restore=%q", executor.restoreSessionName)
+	}
+	if got, want := executor.calls, []string{"authorize:" + project, "ensure:workspace", "open:workspace"}; !equalStrings(got, want) {
+		t.Fatalf("calls = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `openProjectTarget` previously returned `nil` when the user denied the `.projmux/config.toml` trust prompt, so the project switch silently aborted with no UI feedback — symptom: "I clicked the project and nothing happened."
- On deny, fall back to `ensureAndOpenProjectSession` so the bare tmux session at the project cwd still opens. The internal trust gate inside `runStartupCommand` already prevents the startup command from firing, and snapshot replay is intentionally bypassed for untrusted projects (avoids re-executing previously-recorded recipes without trust).
- Trust errors (vs. denies) still propagate unchanged.

## Test plan
- [x] `go test ./internal/app/... ./internal/integrations/hooks/...`
- [x] Updated `TestSwitchProjectOpenTrustDenyAfterStartupSelection*` to assert the empty-session fallback (`authorize -> ensure -> open`, no `restore`).
- [x] Added `TestSwitchProjectOpenTrustDenyWithLatestSnapshotSkipsRestoreAndOpensEmpty` to cover the snapshot-present + deny case.
- [ ] Manual: open a project whose `.projmux/config.toml` is not in the trust store, dismiss the popup, confirm an empty tmux session opens at the project cwd and the startup command does NOT fire.