### PR TITLE
fix(badge): decouple pane border badge from ai_state lifecycle

### DIFF
--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -210,10 +210,10 @@ func (c *aiCommand) applyAIStatusWithNotify(state, paneID string, notifyIn atten
 		} else {
 			_ = c.run("tmux", "set-option", "-p", "-t", paneID, attentionStateOption, attentionStateReply)
 			_ = c.run("tmux", "set-option", "-p", "-t", paneID, attentionFocusArmedOption, "1")
-			_ = c.notifyAI(paneID)
 		}
-		// Force only controls notification delivery, not the badge.
+		// Force controls notification delivery (queue + OS), not the badge.
 		if notifyIn.Force || !visible {
+			_ = c.notifyAI(paneID)
 			c.notifyProducer().PushReplyReady(notifyIn)
 		} else {
 			c.notifyProducer().AckReplyReady(notifyIn)

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -200,18 +200,23 @@ func (c *aiCommand) applyAIStatusWithNotify(state, paneID string, notifyIn atten
 	case "waiting":
 		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneStateOption, "waiting")
 		_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionAckOption)
-		if !notifyIn.Force && c.paneVisibleToClient(paneID) {
+		visible := c.paneVisibleToClient(paneID)
+		if visible {
+			// Badge follows visibility only: pane is already in front of the
+			// user, so auto-ack the reply badge regardless of Force.
 			_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionStateOption)
 			_ = c.run("tmux", "set-option", "-p", "-t", paneID, attentionAckOption, "1")
 			_ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, attentionFocusArmedOption)
-			// The pane is already active so no reply badge survives — clear
-			// any stale queue entry instead of pushing a new one.
-			c.notifyProducer().AckReplyReady(notifyIn)
 		} else {
 			_ = c.run("tmux", "set-option", "-p", "-t", paneID, attentionStateOption, attentionStateReply)
 			_ = c.run("tmux", "set-option", "-p", "-t", paneID, attentionFocusArmedOption, "1")
 			_ = c.notifyAI(paneID)
+		}
+		// Force only controls notification delivery, not the badge.
+		if notifyIn.Force || !visible {
 			c.notifyProducer().PushReplyReady(notifyIn)
+		} else {
+			c.notifyProducer().AckReplyReady(notifyIn)
 		}
 	case "idle", "":
 		_ = c.run("tmux", "set-option", "-p", "-t", paneID, aiPaneStateOption, "idle")

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -858,6 +858,76 @@ func TestAIStatusSetWaitingDoesNotAckWhenNoClientViewingPane(t *testing.T) {
 	}
 }
 
+// Regression for the "stuck green badge" bug: when an AI hook (Claude Code /
+// Codex native hook) fires with Force=true and the pane is already visible to
+// some client, Force should only force the notify queue push — it must NOT
+// set @projmux_attention_state=reply, otherwise focus can no longer clear the
+// badge (focus clears attention_state, but used to leave ai_state=waiting and
+// the badge formula ORed both).
+func TestAIStatusSetWaitingForceDoesNotSetBadgeWhenVisible(t *testing.T) {
+	home := t.TempDir()
+	store := &stubNotifyStore{}
+	cmd := testAICommand(home)
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: 10 * time.Minute}
+	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name != "tmux" {
+			return nil, os.ErrNotExist
+		}
+		if reflect.DeepEqual(args, []string{"list-clients", "-F", "#{client_active_pane}"}) {
+			return []byte("%21\n"), nil
+		}
+		if len(args) >= 5 && args[0] == "display-message" && args[1] == "-p" && args[2] == "-t" && args[3] == "%21" {
+			switch args[4] {
+			case "#{@projmux_ai_agent}":
+				return []byte("claude\n"), nil
+			case "#S":
+				return []byte("main\n"), nil
+			case "#{window_id}":
+				return []byte("@4\n"), nil
+			case "#{pane_id}":
+				return []byte("%21\n"), nil
+			case "#{socket_path}":
+				return []byte("/tmp/tmux/default\n"), nil
+			}
+		}
+		return []byte("\n"), nil
+	}
+
+	if err := cmd.applyAIStatusWithNotify("waiting", "%21", attentionNotifyInput{
+		ID:    "ai:test:%21",
+		Text:  "claude: reply ready · forced hook",
+		Force: true,
+	}); err != nil {
+		t.Fatalf("applyAIStatusWithNotify error = %v", err)
+	}
+
+	commands := cmdRecorder(cmd).commands
+	// Badge writes must look like the visible/auto-ack path: ai_state=waiting,
+	// then clear attention_state, set attention_ack=1, clear focus_armed.
+	wantPrefix := []recordedAICommand{
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%21", "@projmux_ai_state", "waiting"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%21", "@projmux_attention_ack"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%21", "@projmux_attention_state"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%21", "@projmux_attention_ack", "1"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%21", "@projmux_attention_focus_armed"}},
+	}
+	if len(commands) < len(wantPrefix) || !reflect.DeepEqual(commands[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("command prefix = %#v, want %#v", commands, wantPrefix)
+	}
+	// attention_state must never be set to "reply" on the visible path,
+	// regardless of Force.
+	for _, got := range commands {
+		if got.name == "tmux" && reflect.DeepEqual(got.args, []string{"set-option", "-p", "-t", "%21", "@projmux_attention_state", "reply"}) {
+			t.Fatalf("commands = %#v, did not expect attention_state=reply when pane visible (Force=true must not touch the badge)", commands)
+		}
+	}
+	// Force still ensures the notify queue gets a push entry even though the
+	// pane is visible.
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1 (Force=true forces notify even when visible)", len(store.pushed))
+	}
+}
+
 func TestAINotifySkipsRecentDuplicateButRefreshesRecord(t *testing.T) {
 	home := t.TempDir()
 	cmd := testAICommand(home)

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -870,6 +870,9 @@ func TestAIStatusSetWaitingForceDoesNotSetBadgeWhenVisible(t *testing.T) {
 	cmd := testAICommand(home)
 	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: 10 * time.Minute}
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "command" && len(args) == 2 && args[0] == "-v" && args[1] == "notify-send" {
+			return []byte("/usr/bin/notify-send\n"), nil
+		}
 		if name != "tmux" {
 			return nil, os.ErrNotExist
 		}
@@ -882,10 +885,16 @@ func TestAIStatusSetWaitingForceDoesNotSetBadgeWhenVisible(t *testing.T) {
 				return []byte("claude\n"), nil
 			case "#S":
 				return []byte("main\n"), nil
+			case "#W":
+				return []byte("dev\n"), nil
 			case "#{window_id}":
 				return []byte("@4\n"), nil
 			case "#{pane_id}":
 				return []byte("%21\n"), nil
+			case "#{pane_title}":
+				return []byte("Claude: reply ready\n"), nil
+			case "#{pane_current_path}":
+				return []byte(home + "\n"), nil
 			case "#{socket_path}":
 				return []byte("/tmp/tmux/default\n"), nil
 			}
@@ -925,6 +934,12 @@ func TestAIStatusSetWaitingForceDoesNotSetBadgeWhenVisible(t *testing.T) {
 	// pane is visible.
 	if len(store.pushed) != 1 {
 		t.Fatalf("push count = %d, want 1 (Force=true forces notify even when visible)", len(store.pushed))
+	}
+	// Force=true on a visible pane must still fire the OS-level notification
+	// (notifyAI) — the badge stays visibility-driven but delivery channels
+	// (queue + OS) follow the Force-or-not-visible rule uniformly.
+	if !containsAICommand(commands, "notify-send") {
+		t.Fatalf("commands = %#v, want notify-send dispatch when Force=true even with visible pane", commands)
 	}
 }
 

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -1137,8 +1137,8 @@ func tmuxAppConfigWithKeymap(binaryPath, defaultShell string, decoration config.
 	shell := tmuxConfigQuote(nonEmpty(strings.TrimSpace(defaultShell), fallbackInteractiveShell))
 	shellPaneLabelFormat := "#{?#{||:#{||:#{||:#{==:#{pane_current_command},zsh},#{==:#{pane_current_command},bash}},#{||:#{==:#{pane_current_command},fish},#{==:#{pane_current_command},sh}}},#{||:#{==:#{pane_current_command},nu},#{==:#{pane_current_command},xonsh}}},#{pane_current_command},#{pane_title}}"
 	paneLabelFormat := "#{?#{&&:#{!=:#{@projmux_ai_agent},},#{!=:#{@projmux_ai_topic},}},#{@projmux_ai_topic}," + shellPaneLabelFormat + "}"
-	paneBusyFormat := "#{||:#{==:#{@projmux_attention_state},busy},#{==:#{@projmux_ai_state},thinking}}"
-	paneReplyFormat := "#{||:#{==:#{@projmux_attention_state},reply},#{==:#{@projmux_ai_state},waiting}}"
+	paneBusyFormat := "#{==:#{@projmux_attention_state},busy}"
+	paneReplyFormat := "#{==:#{@projmux_attention_state},reply}"
 	inactivePaneBorderFormat := "#{?" + paneBusyFormat + ",#[bold#,fg=colour220] ● " + paneLabelFormat + " #[default],#{?" + paneReplyFormat + ",#[bold#,fg=colour46] ● " + paneLabelFormat + " #[default],#[fg=colour244] " + paneLabelFormat + " #[default]}}"
 	paneBorderFormat := "#{?pane_active,#[bold#,fg=colour16#,bg=colour45] > " + paneLabelFormat + " #[default]," + inactivePaneBorderFormat + "}"
 	lines := []string{


### PR DESCRIPTION
## Summary
Splits the pane border badge from AI lifecycle metadata. Closes the regression introduced when notify triggers migrated from the legacy `watch-title` polling loop to agent-native hooks (Claude Code / Codex): the polling loop used to naturally transition `ai_state` back to `idle`, but hooks are edge-triggered and never clear it, so the green badge stayed stuck after focus.

Three concerns are now cleanly separated:

| Concern | State holder | Rule |
|---|---|---|
| AI lifecycle metadata | `@projmux_ai_state` | Reflects hook events as-is. Consumed by notify queue / sidebar / metadata. **Independent of badge.** |
| Live attention badge | `@projmux_attention_state` | Visibility-only. Cleared by focus-in. |
| Notification delivery | `notifyAI` + `notifyProducer.Push/Ack` | `Force=true` only affects this — both OS notification and queue push uniformly. |

## Changes
- `internal/app/tmux.go`: badge formula drops the `ai_state` OR branches. `paneBusy = attention_state=busy`, `paneReply = attention_state=reply`.
- `internal/app/ai.go` `waiting` case: badge writes follow visibility only. `Force` now governs both `notifyAI` (OS) and `PushReplyReady` (queue) uniformly via a single `Force || !visible` gate.
- `internal/app/ai_test.go`: new `TestAIStatusSetWaitingForceDoesNotSetBadgeWhenVisible` covers the previously-broken case (Force=true + visible: no badge, OS notify still fires, queue push still fires). Existing tests around Force=false and not-visible paths unchanged.

Roadmap item: **Pane badge state 분리** (Should tier).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/app/... ./internal/integrations/tmux/... ./internal/integrations/agents/... ./internal/integrations/hooks/...`
- [x] `gofmt -l` clean
- [ ] Manual: trigger an AI hook reply on a focused pane → confirm no green badge (was stuck before), OS notification still fires.
- [ ] Manual: trigger an AI hook reply on a hidden pane → confirm green badge appears, OS notification fires, focus clears badge.