### PR TITLE
ci: split checks for parallel execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,47 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
-    name: Test
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check formatting
+        run: make fmt-check
+
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run unit tests
+        run: make test
+
+  npm-pack:
+    name: NPM Packages
     runs-on: ubuntu-latest
 
     steps:
@@ -26,17 +64,27 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Check formatting
-        run: make fmt-check
-
-      - name: Run unit tests
-        run: make test
-
       - name: Validate npm package staging
         run: make npm-pack
 
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Run integration tests
         run: make test-integration
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Run e2e tests
         run: make test-e2e


### PR DESCRIPTION
## Summary
- split the single CI Test job into independent Format, Unit Tests, NPM Package, Integration Tests, and E2E Tests jobs
- add workflow concurrency so newer pushes cancel stale runs on the same ref
- leave Docker smoke tests without host Go setup because they build inside the test container

## Verification
- make fmt
- make fix
- make test
- make test-integration
- make test-e2e
- make npm-pack