### PR TITLE
ci: skip npm package checks when unrelated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -51,20 +51,63 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect package relevance
+        id: package-scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          needed=0
+          reason="no package-related files changed"
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            case "$PR_TITLE" in
+              "chore(main): release "*)
+                needed=1
+                reason="release PR"
+                ;;
+            esac
+            git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" > changed-files.txt
+          elif [[ "$PUSH_BEFORE" =~ ^0+$ ]]; then
+            git diff-tree --no-commit-id --name-only -r "$PUSH_SHA" > changed-files.txt
+          else
+            git diff --name-only "$PUSH_BEFORE" "$PUSH_SHA" > changed-files.txt
+          fi
+
+          if [[ "$needed" != "1" ]] && grep -Eq '^(package(-lock)?\.json|npm/|scripts/package-npm\.sh|README(\.md|-ko\.md)?|LICENSE|docs/|\.github/workflows/release(-please)?\.yml)' changed-files.txt; then
+            needed=1
+            reason="package-related files changed"
+          fi
+
+          echo "needed=$needed" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          echo "NPM package check: $reason"
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        if: steps.package-scope.outputs.needed == '1'
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        if: steps.package-scope.outputs.needed == '1'
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
       - name: Validate npm package staging
+        if: steps.package-scope.outputs.needed == '1'
         run: make npm-pack
 
   integration:
@@ -73,7 +116,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run integration tests
         run: make test-integration
@@ -84,7 +127,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run e2e tests
         run: make test-e2e

--- a/scripts/package-npm.sh
+++ b/scripts/package-npm.sh
@@ -99,11 +99,33 @@ stage_platform() {
   patch_version "$dir/package.json"
 }
 
-stage_platform linux amd64 x64
-stage_platform linux arm64 arm64
-stage_platform darwin amd64 x64
-stage_platform darwin arm64 arm64
-stage_main
+stage_jobs=()
+stage_names=()
+
+run_stage() {
+  local name="$1"
+  shift
+  "$@" &
+  stage_jobs+=("$!")
+  stage_names+=("$name")
+}
+
+run_stage "@projmux/linux-x64" stage_platform linux amd64 x64
+run_stage "@projmux/linux-arm64" stage_platform linux arm64 arm64
+run_stage "@projmux/darwin-x64" stage_platform darwin amd64 x64
+run_stage "@projmux/darwin-arm64" stage_platform darwin arm64 arm64
+run_stage "projmux" stage_main
+
+stage_status=0
+for i in "${!stage_jobs[@]}"; do
+  if ! wait "${stage_jobs[$i]}"; then
+    echo "failed to stage ${stage_names[$i]}" >&2
+    stage_status=1
+  fi
+done
+if [[ "$stage_status" -ne 0 ]]; then
+  exit "$stage_status"
+fi
 
 if [[ "$pack" -eq 1 ]]; then
   for dir in \


### PR DESCRIPTION
## Summary
- keep the required NPM Packages check but skip Go/Node setup and packaging when package-facing files are unchanged
- still run package validation for release PRs and package/docs/npm metadata changes
- parallelize npm platform package staging so package validation is faster when it does run
- bump first-party GitHub Actions to Node24 runtime majors

## Verification
- bash -n scripts/package-npm.sh
- make fmt
- make fix
- make test
- make test-integration
- make test-e2e
- make npm-pack