### PR TITLE
ci: parallelize release workflow tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,16 @@ permissions:
   contents: write
 
 jobs:
-  test:
-    name: Test
+  fmt:
+    name: Release Format
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -26,18 +26,52 @@ jobs:
       - name: Check formatting
         run: make fmt-check
 
+  unit:
+    name: Release Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Run unit tests
         run: make test
 
+  integration:
+    name: Release Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Run integration tests
         run: make test-integration
+
+  e2e:
+    name: Release E2E Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
 
       - name: Run e2e tests
         run: make test-e2e
 
   release:
     name: Build Release
-    needs: test
+    needs:
+      - fmt
+      - unit
+      - integration
+      - e2e
     runs-on: ubuntu-latest
 
     strategy:
@@ -55,10 +89,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -79,7 +113,7 @@ jobs:
           tar -C dist -czf "dist/${name}.tar.gz" "${name}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: projmux-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/*.tar.gz
@@ -93,10 +127,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true
@@ -116,16 +150,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary
- split the release tag workflow Test job into Release Format, Release Unit Tests, Release Integration Tests, and Release E2E Tests
- gate release builds on all four checks while letting them run in parallel
- update release workflow actions to Node24 runtime majors: checkout/setup-go/setup-node v6 and artifact actions v7

## Verification
- make fmt
- make fix
- make test
- make test-integration
- make test-e2e