### PR TITLE
fix: use exact tmux session targets

### DIFF
--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -886,6 +886,7 @@ func buildPopupToggleWithPickerBackend(mode tmuxPopupToggleMode, binaryPath, mar
 	case "session-popup":
 		options.Width = popupSize(ctx.ClientWidth, 80, 120)
 		options.Height = popupSize(ctx.ClientHeight, 70, 28)
+		addSwitchTargetClientEnv(env, ctx)
 		commandArgs = []string{"sessions", "--ui=popup"}
 	case "sessionizer":
 		options.Width = popupSize(ctx.ClientWidth, 80, 120)

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -860,6 +860,31 @@ func TestBuildPopupToggleSessionizerTrustEnvUsesClientOnly(t *testing.T) {
 	}
 }
 
+func TestBuildPopupToggleSessionPopupPropagatesSwitchTargetClient(t *testing.T) {
+	command, options, err := buildPopupToggleWithPickerBackend(
+		tmuxPopupToggleMode{Raw: "session-popup", Canonical: "session-popup"},
+		"/tmp/projmux",
+		"/tmp/marker",
+		tmuxPopupContext{
+			TargetClient: "/dev/pts/8",
+			OriginPane:   "%2",
+			ClientWidth:  200,
+			ClientHeight: 50,
+		},
+		intpicker.Backend("legacy"),
+		func(string) string { return "" },
+	)
+	if err != nil {
+		t.Fatalf("buildPopupToggleWithPickerBackend() error = %v", err)
+	}
+	if !strings.Contains(command, inttmux.SwitchTargetClientEnv+"='/dev/pts/8'") {
+		t.Fatalf("popup command = %q, want switch target client env", command)
+	}
+	if got := options.Env[inttmux.SwitchTargetClientEnv]; got != "/dev/pts/8" {
+		t.Fatalf("options.Env[%q] = %q, want target client", inttmux.SwitchTargetClientEnv, got)
+	}
+}
+
 func TestAppRunTmuxPopupTogglePropagatesLegacySessionizerRoots(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integrations/tmux/client.go
+++ b/internal/integrations/tmux/client.go
@@ -657,11 +657,12 @@ func (c *Client) OpenSession(ctx context.Context, sessionName string) error {
 		return errSessionNameRequired
 	}
 
-	command := []string{"attach-session", "-t", sessionName}
+	target := exactSessionTarget(sessionName)
+	command := []string{"attach-session", "-t", target}
 	action := "attach"
 	inside := c.InsideSession()
 	if inside {
-		command = c.switchClientCommand(sessionName)
+		command = c.switchClientCommand(target)
 		action = "switch"
 	}
 
@@ -670,7 +671,7 @@ func (c *Client) OpenSession(ctx context.Context, sessionName string) error {
 	}
 
 	if inside {
-		c.runPostAttach(ctx, sessionName, sessionName)
+		c.runPostAttach(ctx, sessionName, target)
 	}
 	return nil
 }
@@ -758,7 +759,7 @@ func (c *Client) SwitchClient(ctx context.Context, sessionName string) error {
 		return errSessionNameRequired
 	}
 
-	if _, err := c.runner.Run(ctx, "tmux", "switch-client", "-t", sessionName); err != nil {
+	if _, err := c.runner.Run(ctx, "tmux", "switch-client", "-t", exactSessionTarget(sessionName)); err != nil {
 		return fmt.Errorf("switch tmux client to session %q: %w", sessionName, err)
 	}
 
@@ -771,7 +772,7 @@ func (c *Client) KillSession(ctx context.Context, sessionName string) error {
 		return errSessionNameRequired
 	}
 
-	if _, err := c.runner.Run(ctx, "tmux", "kill-session", "-t", sessionName); err != nil {
+	if _, err := c.runner.Run(ctx, "tmux", "kill-session", "-t", exactSessionTarget(sessionName)); err != nil {
 		return fmt.Errorf("kill tmux session %q: %w", sessionName, err)
 	}
 
@@ -857,7 +858,7 @@ func (c *Client) InsideSession() bool {
 }
 
 func (c *Client) sessionExists(ctx context.Context, sessionName string) (bool, error) {
-	if _, err := c.runner.Run(ctx, "tmux", "has-session", "-t", sessionName); err != nil {
+	if _, err := c.runner.Run(ctx, "tmux", "has-session", "-t", exactSessionTarget(sessionName)); err != nil {
 		if isExitCode(err, 1) {
 			return false, nil
 		}
@@ -1103,10 +1104,10 @@ func shellQuote(value string) string {
 
 func sessionWindowTarget(sessionName, windowIndex string) string {
 	if strings.TrimSpace(windowIndex) == "" {
-		return strings.TrimSpace(sessionName)
+		return exactSessionTarget(sessionName)
 	}
 
-	return fmt.Sprintf("%s:%s", strings.TrimSpace(sessionName), strings.TrimSpace(windowIndex))
+	return fmt.Sprintf("%s:%s", exactSessionTarget(sessionName), strings.TrimSpace(windowIndex))
 }
 
 func sessionPaneTarget(sessionName, windowIndex, paneIndex string) string {
@@ -1116,6 +1117,14 @@ func sessionPaneTarget(sessionName, windowIndex, paneIndex string) string {
 	}
 
 	return fmt.Sprintf("%s.%s", target, strings.TrimSpace(paneIndex))
+}
+
+func exactSessionTarget(sessionName string) string {
+	sessionName = strings.TrimSpace(sessionName)
+	if sessionName == "" || strings.HasPrefix(sessionName, "=") {
+		return sessionName
+	}
+	return "=" + sessionName
 }
 
 func resolvePopupOptions(options PopupOptions) (PopupOptions, error) {

--- a/internal/integrations/tmux/client_test.go
+++ b/internal/integrations/tmux/client_test.go
@@ -876,7 +876,7 @@ func TestClientEnsureSessionCreatesMissingSession(t *testing.T) {
 	}
 
 	want := []commandCall{
-		{name: "tmux", args: []string{"has-session", "-t", "workspace"}},
+		{name: "tmux", args: []string{"has-session", "-t", "=workspace"}},
 		{name: "tmux", args: []string{"new-session", "-d", "-s", "workspace", "-c", "/tmp/projmux"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
@@ -898,7 +898,7 @@ func TestClientEnsureSessionSkipsCreateWhenSessionExists(t *testing.T) {
 	}
 
 	want := []commandCall{
-		{name: "tmux", args: []string{"has-session", "-t", "workspace"}},
+		{name: "tmux", args: []string{"has-session", "-t", "=workspace"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("unexpected calls %#v", runner.calls)
@@ -1013,7 +1013,7 @@ func TestClientOpenSessionSwitchesInsideTmux(t *testing.T) {
 	}
 
 	want := []commandCall{
-		{name: "tmux", args: []string{"switch-client", "-t", "workspace"}},
+		{name: "tmux", args: []string{"switch-client", "-t", "=workspace"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("unexpected calls %#v", runner.calls)
@@ -1043,7 +1043,7 @@ func TestClientOpenSessionTargetsClientInsideTmux(t *testing.T) {
 	}
 
 	want := []commandCall{
-		{name: "tmux", args: []string{"switch-client", "-c", "/dev/pts/7", "-t", "workspace"}},
+		{name: "tmux", args: []string{"switch-client", "-c", "/dev/pts/7", "-t", "=workspace"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("unexpected calls %#v", runner.calls)
@@ -1064,7 +1064,7 @@ func TestClientOpenSessionAttachesOutsideTmux(t *testing.T) {
 	}
 
 	want := []commandCall{
-		{name: "tmux", args: []string{"attach-session", "-t", "workspace"}},
+		{name: "tmux", args: []string{"attach-session", "-t", "=workspace"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("unexpected calls %#v", runner.calls)
@@ -1099,7 +1099,7 @@ func TestClientSwitchClientRunsTmuxSwitch(t *testing.T) {
 	}
 
 	want := []commandCall{
-		{name: "tmux", args: []string{"switch-client", "-t", "workspace"}},
+		{name: "tmux", args: []string{"switch-client", "-t", "=workspace"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("unexpected calls %#v", runner.calls)
@@ -1150,7 +1150,7 @@ func TestClientKillSessionRunsTmuxKill(t *testing.T) {
 	}
 
 	want := []commandCall{
-		{name: "tmux", args: []string{"kill-session", "-t", "workspace"}},
+		{name: "tmux", args: []string{"kill-session", "-t", "=workspace"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("unexpected calls %#v", runner.calls)
@@ -1380,7 +1380,7 @@ func TestClientOpenSessionTargetSwitchesToPaneInsideTmux(t *testing.T) {
 	}
 
 	want := []commandCall{
-		{name: "tmux", args: []string{"switch-client", "-t", "workspace:3.8"}},
+		{name: "tmux", args: []string{"switch-client", "-t", "=workspace:3.8"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("unexpected calls %#v", runner.calls)
@@ -1410,7 +1410,7 @@ func TestClientOpenSessionTargetTargetsClientInsideTmux(t *testing.T) {
 	}
 
 	want := []commandCall{
-		{name: "tmux", args: []string{"switch-client", "-c", "/dev/pts/7", "-t", "workspace:3.8"}},
+		{name: "tmux", args: []string{"switch-client", "-c", "/dev/pts/7", "-t", "=workspace:3.8"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("unexpected calls %#v", runner.calls)
@@ -1435,8 +1435,8 @@ func TestClientOpenSessionTargetRunsPostAttachAfterInsideTmuxSwitch(t *testing.T
 	}
 
 	want := []commandCall{
-		{name: "tmux", args: []string{"switch-client", "-t", "workspace:3.8"}},
-		{name: "tmux", args: []string{"display-message", "-p", "-t", "workspace:3.8", "-F", "#{pane_current_path}"}},
+		{name: "tmux", args: []string{"switch-client", "-t", "=workspace:3.8"}},
+		{name: "tmux", args: []string{"display-message", "-p", "-t", "=workspace:3.8", "-F", "#{pane_current_path}"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("unexpected calls %#v", runner.calls)
@@ -1463,7 +1463,7 @@ func TestClientOpenSessionTargetAttachesToWindowOutsideTmux(t *testing.T) {
 	}
 
 	want := []commandCall{
-		{name: "tmux", args: []string{"attach-session", "-t", "workspace:3"}},
+		{name: "tmux", args: []string{"attach-session", "-t", "=workspace:3"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("unexpected calls %#v", runner.calls)
@@ -1485,7 +1485,7 @@ func TestClientOpenSessionTargetSkipsPostAttachOutsideTmux(t *testing.T) {
 	}
 
 	want := []commandCall{
-		{name: "tmux", args: []string{"attach-session", "-t", "workspace:3"}},
+		{name: "tmux", args: []string{"attach-session", "-t", "=workspace:3"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("unexpected calls %#v", runner.calls)
@@ -1783,7 +1783,7 @@ func TestClientEnsureSessionRunsLifecycleHooksForNewSession(t *testing.T) {
 	}
 
 	wantCalls := []commandCall{
-		{name: "tmux", args: []string{"has-session", "-t", "workspace"}},
+		{name: "tmux", args: []string{"has-session", "-t", "=workspace"}},
 		{name: "tmux", args: []string{"new-session", "-d", "-s", "workspace", "-c", "/tmp/projmux", "-P", "-F", "#{pane_id}"}},
 		{name: "tmux", args: []string{"display-message", "-p", "-t", "%7", "-F", "#{pane_current_command}"}},
 		{name: "tmux", args: []string{"send-keys", "-t", "%7", "echo ready", "Enter"}},
@@ -1819,7 +1819,7 @@ func TestClientEnsureSessionSkipsStartupMarkersWhenNoStartupHook(t *testing.T) {
 	}
 
 	wantCalls := []commandCall{
-		{name: "tmux", args: []string{"has-session", "-t", "workspace"}},
+		{name: "tmux", args: []string{"has-session", "-t", "=workspace"}},
 		{name: "tmux", args: []string{"new-session", "-d", "-s", "workspace", "-c", "/tmp/projmux", "-P", "-F", "#{pane_id}"}},
 	}
 	if !reflect.DeepEqual(runner.calls, wantCalls) {
@@ -1853,7 +1853,7 @@ func TestClientEnsureSessionSkipsStartupMarkersWhenNoCommand(t *testing.T) {
 			}
 
 			wantCalls := []commandCall{
-				{name: "tmux", args: []string{"has-session", "-t", "workspace"}},
+				{name: "tmux", args: []string{"has-session", "-t", "=workspace"}},
 				{name: "tmux", args: []string{"new-session", "-d", "-s", "workspace", "-c", "/tmp/projmux", "-P", "-F", "#{pane_id}"}},
 			}
 			if !reflect.DeepEqual(runner.calls, wantCalls) {
@@ -1886,7 +1886,7 @@ func TestClientEnsureSessionSkipsStartupMarkersWhenSendKeysFails(t *testing.T) {
 	}
 
 	wantCalls := []commandCall{
-		{name: "tmux", args: []string{"has-session", "-t", "workspace"}},
+		{name: "tmux", args: []string{"has-session", "-t", "=workspace"}},
 		{name: "tmux", args: []string{"new-session", "-d", "-s", "workspace", "-c", "/tmp/projmux", "-P", "-F", "#{pane_id}"}},
 		{name: "tmux", args: []string{"display-message", "-p", "-t", "%7", "-F", "#{pane_current_command}"}},
 		{name: "tmux", args: []string{"send-keys", "-t", "%7", "echo ready", "Enter"}},
@@ -1920,7 +1920,7 @@ func TestClientEnsureSessionPreCreateAbortSkipsNewSession(t *testing.T) {
 		t.Fatalf("EnsureSession error = %v, want pre-create blocked", err)
 	}
 	wantCalls := []commandCall{
-		{name: "tmux", args: []string{"has-session", "-t", "workspace"}},
+		{name: "tmux", args: []string{"has-session", "-t", "=workspace"}},
 	}
 	if !reflect.DeepEqual(runner.calls, wantCalls) {
 		t.Fatalf("unexpected tmux calls %#v", runner.calls)
@@ -1952,7 +1952,7 @@ func TestClientEnsureSessionAppliesProjectSessionEnvOnCreateAndAfterCreate(t *te
 	}
 
 	wantCalls := []commandCall{
-		{name: "tmux", args: []string{"has-session", "-t", "workspace"}},
+		{name: "tmux", args: []string{"has-session", "-t", "=workspace"}},
 		{name: "tmux", args: []string{"new-session", "-d", "-s", "workspace", "-c", "/tmp/projmux", "-e", "FOO=bar", "-e", "ZED=last", "-P", "-F", "#{pane_id}"}},
 		{name: "tmux", args: []string{"set-environment", "-t", "workspace", "FOO", "bar"}},
 		{name: "tmux", args: []string{"set-environment", "-t", "workspace", "ZED", "last"}},
@@ -2133,8 +2133,8 @@ func TestClientOpenSessionRunsPostAttachAfterInsideTmuxSwitch(t *testing.T) {
 	}
 
 	wantCalls := []commandCall{
-		{name: "tmux", args: []string{"switch-client", "-t", "workspace"}},
-		{name: "tmux", args: []string{"display-message", "-p", "-t", "workspace", "-F", "#{pane_current_path}"}},
+		{name: "tmux", args: []string{"switch-client", "-t", "=workspace"}},
+		{name: "tmux", args: []string{"display-message", "-p", "-t", "=workspace", "-F", "#{pane_current_path}"}},
 	}
 	if !reflect.DeepEqual(runner.calls, wantCalls) {
 		t.Fatalf("unexpected tmux calls %#v", runner.calls)
@@ -2162,7 +2162,7 @@ func TestClientOpenSessionSkipsPostAttachOutsideTmux(t *testing.T) {
 	}
 
 	wantCalls := []commandCall{
-		{name: "tmux", args: []string{"attach-session", "-t", "workspace"}},
+		{name: "tmux", args: []string{"attach-session", "-t", "=workspace"}},
 	}
 	if !reflect.DeepEqual(runner.calls, wantCalls) {
 		t.Fatalf("unexpected tmux calls %#v", runner.calls)


### PR DESCRIPTION
## Summary
- use exact tmux session targets to avoid prefix matches like repositories-donus matching repositories-donus-cloud-manager
- propagate the switch target client into the session popup path

## Tests
- make fmt
- make fix
- make test
- make test-integration
- make test-e2e