### PR TITLE
fix: prompt stale project hook trust in popups

### DIFF
--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -1476,7 +1476,7 @@ func (c *switchCommand) openTarget(ctx context.Context, target string) error {
 	if exists {
 		return c.openProjectSession(ctx, sessionName)
 	}
-	return c.ensureAndOpenProjectSession(ctx, sessionName, target)
+	return c.openProjectTarget(ctx, target, sessionName)
 }
 
 func (c *switchCommand) openProjectTargetPath(ctx context.Context, target string) error {

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -198,6 +198,40 @@ func TestSwitchExecuteSidebarHookProjectUsesInlineStartupAndTrust(t *testing.T) 
 	}
 }
 
+func TestSwitchExecutePopupProjectCreateUsesProjectOpenTrust(t *testing.T) {
+	t.Parallel()
+
+	target := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(target, ".projmux"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, ".projmux", "config.toml"), []byte("[hooks.post-create]\nrun = \"echo hook\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sessions := &capturingSwitchSessionExecutor{exists: map[string]bool{"target": false}}
+	cmd := &switchCommand{
+		sessions:  sessions,
+		identity:  stubSwitchIdentityResolver{name: "target"},
+		homeDir:   func() (string, error) { return t.TempDir(), nil },
+		lookupEnv: func(string) string { return "" },
+	}
+
+	reopen, err := cmd.execute(context.Background(), switchPlan{
+		UI:          switchUIPopup,
+		Selection:   target,
+		SessionName: "target",
+	}, nil)
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+	if reopen {
+		t.Fatal("execute() reopen = true, want false")
+	}
+	if got, want := sessions.calls, []string{"authorize:" + target, "ensure:target", "open:target"}; !equalStrings(got, want) {
+		t.Fatalf("calls = %q, want project trust before create", got)
+	}
+}
+
 func TestSwitchExecuteSidebarExistingHookProjectOpensDirectly(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -490,6 +490,7 @@ func (c *tmuxCommand) runPopupSwitch(args []string, stderr io.Writer) error {
 	if c.switchPopup != nil {
 		options = c.switchPopup(popupCtx)
 	}
+	options = withHookTrustInlineEnv(options)
 	options = c.applyPickerPopupBackend(options)
 
 	if err := c.popup.DisplayPopupWithOptions(context.Background(), command, options); err != nil {
@@ -867,6 +868,22 @@ func addHookTrustPopupTargetEnv(env map[string]string, ctx tmuxPopupContext) {
 	}
 }
 
+func addHookTrustInlineEnv(env map[string]string) {
+	env[hookTrustInlineEnv] = "1"
+}
+
+func withHookTrustInlineEnv(options inttmux.PopupOptions) inttmux.PopupOptions {
+	env := options.Env
+	if env == nil {
+		env = map[string]string{}
+	} else {
+		env = maps.Clone(env)
+	}
+	addHookTrustInlineEnv(env)
+	options.Env = env
+	return options
+}
+
 func addSwitchTargetClientEnv(env map[string]string, ctx tmuxPopupContext) {
 	if strings.TrimSpace(ctx.TargetClient) != "" {
 		env[inttmux.SwitchTargetClientEnv] = ctx.TargetClient
@@ -891,6 +908,7 @@ func buildPopupToggleWithPickerBackend(mode tmuxPopupToggleMode, binaryPath, mar
 		options.Width = popupSize(ctx.ClientWidth, 80, 120)
 		options.Height = popupSize(ctx.ClientHeight, 70, 28)
 		cwd = ctx.ContextDir
+		addHookTrustInlineEnv(env)
 		addHookTrustPopupTargetEnv(env, ctx)
 		addSwitchTargetClientEnv(env, ctx)
 		env["TMUX_SESSIONIZER_CONTEXT_DIR"] = ctx.ContextDir
@@ -903,6 +921,7 @@ func buildPopupToggleWithPickerBackend(mode tmuxPopupToggleMode, binaryPath, mar
 		options.X = "0"
 		options.Y = "0"
 		cwd = ctx.ContextDir
+		addHookTrustInlineEnv(env)
 		addHookTrustPopupTargetEnv(env, ctx)
 		addSwitchTargetClientEnv(env, ctx)
 		env["TMUX_SESSIONIZER_CONTEXT_DIR"] = ctx.ContextDir

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -81,9 +81,12 @@ func TestAppRunTmuxPopupSwitchUsesCurrentPanePathAndDefaultOptions(t *testing.T)
 	}
 
 	wantOptions := inttmux.PopupOptions{
-		Width:         "80%",
-		Height:        "70%",
-		Env:           map[string]string{intpicker.BackendEnv: string(intpicker.BackendNative)},
+		Width:  "80%",
+		Height: "70%",
+		Env: map[string]string{
+			hookTrustInlineEnv:   "1",
+			intpicker.BackendEnv: string(intpicker.BackendNative),
+		},
 		NoBorder:      true,
 		CloseBehavior: inttmux.PopupCloseOnExit,
 	}
@@ -208,9 +211,12 @@ func TestAppRunTmuxPopupCommandsUseMinimumReadableSizes(t *testing.T) {
 			args:  []string{"tmux", "popup-switch"},
 			popup: &stubTmuxPopupClient{currentPanePath: "/tmp/work tree"},
 			wantOptions: inttmux.PopupOptions{
-				Width:         "120",
-				Height:        "28",
-				Env:           map[string]string{intpicker.BackendEnv: string(intpicker.BackendNative)},
+				Width:  "120",
+				Height: "28",
+				Env: map[string]string{
+					hookTrustInlineEnv:   "1",
+					intpicker.BackendEnv: string(intpicker.BackendNative),
+				},
 				NoBorder:      true,
 				CloseBehavior: inttmux.PopupCloseOnExit,
 			},
@@ -290,6 +296,7 @@ func TestAppRunTmuxPopupToggleOpensStandaloneSidebar(t *testing.T) {
 		"-E",
 		"-B",
 		"-d", "/tmp/work tree",
+		"-e", "PROJMUX_HOOK_TRUST_INLINE=1",
 		"-e", "PROJMUX_HOOK_TRUST_TARGET_CLIENT=/dev/pts/projmux-test-sidebar",
 		"-e", "PROJMUX_NATIVE_LAUNCH_KEY=alt-1",
 		"-e", "PROJMUX_PICKER_BACKEND=native",
@@ -308,6 +315,7 @@ func TestAppRunTmuxPopupToggleOpensStandaloneSidebar(t *testing.T) {
 	command := got.args[len(got.args)-1]
 	for _, want := range []string{
 		"cd -- '/tmp/work tree'",
+		"PROJMUX_HOOK_TRUST_INLINE='1'",
 		"PROJMUX_HOOK_TRUST_TARGET_CLIENT='/dev/pts/projmux-test-sidebar'",
 		"PROJMUX_SWITCH_TARGET_CLIENT='/dev/pts/projmux-test-sidebar'",
 		"TMUX_SESSIONIZER_CONTEXT_SESSION='work'",
@@ -319,7 +327,6 @@ func TestAppRunTmuxPopupToggleOpensStandaloneSidebar(t *testing.T) {
 		}
 	}
 	for _, unwanted := range []string{
-		"PROJMUX_HOOK_TRUST_INLINE",
 		"PROJMUX_HOOK_TRUST_TARGET_PANE",
 	} {
 		if strings.Contains(command, unwanted) {
@@ -787,6 +794,7 @@ func TestBuildPopupTogglePropagatesPickerEnvironment(t *testing.T) {
 		"PROJMUX_NATIVE_TTY_FALLBACK='0'",
 		"PROJMUX_PROJDIR='/workspace/projects'",
 		"PROJMUX_MANAGED_ROOTS='/workspace/projects'",
+		hookTrustInlineEnv + "='1'",
 		hookTrustPopupTargetClientEnv + "='/dev/pts/7'",
 		inttmux.SwitchTargetClientEnv + "='/dev/pts/7'",
 	} {
@@ -794,7 +802,7 @@ func TestBuildPopupTogglePropagatesPickerEnvironment(t *testing.T) {
 			t.Fatalf("popup command = %q, want substring %q", command, want)
 		}
 	}
-	for _, unwanted := range []string{hookTrustInlineEnv, hookTrustPopupTargetPaneEnv} {
+	for _, unwanted := range []string{hookTrustPopupTargetPaneEnv} {
 		if strings.Contains(command, unwanted) {
 			t.Fatalf("popup command = %q, unwanted substring %q", command, unwanted)
 		}
@@ -805,6 +813,7 @@ func TestBuildPopupTogglePropagatesPickerEnvironment(t *testing.T) {
 		"PROJMUX_NATIVE_TTY_FALLBACK": "0",
 		"PROJMUX_PROJDIR":             "/workspace/projects",
 		"PROJMUX_MANAGED_ROOTS":       "/workspace/projects",
+		hookTrustInlineEnv:            "1",
 		hookTrustPopupTargetClientEnv: "/dev/pts/7",
 		inttmux.SwitchTargetClientEnv: "/dev/pts/7",
 	} {
@@ -812,7 +821,7 @@ func TestBuildPopupTogglePropagatesPickerEnvironment(t *testing.T) {
 			t.Fatalf("options.Env[%q] = %q, want %q", key, got, want)
 		}
 	}
-	for _, key := range []string{hookTrustInlineEnv, hookTrustPopupTargetPaneEnv} {
+	for _, key := range []string{hookTrustPopupTargetPaneEnv} {
 		if value, ok := options.Env[key]; ok {
 			t.Fatalf("options.Env[%q] = %q, want absent", key, value)
 		}
@@ -844,7 +853,10 @@ func TestBuildPopupToggleSessionizerTrustEnvUsesClientOnly(t *testing.T) {
 	if !strings.Contains(command, inttmux.SwitchTargetClientEnv+"='/dev/pts/8'") {
 		t.Fatalf("popup command = %q, want switch target client env", command)
 	}
-	for _, unwanted := range []string{hookTrustInlineEnv, hookTrustPopupTargetPaneEnv} {
+	if !strings.Contains(command, hookTrustInlineEnv+"='1'") {
+		t.Fatalf("popup command = %q, want inline trust env", command)
+	}
+	for _, unwanted := range []string{hookTrustPopupTargetPaneEnv} {
 		if strings.Contains(command, unwanted) {
 			t.Fatalf("popup command = %q, unwanted substring %q", command, unwanted)
 		}
@@ -857,6 +869,9 @@ func TestBuildPopupToggleSessionizerTrustEnvUsesClientOnly(t *testing.T) {
 	}
 	if got := options.Env[inttmux.SwitchTargetClientEnv]; got != "/dev/pts/8" {
 		t.Fatalf("options.Env[%q] = %q, want target client", inttmux.SwitchTargetClientEnv, got)
+	}
+	if got := options.Env[hookTrustInlineEnv]; got != "1" {
+		t.Fatalf("options.Env[%q] = %q, want inline trust", hookTrustInlineEnv, got)
 	}
 }
 


### PR DESCRIPTION
$## Summary
- route popup project creation through the project-open trust gate
- force sessionizer and popup switch trust prompts to run inline inside the existing popup
- add regression coverage for popup project trust and inline trust env

## Validation
- make fmt
- make fix
- make test
- make test-integration
- make test-e2e

## Notes
- Leaves existing untracked .claude/ untouched.