### PR TITLE
feat: add projmux quit lifecycle

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -43,6 +43,7 @@
 - `make test` also covers `projmux ai integrate tmux-bell` dry-run/install/remove tmux command planning, managed `alert-bell` hook append/idempotence/removal, preservation of unmanaged bell hooks, and `projmux ai ingest bell --pane` queue push/metadata/dedupe behavior for non-AI-managed panes.
 - `make test` also covers `projmux ai ingest log` tail/path rendering and bounded JSONL log trimming for ingest diagnostics.
 - `make test` also now covers onboarding revisit and welcome wiring (`projmux welcome`, `Settings > About > Welcome`, `pending_attach_welcome`, attach-time `welcome --popup` one-time claim/env suppression/tmux popup payload, and generated `client-attached` app config wiring) via shell welcome tests.
+- `make test` also covers `projmux quit` action-picker rows, cancel/close no-op behavior, explicit quit of only app-owned `tmux -L projmux` runtimes marked by `@projmux_app=1`, missing/default runtime no-ops, dispatcher wiring, and `Settings > About > Quit projmux` routing through the same picker before any shutdown side effect.
 - Current focused unit coverage also includes strict notify SOT behavior
   (TTL does not remove rows, focus success and target-gone clicks ack,
   reconcile reports stale rows), `notify list --live` queue/live explanations, notify sidebar

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,6 +31,7 @@ projmux <command> [args...]
 | `pin` | Manage pinned project directories. |
 | `preview` | Manage persisted tmux preview selection. |
 | `prune` | Trim stale tmux lifecycle state. |
+| `quit` | Quit the app-owned projmux tmux runtime. |
 | `sessions` | Pick and open an existing tmux session. |
 | `session-popup` | Read tmux popup preview state. |
 | `settings` | Configure projmux. |
@@ -653,7 +654,7 @@ flags with the top-level `switch` UX:
   retention window.
 - `tag` — manage the tagged-selection set.
 
-## current / shell / attach / settings
+## current / shell / attach / settings / quit
 
 - `current` — print `pane_current_path` for the active tmux pane (used
   by the shell jump binding).
@@ -666,6 +667,12 @@ flags with the top-level `switch` UX:
   snapshot`, and `Empty session` before creating a closed project session.
   `Latest snapshot` is auto-saved; named snapshots are fixed until the user
   saves or replaces them.
+- `quit` — open an action picker with `Quit projmux` and `Cancel`. Selecting
+  `Quit projmux` terminates only a `tmux -L projmux` runtime whose global
+  `@projmux_app` option is set by the generated app config. Missing servers,
+  default tmux servers, embedded tmux servers, and other tmux runtimes without
+  that marker are no-ops. Non-interactive callers must pass `--yes` or
+  `--force`; the default command always goes through the action picker.
 - `attach auto [--keep=N] [--fallback=home|ephemeral]` — auto-attach to
   the most recent session, with bounded retention and a fallback policy.
 - `settings` — interactive configuration UI for the project picker, AI
@@ -686,9 +693,10 @@ flags with the top-level `switch` UX:
   available for experimental settings. The About section reads the cached
   update status without network access;
   selecting Check Updates runs `projmux update check`, and Update Now runs
-  `projmux update apply`. The same About section also lists the keybinding
-  diagnostic path: zero-config first, `setup` for swallowed keys, `init` for
-  supported terminal fallbacks, and `doctor` for dependencies.
+  `projmux update apply`. `Settings > About > Quit projmux` routes through the
+  same `projmux quit` action picker. The same About section also lists the
+  keybinding diagnostic path: zero-config first, `setup` for swallowed keys,
+  `init` for supported terminal fallbacks, and `doctor` for dependencies.
 
 ## See also
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -73,6 +73,7 @@ type App struct {
 	popupWaitKey *popupWaitKeyCommand
 	preview      *previewCommand
 	prune        *pruneCommand
+	quit         *quitCommand
 	sessions     *sessionsCommand
 	sessionState *sessionStateCommand
 	sessionPopup *sessionPopupCommand
@@ -95,6 +96,7 @@ func New() *App {
 	ai := newAICommand()
 	switcher := newSwitchCommand()
 	update := newUpdateCommand()
+	quit := newQuitCommand()
 	return &App{
 		ai:           ai,
 		attention:    newAttentionCommand(),
@@ -110,10 +112,11 @@ func New() *App {
 		popupWaitKey: newPopupWaitKeyCommand(),
 		preview:      newPreviewCommand(),
 		prune:        newPruneCommand(),
+		quit:         quit,
 		sessions:     newSessionsCommand(),
 		sessionState: newSessionStateCommand(),
 		sessionPopup: newSessionPopupCommand(),
-		settings:     newSettingsCommand(ai, switcher, update),
+		settings:     newSettingsCommand(ai, switcher, update, quit),
 		setup:        newSetupCommand(),
 		shell:        newShellCommand(update),
 		status:       newStatusCommand(),
@@ -168,6 +171,8 @@ func (a *App) Run(args []string, stdout, stderr io.Writer) error {
 		return a.preview.Run(args[1:], stdout, stderr)
 	case "prune":
 		return a.prune.Run(args[1:], stdout, stderr)
+	case "quit":
+		return a.quit.Run(args[1:], stdout, stderr)
 	case "sessions":
 		return a.sessions.Run(args[1:], stdout, stderr)
 	case "session-state":
@@ -227,6 +232,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  pin       Manage pinned project directories")
 	fmt.Fprintln(w, "  preview   Manage persisted tmux preview selection")
 	fmt.Fprintln(w, "  prune     Trim stale tmux lifecycle state")
+	fmt.Fprintln(w, "  quit      Quit the app-owned projmux tmux runtime")
 	fmt.Fprintln(w, "  sessions  Pick and open an existing tmux session")
 	fmt.Fprintln(w, "  session-state  Inspect and manage saved tmux session snapshots")
 	fmt.Fprintln(w, "  session-popup  Read tmux popup preview state")

--- a/internal/app/native_picker_test.go
+++ b/internal/app/native_picker_test.go
@@ -236,7 +236,7 @@ func TestProductionPickerConstructorsDoNotCreateCompatRunner(t *testing.T) {
 	if cmd := newAICommand(); cmd.runner != nil {
 		t.Fatal("newAICommand() created compat runner")
 	}
-	if cmd := newSettingsCommand(testAICommand(t.TempDir()), testSettingsSwitchCommand(t, &stubSwitchPinStore{}), nil); cmd.runner != nil {
+	if cmd := newSettingsCommand(testAICommand(t.TempDir()), testSettingsSwitchCommand(t, &stubSwitchPinStore{}), nil, nil); cmd.runner != nil {
 		t.Fatal("newSettingsCommand() created compat runner")
 	}
 	if cmd := newSwitchCommand(); cmd.runner != nil {

--- a/internal/app/quit.go
+++ b/internal/app/quit.go
@@ -1,0 +1,150 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
+)
+
+const (
+	quitActionQuit   = "quit:quit"
+	quitActionCancel = "quit:cancel"
+)
+
+type quitCommand struct {
+	lookupEnv    func(string) string
+	runner       tmuxRunner
+	picker       intpickercompat.Runner
+	nativePicker intpicker.Runner
+}
+
+func newQuitCommand() *quitCommand {
+	return &quitCommand{
+		lookupEnv:    os.Getenv,
+		runner:       inttmux.ExecRunner{},
+		nativePicker: intpicker.NativeRunner{In: os.Stdin, Out: os.Stdout},
+	}
+}
+
+func (c *quitCommand) Run(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("quit", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	yes := fs.Bool("yes", false, "quit without opening the action picker")
+	force := fs.Bool("force", false, "quit without opening the action picker")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		printQuitUsage(stderr)
+		return errors.New("quit does not accept positional arguments")
+	}
+
+	if !*yes && !*force {
+		action, err := c.pickAction()
+		if err != nil {
+			return err
+		}
+		switch action {
+		case quitActionQuit:
+		case "", quitActionCancel:
+			return nil
+		default:
+			return fmt.Errorf("unknown quit action: %s", action)
+		}
+	}
+	return c.shutdownAppRuntime(context.Background(), defaultAppSocket)
+}
+
+func (c *quitCommand) pickAction() (string, error) {
+	result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.picker, quitActionOptions())
+	if err != nil {
+		if isNoSelectionExit(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("run quit picker: %w", err)
+	}
+	if result.Key != "enter" {
+		return "", nil
+	}
+	return strings.TrimSpace(result.Value), nil
+}
+
+func quitActionOptions() intpickercompat.Options {
+	return intpickercompat.Options{
+		UI:            "quit",
+		Title:         "Quit projmux",
+		Prompt:        "Quit > ",
+		Footer:        projmuxFooter("Enter: choose  |  Esc: cancel"),
+		ExpectKeys:    []string{"enter"},
+		DisableSearch: true,
+		Entries: []intpickercompat.Entry{
+			{
+				Label: settingsLabel(settingsGlyphRemove, settingsColorRemove, "Quit projmux", "terminate the app-owned tmux runtime"),
+				Value: quitActionQuit,
+			},
+			{
+				Label: settingsLabel(settingsGlyphBack, settingsColorBack, "Cancel", "keep projmux running"),
+				Value: quitActionCancel,
+			},
+		},
+		Bindings: pickerCloseBindings("esc", "ctrl-c"),
+	}
+}
+
+func (c *quitCommand) shutdownAppRuntime(ctx context.Context, socketName string) error {
+	if strings.TrimSpace(socketName) == "" {
+		return errors.New("quit target socket is required")
+	}
+	if c.runner == nil {
+		return errors.New("quit tmux runner is not configured")
+	}
+	appOwned, err := c.appRuntimeOwned(ctx, socketName)
+	if err != nil {
+		return err
+	}
+	if !appOwned {
+		return nil
+	}
+	_, err = c.runner.Run(ctx, "tmux", "-L", socketName, "kill-server")
+	if err != nil {
+		return fmt.Errorf("quit app tmux runtime: %w", err)
+	}
+	return nil
+}
+
+func (c *quitCommand) appRuntimeOwned(ctx context.Context, socketName string) (bool, error) {
+	output, err := c.runner.Run(ctx, "tmux", "-L", socketName, "show-option", "-gv", "@projmux_app")
+	if err != nil {
+		if tmuxServerMissing(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("check app tmux runtime: %w", err)
+	}
+	return strings.TrimSpace(string(output)) == "1", nil
+}
+
+func tmuxServerMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no server running") ||
+		strings.Contains(msg, "can't find server") ||
+		strings.Contains(msg, "failed to connect")
+}
+
+func printQuitUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  projmux quit [--yes|--force]")
+}

--- a/internal/app/quit_test.go
+++ b/internal/app/quit_test.go
@@ -1,0 +1,161 @@
+package app
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
+)
+
+func TestQuitCommandPickerShowsQuitAndCancel(t *testing.T) {
+	t.Parallel()
+
+	var got intpickercompat.Options
+	cmd := &quitCommand{
+		runner: &recordingTmuxRunner{},
+		nativePicker: nativePickerFromCompatRunner(switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
+			got = options
+			return intpickercompat.Result{Key: "enter", Value: quitActionCancel}, nil
+		})),
+	}
+
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got.UI != "quit" {
+		t.Fatalf("quit picker UI = %q, want quit", got.UI)
+	}
+	if got.DisableSearch != true {
+		t.Fatalf("quit picker DisableSearch = false, want true")
+	}
+	for _, want := range []string{"Quit projmux", "Cancel"} {
+		if !hasEntryLabelContaining(got.Entries, want) {
+			t.Fatalf("quit picker entries = %#v, want label containing %q", got.Entries, want)
+		}
+	}
+	if got, want := entryValues(got.Entries), []string{quitActionQuit, quitActionCancel}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("quit picker entry values = %#v, want %#v", got, want)
+	}
+}
+
+func TestQuitCommandSelectionKillsOnlyAppOwnedRuntime(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingTmuxRunner{
+		outputs: map[string]string{
+			strings.Join([]string{"tmux", "-L", defaultAppSocket, "show-option", "-gv", "@projmux_app"}, "\x00"): "1\n",
+		},
+	}
+	cmd := &quitCommand{
+		runner: runner,
+		nativePicker: nativePickerFromCompatRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+			return intpickercompat.Result{Key: "enter", Value: quitActionQuit}, nil
+		})),
+	}
+
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	want := []recordedTmuxCall{
+		{name: "tmux", args: []string{"-L", defaultAppSocket, "show-option", "-gv", "@projmux_app"}},
+		{name: "tmux", args: []string{"-L", defaultAppSocket, "kill-server"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("tmux calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+func TestQuitCommandCancelAndCloseDoNotShutdown(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		result intpickercompat.Result
+		err    error
+	}{
+		{name: "cancel action", result: intpickercompat.Result{Key: "enter", Value: quitActionCancel}},
+		{name: "escape result", result: intpickercompat.Result{Key: "esc", Value: quitActionQuit}},
+		{name: "closed picker", err: errors.New("exit status 130")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := &recordingTmuxRunner{}
+			cmd := &quitCommand{
+				runner: runner,
+				nativePicker: nativePickerFromCompatRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+					return tc.result, tc.err
+				})),
+			}
+			if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			if len(runner.calls) != 0 {
+				t.Fatalf("tmux calls = %#v, want none", runner.calls)
+			}
+		})
+	}
+}
+
+func TestQuitCommandNonAppRuntimeIsNoop(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingTmuxRunner{
+		outputs: map[string]string{
+			strings.Join([]string{"tmux", "-L", defaultAppSocket, "show-option", "-gv", "@projmux_app"}, "\x00"): "0\n",
+		},
+	}
+	cmd := &quitCommand{runner: runner}
+
+	if err := cmd.Run([]string{"--yes"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	want := []recordedTmuxCall{
+		{name: "tmux", args: []string{"-L", defaultAppSocket, "show-option", "-gv", "@projmux_app"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("tmux calls = %#v, want only ownership check", runner.calls)
+	}
+}
+
+func TestQuitCommandMissingRuntimeIsNoop(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingTmuxRunner{err: errors.New("no server running on /tmp/tmux-1000/projmux")}
+	cmd := &quitCommand{runner: runner}
+
+	if err := cmd.Run([]string{"--force"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	want := []recordedTmuxCall{
+		{name: "tmux", args: []string{"-L", defaultAppSocket, "show-option", "-gv", "@projmux_app"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("tmux calls = %#v, want only ownership check", runner.calls)
+	}
+}
+
+func TestAppRunDispatchesQuit(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	app := &App{
+		quit: &quitCommand{
+			runner: &recordingTmuxRunner{},
+			nativePicker: nativePickerFromCompatRunner(switchRunnerFunc(func(intpickercompat.Options) (intpickercompat.Result, error) {
+				called = true
+				return intpickercompat.Result{Key: "enter", Value: quitActionCancel}, nil
+			})),
+		},
+	}
+
+	if err := app.Run([]string{"quit"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !called {
+		t.Fatal("quit picker was not called")
+	}
+}

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -32,6 +32,7 @@ type settingsCommand struct {
 	ai                  *aiCommand
 	switcher            *switchCommand
 	update              *updateCommand
+	quit                *quitCommand
 	runner              intpickercompat.Runner
 	nativePicker        intpicker.Runner
 	homeDir             func() (string, error)
@@ -112,6 +113,7 @@ var settingsEntryCatalog = map[string]settingsEntryMeta{
 	settingsUpdateApply:                {Name: "Update Now", Axis: settingsAxisGlobal},
 	settingsUpdateCheck:                {Name: "Check Updates", Axis: settingsAxisGlobal},
 	settingsWelcomeShow:                {Name: "Welcome", Axis: settingsAxisGlobal},
+	settingsQuitOpen:                   {Name: "Quit projmux", Axis: settingsAxisGlobal},
 }
 
 var settingsEntryPrefixCatalog = []struct {
@@ -190,6 +192,7 @@ const (
 	settingsActionPrefixSwitch             = "switch:"
 	settingsActionPrefixUpdate             = "update:"
 	settingsActionPrefixWorkdir            = "workdir:"
+	settingsActionPrefixQuit               = "quit:"
 	settingsProjectAdd                     = "project:add"
 	settingsProjectPins                    = "project:pins"
 	settingsProjectRootManage              = "project-root:manage"
@@ -198,6 +201,7 @@ const (
 	settingsProjdirSetTyped                = "projdir:set-typed"
 	settingsUpdateApply                    = "update:apply"
 	settingsUpdateCheck                    = "update:check"
+	settingsQuitOpen                       = "quit:open"
 	settingsWorkdirAdd                     = "workdir:add"
 	settingsWorkdirList                    = "workdir:list"
 	settingsWorkdirTyped                   = "workdir:typed"
@@ -221,11 +225,12 @@ const (
 	settingsKeymapFieldPrefix              = "prefix"
 )
 
-func newSettingsCommand(ai *aiCommand, switcher *switchCommand, update *updateCommand) *settingsCommand {
+func newSettingsCommand(ai *aiCommand, switcher *switchCommand, update *updateCommand, quit *quitCommand) *settingsCommand {
 	return &settingsCommand{
 		ai:           ai,
 		switcher:     switcher,
 		update:       update,
+		quit:         quit,
 		nativePicker: intpicker.NativeRunner{In: os.Stdin, Out: os.Stdout},
 		homeDir:      os.UserHomeDir,
 		lookupEnv:    os.Getenv,
@@ -3610,6 +3615,10 @@ func (c *settingsCommand) aboutEntries() []intpickercompat.Entry {
 		Label: settingsLabel(settingsGlyphOpen, settingsColorType, "Welcome", "revisit the shell quickstart guide"),
 		Value: settingsWelcomeShow,
 	})
+	entries = append(entries, intpickercompat.Entry{
+		Label: settingsLabel(settingsGlyphRemove, settingsColorRemove, "Quit projmux", "open quit actions"),
+		Value: settingsQuitOpen,
+	})
 	if statusErr != nil {
 		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabelInfo("Update", "status unavailable", statusErr.Error()),
@@ -3709,6 +3718,16 @@ func (c *settingsCommand) execute(value string, stdout, stderr io.Writer) error 
 			return welcome.Run(nil, stdout, stderr)
 		default:
 			return fmt.Errorf("unknown welcome settings action: %s", value)
+		}
+	case strings.HasPrefix(value, settingsActionPrefixQuit):
+		if c.quit == nil {
+			return errors.New("quit settings are not configured")
+		}
+		switch strings.TrimPrefix(value, settingsActionPrefixQuit) {
+		case "open":
+			return c.quit.Run(nil, stdout, stderr)
+		default:
+			return fmt.Errorf("unknown quit settings action: %s", value)
 		}
 	case strings.HasPrefix(value, settingsActionPrefixWorkdir):
 		action := strings.TrimPrefix(value, settingsActionPrefixWorkdir)

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -3277,11 +3277,15 @@ func TestSettingsHubShowsAboutSection(t *testing.T) {
 	if !hasEntryValue(aboutOptions.Entries, settingsUpdateApply) {
 		t.Fatalf("settings about entries = %#v, want update apply action", aboutOptions.Entries)
 	}
+	if !hasEntryValue(aboutOptions.Entries, settingsQuitOpen) {
+		t.Fatalf("settings about entries = %#v, want quit action", aboutOptions.Entries)
+	}
 	for _, want := range []string{
 		"projmux " + version.String(),
 		"https://github.com/crevissepartners/projmux",
 		"Update Now",
 		"Check Updates",
+		"Quit projmux",
 		latest,
 		"update_available",
 		"Installer",
@@ -3301,6 +3305,46 @@ func TestSettingsHubShowsAboutSection(t *testing.T) {
 		if !hasEntryLabelContaining(aboutOptions.Entries, want) {
 			t.Fatalf("settings about entries = %#v, want label containing %q", aboutOptions.Entries, want)
 		}
+	}
+}
+
+func TestSettingsAboutQuitRowRoutesThroughQuitPicker(t *testing.T) {
+	t.Parallel()
+
+	tmuxRunner := &recordingTmuxRunner{}
+	var quitOptions intpickercompat.Options
+	runner, native := scriptedPicker(t, []pickerStep{
+		{reply: intpickercompat.Result{Key: "enter", Value: settingsSectionAbout}},
+		{reply: intpickercompat.Result{Key: "enter", Value: settingsQuitOpen}},
+		{observe: func(o intpickercompat.Options) { quitOptions = o },
+			reply: intpickercompat.Result{Key: "enter", Value: quitActionCancel}},
+		{reply: intpickercompat.Result{Key: "enter", Value: settingsBackValue}},
+		{reply: intpickercompat.Result{}},
+	})
+	quit := &quitCommand{
+		runner:       tmuxRunner,
+		nativePicker: native,
+	}
+	cmd := &settingsCommand{
+		ai:           testAICommand(t.TempDir()),
+		switcher:     testSettingsSwitchCommand(t, &stubSwitchPinStore{}),
+		update:       nil,
+		quit:         quit,
+		runner:       runner,
+		nativePicker: native,
+	}
+
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if quitOptions.UI != "quit" {
+		t.Fatalf("quit options UI = %q, want quit", quitOptions.UI)
+	}
+	if !hasEntryValue(quitOptions.Entries, quitActionQuit) || !hasEntryValue(quitOptions.Entries, quitActionCancel) {
+		t.Fatalf("quit options entries = %#v, want quit and cancel actions", quitOptions.Entries)
+	}
+	if len(tmuxRunner.calls) != 0 {
+		t.Fatalf("about quit row caused tmux calls before explicit quit selection: %#v", tmuxRunner.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Completed Phase 0, Phase 1, and Phase 2 of the Projmux quit lifecycle roadmap.
- Added `projmux quit` as an action-picker flow with `Quit projmux` and `Cancel`.
- Added `Settings > About > Quit projmux`, routed through the same quit picker path.

## User-Facing Surface

- `projmux quit`
- `Settings > About > Quit projmux`
- CLI docs and maintained agent test list

## Runtime Guard

Quit is limited to the app-owned `tmux -L projmux` runtime. It checks the generated app config marker `@projmux_app=1` before dispatching `kill-server`, so missing servers, default/user tmux servers, embedded tmux servers, and unmarked runtimes are no-op.

## Explicitly Excluded Backlog

- Save before Quit
- named snapshot save UI
- Quit recovery or last saved snapshot guidance
- live session destructive restore
- OS app close / terminal close interception
- default/embedded tmux server shutdown UI

## Verification

- `go test ./internal/app -run 'Test(QuitCommand|SettingsAboutQuit|AppRunDispatchesQuit)'`
- `make fmt`
- `make fix`
- `make test`
- `make test-integration`
- `make test-e2e`

## Unverified / Follow-Up

- No manual interactive terminal UI session was run. Picker behavior is covered by backend-neutral unit tests.
- Save before Quit and recovery policy remain Backlog.
