### PR TITLE
fix(notify): bulk ack stale AI rows

### DIFF
--- a/internal/app/notify_classify_test.go
+++ b/internal/app/notify_classify_test.go
@@ -311,14 +311,49 @@ func TestStatusbarClickNotifyStaleHeadSkipsFocus(t *testing.T) {
 			return nil, nil
 		},
 	}
-	store := &stubNotifyStore{listEntries: []notify.Notification{{
-		ID:      "ai:main:%2",
-		Text:    "codex: reply ready",
-		Source:  notify.SourceAI,
-		Session: "main",
-		Window:  "1",
-		Pane:    "%2",
-	}}}
+	now := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	store := &stubNotifyStore{listEntries: []notify.Notification{
+		{
+			ID:        "ai:main:%2",
+			Text:      "codex: reply ready",
+			Severity:  notify.SeverityCritical,
+			Source:    notify.SourceAI,
+			Session:   "main",
+			Window:    "1",
+			Pane:      "%2",
+			CreatedAt: now,
+		},
+		{
+			ID:        "ai:main:%2:older-info",
+			Text:      "older same-pane info",
+			Severity:  notify.SeverityInfo,
+			Source:    notify.SourceAI,
+			Session:   "main",
+			Window:    "1",
+			Pane:      "%2",
+			CreatedAt: now.Add(-time.Minute),
+		},
+		{
+			ID:        "ai:main:%2:older-critical",
+			Text:      "older same-pane critical",
+			Severity:  notify.SeverityCritical,
+			Source:    notify.SourceAI,
+			Session:   "main",
+			Window:    "1",
+			Pane:      "%2",
+			CreatedAt: now.Add(-2 * time.Minute),
+		},
+		{
+			ID:        "ai:main:%3:older-info",
+			Text:      "older other-pane info",
+			Severity:  notify.SeverityInfo,
+			Source:    notify.SourceAI,
+			Session:   "main",
+			Window:    "1",
+			Pane:      "%3",
+			CreatedAt: now.Add(-3 * time.Minute),
+		},
+	}}
 	cmd := newStatusbarTestCommand(runner, store)
 
 	if err := cmd.Run([]string{"click", "notify"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
@@ -332,8 +367,9 @@ func TestStatusbarClickNotifyStaleHeadSkipsFocus(t *testing.T) {
 	if !sawTmuxDisplayMessage(runner.calls, notifyAckOnlyToast(notifyDisplayStale)) {
 		t.Fatalf("missing stale ack-only toast; calls = %#v", runner.calls)
 	}
-	if store.ackedID != "ai:main:%2" {
-		t.Fatalf("ackedID = %q, want %q (stale fast path must still ack so the row clears)", store.ackedID, "ai:main:%2")
+	wantAcked := []string{"ai:main:%2", "ai:main:%2:older-info"}
+	if !equalStringSlices(store.ackedIDs, wantAcked) {
+		t.Fatalf("ackedIDs = %#v, want %#v (stale fast path must clear selected row and older same-pane non-critical AI rows)", store.ackedIDs, wantAcked)
 	}
 }
 

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -582,8 +582,7 @@ func (c *statusbarCommand) handleNotify(opts statusbarClickOptions, _, stderr io
 	// and the user would be stuck repeatedly toasting the same row. The toast
 	// remains as a UX signal that the focus side of the click was skipped.
 	if display := c.classifyHeadDisplayBestEffort(head); display != notifyDisplayLive {
-		ackErr := store.Ack(head.ID)
-		if ackErr != nil {
+		if ackErr := ackFocusedNotification(store, head, entries); ackErr != nil {
 			return c.runTmux(stderr, "display-message", fmt.Sprintf("%s; ack failed: %s", notifyAckOnlyToast(display), focusFailureSummary(ackErr)))
 		}
 		return c.runTmux(stderr, "display-message", notifyAckOnlyToast(display))
@@ -616,7 +615,7 @@ func (c *statusbarCommand) handleNotify(opts statusbarClickOptions, _, stderr io
 		// entry so the user can retry, and surface the reason as a toast instead
 		// of a tmux error popup.
 		if isFocusTargetUnresolved(runErr) {
-			if err := store.Ack(head.ID); err != nil {
+			if err := ackFocusedNotification(store, head, entries); err != nil {
 				return c.runTmux(stderr, "display-message", fmt.Sprintf("notify target gone; ack failed: %s", focusFailureSummary(err)))
 			}
 			return c.runTmux(stderr, "display-message", "notify target gone; cleared")


### PR DESCRIPTION
## Summary
- Route statusbar stale/gone ack-only paths through the existing focused-notification bulk ack helper.
- Preserve the existing guardrails: only older same-pane AI non-critical rows are bulk-acked; critical/protected/other-pane rows remain.
- Extend the stale fast-path test to cover selected stale ack plus older same-pane info cleanup.

## Verification
- `GOCACHE=/tmp/projmux-go-cache go test ./internal/app -run 'TestStatusbarClickNotifyStaleHeadSkipsFocus|TestStatusbarClickNotifyTargetGoneAcksEntryAndShowsToast|TestAckFocusedNotificationConsumesSelectedCriticalAndOlderSamePaneAIOnly'`
- `GOCACHE=/tmp/projmux-go-cache make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `git diff --check`
