### PR TITLE
fix: clip notify status body before metadata

### DIFF
--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -75,6 +75,13 @@ The notify segment renders the newest queued item as a single notification
 block: project, state (`NEED`/`INFO`/`WARN`/`CRIT`), optional agent, text,
 age, and `+N` for older pending entries. Window/pane ids are not shown in the
 compact status segment.
+When the notify block is wider than its cell budget, clipping shrinks the body
+text first and appends an ellipsis while preserving project, state, agent, age,
+and count metadata. If the segment is still too wide, the age is dropped next
+while badges and the `+N` count stay visible when possible. Very narrow widths
+fall back to the severity-colored dot plus clipped text and count; the final
+hard-truncate path still closes with `#[default]` so later status segments do
+not inherit notification styling.
 `usage` opens a native-framed detail HUD for the compact usage bar. It reads
 the cached usage state in-process, keeps the existing `projmux usage` CLI
 output shape unchanged for external consumers, aligns model/window rows with

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -513,10 +513,10 @@ var notifyKnownAgents = []string{"claude", "codex"}
 // The renderer degrades through five tiers as `maxWidth` shrinks:
 //
 //  1. Full long form: line block + badges + text + age + count.
-//  2. Drop `<age>` (and its preceding `·`).
-//  3. Truncate `<text>` with a trailing `…`.
-//  4. Drop the badges entirely; fall back to a standalone `●` severity icon.
-//  5. Hard truncate everything (icon + count are still preserved).
+//  2. Truncate `<text>` with a trailing `…`, preserving age and count.
+//  3. Drop `<age>` (and its preceding `·`) while preserving badges and count.
+//  4. Drop the badges; fall back to a standalone `●` severity icon + text.
+//  5. Hard truncate everything, appending the reset directive.
 //
 // `now` is the wall-clock used to compute the relative age. Pass the zero
 // time to suppress the age field entirely.
@@ -555,9 +555,13 @@ func formatStatusNotifyWithLive(entries []notify.Notification, maxWidth int, now
 	tiers := []func() string{
 		// Tier 1: full long form.
 		func() string { return assembleNotify(badge, text, age, plus) },
-		// Tier 2: drop age.
-		func() string { return assembleNotify(badge, text, "", plus) },
-		// Tier 3: truncate text with trailing ellipsis.
+		// Tier 2: keep badges, age, and count; shrink body text first.
+		func() string {
+			budget := tierBudget(maxWidth, badge, age, plus)
+			truncated := shrinkText(text, budget)
+			return assembleNotify(badge, truncated, age, plus)
+		},
+		// Tier 3: if clipping text is still too wide, drop age next.
 		func() string {
 			budget := tierBudget(maxWidth, badge, "", plus)
 			truncated := shrinkText(text, budget)

--- a/internal/app/status_notify_test.go
+++ b/internal/app/status_notify_test.go
@@ -265,6 +265,40 @@ func fixtureAIEntry(now time.Time) []notify.Notification {
 	}
 }
 
+func TestStatusNotifyLongBodyClipsBeforeDroppingAge(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	entries := []notify.Notification{
+		{
+			ID:        "a",
+			Text:      "claude: reply ready with a very long body that should clip before metadata disappears",
+			Severity:  notify.SeverityInfo,
+			Source:    notify.SourceAI,
+			Session:   "project",
+			CreatedAt: now,
+		},
+		{ID: "b", Text: "older", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "project"},
+		{ID: "c", Text: "oldest", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "project"},
+	}
+	out := formatStatusNotify(entries, 80, now)
+	if visualLen(out) > 80 {
+		t.Fatalf("visualLen=%d > 80: %q", visualLen(out), out)
+	}
+	for _, want := range []string{
+		notifyLineOpen + renderNotifyProjectBadge("project"),
+		renderNotifyBadge("NEED", notify.SeverityInfo),
+		renderNotifyAgentBadge("claude"),
+		"just now",
+		"+2",
+		"…",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in %q", want, out)
+		}
+	}
+}
+
 func TestStatusNotifyWidthTier1Long(t *testing.T) {
 	t.Parallel()
 
@@ -287,11 +321,11 @@ func TestStatusNotifyWidthTier1Long(t *testing.T) {
 	}
 }
 
-func TestStatusNotifyWidthTier2DropsAge(t *testing.T) {
+func TestStatusNotifyWidthTier2ClipsTextBeforeAge(t *testing.T) {
 	t.Parallel()
 
 	// The project/state/agent badge stack makes this budget tight enough to
-	// drop age while retaining the contextual badges.
+	// clip body text while retaining contextual badges and age.
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	out := formatStatusNotify(fixtureAIEntry(now), 45, now)
 	if visualLen(out) > 45 {
@@ -302,29 +336,30 @@ func TestStatusNotifyWidthTier2DropsAge(t *testing.T) {
 		renderNotifyBadge("NEED", notify.SeverityInfo),
 		renderNotifyAgentBadge("claude"),
 		"reply ready",
+		"2m",
 		"+1",
+		"…",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("tier2 missing %q in %q", want, out)
 		}
 	}
-	if strings.Contains(out, "2m") {
-		t.Fatalf("tier2 must drop age: %q", out)
-	}
 }
 
-func TestStatusNotifyWidthTier3TruncatesText(t *testing.T) {
+func TestStatusNotifyWidthTier3DropsAgeAfterClippingText(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
-	out := formatStatusNotify(fixtureAIEntry(now), 40, now)
-	if visualLen(out) > 40 {
-		t.Fatalf("tier3 visualLen=%d > 40: %q", visualLen(out), out)
+	out := formatStatusNotify(fixtureAIEntry(now), 28, now)
+	if visualLen(out) > 28 {
+		t.Fatalf("tier3 visualLen=%d > 28: %q", visualLen(out), out)
 	}
 	for _, want := range []string{
 		notifyLineOpen + renderNotifyProjectBadge("s"),
 		renderNotifyBadge("NEED", notify.SeverityInfo),
+		renderNotifyAgentBadge("claude"),
 		"+1",
+		"…",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("tier3 missing %q in %q", want, out)


### PR DESCRIPTION
## 완료한 범위

- `formatStatusNotifyWithLive` 의 notify status width tier 를 조정해 긴 body text 가 status row 를 밀지 않도록 했습니다.
- 긴 body + extras 케이스에서 `formatStatusNotify(entries, 80, now)` 가 badge, `just now`, `+N`, ellipsis 를 함께 유지하도록 테스트를 추가했습니다.
- `docs/statusbar.md` 에 notify segment clipping 정책을 반영했습니다.

## Notify Status Tier 변경 요약

- Tier 1: badge + full text + age + count
- Tier 2: badge + clipped text + age + count
- Tier 3: badge + clipped text + count, age drop
- Tier 4: severity icon fallback + clipped text + count
- Tier 5: hard truncate + `#[default]` reset

## Badge/Age/Count 보존 정책

- project/state/agent badge 는 body text 보다 먼저 보존합니다.
- `just now` 같은 age 는 body text clipping 이후에만 drop 합니다.
- `+N` count 는 age drop 이후와 icon fallback tier 에서도 가능한 한 유지합니다.

## 명시 제외 범위

- notify queue schema 변경 없음
- statusbar 전체 layout / `status 2` 구조 변경 없음
- `statusbarAuxLineFormat` 의 `--max-width 80` 계약 변경 없음
- notify sidebar / notify list 출력 변경 없음
- OS notification / desktop toast 동작 변경 없음

## 검증 명령

- `GOCACHE=/tmp/projmux-go-cache go test ./internal/app -run StatusNotify`
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `git diff --check`

## 미검증 항목과 후속 작업

- tmux 실제 status row 시각 캡처는 별도로 수행하지 않았습니다. 이번 변경은 formatter 단위 테스트와 기존 docker integration/e2e gate 로 검증했습니다.
