### PR TITLE
fix(sessionstate): direct-start agent replay

### DIFF
--- a/docs/session-restore.md
+++ b/docs/session-restore.md
@@ -38,6 +38,17 @@ unknown sources are low or none. The old statusbar Session State shortcut has
 been removed; use `Projects > Sessions > State` or the `projmux session-state`
 CLI for inspection/actions.
 
+Agent restore direct-starts supported resume commands when creating fresh tmux
+panes, matching the `projmux ai split` wrapper shape: the wrapper prepends the
+agent binary directory to `PATH`, changes to the saved cwd, sets the terminal
+and tmux pane title from the saved agent topic, then execs `codex resume <id>`
+or `claude --resume <id>`. This avoids typing agent resumes with
+`tmux send-keys`. The restore wrapper is still a non-interactive shell command
+tail, so it does not replay the original pane's interactive shell startup,
+environment, shell functions, aliases, or live process state. Startup recipes
+continue to use their saved `send-keys` command replay, and shell recipes only
+restore cwd/layout.
+
 Settings > Session State is global settings only: global auto-save, auto-save
 interval, and storage/retention policy. It does not show the current
 snapshot tree. Delete for current-session snapshots and destructive restore

--- a/internal/integrations/sessionstate/replay.go
+++ b/internal/integrations/sessionstate/replay.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -24,6 +26,12 @@ type ReplayOptions struct {
 	// FallbackCWD is used when a stored cwd no longer exists. When empty or
 	// unusable, panes fall back to the snapshot default cwd and then $HOME.
 	FallbackCWD string
+
+	// AgentBinaryResolver overrides agent executable discovery for tests.
+	AgentBinaryResolver func(agent string) string
+
+	// CommandShell overrides the POSIX shell used for direct-start wrappers.
+	CommandShell string
 }
 
 // ApplyToExistingSessionOptions controls destructive replay into an
@@ -56,11 +64,12 @@ type ReplayWarning struct {
 // environment variables, including secrets. Agent recipe replay is limited to
 // adapters with explicit safe command generation.
 func Replay(ctx context.Context, runner Runner, snap Snapshot, opts ReplayOptions) (ReplayResult, error) {
-	return replay(ctx, runner, snap, opts, replayOptions{replayPaneRecipes: true})
+	return replay(ctx, runner, snap, opts, replayOptions{replayPaneRecipes: true, directStartAgents: true})
 }
 
 type replayOptions struct {
 	replayPaneRecipes bool
+	directStartAgents bool
 }
 
 func replay(ctx context.Context, runner Runner, snap Snapshot, opts ReplayOptions, replayOpts replayOptions) (ReplayResult, error) {
@@ -76,6 +85,7 @@ func replay(ctx context.Context, runner Runner, snap Snapshot, opts ReplayOption
 	if err != nil {
 		return result, err
 	}
+	agentLauncher := newAgentLaunchResolver(opts)
 
 	windows := sortedWindows(snap.Windows)
 	sessionCWD := resolver.resolveSession(snap.DefaultCWD, &result)
@@ -88,7 +98,13 @@ func replay(ctx context.Context, runner Runner, snap Snapshot, opts ReplayOption
 		}
 	}
 
-	if _, err := runner.Run(ctx, "tmux", "new-session", "-d", "-s", snap.Session, "-c", createCWD); err != nil {
+	args := []string{"new-session", "-d", "-s", snap.Session, "-c", createCWD}
+	if len(windows) > 0 {
+		if panes := sortedPanes(windows[0].Panes); len(panes) > 0 {
+			args = append(args, replayPaneLaunchTail(agentLauncher, windows[0], panes[0], createCWD, &result, replayOpts)...)
+		}
+	}
+	if _, err := runner.Run(ctx, "tmux", args...); err != nil {
 		return result, fmt.Errorf("replay tmux session %q: %w", snap.Session, err)
 	}
 	if len(windows) == 0 {
@@ -116,6 +132,9 @@ func replay(ctx context.Context, runner Runner, snap Snapshot, opts ReplayOption
 			if strings.TrimSpace(window.Name) != "" {
 				args = append(args, "-n", window.Name)
 			}
+			if len(panes) > 0 {
+				args = append(args, replayPaneLaunchTail(agentLauncher, window, panes[0], windowCWD, &result, replayOpts)...)
+			}
 			if _, err := runner.Run(ctx, "tmux", args...); err != nil {
 				return result, fmt.Errorf("replay tmux window %d: %w", window.Index, err)
 			}
@@ -125,7 +144,9 @@ func replay(ctx context.Context, runner Runner, snap Snapshot, opts ReplayOption
 			pane := panes[paneOffset]
 			cwd := resolver.resolvePane(pane.CWD, window.Index, pane.Index, &result)
 			targetPane := panes[paneOffset-1].Index
-			if _, err := runner.Run(ctx, "tmux", "split-window", "-d", "-t", paneTarget(snap.Session, window.Index, targetPane), "-c", cwd); err != nil {
+			args := []string{"split-window", "-d", "-t", paneTarget(snap.Session, window.Index, targetPane), "-c", cwd}
+			args = append(args, replayPaneLaunchTail(agentLauncher, window, pane, cwd, &result, replayOpts)...)
+			if _, err := runner.Run(ctx, "tmux", args...); err != nil {
 				return result, fmt.Errorf("replay tmux window %d pane %d: %w", window.Index, pane.Index, err)
 			}
 		}
@@ -141,7 +162,7 @@ func replay(ctx context.Context, runner Runner, snap Snapshot, opts ReplayOption
 			}
 		}
 		if replayOpts.replayPaneRecipes {
-			if err := replayPaneRecipes(ctx, runner, snap.Session, window, panes, &result); err != nil {
+			if err := replayPaneRecipes(ctx, runner, snap.Session, window, panes, &result, replayOpts); err != nil {
 				return result, err
 			}
 		}
@@ -229,7 +250,7 @@ func ApplyToExistingSession(ctx context.Context, runner Runner, snap Snapshot, o
 	}
 
 	for _, window := range windows {
-		if err := replayPaneRecipes(ctx, runner, snap.Session, window, sortedPanes(window.Panes), &result); err != nil {
+		if err := replayPaneRecipes(ctx, runner, snap.Session, window, sortedPanes(window.Panes), &result, replayOptions{replayPaneRecipes: true}); err != nil {
 			return result, err
 		}
 	}
@@ -240,8 +261,11 @@ func ApplyToExistingSession(ctx context.Context, runner Runner, snap Snapshot, o
 	return result, nil
 }
 
-func replayPaneRecipes(ctx context.Context, runner Runner, session string, window Window, panes []Pane, result *ReplayResult) error {
+func replayPaneRecipes(ctx context.Context, runner Runner, session string, window Window, panes []Pane, result *ReplayResult, replayOpts replayOptions) error {
 	for _, pane := range panes {
+		if replayOpts.directStartAgents && pane.Recipe.Kind == RecipeKindAgent {
+			continue
+		}
 		if err := replayPaneRecipe(ctx, runner, paneTarget(session, window.Index, pane.Index), window.Index, pane, result); err != nil {
 			return err
 		}
@@ -258,6 +282,83 @@ func replayPaneRecipe(ctx context.Context, runner Runner, target string, windowI
 	default:
 		return nil
 	}
+}
+
+type agentLaunchResolver struct {
+	binaryResolver func(agent string) string
+	commandShell   string
+}
+
+func newAgentLaunchResolver(opts ReplayOptions) agentLaunchResolver {
+	resolver := opts.AgentBinaryResolver
+	if resolver == nil {
+		resolver = findAgentBinary
+	}
+	shell := strings.TrimSpace(opts.CommandShell)
+	if shell == "" {
+		shell = commandShell()
+	}
+	return agentLaunchResolver{binaryResolver: resolver, commandShell: shell}
+}
+
+func replayPaneLaunchTail(launcher agentLaunchResolver, window Window, pane Pane, cwd string, result *ReplayResult, replayOpts replayOptions) []string {
+	if !replayOpts.directStartAgents || !replayOpts.replayPaneRecipes || pane.Recipe.Kind != RecipeKindAgent {
+		return nil
+	}
+	agent := strings.ToLower(strings.TrimSpace(pane.Recipe.Agent))
+	var resumeArgs []string
+	var err error
+	switch agent {
+	case claudeagent.AgentName:
+		resumeArgs, err = claudeagent.ResumeArgs(pane.Recipe.ResumeID)
+	case codexagent.AgentName:
+		resumeArgs, err = codexagent.ResumeArgs(pane.Recipe.ResumeID)
+	default:
+		return nil
+	}
+	if err != nil {
+		appendReplayWarning(result, ReplayWarning{
+			Scope:       "agent",
+			WindowIndex: window.Index,
+			PaneIndex:   pane.Index,
+			Reason:      err.Error(),
+		})
+		return nil
+	}
+	agentBin := launcher.binaryResolver(agent)
+	if agentBin == "" {
+		appendReplayWarning(result, ReplayWarning{
+			Scope:       "agent",
+			WindowIndex: window.Index,
+			PaneIndex:   pane.Index,
+			Reason:      "missing " + agent + " binary",
+		})
+		return nil
+	}
+	title := strings.TrimSpace(pane.Recipe.Topic)
+	if title == "" {
+		title = agent
+	}
+	command := agentLaunchCommand(agent, agentBin, cwd, title, resumeArgs[1:])
+	return []string{launcher.commandShell, "-lc", command}
+}
+
+func agentLaunchCommand(agent, agentBin, cwd, title string, argv []string) string {
+	titleVar := "__" + agent + "_title"
+	parts := []string{}
+	if binDir := filepath.Dir(agentBin); binDir != "" && binDir != "." && binDir != "/" {
+		parts = append(parts, "export PATH="+shellQuote(binDir)+`":$PATH"`)
+	}
+	if cwd != "" {
+		parts = append(parts, "cd "+shellQuote(cwd))
+	}
+	parts = append(parts,
+		titleVar+"="+shellQuote(title),
+		`printf '\033]0;%s\007' "$`+titleVar+`"`,
+		`if [ -n "${TMUX:-}" ]; then tmux select-pane -T "$`+titleVar+`" >/dev/null 2>&1 || true; fi`,
+		"exec "+shellJoin(append([]string{agentBin}, argv...)),
+	)
+	return strings.Join(parts, " && ")
 }
 
 func replayAgentRecipe(ctx context.Context, runner Runner, target string, windowIndex int, pane Pane, result *ReplayResult) error {
@@ -351,6 +452,114 @@ func appendReplayWarning(result *ReplayResult, warning ReplayWarning) {
 		return
 	}
 	result.Warnings = append(result.Warnings, warning)
+}
+
+func findAgentBinary(agent string) string {
+	binName := strings.TrimSpace(agent)
+	switch binName {
+	case claudeagent.AgentName, codexagent.AgentName:
+	default:
+		return ""
+	}
+
+	home, _ := os.UserHomeDir()
+	if path := firstExecutable(
+		lookPath(binName),
+		filepath.Join(home, ".npm-global", "bin", binName),
+		filepath.Join(home, ".local", "bin", binName),
+	); path != "" {
+		return path
+	}
+	if path := newestExecutable(nodeManagerCandidates(home, binName)); path != "" {
+		return path
+	}
+	if binName == codexagent.AgentName {
+		matches, _ := filepath.Glob(filepath.Join(home, ".vscode", "extensions", "openai.chatgpt-*", "bin", "*", "codex"))
+		return newestExecutable(matches)
+	}
+	return ""
+}
+
+func commandShell() string {
+	shell := strings.TrimSpace(os.Getenv("SHELL"))
+	if shell == "" || !filepath.IsAbs(shell) || strings.ContainsAny(shell, "\x00\r\n") {
+		return "/bin/sh"
+	}
+	switch filepath.Base(shell) {
+	case "bash", "dash", "ksh", "mksh", "sh", "zsh":
+		return shell
+	default:
+		return "/bin/sh"
+	}
+}
+
+func lookPath(binName string) string {
+	path, err := exec.LookPath(binName)
+	if err != nil {
+		return ""
+	}
+	return path
+}
+
+func firstExecutable(paths ...string) string {
+	for _, path := range paths {
+		if isExecutable(path) {
+			return path
+		}
+	}
+	return ""
+}
+
+func newestExecutable(paths []string) string {
+	var newest string
+	var newestModTime int64
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+			continue
+		}
+		modTime := info.ModTime().UnixNano()
+		if newest == "" || modTime > newestModTime {
+			newest = path
+			newestModTime = modTime
+		}
+	}
+	return newest
+}
+
+func nodeManagerCandidates(home, binName string) []string {
+	if home == "" || binName == "" {
+		return nil
+	}
+	var candidates []string
+	globs := []string{
+		filepath.Join(home, ".nvm", "versions", "node", "*", "bin", binName),
+		filepath.Join(home, ".fnm", "node-versions", "*", "installation", "bin", binName),
+		filepath.Join(home, ".asdf", "installs", "nodejs", "*", "bin", binName),
+	}
+	for _, pattern := range globs {
+		matches, _ := filepath.Glob(pattern)
+		candidates = append(candidates, matches...)
+	}
+	candidates = append(candidates, filepath.Join(home, ".volta", "bin", binName))
+	return candidates
+}
+
+func isExecutable(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir() && info.Mode()&0o111 != 0
+}
+
+func shellJoin(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuote(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
 type cwdResolver struct {

--- a/internal/integrations/sessionstate/replay_test.go
+++ b/internal/integrations/sessionstate/replay_test.go
@@ -158,45 +158,7 @@ func TestReplayActivePaneSelection(t *testing.T) {
 	}
 }
 
-func TestReplayResumesClaudeAgentRecipeAfterLayoutAndPaneSelection(t *testing.T) {
-	t.Parallel()
-
-	cwd := t.TempDir()
-	snap := replaySnapshot(cwd)
-	snap.Windows = []Window{
-		{
-			Index:           0,
-			Name:            "agent",
-			Layout:          "d3a9,120x36,0,0{60x36,0,0,1,59x36,61,0,2}",
-			ActivePaneIndex: 1,
-			Panes: []Pane{
-				{Index: 0, CWD: cwd, Recipe: ShellRecipe()},
-				{Index: 1, CWD: cwd, Recipe: AgentRecipe("claude", "abcdef-1234", "topic")},
-			},
-		},
-	}
-	runner := &recordingReplayRunner{}
-
-	result, err := Replay(context.Background(), runner, snap, ReplayOptions{})
-	if err != nil {
-		t.Fatalf("Replay() error = %v", err)
-	}
-	if len(result.Warnings) != 0 {
-		t.Fatalf("Replay() warnings = %#v, want none", result.Warnings)
-	}
-
-	layoutIndex := replayCommandIndex(runner.commands, []string{"select-layout", "-t", "home:0", "d3a9,120x36,0,0{60x36,0,0,1,59x36,61,0,2}"})
-	sendIndex := replayCommandIndex(runner.commands, []string{"send-keys", "-t", "home:0.1", "claude --resume abcdef-1234", "Enter"})
-	selectIndex := replayCommandIndex(runner.commands, []string{"select-pane", "-t", "home:0.1"})
-	if layoutIndex < 0 || sendIndex < 0 || selectIndex < 0 {
-		t.Fatalf("commands = %#v, want layout, claude resume, and active pane select", runner.commands)
-	}
-	if !(layoutIndex < selectIndex && selectIndex < sendIndex) {
-		t.Fatalf("command order layout=%d select=%d send=%d, want resume after layout and active pane selection", layoutIndex, selectIndex, sendIndex)
-	}
-}
-
-func TestReplayResumesCodexAgentRecipeAfterLayoutAndPaneSelection(t *testing.T) {
+func TestReplayAgentDirectStartEmitsNoSendKeys(t *testing.T) {
 	t.Parallel()
 
 	cwd := t.TempDir()
@@ -215,7 +177,7 @@ func TestReplayResumesCodexAgentRecipeAfterLayoutAndPaneSelection(t *testing.T) 
 	}
 	runner := &recordingReplayRunner{}
 
-	result, err := Replay(context.Background(), runner, snap, ReplayOptions{})
+	result, err := Replay(context.Background(), runner, snap, replayAgentOptions("/opt/codex/bin/codex"))
 	if err != nil {
 		t.Fatalf("Replay() error = %v", err)
 	}
@@ -223,14 +185,115 @@ func TestReplayResumesCodexAgentRecipeAfterLayoutAndPaneSelection(t *testing.T) 
 		t.Fatalf("Replay() warnings = %#v, want none", result.Warnings)
 	}
 
-	layoutIndex := replayCommandIndex(runner.commands, []string{"select-layout", "-t", "home:0", "d3a9,120x36,0,0{60x36,0,0,1,59x36,61,0,2}"})
-	sendIndex := replayCommandIndex(runner.commands, []string{"send-keys", "-t", "home:0.1", "codex resume 01973f21-abc", "Enter"})
-	selectIndex := replayCommandIndex(runner.commands, []string{"select-pane", "-t", "home:0.1"})
-	if layoutIndex < 0 || sendIndex < 0 || selectIndex < 0 {
-		t.Fatalf("commands = %#v, want layout, codex resume, and active pane select", runner.commands)
+	for _, command := range runner.commands {
+		if len(command.args) > 0 && command.args[0] == "send-keys" {
+			t.Fatalf("Replay() sent agent resume through send-keys: %#v", command)
+		}
 	}
-	if !(layoutIndex < selectIndex && selectIndex < sendIndex) {
-		t.Fatalf("command order layout=%d select=%d send=%d, want resume after layout and active pane selection", layoutIndex, selectIndex, sendIndex)
+}
+
+func TestReplayAgentDirectStartFirstWindowFirstPaneUsesNewSessionTail(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	agentBin := "/opt/claude/bin/claude"
+	snap := replaySnapshot(cwd)
+	snap.Windows = []Window{
+		{
+			Index:           0,
+			Name:            "agent",
+			ActivePaneIndex: 0,
+			Panes: []Pane{
+				{Index: 0, CWD: cwd, Recipe: AgentRecipe("claude", "abcdef-1234", "restore topic")},
+			},
+		},
+	}
+	runner := &recordingReplayRunner{}
+
+	result, err := Replay(context.Background(), runner, snap, replayAgentOptions(agentBin))
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("Replay() warnings = %#v, want none", result.Warnings)
+	}
+
+	want := append([]string{"new-session", "-d", "-s", "home", "-c", cwd}, replayAgentTail("claude", agentBin, cwd, "restore topic", "--resume", "abcdef-1234")...)
+	if got := runner.commands[0].args; !reflect.DeepEqual(got, want) {
+		t.Fatalf("new-session args = %#v, want %#v", got, want)
+	}
+}
+
+func TestReplayAgentDirectStartLaterWindowFirstPaneUsesNewWindowTail(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	agentBin := "/opt/codex/bin/codex"
+	snap := replaySnapshot(cwd)
+	snap.Windows = []Window{
+		{
+			Index:           0,
+			Name:            "main",
+			ActivePaneIndex: 0,
+			Panes: []Pane{
+				{Index: 0, CWD: cwd, Recipe: ShellRecipe()},
+			},
+		},
+		{
+			Index:           1,
+			Name:            "agent",
+			ActivePaneIndex: 0,
+			Panes: []Pane{
+				{Index: 0, CWD: cwd, Recipe: AgentRecipe("codex", "01973f21-abc", "codex topic")},
+			},
+		},
+	}
+	runner := &recordingReplayRunner{}
+
+	result, err := Replay(context.Background(), runner, snap, replayAgentOptions(agentBin))
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("Replay() warnings = %#v, want none", result.Warnings)
+	}
+
+	want := append([]string{"new-window", "-d", "-t", "home:1", "-c", cwd, "-n", "agent"}, replayAgentTail("codex", agentBin, cwd, "codex topic", "resume", "01973f21-abc")...)
+	if !hasReplayCommand(runner.commands, want) {
+		t.Fatalf("commands = %#v, want new-window direct-start tail %#v", runner.commands, want)
+	}
+}
+
+func TestReplayAgentDirectStartSplitPaneUsesSplitWindowTail(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	agentBin := "/opt/codex/bin/codex"
+	snap := replaySnapshot(cwd)
+	snap.Windows = []Window{
+		{
+			Index:           0,
+			Name:            "main",
+			ActivePaneIndex: 1,
+			Panes: []Pane{
+				{Index: 0, CWD: cwd, Recipe: ShellRecipe()},
+				{Index: 1, CWD: cwd, Recipe: AgentRecipe("codex", "01973f21-abc", "split topic")},
+			},
+		},
+	}
+	runner := &recordingReplayRunner{}
+
+	result, err := Replay(context.Background(), runner, snap, replayAgentOptions(agentBin))
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("Replay() warnings = %#v, want none", result.Warnings)
+	}
+
+	want := append([]string{"split-window", "-d", "-t", "home:0.0", "-c", cwd}, replayAgentTail("codex", agentBin, cwd, "split topic", "resume", "01973f21-abc")...)
+	if !hasReplayCommand(runner.commands, want) {
+		t.Fatalf("commands = %#v, want split-window direct-start tail %#v", runner.commands, want)
 	}
 }
 
@@ -384,6 +447,7 @@ func TestReplaySkipsClaudeResumeWithEmptyResumeID(t *testing.T) {
 	if result.Warnings[0].Scope != "agent" || !strings.Contains(result.Warnings[0].Reason, "invalid claude resume id") {
 		t.Fatalf("warning = %#v, want empty claude resume id warning", result.Warnings[0])
 	}
+	assertAgentFallbackShellPane(t, runner.commands, []string{"new-session", "-d", "-s", "home", "-c", cwd})
 	for _, command := range runner.commands {
 		if len(command.args) > 0 && command.args[0] == "send-keys" {
 			t.Fatalf("Replay() sent unsafe resume command: %#v", command)
@@ -429,12 +493,51 @@ func TestReplaySkipsCodexResumeWithInvalidResumeID(t *testing.T) {
 			if result.Warnings[0].Scope != "agent" || !strings.Contains(result.Warnings[0].Reason, "invalid codex resume id") {
 				t.Fatalf("warning = %#v, want invalid codex resume id warning", result.Warnings[0])
 			}
+			assertAgentFallbackShellPane(t, runner.commands, []string{"new-session", "-d", "-s", "home", "-c", cwd})
 			for _, command := range runner.commands {
 				if len(command.args) > 0 && command.args[0] == "send-keys" {
 					t.Fatalf("Replay() sent unsafe resume command: %#v", command)
 				}
 			}
 		})
+	}
+}
+
+func TestReplaySkipsAgentDirectStartWithMissingBinary(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	snap := replaySnapshot(cwd)
+	snap.Windows = []Window{
+		{
+			Index:           0,
+			Name:            "agent",
+			ActivePaneIndex: 0,
+			Panes: []Pane{
+				{Index: 0, CWD: cwd, Recipe: AgentRecipe("codex", "01973f21-abc", "topic")},
+			},
+		},
+	}
+	runner := &recordingReplayRunner{}
+
+	result, err := Replay(context.Background(), runner, snap, ReplayOptions{
+		AgentBinaryResolver: func(string) string { return "" },
+		CommandShell:        "/bin/bash",
+	})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("warnings = %#v, want one missing binary warning", result.Warnings)
+	}
+	if result.Warnings[0].Scope != "agent" || !strings.Contains(result.Warnings[0].Reason, "missing codex binary") {
+		t.Fatalf("warning = %#v, want missing codex binary warning", result.Warnings[0])
+	}
+	assertAgentFallbackShellPane(t, runner.commands, []string{"new-session", "-d", "-s", "home", "-c", cwd})
+	for _, command := range runner.commands {
+		if len(command.args) > 0 && command.args[0] == "send-keys" {
+			t.Fatalf("Replay() sent missing-binary resume command: %#v", command)
+		}
 	}
 }
 
@@ -619,6 +722,52 @@ func replayCommandsContainInOrder(commands []replayCommand, want [][]string) boo
 		last = next
 	}
 	return true
+}
+
+func replayAgentOptions(agentBin string) ReplayOptions {
+	return ReplayOptions{
+		AgentBinaryResolver: func(string) string { return agentBin },
+		CommandShell:        "/bin/bash",
+	}
+}
+
+func replayAgentTail(agent, agentBin, cwd, title string, argv ...string) []string {
+	titleVar := "__" + agent + "_title"
+	command := strings.Join([]string{
+		"export PATH=" + shellQuote(agentBinDir(agentBin)) + `":$PATH"`,
+		"cd " + shellQuote(cwd),
+		titleVar + "=" + shellQuote(title),
+		`printf '\033]0;%s\007' "$` + titleVar + `"`,
+		`if [ -n "${TMUX:-}" ]; then tmux select-pane -T "$` + titleVar + `" >/dev/null 2>&1 || true; fi`,
+		"exec " + shellJoin(append([]string{agentBin}, argv...)),
+	}, " && ")
+	return []string{"/bin/bash", "-lc", command}
+}
+
+func agentBinDir(agentBin string) string {
+	index := strings.LastIndex(agentBin, "/")
+	if index < 0 {
+		return "."
+	}
+	if index == 0 {
+		return "/"
+	}
+	return agentBin[:index]
+}
+
+func assertAgentFallbackShellPane(t *testing.T, commands []replayCommand, createArgs []string) {
+	t.Helper()
+	if !hasReplayCommand(commands, createArgs) {
+		t.Fatalf("commands = %#v, want shell fallback create command %#v", commands, createArgs)
+	}
+	for _, command := range commands {
+		if len(command.args) >= len(createArgs)+3 &&
+			reflect.DeepEqual(command.args[:len(createArgs)], createArgs) &&
+			(command.args[len(createArgs)] == "/bin/bash" || strings.HasSuffix(command.args[len(createArgs)], "/sh")) &&
+			command.args[len(createArgs)+1] == "-lc" {
+			t.Fatalf("commands = %#v, want shell fallback without launch tail", commands)
+		}
+	}
 }
 
 func replayOutputKey(name string, args ...string) string {


### PR DESCRIPTION
## 완료한 범위

- `sessionstate.Replay` 의 supported agent recipe replay 를 fresh pane 생성 시점 direct-start 로 전환했습니다.
- 첫 window 첫 pane 은 `tmux new-session` command tail, 이후 window 첫 pane 은 `tmux new-window` command tail, split pane 은 `tmux split-window` command tail 에 agent launch wrapper 를 붙입니다.
- `docs/session-restore.md` 에 agent restore 가 AI split parity direct-start 라는 점과 shell/env 차이를 기록했습니다.

## AI split parity direct-start 로 바꾼 이유

기존 restore 는 agent pane 을 shell 로 만든 뒤 `tmux send-keys ... Enter` 로 resume command 를 입력했습니다. 이 방식은 shell prompt 준비와 입력 타이밍에 의존합니다.

이번 변경은 `projmux ai split` 과 같은 lifecycle 을 따릅니다. wrapper 가 agent binary dir 를 `PATH` 앞에 붙이고, saved cwd 로 이동하고, saved agent topic 기반 terminal/tmux pane title 을 설정한 뒤 마지막에 `exec codex resume <id>` 또는 `exec claude --resume <id>` 를 실행합니다.

## 유지한 semantics

- startup recipe 는 기존 shell command semantics 그대로 `send-keys` replay 를 유지합니다.
- shell recipe 는 command 실행 없이 cwd/layout 복원만 유지합니다.
- snapshot schema 는 변경하지 않았습니다.
- raw argv direct-start 를 canonical path 로 만들지 않았습니다.

## Fallback 정책

- missing/invalid resume id 는 restore 전체 실패가 아니라 warning + shell pane fallback 입니다.
- agent binary 를 찾지 못한 경우도 restore 전체 실패가 아니라 warning + shell pane fallback 입니다.
- fallback shell pane 에 resume command 를 `send-keys` 로 입력하지 않습니다.

## 명시적으로 제외한 범위

- live session overwrite restore 구현은 제외했습니다.
- `session-state restore` 의 non-dry-run 실행 개방은 제외했습니다.
- `ApplyToExistingSession` cleanup / destructive live overwrite primitive 삭제 검토는 제외했습니다.
- restore UI / Settings IA 확장은 제외했습니다.
- agent resume id capture 로직 재설계와 Codex/Claude hook ingest 정책 변경은 제외했습니다.

## 검증 명령

- `go test ./internal/integrations/sessionstate ./internal/app ./internal/integrations/tmux`
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `git diff --check`

## 미검증 smoke 및 후속 작업

- 실제 restored pane 에서 Codex / Claude resume 이 외부 CLI 세션으로 정상 attach 되는 manual smoke 는 수행하지 않았습니다.
- `ApplyToExistingSession` / destructive live overwrite primitive 삭제 검토는 메인 로드맵 Backlog 의 별도 항목으로 남깁니다.
