### PR TITLE
fix(notify): preserve WSL toast URI forwarding

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,7 +279,7 @@ gated here.
 
 Click activation is wired only for `raise`. The `projmux://` URI handler is
 registered on the first `raise` Notify of each tmux server (gated by the
-`@projmux_uri_protocol_registered_v3` marker). The
+`@projmux_uri_protocol_registered_v4` marker). The
 mode only controls whether a toast fires at all and whether to follow it
 up with an on-push auto-raise.
 
@@ -319,10 +319,13 @@ the first time a Toast is dispatched on each tmux server. Clicking the
 toast hands control back to projmux inside WSL via the registered command:
 
 ```text
-powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "<hidden launcher>" "%1"
+powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "<hidden launcher>"
 ```
 
-The hidden launcher then runs `wsl.exe` with argv semantics equivalent to:
+The hidden launcher stores the substituted `%1` URI in a PowerShell variable,
+then starts `wsl.exe` through `System.Diagnostics.ProcessStartInfo` with
+`UseShellExecute=false` and `CreateNoWindow=true`. Its argv semantics are
+equivalent to:
 
 ```text
 wsl.exe -d $WSL_DISTRO_NAME --exec <absolute-path-to-projmux> focus --uri <uri>
@@ -353,10 +356,11 @@ notify path so users do not configure anything:
    `wsl.exe -- <cmd>` routes its tail through the user's login shell, which
    parses `&` query-string separators as background-job operators (zsh emits
    `parse error near '&'`). `--exec` skips the shell and invokes the binary
-   directly. The `%1` URI is forwarded as a PowerShell argument and then as a
-   `wsl.exe` argv element, not interpolated into a shell command. The absolute
-   WSL filesystem path to the binary is captured at registration so PATH does
-   not need to be populated under `--exec`.
+   directly. The `%1` URI is assigned inside a PowerShell single-quoted
+   literal before the `wsl.exe` argument string is built, so `&` query
+   separators are data instead of PowerShell or shell syntax. The absolute WSL
+   filesystem path to the binary is captured at registration so PATH does not
+   need to be populated under `--exec`.
 
 The URI carries the originating pane id and tmux socket so the click
 round-trips back to the exact pane that fired the notification, which
@@ -367,12 +371,13 @@ Registration markers and the writes involved:
 - Registry keys (HKCU): `SOFTWARE\Classes\projmux\(Default)`,
   `SOFTWARE\Classes\projmux\URL Protocol`, and
   `SOFTWARE\Classes\projmux\shell\open\command\(Default)`.
-- tmux user-option marker `@projmux_uri_protocol_registered_v3` records that
+- tmux user-option marker `@projmux_uri_protocol_registered_v4` records that
   registration has been attempted on this server so the script runs at most
-  once per server boot. (The v2 marker
-  `@projmux_uri_protocol_registered_v2` was bumped when the registry command
-  moved behind the hidden wrapper; existing v2 users re-register
-  transparently on the next Notify after upgrade and the orphaned v2 key
+  once per server boot. (The v3 marker
+  `@projmux_uri_protocol_registered_v3` was bumped when the hidden wrapper
+  stopped passing `%1` after `-Command` and moved to
+  `ProcessStartInfo`/`CreateNoWindow`; existing v3 users re-register
+  transparently on the next Notify after upgrade and the orphaned v3 key
   requires no cleanup.)
 
 Limitations:

--- a/docs/notify-os-focus-poc.md
+++ b/docs/notify-os-focus-poc.md
@@ -329,15 +329,17 @@ machine is:
    click path. `cmd.exe /c exit` is benign and survives.
 4. **WSL handler command uses a hidden wrapper and keeps `--exec`**. The
    registry protocol handler launches PowerShell with `-WindowStyle Hidden`
-   so ShellExecute does not flash a visible `wsl.exe` console window. Inside
-   that wrapper, `wsl.exe -- <cmd>` remains forbidden because it routes its
-   tail through the user's default login shell, which parses `&`
-   query-string separators as background-job operators (zsh emits
-   `parse error near '&'`). `--exec` skips the shell and invokes the binary
-   directly. PATH is empty under `--exec`, so the registry command uses the
-   absolute WSL filesystem path captured at registration time. The `%1` URI
-   is passed as an argument to the hidden wrapper and then as the `--uri` argv
-   value, not shell-interpolated.
+   so ShellExecute does not flash a visible `wsl.exe` console window. The
+   wrapper starts `wsl.exe` through `System.Diagnostics.ProcessStartInfo` with
+   `UseShellExecute=false` and `CreateNoWindow=true`. Inside that wrapper,
+   `wsl.exe -- <cmd>` remains forbidden because it routes its tail through the
+   user's default login shell, which parses `&` query-string separators as
+   background-job operators (zsh emits `parse error near '&'`). `--exec` skips
+   the shell and invokes the binary directly. PATH is empty under `--exec`, so
+   the registry command uses the absolute WSL filesystem path captured at
+   registration time. The `%1` URI is assigned inside a PowerShell
+   single-quoted literal and then forwarded as the `--uri` argv value, not
+   shell-interpolated.
 
 #### Lessons (so future readers don't repeat them)
 
@@ -351,9 +353,10 @@ machine is:
 - Do not use `wsl.exe -- projmux ...` in the registry handler.
   Re-introducing the login-shell hop will surface as `parse error near
   '&'` from the user's shell at click time.
-- The `@projmux_uri_protocol_registered_v3` marker exists because v2 came
-  before the hidden-wrapper fix. Re-registration is idempotent so upgrades
-  from v2 transparently install the new handler — the old marker key just
+- The `@projmux_uri_protocol_registered_v4` marker exists because v3 passed
+  `%1` after `-Command`, letting PowerShell parse `&` query separators before
+  `projmux focus --uri` could run. Re-registration is idempotent so upgrades
+  from v3 transparently install the new handler — the old marker key just
   goes orphaned.
 
 Multi-distro dispatch (one handler per distro, or a distro-selector

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -1955,12 +1955,47 @@ try {
 }
 
 func buildWSLURIProtocolHandlerCommand(distro, binaryPath string) string {
-	launcher := `& { param([string]$uri) Start-Process -WindowStyle Hidden -FilePath 'wsl.exe' -ArgumentList @('-d', ` + psSingleQuoted(distro) + `, '--exec', ` + psSingleQuoted(binaryPath) + `, 'focus', '--uri', $uri) }`
-	return `powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "` + launcher + `" "%1"`
+	args := strings.Join([]string{
+		windowsCommandLineArg("-d"),
+		windowsCommandLineArg(distro),
+		windowsCommandLineArg("--exec"),
+		windowsCommandLineArg(binaryPath),
+		windowsCommandLineArg("focus"),
+		windowsCommandLineArg("--uri"),
+	}, " ")
+	launcher := `$uri = '%1'; $psi = New-Object System.Diagnostics.ProcessStartInfo; $psi.FileName = 'wsl.exe'; $psi.UseShellExecute = $false; $psi.CreateNoWindow = $true; $psi.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Hidden; $psi.Arguments = ` + psSingleQuoted(args+` "`) + ` + $uri + ` + psSingleQuoted(`"`) + `; [System.Diagnostics.Process]::Start($psi) | Out-Null`
+	return `powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "` + launcher + `"`
 }
 
 func psSingleQuoted(value string) string {
 	return "'" + psEscape(value) + "'"
+}
+
+func windowsCommandLineArg(value string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	backslashes := 0
+	for _, r := range value {
+		switch r {
+		case '\\':
+			backslashes++
+		case '"':
+			b.WriteString(strings.Repeat("\\", backslashes*2+1))
+			b.WriteRune(r)
+			backslashes = 0
+		default:
+			if backslashes > 0 {
+				b.WriteString(strings.Repeat("\\", backslashes))
+				backslashes = 0
+			}
+			b.WriteRune(r)
+		}
+	}
+	if backslashes > 0 {
+		b.WriteString(strings.Repeat("\\", backslashes*2))
+	}
+	b.WriteByte('"')
+	return b.String()
 }
 
 func buildRegisterToastAppIDPowerShell(appID, displayName, iconURI string) string {

--- a/internal/app/notification_appid.go
+++ b/internal/app/notification_appid.go
@@ -57,5 +57,10 @@ const (
 	// v3 — incremented after the handler moved from direct `wsl.exe` launch to
 	// a hidden PowerShell wrapper to avoid the visible Windows console flash on
 	// Toast click. Existing v2 markers are left orphaned for the same reason.
-	uriProtocolRegisteredTmuxOption = "@projmux_uri_protocol_registered_v3"
+	//
+	// v4 — incremented after the hidden wrapper stopped passing `%1` after
+	// `-Command`, which PowerShell parsed as command text and broke URI query
+	// separators. Existing v3 markers are left orphaned so affected servers
+	// install the ProcessStartInfo/CreateNoWindow wrapper on their next Notify.
+	uriProtocolRegisteredTmuxOption = "@projmux_uri_protocol_registered_v4"
 )

--- a/internal/app/notification_toast_launch_test.go
+++ b/internal/app/notification_toast_launch_test.go
@@ -63,7 +63,7 @@ func TestBuildRegisterURIProtocolPowerShell_WritesAllRegistryKeys(t *testing.T) 
 		`Set-ItemProperty -Path $regPath -Name '(Default)' -Value 'URL:projmux'`,
 		"Set-ItemProperty -Path $regPath -Name 'URL Protocol' -Value ''",
 		`powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass`,
-		`Start-Process -WindowStyle Hidden -FilePath ''wsl.exe''`,
+		`$psi.CreateNoWindow = $true`,
 		`Set-ItemProperty -Path $cmdPath -Name '(Default)'`,
 	}
 	for _, want := range wantSubstrings {
@@ -83,7 +83,10 @@ func TestBuildRegisterURIProtocolPowerShell_UsesHiddenLauncherNotDirectWSLComman
 	}
 	for _, want := range []string{
 		`powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass`,
-		`Start-Process -WindowStyle Hidden -FilePath ''wsl.exe''`,
+		`$psi.FileName = ''wsl.exe''`,
+		`$psi.UseShellExecute = $false`,
+		`$psi.CreateNoWindow = $true`,
+		`$psi.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Hidden`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("script missing hidden launcher intent %q:\n%s", want, script)
@@ -102,14 +105,14 @@ func TestBuildWSLURIProtocolHandlerCommand_BypassesShellWithExecAndAbsolutePath(
 	// `-- projmux focus` form shipped in PR #178 broke on the very first
 	// `&`-bearing toast click; do not let it come back.
 	command := buildWSLURIProtocolHandlerCommand("Ubuntu-24.04", "/home/me/go/bin/projmux")
-	wantLaunch := `Start-Process -WindowStyle Hidden -FilePath 'wsl.exe' -ArgumentList @('-d', 'Ubuntu-24.04', '--exec', '/home/me/go/bin/projmux', 'focus', '--uri', $uri)`
+	wantLaunch := `$psi.Arguments = '"-d" "Ubuntu-24.04" "--exec" "/home/me/go/bin/projmux" "focus" "--uri" "' + $uri + '"'`
 	if !strings.Contains(command, wantLaunch) {
 		t.Fatalf("expected hidden launch command %q in command:\n%s", wantLaunch, command)
 	}
 	if strings.Contains(command, `-- projmux focus`) {
 		t.Fatalf("command must not use the legacy `-- projmux focus` form (shell-interpreted, breaks on `&`):\n%s", command)
 	}
-	if !strings.Contains(command, "'--exec'") {
+	if !strings.Contains(command, `"--exec"`) {
 		t.Fatalf("command must use `--exec` to bypass the login shell:\n%s", command)
 	}
 }
@@ -119,9 +122,8 @@ func TestBuildWSLURIProtocolHandlerCommand_ForwardsURIAsArgument(t *testing.T) {
 
 	command := buildWSLURIProtocolHandlerCommand("Ubuntu-24.04", "/home/me/go/bin/projmux")
 	for _, want := range []string{
-		`param([string]$uri)`,
-		`'focus', '--uri', $uri`,
-		`"%1"`,
+		`$uri = '%1'`,
+		`"focus" "--uri" "' + $uri + '"'`,
 	} {
 		if !strings.Contains(command, want) {
 			t.Fatalf("handler command missing URI forwarding token %q:\n%s", want, command)
@@ -129,9 +131,10 @@ func TestBuildWSLURIProtocolHandlerCommand_ForwardsURIAsArgument(t *testing.T) {
 	}
 	for _, forbidden := range []string{
 		`--uri "%1"`,
-		`--uri '%1'`,
+		`--uri" "%1`,
 		`$uri = "%1"`,
-		`$uri = '%1'`,
+		`param([string]$uri)`,
+		`" "%1"`,
 	} {
 		if strings.Contains(command, forbidden) {
 			t.Fatalf("handler command shell-interpolates %%1 with %q:\n%s", forbidden, command)
@@ -146,7 +149,7 @@ func TestBuildWSLURIProtocolHandlerCommand_PSEscapesDistro(t *testing.T) {
 	// WSL distro registration) must be PowerShell-escaped to keep the
 	// quoted string literal balanced.
 	command := buildWSLURIProtocolHandlerCommand("weird's-distro", "/home/me/go/bin/projmux")
-	if !strings.Contains(command, `'-d', 'weird''s-distro', '--exec'`) {
+	if !strings.Contains(command, `"weird''s-distro"`) {
 		t.Fatalf("expected single-quote-escaped distro in launch command; got:\n%s", command)
 	}
 }
@@ -158,7 +161,17 @@ func TestBuildWSLURIProtocolHandlerCommand_PSEscapesBinaryPath(t *testing.T) {
 	// the quoted PowerShell literal so a pathological install location can't
 	// break the registration script.
 	command := buildWSLURIProtocolHandlerCommand("Ubuntu-24.04", "/home/o'brien/bin/projmux")
-	if !strings.Contains(command, `'--exec', '/home/o''brien/bin/projmux', 'focus'`) {
+	if !strings.Contains(command, `"/home/o''brien/bin/projmux"`) {
 		t.Fatalf("expected single-quote-escaped binary path in launch command; got:\n%s", command)
+	}
+}
+
+func TestWindowsCommandLineArgQuotesSpacesAndQuotes(t *testing.T) {
+	t.Parallel()
+
+	got := windowsCommandLineArg(`C:\Program Files\projmux "test"\`)
+	want := `"C:\Program Files\projmux \"test\"\\"`
+	if got != want {
+		t.Fatalf("windowsCommandLineArg() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Completed scope
- Fixes the WSL + Windows Terminal Toast click handler regression where the hidden PowerShell wrapper still allowed `%1` URI text to be parsed after `-Command`.
- Keeps click-to-focus routed through `projmux focus --uri` for `projmux://focus?...` launch URIs.
- Bumps the tmux registration marker to `@projmux_uri_protocol_registered_v4` so machines that already installed the broken v3 handler re-register on the next raise notification.
- Updates Toast click handler docs to describe the new command shape.

## Protocol handler command change
- The registry command remains a hidden PowerShell launcher.
- The launcher now assigns the substituted `%1` URI inside the PowerShell script and starts `wsl.exe` via `System.Diagnostics.ProcessStartInfo` with `UseShellExecute=false`, `CreateNoWindow=true`, and hidden `WindowStyle`.
- The resulting WSL argv semantics remain:
  `wsl.exe -d <distro> --exec <absolute-path-to-projmux> focus --uri <uri>`
- This avoids passing `"%1"` after `-Command`, which let PowerShell parse `&socket=...&source=...` before `projmux focus` could receive it.

## Preserved constraints
- `wsl.exe --exec` is preserved; this does not switch to `wsl.exe --`.
- Existing `projmux://focus?...` URI shape is preserved.
- Start Menu shortcut target remains `cmd.exe /c exit`; this PR does not reintroduce `powershell.exe -WindowStyle Hidden` there.
- AppID, shortcut, Toast XML, notify/raise semantics, multi-distro behavior, and `internal/integrations/osfocus` are not redesigned or expanded.

## Explicitly out of scope
- WSL multi-distro handler routing.
- Non-Windows Terminal adapters.
- Generic hook notification changes.
- Desktop notification delivery redesign.

## Verification
- `go test ./internal/app -run 'Toast|URI|Notification|AppID'`
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- Direct Windows PowerShell probe confirmed a representative `projmux://focus?pane_id=%258&socket=/tmp/tmux-1000/projmux&source=toast` URI keeps both `&` query separators as data when assigned inside the wrapper.

## Manual smoke
Not yet smoke-tested by clicking a live Toast on WSL + Windows Terminal in this PR. After merge/install, the v4 marker should force re-registration on the next `raise` notification before repeating the manual click test.
