### PR TITLE
fix(notify): use WScript for WSL toast clicks

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,7 +279,7 @@ gated here.
 
 Click activation is wired only for `raise`. The `projmux://` URI handler is
 registered on the first `raise` Notify of each tmux server (gated by the
-`@projmux_uri_protocol_registered_v4` marker). The
+`@projmux_uri_protocol_registered_v5` marker). The
 mode only controls whether a toast fires at all and whether to follow it
 up with an on-push auto-raise.
 
@@ -319,13 +319,13 @@ the first time a Toast is dispatched on each tmux server. Clicking the
 toast hands control back to projmux inside WSL via the registered command:
 
 ```text
-powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "<hidden launcher>"
+wscript.exe //B //Nologo "%LOCALAPPDATA%\projmux\projmux-uri-handler.vbs" "%1"
 ```
 
-The hidden launcher stores the substituted `%1` URI in a PowerShell variable,
-then starts `wsl.exe` through `System.Diagnostics.ProcessStartInfo` with
-`UseShellExecute=false` and `CreateNoWindow=true`. Its argv semantics are
-equivalent to:
+Registration writes the VBScript launcher under `%LOCALAPPDATA%\projmux`.
+The launcher receives `%1` as a WScript argument, quotes it as an argv value,
+and starts `wsl.exe` hidden through `WScript.Shell.Run`. Its argv semantics
+are equivalent to:
 
 ```text
 wsl.exe -d $WSL_DISTRO_NAME --exec <absolute-path-to-projmux> focus --uri <uri>
@@ -350,17 +350,17 @@ notify path so users do not configure anything:
    silently quarantines such shortcuts moments after creation, which
    leaves no AppID-tagged shortcut and breaks both the routing and the
    click path. `cmd.exe /c exit` is treated as benign and survives.
-4. The WSL handler uses a PowerShell hidden wrapper instead of launching
-   `wsl.exe` directly, avoiding the transient Windows console flash on Toast
-   click. Inside that wrapper it still uses `--exec`, not `--`.
+4. The WSL handler uses a WScript launcher instead of launching `wsl.exe` or
+   `powershell.exe` directly, avoiding the transient Windows console flash on
+   Toast click. Inside that launcher it still uses `--exec`, not `--`.
    `wsl.exe -- <cmd>` routes its tail through the user's login shell, which
    parses `&` query-string separators as background-job operators (zsh emits
    `parse error near '&'`). `--exec` skips the shell and invokes the binary
-   directly. The `%1` URI is assigned inside a PowerShell single-quoted
-   literal before the `wsl.exe` argument string is built, so `&` query
-   separators are data instead of PowerShell or shell syntax. The absolute WSL
-   filesystem path to the binary is captured at registration so PATH does not
-   need to be populated under `--exec`.
+   directly. The `%1` URI is passed as a WScript argument and then quoted as
+   the `--uri` argv value, so `&` query separators are data instead of
+   PowerShell or shell syntax. The absolute WSL filesystem path to the binary
+   is captured at registration so PATH does not need to be populated under
+   `--exec`.
 
 The URI carries the originating pane id and tmux socket so the click
 round-trips back to the exact pane that fired the notification, which
@@ -371,13 +371,14 @@ Registration markers and the writes involved:
 - Registry keys (HKCU): `SOFTWARE\Classes\projmux\(Default)`,
   `SOFTWARE\Classes\projmux\URL Protocol`, and
   `SOFTWARE\Classes\projmux\shell\open\command\(Default)`.
-- tmux user-option marker `@projmux_uri_protocol_registered_v4` records that
+- Launcher file: `%LOCALAPPDATA%\projmux\projmux-uri-handler.vbs`.
+- tmux user-option marker `@projmux_uri_protocol_registered_v5` records that
   registration has been attempted on this server so the script runs at most
-  once per server boot. (The v3 marker
-  `@projmux_uri_protocol_registered_v3` was bumped when the hidden wrapper
-  stopped passing `%1` after `-Command` and moved to
-  `ProcessStartInfo`/`CreateNoWindow`; existing v3 users re-register
-  transparently on the next Notify after upgrade and the orphaned v3 key
+  once per server boot. (The v4 marker
+  `@projmux_uri_protocol_registered_v4` was bumped when the protocol command's
+  first process moved from console-subsystem PowerShell to GUI-subsystem
+  WScript; existing v4 users re-register transparently on the next Notify
+  after upgrade and the orphaned v4 key
   requires no cleanup.)
 
 Limitations:

--- a/docs/notify-os-focus-poc.md
+++ b/docs/notify-os-focus-poc.md
@@ -327,19 +327,18 @@ machine is:
    leaves no AppID-tagged shortcut at all and breaks both the toast
    routing and (since the AppID has to be live when the toast fires) the
    click path. `cmd.exe /c exit` is benign and survives.
-4. **WSL handler command uses a hidden wrapper and keeps `--exec`**. The
-   registry protocol handler launches PowerShell with `-WindowStyle Hidden`
-   so ShellExecute does not flash a visible `wsl.exe` console window. The
-   wrapper starts `wsl.exe` through `System.Diagnostics.ProcessStartInfo` with
-   `UseShellExecute=false` and `CreateNoWindow=true`. Inside that wrapper,
+4. **WSL handler command uses a GUI launcher and keeps `--exec`**. The
+   registry protocol handler launches `wscript.exe //B //Nologo` with a
+   VBScript launcher written under `%LOCALAPPDATA%\projmux`, so ShellExecute
+   does not start a console-subsystem first process. The launcher starts
+   `wsl.exe` hidden through `WScript.Shell.Run`. Inside that launcher,
    `wsl.exe -- <cmd>` remains forbidden because it routes its tail through the
    user's default login shell, which parses `&` query-string separators as
    background-job operators (zsh emits `parse error near '&'`). `--exec` skips
    the shell and invokes the binary directly. PATH is empty under `--exec`, so
    the registry command uses the absolute WSL filesystem path captured at
-   registration time. The `%1` URI is assigned inside a PowerShell
-   single-quoted literal and then forwarded as the `--uri` argv value, not
-   shell-interpolated.
+   registration time. The `%1` URI is passed as a WScript argument and then
+   forwarded as the `--uri` argv value, not shell-interpolated.
 
 #### Lessons (so future readers don't repeat them)
 
@@ -353,10 +352,11 @@ machine is:
 - Do not use `wsl.exe -- projmux ...` in the registry handler.
   Re-introducing the login-shell hop will surface as `parse error near
   '&'` from the user's shell at click time.
-- The `@projmux_uri_protocol_registered_v4` marker exists because v3 passed
-  `%1` after `-Command`, letting PowerShell parse `&` query separators before
-  `projmux focus --uri` could run. Re-registration is idempotent so upgrades
-  from v3 transparently install the new handler — the old marker key just
+- The `@projmux_uri_protocol_registered_v5` marker exists because v4 still
+  used console-subsystem PowerShell as the protocol command's first process,
+  which could flash before `-WindowStyle Hidden` took effect. Re-registration
+  is idempotent so upgrades from v4 transparently install the new handler —
+  the old marker key just
   goes orphaned.
 
 Multi-distro dispatch (one handler per distro, or a distro-selector

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -1910,20 +1910,20 @@ $toast = [Windows.UI.Notifications.ToastNotification]::new($tpl)
 //
 //	(Default)                          = "URL:projmux"
 //	URL Protocol                       = ""
-//	shell\open\command\(Default)       = powershell.exe ... -WindowStyle Hidden ... "%1"
+//	shell\open\command\(Default)       = wscript.exe //B //Nologo <launcher.vbs> "%1"
 //
-// The hidden PowerShell wrapper avoids the visible console flash caused by
-// Windows ShellExecute launching console-subsystem `wsl.exe` directly from the
-// protocol handler. Inside the wrapper, `--exec` instead of `--` remains
-// load-bearing: `wsl.exe -- <cmd> <args>` routes `<cmd> <args>` through the
-// user's default login shell (zsh/bash). The `projmux://` URI carries `&`
-// characters as query-parameter separators, and zsh parses `&` as a
-// background-job operator before projmux ever runs, emitting
-// `zsh:1: parse error near '&'`. `--exec` skips the shell and invokes the
-// binary directly with the args verbatim. Because `--exec` doesn't load shell
-// init files, PATH may be empty, so we register the absolute WSL filesystem
-// path to the projmux binary captured at registration time (whichever binary
-// actually wrote the registry key).
+// The GUI-subsystem WScript launcher avoids the visible console flash caused
+// by Windows ShellExecute launching console-subsystem `wsl.exe` or
+// `powershell.exe` directly from the protocol handler. Inside the launcher,
+// `--exec` instead of `--` remains load-bearing: `wsl.exe -- <cmd> <args>`
+// routes `<cmd> <args>` through the user's default login shell (zsh/bash). The
+// `projmux://` URI carries `&` characters as query-parameter separators, and
+// zsh parses `&` as a background-job operator before projmux ever runs,
+// emitting `zsh:1: parse error near '&'`. `--exec` skips the shell and invokes
+// the binary directly with the args verbatim. Because `--exec` doesn't load
+// shell init files, PATH may be empty, so we register the absolute WSL
+// filesystem path to the projmux binary captured at registration time
+// (whichever binary actually wrote the registry key).
 //
 // The handler captures the user's *current* WSL_DISTRO_NAME because the
 // click is received on the Windows side with no knowledge of which distro
@@ -1939,6 +1939,15 @@ $toast = [Windows.UI.Notifications.ToastNotification]::new($tpl)
 func buildRegisterURIProtocolPowerShell(scheme, distro, binaryPath string) string {
 	return `$regPath = "HKCU:\SOFTWARE\Classes\` + psEscape(scheme) + `"
 $cmdPath = "$regPath\shell\open\command"
+$launcherRoot = $env:LOCALAPPDATA
+if ([string]::IsNullOrWhiteSpace($launcherRoot)) {
+  $launcherRoot = $env:TEMP
+}
+$launcherDir = Join-Path $launcherRoot 'projmux'
+$launcherPath = Join-Path $launcherDir '` + psEscape(scheme) + `-uri-handler.vbs'
+$launcherScript = @'
+` + buildWSLURIProtocolLauncherVBScript(distro, binaryPath) + `
+'@
 try {
   if (-not (Test-Path $regPath)) {
     New-Item -Path $regPath -Force | Out-Null
@@ -1946,56 +1955,67 @@ try {
   if (-not (Test-Path $cmdPath)) {
     New-Item -Path $cmdPath -Force | Out-Null
   }
+  if (-not (Test-Path $launcherDir)) {
+    New-Item -Path $launcherDir -ItemType Directory -Force | Out-Null
+  }
+  Set-Content -Path $launcherPath -Value $launcherScript -Encoding ASCII
   Set-ItemProperty -Path $regPath -Name '(Default)' -Value 'URL:` + psEscape(scheme) + `' -Type String
   Set-ItemProperty -Path $regPath -Name 'URL Protocol' -Value '' -Type String
-  $launchCmd = '` + psEscape(buildWSLURIProtocolHandlerCommand(distro, binaryPath)) + `'
+  $launchCmd = 'wscript.exe //B //Nologo "' + $launcherPath + '" "%1"'
   Set-ItemProperty -Path $cmdPath -Name '(Default)' -Value $launchCmd -Type String
 } catch { }
 `
 }
 
-func buildWSLURIProtocolHandlerCommand(distro, binaryPath string) string {
-	args := strings.Join([]string{
-		windowsCommandLineArg("-d"),
-		windowsCommandLineArg(distro),
-		windowsCommandLineArg("--exec"),
-		windowsCommandLineArg(binaryPath),
-		windowsCommandLineArg("focus"),
-		windowsCommandLineArg("--uri"),
-	}, " ")
-	launcher := `$uri = '%1'; $psi = New-Object System.Diagnostics.ProcessStartInfo; $psi.FileName = 'wsl.exe'; $psi.UseShellExecute = $false; $psi.CreateNoWindow = $true; $psi.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Hidden; $psi.Arguments = ` + psSingleQuoted(args+` "`) + ` + $uri + ` + psSingleQuoted(`"`) + `; [System.Diagnostics.Process]::Start($psi) | Out-Null`
-	return `powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "` + launcher + `"`
+func buildWSLURIProtocolLauncherVBScript(distro, binaryPath string) string {
+	argv := []string{"wsl.exe", "-d", distro, "--exec", binaryPath, "focus", "--uri"}
+	quoted := make([]string, 0, len(argv)+1)
+	for _, arg := range argv {
+		quoted = append(quoted, "QuoteArg("+vbsDoubleQuoted(arg)+")")
+	}
+	quoted = append(quoted, "QuoteArg(uri)")
+	commandExpr := strings.Join(quoted, ` & " " & `)
+	return `Option Explicit
+
+Dim uri
+If WScript.Arguments.Count < 1 Then
+  WScript.Quit 0
+End If
+uri = WScript.Arguments.Item(0)
+
+Dim shell, command
+command = ` + commandExpr + `
+Set shell = CreateObject("WScript.Shell")
+shell.Run command, 0, False
+
+Function QuoteArg(value)
+  Dim result, i, ch, backslashes
+  result = """"
+  backslashes = 0
+  For i = 1 To Len(value)
+    ch = Mid(value, i, 1)
+    If ch = "\" Then
+      backslashes = backslashes + 1
+    ElseIf ch = """" Then
+      result = result & String(backslashes * 2 + 1, "\") & """"
+      backslashes = 0
+    Else
+      If backslashes > 0 Then
+        result = result & String(backslashes, "\")
+        backslashes = 0
+      End If
+      result = result & ch
+    End If
+  Next
+  If backslashes > 0 Then
+    result = result & String(backslashes * 2, "\")
+  End If
+  QuoteArg = result & """"
+End Function`
 }
 
-func psSingleQuoted(value string) string {
-	return "'" + psEscape(value) + "'"
-}
-
-func windowsCommandLineArg(value string) string {
-	var b strings.Builder
-	b.WriteByte('"')
-	backslashes := 0
-	for _, r := range value {
-		switch r {
-		case '\\':
-			backslashes++
-		case '"':
-			b.WriteString(strings.Repeat("\\", backslashes*2+1))
-			b.WriteRune(r)
-			backslashes = 0
-		default:
-			if backslashes > 0 {
-				b.WriteString(strings.Repeat("\\", backslashes))
-				backslashes = 0
-			}
-			b.WriteRune(r)
-		}
-	}
-	if backslashes > 0 {
-		b.WriteString(strings.Repeat("\\", backslashes*2))
-	}
-	b.WriteByte('"')
-	return b.String()
+func vbsDoubleQuoted(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
 }
 
 func buildRegisterToastAppIDPowerShell(appID, displayName, iconURI string) string {

--- a/internal/app/notification_appid.go
+++ b/internal/app/notification_appid.go
@@ -30,7 +30,7 @@ const (
 	// WSL. The scheme is shared across all environments — only WSL +
 	// Windows Terminal users actually register the handler today (other
 	// platforms keep the in-app focus path). The handler command we register
-	// launches a hidden PowerShell wrapper which then runs
+	// launches a GUI-subsystem WScript wrapper which then runs
 	// `wsl.exe -d <distro> --exec <abs-binary-path> focus --uri <uri>`.
 	// `--exec` bypasses the user's login shell so URI query separators (`&`)
 	// don't get parsed as background-job operators by zsh/bash.
@@ -62,5 +62,9 @@ const (
 	// `-Command`, which PowerShell parsed as command text and broke URI query
 	// separators. Existing v3 markers are left orphaned so affected servers
 	// install the ProcessStartInfo/CreateNoWindow wrapper on their next Notify.
-	uriProtocolRegisteredTmuxOption = "@projmux_uri_protocol_registered_v4"
+	//
+	// v5 — incremented after the first process in the protocol command moved
+	// from console-subsystem PowerShell to GUI-subsystem WScript because
+	// PowerShell itself could still flash before hiding its window.
+	uriProtocolRegisteredTmuxOption = "@projmux_uri_protocol_registered_v5"
 )

--- a/internal/app/notification_toast_launch_test.go
+++ b/internal/app/notification_toast_launch_test.go
@@ -58,12 +58,16 @@ func TestBuildRegisterURIProtocolPowerShell_WritesAllRegistryKeys(t *testing.T) 
 	wantSubstrings := []string{
 		`$regPath = "HKCU:\SOFTWARE\Classes\projmux"`,
 		`$cmdPath = "$regPath\shell\open\command"`,
+		`$launcherDir = Join-Path $launcherRoot 'projmux'`,
+		`$launcherPath = Join-Path $launcherDir 'projmux-uri-handler.vbs'`,
 		"New-Item -Path $regPath -Force",
 		"New-Item -Path $cmdPath -Force",
+		"New-Item -Path $launcherDir -ItemType Directory -Force",
+		"Set-Content -Path $launcherPath -Value $launcherScript -Encoding ASCII",
 		`Set-ItemProperty -Path $regPath -Name '(Default)' -Value 'URL:projmux'`,
 		"Set-ItemProperty -Path $regPath -Name 'URL Protocol' -Value ''",
-		`powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass`,
-		`$psi.CreateNoWindow = $true`,
+		`wscript.exe //B //Nologo "`,
+		`projmux-uri-handler.vbs`,
 		`Set-ItemProperty -Path $cmdPath -Name '(Default)'`,
 	}
 	for _, want := range wantSubstrings {
@@ -82,19 +86,27 @@ func TestBuildRegisterURIProtocolPowerShell_UsesHiddenLauncherNotDirectWSLComman
 		t.Fatalf("script must not register direct wsl.exe protocol command %q:\n%s", direct, script)
 	}
 	for _, want := range []string{
-		`powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass`,
-		`$psi.FileName = ''wsl.exe''`,
-		`$psi.UseShellExecute = $false`,
-		`$psi.CreateNoWindow = $true`,
-		`$psi.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Hidden`,
+		`wscript.exe //B //Nologo "`,
+		`"%1"`,
+		`shell.Run command, 0, False`,
+		`QuoteArg("wsl.exe") & " " & QuoteArg("-d")`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("script missing hidden launcher intent %q:\n%s", want, script)
 		}
 	}
+	for _, forbidden := range []string{
+		`powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command`,
+		`Start-Process -WindowStyle Hidden -FilePath`,
+		`$psi.CreateNoWindow = $true`,
+	} {
+		if strings.Contains(script, forbidden) {
+			t.Fatalf("script must not register console-subsystem hidden wrapper %q:\n%s", forbidden, script)
+		}
+	}
 }
 
-func TestBuildWSLURIProtocolHandlerCommand_BypassesShellWithExecAndAbsolutePath(t *testing.T) {
+func TestBuildWSLURIProtocolLauncherVBScript_BypassesShellWithExecAndAbsolutePath(t *testing.T) {
 	t.Parallel()
 
 	// Regression guard: the registered launch command must use `--exec`
@@ -104,74 +116,82 @@ func TestBuildWSLURIProtocolHandlerCommand_BypassesShellWithExecAndAbsolutePath(
 	// doesn't load shell init files, so PATH is unreliable). The bare
 	// `-- projmux focus` form shipped in PR #178 broke on the very first
 	// `&`-bearing toast click; do not let it come back.
-	command := buildWSLURIProtocolHandlerCommand("Ubuntu-24.04", "/home/me/go/bin/projmux")
-	wantLaunch := `$psi.Arguments = '"-d" "Ubuntu-24.04" "--exec" "/home/me/go/bin/projmux" "focus" "--uri" "' + $uri + '"'`
-	if !strings.Contains(command, wantLaunch) {
-		t.Fatalf("expected hidden launch command %q in command:\n%s", wantLaunch, command)
+	script := buildWSLURIProtocolLauncherVBScript("Ubuntu-24.04", "/home/me/go/bin/projmux")
+	for _, want := range []string{
+		`QuoteArg("wsl.exe")`,
+		`QuoteArg("-d")`,
+		`QuoteArg("Ubuntu-24.04")`,
+		`QuoteArg("--exec")`,
+		`QuoteArg("/home/me/go/bin/projmux")`,
+		`QuoteArg("focus")`,
+		`QuoteArg("--uri")`,
+		`QuoteArg(uri)`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("expected launcher token %q in script:\n%s", want, script)
+		}
 	}
-	if strings.Contains(command, `-- projmux focus`) {
-		t.Fatalf("command must not use the legacy `-- projmux focus` form (shell-interpreted, breaks on `&`):\n%s", command)
+	if strings.Contains(script, `-- projmux focus`) {
+		t.Fatalf("launcher must not use the legacy `-- projmux focus` form (shell-interpreted, breaks on `&`):\n%s", script)
 	}
-	if !strings.Contains(command, `"--exec"`) {
-		t.Fatalf("command must use `--exec` to bypass the login shell:\n%s", command)
+	if !strings.Contains(script, `QuoteArg("--exec")`) {
+		t.Fatalf("launcher must use `--exec` to bypass the login shell:\n%s", script)
 	}
 }
 
-func TestBuildWSLURIProtocolHandlerCommand_ForwardsURIAsArgument(t *testing.T) {
+func TestBuildWSLURIProtocolLauncherVBScript_ForwardsURIAsArgument(t *testing.T) {
 	t.Parallel()
 
-	command := buildWSLURIProtocolHandlerCommand("Ubuntu-24.04", "/home/me/go/bin/projmux")
+	registerScript := buildRegisterURIProtocolPowerShell("projmux", "Ubuntu-24.04", "/home/me/go/bin/projmux")
+	launcherScript := buildWSLURIProtocolLauncherVBScript("Ubuntu-24.04", "/home/me/go/bin/projmux")
 	for _, want := range []string{
-		`$uri = '%1'`,
-		`"focus" "--uri" "' + $uri + '"'`,
+		`wscript.exe //B //Nologo "`,
+		`"%1"`,
+		`uri = WScript.Arguments.Item(0)`,
+		`QuoteArg("--uri") & " " & QuoteArg(uri)`,
 	} {
-		if !strings.Contains(command, want) {
-			t.Fatalf("handler command missing URI forwarding token %q:\n%s", want, command)
+		if !strings.Contains(registerScript+"\n"+launcherScript, want) {
+			t.Fatalf("handler command missing URI forwarding token %q:\n%s\n%s", want, registerScript, launcherScript)
 		}
 	}
 	for _, forbidden := range []string{
 		`--uri "%1"`,
 		`--uri" "%1`,
 		`$uri = "%1"`,
+		`$uri = '%1'`,
 		`param([string]$uri)`,
-		`" "%1"`,
+		`-Command`,
 	} {
-		if strings.Contains(command, forbidden) {
-			t.Fatalf("handler command shell-interpolates %%1 with %q:\n%s", forbidden, command)
+		if strings.Contains(registerScript, forbidden) {
+			t.Fatalf("handler command shell-interpolates %%1 with %q:\n%s", forbidden, registerScript)
 		}
 	}
 }
 
-func TestBuildWSLURIProtocolHandlerCommand_PSEscapesDistro(t *testing.T) {
+func TestBuildWSLURIProtocolLauncherVBScript_EscapesDistro(t *testing.T) {
 	t.Parallel()
 
-	// Distro names with single quotes (unusual but technically allowed in
-	// WSL distro registration) must be PowerShell-escaped to keep the
-	// quoted string literal balanced.
-	command := buildWSLURIProtocolHandlerCommand("weird's-distro", "/home/me/go/bin/projmux")
-	if !strings.Contains(command, `"weird''s-distro"`) {
-		t.Fatalf("expected single-quote-escaped distro in launch command; got:\n%s", command)
+	script := buildWSLURIProtocolLauncherVBScript(`weird"distro`, "/home/me/go/bin/projmux")
+	if !strings.Contains(script, `QuoteArg("weird""distro")`) {
+		t.Fatalf("expected double-quote-escaped distro in launcher script; got:\n%s", script)
 	}
 }
 
-func TestBuildWSLURIProtocolHandlerCommand_PSEscapesBinaryPath(t *testing.T) {
+func TestBuildWSLURIProtocolLauncherVBScript_EscapesBinaryPath(t *testing.T) {
 	t.Parallel()
 
-	// Binary paths shouldn't contain single quotes in practice, but defend
-	// the quoted PowerShell literal so a pathological install location can't
-	// break the registration script.
-	command := buildWSLURIProtocolHandlerCommand("Ubuntu-24.04", "/home/o'brien/bin/projmux")
-	if !strings.Contains(command, `"/home/o''brien/bin/projmux"`) {
-		t.Fatalf("expected single-quote-escaped binary path in launch command; got:\n%s", command)
+	script := buildWSLURIProtocolLauncherVBScript("Ubuntu-24.04", `/home/me/bin/proj"mux`)
+	if !strings.Contains(script, `QuoteArg("/home/me/bin/proj""mux")`) {
+		t.Fatalf("expected double-quote-escaped binary path in launcher script; got:\n%s", script)
 	}
 }
 
-func TestWindowsCommandLineArgQuotesSpacesAndQuotes(t *testing.T) {
+func TestVBSDoubleQuotedEscapesQuotes(t *testing.T) {
 	t.Parallel()
 
-	got := windowsCommandLineArg(`C:\Program Files\projmux "test"\`)
-	want := `"C:\Program Files\projmux \"test\"\\"`
+	got := vbsDoubleQuoted(`C:\Program Files\projmux "test"\`)
+	want := `"C:\Program Files\projmux ""test""\"`
 	if got != want {
-		t.Fatalf("windowsCommandLineArg() = %q, want %q", got, want)
+		t.Fatalf("vbsDoubleQuoted() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Completed scope
- Moves the WSL Toast click protocol handler's first process from console-subsystem PowerShell to GUI-subsystem `wscript.exe`.
- Writes a small VBScript launcher under `%LOCALAPPDATA%\projmux\projmux-uri-handler.vbs` during URI protocol registration.
- Keeps click-to-focus routed through `projmux focus --uri` for the existing `projmux://focus?...` URI shape.
- Bumps the tmux registration marker to `@projmux_uri_protocol_registered_v5` so machines with the v4 PowerShell handler re-register on the next raise notification.
- Updates the Toast click handler docs.

## Protocol handler command change
- Registry command changes from a hidden PowerShell protocol command to:
  `wscript.exe //B //Nologo "<launcher.vbs>" "%1"`
- The VBScript launcher starts WSL hidden through `WScript.Shell.Run`.
- The resulting WSL argv semantics remain:
  `wsl.exe -d <distro> --exec <absolute-path-to-projmux> focus --uri <uri>`
- `%1` is received as a WScript argument and quoted as the `--uri` argv value. It is not parsed by PowerShell, cmd, or a WSL login shell.

## Preserved constraints
- `wsl.exe --exec` is preserved; this does not switch to `wsl.exe --`.
- Existing `projmux://focus?...` URI shape is preserved.
- Start Menu shortcut target remains `cmd.exe /c exit`.
- AppID, shortcut property bag, Toast XML, notify/raise semantics, multi-distro behavior, and `internal/integrations/osfocus` are not redesigned or expanded.

## Explicitly out of scope
- WSL multi-distro handler routing.
- Non-Windows Terminal adapters.
- Generic hook notification changes.
- Desktop notification delivery redesign.

## Verification
- `go test ./internal/app -run 'Toast|URI|Notification|AppID'`
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`

## Manual smoke
- User confirmed after PR #285 that focus return works, but a visible console still flashes.
- This PR addresses that remaining flash by avoiding a console-subsystem first process. Live Toast click smoke will be repeated after merge/install.
