### PR TITLE
fix(notify): keep sidebar open after row ack

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -49,7 +49,9 @@
   (TTL does not remove rows, focus success and target-gone clicks ack,
   reconcile reports stale rows), `notify list --live` queue/live explanations, notify sidebar
   two-line card rendering with age/project/window/pane metadata plus focus/ack/clear-all
-  actions, and `focus` dispatch diagnostics for session fallback, unresolved
+  actions, including in-place `x` ack that refreshes the sidebar without
+  focusing, preserves selection position where possible, and renders the empty
+  state after the last row is acked, and `focus` dispatch diagnostics for session fallback, unresolved
   targets, window fallback, pane fallback, explicit id failures as unresolved exits, and
   notify-only fallback.
 - Picker focused unit coverage includes backend-neutral picker item/action mapping, native title-focused filtering, numeric selection, shared close actions including raw and CSI-u Ctrl-X native custom actions, deprecated picker backend value normalization, AI picker title chrome and stable search-key ordering, Settings title chrome and root section order, Settings Labs shell without backend choices plus keybinding diagnostic list/detail/probe outcome/init delegation coverage, environment override normalization, compact multi-line metadata gutters with one-column-indented metadata, proportional native scrollbar thumb rendering, multiline partial next/previous item row rendering with rendered-row scrollbar units, fixed split-preview and sidebar list viewports with scrollbar tracks, native up/down-family navigation wrap with empty-list safety and PageUp/PageDown/Home/End clamp regression coverage, native mouse down/follow-drag/release behavior, preview tab/control normalization before width clipping, optional native frame titlebars without same-line rule fill and with titlebar border reset guards, titled native Alt-1 sidebar chrome, statusbar-preserving sidebar popup height, native-only compact project sidebar popup sizing, and notify sidebar title/popup sizing.

--- a/docs/notify-queue.md
+++ b/docs/notify-queue.md
@@ -94,11 +94,14 @@ preserves the stable JSON array used by scripts.
 
 `--ui=sidebar` opens the notify queue as an interactive right-side list when
 run inside the tmux popup surface. Enter focuses the selected target pane and
-acks the row after focus succeeds. `x` acks the selected row. `Ctrl-X` clears
-all rows via `notify ack --all`. Rows are intentionally compact: the visible
-label keeps notification text first, then age, project, window, and pane
-metadata; hidden queue ids remain action values but the sidebar has no search
-input and intentionally does not expose a separate metadata detail view.
+acks the row after focus succeeds. `x` acks the selected row in place, keeps
+the sidebar open, and refreshes the list from the queue while preserving the
+selection position where possible; acking the last remaining row renders the
+empty state until the popup is closed. `Ctrl-X` clears all rows via `notify ack
+--all` and exits. Rows are intentionally compact: the visible label keeps
+notification text first, then age, project, window, and pane metadata; hidden
+queue ids remain action values but the sidebar has no search input and
+intentionally does not expose a separate metadata detail view.
 
 `--live` adds a non-mutating explanation view that reads
 `tmux list-panes -a` and compares the queue with live reply-state panes. It

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -103,7 +103,10 @@ needed, and colors that sync line amber once it is more than 60 seconds old.
 The notification HUD detail surface (`Alt-2` / `User2`) opens the right-side
 notification popup with newest-first rows and an amber title. When notification
 icon decoration is `symbol` or `emoji`, the bell appears before the title text.
-Selecting a row still focuses and acknowledges that notification.
+Selecting a row still focuses and acknowledges that notification. Pressing `x`
+on a row acknowledges it without focusing, keeps the popup open, and refreshes
+the remaining rows from the queue while preserving the selection position where
+possible.
 
 Empty `#{mouse_status_range}` (a click on whitespace) falls through to
 `select-window -t @<mouse_window>` when `--mouse-window` is non-empty,

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -248,6 +248,10 @@ func (c *notifyCommand) runList(args []string, stdout, stderr io.Writer) error {
 		return err
 	}
 
+	if *ui == "sidebar" {
+		return c.runSidebar(store, severities, sources, *limit, stdout, stderr, c.notifyOriginClient(*clientTTY))
+	}
+
 	entries, err := store.List()
 	if err != nil {
 		return fmt.Errorf("list notifications: %w", err)
@@ -256,10 +260,6 @@ func (c *notifyCommand) runList(args []string, stdout, stderr io.Writer) error {
 	entries = filterEntries(entries, severities, sources)
 	if *limit > 0 && len(entries) > *limit {
 		entries = entries[:*limit]
-	}
-
-	if *ui == "sidebar" {
-		return c.runSidebar(entries, stdout, stderr, c.notifyOriginClient(*clientTTY))
 	}
 
 	if *asJSON {
@@ -285,68 +285,87 @@ func (c *notifyCommand) runList(args []string, stdout, stderr io.Writer) error {
 	return writeNotifyTable(stdout, entries, c.clock())
 }
 
-func (c *notifyCommand) runSidebar(entries []notify.Notification, stdout, stderr io.Writer, clientTTY string) error {
+func (c *notifyCommand) runSidebar(store notifyStore, severities, sources []string, limit int, stdout, stderr io.Writer, clientTTY string) error {
 	if c.native == nil {
 		return errors.New("native picker is not configured")
 	}
-	now := c.clock()
-	liveByID := c.notifyLiveByIDBestEffort()
-	compatOptions := intpickercompat.Options{
-		UI:            "notify-sidebar",
-		Read0:         true,
-		Title:         "\x1b[1;38;5;220m" + notifyHeaderDecorator(c.statusbarDecoration()) + "Pending Notifications\x1b[0m",
-		Prompt:        "Notify > ",
-		Header:        "Newest first",
-		Footer:        "Enter: focus + ack  |  x: ack  |  Ctrl-X: clear all  |  Esc/Alt-2: close",
-		ExpectKeys:    []string{"x", "ctrl-x"},
-		Bindings:      []string{"alt-2:abort"},
-		Entries:       notifySidebarEntriesWithLive(entries, now, liveByID),
-		DisableSearch: true,
-	}
-	result, err := runPickerOptionBackend(c.lookupEnv, c.native, c.picker, compatOptions)
-	if err != nil {
-		return fmt.Errorf("run notify sidebar: %w", err)
-	}
-	id := strings.TrimSpace(result.Value)
-	if id == "" || id == notifySidebarEmptyValue {
-		return nil
-	}
-	store, err := c.requireStore()
-	if err != nil {
-		return err
-	}
-	switch result.Key {
-	case "ctrl-x":
-		removed, err := store.AckAll()
+
+	nextIndex := -1
+	for {
+		entries, err := store.List()
 		if err != nil {
-			return fmt.Errorf("clear all notifications: %w", err)
+			return fmt.Errorf("list notifications: %w", err)
 		}
-		_, err = fmt.Fprintf(stdout, "cleared %d notification(s)\n", removed)
-		return err
-	case "x":
-		if err := store.Ack(id); err != nil {
-			return fmt.Errorf("ack notification: %w", err)
+		entries = filterEntries(entries, severities, sources)
+		if limit > 0 && len(entries) > limit {
+			entries = entries[:limit]
 		}
-		_, err = fmt.Fprintf(stdout, "ack %s\n", id)
-		return err
-	default:
-		entry, ok := findNotificationByID(entries, id)
-		if !ok {
-			return fmt.Errorf("focus notification: %w: %s", notify.ErrNotFound, id)
-		}
-		if err := c.focusNotification(entry, "notify-sidebar", "row-select", clientTTY); err != nil {
-			if isFocusTargetUnresolved(err) {
-				if ackErr := store.Ack(id); ackErr != nil {
-					return fmt.Errorf("ack target-gone notification: %w", ackErr)
-				}
-				return nil
+		bindings := []string{"alt-2:abort"}
+		if len(entries) == 0 {
+			nextIndex = -1
+		} else if nextIndex >= 0 {
+			if nextIndex >= len(entries) {
+				nextIndex = len(entries) - 1
 			}
+			bindings = append(bindings, fmt.Sprintf("start:pos(%d)", nextIndex+1))
+		}
+
+		now := c.clock()
+		liveByID := c.notifyLiveByIDBestEffort()
+		compatOptions := intpickercompat.Options{
+			UI:            "notify-sidebar",
+			Read0:         true,
+			Title:         "\x1b[1;38;5;220m" + notifyHeaderDecorator(c.statusbarDecoration()) + "Pending Notifications\x1b[0m",
+			Prompt:        "Notify > ",
+			Header:        "Newest first",
+			Footer:        "Enter: focus + ack  |  x: ack  |  Ctrl-X: clear all  |  Esc/Alt-2: close",
+			ExpectKeys:    []string{"x", "ctrl-x"},
+			Bindings:      bindings,
+			Entries:       notifySidebarEntriesWithLive(entries, now, liveByID),
+			DisableSearch: true,
+		}
+		result, err := runPickerOptionBackend(c.lookupEnv, c.native, c.picker, compatOptions)
+		if err != nil {
+			return fmt.Errorf("run notify sidebar: %w", err)
+		}
+		id := strings.TrimSpace(result.Value)
+		if id == "" || id == notifySidebarEmptyValue {
+			return nil
+		}
+
+		switch result.Key {
+		case "ctrl-x":
+			removed, err := store.AckAll()
+			if err != nil {
+				return fmt.Errorf("clear all notifications: %w", err)
+			}
+			_, err = fmt.Fprintf(stdout, "cleared %d notification(s)\n", removed)
 			return err
+		case "x":
+			nextIndex = indexNotificationByID(entries, id)
+			if err := store.Ack(id); err != nil {
+				return fmt.Errorf("ack notification: %w", err)
+			}
+			continue
+		default:
+			entry, ok := findNotificationByID(entries, id)
+			if !ok {
+				return fmt.Errorf("focus notification: %w: %s", notify.ErrNotFound, id)
+			}
+			if err := c.focusNotification(entry, "notify-sidebar", "row-select", clientTTY); err != nil {
+				if isFocusTargetUnresolved(err) {
+					if ackErr := store.Ack(id); ackErr != nil {
+						return fmt.Errorf("ack target-gone notification: %w", ackErr)
+					}
+					return nil
+				}
+				return err
+			}
+			if err := ackFocusedNotification(store, entry, entries); err != nil {
+				return fmt.Errorf("ack focused notification: %w", err)
+			}
+			return nil
 		}
-		if err := ackFocusedNotification(store, entry, entries); err != nil {
-			return fmt.Errorf("ack focused notification: %w", err)
-		}
-		return nil
 	}
 }
 
@@ -537,6 +556,15 @@ func findNotificationByID(entries []notify.Notification, id string) (notify.Noti
 		}
 	}
 	return notify.Notification{}, false
+}
+
+func indexNotificationByID(entries []notify.Notification, id string) int {
+	for i, e := range entries {
+		if e.ID == id {
+			return i
+		}
+	}
+	return -1
 }
 
 func (c *notifyCommand) notifyOriginClient(explicit string) string {

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -22,6 +22,7 @@ type stubNotifyStore struct {
 
 	listEntries []notify.Notification
 	listErr     error
+	listCalls   int
 
 	ackedID  string
 	ackedIDs []string
@@ -41,6 +42,25 @@ func (p *stubNotifyPicker) Run(options intpickercompat.Options) (intpickercompat
 	return p.result, p.err
 }
 
+type recordingNotifyPicker struct {
+	options []intpickercompat.Options
+	results []intpickercompat.Result
+	err     error
+}
+
+func (p *recordingNotifyPicker) Run(options intpickercompat.Options) (intpickercompat.Result, error) {
+	p.options = append(p.options, options)
+	if p.err != nil {
+		return intpickercompat.Result{}, p.err
+	}
+	if len(p.results) == 0 {
+		return intpickercompat.Result{}, nil
+	}
+	result := p.results[0]
+	p.results = p.results[1:]
+	return result, nil
+}
+
 type notifyPickerFunc func(options intpickercompat.Options) (intpickercompat.Result, error)
 
 func (f notifyPickerFunc) Run(options intpickercompat.Options) (intpickercompat.Result, error) {
@@ -53,17 +73,30 @@ func (s *stubNotifyStore) Push(in notify.PushInput) (notify.Notification, notify
 }
 
 func (s *stubNotifyStore) List() ([]notify.Notification, error) {
+	s.listCalls++
 	return append([]notify.Notification(nil), s.listEntries...), s.listErr
 }
 
 func (s *stubNotifyStore) Ack(id string) error {
 	s.ackedID = id
 	s.ackedIDs = append(s.ackedIDs, id)
+	if s.ackErr == nil {
+		next := s.listEntries[:0]
+		for _, entry := range s.listEntries {
+			if entry.ID != id {
+				next = append(next, entry)
+			}
+		}
+		s.listEntries = next
+	}
 	return s.ackErr
 }
 
 func (s *stubNotifyStore) AckAll() (int, error) {
 	s.ackAllOK = true
+	if s.ackErr == nil {
+		s.listEntries = nil
+	}
 	return s.ackAll, s.ackErr
 }
 
@@ -560,9 +593,74 @@ func TestNotifyListSidebarAcksSelectedRow(t *testing.T) {
 	t.Parallel()
 
 	store := &stubNotifyStore{
+		listEntries: []notify.Notification{
+			{ID: "abc", Text: "deploy ok", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+			{ID: "def", Text: "reply ready", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+			{ID: "ghi", Text: "blocked", Severity: notify.SeverityWarn, Source: notify.SourceAI, Session: "main"},
+		},
+	}
+	picker := &recordingNotifyPicker{
+		results: []intpickercompat.Result{
+			{Key: "x", Value: "def"},
+			{},
+		},
+	}
+	runner := &focusFakeRunner{}
+	cmd := newCmd(store)
+	cmd.picker = picker
+	cmd.native = nativePickerFromCompatRunner(picker)
+	cmd.runner = runner
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if store.ackedID != "def" {
+		t.Fatalf("ackedID = %q, want def", store.ackedID)
+	}
+	if got, want := store.ackedIDs, []string{"def"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ackedIDs = %#v, want %#v", got, want)
+	}
+	if store.listCalls != 2 {
+		t.Fatalf("List calls = %d, want 2", store.listCalls)
+	}
+	if len(picker.options) != 2 {
+		t.Fatalf("picker runs = %d, want 2", len(picker.options))
+	}
+	first := picker.options[0].Entries
+	if len(first) != 3 || first[0].Value != "abc" || first[1].Value != "def" || first[2].Value != "ghi" {
+		t.Fatalf("first picker entries = %#v, want abc then def then ghi", first)
+	}
+	if got, want := picker.options[0].Bindings, []string{"alt-2:abort"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("first picker bindings = %#v, want %#v", got, want)
+	}
+	second := picker.options[1].Entries
+	if len(second) != 2 || second[0].Value != "abc" || second[1].Value != "ghi" {
+		t.Fatalf("second picker entries = %#v, want abc then ghi", second)
+	}
+	if got, want := picker.options[1].Bindings, []string{"alt-2:abort", "start:pos(2)"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("second picker bindings = %#v, want %#v", got, want)
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want no sidebar ack output", stdout.String())
+	}
+	if focusCalls := filterFocusCalls(runner.calls); len(focusCalls) != 0 {
+		t.Fatalf("focus calls = %#v, want none", focusCalls)
+	}
+}
+
+func TestNotifyListSidebarXAckLastRowRendersEmptyState(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{
 		listEntries: []notify.Notification{{ID: "abc", Text: "deploy ok", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"}},
 	}
-	picker := &stubNotifyPicker{result: intpickercompat.Result{Key: "x", Value: "abc"}}
+	picker := &recordingNotifyPicker{
+		results: []intpickercompat.Result{
+			{Key: "x", Value: "abc"},
+			{},
+		},
+	}
 	cmd := newCmd(store)
 	cmd.picker = picker
 	cmd.native = nativePickerFromCompatRunner(picker)
@@ -571,11 +669,115 @@ func TestNotifyListSidebarAcksSelectedRow(t *testing.T) {
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run error = %v", err)
 	}
-	if store.ackedID != "abc" {
-		t.Fatalf("ackedID = %q, want abc", store.ackedID)
+	if got, want := store.ackedIDs, []string{"abc"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ackedIDs = %#v, want %#v", got, want)
 	}
-	if !strings.Contains(stdout.String(), "ack abc") {
-		t.Fatalf("stdout = %q", stdout.String())
+	if len(picker.options) != 2 {
+		t.Fatalf("picker runs = %d, want 2", len(picker.options))
+	}
+	second := picker.options[1].Entries
+	if len(second) != 1 || second[0].Value != notifySidebarEmptyValue {
+		t.Fatalf("second picker entries = %#v, want empty state", second)
+	}
+	if second[0].Label != "No pending notifications" {
+		t.Fatalf("empty label = %q", second[0].Label)
+	}
+	if got, want := picker.options[1].Bindings, []string{"alt-2:abort"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("empty picker bindings = %#v, want %#v", got, want)
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want no sidebar ack output", stdout.String())
+	}
+}
+
+func TestNotifyListSidebarXAckLastRowStartsAtPreviousRow(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{
+		listEntries: []notify.Notification{
+			{ID: "abc", Text: "deploy ok", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+			{ID: "def", Text: "reply ready", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+		},
+	}
+	picker := &recordingNotifyPicker{
+		results: []intpickercompat.Result{
+			{Key: "x", Value: "def"},
+			{},
+		},
+	}
+	cmd := newCmd(store)
+	cmd.picker = picker
+	cmd.native = nativePickerFromCompatRunner(picker)
+
+	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if got, want := store.ackedIDs, []string{"def"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ackedIDs = %#v, want %#v", got, want)
+	}
+	if len(picker.options) != 2 {
+		t.Fatalf("picker runs = %d, want 2", len(picker.options))
+	}
+	second := picker.options[1].Entries
+	if len(second) != 1 || second[0].Value != "abc" {
+		t.Fatalf("second picker entries = %#v, want only abc", second)
+	}
+	if got, want := picker.options[1].Bindings, []string{"alt-2:abort", "start:pos(1)"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("second picker bindings = %#v, want %#v", got, want)
+	}
+}
+
+func TestNotifyListSidebarXAckRefreshesLiveStateEachLoop(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
+	store := &stubNotifyStore{
+		listEntries: []notify.Notification{
+			{ID: "ai:main:%2", Text: "codex: first", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main", Window: "@1", Pane: "%2", CreatedAt: now},
+			{ID: "ai:main:%3", Text: "codex: second", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main", Window: "@1", Pane: "%3", CreatedAt: now},
+		},
+	}
+	picker := &recordingNotifyPicker{
+		results: []intpickercompat.Result{
+			{Key: "x", Value: "ai:main:%2"},
+			{},
+		},
+	}
+	var liveCalls int
+	runner := &focusFakeRunner{respond: func(args []string) ([]byte, error) {
+		if containsArg(args, "list-panes") {
+			liveCalls++
+			if liveCalls == 1 {
+				return notifyLivePaneRows(
+					[]string{"main", "@1", "%2", "0", "codex", "reply", "waiting", "codex", "first", "/tmp/tmux/default"},
+					[]string{"main", "@1", "%3", "0", "codex", "reply", "waiting", "codex", "second", "/tmp/tmux/default"},
+				), nil
+			}
+			return []byte{}, nil
+		}
+		return nil, errors.New("unexpected runner call")
+	}}
+	cmd := newCmd(store)
+	cmd.now = func() time.Time { return now }
+	cmd.picker = picker
+	cmd.native = nativePickerFromCompatRunner(picker)
+	cmd.runner = runner
+
+	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if liveCalls != 2 {
+		t.Fatalf("live list calls = %d, want 2", liveCalls)
+	}
+	if len(picker.options) != 2 {
+		t.Fatalf("picker runs = %d, want 2", len(picker.options))
+	}
+	second := picker.options[1].Entries
+	if len(second) != 1 || second[0].Value != "ai:main:%3" {
+		t.Fatalf("second picker entries = %#v, want only ai:main:%%3", second)
+	}
+	if !strings.Contains(second[0].Label, "STALE") {
+		t.Fatalf("second label = %q, want refreshed stale state", second[0].Label)
 	}
 }
 


### PR DESCRIPTION
## Completed Phase

Phase 1 — Notify sidebar x ack 유지

## User-Facing Surface Changed

- `projmux notify list --ui=sidebar` now treats `x` as ack-and-stay-open for the selected row.
- After `x`, the sidebar re-lists from the notify store and refreshes the remaining rows in the same popup flow.
- Acking the last remaining row with `x` keeps the popup open on the empty state.
- Selection position is preserved where possible after a row is acked.
- `x` no longer emits `ack <id>` stdout in the sidebar path, so it does not pollute the interactive popup.

## Explicitly Excluded

- No change to `Enter` focus + ack behavior.
- No change to `Ctrl-X` clear-all then exit behavior.
- No notify queue schema or persistence format changes.
- No statusbar click consume policy changes.
- No OS toast behavior changes.

## Model Boundary

This PR does not redesign the notify queue data model or the focus consume policy. The change is limited to the notify sidebar interaction loop, tests, and docs.

## Verification

- `make fmt`
- `make fix`
- `make test`
- `go test ./internal/app -run 'TestNotifyListSidebar' -count=1`
- `make test-integration` (Docker-backed; sandbox run could not access `/var/run/docker.sock`, escalated rerun passed)
- `make test-install-smoke` (Docker-backed; sandbox run could not access `/var/run/docker.sock`, escalated rerun passed)
- `make test-e2e` (Docker-backed; sandbox run could not access `/var/run/docker.sock`, escalated rerun passed)

## Unverified / Follow-Up Scope

- No manual live tmux popup interaction was performed in a real terminal for pressing `x`, `Enter`, `Esc`/`Alt-2`, and `Ctrl-X`; the behavior is covered by unit tests and Docker-backed gates.
- Any broader consume-policy, statusbar click, toast, or queue-model redesign remains outside this phase.