### PR TITLE
fix(notify): route WSL toast clicks through hidden cmd

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,7 +279,7 @@ gated here.
 
 Click activation is wired only for `raise`. The `projmux://` URI handler is
 registered on the first `raise` Notify of each tmux server (gated by the
-`@projmux_uri_protocol_registered_v5` marker). The
+`@projmux_uri_protocol_registered_v6` marker). The
 mode only controls whether a toast fires at all and whether to follow it
 up with an on-push auto-raise.
 
@@ -323,9 +323,9 @@ wscript.exe //B //Nologo "%LOCALAPPDATA%\projmux\projmux-uri-handler.vbs" "%1"
 ```
 
 Registration writes the VBScript launcher under `%LOCALAPPDATA%\projmux`.
-The launcher receives `%1` as a WScript argument, quotes it as an argv value,
-and starts `wsl.exe` hidden through `WScript.Shell.Run`. Its argv semantics
-are equivalent to:
+The launcher receives `%1` as a WScript argument, caret-escapes command-line
+metacharacters such as `&`, and starts a hidden `%ComSpec% /d /s /c` command
+that invokes `wsl.exe`. Its argv semantics are equivalent to:
 
 ```text
 wsl.exe -d $WSL_DISTRO_NAME --exec <absolute-path-to-projmux> focus --uri <uri>
@@ -356,11 +356,11 @@ notify path so users do not configure anything:
    `wsl.exe -- <cmd>` routes its tail through the user's login shell, which
    parses `&` query-string separators as background-job operators (zsh emits
    `parse error near '&'`). `--exec` skips the shell and invokes the binary
-   directly. The `%1` URI is passed as a WScript argument and then quoted as
-   the `--uri` argv value, so `&` query separators are data instead of
-   PowerShell or shell syntax. The absolute WSL filesystem path to the binary
-   is captured at registration so PATH does not need to be populated under
-   `--exec`.
+   directly. The `%1` URI is passed as a WScript argument and then forwarded
+   through a hidden cmd.exe command line with `&` escaped as `^&`, so query
+   separators are data instead of PowerShell, cmd, or WSL login-shell syntax.
+   The absolute WSL filesystem path to the binary is captured at registration
+   so PATH does not need to be populated under `--exec`.
 
 The URI carries the originating pane id and tmux socket so the click
 round-trips back to the exact pane that fired the notification, which
@@ -372,13 +372,12 @@ Registration markers and the writes involved:
   `SOFTWARE\Classes\projmux\URL Protocol`, and
   `SOFTWARE\Classes\projmux\shell\open\command\(Default)`.
 - Launcher file: `%LOCALAPPDATA%\projmux\projmux-uri-handler.vbs`.
-- tmux user-option marker `@projmux_uri_protocol_registered_v5` records that
+- tmux user-option marker `@projmux_uri_protocol_registered_v6` records that
   registration has been attempted on this server so the script runs at most
-  once per server boot. (The v4 marker
-  `@projmux_uri_protocol_registered_v4` was bumped when the protocol command's
-  first process moved from console-subsystem PowerShell to GUI-subsystem
-  WScript; existing v4 users re-register transparently on the next Notify
-  after upgrade and the orphaned v4 key
+  once per server boot. (The v5 marker
+  `@projmux_uri_protocol_registered_v5` was bumped when the WScript launcher
+  added the hidden cmd.exe parser hop; existing v5 users re-register
+  transparently on the next Notify after upgrade and the orphaned v5 key
   requires no cleanup.)
 
 Limitations:

--- a/docs/notify-os-focus-poc.md
+++ b/docs/notify-os-focus-poc.md
@@ -330,15 +330,17 @@ machine is:
 4. **WSL handler command uses a GUI launcher and keeps `--exec`**. The
    registry protocol handler launches `wscript.exe //B //Nologo` with a
    VBScript launcher written under `%LOCALAPPDATA%\projmux`, so ShellExecute
-   does not start a console-subsystem first process. The launcher starts
-   `wsl.exe` hidden through `WScript.Shell.Run`. Inside that launcher,
-   `wsl.exe -- <cmd>` remains forbidden because it routes its tail through the
-   user's default login shell, which parses `&` query-string separators as
-   background-job operators (zsh emits `parse error near '&'`). `--exec` skips
-   the shell and invokes the binary directly. PATH is empty under `--exec`, so
-   the registry command uses the absolute WSL filesystem path captured at
-   registration time. The `%1` URI is passed as a WScript argument and then
-   forwarded as the `--uri` argv value, not shell-interpolated.
+   does not start a console-subsystem first process. The launcher starts a
+   hidden `%ComSpec% /d /s /c` command through `WScript.Shell.Run`; that cmd
+   command invokes `wsl.exe` after stripping caret escapes from URI query
+   separators. Inside that command, `wsl.exe -- <cmd>` remains forbidden
+   because it routes its tail through the user's default login shell, which
+   parses `&` query-string separators as background-job operators (zsh emits
+   `parse error near '&'`). `--exec` skips the shell and invokes the binary
+   directly. PATH is empty under `--exec`, so the registry command uses the
+   absolute WSL filesystem path captured at registration time. The `%1` URI is
+   passed as a WScript argument and then forwarded as the `--uri` argv value,
+   not shell-interpolated.
 
 #### Lessons (so future readers don't repeat them)
 
@@ -352,11 +354,10 @@ machine is:
 - Do not use `wsl.exe -- projmux ...` in the registry handler.
   Re-introducing the login-shell hop will surface as `parse error near
   '&'` from the user's shell at click time.
-- The `@projmux_uri_protocol_registered_v5` marker exists because v4 still
-  used console-subsystem PowerShell as the protocol command's first process,
-  which could flash before `-WindowStyle Hidden` took effect. Re-registration
-  is idempotent so upgrades from v4 transparently install the new handler —
-  the old marker key just
+- The `@projmux_uri_protocol_registered_v6` marker exists because v5 invoked
+  `wsl.exe` directly from WScript with quoted fixed arguments, which avoided
+  flash but broke the focus command. Re-registration is idempotent so upgrades
+  from v5 transparently install the new handler — the old marker key just
   goes orphaned.
 
 Multi-distro dispatch (one handler per distro, or a distro-selector

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -2014,16 +2014,19 @@ $toast = [Windows.UI.Notifications.ToastNotification]::new($tpl)
 //
 // The GUI-subsystem WScript launcher avoids the visible console flash caused
 // by Windows ShellExecute launching console-subsystem `wsl.exe` or
-// `powershell.exe` directly from the protocol handler. Inside the launcher,
-// `--exec` instead of `--` remains load-bearing: `wsl.exe -- <cmd> <args>`
-// routes `<cmd> <args>` through the user's default login shell (zsh/bash). The
-// `projmux://` URI carries `&` characters as query-parameter separators, and
-// zsh parses `&` as a background-job operator before projmux ever runs,
-// emitting `zsh:1: parse error near '&'`. `--exec` skips the shell and invokes
-// the binary directly with the args verbatim. Because `--exec` doesn't load
-// shell init files, PATH may be empty, so we register the absolute WSL
-// filesystem path to the projmux binary captured at registration time
-// (whichever binary actually wrote the registry key).
+// `powershell.exe` directly from the protocol handler. WScript.Shell.Run does
+// not pass quoted fixed arguments to wsl.exe the same way PowerShell does, so
+// the launcher uses hidden `%ComSpec% /d /s /c` as the command-line parser and
+// caret-escapes URI query separators before invoking wsl.exe. Inside that
+// command, `--exec` instead of `--` remains load-bearing: `wsl.exe -- <cmd>
+// <args>` routes `<cmd> <args>` through the user's default login shell
+// (zsh/bash). The `projmux://` URI carries `&` characters as query-parameter
+// separators, and zsh parses `&` as a background-job operator before projmux
+// ever runs, emitting `zsh:1: parse error near '&'`. `--exec` skips the shell
+// and invokes the binary directly with the args verbatim. Because `--exec`
+// doesn't load shell init files, PATH may be empty, so we register the
+// absolute WSL filesystem path to the projmux binary captured at registration
+// time (whichever binary actually wrote the registry key).
 //
 // The handler captures the user's *current* WSL_DISTRO_NAME because the
 // click is received on the Windows side with no knowledge of which distro
@@ -2068,13 +2071,6 @@ try {
 }
 
 func buildWSLURIProtocolLauncherVBScript(distro, binaryPath string) string {
-	argv := []string{"wsl.exe", "-d", distro, "--exec", binaryPath, "focus", "--uri"}
-	quoted := make([]string, 0, len(argv)+1)
-	for _, arg := range argv {
-		quoted = append(quoted, "QuoteArg("+vbsDoubleQuoted(arg)+")")
-	}
-	quoted = append(quoted, "QuoteArg(uri)")
-	commandExpr := strings.Join(quoted, ` & " " & `)
 	return `Option Explicit
 
 Dim uri
@@ -2083,34 +2079,21 @@ If WScript.Arguments.Count < 1 Then
 End If
 uri = WScript.Arguments.Item(0)
 
-Dim shell, command
-command = ` + commandExpr + `
+Dim shell, inner, command
+inner = "wsl.exe -d " & CmdEscape(` + vbsDoubleQuoted(distro) + `) & " --exec " & CmdEscape(` + vbsDoubleQuoted(binaryPath) + `) & " focus --uri " & CmdEscape(uri)
+command = "%ComSpec% /d /s /c " & Chr(34) & inner & Chr(34)
 Set shell = CreateObject("WScript.Shell")
 shell.Run command, 0, False
 
-Function QuoteArg(value)
-  Dim result, i, ch, backslashes
-  result = """"
-  backslashes = 0
-  For i = 1 To Len(value)
-    ch = Mid(value, i, 1)
-    If ch = "\" Then
-      backslashes = backslashes + 1
-    ElseIf ch = """" Then
-      result = result & String(backslashes * 2 + 1, "\") & """"
-      backslashes = 0
-    Else
-      If backslashes > 0 Then
-        result = result & String(backslashes, "\")
-        backslashes = 0
-      End If
-      result = result & ch
-    End If
-  Next
-  If backslashes > 0 Then
-    result = result & String(backslashes * 2, "\")
-  End If
-  QuoteArg = result & """"
+Function CmdEscape(value)
+  Dim s
+  s = value
+  s = Replace(s, "^", "^^")
+  s = Replace(s, "&", "^&")
+  s = Replace(s, "|", "^|")
+  s = Replace(s, "<", "^<")
+  s = Replace(s, ">", "^>")
+  CmdEscape = s
 End Function`
 }
 

--- a/internal/app/notification_appid.go
+++ b/internal/app/notification_appid.go
@@ -66,5 +66,10 @@ const (
 	// v5 — incremented after the first process in the protocol command moved
 	// from console-subsystem PowerShell to GUI-subsystem WScript because
 	// PowerShell itself could still flash before hiding its window.
-	uriProtocolRegisteredTmuxOption = "@projmux_uri_protocol_registered_v5"
+	//
+	// v6 — incremented after the WScript launcher added a hidden cmd.exe
+	// command-line parser hop. WScript.Shell.Run passed quoted wsl.exe
+	// arguments literally enough to break focus; cmd.exe strips the caret
+	// escapes around URI `&` separators before wsl.exe receives the argv.
+	uriProtocolRegisteredTmuxOption = "@projmux_uri_protocol_registered_v6"
 )

--- a/internal/app/notification_toast_launch_test.go
+++ b/internal/app/notification_toast_launch_test.go
@@ -89,7 +89,8 @@ func TestBuildRegisterURIProtocolPowerShell_UsesHiddenLauncherNotDirectWSLComman
 		`wscript.exe //B //Nologo "`,
 		`"%1"`,
 		`shell.Run command, 0, False`,
-		`QuoteArg("wsl.exe") & " " & QuoteArg("-d")`,
+		`%ComSpec% /d /s /c `,
+		`CmdEscape(uri)`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("script missing hidden launcher intent %q:\n%s", want, script)
@@ -118,14 +119,9 @@ func TestBuildWSLURIProtocolLauncherVBScript_BypassesShellWithExecAndAbsolutePat
 	// `&`-bearing toast click; do not let it come back.
 	script := buildWSLURIProtocolLauncherVBScript("Ubuntu-24.04", "/home/me/go/bin/projmux")
 	for _, want := range []string{
-		`QuoteArg("wsl.exe")`,
-		`QuoteArg("-d")`,
-		`QuoteArg("Ubuntu-24.04")`,
-		`QuoteArg("--exec")`,
-		`QuoteArg("/home/me/go/bin/projmux")`,
-		`QuoteArg("focus")`,
-		`QuoteArg("--uri")`,
-		`QuoteArg(uri)`,
+		`inner = "wsl.exe -d " & CmdEscape("Ubuntu-24.04") & " --exec " & CmdEscape("/home/me/go/bin/projmux") & " focus --uri " & CmdEscape(uri)`,
+		`command = "%ComSpec% /d /s /c " & Chr(34) & inner & Chr(34)`,
+		`shell.Run command, 0, False`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("expected launcher token %q in script:\n%s", want, script)
@@ -134,7 +130,7 @@ func TestBuildWSLURIProtocolLauncherVBScript_BypassesShellWithExecAndAbsolutePat
 	if strings.Contains(script, `-- projmux focus`) {
 		t.Fatalf("launcher must not use the legacy `-- projmux focus` form (shell-interpreted, breaks on `&`):\n%s", script)
 	}
-	if !strings.Contains(script, `QuoteArg("--exec")`) {
+	if !strings.Contains(script, ` --exec `) {
 		t.Fatalf("launcher must use `--exec` to bypass the login shell:\n%s", script)
 	}
 }
@@ -148,7 +144,8 @@ func TestBuildWSLURIProtocolLauncherVBScript_ForwardsURIAsArgument(t *testing.T)
 		`wscript.exe //B //Nologo "`,
 		`"%1"`,
 		`uri = WScript.Arguments.Item(0)`,
-		`QuoteArg("--uri") & " " & QuoteArg(uri)`,
+		`focus --uri " & CmdEscape(uri)`,
+		`s = Replace(s, "&", "^&")`,
 	} {
 		if !strings.Contains(registerScript+"\n"+launcherScript, want) {
 			t.Fatalf("handler command missing URI forwarding token %q:\n%s\n%s", want, registerScript, launcherScript)
@@ -172,7 +169,7 @@ func TestBuildWSLURIProtocolLauncherVBScript_EscapesDistro(t *testing.T) {
 	t.Parallel()
 
 	script := buildWSLURIProtocolLauncherVBScript(`weird"distro`, "/home/me/go/bin/projmux")
-	if !strings.Contains(script, `QuoteArg("weird""distro")`) {
+	if !strings.Contains(script, `CmdEscape("weird""distro")`) {
 		t.Fatalf("expected double-quote-escaped distro in launcher script; got:\n%s", script)
 	}
 }
@@ -181,7 +178,7 @@ func TestBuildWSLURIProtocolLauncherVBScript_EscapesBinaryPath(t *testing.T) {
 	t.Parallel()
 
 	script := buildWSLURIProtocolLauncherVBScript("Ubuntu-24.04", `/home/me/bin/proj"mux`)
-	if !strings.Contains(script, `QuoteArg("/home/me/bin/proj""mux")`) {
+	if !strings.Contains(script, `CmdEscape("/home/me/bin/proj""mux")`) {
 		t.Fatalf("expected double-quote-escaped binary path in launcher script; got:\n%s", script)
 	}
 }


### PR DESCRIPTION
## Completed scope
- Fixes the WScript protocol handler follow-up by routing the WSL Toast click through hidden `%ComSpec% /d /s /c`.
- Keeps the protocol handler's first process as GUI-subsystem `wscript.exe`, preserving the no-flash behavior verified in smoke.
- Keeps click-to-focus routed through `projmux focus --uri` for the existing `projmux://focus?...` URI shape.
- Bumps the tmux registration marker to `@projmux_uri_protocol_registered_v6` so machines with the v5 direct-WScript handler re-register on the next raise notification.

## Protocol handler command change
- Registry command remains:
  `wscript.exe //B //Nologo "<launcher.vbs>" "%1"`
- The VBScript launcher now builds:
  `%ComSpec% /d /s /c "wsl.exe -d <distro> --exec <absolute-path-to-projmux> focus --uri <escaped-uri>"`
- The URI is received as a WScript argument and caret-escapes cmd metacharacters (`^`, `&`, `|`, `<`, `>`) before the hidden cmd hop strips those escapes for `wsl.exe`.

## Preserved constraints
- `wsl.exe --exec` is preserved; this does not switch to `wsl.exe --`.
- Existing `projmux://focus?...` URI shape is preserved.
- Start Menu shortcut target remains `cmd.exe /c exit`.
- AppID, shortcut property bag, Toast XML, notify/raise semantics, multi-distro behavior, and `internal/integrations/osfocus` are not redesigned or expanded.

## Explicitly out of scope
- WSL multi-distro handler routing.
- Non-Windows Terminal adapters.
- Generic hook notification changes.
- Desktop notification delivery redesign.

## Verification
- `go test ./internal/app -run 'Toast|URI|Notification|AppID'`
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`

## Pre-merge manual smoke
- Built branch binary at `/tmp/projmux-cmdwrap-smoke/projmux`.
- Cleared the v6 tmux registration marker and registered/sent a Toast through the branch binary.
- User-verified result: no console flash, Toast click returned focus to target pane `%44` / `repos-projmux:0.3` after a short delay.
