### PR TITLE
docs(ai): add agent shortcut registration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ For update behavior by installer type, see [Upgrading](docs/upgrading.md).
 - [Install](docs/install.md)
 - [Configuration](docs/configuration.md)
 - [Terminal Keybindings](docs/keybindings.md)
+- [AI Agent Shortcuts](docs/ai-agent-shortcuts.md)
 - [CLI Reference](docs/cli.md)
 - [Statusbar](docs/statusbar.md)
 - [Hooks](docs/hooks.md)

--- a/docs/ai-agent-shortcuts.md
+++ b/docs/ai-agent-shortcuts.md
@@ -1,0 +1,238 @@
+# AI Agent Shortcut Registration
+
+`projmux ai split` is intentionally tool-general: user-level shortcuts,
+skills, slash commands, terminal actions, and editor commands can all map to
+the same split contract.
+
+```sh
+projmux ai split --agent <agent> <right|down>
+projmux ai split --agent <agent> <right|down> -- <extra args...>
+```
+
+Use this page for shareable registration patterns. Keep machine-local policy,
+private prompt text, and personal workflow recipes in your own dotfiles or
+local tool configuration, not in tracked repo docs.
+
+## Command Contract
+
+Choose a direct agent when a shortcut should always open that agent:
+
+```sh
+projmux ai split --agent codex right
+projmux ai split --agent claude down
+```
+
+Add the separator only when you have extra arguments for the selected agent:
+
+```sh
+projmux ai split --agent codex right -- --model <model>
+projmux ai split --agent claude down -- <agent flags>
+```
+
+The `--` separates projmux arguments from agent arguments. Everything after
+that separator is passed to the resolved selected agent executable. It is not
+an executable override. In the examples above, projmux still chooses the
+configured `codex` or `claude` executable, creates the tmux split, sets pane
+metadata, applies the title watcher, and appends the tail arguments to the
+agent command.
+
+Model, permission, and other agent flags are examples to customize privately in
+your user-level config. Avoid treating placeholder flags in this guide as
+project defaults or current recommendations. If there are no private extra
+arguments, omit the separator entirely; do not leave a trailing bare `--`.
+
+`shell` and `selective` are not targets for extra agent arguments. Use them
+without a tail:
+
+```sh
+projmux ai split --agent shell right
+projmux ai split --agent selective down
+```
+
+`shell` opens a plain shell split. `selective` opens the existing picker, where
+the user chooses the launch mode interactively.
+
+## Naming Pattern
+
+Pick names that encode the target agent and split direction, then keep the
+body as a small command wrapper.
+
+For Codex-style skill surfaces, names can follow:
+
+```text
+$projmux-<agent>-right
+$projmux-<agent>-down
+```
+
+Concrete examples:
+
+```text
+$projmux-codex-right
+$projmux-claude-down
+```
+
+For Claude-style slash-command surfaces, names can follow:
+
+```text
+/projmux:<agent>-right
+/projmux:<agent>-down
+```
+
+Concrete examples:
+
+```text
+/projmux:codex-right
+/projmux:claude-down
+```
+
+The same pattern also works for editor commands, launcher actions, shell
+aliases, or terminal custom actions. The important part is that the registered
+surface calls `projmux ai split --agent <agent> <direction>` and passes only
+agent flags after `--`.
+
+## Skill Template
+
+Use this shape when a tool lets you define a user-level skill that tells an
+agent to run a shell command. Actual loader paths vary by installation; the
+intended home is user-level config or dotfiles, not this repository.
+
+Example Codex-style skill file:
+
+```text
+~/.codex/skills/projmux-codex-right/SKILL.md
+```
+
+````markdown
+---
+name: projmux-codex-right
+description: Open a projmux-managed Codex split to the right.
+---
+
+Run this command:
+
+```sh
+projmux ai split --agent codex right
+```
+
+If you have private Codex flags, use the explicit extra-args form instead:
+
+```sh
+projmux ai split --agent codex right -- --model <model>
+```
+````
+
+Non-Codex target example:
+
+```text
+~/.codex/skills/projmux-claude-down/SKILL.md
+```
+
+````markdown
+---
+name: projmux-claude-down
+description: Open a projmux-managed Claude split below.
+---
+
+Run this command:
+
+```sh
+projmux ai split --agent claude down
+```
+
+If you have private Claude flags, use the explicit extra-args form instead:
+
+```sh
+projmux ai split --agent claude down -- <agent flags>
+```
+````
+
+If your tool stores skills as JSON, TOML, or another format, keep the same
+fields conceptually:
+
+- Name: the user-facing shortcut, such as `$projmux-codex-right`.
+- Description: one sentence saying which agent and direction it opens.
+- Command: the `projmux ai split` invocation.
+- Arguments: optional agent arguments placed after `--`.
+
+## Slash Command Template
+
+Use this shape when a tool lets you define user-level slash commands. Actual
+loader paths and interpolation variables can vary by installation; user-level
+config or dotfiles is the intended home.
+
+```text
+~/.claude/commands/projmux/codex-right.md
+```
+
+This maps to a slash command named `/projmux:codex-right`:
+
+````markdown
+Open a Codex split to the right in the current projmux session.
+
+Run this command:
+
+```sh
+projmux ai split --agent codex right
+```
+````
+
+For an argument-aware wrapper, include the separator only when arguments are
+non-empty. Adapt this shell shape to the tool's command-file format:
+
+```sh
+if [ -n "$ARGUMENTS" ]; then
+  projmux ai split --agent codex right -- $ARGUMENTS
+else
+  projmux ai split --agent codex right
+fi
+```
+
+Then invoke it with private agent flags only when needed, such as
+`/projmux:codex-right --model <model>`.
+
+For a Claude target, use a sibling file such as:
+
+```text
+~/.claude/commands/projmux/claude-down.md
+```
+
+This maps to `/projmux:claude-down`:
+
+````markdown
+Open a Claude split below in the current projmux session.
+
+Run this command:
+
+```sh
+projmux ai split --agent claude down
+```
+````
+
+For an argument-aware wrapper, use the same non-empty check:
+
+```sh
+if [ -n "$ARGUMENTS" ]; then
+  projmux ai split --agent claude down -- $ARGUMENTS
+else
+  projmux ai split --agent claude down
+fi
+```
+
+Then pass private Claude flags at invocation time only when needed, such as
+`/projmux:claude-down <agent flags>`.
+
+If the tool separates command metadata from the shell body, put only the
+`projmux ai split ...` line in the executable body. Avoid embedding
+machine-specific project roots, permission policies, or personal model choices
+in shared docs; put those in your private user-level command files.
+
+## Checklist
+
+- Register shortcuts at user level in the AI tool, editor, launcher, or
+  terminal that owns the surface.
+- Use `--agent codex` or `--agent claude` when passing extra agent arguments.
+- Put agent flags after the separator, for example `-- --model <model>`.
+- Omit the separator entirely when there are no extra agent arguments.
+- Use `--agent shell` with no tail for a plain shell split.
+- Use `--agent selective` with no tail for the picker.
+- Keep tracked project docs and `AGENTS.md` free of private shortcut policy.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -348,6 +348,8 @@ existing picker flow; `--agent shell` opens the existing plain shell split.
 Arguments after `--` are extra arguments appended to the resolved `claude` or
 `codex` executable inside the managed wrapper; projmux still sets the context
 directory, tmux title, AI pane metadata, title watcher, and split layout.
+For user-level skill, slash-command, editor, or launcher registrations that
+call this contract, see [AI Agent Shortcuts](ai-agent-shortcuts.md).
 
 `ingest codex-hook` is the hook-facing entrypoint for Codex hooks-engine JSON.
 It reads one JSON payload from stdin and handles the default Codex hook catalog

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -83,7 +83,9 @@ does not stretch lopsided.
 The AI split bindings use the configured default mode. For one-shot launches,
 run `projmux ai split --agent claude|codex|shell|selective right|down`. Extra
 args after `--` are appended to the resolved `claude` or `codex` executable for
-a managed pane.
+a managed pane. To register user-level skills, slash commands, editor actions,
+or launcher shortcuts that call those one-shot launches, see
+[AI Agent Shortcuts](ai-agent-shortcuts.md).
 
 ### Inside the pickers
 


### PR DESCRIPTION
## Summary
- Add a tool-general guide for registering user-level projmux AI split shortcuts.
- Document Codex-style skill naming and Claude-style slash command naming without adding repo aliases or CLI behavior.
- Show safe no-arg and extra-arg forms for `projmux ai split --agent <agent> <direction>`.

## Test plan
- [x] make fmt
- [x] make fix
- [x] git diff --check
- [x] rg -n -- '-- (codex|claude)( |$)' README.md docs

Docs-only change; no `make install` run before merge.