### PR TITLE
fix(notify): clean old URI protocol markers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -377,8 +377,9 @@ Registration markers and the writes involved:
   once per server boot. (The v5 marker
   `@projmux_uri_protocol_registered_v5` was bumped when the WScript launcher
   added the hidden cmd.exe parser hop; existing v5 users re-register
-  transparently on the next Notify after upgrade and the orphaned v5 key
-  requires no cleanup.)
+  transparently on the next Notify after upgrade. After successful v6
+  registration, projmux removes legacy URI marker keys from v1 through v5 so
+  tmux state reflects only the active handler generation.)
 
 Limitations:
 

--- a/docs/notify-os-focus-poc.md
+++ b/docs/notify-os-focus-poc.md
@@ -357,8 +357,9 @@ machine is:
 - The `@projmux_uri_protocol_registered_v6` marker exists because v5 invoked
   `wsl.exe` directly from WScript with quoted fixed arguments, which avoided
   flash but broke the focus command. Re-registration is idempotent so upgrades
-  from v5 transparently install the new handler — the old marker key just
-  goes orphaned.
+  from v5 transparently install the new handler. Once v6 registration
+  succeeds, projmux removes the legacy URI marker keys from v1 through v5 so
+  old handler generations do not linger in tmux state.
 
 Multi-distro dispatch (one handler per distro, or a distro-selector
 arg) is a known tier-2 follow-up — current registration captures the

--- a/internal/app/notification.go
+++ b/internal/app/notification.go
@@ -271,6 +271,9 @@ func (c *aiCommand) ensureWSLURIProtocol() {
 	if err := c.run(powerShell, "-NoProfile", "-NonInteractive", "-EncodedCommand", encodeUTF16LEBase64(script)); err != nil {
 		return
 	}
+	for _, option := range legacyURIProtocolRegisteredTmuxOptions {
+		_ = c.run("tmux", "set-option", "-g", "-u", option)
+	}
 	_ = c.run("tmux", "set-option", "-g", uriProtocolRegisteredTmuxOption, "1")
 }
 

--- a/internal/app/notification_appid.go
+++ b/internal/app/notification_appid.go
@@ -50,13 +50,11 @@ const (
 	// v2 — incremented after the hot-fix that switched the registry command
 	// from `wsl.exe -- projmux ...` (broke on `&` due to shell
 	// interpretation) to `wsl.exe --exec <abs-path> ...`. Existing v1 marker
-	// users get a fresh registration on their next Notify dispatch; the v1
-	// key (`@projmux_uri_protocol_registered`) is left orphaned —
-	// re-registration is idempotent so no cleanup is needed.
+	// users get a fresh registration on their next Notify dispatch.
 	//
 	// v3 — incremented after the handler moved from direct `wsl.exe` launch to
 	// a hidden PowerShell wrapper to avoid the visible Windows console flash on
-	// Toast click. Existing v2 markers are left orphaned for the same reason.
+	// Toast click.
 	//
 	// v4 — incremented after the hidden wrapper stopped passing `%1` after
 	// `-Command`, which PowerShell parsed as command text and broke URI query
@@ -73,3 +71,11 @@ const (
 	// escapes around URI `&` separators before wsl.exe receives the argv.
 	uriProtocolRegisteredTmuxOption = "@projmux_uri_protocol_registered_v6"
 )
+
+var legacyURIProtocolRegisteredTmuxOptions = []string{
+	"@projmux_uri_protocol_registered",
+	"@projmux_uri_protocol_registered_v2",
+	"@projmux_uri_protocol_registered_v3",
+	"@projmux_uri_protocol_registered_v4",
+	"@projmux_uri_protocol_registered_v5",
+}

--- a/internal/app/notification_raise_test.go
+++ b/internal/app/notification_raise_test.go
@@ -127,6 +127,11 @@ func TestNotifyMode_RaiseWSLToastKeepsClickTarget(t *testing.T) {
 	if !containsAICommandArgs(cmdRecorder(cmd).commands, "tmux", []string{"set-option", "-g", uriProtocolRegisteredTmuxOption, "1"}) {
 		t.Fatalf("commands = %#v, want uri protocol marker write in raise mode", cmdRecorder(cmd).commands)
 	}
+	for _, option := range legacyURIProtocolRegisteredTmuxOptions {
+		if !containsAICommandArgs(cmdRecorder(cmd).commands, "tmux", []string{"set-option", "-g", "-u", option}) {
+			t.Fatalf("commands = %#v, want legacy uri protocol marker cleanup for %s", cmdRecorder(cmd).commands, option)
+		}
+	}
 	if got := chain.snapshot(); len(got) != 1 {
 		t.Fatalf("osfocus chain calls = %#v, want one raise call", got)
 	}


### PR DESCRIPTION
## Completed scope
- Cleans legacy `@projmux_uri_protocol_registered*` tmux markers after successful v6 URI protocol registration.
- Leaves retry semantics unchanged: cleanup and the v6 marker write happen only after the Windows registration PowerShell command succeeds.
- Updates docs to state that v1-v5 markers are removed after v6 registration.

## Behavior
- On successful registration, projmux runs:
  - `tmux set-option -g -u @projmux_uri_protocol_registered`
  - `tmux set-option -g -u @projmux_uri_protocol_registered_v2`
  - `tmux set-option -g -u @projmux_uri_protocol_registered_v3`
  - `tmux set-option -g -u @projmux_uri_protocol_registered_v4`
  - `tmux set-option -g -u @projmux_uri_protocol_registered_v5`
  - `tmux set-option -g @projmux_uri_protocol_registered_v6 1`

## Preserved constraints
- No change to the registered `projmux://` URI shape.
- No change to `wsl.exe --exec`.
- No change to Start Menu shortcut target, Toast XML, notify/raise semantics, multi-distro behavior, or `internal/integrations/osfocus`.

## Verification
- `go test ./internal/app -run 'Toast|URI|Notification|AppID|NotifyMode_Raise'`
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`

## Manual smoke
- Not repeated for this marker-only cleanup PR. The preceding v6 handler was already manually smoke-tested for no flash and click-focus return.
