### PR TITLE
fix: clean up notify sidebar keymap

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -49,10 +49,10 @@
 - Current focused unit coverage also includes strict notify SOT behavior
   (TTL does not remove rows, focus success and target-gone clicks ack,
   reconcile reports stale rows), `notify list --live` queue/live explanations, notify sidebar
-  two-line card rendering with age/project/window/pane metadata plus focus/ack/clear-all
-  actions, including in-place `x` ack that refreshes the sidebar without
-  focusing, preserves selection position where possible, and renders the empty
-  state after the last row is acked, and `focus` dispatch diagnostics for session fallback, unresolved
+  two-line card rendering with age/project/window/pane metadata plus focus/ack/non-critical-clear/clear-all
+  actions, including in-place `a` ack that refreshes the sidebar without
+  focusing, non-critical `x` bulk clear that preserves critical rows, and empty
+  state rendering after all visible non-critical rows are cleared, and `focus` dispatch diagnostics for session fallback, unresolved
   targets, window fallback, pane fallback, explicit id failures as unresolved exits, and
   notify-only fallback.
 - Picker focused unit coverage includes backend-neutral picker item/action mapping, native title-focused filtering, numeric selection, shared close actions including raw and CSI-u Ctrl-X native custom actions, deprecated picker backend value normalization, AI picker title chrome and stable search-key ordering, Settings title chrome and root section order, Settings Labs shell without backend choices plus keybinding diagnostic list/detail/probe outcome/init delegation coverage, environment override normalization, compact multi-line metadata gutters with one-column-indented metadata, proportional native scrollbar thumb rendering, multiline partial next/previous item row rendering with rendered-row scrollbar units, fixed split-preview and sidebar list viewports with scrollbar tracks, native up/down-family navigation wrap with empty-list safety and PageUp/PageDown/Home/End clamp regression coverage, native mouse down/follow-drag/release behavior, preview tab/control normalization before width clipping, optional native frame titlebars without same-line rule fill and with titlebar border reset guards, titled native Alt-1 sidebar chrome, statusbar-preserving sidebar popup height, native-only compact project sidebar popup sizing, and notify sidebar title/popup sizing.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -211,9 +211,9 @@ projmux notify reconcile [--json]
   reply badges that do not queue because no AI agent is attached, live AI
   reply panes missing a queue entry, matched AI reply entries, and stale
   queue entries whose live pane no longer matches. `--ui=sidebar` opens the
-  compact interactive notify list where Enter focuses and acks a target, `x`
-  acks the selected row, and `Ctrl-X` clears all; opening or navigating the
-  sidebar does not ack. The sidebar uses two-line cards with notification text
+  compact interactive notify list where Enter focuses and acks a target, `a`
+  acks the selected row, `x` clears non-critical rows, and `Ctrl-X` clears all;
+  opening or navigating the sidebar does not ack. The sidebar uses two-line cards with notification text
   first and compact age/project/window/pane metadata below. Hidden queue ids
   remain action values, but the sidebar has no search input. `--client` is
   used by tmux popup launchers to keep row-select focus on the clicked client.

--- a/docs/native-picker-no-fzf-poc.md
+++ b/docs/native-picker-no-fzf-poc.md
@@ -29,7 +29,7 @@ The fzf compatibility surface for the native engine is tracked in
 - The native picker supports ranked fuzzy search/filter, arrow-key selection in
   normal CSI and tmux application-cursor modes, Enter, Esc, Ctrl-C, Backspace,
   Ctrl-U, Ctrl-W, PageUp/PageDown, Home/End, modified CSI keys, custom expect
-  keys such as Ctrl-X/Alt-P, printable expect keys such as notify `x`, control
+  keys such as Ctrl-X/Alt-P, printable expect keys such as notify `a`/`x`, control
   expect keys such as notify `Ctrl-X`, `start:pos(N)` initial focus, preview
   command output, preview cycle command bindings, and sidebar focus command
   bindings.

--- a/docs/native-picker-parity.md
+++ b/docs/native-picker-parity.md
@@ -27,7 +27,7 @@ native picker engine and is not a public dependency-policy change.
 | selected multi-line marker | selected switch/session/notify cards | Covered for app multiline rows | native uses the same compact pointer-width red `▌` gutter as the first selected project line, and metadata lines align to the project-name column without the old deeper indent; `nativeContinuation`; `TestNativeInteractiveRendersSelectedMultilineContinuationMarker`; `TestInteractiveRowLinesUsesCompactSelectedMetaIndent`; `TestInteractiveRowLinesAlignsUnselectedMetaWithProjectName` |
 | fzf current row colors | simple and multi-line rows | Covered for app rows | `nativeCurrentStart`, `nativePointer`; pointer/continuation gutter tokens carry the current-row background; `TestNativeSelectedContentKeepsCurrentStyleAfterReset`; `TestNativeInteractiveUsesCurrentStyleForSimpleSelection` |
 | `--expect` keys | Enter/Ctrl-X/Alt-P/notify keys | Covered | `pickercompat.PickerOptions`; `TestNativeInteractiveSupportsCustomExpectKeys` |
-| printable expect keys | notify sidebar `x` ack | Covered | `TestNativeInteractiveSupportsPrintableExpectKeys`; Docker no-fzf e2e |
+| printable expect keys | notify sidebar `a` ack and `x` non-critical clear | Covered | `TestNativeInteractiveSupportsPrintableExpectKeys`; Docker no-fzf e2e |
 | control expect keys | notify sidebar `Ctrl-X`, settings `Ctrl-Alt-S` close | Covered | `TestNativeInteractiveSupportsControlExpectKeys`; `TestNativeInteractiveSupportsControlAltCloseKeys` |
 | close `--bind key:abort` | Esc, Ctrl-C, Alt-N, Ctrl-Alt-S variants | Covered | `CloseActions`; `TestNativeRunnerUsesSharedCloseActions` |
 | terminal CSI-u key encoding | app keybind probe sequences, Ghostty/kitty-style modified keys | Covered | native handles app-specific Alt keys, generic modified letters/digits, and non-text keys such as Enter/Esc/Backspace/Tab; `TestNativeInteractiveSupportsCSIuAppKeyBindings` |
@@ -108,7 +108,7 @@ contract; native popups still rely on the existing borderless tmux popup path.
   preview cursor, selects `bravo-web`, and asserts tmux reports the selected
   session's active target on the expected window with the expected pane path.
 - `notify sidebar`: native routing is unit-covered; Docker no-fzf e2e pushes a
-  notification, presses printable expect key `x`, and verifies the row is acked.
+  notification, presses printable expect key `a`, and verifies the row is acked.
 
 ## Experimental Boundaries
 

--- a/docs/notify-queue.md
+++ b/docs/notify-queue.md
@@ -94,11 +94,14 @@ preserves the stable JSON array used by scripts.
 
 `--ui=sidebar` opens the notify queue as an interactive right-side list when
 run inside the tmux popup surface. Enter focuses the selected target pane and
-acks the row after focus succeeds. `x` acks the selected row in place, keeps
+acks the row after focus succeeds. `a` acks the selected row in place, keeps
 the sidebar open, and refreshes the list from the queue while preserving the
 selection position where possible; acking the last remaining row renders the
-empty state until the popup is closed. `Ctrl-X` clears all rows via `notify ack
---all` and exits. Rows are intentionally compact: the visible label keeps
+empty state until the popup is closed. `x` bulk-clears non-critical rows
+(`severity != critical`) without focusing and preserves critical rows.
+`Ctrl-X` clears all rows via `notify ack --all` and exits. Footer: `Enter:
+focus + ack  |  a: ack  |  x: clear non-critical  |  Ctrl-X: clear all  |
+Esc/Alt-2: close`. Rows are intentionally compact: the visible label keeps
 notification text first, then age, project, window, and pane metadata; hidden
 queue ids remain action values but the sidebar has no search input and
 intentionally does not expose a separate metadata detail view.

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -104,8 +104,9 @@ The notification HUD detail surface (`Alt-2` / `User2`) opens the right-side
 notification popup with newest-first rows and an amber title. When notification
 icon decoration is `symbol` or `emoji`, the bell appears before the title text.
 Selecting a row still focuses and acknowledges that notification. Pressing `x`
-on a row acknowledges it without focusing, keeps the popup open, and refreshes
-the remaining rows from the queue while preserving the selection position where
+bulk-clears non-critical rows without focusing, keeps the popup open, and
+refreshes the remaining rows from the queue. Pressing `a` acknowledges the
+selected row without focusing and preserves the selection position where
 possible.
 
 Empty `#{mouse_status_range}` (a click on whitespace) falls through to

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -318,8 +318,8 @@ func (c *notifyCommand) runSidebar(store notifyStore, severities, sources []stri
 			Title:         "\x1b[1;38;5;220m" + notifyHeaderDecorator(c.statusbarDecoration()) + "Pending Notifications\x1b[0m",
 			Prompt:        "Notify > ",
 			Header:        "Newest first",
-			Footer:        "Enter: focus + ack  |  x: ack  |  Ctrl-X: clear all  |  Esc/Alt-2: close",
-			ExpectKeys:    []string{"x", "ctrl-x"},
+			Footer:        "Enter: focus + ack  |  a: ack  |  x: clear non-critical  |  Ctrl-X: clear all  |  Esc/Alt-2: close",
+			ExpectKeys:    []string{"a", "x", "ctrl-x"},
 			Bindings:      bindings,
 			Entries:       notifySidebarEntriesWithLive(entries, now, liveByID),
 			DisableSearch: true,
@@ -341,10 +341,16 @@ func (c *notifyCommand) runSidebar(store notifyStore, severities, sources []stri
 			}
 			_, err = fmt.Fprintf(stdout, "cleared %d notification(s)\n", removed)
 			return err
-		case "x":
+		case "a":
 			nextIndex = indexNotificationByID(entries, id)
 			if err := store.Ack(id); err != nil {
 				return fmt.Errorf("ack notification: %w", err)
+			}
+			continue
+		case "x":
+			nextIndex = indexNotificationByID(entries, id)
+			if err := ackNonCriticalNotifications(store, entries); err != nil {
+				return err
 			}
 			continue
 		default:
@@ -367,6 +373,18 @@ func (c *notifyCommand) runSidebar(store notifyStore, severities, sources []stri
 			return nil
 		}
 	}
+}
+
+func ackNonCriticalNotifications(store notifyStore, entries []notify.Notification) error {
+	for _, entry := range entries {
+		if entry.Severity == notify.SeverityCritical {
+			continue
+		}
+		if err := store.Ack(entry.ID); err != nil {
+			return fmt.Errorf("clear non-critical notification: %w", err)
+		}
+	}
+	return nil
 }
 
 const notifySidebarEmptyValue = "__projmux_notify_empty__"

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -323,10 +323,10 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if got, want := picker.options.Header, "Newest first"; got != want {
 		t.Fatalf("picker header = %q, want %q", got, want)
 	}
-	if got, want := picker.options.Footer, "Enter: focus + ack  |  x: ack  |  Ctrl-X: clear all  |  Esc/Alt-2: close"; got != want {
+	if got, want := picker.options.Footer, "Enter: focus + ack  |  a: ack  |  x: clear non-critical  |  Ctrl-X: clear all  |  Esc/Alt-2: close"; got != want {
 		t.Fatalf("picker footer = %q, want %q", got, want)
 	}
-	if got, want := picker.options.ExpectKeys, []string{"x", "ctrl-x"}; !reflect.DeepEqual(got, want) {
+	if got, want := picker.options.ExpectKeys, []string{"a", "x", "ctrl-x"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("expect keys = %#v, want %#v", got, want)
 	}
 	if len(picker.options.Entries) != 1 || picker.options.Entries[0].Value != "abc" {
@@ -589,7 +589,7 @@ func TestNotifyListSidebarTargetGoneAcksSelectedRow(t *testing.T) {
 	}
 }
 
-func TestNotifyListSidebarAcksSelectedRow(t *testing.T) {
+func TestNotifyListSidebarAAcksSelectedRowAndRefreshes(t *testing.T) {
 	t.Parallel()
 
 	store := &stubNotifyStore{
@@ -601,7 +601,8 @@ func TestNotifyListSidebarAcksSelectedRow(t *testing.T) {
 	}
 	picker := &recordingNotifyPicker{
 		results: []intpickercompat.Result{
-			{Key: "x", Value: "def"},
+			{Key: "a", Value: "def"},
+			{Key: "a", Value: "abc"},
 			{},
 		},
 	}
@@ -615,17 +616,17 @@ func TestNotifyListSidebarAcksSelectedRow(t *testing.T) {
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run error = %v", err)
 	}
-	if store.ackedID != "def" {
-		t.Fatalf("ackedID = %q, want def", store.ackedID)
+	if store.ackedID != "abc" {
+		t.Fatalf("ackedID = %q, want abc", store.ackedID)
 	}
-	if got, want := store.ackedIDs, []string{"def"}; !reflect.DeepEqual(got, want) {
+	if got, want := store.ackedIDs, []string{"def", "abc"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("ackedIDs = %#v, want %#v", got, want)
 	}
-	if store.listCalls != 2 {
-		t.Fatalf("List calls = %d, want 2", store.listCalls)
+	if store.listCalls != 3 {
+		t.Fatalf("List calls = %d, want 3", store.listCalls)
 	}
-	if len(picker.options) != 2 {
-		t.Fatalf("picker runs = %d, want 2", len(picker.options))
+	if len(picker.options) != 3 {
+		t.Fatalf("picker runs = %d, want 3", len(picker.options))
 	}
 	first := picker.options[0].Entries
 	if len(first) != 3 || first[0].Value != "abc" || first[1].Value != "def" || first[2].Value != "ghi" {
@@ -641,6 +642,13 @@ func TestNotifyListSidebarAcksSelectedRow(t *testing.T) {
 	if got, want := picker.options[1].Bindings, []string{"alt-2:abort", "start:pos(2)"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("second picker bindings = %#v, want %#v", got, want)
 	}
+	third := picker.options[2].Entries
+	if len(third) != 1 || third[0].Value != "ghi" {
+		t.Fatalf("third picker entries = %#v, want ghi", third)
+	}
+	if got, want := picker.options[2].Bindings, []string{"alt-2:abort", "start:pos(1)"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("third picker bindings = %#v, want %#v", got, want)
+	}
 	if stdout.String() != "" {
 		t.Fatalf("stdout = %q, want no sidebar ack output", stdout.String())
 	}
@@ -649,11 +657,63 @@ func TestNotifyListSidebarAcksSelectedRow(t *testing.T) {
 	}
 }
 
-func TestNotifyListSidebarXAckLastRowRendersEmptyState(t *testing.T) {
+func TestNotifyListSidebarXClearsNonCriticalAndPreservesCritical(t *testing.T) {
 	t.Parallel()
 
 	store := &stubNotifyStore{
-		listEntries: []notify.Notification{{ID: "abc", Text: "deploy ok", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"}},
+		listEntries: []notify.Notification{
+			{ID: "abc", Text: "deploy ok", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+			{ID: "def", Text: "blocked", Severity: notify.SeverityCritical, Source: notify.SourceAI, Session: "main"},
+			{ID: "ghi", Text: "warn", Severity: notify.SeverityWarn, Source: notify.SourceAI, Session: "main"},
+		},
+	}
+	picker := &recordingNotifyPicker{
+		results: []intpickercompat.Result{
+			{Key: "x", Value: "def"},
+			{},
+		},
+	}
+	cmd := newCmd(store)
+	cmd.picker = picker
+	cmd.native = nativePickerFromCompatRunner(picker)
+	cmd.runner = &focusFakeRunner{}
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if got, want := store.ackedIDs, []string{"abc", "ghi"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ackedIDs = %#v, want %#v", got, want)
+	}
+	if len(picker.options) != 2 {
+		t.Fatalf("picker runs = %d, want 2", len(picker.options))
+	}
+	second := picker.options[1].Entries
+	if len(second) != 1 || second[0].Value != "def" {
+		t.Fatalf("second picker entries = %#v, want critical def preserved", second)
+	}
+	if second[0].Value == "abc" || second[0].Value == "ghi" {
+		t.Fatalf("second picker entries = %#v, want non-critical rows removed", second)
+	}
+	if got, want := picker.options[1].Bindings, []string{"alt-2:abort", "start:pos(1)"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("second picker bindings = %#v, want %#v", got, want)
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want no sidebar clear output", stdout.String())
+	}
+	if focusCalls := filterFocusCalls(cmd.runner.(*focusFakeRunner).calls); len(focusCalls) != 0 {
+		t.Fatalf("focus calls = %#v, want none", focusCalls)
+	}
+}
+
+func TestNotifyListSidebarXClearNonCriticalRendersEmptyState(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{
+		listEntries: []notify.Notification{
+			{ID: "abc", Text: "deploy ok", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+			{ID: "def", Text: "warn", Severity: notify.SeverityWarn, Source: notify.SourceAI, Session: "main"},
+		},
 	}
 	picker := &recordingNotifyPicker{
 		results: []intpickercompat.Result{
@@ -669,7 +729,7 @@ func TestNotifyListSidebarXAckLastRowRendersEmptyState(t *testing.T) {
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run error = %v", err)
 	}
-	if got, want := store.ackedIDs, []string{"abc"}; !reflect.DeepEqual(got, want) {
+	if got, want := store.ackedIDs, []string{"abc", "def"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("ackedIDs = %#v, want %#v", got, want)
 	}
 	if len(picker.options) != 2 {
@@ -686,11 +746,11 @@ func TestNotifyListSidebarXAckLastRowRendersEmptyState(t *testing.T) {
 		t.Fatalf("empty picker bindings = %#v, want %#v", got, want)
 	}
 	if stdout.String() != "" {
-		t.Fatalf("stdout = %q, want no sidebar ack output", stdout.String())
+		t.Fatalf("stdout = %q, want no sidebar clear output", stdout.String())
 	}
 }
 
-func TestNotifyListSidebarXAckLastRowStartsAtPreviousRow(t *testing.T) {
+func TestNotifyListSidebarAAckLastRowStartsAtPreviousRow(t *testing.T) {
 	t.Parallel()
 
 	store := &stubNotifyStore{
@@ -701,7 +761,7 @@ func TestNotifyListSidebarXAckLastRowStartsAtPreviousRow(t *testing.T) {
 	}
 	picker := &recordingNotifyPicker{
 		results: []intpickercompat.Result{
-			{Key: "x", Value: "def"},
+			{Key: "a", Value: "def"},
 			{},
 		},
 	}
@@ -727,7 +787,7 @@ func TestNotifyListSidebarXAckLastRowStartsAtPreviousRow(t *testing.T) {
 	}
 }
 
-func TestNotifyListSidebarXAckRefreshesLiveStateEachLoop(t *testing.T) {
+func TestNotifyListSidebarAAckRefreshesLiveStateEachLoop(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
@@ -739,7 +799,7 @@ func TestNotifyListSidebarXAckRefreshesLiveStateEachLoop(t *testing.T) {
 	}
 	picker := &recordingNotifyPicker{
 		results: []intpickercompat.Result{
-			{Key: "x", Value: "ai:main:%2"},
+			{Key: "a", Value: "ai:main:%2"},
 			{},
 		},
 	}

--- a/scripts/poc-native-picker-no-fzf-e2e.sh
+++ b/scripts/poc-native-picker-no-fzf-e2e.sh
@@ -349,18 +349,18 @@ EOF
     assert_native_launch_close "alt-4" "ai picker" "/tmp/projmux ai picker --inside right"
     assert_native_launch_close "alt-5" "ai settings" "/tmp/projmux ai settings"
     echo "[poc/no-fzf] native Alt-2/3/4/5 launch keys close immediately"
-    echo "[poc/no-fzf] exercise native notify sidebar printable expect key"
+    echo "[poc/no-fzf] exercise native notify sidebar printable ack key"
     /tmp/projmux notify push --text "deploy ok" --target main --source ai --id poc-notify
     notify_log=/tmp/projmux-notify.log
     notify_status=0
-    printf "x" | timeout 8s script -q -e -E never -c "env PROJMUX_PICKER_BACKEND=native PROJMUX_NATIVE_LAUNCH_KEY=alt-2 /tmp/projmux notify list --ui=sidebar" "$notify_log" || notify_status=$?
+    printf "a" | timeout 8s script -q -e -E never -c "env PROJMUX_PICKER_BACKEND=native PROJMUX_NATIVE_LAUNCH_KEY=alt-2 /tmp/projmux notify list --ui=sidebar" "$notify_log" || notify_status=$?
     if [[ "$notify_status" != 0 ]]; then
       cat "$notify_log"
       exit "$notify_status"
     fi
-    if ! grep -q "ack poc-notify" "$notify_log"; then
+    if /tmp/projmux notify list --json | grep -q '"id": "poc-notify"'; then
       cat "$notify_log"
-      echo "native notify sidebar did not ack with printable expect key" >&2
+      echo "native notify sidebar did not ack with printable ack key" >&2
       exit 1
     fi
     if grep -q "Notify >" "$notify_log"; then


### PR DESCRIPTION
## Summary
- move notify sidebar selected-row ack from x to a
- change x to clear visible non-critical notifications while preserving critical rows
- update footer/docs/native e2e references for the new keymap

## Validation
- GOCACHE=/tmp/projmux-go-cache make fmt
- GOCACHE=/tmp/projmux-go-cache make fix
- GOCACHE=/tmp/projmux-go-cache make test
- GOCACHE=/tmp/projmux-go-cache make test-integration
- GOCACHE=/tmp/projmux-go-cache make test-e2e