### PR TITLE
feat: add mux runner wrapper

### DIFF
--- a/docs/tmux-surface-inventory.md
+++ b/docs/tmux-surface-inventory.md
@@ -39,6 +39,15 @@ and legacy cleanup candidates. Test fixture command strings are used to confirm
 the production contract, but they are not treated as separate product surface
 unless the corresponding production path exists.
 
+## Phase 1 Runner Boundary
+
+Phase 1 introduces `internal/integrations/mux` as a thin command-runner
+boundary over the existing tmux backend. New app-layer subprocess calls to the
+`tmux` binary should use `mux.Run`, `mux.Read`, or `mux.ReadTrimmed` so raw
+binary invocation does not spread further. Existing typed tmux clients and
+test-injected runner fields remain valid and do not need a broad rewrite in
+this phase.
+
 ## Classification Key
 
 | Class | Meaning |

--- a/internal/app/notification_toggle.go
+++ b/internal/app/notification_toggle.go
@@ -1,8 +1,10 @@
 package app
 
 import (
-	"os/exec"
+	"context"
 	"strings"
+
+	"github.com/crevissepartners/projmux/internal/integrations/mux"
 )
 
 // notification_toggle.go owns the OS-desktop-notification mode selector.
@@ -205,9 +207,9 @@ func (c *aiCommand) desktopNotifyModeResolution() (desktopNotifyMode, desktopNot
 }
 
 // settingsDesktopNotifyResolver builds the same resolver from a
-// `settingsCommand`. settingsCommand uses raw `runCommand` / direct
-// `exec.Command` for its tmux reads, so we wire the lookup through
-// `exec.Command` directly (mirroring `tmuxProjdirOption`).
+// `settingsCommand`. settingsCommand does not own an injected tmux reader, so
+// production tmux reads go through the central mux runner while the pure
+// resolver remains unit-testable.
 //
 // isWSL and wtPresent are derived from the env lookup so the Settings
 // render path computes the same default as the runtime gate.
@@ -224,11 +226,11 @@ func settingsDesktopNotifyResolver(lookupEnv func(string) string) desktopNotifyR
 			if lookupEnv == nil || strings.TrimSpace(lookupEnv("TMUX")) == "" {
 				return ""
 			}
-			out, err := exec.Command("tmux", "show-option", "-gqv", name).Output()
+			out, err := mux.ReadTrimmed(context.Background(), "show-option", "-gqv", name)
 			if err != nil {
 				return ""
 			}
-			return strings.TrimSpace(string(out))
+			return out
 		},
 		isWSL:     wsl,
 		wtPresent: wt,

--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -18,6 +18,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/core/pins"
 	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
 	coretags "github.com/crevissepartners/projmux/internal/core/tags"
+	"github.com/crevissepartners/projmux/internal/integrations/mux"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
@@ -1173,11 +1174,11 @@ func tmuxProjdirOption() string {
 	if os.Getenv("TMUX") == "" {
 		return ""
 	}
-	out, err := exec.Command("tmux", "show-option", "-gqv", "@projmux_projdir").Output()
+	out, err := mux.ReadTrimmed(context.Background(), "show-option", "-gqv", "@projmux_projdir")
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(out))
+	return out
 }
 
 // memoizeProjdir best-effort persists value to the saved-projdir file. It

--- a/internal/integrations/mux/runner.go
+++ b/internal/integrations/mux/runner.go
@@ -1,0 +1,77 @@
+// Package mux provides the minimal command-runner boundary for mux backend
+// subprocess calls. Phase 1 keeps tmux as the only production backend and
+// intentionally passes tmux arguments through unchanged.
+package mux
+
+import (
+	"context"
+	"strings"
+
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+)
+
+// Backend is the low-level command runner contract used by the mux boundary.
+type Backend interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// Runner invokes mux backend commands. The default production backend is tmux.
+type Runner struct {
+	backend Backend
+}
+
+// NewRunner builds a mux runner over backend. A nil backend uses the tmux
+// backend so production callers can stay concise.
+func NewRunner(backend Backend) Runner {
+	if backend == nil {
+		backend = inttmux.ExecRunner{}
+	}
+	return Runner{backend: backend}
+}
+
+// DefaultRunner returns the production tmux-backed mux runner.
+func DefaultRunner() Runner {
+	return NewRunner(inttmux.ExecRunner{})
+}
+
+// Run executes tmux with args and discards output.
+func Run(ctx context.Context, args ...string) error {
+	return DefaultRunner().Run(ctx, args...)
+}
+
+// Read executes tmux with args and returns the raw backend output.
+func Read(ctx context.Context, args ...string) ([]byte, error) {
+	return DefaultRunner().Read(ctx, args...)
+}
+
+// ReadTrimmed executes tmux with args and trims surrounding whitespace.
+func ReadTrimmed(ctx context.Context, args ...string) (string, error) {
+	return DefaultRunner().ReadTrimmed(ctx, args...)
+}
+
+// Run executes tmux with args and discards output.
+func (r Runner) Run(ctx context.Context, args ...string) error {
+	_, err := r.Read(ctx, args...)
+	return err
+}
+
+// Read executes tmux with args and returns the raw backend output.
+func (r Runner) Read(ctx context.Context, args ...string) ([]byte, error) {
+	return r.runner().Run(ctx, "tmux", args...)
+}
+
+// ReadTrimmed executes tmux with args and trims surrounding whitespace.
+func (r Runner) ReadTrimmed(ctx context.Context, args ...string) (string, error) {
+	out, err := r.Read(ctx, args...)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (r Runner) runner() Backend {
+	if r.backend == nil {
+		return inttmux.ExecRunner{}
+	}
+	return r.backend
+}

--- a/internal/integrations/mux/runner_test.go
+++ b/internal/integrations/mux/runner_test.go
@@ -1,0 +1,79 @@
+package mux
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type recordingBackend struct {
+	name string
+	args []string
+	out  []byte
+	err  error
+}
+
+func (b *recordingBackend) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	b.name = name
+	b.args = append([]string(nil), args...)
+	return append([]byte(nil), b.out...), b.err
+}
+
+func TestRunnerReadInvokesTmuxWithExactArgs(t *testing.T) {
+	backend := &recordingBackend{out: []byte("  value \n")}
+	runner := NewRunner(backend)
+
+	out, err := runner.Read(context.Background(), "show-option", "-gqv", "@projmux_projdir")
+	if err != nil {
+		t.Fatalf("Read returned error: %v", err)
+	}
+
+	if backend.name != "tmux" {
+		t.Fatalf("backend name = %q, want tmux", backend.name)
+	}
+	wantArgs := []string{"show-option", "-gqv", "@projmux_projdir"}
+	if !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend args = %#v, want %#v", backend.args, wantArgs)
+	}
+	if string(out) != "  value \n" {
+		t.Fatalf("Read output = %q, want raw output", string(out))
+	}
+}
+
+func TestRunnerReadTrimmedTrimsOnlyReadTrimmedOutput(t *testing.T) {
+	backend := &recordingBackend{out: []byte("  value \n")}
+	runner := NewRunner(backend)
+
+	raw, err := runner.Read(context.Background(), "display-message", "-p", "#{pane_id}")
+	if err != nil {
+		t.Fatalf("Read returned error: %v", err)
+	}
+	if string(raw) != "  value \n" {
+		t.Fatalf("Read output = %q, want raw output", string(raw))
+	}
+
+	trimmed, err := runner.ReadTrimmed(context.Background(), "display-message", "-p", "#{pane_id}")
+	if err != nil {
+		t.Fatalf("ReadTrimmed returned error: %v", err)
+	}
+	if trimmed != "value" {
+		t.Fatalf("ReadTrimmed output = %q, want value", trimmed)
+	}
+}
+
+func TestRunnerRunReturnsBackendError(t *testing.T) {
+	wantErr := errors.New("boom")
+	backend := &recordingBackend{err: wantErr}
+	runner := NewRunner(backend)
+
+	err := runner.Run(context.Background(), "set-option", "-g", "@projmux_app", "1")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Run error = %v, want %v", err, wantErr)
+	}
+
+	wantArgs := []string{"set-option", "-g", "@projmux_app", "1"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+}


### PR DESCRIPTION
## Completed Phase

- Phase 1 — mux command runner wrapper

## Mux Runner Wrapper

- Added `internal/integrations/mux` with thin helpers:
  - `mux.Run(ctx, args...)`
  - `mux.Read(ctx, args...)`
  - `mux.ReadTrimmed(ctx, args...)`
  - injectable `mux.Runner` / `mux.Backend`
- The default production backend remains `internal/integrations/tmux.ExecRunner`.
- The wrapper passes command args through unchanged as `tmux <args...>`.

## Migrated tmux Call Surface

- Moved direct app-layer `tmux show-option -gqv ...` reads through the mux runner in:
  - `settingsDesktopNotifyResolver`
  - `tmuxProjdirOption`
- Added a Phase 1 boundary note to `docs/tmux-surface-inventory.md`: new app-layer tmux subprocess calls should use the central mux runner, while existing typed tmux clients and injected runner fields remain valid.

## Explicitly Excluded Phase 2+ Scope

- Did not introduce semantic mux APIs for AI split, notify focus, statusbar popup, or session-state replay.
- Did not implement a psmux backend.
- Did not add a stable backend selection CLI/config/product option.
- Did not redesign tmux command behavior.
- Did not start a native/Rust mux engine.
- Did not attempt to remove every raw tmux call in one PR.

## Validation

- `GOCACHE=/tmp/projmux-go-cache go test ./internal/integrations/mux`
- `rg 'exec.Command\("tmux"|run\("tmux"|read\("tmux"' internal`
- `GOCACHE=/tmp/projmux-go-cache make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `git diff --check`
- `git diff --cached --check`

## Remaining Raw tmux Calls And Follow-Up

`rg 'exec.Command\("tmux"|run\("tmux"|read\("tmux"' internal` no longer reports `exec.Command("tmux"...)` under `internal`.

Remaining matches are existing injected helper/fake-runner surfaces in:

- `internal/app/ai.go`
- `internal/app/ai_ingest.go`
- `internal/app/ai_integrate.go`
- `internal/app/attention.go`
- `internal/app/notification.go`

Those were intentionally left because Phase 1 preserves current runner injection/fake runner patterns and avoids a broad semantic API extraction. They are candidates for Phase 2+ or focused follow-up conversion.

## Unverified / E2E Candidate

- No tmux-real e2e flow was run for this phase. The migrated calls are thin `show-option` reads, covered by wrapper unit tests and full Go test coverage; live tmux behavior remains an e2e candidate for later phases.
