### PR TITLE
feat: add semantic mux pane option API

### DIFF
--- a/docs/tmux-surface-inventory.md
+++ b/docs/tmux-surface-inventory.md
@@ -48,6 +48,22 @@ binary invocation does not spread further. Existing typed tmux clients and
 test-injected runner fields remain valid and do not need a broad rewrite in
 this phase.
 
+## Phase 2A Semantic Mux Reads And Pane Options
+
+Phase 2A adds semantic helpers in `internal/integrations/mux` for the pane
+metadata/read surfaces that psmux must eventually model:
+
+- `SetPaneOption`, `UnsetPaneOption`, and `ShowPaneOption` cover
+  `set-option -p` writes/unsets and `display-message -p "#{@...}"` reads.
+- `DisplayMessage` and `DisplayMessageTrimmed` cover `display-message -p`
+  format reads while preserving fake-runner injection through app-owned mux
+  runners.
+- `TmuxFormat`, `PaneOptionFormat`, and `JoinFormats` centralize common tmux
+  format assembly so converted call sites do not hand-build `#{...}` strings.
+
+Phase 2A intentionally does not introduce list-pane/list-window, popup, focus,
+capture, lifecycle, or psmux backend behavior.
+
 ## Classification Key
 
 | Class | Meaning |
@@ -111,7 +127,7 @@ this phase.
 | `show-option -gv @projmux_app` | `required MVP` for app quit | `quitCommand` | Confirms a socket is app-owned before `kill-server`. |
 | `set-option -g <option> <value>` | `hooks/status` | settings, notification registration, generated config, tmux bell integration | Writes statusbar decoration, desktop notify mode markers, toast URI markers, and tmux bell options. |
 | `set-option -g -u <option>` | `legacy/cleanup candidate` | notification URI migration | Unsets older URI registration markers. |
-| `set-option -p [-u] -t <pane> <option> [value]` | `hooks/status`, `required MVP` for AI | AI state, attention, topics, notification dedupe, session-state recipe metadata | Core pane metadata storage. |
+| `set-option -p [-u] -t <pane> <option> [value]` | `hooks/status`, `required MVP` for AI | AI state, attention, topics, notification dedupe, session-state recipe metadata | Core pane metadata storage. Phase 2A mux API: `SetPaneOption`, `UnsetPaneOption`. |
 | `set-option -t <session> -q <option> <value>` | `session-state`, `required MVP` | session autosave/source, ephemeral sessions | Stores session-level live markers. |
 | `source-file <config>` | `e2e/support`, app runtime support | `tmux apply`, install smoke | Reloads generated app config into live `-L projmux` server. |
 
@@ -382,13 +398,13 @@ Status values for Phase 3: `pass`, `partial`, `missing`, `unknown`.
 | Pane inventory | `list-panes -a/-s -F` plus pane/user-option formats | `required MVP`, `hooks/status`, `session-state` | `unknown` | Highest-risk metadata surface. |
 | Popup launch | `display-popup` with target/client/env/cwd/size/border/title/close flags | `interactive UI` | `unknown` | Roadmap already flags popup as a major risk. |
 | Popup close | `display-popup -C` | `interactive UI` | `unknown` | Needed for toggle semantics. |
-| Current context formats | `display-message -p -F #{pane_current_path}`, `#{pane_id}`, `#{client_tty}`, `#{client_width}`, `#{client_height}` | `interactive UI` | `unknown` | Popup and AI split depend on these. |
+| Current context formats | `display-message -p -F #{pane_current_path}`, `#{pane_id}`, `#{client_tty}`, `#{client_width}`, `#{client_height}` | `interactive UI` | `unknown` | Popup and AI split depend on these. Phase 2A mux API: `DisplayMessage`, `DisplayMessageTrimmed`. |
 | Focus URI translation | `display-message -p -t %N "#S<sep>#I"` | `focus` | `unknown` | Must map pane id to session/window for toast clicks. |
 | Client inventory | `list-clients -F #{client_name} #{client_session} #{client_active_pane}` | `focus`, `hooks/status` | `unknown` | Needed for focus and reply auto-ack correctness. |
 | Pane split | `split-window -h/-v [-P -F "#{pane_id}"] [-t] [-c] <cmd>` | `required MVP` | `unknown` | MVP AI/shell split requirement. |
 | Resize panes | `resize-pane -x/-y` | `interactive UI` | `unknown` | Can be `partial` if MVP can tolerate default split sizing. |
 | Pane title | `select-pane -T` and `#{pane_title}` | `interactive UI`, `hooks/status` | `unknown` | Used by attention and AI labels. |
-| Pane options | `set-option -p`, `display-message -p "#{@...}"` | `required MVP`, `hooks/status`, `session-state` | `unknown` | Needs arbitrary user option storage or replacement metadata store. |
+| Pane options | `set-option -p`, `display-message -p "#{@...}"` | `required MVP`, `hooks/status`, `session-state` | `unknown` | Needs arbitrary user option storage or replacement metadata store. Phase 2A mux API: `SetPaneOption`, `UnsetPaneOption`, `ShowPaneOption`, `PaneOptionFormat`. |
 | Global/session options | `set-option -g`, `show-option -gqv`, `set-option -t -q` | `hooks/status`, `session-state` | `unknown` | Required for settings, decoration, app markers, session-state source. |
 | Generated statusbar | `status`, `status-format`, `#[range=user|...]`, `#(...)`, `#{W:...}` | `hooks/status` | `unknown` | May need a separate psmux-native status model. |
 | Statusbar mouse/key dispatch | `MouseDown1Status`, `if-shell -F`, `switch-client -T`, `run-shell` | `interactive UI`, `hooks/status` | `unknown` | Product UX should degrade explicitly if unsupported. |

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -17,6 +17,7 @@ import (
 	"time"
 	"unicode/utf16"
 
+	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
@@ -114,7 +115,7 @@ func (l aiNotifyLookup) PaneFormat(paneID, format string) string {
 	if l.cmd == nil {
 		return ""
 	}
-	return l.cmd.readTrimmed("tmux", "display-message", "-p", "-t", paneID, format)
+	return l.cmd.readTmuxDisplayMessageTrimmed(paneID, format)
 }
 
 func (c *aiCommand) Run(args []string, stdout, stderr io.Writer) error {
@@ -1324,6 +1325,31 @@ func (c *aiCommand) read(name string, args ...string) ([]byte, error) {
 	return c.readCommand(context.Background(), name, args...)
 }
 
+func (c *aiCommand) muxRunner() intmux.Runner {
+	return intmux.NewRunner(aiCommandMuxBackend{
+		runCommand:  c.runCommand,
+		readCommand: c.readCommand,
+	})
+}
+
+type aiCommandMuxBackend struct {
+	runCommand  func(ctx context.Context, name string, args ...string) error
+	readCommand func(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+func (b aiCommandMuxBackend) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	if name == "tmux" && len(args) > 0 && args[0] == "set-option" {
+		if b.runCommand == nil {
+			return nil, errors.New("ai command runner is not configured")
+		}
+		return nil, b.runCommand(ctx, name, args...)
+	}
+	if b.readCommand == nil {
+		return nil, errors.New("ai command reader is not configured")
+	}
+	return b.readCommand(ctx, name, args...)
+}
+
 func (c *aiCommand) readTrimmed(name string, args ...string) string {
 	out, err := c.read(name, args...)
 	if err != nil {
@@ -1332,8 +1358,23 @@ func (c *aiCommand) readTrimmed(name string, args ...string) string {
 	return strings.TrimSpace(string(out))
 }
 
+func (c *aiCommand) readTmuxDisplayMessageTrimmed(paneID, format string) string {
+	output, err := c.muxRunner().DisplayMessageTrimmed(context.Background(), intmux.DisplayMessageOptions{
+		Target: paneID,
+		Format: format,
+	})
+	if err != nil {
+		return ""
+	}
+	return output
+}
+
 func (c *aiCommand) readTmuxPaneOption(paneID, option string) string {
-	return c.readTrimmed("tmux", "display-message", "-p", "-t", paneID, "#{"+option+"}")
+	output, err := c.muxRunner().ShowPaneOption(context.Background(), paneID, option)
+	if err != nil {
+		return ""
+	}
+	return output
 }
 
 // paneVisibleToClient mirrors attentionCommand.paneVisibleToClient: a pane is
@@ -1369,11 +1410,12 @@ func (c *aiCommand) duplicateAINotificationRecent(paneID, key string) bool {
 }
 
 func (c *aiCommand) recordAINotification(paneID, key string) {
-	_ = c.run("tmux", "set-option", "-p", "-t", paneID, "@projmux_desktop_notified", "1")
+	runner := c.muxRunner()
+	_ = runner.SetPaneOption(context.Background(), paneID, "@projmux_desktop_notified", "1")
 	if key != "" {
-		_ = c.run("tmux", "set-option", "-p", "-t", paneID, "@projmux_desktop_notification_key", key)
+		_ = runner.SetPaneOption(context.Background(), paneID, "@projmux_desktop_notification_key", key)
 	}
-	_ = c.run("tmux", "set-option", "-p", "-t", paneID, "@projmux_desktop_notification_at", fmt.Sprintf("%d", c.now().Unix()))
+	_ = runner.SetPaneOption(context.Background(), paneID, "@projmux_desktop_notification_at", fmt.Sprintf("%d", c.now().Unix()))
 }
 
 func (c *aiCommand) resolvePowerShell() string {

--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
@@ -80,11 +81,14 @@ func (l attentionLookup) PaneFormat(paneID, format string) string {
 	if l.cmd == nil || l.cmd.runner == nil {
 		return ""
 	}
-	output, err := l.cmd.run("tmux", "display-message", "-p", "-t", paneID, format)
+	output, err := intmux.NewRunner(l.cmd.runner).DisplayMessageTrimmed(context.Background(), intmux.DisplayMessageOptions{
+		Target: paneID,
+		Format: format,
+	})
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(output))
+	return output
 }
 
 func (c *attentionCommand) Run(args []string, stdout, stderr io.Writer) error {
@@ -270,7 +274,13 @@ type attentionPaneRow struct {
 }
 
 func (c *attentionCommand) paneTitle(paneID string) string {
-	output, err := c.run("tmux", "display-message", "-p", "-t", paneID, "#{pane_title}")
+	if c.runner == nil {
+		return ""
+	}
+	output, err := intmux.NewRunner(c.runner).DisplayMessage(context.Background(), intmux.DisplayMessageOptions{
+		Target: paneID,
+		Format: intmux.TmuxFormat("pane_title"),
+	})
 	if err != nil {
 		return ""
 	}
@@ -299,11 +309,14 @@ func (c *attentionCommand) paneVisibleToClient(paneID string) bool {
 }
 
 func (c *attentionCommand) paneOption(paneID, option string) string {
-	output, err := c.run("tmux", "display-message", "-p", "-t", paneID, "#{"+option+"}")
+	if c.runner == nil {
+		return ""
+	}
+	output, err := intmux.NewRunner(c.runner).ShowPaneOption(context.Background(), paneID, option)
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(output))
+	return output
 }
 
 func (c *attentionCommand) windowAttentionRows(windowID string) []attentionWindowRow {
@@ -418,11 +431,17 @@ func formatAttentionActive(active bool) string {
 }
 
 func (c *attentionCommand) setPaneOption(paneID, option, value string) {
-	_, _ = c.run("tmux", "set-option", "-p", "-t", paneID, option, value)
+	if c.runner == nil {
+		return
+	}
+	_ = intmux.NewRunner(c.runner).SetPaneOption(context.Background(), paneID, option, value)
 }
 
 func (c *attentionCommand) unsetPaneOption(paneID, option string) {
-	_, _ = c.run("tmux", "set-option", "-p", "-u", "-t", paneID, option)
+	if c.runner == nil {
+		return
+	}
+	_ = intmux.NewRunner(c.runner).UnsetPaneOption(context.Background(), paneID, option)
 }
 
 func (c *attentionCommand) selectPaneTitle(paneID, title string) {

--- a/internal/integrations/mux/runner.go
+++ b/internal/integrations/mux/runner.go
@@ -39,6 +39,31 @@ func Run(ctx context.Context, args ...string) error {
 	return DefaultRunner().Run(ctx, args...)
 }
 
+// SetPaneOption writes a pane-scoped tmux option.
+func SetPaneOption(ctx context.Context, paneTarget, option, value string) error {
+	return DefaultRunner().SetPaneOption(ctx, paneTarget, option, value)
+}
+
+// UnsetPaneOption removes a pane-scoped tmux option.
+func UnsetPaneOption(ctx context.Context, paneTarget, option string) error {
+	return DefaultRunner().UnsetPaneOption(ctx, paneTarget, option)
+}
+
+// ShowPaneOption reads a pane-scoped tmux option through display-message.
+func ShowPaneOption(ctx context.Context, paneTarget, option string) (string, error) {
+	return DefaultRunner().ShowPaneOption(ctx, paneTarget, option)
+}
+
+// DisplayMessage executes `tmux display-message -p` and returns raw output.
+func DisplayMessage(ctx context.Context, opts DisplayMessageOptions) ([]byte, error) {
+	return DefaultRunner().DisplayMessage(ctx, opts)
+}
+
+// DisplayMessageTrimmed executes `tmux display-message -p` and trims output.
+func DisplayMessageTrimmed(ctx context.Context, opts DisplayMessageOptions) (string, error) {
+	return DefaultRunner().DisplayMessageTrimmed(ctx, opts)
+}
+
 // Read executes tmux with args and returns the raw backend output.
 func Read(ctx context.Context, args ...string) ([]byte, error) {
 	return DefaultRunner().Read(ctx, args...)
@@ -53,6 +78,55 @@ func ReadTrimmed(ctx context.Context, args ...string) (string, error) {
 func (r Runner) Run(ctx context.Context, args ...string) error {
 	_, err := r.Read(ctx, args...)
 	return err
+}
+
+// SetPaneOption writes a pane-scoped tmux option.
+func (r Runner) SetPaneOption(ctx context.Context, paneTarget, option, value string) error {
+	args := []string{"set-option", "-p"}
+	args = appendPaneTargetArgs(args, paneTarget)
+	args = append(args, strings.TrimSpace(option), value)
+	return r.Run(ctx, args...)
+}
+
+// UnsetPaneOption removes a pane-scoped tmux option.
+func (r Runner) UnsetPaneOption(ctx context.Context, paneTarget, option string) error {
+	args := []string{"set-option", "-p", "-u"}
+	args = appendPaneTargetArgs(args, paneTarget)
+	args = append(args, strings.TrimSpace(option))
+	return r.Run(ctx, args...)
+}
+
+// ShowPaneOption reads a pane-scoped tmux option through display-message.
+func (r Runner) ShowPaneOption(ctx context.Context, paneTarget, option string) (string, error) {
+	return r.DisplayMessageTrimmed(ctx, DisplayMessageOptions{
+		Target: paneTarget,
+		Format: PaneOptionFormat(option),
+	})
+}
+
+// DisplayMessageOptions describes a `display-message -p` read.
+type DisplayMessageOptions struct {
+	Target string
+	Format string
+}
+
+// DisplayMessage executes `tmux display-message -p` and returns raw output.
+func (r Runner) DisplayMessage(ctx context.Context, opts DisplayMessageOptions) ([]byte, error) {
+	args := []string{"display-message", "-p"}
+	args = appendPaneTargetArgs(args, opts.Target)
+	if strings.TrimSpace(opts.Format) != "" {
+		args = append(args, opts.Format)
+	}
+	return r.Read(ctx, args...)
+}
+
+// DisplayMessageTrimmed executes `tmux display-message -p` and trims output.
+func (r Runner) DisplayMessageTrimmed(ctx context.Context, opts DisplayMessageOptions) (string, error) {
+	out, err := r.DisplayMessage(ctx, opts)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 // Read executes tmux with args and returns the raw backend output.
@@ -74,4 +148,26 @@ func (r Runner) runner() Backend {
 		return inttmux.ExecRunner{}
 	}
 	return r.backend
+}
+
+// PaneOptionFormat renders a tmux format for a pane option.
+func PaneOptionFormat(option string) string {
+	return TmuxFormat(strings.TrimSpace(option))
+}
+
+// TmuxFormat renders a tmux braced format token.
+func TmuxFormat(name string) string {
+	return "#{" + strings.TrimSpace(name) + "}"
+}
+
+// JoinFormats joins pre-rendered tmux formats with a caller-owned delimiter.
+func JoinFormats(delimiter string, formats ...string) string {
+	return strings.Join(formats, delimiter)
+}
+
+func appendPaneTargetArgs(args []string, paneTarget string) []string {
+	if target := strings.TrimSpace(paneTarget); target != "" {
+		args = append(args, "-t", target)
+	}
+	return args
 }

--- a/internal/integrations/mux/runner_test.go
+++ b/internal/integrations/mux/runner_test.go
@@ -77,3 +77,98 @@ func TestRunnerRunReturnsBackendError(t *testing.T) {
 		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
 	}
 }
+
+func TestRunnerSetPaneOptionBuildsPaneScopedSetOption(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	if err := runner.SetPaneOption(context.Background(), " %9 ", " @projmux_ai_state ", "waiting"); err != nil {
+		t.Fatalf("SetPaneOption returned error: %v", err)
+	}
+
+	wantArgs := []string{"set-option", "-p", "-t", "%9", "@projmux_ai_state", "waiting"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+}
+
+func TestRunnerUnsetPaneOptionBuildsPaneScopedUnsetOption(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	if err := runner.UnsetPaneOption(context.Background(), "%9", "@projmux_attention_ack"); err != nil {
+		t.Fatalf("UnsetPaneOption returned error: %v", err)
+	}
+
+	wantArgs := []string{"set-option", "-p", "-u", "-t", "%9", "@projmux_attention_ack"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+}
+
+func TestRunnerShowPaneOptionReadsDisplayMessageFormat(t *testing.T) {
+	backend := &recordingBackend{out: []byte(" reply \n")}
+	runner := NewRunner(backend)
+
+	got, err := runner.ShowPaneOption(context.Background(), "%9", "@projmux_attention_state")
+	if err != nil {
+		t.Fatalf("ShowPaneOption returned error: %v", err)
+	}
+
+	wantArgs := []string{"display-message", "-p", "-t", "%9", "#{@projmux_attention_state}"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+	if got != "reply" {
+		t.Fatalf("ShowPaneOption = %q, want reply", got)
+	}
+}
+
+func TestRunnerDisplayMessageBuildsPaneScopedRead(t *testing.T) {
+	backend := &recordingBackend{out: []byte("  title  \n")}
+	runner := NewRunner(backend)
+
+	got, err := runner.DisplayMessage(context.Background(), DisplayMessageOptions{
+		Target: " %9 ",
+		Format: TmuxFormat("pane_title"),
+	})
+	if err != nil {
+		t.Fatalf("DisplayMessage returned error: %v", err)
+	}
+
+	wantArgs := []string{"display-message", "-p", "-t", "%9", "#{pane_title}"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+	if string(got) != "  title  \n" {
+		t.Fatalf("DisplayMessage = %q, want raw output", string(got))
+	}
+}
+
+func TestRunnerDisplayMessageAllowsTargetlessRead(t *testing.T) {
+	backend := &recordingBackend{out: []byte("%3\n")}
+	runner := NewRunner(backend)
+
+	got, err := runner.DisplayMessageTrimmed(context.Background(), DisplayMessageOptions{
+		Format: TmuxFormat("pane_id"),
+	})
+	if err != nil {
+		t.Fatalf("DisplayMessageTrimmed returned error: %v", err)
+	}
+
+	wantArgs := []string{"display-message", "-p", "#{pane_id}"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+	if got != "%3" {
+		t.Fatalf("DisplayMessageTrimmed = %q, want %%3", got)
+	}
+}
+
+func TestJoinFormatsKeepsCallerDelimiter(t *testing.T) {
+	got := JoinFormats("|", TmuxFormat("pane_title"), PaneOptionFormat("@projmux_ai_state"))
+	want := "#{pane_title}|#{@projmux_ai_state}"
+	if got != want {
+		t.Fatalf("JoinFormats = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Completed Phase

- Phase 2A — pane option + display-message minimal slice.

## Semantic mux API

Added in `internal/integrations/mux`:

- `SetPaneOption`
- `UnsetPaneOption`
- `ShowPaneOption`
- `DisplayMessage`
- `DisplayMessageTrimmed`
- `TmuxFormat`
- `PaneOptionFormat`
- `JoinFormats`

## App surfaces moved to semantic API

- `attentionCommand`: pane option reads/writes, pane title display-message read, and attention notify lookup display-message read now go through `mux.Runner` semantic helpers.
- `aiCommand`: pane option reads, notification dedupe record writes, and AI notify lookup display-message read now go through `mux.Runner` semantic helpers while preserving existing fake runner/test injection through an app-owned backend adapter.

## Explicitly excluded

- Did not expand into Phase 2B pane/window inventory APIs.
- Did not expand into Phase 2C popup/focus/capture APIs.
- Did not expand into Phase 2D lifecycle/split/hook APIs.
- Did not change `display-popup`, `split-window`, or session-state replay.
- Did not implement a psmux backend.
- Did not change tmux behavior.
- Did not expose backend selection as a stable user-facing option.
- Did not attempt a broad rewrite of every raw tmux call.
- Did not mark psmux parity pass/fail statuses.

## Validation

- `GOCACHE=/tmp/projmux-go-cache go test ./internal/integrations/mux ./internal/app`
- `GOCACHE=/tmp/projmux-go-cache make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `git diff --check`
- `rg 'set-option.*-p|display-message.*-p|ShowPaneOption|SetPaneOption|DisplayMessage' internal docs/tmux-surface-inventory.md`

## Remaining raw pane option / display-message calls and follow-up

The `rg` check still shows raw `set-option -p` / `display-message -p` callsites in AI split/setup, generated keybinding tmux bodies, notification socket lookup, status/statusbar reads, focus URI translation, session-state/tmux integration paths, and tests/fixtures. These are intentionally left for later Phase 2 slices or backend-specific integrations instead of being batch-converted in Phase 2A.

No live tmux-real manual/e2e smoke was run for this PR; tmux behavior coverage here is existing unit/fake-runner command-argument coverage plus the standard unit suite.