### PR TITLE
feat: add mux inventory read API

### DIFF
--- a/docs/tmux-surface-inventory.md
+++ b/docs/tmux-surface-inventory.md
@@ -64,6 +64,36 @@ metadata/read surfaces that psmux must eventually model:
 Phase 2A intentionally does not introduce list-pane/list-window, popup, focus,
 capture, lifecycle, or psmux backend behavior.
 
+## Phase 2B Pane And Window Inventory Reads
+
+Phase 2B adds semantic structured inventory helpers in
+`internal/integrations/mux` while keeping tmux as the only production backend:
+
+- `ListPanes` covers fixed-format `list-panes -F` reads for pane inventory.
+- `ListWindows` covers fixed-format `list-windows -F` reads for window
+  inventory.
+- `DisplayPaneFields` covers one-pane `display-message -p` field reads.
+- `FieldDelimiter` and `ParseFormatRows` centralize delimiter choice, escaped
+  unit-separator compatibility, malformed-row skipping, and field trimming.
+
+Converted app-layer read paths include AI hook pane matching, tmux bell pane
+field reads, `attention list`/window badge reads, and notify queue reconcile.
+The session-state typed tmux client remains on its existing capture path in this
+phase so replay schema and generation logic stay unchanged.
+
+### Phase 2B psmux Audit Capability Mapping
+
+The table below maps the tmux format variables used by Phase 2B inventory reads
+to the semantic capability that a future psmux audit/backend must provide.
+
+| Capability | Current tmux read | Format variables / options | Converted read paths |
+| --- | --- | --- | --- |
+| `ListPanes` pane identity | `list-panes -a -F` | `#{session_name}`, `#{window_id}`, `#{pane_id}`, `#{pane_active}`, `#{socket_path}` | `attention list`, notify reconcile |
+| `ListPanes` pane labels/state | `list-panes -a -F`, `list-panes -t <window> -F` | `#{pane_title}`, `#{@projmux_attention_state}`, `#{@projmux_ai_state}`, `#{@projmux_ai_agent}`, `#{@projmux_ai_topic}` | `attention list`, attention window badge, notify reconcile |
+| `ListPanes` AI hook match fields | `list-panes -a -F` | `#{pane_id}`, `#{pane_current_path}`, `#{@projmux_ai_thread_id}`, `#{@projmux_ai_session_id}` | AI hook pane matching |
+| `DisplayPaneFields` bell pane fields | `display-message -p -t <pane>` | `#{session_name}`, `#{window_id}`, `#{window_name}`, `#{pane_id}`, `#{pane_title}`, `#{pane_current_command}`, `#{socket_path}` | tmux bell ingest |
+| `ListWindows` window inventory | `list-windows -F` | `#{window_index}`, `#{window_id}`, `#{window_name}`, `#{window_layout}`, `#{window_panes}`, `#{pane_current_path}` | API available for the existing typed tmux window reads; conversion deferred outside Phase 2B app read slice |
+
 ## Classification Key
 
 | Class | Meaning |

--- a/internal/app/ai_ingest.go
+++ b/internal/app/ai_ingest.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -15,18 +16,38 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/notify"
+	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
 )
 
-const aiIngestListPanesFormat = "#{pane_id}\x1f#{pane_current_path}\x1f#{" + aiPaneThreadIDOption + "}\x1f#{" + aiPaneSessionIDOption + "}"
 const claudeTranscriptTailLimit = 256 * 1024
 const (
 	aiBellDedupeOption = "@projmux_ai_bell_notified_at"
 	aiBellDedupeWindow = 5 * time.Second
-	aiBellPaneFormat   = "#{session_name}\x1f#{window_id}\x1f#{window_name}\x1f#{pane_id}\x1f#{pane_title}\x1f#{pane_current_command}\x1f#{socket_path}"
 	aiIngestLogName    = "ai-ingest.log"
 	aiIngestLogMaxSize = 1024 * 1024
 	aiIngestLogRetain  = 512 * 1024
 )
+
+var aiIngestListPanesFormats = []string{
+	intmux.TmuxFormat("pane_id"),
+	intmux.TmuxFormat("pane_current_path"),
+	intmux.PaneOptionFormat(aiPaneThreadIDOption),
+	intmux.PaneOptionFormat(aiPaneSessionIDOption),
+}
+
+var aiIngestListPanesFormat = intmux.JoinFormats(intmux.FieldDelimiter, aiIngestListPanesFormats...)
+
+var aiBellPaneFormats = []string{
+	intmux.TmuxFormat("session_name"),
+	intmux.TmuxFormat("window_id"),
+	intmux.TmuxFormat("window_name"),
+	intmux.TmuxFormat("pane_id"),
+	intmux.TmuxFormat("pane_title"),
+	intmux.TmuxFormat("pane_current_command"),
+	intmux.TmuxFormat("socket_path"),
+}
+
+var aiBellPaneFormat = intmux.JoinFormats(intmux.FieldDelimiter, aiBellPaneFormats...)
 
 type codexHookPayload struct {
 	EventName      string
@@ -299,22 +320,18 @@ func (c *aiCommand) aiNotifyStore() (notifyStore, error) {
 }
 
 func (c *aiCommand) readBellPaneInfo(paneID string) (bellPaneInfo, bool) {
-	out := c.readTrimmed("tmux", "display-message", "-p", "-t", paneID, aiBellPaneFormat)
-	if out == "" {
-		return bellPaneInfo{}, false
-	}
-	fields := splitTmuxUnitFields(out)
-	if len(fields) < 7 {
+	fields, err := c.muxRunner().DisplayPaneFields(context.Background(), paneID, aiBellPaneFormats...)
+	if err != nil || len(fields) < 7 {
 		return bellPaneInfo{}, false
 	}
 	info := bellPaneInfo{
-		Session: strings.TrimSpace(fields[0]),
-		Window:  strings.TrimSpace(fields[1]),
-		WinName: strings.TrimSpace(fields[2]),
-		Pane:    strings.TrimSpace(fields[3]),
-		Title:   strings.TrimSpace(fields[4]),
-		Command: strings.TrimSpace(fields[5]),
-		Socket:  strings.TrimSpace(fields[6]),
+		Session: fields[0],
+		Window:  fields[1],
+		WinName: fields[2],
+		Pane:    fields[3],
+		Title:   fields[4],
+		Command: fields[5],
+		Socket:  fields[6],
 	}
 	if info.Pane == "" {
 		info.Pane = paneID
@@ -1103,36 +1120,27 @@ func (c *aiCommand) matchAIPane(in aiPaneMatchInput) string {
 }
 
 func (c *aiCommand) listAIPaneMatchRows() []aiPaneMatchRow {
-	out, err := c.read("tmux", "list-panes", "-a", "-F", aiIngestListPanesFormat)
+	rows, err := c.muxRunner().ListPanes(context.Background(), intmux.ListPanesOptions{
+		All:     true,
+		Formats: aiIngestListPanesFormats,
+	})
 	if err != nil {
 		return nil
 	}
-	rows := strings.Split(strings.TrimSpace(string(out)), "\n")
 	matches := make([]aiPaneMatchRow, 0, len(rows))
-	for _, raw := range rows {
-		fields := splitTmuxUnitFields(raw)
-		if len(fields) != 4 {
-			continue
-		}
-		paneID := strings.TrimSpace(fields[0])
+	for _, fields := range rows {
+		paneID := fields[0]
 		if paneID == "" {
 			continue
 		}
 		matches = append(matches, aiPaneMatchRow{
 			PaneID:    paneID,
-			CWD:       strings.TrimSpace(fields[1]),
-			ThreadID:  strings.TrimSpace(fields[2]),
-			SessionID: strings.TrimSpace(fields[3]),
+			CWD:       fields[1],
+			ThreadID:  fields[2],
+			SessionID: fields[3],
 		})
 	}
 	return matches
-}
-
-func splitTmuxUnitFields(raw string) []string {
-	if strings.Contains(raw, "\x1f") {
-		return strings.Split(raw, "\x1f")
-	}
-	return strings.Split(raw, "\\037")
 }
 
 func cleanMatchPath(path string) string {

--- a/internal/app/ai_ingest_test.go
+++ b/internal/app/ai_ingest_test.go
@@ -572,20 +572,6 @@ func TestIngestBellPushesQueueEntryAndDedupesPane(t *testing.T) {
 	}
 }
 
-func TestSplitTmuxUnitFieldsAcceptsRawAndEscapedSeparators(t *testing.T) {
-	for name, raw := range map[string]string{
-		"raw":     "one\x1ftwo\x1fthree",
-		"escaped": "one\\037two\\037three",
-	} {
-		t.Run(name, func(t *testing.T) {
-			got := splitTmuxUnitFields(raw)
-			if !reflect.DeepEqual(got, []string{"one", "two", "three"}) {
-				t.Fatalf("splitTmuxUnitFields(%q) = %#v", raw, got)
-			}
-		})
-	}
-}
-
 func TestIngestBellRequiresPaneFlag(t *testing.T) {
 	cmd := testAICommand(t.TempDir())
 	err := cmd.Run([]string{"ingest", "bell"}, &bytes.Buffer{}, &bytes.Buffer{})

--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -23,18 +23,23 @@ const (
 )
 
 const (
-	attentionListSeparator = "\x1f"
-	attentionListFormat    = "#{session_name}" + attentionListSeparator +
-		"#{window_id}" + attentionListSeparator +
-		"#{pane_id}" + attentionListSeparator +
-		"#{pane_active}" + attentionListSeparator +
-		"#{pane_title}" + attentionListSeparator +
-		"#{" + attentionStateOption + "}" + attentionListSeparator +
-		"#{" + aiPaneStateOption + "}" + attentionListSeparator +
-		"#{" + aiPaneAgentOption + "}" + attentionListSeparator +
-		"#{" + aiPaneTopicOption + "}" + attentionListSeparator +
-		"#{socket_path}"
+	attentionListSeparator = intmux.FieldDelimiter
 )
+
+var attentionListFormats = []string{
+	intmux.TmuxFormat("session_name"),
+	intmux.TmuxFormat("window_id"),
+	intmux.TmuxFormat("pane_id"),
+	intmux.TmuxFormat("pane_active"),
+	intmux.TmuxFormat("pane_title"),
+	intmux.PaneOptionFormat(attentionStateOption),
+	intmux.PaneOptionFormat(aiPaneStateOption),
+	intmux.PaneOptionFormat(aiPaneAgentOption),
+	intmux.PaneOptionFormat(aiPaneTopicOption),
+	intmux.TmuxFormat("socket_path"),
+}
+
+var attentionListFormat = intmux.JoinFormats(attentionListSeparator, attentionListFormats...)
 
 type attentionCommand struct {
 	runner   tmuxRunner
@@ -320,62 +325,64 @@ func (c *attentionCommand) paneOption(paneID, option string) string {
 }
 
 func (c *attentionCommand) windowAttentionRows(windowID string) []attentionWindowRow {
-	output, err := c.run("tmux", "list-panes", "-t", windowID, "-F", "#{pane_title}\t#{@projmux_attention_state}")
+	if c == nil || c.runner == nil {
+		return nil
+	}
+	rows, err := intmux.NewRunner(c.runner).ListPanes(context.Background(), intmux.ListPanesOptions{
+		Target: windowID,
+		Formats: []string{
+			intmux.TmuxFormat("pane_title"),
+			intmux.PaneOptionFormat(attentionStateOption),
+		},
+	})
 	if err != nil {
 		return nil
 	}
 
-	lines := strings.Split(strings.TrimRight(string(output), "\r\n"), "\n")
-	rows := make([]attentionWindowRow, 0, len(lines))
-	for _, line := range lines {
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		fields := strings.SplitN(line, "\t", 2)
-		row := attentionWindowRow{Title: fields[0]}
-		if len(fields) == 2 {
-			row.State = strings.TrimSpace(fields[1])
-		}
-		rows = append(rows, row)
+	out := make([]attentionWindowRow, 0, len(rows))
+	for _, fields := range rows {
+		out = append(out, attentionWindowRow{
+			Title: fields[0],
+			State: fields[1],
+		})
 	}
-	return rows
+	return out
 }
 
 func (c *attentionCommand) listAttentionPanes() ([]attentionPaneRow, error) {
-	output, err := c.run("tmux", "list-panes", "-a", "-F", attentionListFormat)
+	if c == nil || c.runner == nil {
+		return nil, errors.New("attention tmux runner is not configured")
+	}
+	rows, err := intmux.NewRunner(c.runner).ListPanes(context.Background(), intmux.ListPanesOptions{
+		All:              true,
+		Formats:          attentionListFormats,
+		Delimiter:        attentionListSeparator,
+		AllowExtraFields: true,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("tmux list-panes: %w", err)
 	}
 
-	lines := strings.Split(strings.TrimRight(string(output), "\r\n"), "\n")
-	rows := make([]attentionPaneRow, 0, len(lines))
-	for _, line := range lines {
-		line = strings.TrimRight(line, "\r")
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		fields := strings.Split(line, attentionListSeparator)
-		if len(fields) < 10 {
-			continue
-		}
+	out := make([]attentionPaneRow, 0, len(rows))
+	for _, fields := range rows {
 		row := attentionPaneRow{
-			Session:        strings.TrimSpace(fields[0]),
-			Window:         strings.TrimSpace(fields[1]),
-			Pane:           strings.TrimSpace(fields[2]),
-			Active:         strings.TrimSpace(fields[3]) == "1",
-			Title:          strings.TrimSpace(fields[4]),
-			AttentionState: strings.TrimSpace(fields[5]),
-			AIState:        strings.TrimSpace(fields[6]),
-			Agent:          strings.TrimSpace(fields[7]),
-			Topic:          strings.TrimSpace(fields[8]),
-			Socket:         strings.TrimSpace(fields[9]),
+			Session:        fields[0],
+			Window:         fields[1],
+			Pane:           fields[2],
+			Active:         fields[3] == "1",
+			Title:          fields[4],
+			AttentionState: fields[5],
+			AIState:        fields[6],
+			Agent:          fields[7],
+			Topic:          fields[8],
+			Socket:         fields[9],
 		}
 		if row.Session == "" || row.Pane == "" {
 			continue
 		}
-		rows = append(rows, row)
+		out = append(out, row)
 	}
-	return rows, nil
+	return out, nil
 }
 
 func filterAttentionRows(rows []attentionPaneRow) []attentionPaneRow {

--- a/internal/app/attention_test.go
+++ b/internal/app/attention_test.go
@@ -252,7 +252,7 @@ func TestAttentionWindowPrefersBusyBadge(t *testing.T) {
 
 	runner := &recordingAttentionRunner{
 		outputs: map[string][]byte{
-			"tmux list-panes -t @1 -F #{pane_title}\t#{@projmux_attention_state}": []byte("plain\treply\n⠋ working\t\n"),
+			"tmux list-panes -t @1 -F #{pane_title}" + attentionListSeparator + "#{@projmux_attention_state}": []byte("plain\treply" + attentionListSeparator + "reply\n⠋ working" + attentionListSeparator + "\n"),
 		},
 	}
 	cmd := &attentionCommand{runner: runner}
@@ -271,7 +271,7 @@ func TestAttentionWindowShowsReplyBadge(t *testing.T) {
 
 	runner := &recordingAttentionRunner{
 		outputs: map[string][]byte{
-			"tmux list-panes -t @2 -F #{pane_title}\t#{@projmux_attention_state}": []byte("plain\t\n✳ ready\t\n"),
+			"tmux list-panes -t @2 -F #{pane_title}" + attentionListSeparator + "#{@projmux_attention_state}": []byte("plain" + attentionListSeparator + "\n✳ ready" + attentionListSeparator + "\n"),
 		},
 	}
 	cmd := &attentionCommand{runner: runner}

--- a/internal/app/notify_reconcile.go
+++ b/internal/app/notify_reconcile.go
@@ -9,22 +9,26 @@ import (
 	"strings"
 
 	"github.com/crevissepartners/projmux/internal/core/notify"
+	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
-// reconcileListPanesFormat is the tab/pipe-separated format used by the
-// reconcile pass. The producer key set (session, pane id, agent, topic,
-// socket) drives id construction and queue text composition; the
+// reconcileListPanesFormats are the fields used by the reconcile pass. The
+// producer key set (session, pane id, agent, topic, socket) drives id
+// construction and queue text composition; the
 // attention/ai state fields decide whether the pane should be in the queue.
-const reconcileListPanesFormat = "" +
-	"#{session_name}|" +
-	"#{window_id}|" +
-	"#{pane_id}|" +
-	"#{" + attentionStateOption + "}|" +
-	"#{" + aiPaneStateOption + "}|" +
-	"#{" + aiPaneAgentOption + "}|" +
-	"#{" + aiPaneTopicOption + "}|" +
-	"#{socket_path}"
+var reconcileListPanesFormats = []string{
+	intmux.TmuxFormat("session_name"),
+	intmux.TmuxFormat("window_id"),
+	intmux.TmuxFormat("pane_id"),
+	intmux.PaneOptionFormat(attentionStateOption),
+	intmux.PaneOptionFormat(aiPaneStateOption),
+	intmux.PaneOptionFormat(aiPaneAgentOption),
+	intmux.PaneOptionFormat(aiPaneTopicOption),
+	intmux.TmuxFormat("socket_path"),
+}
+
+var reconcileListPanesFormat = intmux.JoinFormats("|", reconcileListPanesFormats...)
 
 // reconcileResult is the summary returned by the reconcile pass.
 type reconcileResult struct {
@@ -188,32 +192,26 @@ func (c *notifyCommand) listReconcilePanes() ([]reconcilePane, error) {
 	if c == nil || c.runner == nil {
 		return nil, errors.New("tmux runner is not configured")
 	}
-	output, err := c.runner.Run(context.Background(), "tmux", "list-panes", "-a", "-F", reconcileListPanesFormat)
+	rows, err := intmux.NewRunner(c.runner).ListPanes(context.Background(), intmux.ListPanesOptions{
+		All:              true,
+		Formats:          reconcileListPanesFormats,
+		Delimiter:        "|",
+		AllowExtraFields: true,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("tmux list-panes: %w", err)
 	}
-	lines := strings.Split(strings.TrimRight(string(output), "\r\n"), "\n")
-	out := make([]reconcilePane, 0, len(lines))
-	for _, line := range lines {
-		line = strings.TrimRight(line, "\r")
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		fields := strings.Split(line, "|")
-		// The format string emits exactly 8 fields; tmux silently substitutes
-		// empty strings for unset options so a short row is malformed.
-		if len(fields) < 8 {
-			continue
-		}
+	out := make([]reconcilePane, 0, len(rows))
+	for _, fields := range rows {
 		p := reconcilePane{
-			Session:        strings.TrimSpace(fields[0]),
-			Window:         strings.TrimSpace(fields[1]),
-			Pane:           strings.TrimSpace(fields[2]),
-			AttentionState: strings.TrimSpace(fields[3]),
-			AIState:        strings.TrimSpace(fields[4]),
-			Agent:          strings.TrimSpace(fields[5]),
-			Topic:          strings.TrimSpace(fields[6]),
-			Socket:         strings.TrimSpace(fields[7]),
+			Session:        fields[0],
+			Window:         fields[1],
+			Pane:           fields[2],
+			AttentionState: fields[3],
+			AIState:        fields[4],
+			Agent:          fields[5],
+			Topic:          fields[6],
+			Socket:         fields[7],
 		}
 		if p.Session == "" || p.Pane == "" {
 			continue

--- a/internal/integrations/mux/inventory.go
+++ b/internal/integrations/mux/inventory.go
@@ -1,0 +1,167 @@
+package mux
+
+import (
+	"context"
+	"strings"
+)
+
+// FieldDelimiter is the default delimiter for structured tmux format rows.
+// It is intentionally outside ordinary user text so pane titles and topics are
+// less likely to collide with the parser.
+const FieldDelimiter = "\x1f"
+
+// ListPanesOptions describes a structured `list-panes -F` read.
+type ListPanesOptions struct {
+	All              bool
+	Target           string
+	Formats          []string
+	Delimiter        string
+	AllowExtraFields bool
+}
+
+// ListWindowsOptions describes a structured `list-windows -F` read.
+type ListWindowsOptions struct {
+	Target           string
+	Formats          []string
+	Delimiter        string
+	AllowExtraFields bool
+}
+
+// FormatRowsOptions controls parsing for tmux `-F`/`display-message -p`
+// output built from a fixed field list.
+type FormatRowsOptions struct {
+	Delimiter        string
+	FieldCount       int
+	AllowExtraFields bool
+}
+
+// ListPanes executes `tmux list-panes -F` and parses fixed-width rows.
+func ListPanes(ctx context.Context, opts ListPanesOptions) ([][]string, error) {
+	return DefaultRunner().ListPanes(ctx, opts)
+}
+
+// ListWindows executes `tmux list-windows -F` and parses fixed-width rows.
+func ListWindows(ctx context.Context, opts ListWindowsOptions) ([][]string, error) {
+	return DefaultRunner().ListWindows(ctx, opts)
+}
+
+// DisplayPaneFields executes `tmux display-message -p` for one pane target and
+// parses the result as a fixed field row.
+func DisplayPaneFields(ctx context.Context, target string, formats ...string) ([]string, error) {
+	return DefaultRunner().DisplayPaneFields(ctx, target, formats...)
+}
+
+// ListPanes executes `tmux list-panes -F` and parses fixed-width rows.
+func (r Runner) ListPanes(ctx context.Context, opts ListPanesOptions) ([][]string, error) {
+	if len(opts.Formats) == 0 {
+		return nil, nil
+	}
+	delimiter := formatDelimiter(opts.Delimiter)
+	args := []string{"list-panes"}
+	if opts.All {
+		args = append(args, "-a")
+	}
+	args = appendPaneTargetArgs(args, opts.Target)
+	args = append(args, "-F", JoinFormats(delimiter, opts.Formats...))
+	out, err := r.Read(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseFormatRows(out, FormatRowsOptions{
+		Delimiter:        delimiter,
+		FieldCount:       len(opts.Formats),
+		AllowExtraFields: opts.AllowExtraFields,
+	}), nil
+}
+
+// ListWindows executes `tmux list-windows -F` and parses fixed-width rows.
+func (r Runner) ListWindows(ctx context.Context, opts ListWindowsOptions) ([][]string, error) {
+	if len(opts.Formats) == 0 {
+		return nil, nil
+	}
+	delimiter := formatDelimiter(opts.Delimiter)
+	args := []string{"list-windows"}
+	args = appendPaneTargetArgs(args, opts.Target)
+	args = append(args, "-F", JoinFormats(delimiter, opts.Formats...))
+	out, err := r.Read(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseFormatRows(out, FormatRowsOptions{
+		Delimiter:        delimiter,
+		FieldCount:       len(opts.Formats),
+		AllowExtraFields: opts.AllowExtraFields,
+	}), nil
+}
+
+// DisplayPaneFields executes `tmux display-message -p` for one pane target and
+// parses the result as a fixed field row.
+func (r Runner) DisplayPaneFields(ctx context.Context, target string, formats ...string) ([]string, error) {
+	if len(formats) == 0 {
+		return nil, nil
+	}
+	out, err := r.DisplayMessage(ctx, DisplayMessageOptions{
+		Target: target,
+		Format: JoinFormats(FieldDelimiter, formats...),
+	})
+	if err != nil {
+		return nil, err
+	}
+	rows := ParseFormatRows(out, FormatRowsOptions{
+		Delimiter:  FieldDelimiter,
+		FieldCount: len(formats),
+	})
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return rows[0], nil
+}
+
+// ParseFormatRows parses fixed-field tmux format output. Blank rows and
+// malformed rows are skipped. Fields are whitespace-trimmed; accepted rows with
+// extra delimiter splits are truncated to the requested field count only when
+// AllowExtraFields is true.
+func ParseFormatRows(output []byte, opts FormatRowsOptions) [][]string {
+	if opts.FieldCount <= 0 {
+		return nil
+	}
+	delimiter := formatDelimiter(opts.Delimiter)
+	lines := strings.Split(strings.TrimRight(string(output), "\r\n"), "\n")
+	rows := make([][]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := splitFormatFields(line, delimiter)
+		if len(fields) < opts.FieldCount {
+			continue
+		}
+		if len(fields) > opts.FieldCount {
+			if !opts.AllowExtraFields {
+				continue
+			}
+			fields = fields[:opts.FieldCount]
+		}
+		row := make([]string, len(fields))
+		for i, field := range fields {
+			row[i] = strings.TrimSpace(field)
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func splitFormatFields(raw, delimiter string) []string {
+	if delimiter == FieldDelimiter && !strings.Contains(raw, FieldDelimiter) {
+		return strings.Split(raw, "\\037")
+	}
+	return strings.Split(raw, delimiter)
+}
+
+func formatDelimiter(delimiter string) string {
+	if delimiter == "" {
+		return FieldDelimiter
+	}
+	return delimiter
+}

--- a/internal/integrations/mux/runner_test.go
+++ b/internal/integrations/mux/runner_test.go
@@ -172,3 +172,108 @@ func TestJoinFormatsKeepsCallerDelimiter(t *testing.T) {
 		t.Fatalf("JoinFormats = %q, want %q", got, want)
 	}
 }
+
+func TestRunnerListPanesBuildsStructuredInventoryRead(t *testing.T) {
+	backend := &recordingBackend{out: []byte(" dev \x1f %3 \x1f reply \nshort\n")}
+	runner := NewRunner(backend)
+
+	rows, err := runner.ListPanes(context.Background(), ListPanesOptions{
+		All: true,
+		Formats: []string{
+			TmuxFormat("session_name"),
+			TmuxFormat("pane_id"),
+			PaneOptionFormat("@projmux_attention_state"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("ListPanes returned error: %v", err)
+	}
+
+	wantArgs := []string{
+		"list-panes",
+		"-a",
+		"-F",
+		"#{session_name}" + FieldDelimiter + "#{pane_id}" + FieldDelimiter + "#{@projmux_attention_state}",
+	}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+	wantRows := [][]string{{"dev", "%3", "reply"}}
+	if !reflect.DeepEqual(rows, wantRows) {
+		t.Fatalf("ListPanes rows = %#v, want %#v", rows, wantRows)
+	}
+}
+
+func TestRunnerListWindowsBuildsStructuredInventoryRead(t *testing.T) {
+	backend := &recordingBackend{out: []byte("1|editor\n")}
+	runner := NewRunner(backend)
+
+	rows, err := runner.ListWindows(context.Background(), ListWindowsOptions{
+		Target:    " dev ",
+		Delimiter: "|",
+		Formats: []string{
+			TmuxFormat("window_index"),
+			TmuxFormat("window_name"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("ListWindows returned error: %v", err)
+	}
+
+	wantArgs := []string{"list-windows", "-t", "dev", "-F", "#{window_index}|#{window_name}"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+	wantRows := [][]string{{"1", "editor"}}
+	if !reflect.DeepEqual(rows, wantRows) {
+		t.Fatalf("ListWindows rows = %#v, want %#v", rows, wantRows)
+	}
+}
+
+func TestRunnerDisplayPaneFieldsBuildsDisplayMessageRead(t *testing.T) {
+	backend := &recordingBackend{out: []byte(" dev \x1f @1 \x1f %3 \n")}
+	runner := NewRunner(backend)
+
+	row, err := runner.DisplayPaneFields(
+		context.Background(),
+		" %3 ",
+		TmuxFormat("session_name"),
+		TmuxFormat("window_id"),
+		TmuxFormat("pane_id"),
+	)
+	if err != nil {
+		t.Fatalf("DisplayPaneFields returned error: %v", err)
+	}
+
+	wantArgs := []string{"display-message", "-p", "-t", "%3", "#{session_name}" + FieldDelimiter + "#{window_id}" + FieldDelimiter + "#{pane_id}"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+	wantRow := []string{"dev", "@1", "%3"}
+	if !reflect.DeepEqual(row, wantRow) {
+		t.Fatalf("DisplayPaneFields row = %#v, want %#v", row, wantRow)
+	}
+}
+
+func TestParseFormatRowsPinsMalformedAndTrimmingBehavior(t *testing.T) {
+	output := []byte("  one \x1f two \r\nmissing\nthree\x1ffour\x1fextra\n five\\037six \n")
+
+	rows := ParseFormatRows(output, FormatRowsOptions{
+		Delimiter:  FieldDelimiter,
+		FieldCount: 2,
+	})
+	want := [][]string{{"one", "two"}, {"five", "six"}}
+	if !reflect.DeepEqual(rows, want) {
+		t.Fatalf("ParseFormatRows strict rows = %#v, want %#v", rows, want)
+	}
+
+	rows = ParseFormatRows(output, FormatRowsOptions{
+		Delimiter:        FieldDelimiter,
+		FieldCount:       2,
+		AllowExtraFields: true,
+	})
+	want = [][]string{{"one", "two"}, {"three", "four"}, {"five", "six"}}
+	if !reflect.DeepEqual(rows, want) {
+		t.Fatalf("ParseFormatRows extra rows = %#v, want %#v", rows, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Completed Phase: Phase 2B — pane/window inventory read slice.
- Added semantic mux APIs: `ListPanes`, `ListWindows`, `DisplayPaneFields`, plus centralized `FieldDelimiter` / `ParseFormatRows` helpers.
- Converted read path surface: AI hook pane matching, tmux bell pane field reads, attention list/window badge reads, and notify queue reconcile.
- Updated `docs/tmux-surface-inventory.md` with Phase 2B capability names and psmux audit mappings for related tmux format variables.

## Explicitly Excluded

- Did not implement Phase 2C interactive command APIs (`display-popup`, `capture-pane`, `switch-client`, `select-pane`, `select-window`).
- Did not implement Phase 2D lifecycle/split/hook APIs (`new-session`, `new-window`, `split-window`, hook installation APIs).
- Did not implement psmux backend support, backend selection model changes, or a native mux engine.
- Did not redesign session-state snapshot schema, replay generation, project/session lifecycle, or tmux production default behavior.

## Verification

- `GOCACHE=/tmp/projmux-go-cache go test ./internal/integrations/mux ./internal/app`
- `GOCACHE=/tmp/projmux-go-cache make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `git diff --check`
- `git diff --cached --check`

## Unverified / Follow-up

- PR CI pending at creation time.
- Manual tmux-real smoke outside Docker integration/e2e was not run.
- Follow-up phases remain Phase 2C interactive command slice, Phase 2D lifecycle/split/hook slice, then Phase 3 psmux parity audit.
