### PR TITLE
feat: extract interactive mux API

### DIFF
--- a/docs/tmux-surface-inventory.md
+++ b/docs/tmux-surface-inventory.md
@@ -94,6 +94,38 @@ to the semantic capability that a future psmux audit/backend must provide.
 | `DisplayPaneFields` bell pane fields | `display-message -p -t <pane>` | `#{session_name}`, `#{window_id}`, `#{window_name}`, `#{pane_id}`, `#{pane_title}`, `#{pane_current_command}`, `#{socket_path}` | tmux bell ingest |
 | `ListWindows` window inventory | `list-windows -F` | `#{window_index}`, `#{window_id}`, `#{window_name}`, `#{window_layout}`, `#{window_panes}`, `#{pane_current_path}` | API available for the existing typed tmux window reads; conversion deferred outside Phase 2B app read slice |
 
+## Phase 2C Interactive Command Slice
+
+Phase 2C adds semantic helpers in `internal/integrations/mux` for the visible
+interactive tmux commands that a future backend must either support or report
+as unsupported:
+
+- `DisplayPopup` covers `display-popup` launch args while preserving the
+  existing tmux option ordering from `BuildDisplayPopupArgs`.
+- `ClosePopup` covers scoped `display-popup [-c <client>] [-t <pane>] -C`
+  close behavior.
+- `CapturePane` covers both `capture-pane -p -J -S <n> -t <pane>` and
+  `capture-pane -p -t <pane> -S <n>` forms.
+- `SwitchClient`, `SelectPane`, and `SelectWindow` cover focus/statusbar
+  navigation commands, including optional `-S <socket>` and `-c <client>`
+  targeting where the current tmux paths use them.
+
+Converted app-layer paths include popup-toggle open/close (including notify
+sidebar popup close-by-client), statusbar path/usage popups and window-list
+passthrough, focus switch/window/pane selection, and AI watch-title joined
+capture.
+
+### Phase 2C psmux Audit Capability Mapping
+
+| Capability | Current tmux command | Converted paths |
+| --- | --- | --- |
+| `DisplayPopup` | `display-popup [-c <client>] [-t <pane>] [-E] [-B] [-d <cwd>] [-e KEY=VALUE] [-x <x>] [-y <y>] [-w <w>] [-h <h>] [-T <title>] <command>` | `tmux popup-toggle`, statusbar path popup, statusbar usage popup |
+| `ClosePopup` | `display-popup [-c <client>] [-t <pane>] -C` | `tmux popup-toggle` close path, including notify sidebar client-scoped close |
+| `CapturePane` | `capture-pane -p -J -S -80 -t <pane>`; `capture-pane -p -t <pane> -S <start>` | AI watch-title capture path converted; generic typed tmux client helper remains a tmux client path |
+| `SwitchClient` | `[-S <socket>] switch-client [-c <client>] -t <session>` | `projmux focus` dispatch |
+| `SelectPane` | `[-S <socket>] select-pane [-T <title>] -t <target>` | `projmux focus` pane selection; title form available for existing pane-title surfaces |
+| `SelectWindow` | `[-S <socket>] select-window -t <target>` | `projmux focus` window selection, statusbar window-list passthrough |
+
 ## Classification Key
 
 | Class | Meaning |
@@ -114,7 +146,7 @@ to the semantic capability that a future psmux audit/backend must provide.
 | `new-session -d -s <session> -c <cwd> [-e KEY=VALUE]` | `required MVP` | `Client.createDetachedSession` | Create detached project sessions. With lifecycle hooks enabled, adds `-P -F "#{pane_id}"` to capture the first pane id. |
 | `new-session -A -s <session> [-c <cwd>]` | `required MVP` | `projmux shell` | Attach/create the isolated app session. Wrapped with `-L <socket> -f <config>`. |
 | `attach-session -t <target>` | `required MVP` | `Client.OpenSession`, `Client.OpenSessionTarget` | Outside-tmux open path. Pane targets degrade to session/window where attach cannot select a pane. |
-| `switch-client [-c <client>] -t <target>` | `required MVP`, `focus` | `Client.OpenSession`, `focusCommand`, generated status key table | Inside-tmux open/focus path. `PROJMUX_SWITCH_TARGET_CLIENT` can force the originating client. |
+| `switch-client [-c <client>] -t <target>` | `required MVP`, `focus` | `Client.OpenSession`, `focusCommand`, generated status key table | Inside-tmux open/focus path. `PROJMUX_SWITCH_TARGET_CLIENT` can force the originating client. Phase 2C mux API: `SwitchClient`. |
 | `list-sessions -F ...` | `required MVP`, `focus`, `e2e/support` | `RecentSessions`, `RecentSessionSummaries`, `ListEphemeralSessions`, `focus`, `tmux apply` | Drives session picker rows, focus fallback, app reload probe, and ephemeral cleanup. |
 | `list-windows -F ...` | `required MVP`, `session-state`, `hooks/status` | `ListSessionWindows`, `runRebalancePanes`, session-state capture/replay | Reads window inventory, window ids, pane counts, layouts. |
 | `list-panes -F ...` | `required MVP`, `hooks/status`, `session-state` | `ListAllPanes`, AI matching, attention list, notify reconcile, session-state capture | Main pane inventory primitive. |
@@ -126,12 +158,12 @@ to the semantic capability that a future psmux audit/backend must provide.
 
 | Command | Class | Production call sites | Purpose / notes |
 | --- | --- | --- | --- |
-| `display-popup ... <command>` | `interactive UI` | `tmux popup-*`, AI picker, hook trust prompt, welcome popup, statusbar pwd/usage popups | Native tmux popup surface. Uses `-E`, `-B`, `-c`, `-t`, `-d`, `-e`, `-x`, `-y`, `-w`, `-h`, `-T` depending on mode. |
-| `display-popup [-c <client>] [-t <pane>] -C` | `interactive UI` | `tmux popup-toggle` | Closes a scoped popup. Notify sidebar close targets client instead of origin pane. |
+| `display-popup ... <command>` | `interactive UI` | `tmux popup-*`, AI picker, hook trust prompt, welcome popup, statusbar pwd/usage popups | Native tmux popup surface. Uses `-E`, `-B`, `-c`, `-t`, `-d`, `-e`, `-x`, `-y`, `-w`, `-h`, `-T` depending on mode. Phase 2C mux API: `DisplayPopup`. |
+| `display-popup [-c <client>] [-t <pane>] -C` | `interactive UI` | `tmux popup-toggle` | Closes a scoped popup. Notify sidebar close targets client instead of origin pane. Phase 2C mux API: `ClosePopup`. |
 | `display-message [message]` | `interactive UI`, `hooks/status` | AI/status/settings/attention/statusbar fallback paths | User-visible toasts and error fallbacks that avoid tmux `run-shell` error popups. |
-| `select-pane -T <title> -t <pane>` | `interactive UI`, `hooks/status`, `session-state` | attention toggle/clear, AI topic/title, `tmux rename-pane`, replay shell wrapper | Sets pane title and topic-adjacent UI metadata. |
-| `select-pane -t <target>` | `focus`, `session-state` | `focusCommand`, session-state replay | Selects target pane after focus or replay. |
-| `select-window -t <target>` | `interactive UI`, `focus`, `session-state` | statusbar window-list passthrough, focus, live replay | Restores native window click behavior and selects replay/focus targets. |
+| `select-pane -T <title> -t <pane>` | `interactive UI`, `hooks/status`, `session-state` | attention toggle/clear, AI topic/title, `tmux rename-pane`, replay shell wrapper | Sets pane title and topic-adjacent UI metadata. Phase 2C mux API: `SelectPane`. |
+| `select-pane -t <target>` | `focus`, `session-state` | `focusCommand`, session-state replay | Selects target pane after focus or replay. Phase 2C mux API: `SelectPane`. |
+| `select-window -t <target>` | `interactive UI`, `focus`, `session-state` | statusbar window-list passthrough, focus, live replay | Restores native window click behavior and selects replay/focus targets. Phase 2C mux API: `SelectWindow`. |
 | `split-window [-h|-v] [-P -F "#{pane_id}"] [-t <pane>] [-c <cwd>] <cmd>` | `required MVP`, `interactive UI` | AI split, session-state replay | Creates AI/shell panes. AI agent split reads the new pane id from `-P -F`. |
 | `resize-pane -t <pane> -x|-y <size>` | `interactive UI` | AI split layout rebalance | Best-effort equal sizing after AI split. |
 | `set-buffer -w -- <text>` | `interactive UI` | Settings copy helpers | Copies generated install/remove/dry-run commands to the tmux clipboard. |
@@ -165,8 +197,8 @@ to the semantic capability that a future psmux audit/backend must provide.
 
 | Command | Class | Production call sites | Purpose / notes |
 | --- | --- | --- | --- |
-| `capture-pane -p -J -S -80 -t <pane>` | `capture`, `hooks/status` | AI watch-title/notification inference | Reads recent pane text joined into logical lines. |
-| `capture-pane -p -t <pane> -S <n>` | `capture`, `required MVP` if generic pane viewer is used | `Client.CapturePane` | Generic typed tmux client capture helper. |
+| `capture-pane -p -J -S -80 -t <pane>` | `capture`, `hooks/status` | AI watch-title/notification inference | Reads recent pane text joined into logical lines. Phase 2C mux API: `CapturePane`. |
+| `capture-pane -p -t <pane> -S <n>` | `capture`, `required MVP` if generic pane viewer is used | `Client.CapturePane` | Generic typed tmux client capture helper. Phase 2C mux API supports this form; typed client conversion remains deferred. |
 | `rename-window -t <target> <name>` | `session-state` | session-state replay | Restores first window name. |
 | `new-window -d -t <target> -c <cwd> [-n <name>] [cmd...]` | `session-state` | session-state replay | Recreates additional windows. |
 | `select-layout -t <target> <layout>` | `session-state` | session-state replay | Restores captured window layouts. |
@@ -328,6 +360,7 @@ Required tmux commands:
 - `display-message -p -F #{client_tty|client_pid|pane_id|#S|pane_current_path|client_width|client_height|@projmux_statusbar_decoration}`
 - `display-popup` with sizing, target/client, env, cwd, border, title, and close-on-exit flags.
 - `display-popup -C` to close toggle popups.
+- Phase 2C mux APIs: `DisplayPopup`, `ClosePopup`.
 
 Dependent generated commands:
 
@@ -345,6 +378,7 @@ Required tmux commands/config:
 - `bind-key s switch-client -T projmux-status`
 - `bind-key -T projmux-status <key> run-shell ...`
 - Runtime handlers: `display-message`, `display-popup`, `select-window`, `show-option`, `list-panes`.
+- Phase 2C mux APIs used by runtime handlers: `DisplayPopup`, `SelectWindow`.
 
 ### Hook
 
@@ -362,6 +396,7 @@ Required tmux commands:
 
 - AI title/watch inference: `capture-pane -p -J -S -80 -t <pane>`.
 - Generic tmux client helper: `capture-pane -p -t <pane> -S <start>`.
+- Phase 2C mux API: `CapturePane`.
 
 psmux audit should check both forms separately because joined-line capture
 (`-J`) is product-visible for AI topic/notification inference.
@@ -377,6 +412,7 @@ Required tmux commands:
 - `select-pane -t <session>:<window>.<pane>`
 - URI translation: `display-message -p -t <pane-id> "#S<sep>#I"`
 - Optional socket wrapper: `tmux -S <socket> ...`
+- Phase 2C mux APIs: `SwitchClient`, `SelectWindow`, `SelectPane`.
 
 ### Session-State
 
@@ -421,29 +457,29 @@ Status values for Phase 3: `pass`, `partial`, `missing`, `unknown`.
 | Capability | tmux command / format surface | Current class | psmux status | Audit notes |
 | --- | --- | --- | --- | --- |
 | Create detached project session | `new-session -d -s -c [-e] [-P -F "#{pane_id}"]` | `required MVP` | `unknown` | Must return first pane id when lifecycle/startup hooks need it. |
-| Attach or switch to session | `attach-session`, `switch-client [-c] -t` | `required MVP`, `focus` | `unknown` | Outside/inside mux behavior may differ on Windows Terminal. |
+| Attach or switch to session | `attach-session`, `switch-client [-c] -t` | `required MVP`, `focus` | `unknown` | Outside/inside mux behavior may differ on Windows Terminal. Phase 2C mux API: `SwitchClient`. |
 | App shell server | `tmux -L <socket> -f <config> new-session -A -s` | `required MVP` | `unknown` | Need socket/server equivalent or explicit unsupported capability. |
 | Session inventory | `list-sessions -F` plus session formats | `required MVP`, `focus` | `unknown` | Requires activity, attached count, windows, ids. |
 | Window inventory | `list-windows -F` plus window formats | `required MVP`, `session-state` | `unknown` | Requires layout and window id for restore/live replay. |
 | Pane inventory | `list-panes -a/-s -F` plus pane/user-option formats | `required MVP`, `hooks/status`, `session-state` | `unknown` | Highest-risk metadata surface. |
-| Popup launch | `display-popup` with target/client/env/cwd/size/border/title/close flags | `interactive UI` | `unknown` | Roadmap already flags popup as a major risk. |
-| Popup close | `display-popup -C` | `interactive UI` | `unknown` | Needed for toggle semantics. |
+| Popup launch | `display-popup` with target/client/env/cwd/size/border/title/close flags | `interactive UI` | `unknown` | Roadmap already flags popup as a major risk. Phase 2C mux API: `DisplayPopup`. |
+| Popup close | `display-popup -C` | `interactive UI` | `unknown` | Needed for toggle semantics. Phase 2C mux API: `ClosePopup`. |
 | Current context formats | `display-message -p -F #{pane_current_path}`, `#{pane_id}`, `#{client_tty}`, `#{client_width}`, `#{client_height}` | `interactive UI` | `unknown` | Popup and AI split depend on these. Phase 2A mux API: `DisplayMessage`, `DisplayMessageTrimmed`. |
 | Focus URI translation | `display-message -p -t %N "#S<sep>#I"` | `focus` | `unknown` | Must map pane id to session/window for toast clicks. |
 | Client inventory | `list-clients -F #{client_name} #{client_session} #{client_active_pane}` | `focus`, `hooks/status` | `unknown` | Needed for focus and reply auto-ack correctness. |
 | Pane split | `split-window -h/-v [-P -F "#{pane_id}"] [-t] [-c] <cmd>` | `required MVP` | `unknown` | MVP AI/shell split requirement. |
 | Resize panes | `resize-pane -x/-y` | `interactive UI` | `unknown` | Can be `partial` if MVP can tolerate default split sizing. |
-| Pane title | `select-pane -T` and `#{pane_title}` | `interactive UI`, `hooks/status` | `unknown` | Used by attention and AI labels. |
+| Pane title | `select-pane -T` and `#{pane_title}` | `interactive UI`, `hooks/status` | `unknown` | Used by attention and AI labels. Phase 2C mux API: `SelectPane`. |
 | Pane options | `set-option -p`, `display-message -p "#{@...}"` | `required MVP`, `hooks/status`, `session-state` | `unknown` | Needs arbitrary user option storage or replacement metadata store. Phase 2A mux API: `SetPaneOption`, `UnsetPaneOption`, `ShowPaneOption`, `PaneOptionFormat`. |
 | Global/session options | `set-option -g`, `show-option -gqv`, `set-option -t -q` | `hooks/status`, `session-state` | `unknown` | Required for settings, decoration, app markers, session-state source. |
 | Generated statusbar | `status`, `status-format`, `#[range=user|...]`, `#(...)`, `#{W:...}` | `hooks/status` | `unknown` | May need a separate psmux-native status model. |
 | Statusbar mouse/key dispatch | `MouseDown1Status`, `if-shell -F`, `switch-client -T`, `run-shell` | `interactive UI`, `hooks/status` | `unknown` | Product UX should degrade explicitly if unsupported. |
 | Hooks | `set-hook`, `show-hooks`, `run-shell -b`, `#{hook_pane}` | `hooks/status` | `unknown` | Alert bell and focus hooks may be unavailable. |
 | Bell fallback | `monitor-bell`, `bell-action`, `alert-bell`, `#{pane_id}` | `hooks/status` | `unknown` | Optional but important for unknown AI tools. |
-| Capture pane | `capture-pane -p`, `capture-pane -p -J` | `capture` | `unknown` | Joined capture is separately audited from raw capture. |
+| Capture pane | `capture-pane -p`, `capture-pane -p -J` | `capture` | `unknown` | Joined capture is separately audited from raw capture. Phase 2C mux API: `CapturePane`. |
 | Session-state replay | `new-window`, `split-window`, `rename-window`, `select-layout`, `select-pane`, `send-keys` | `session-state` | `unknown` | Likely outside psmux MVP except basic create/split. |
-| Live overwrite replay | `move-window`, `kill-window`, `select-window` | `legacy/cleanup candidate` | `unknown` | Candidate to exclude from psmux MVP and possibly remove. |
+| Live overwrite replay | `move-window`, `kill-window`, `select-window` | `legacy/cleanup candidate` | `unknown` | Candidate to exclude from psmux MVP and possibly remove. Phase 2C mux API covers `SelectWindow` only. |
 | Config reload | `source-file`, generated config file semantics | `e2e/support` | `unknown` | Required only if psmux has config-file parity. |
 | Clipboard helper | `set-buffer -w` | `interactive UI` | `unknown` | Settings copy helper can fall back to OS clipboard later. |
-| Socket targeting | `-L <socket>`, `-S <socket>` | `required MVP`, `focus` | `unknown` | psmux equivalent may be named server/session context. |
+| Socket targeting | `-L <socket>`, `-S <socket>` | `required MVP`, `focus` | `unknown` | psmux equivalent may be named server/session context. Phase 2C focus APIs carry `-S <socket>`. |
 | Quoting/process launch | POSIX shell wrappers, tmux config quoting, `run-shell` | `required MVP`, `interactive UI` | `unknown` | Phase 3 must audit PowerShell-native quoting separately. |

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -1611,7 +1611,15 @@ func (c *aiCommand) readAIWatchTitleGate(paneID string) (alive bool, hookActive 
 }
 
 func (c *aiCommand) readAIPaneCapture(paneID string) string {
-	return c.readTrimmed("tmux", "capture-pane", "-p", "-J", "-S", "-80", "-t", paneID)
+	out, err := c.muxRunner().CapturePane(context.Background(), intmux.CapturePaneOptions{
+		Target:    paneID,
+		StartLine: -80,
+		JoinLines: true,
+	})
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
 }
 
 func (c *aiCommand) recordAITopic(paneID, topic, manual string) {

--- a/internal/app/focus.go
+++ b/internal/app/focus.go
@@ -15,6 +15,7 @@ import (
 
 	corefocus "github.com/crevissepartners/projmux/internal/core/focus"
 	"github.com/crevissepartners/projmux/internal/core/notify"
+	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
 )
 
 // focusExitNotResolved is the exit code emitted when an explicit target cannot
@@ -492,26 +493,40 @@ func (c *focusCommand) listClients(ctx context.Context, socket string) ([]focusC
 }
 
 func (c *focusCommand) switchClient(ctx context.Context, socket, clientName, sessionName string) error {
-	tail := []string{"switch-client"}
-	if clientName != "" {
-		tail = append(tail, "-c", clientName)
+	if c.runner == nil {
+		return errors.New("focus runner is not configured")
 	}
-	tail = append(tail, "-t", sessionName)
-	if _, err := c.runner.Run(ctx, "tmux", c.tmuxArgs(socket, tail...)...); err != nil {
+	if err := intmux.NewRunner(c.runner).SwitchClient(ctx, intmux.SwitchClientOptions{
+		Socket: socket,
+		Client: clientName,
+		Target: sessionName,
+	}); err != nil {
 		return fmt.Errorf("focus: switch-client to %q: %w", sessionName, err)
 	}
 	return nil
 }
 
 func (c *focusCommand) selectWindow(ctx context.Context, socket, target string) error {
-	if _, err := c.runner.Run(ctx, "tmux", c.tmuxArgs(socket, "select-window", "-t", target)...); err != nil {
+	if c.runner == nil {
+		return errors.New("focus runner is not configured")
+	}
+	if err := intmux.NewRunner(c.runner).SelectWindow(ctx, intmux.SelectWindowOptions{
+		Socket: socket,
+		Target: target,
+	}); err != nil {
 		return fmt.Errorf("focus: select-window %q: %w", target, err)
 	}
 	return nil
 }
 
 func (c *focusCommand) selectPane(ctx context.Context, socket, target string) error {
-	if _, err := c.runner.Run(ctx, "tmux", c.tmuxArgs(socket, "select-pane", "-t", target)...); err != nil {
+	if c.runner == nil {
+		return errors.New("focus runner is not configured")
+	}
+	if err := intmux.NewRunner(c.runner).SelectPane(ctx, intmux.SelectPaneOptions{
+		Socket: socket,
+		Target: target,
+	}); err != nil {
 		return fmt.Errorf("focus: select-pane %q: %w", target, err)
 	}
 	return nil

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -27,6 +27,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/notify"
 	coreusage "github.com/crevissepartners/projmux/internal/core/usage"
+	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
 	"github.com/crevissepartners/projmux/internal/ui/projmuxpicker"
 )
 
@@ -271,7 +272,7 @@ func (c *statusbarCommand) runClick(args []string, stdout, stderr io.Writer) err
 			return c.handleWindowListClick(opts, stderr)
 		}
 		if idx := windowIndexFromRangeToken(raw); idx != "" {
-			return c.runTmux(stderr, "select-window", "-t", ":"+idx)
+			return c.selectWindow(stderr, ":"+idx)
 		}
 		return nil
 	}
@@ -337,7 +338,7 @@ func (c *statusbarCommand) handleWindowListClick(opts statusbarClickOptions, std
 	if id == "" {
 		return nil
 	}
-	return c.runTmux(stderr, "select-window", "-t", "@"+id)
+	return c.selectWindow(stderr, "@"+id)
 }
 
 // dispatchTable maps each known range id to its click handler. A method on the
@@ -395,14 +396,12 @@ func (c *statusbarCommand) handlePwd(_ statusbarClickOptions, _, stderr io.Write
 	// `-T` border title — `frame.go` renders an identical title bar inline so
 	// duplicating it via tmux chrome would offset the visual header and
 	// double-decorate the surface.
-	if err := c.runTmuxNoFallback(stderr,
-		"display-popup",
-		"-E",
-		"-B",
-		"-w", strconv.Itoa(popup.Width),
-		"-h", strconv.Itoa(popup.Height),
-		popup.Command,
-	); err == nil {
+	if err := c.displayPopupNoFallback(popup.Command, intmux.PopupOptions{
+		NoBorder:      true,
+		Width:         strconv.Itoa(popup.Width),
+		Height:        strconv.Itoa(popup.Height),
+		CloseBehavior: intmux.PopupCloseOnExit,
+	}); err == nil {
 		return nil
 	}
 
@@ -468,14 +467,12 @@ func (c *statusbarCommand) handleUsage(_ statusbarClickOptions, _, stderr io.Wri
 	// chrome (outer box + titlebar + divider) so we drop tmux's `-T` border
 	// title and pass `-B` to suppress tmux's popup border entirely. Mixing
 	// both would double-decorate the popup and offset the geometry.
-	if err := c.runTmuxNoFallback(stderr,
-		"display-popup",
-		"-E",
-		"-B",
-		"-w", strconv.Itoa(popup.Width),
-		"-h", strconv.Itoa(popup.Height),
-		popup.Command,
-	); err == nil {
+	if err := c.displayPopupNoFallback(popup.Command, intmux.PopupOptions{
+		NoBorder:      true,
+		Width:         strconv.Itoa(popup.Width),
+		Height:        strconv.Itoa(popup.Height),
+		CloseBehavior: intmux.PopupCloseOnExit,
+	}); err == nil {
 		return nil
 	}
 	return c.runTmux(stderr, "display-message", popup.Toast)
@@ -1217,6 +1214,23 @@ func (c *statusbarCommand) runTmuxNoFallback(_ io.Writer, args ...string) error 
 	}
 	_, err := c.runner.Run(context.Background(), "tmux", args...)
 	return err
+}
+
+func (c *statusbarCommand) selectWindow(stderr io.Writer, target string) error {
+	if c.runner == nil {
+		return c.runTmux(stderr, "select-window", "-t", target)
+	}
+	if err := intmux.NewRunner(c.runner).SelectWindow(context.Background(), intmux.SelectWindowOptions{Target: target}); err != nil {
+		fmt.Fprintf(stderr, "statusbar: tmux select-window -t %s: %v\n", target, err)
+	}
+	return nil
+}
+
+func (c *statusbarCommand) displayPopupNoFallback(command string, options intmux.PopupOptions) error {
+	if c.runner == nil {
+		return errors.New("statusbar runner is not configured")
+	}
+	return intmux.NewRunner(c.runner).DisplayPopup(context.Background(), command, options)
 }
 
 func printStatusbarUsage(w io.Writer) {

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/crevissepartners/projmux/internal/config"
+	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
 	"github.com/crevissepartners/projmux/internal/integrations/sessionstate"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
@@ -416,12 +417,7 @@ func (c *tmuxCommand) runPopupToggle(args []string, stderr io.Writer) error {
 	if err := os.WriteFile(marker, []byte(popupCtx.OriginPane+"\n"), 0o644); err != nil {
 		return fmt.Errorf("write tmux popup marker: %w", err)
 	}
-	displayArgs, err := inttmux.BuildDisplayPopupArgs(command, options)
-	if err != nil {
-		_ = os.Remove(marker)
-		return err
-	}
-	if _, err := c.runner.Run(ctx, "tmux", displayArgs...); err != nil {
+	if err := intmux.NewRunner(c.runner).DisplayPopup(ctx, command, intmux.PopupOptions(options)); err != nil {
 		_ = os.Remove(marker)
 		if isNoSelectionExit(err) {
 			return nil
@@ -844,15 +840,13 @@ func (c *tmuxCommand) tmuxFormat(ctx context.Context, format string) string {
 }
 
 func (c *tmuxCommand) closePopup(ctx context.Context, targetPane, targetClient string) error {
-	args := []string{"display-popup"}
-	if strings.TrimSpace(targetClient) != "" {
-		args = append(args, "-c", targetClient)
+	if c.runner == nil {
+		return errors.New("configure tmux runner: tmux runner is not configured")
 	}
-	if strings.TrimSpace(targetPane) != "" {
-		args = append(args, "-t", targetPane)
-	}
-	args = append(args, "-C")
-	if _, err := c.runner.Run(ctx, "tmux", args...); err != nil {
+	if err := intmux.NewRunner(c.runner).ClosePopup(ctx, intmux.ClosePopupOptions{
+		Client: targetClient,
+		Target: targetPane,
+	}); err != nil {
 		return fmt.Errorf("close tmux popup: %w", err)
 	}
 	return nil

--- a/internal/integrations/mux/interactive.go
+++ b/internal/integrations/mux/interactive.go
@@ -1,0 +1,160 @@
+package mux
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+)
+
+type PopupOptions = inttmux.PopupOptions
+type PopupCloseBehavior = inttmux.PopupCloseBehavior
+
+const (
+	PopupCloseOnExit = inttmux.PopupCloseOnExit
+	PopupKeepOpen    = inttmux.PopupKeepOpen
+)
+
+// ClosePopupOptions describes a scoped `display-popup -C` close command.
+type ClosePopupOptions struct {
+	Socket string
+	Client string
+	Target string
+}
+
+// CapturePaneOptions describes a `capture-pane -p` read.
+type CapturePaneOptions struct {
+	Socket    string
+	Target    string
+	StartLine int
+	JoinLines bool
+}
+
+// SwitchClientOptions describes a `switch-client` command.
+type SwitchClientOptions struct {
+	Socket string
+	Client string
+	Target string
+}
+
+// SelectPaneOptions describes a `select-pane` command.
+type SelectPaneOptions struct {
+	Socket   string
+	Target   string
+	Title    string
+	SetTitle bool
+}
+
+// SelectWindowOptions describes a `select-window` command.
+type SelectWindowOptions struct {
+	Socket string
+	Target string
+}
+
+// DisplayPopup opens a tmux popup and executes the provided shell command.
+func DisplayPopup(ctx context.Context, command string, options PopupOptions) error {
+	return DefaultRunner().DisplayPopup(ctx, command, options)
+}
+
+// ClosePopup closes a scoped tmux popup.
+func ClosePopup(ctx context.Context, opts ClosePopupOptions) error {
+	return DefaultRunner().ClosePopup(ctx, opts)
+}
+
+// CapturePane reads visible text from a tmux pane.
+func CapturePane(ctx context.Context, opts CapturePaneOptions) (string, error) {
+	return DefaultRunner().CapturePane(ctx, opts)
+}
+
+// SwitchClient switches a tmux client to the target.
+func SwitchClient(ctx context.Context, opts SwitchClientOptions) error {
+	return DefaultRunner().SwitchClient(ctx, opts)
+}
+
+// SelectPane selects or retitles a tmux pane.
+func SelectPane(ctx context.Context, opts SelectPaneOptions) error {
+	return DefaultRunner().SelectPane(ctx, opts)
+}
+
+// SelectWindow selects a tmux window.
+func SelectWindow(ctx context.Context, opts SelectWindowOptions) error {
+	return DefaultRunner().SelectWindow(ctx, opts)
+}
+
+// DisplayPopup opens a tmux popup and executes the provided shell command.
+func (r Runner) DisplayPopup(ctx context.Context, command string, options PopupOptions) error {
+	args, err := inttmux.BuildDisplayPopupArgs(command, options)
+	if err != nil {
+		return err
+	}
+	return r.Run(ctx, args...)
+}
+
+// ClosePopup closes a scoped tmux popup.
+func (r Runner) ClosePopup(ctx context.Context, opts ClosePopupOptions) error {
+	args := appendSocketArgs(nil, opts.Socket)
+	args = append(args, "display-popup")
+	if client := strings.TrimSpace(opts.Client); client != "" {
+		args = append(args, "-c", client)
+	}
+	if target := strings.TrimSpace(opts.Target); target != "" {
+		args = append(args, "-t", target)
+	}
+	args = append(args, "-C")
+	return r.Run(ctx, args...)
+}
+
+// CapturePane reads visible text from a tmux pane.
+func (r Runner) CapturePane(ctx context.Context, opts CapturePaneOptions) (string, error) {
+	args := appendSocketArgs(nil, opts.Socket)
+	args = append(args, "capture-pane", "-p")
+	if opts.JoinLines {
+		args = append(args, "-J", "-S", strconv.Itoa(opts.StartLine))
+		args = appendPaneTargetArgs(args, opts.Target)
+	} else {
+		args = appendPaneTargetArgs(args, opts.Target)
+		args = append(args, "-S", strconv.Itoa(opts.StartLine))
+	}
+	out, err := r.Read(ctx, args...)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(out), "\r\n"), nil
+}
+
+// SwitchClient switches a tmux client to the target.
+func (r Runner) SwitchClient(ctx context.Context, opts SwitchClientOptions) error {
+	args := appendSocketArgs(nil, opts.Socket)
+	args = append(args, "switch-client")
+	if client := strings.TrimSpace(opts.Client); client != "" {
+		args = append(args, "-c", client)
+	}
+	args = append(args, "-t", strings.TrimSpace(opts.Target))
+	return r.Run(ctx, args...)
+}
+
+// SelectPane selects or retitles a tmux pane.
+func (r Runner) SelectPane(ctx context.Context, opts SelectPaneOptions) error {
+	args := appendSocketArgs(nil, opts.Socket)
+	args = append(args, "select-pane")
+	if opts.SetTitle {
+		args = append(args, "-T", opts.Title)
+	}
+	args = appendPaneTargetArgs(args, opts.Target)
+	return r.Run(ctx, args...)
+}
+
+// SelectWindow selects a tmux window.
+func (r Runner) SelectWindow(ctx context.Context, opts SelectWindowOptions) error {
+	args := appendSocketArgs(nil, opts.Socket)
+	args = append(args, "select-window", "-t", strings.TrimSpace(opts.Target))
+	return r.Run(ctx, args...)
+}
+
+func appendSocketArgs(args []string, socket string) []string {
+	if resolved := strings.TrimSpace(socket); resolved != "" {
+		args = append(args, "-S", resolved)
+	}
+	return args
+}

--- a/internal/integrations/mux/runner_test.go
+++ b/internal/integrations/mux/runner_test.go
@@ -255,6 +255,153 @@ func TestRunnerDisplayPaneFieldsBuildsDisplayMessageRead(t *testing.T) {
 	}
 }
 
+func TestRunnerDisplayPopupBuildsExistingPopupArgs(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	err := runner.DisplayPopup(context.Background(), "printf hello", PopupOptions{
+		Target:        "%4",
+		Cwd:           "/repo",
+		Env:           map[string]string{"PROJMUX_PICKER_BACKEND": "native"},
+		NoBorder:      true,
+		X:             "0",
+		Y:             "0",
+		Width:         "40",
+		Height:        "20",
+		CloseBehavior: PopupCloseOnExit,
+	})
+	if err != nil {
+		t.Fatalf("DisplayPopup returned error: %v", err)
+	}
+
+	wantArgs := []string{
+		"display-popup",
+		"-t", "%4",
+		"-E",
+		"-B",
+		"-d", "/repo",
+		"-e", "PROJMUX_PICKER_BACKEND=native",
+		"-x", "0",
+		"-y", "0",
+		"-w", "40",
+		"-h", "20",
+		"printf hello",
+	}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+}
+
+func TestRunnerClosePopupBuildsScopedCloseArgs(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	if err := runner.ClosePopup(context.Background(), ClosePopupOptions{
+		Client: " /dev/pts/7 ",
+		Target: " %4 ",
+	}); err != nil {
+		t.Fatalf("ClosePopup returned error: %v", err)
+	}
+
+	wantArgs := []string{"display-popup", "-c", "/dev/pts/7", "-t", "%4", "-C"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+}
+
+func TestRunnerCapturePaneBuildsExistingJoinedCaptureArgs(t *testing.T) {
+	backend := &recordingBackend{out: []byte(" line one \n")}
+	runner := NewRunner(backend)
+
+	got, err := runner.CapturePane(context.Background(), CapturePaneOptions{
+		Target:    "%8",
+		StartLine: -80,
+		JoinLines: true,
+	})
+	if err != nil {
+		t.Fatalf("CapturePane returned error: %v", err)
+	}
+
+	wantArgs := []string{"capture-pane", "-p", "-J", "-S", "-80", "-t", "%8"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+	if got != " line one " {
+		t.Fatalf("CapturePane = %q, want line with only trailing newline trimmed", got)
+	}
+}
+
+func TestRunnerCapturePaneBuildsExistingGenericCaptureArgs(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	if _, err := runner.CapturePane(context.Background(), CapturePaneOptions{
+		Target:    "%8",
+		StartLine: -80,
+	}); err != nil {
+		t.Fatalf("CapturePane returned error: %v", err)
+	}
+
+	wantArgs := []string{"capture-pane", "-p", "-t", "%8", "-S", "-80"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+}
+
+func TestRunnerSwitchClientBuildsSocketScopedArgs(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	if err := runner.SwitchClient(context.Background(), SwitchClientOptions{
+		Socket: "/tmp/projmux.sock",
+		Client: "/dev/pts/9",
+		Target: "workspace",
+	}); err != nil {
+		t.Fatalf("SwitchClient returned error: %v", err)
+	}
+
+	wantArgs := []string{"-S", "/tmp/projmux.sock", "switch-client", "-c", "/dev/pts/9", "-t", "workspace"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+}
+
+func TestRunnerSelectPaneBuildsTargetAndTitleArgs(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	if err := runner.SelectPane(context.Background(), SelectPaneOptions{
+		Socket:   "/tmp/projmux.sock",
+		Target:   "%9",
+		Title:    "",
+		SetTitle: true,
+	}); err != nil {
+		t.Fatalf("SelectPane returned error: %v", err)
+	}
+
+	wantArgs := []string{"-S", "/tmp/projmux.sock", "select-pane", "-T", "", "-t", "%9"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+}
+
+func TestRunnerSelectWindowBuildsSocketScopedArgs(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	if err := runner.SelectWindow(context.Background(), SelectWindowOptions{
+		Socket: "/tmp/projmux.sock",
+		Target: "workspace:1",
+	}); err != nil {
+		t.Fatalf("SelectWindow returned error: %v", err)
+	}
+
+	wantArgs := []string{"-S", "/tmp/projmux.sock", "select-window", "-t", "workspace:1"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+}
+
 func TestParseFormatRowsPinsMalformedAndTrimmingBehavior(t *testing.T) {
 	output := []byte("  one \x1f two \r\nmissing\nthree\x1ffour\x1fextra\n five\\037six \n")
 


### PR DESCRIPTION
## Completed Phase

- Phase 2C — interactive command slice.

## Interactive User-Facing Surfaces Updated

- `tmux popup-toggle` open/close paths now use semantic mux APIs, including notify sidebar client-scoped popup close.
- Statusbar path and usage popups now use `DisplayPopup`.
- Statusbar window-list passthrough now uses `SelectWindow`.
- `projmux focus` dispatch now uses `SwitchClient`, `SelectWindow`, and `SelectPane`.
- AI watch-title joined capture now uses `CapturePane`.

## Semantic Mux APIs Added

- `DisplayPopup`
- `ClosePopup`
- `CapturePane`
- `SwitchClient`
- `SelectPane`
- `SelectWindow`

## Explicitly Excluded

- Phase 2D lifecycle / split / hook APIs were not implemented.
- No `new-session`, `new-window`, `split-window`, hook install, psmux backend, native mux engine, or Windows-native process launch redesign was added.
- Popup UI behavior, focus policy, OS focus adapter, session-state schema, replay engine, and project/session lifecycle were not redesigned.

## Inventory Docs

- Updated `docs/tmux-surface-inventory.md` with Phase 2C capability names and psmux audit matrix mappings for popup, close, capture, switch, pane selection, and window selection.
- Documented that generic typed `Client.CapturePane` remains on the existing tmux client path while the new `CapturePane` API supports that command form.

## Verification

- `GOCACHE=/tmp/projmux-go-cache make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `git diff --check`

## Unverified / Follow-Up

- No unverified local validation remains for this slice.
- Follow-up phases: Phase 2D lifecycle / split / hook slice, then Phase 3 psmux parity audit.
