### PR TITLE
feat: extract mux lifecycle split hook APIs

### DIFF
--- a/docs/tmux-surface-inventory.md
+++ b/docs/tmux-surface-inventory.md
@@ -126,6 +126,35 @@ capture.
 | `SelectPane` | `[-S <socket>] select-pane [-T <title>] -t <target>` | `projmux focus` pane selection; title form available for existing pane-title surfaces |
 | `SelectWindow` | `[-S <socket>] select-window -t <target>` | `projmux focus` window selection, statusbar window-list passthrough |
 
+## Phase 2D Lifecycle / Split / Hook Slice
+
+Phase 2D adds semantic helpers in `internal/integrations/mux` for tmux
+lifecycle, pane split, hook, and global/session option commands:
+
+- `NewSession` covers `new-session` lifecycle args, including detached or
+  attach/create mode, socket/config prefixes, session name, cwd, sorted
+  environment injection, optional pane id return via `-P -F "#{pane_id}"`, and
+  an optional command tail.
+- `SplitWindow` covers `split-window -h/-v`, detached splits, target, cwd,
+  optional pane id return via `-P -F "#{pane_id}"`, and command tail ordering.
+- `SetHook` covers global append and unset forms used by tmux bell integration.
+- `SetOption` and `ShowOption` cover global/session option writes and reads
+  where runtime code needs structured option commands rather than raw argv.
+
+Converted paths include project session creation, AI agent/shell split, and
+tmux bell integration option/hook install and removal. Session-state replay
+creation remains on the existing typed tmux path in this phase.
+
+### Phase 2D psmux Audit Capability Mapping
+
+| Capability | Current tmux command | Converted paths |
+| --- | --- | --- |
+| `NewSession` | `[-S <socket>] [-f <config>] new-session [-d] [-A] [-s <session>] [-c <cwd>] [-e KEY=VALUE] [-P -F "#{pane_id}"] [command...]` | Project session create, including lifecycle startup pane id capture |
+| `SplitWindow` | `split-window [-d] [-P -F "#{pane_id}"] [-h/-v] [-t <target>] [-c <cwd>] [command...]` | AI agent split, AI shell split |
+| `SetHook` | `set-hook -ag <hook> <command>`, `set-hook -gu <hook[index]>` | `projmux ai integrate tmux-bell` install/remove |
+| `SetOption` | `set-option -g <option> <value>`, `set-option -t <session> -q <option> <value>` | tmux bell integration option install; API available for session-scoped markers |
+| `ShowOption` | `show-option [-g] [-q] [-v] [-t <target>] <option>` | API available for global/session option reads; conversion deferred to low-risk call sites |
+
 ## Classification Key
 
 | Class | Meaning |
@@ -143,8 +172,8 @@ capture.
 | Command | Class | Production call sites | Purpose / notes |
 | --- | --- | --- | --- |
 | `has-session -t <target>` | `required MVP` | `Client.sessionExists`, `tmuxSessionExists` | Check whether a project/app session exists before create/open. |
-| `new-session -d -s <session> -c <cwd> [-e KEY=VALUE]` | `required MVP` | `Client.createDetachedSession` | Create detached project sessions. With lifecycle hooks enabled, adds `-P -F "#{pane_id}"` to capture the first pane id. |
-| `new-session -A -s <session> [-c <cwd>]` | `required MVP` | `projmux shell` | Attach/create the isolated app session. Wrapped with `-L <socket> -f <config>`. |
+| `new-session -d -s <session> -c <cwd> [-e KEY=VALUE]` | `required MVP` | `Client.createDetachedSession` | Create detached project sessions. With lifecycle hooks enabled, adds `-P -F "#{pane_id}"` to capture the first pane id. Phase 2D mux API: `NewSession`. |
+| `new-session -A -s <session> [-c <cwd>]` | `required MVP` | `projmux shell` | Attach/create the isolated app session. Wrapped with `-L <socket> -f <config>`. Phase 2D mux API available: `NewSession`. |
 | `attach-session -t <target>` | `required MVP` | `Client.OpenSession`, `Client.OpenSessionTarget` | Outside-tmux open path. Pane targets degrade to session/window where attach cannot select a pane. |
 | `switch-client [-c <client>] -t <target>` | `required MVP`, `focus` | `Client.OpenSession`, `focusCommand`, generated status key table | Inside-tmux open/focus path. `PROJMUX_SWITCH_TARGET_CLIENT` can force the originating client. Phase 2C mux API: `SwitchClient`. |
 | `list-sessions -F ...` | `required MVP`, `focus`, `e2e/support` | `RecentSessions`, `RecentSessionSummaries`, `ListEphemeralSessions`, `focus`, `tmux apply` | Drives session picker rows, focus fallback, app reload probe, and ephemeral cleanup. |
@@ -164,7 +193,7 @@ capture.
 | `select-pane -T <title> -t <pane>` | `interactive UI`, `hooks/status`, `session-state` | attention toggle/clear, AI topic/title, `tmux rename-pane`, replay shell wrapper | Sets pane title and topic-adjacent UI metadata. Phase 2C mux API: `SelectPane`. |
 | `select-pane -t <target>` | `focus`, `session-state` | `focusCommand`, session-state replay | Selects target pane after focus or replay. Phase 2C mux API: `SelectPane`. |
 | `select-window -t <target>` | `interactive UI`, `focus`, `session-state` | statusbar window-list passthrough, focus, live replay | Restores native window click behavior and selects replay/focus targets. Phase 2C mux API: `SelectWindow`. |
-| `split-window [-h|-v] [-P -F "#{pane_id}"] [-t <pane>] [-c <cwd>] <cmd>` | `required MVP`, `interactive UI` | AI split, session-state replay | Creates AI/shell panes. AI agent split reads the new pane id from `-P -F`. |
+| `split-window [-h|-v] [-P -F "#{pane_id}"] [-t <pane>] [-c <cwd>] <cmd>` | `required MVP`, `interactive UI` | AI split, session-state replay | Creates AI/shell panes. AI agent split reads the new pane id from `-P -F`. Phase 2D mux API: `SplitWindow` for AI splits; session-state replay remains on the typed tmux path. |
 | `resize-pane -t <pane> -x|-y <size>` | `interactive UI` | AI split layout rebalance | Best-effort equal sizing after AI split. |
 | `set-buffer -w -- <text>` | `interactive UI` | Settings copy helpers | Copies generated install/remove/dry-run commands to the tmux clipboard. |
 | `command-prompt` | `interactive UI` | generated keymap | Prompt-based rename/topic actions in generated config. |
@@ -181,13 +210,13 @@ capture.
 | `set-hook -g after-select-pane run-shell -b ...` | `hooks/status` | generated standalone/app config | Clears attention on selected pane. Uses `#{pane_id}`. |
 | `set-hook -g pane-exited` / `after-kill-pane` | `hooks/status` | generated standalone/app config | Calls `projmux tmux rebalance-panes` after pane removal. |
 | `set-hook -g client-attached` | `hooks/status` | generated app config | Opens the welcome popup once after client attach. |
-| `set-hook -ag alert-bell ...` | `hooks/status` | `projmux ai integrate tmux-bell` | Installs bell fallback to `projmux ai ingest bell --pane "#{pane_id}"`. |
-| `set-hook -gu alert-bell[...]` | `legacy/cleanup candidate`, `hooks/status` | `projmux ai integrate tmux-bell --remove` | Removes projmux-managed alert-bell entries. |
+| `set-hook -ag alert-bell ...` | `hooks/status` | `projmux ai integrate tmux-bell` | Installs bell fallback to `projmux ai ingest bell --pane "#{pane_id}"`. Phase 2D mux API: `SetHook`. |
+| `set-hook -gu alert-bell[...]` | `legacy/cleanup candidate`, `hooks/status` | `projmux ai integrate tmux-bell --remove` | Removes projmux-managed alert-bell entries. Phase 2D mux API: `SetHook`. |
 | `show-hooks -g alert-bell` | `hooks/status` | tmux bell integration planning | Detects existing managed bell fallback. |
 | `run-shell -b <command>` | `hooks/status`, `interactive UI` | generated hooks, generated statusbar binds, AI watch-title | Async hook/status dispatch and title watcher launch. |
-| `show-option -gqv <option>` | `hooks/status`, `legacy/cleanup candidate` | notification mode, statusbar decoration, `@projmux_projdir`, app ownership | Reads global user options and generated app markers. Some call sites still use direct `exec.Command("tmux", ...)`. |
-| `show-option -gv @projmux_app` | `required MVP` for app quit | `quitCommand` | Confirms a socket is app-owned before `kill-server`. |
-| `set-option -g <option> <value>` | `hooks/status` | settings, notification registration, generated config, tmux bell integration | Writes statusbar decoration, desktop notify mode markers, toast URI markers, and tmux bell options. |
+| `show-option -gqv <option>` | `hooks/status`, `legacy/cleanup candidate` | notification mode, statusbar decoration, `@projmux_projdir`, app ownership | Reads global user options and generated app markers. Some call sites still use direct `exec.Command("tmux", ...)`. Phase 2D mux API available: `ShowOption`. |
+| `show-option -gv @projmux_app` | `required MVP` for app quit | `quitCommand` | Confirms a socket is app-owned before `kill-server`. Phase 2D mux API available: `ShowOption`. |
+| `set-option -g <option> <value>` | `hooks/status` | settings, notification registration, generated config, tmux bell integration | Writes statusbar decoration, desktop notify mode markers, toast URI markers, and tmux bell options. Phase 2D mux API: `SetOption` for tmux bell integration. |
 | `set-option -g -u <option>` | `legacy/cleanup candidate` | notification URI migration | Unsets older URI registration markers. |
 | `set-option -p [-u] -t <pane> <option> [value]` | `hooks/status`, `required MVP` for AI | AI state, attention, topics, notification dedupe, session-state recipe metadata | Core pane metadata storage. Phase 2A mux API: `SetPaneOption`, `UnsetPaneOption`. |
 | `set-option -t <session> -q <option> <value>` | `session-state`, `required MVP` | session autosave/source, ephemeral sessions | Stores session-level live markers. |
@@ -456,9 +485,9 @@ Status values for Phase 3: `pass`, `partial`, `missing`, `unknown`.
 
 | Capability | tmux command / format surface | Current class | psmux status | Audit notes |
 | --- | --- | --- | --- | --- |
-| Create detached project session | `new-session -d -s -c [-e] [-P -F "#{pane_id}"]` | `required MVP` | `unknown` | Must return first pane id when lifecycle/startup hooks need it. |
+| Create detached project session | `new-session -d -s -c [-e] [-P -F "#{pane_id}"]` | `required MVP` | `unknown` | Must return first pane id when lifecycle/startup hooks need it. Phase 2D mux API: `NewSession`. |
 | Attach or switch to session | `attach-session`, `switch-client [-c] -t` | `required MVP`, `focus` | `unknown` | Outside/inside mux behavior may differ on Windows Terminal. Phase 2C mux API: `SwitchClient`. |
-| App shell server | `tmux -L <socket> -f <config> new-session -A -s` | `required MVP` | `unknown` | Need socket/server equivalent or explicit unsupported capability. |
+| App shell server | `tmux -L <socket> -f <config> new-session -A -s` | `required MVP` | `unknown` | Need socket/server equivalent or explicit unsupported capability. Phase 2D mux API available: `NewSession`. |
 | Session inventory | `list-sessions -F` plus session formats | `required MVP`, `focus` | `unknown` | Requires activity, attached count, windows, ids. |
 | Window inventory | `list-windows -F` plus window formats | `required MVP`, `session-state` | `unknown` | Requires layout and window id for restore/live replay. |
 | Pane inventory | `list-panes -a/-s -F` plus pane/user-option formats | `required MVP`, `hooks/status`, `session-state` | `unknown` | Highest-risk metadata surface. |
@@ -467,15 +496,15 @@ Status values for Phase 3: `pass`, `partial`, `missing`, `unknown`.
 | Current context formats | `display-message -p -F #{pane_current_path}`, `#{pane_id}`, `#{client_tty}`, `#{client_width}`, `#{client_height}` | `interactive UI` | `unknown` | Popup and AI split depend on these. Phase 2A mux API: `DisplayMessage`, `DisplayMessageTrimmed`. |
 | Focus URI translation | `display-message -p -t %N "#S<sep>#I"` | `focus` | `unknown` | Must map pane id to session/window for toast clicks. |
 | Client inventory | `list-clients -F #{client_name} #{client_session} #{client_active_pane}` | `focus`, `hooks/status` | `unknown` | Needed for focus and reply auto-ack correctness. |
-| Pane split | `split-window -h/-v [-P -F "#{pane_id}"] [-t] [-c] <cmd>` | `required MVP` | `unknown` | MVP AI/shell split requirement. |
+| Pane split | `split-window -h/-v [-P -F "#{pane_id}"] [-t] [-c] <cmd>` | `required MVP` | `unknown` | MVP AI/shell split requirement. Phase 2D mux API: `SplitWindow`. |
 | Resize panes | `resize-pane -x/-y` | `interactive UI` | `unknown` | Can be `partial` if MVP can tolerate default split sizing. |
 | Pane title | `select-pane -T` and `#{pane_title}` | `interactive UI`, `hooks/status` | `unknown` | Used by attention and AI labels. Phase 2C mux API: `SelectPane`. |
 | Pane options | `set-option -p`, `display-message -p "#{@...}"` | `required MVP`, `hooks/status`, `session-state` | `unknown` | Needs arbitrary user option storage or replacement metadata store. Phase 2A mux API: `SetPaneOption`, `UnsetPaneOption`, `ShowPaneOption`, `PaneOptionFormat`. |
-| Global/session options | `set-option -g`, `show-option -gqv`, `set-option -t -q` | `hooks/status`, `session-state` | `unknown` | Required for settings, decoration, app markers, session-state source. |
+| Global/session options | `set-option -g`, `show-option -gqv`, `set-option -t -q` | `hooks/status`, `session-state` | `unknown` | Required for settings, decoration, app markers, session-state source. Phase 2D mux APIs: `SetOption`, `ShowOption`. |
 | Generated statusbar | `status`, `status-format`, `#[range=user|...]`, `#(...)`, `#{W:...}` | `hooks/status` | `unknown` | May need a separate psmux-native status model. |
 | Statusbar mouse/key dispatch | `MouseDown1Status`, `if-shell -F`, `switch-client -T`, `run-shell` | `interactive UI`, `hooks/status` | `unknown` | Product UX should degrade explicitly if unsupported. |
-| Hooks | `set-hook`, `show-hooks`, `run-shell -b`, `#{hook_pane}` | `hooks/status` | `unknown` | Alert bell and focus hooks may be unavailable. |
-| Bell fallback | `monitor-bell`, `bell-action`, `alert-bell`, `#{pane_id}` | `hooks/status` | `unknown` | Optional but important for unknown AI tools. |
+| Hooks | `set-hook`, `show-hooks`, `run-shell -b`, `#{hook_pane}` | `hooks/status` | `unknown` | Alert bell and focus hooks may be unavailable. Phase 2D mux API: `SetHook`. |
+| Bell fallback | `monitor-bell`, `bell-action`, `alert-bell`, `#{pane_id}` | `hooks/status` | `unknown` | Optional but important for unknown AI tools. Phase 2D mux APIs: `SetOption`, `SetHook`. |
 | Capture pane | `capture-pane -p`, `capture-pane -p -J` | `capture` | `unknown` | Joined capture is separately audited from raw capture. Phase 2C mux API: `CapturePane`. |
 | Session-state replay | `new-window`, `split-window`, `rename-window`, `select-layout`, `select-pane`, `send-keys` | `session-state` | `unknown` | Likely outside psmux MVP except basic create/split. |
 | Live overwrite replay | `move-window`, `kill-window`, `select-window` | `legacy/cleanup candidate` | `unknown` | Candidate to exclude from psmux MVP and possibly remove. Phase 2C mux API covers `SelectWindow` only. |

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"syscall"
@@ -861,20 +862,20 @@ func (c *aiCommand) runAgentSplitWithExtraArgs(mode, direction string, extraArgs
 		return c.run(commandShell, "-lc", command)
 	}
 
-	splitFlag := "-h"
+	splitDirection := intmux.SplitRight
 	if direction == "down" {
-		splitFlag = "-v"
+		splitDirection = intmux.SplitDown
 	}
-	args := []string{"split-window", "-P", "-F", "#{pane_id}", splitFlag, "-t", targetPane}
-	if contextDir != "" {
-		args = append(args, "-c", contextDir)
-	}
-	args = append(args, commandShell, "-lc", command)
-	out, err := c.read("tmux", args...)
+	paneID, err := c.muxRunner().SplitWindow(context.Background(), intmux.SplitWindowOptions{
+		ReturnPaneID: true,
+		Direction:    splitDirection,
+		Target:       targetPane,
+		Cwd:          contextDir,
+		Command:      []string{commandShell, "-lc", command},
+	})
 	if err != nil {
 		return err
 	}
-	paneID := strings.TrimSpace(string(out))
 	c.configureAIPane(paneID, mode, contextDir, title)
 	c.applySplitLayout(targetPane, direction)
 	c.startAIWatchTitle(paneID)
@@ -901,20 +902,18 @@ func (c *aiCommand) agentExecArgv(mode string, extraArgs []string) ([]string, st
 func (c *aiCommand) runShellSplit(direction string) error {
 	targetPane := c.resolveTargetPane()
 	contextDir := c.resolveContextDir()
-	splitFlag := "-h"
+	splitDirection := intmux.SplitRight
 	if direction == "down" {
-		splitFlag = "-v"
+		splitDirection = intmux.SplitDown
 	}
 
-	args := []string{"split-window", splitFlag}
-	if targetPane != "" {
-		args = append(args, "-t", targetPane)
-	}
-	if contextDir != "" {
-		args = append(args, "-c", contextDir)
-	}
-	args = append(args, loginShellCommand(defaultInteractiveShell(c.lookupEnv))...)
-	if err := c.run("tmux", args...); err != nil {
+	_, err := c.muxRunner().SplitWindow(context.Background(), intmux.SplitWindowOptions{
+		Direction: splitDirection,
+		Target:    targetPane,
+		Cwd:       contextDir,
+		Command:   loginShellCommand(defaultInteractiveShell(c.lookupEnv)),
+	})
+	if err != nil {
 		return err
 	}
 	c.applySplitLayout(targetPane, direction)
@@ -1338,16 +1337,31 @@ type aiCommandMuxBackend struct {
 }
 
 func (b aiCommandMuxBackend) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
-	if name == "tmux" && len(args) > 0 && args[0] == "set-option" {
-		if b.runCommand == nil {
-			return nil, errors.New("ai command runner is not configured")
+	if name == "tmux" && !aiMuxCommandNeedsOutput(args) {
+		if b.runCommand != nil {
+			return nil, b.runCommand(ctx, name, args...)
 		}
-		return nil, b.runCommand(ctx, name, args...)
+		return nil, errors.New("ai command runner is not configured")
 	}
 	if b.readCommand == nil {
 		return nil, errors.New("ai command reader is not configured")
 	}
 	return b.readCommand(ctx, name, args...)
+}
+
+func aiMuxCommandNeedsOutput(args []string) bool {
+	if len(args) == 0 {
+		return true
+	}
+	switch args[0] {
+	case "display-message", "list-panes", "list-windows", "capture-pane", "show-option", "show-hooks":
+		return true
+	case "split-window", "new-session":
+		if slices.Contains(args[1:], "-P") {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *aiCommand) readTrimmed(name string, args ...string) string {

--- a/internal/app/ai_integrate.go
+++ b/internal/app/ai_integrate.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -9,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
 )
 
 const (
@@ -95,12 +98,38 @@ func (c *aiCommand) runIntegrateTmuxBell(args []string, stdout, stderr io.Writer
 		commands = plan.removeCommands
 	}
 	for _, args := range commands {
-		if err := c.run("tmux", args...); err != nil {
+		if err := c.runTmuxBellCommand(args); err != nil {
 			return fmt.Errorf("tmux %s: %w", strings.Join(args, " "), err)
 		}
 	}
 	_, err := fmt.Fprintf(stdout, "%s\n", plan.action)
 	return err
+}
+
+func (c *aiCommand) runTmuxBellCommand(args []string) error {
+	if len(args) == 4 && args[0] == "set-option" && args[1] == "-g" {
+		return c.muxRunner().SetOption(context.Background(), intmux.SetOptionOptions{
+			Global: true,
+			Option: args[2],
+			Value:  args[3],
+		})
+	}
+	if len(args) == 4 && args[0] == "set-hook" && args[1] == "-ag" {
+		return c.muxRunner().SetHook(context.Background(), intmux.SetHookOptions{
+			Global:  true,
+			Append:  true,
+			Hook:    args[2],
+			Command: args[3],
+		})
+	}
+	if len(args) == 3 && args[0] == "set-hook" && args[1] == "-gu" {
+		return c.muxRunner().SetHook(context.Background(), intmux.SetHookOptions{
+			Global: true,
+			Unset:  true,
+			Hook:   args[2],
+		})
+	}
+	return c.run("tmux", args...)
 }
 
 func (c *aiCommand) runIntegrateClaude(args []string, stdout, stderr io.Writer) error {

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -2140,6 +2140,24 @@ func TestBuildRegisterToastAppIDShortcutTargetIsCmdExe(t *testing.T) {
 	}
 }
 
+func TestAICommandMuxBackendNonOutputCommandRequiresRunner(t *testing.T) {
+	readerCalled := false
+	backend := aiCommandMuxBackend{
+		readCommand: func(context.Context, string, ...string) ([]byte, error) {
+			readerCalled = true
+			return []byte("unexpected"), nil
+		},
+	}
+
+	_, err := backend.Run(context.Background(), "tmux", "set-hook", "-ag", "alert-bell", "run-shell -b true")
+	if err == nil || err.Error() != "ai command runner is not configured" {
+		t.Fatalf("Run error = %v, want ai command runner is not configured", err)
+	}
+	if readerCalled {
+		t.Fatal("readCommand called for non-output mux command")
+	}
+}
+
 // TestBuildRegisterToastAppIDDoesNotSetToastActivatorCLSID guards against a
 // well-meaning "fix" that adds PKEY_AppUserModel_ToastActivatorCLSID
 // (pid=26) to the shortcut. Setting that property routes Windows toast

--- a/internal/integrations/mux/interactive.go
+++ b/internal/integrations/mux/interactive.go
@@ -2,19 +2,36 @@ package mux
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"strings"
-
-	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
-type PopupOptions = inttmux.PopupOptions
-type PopupCloseBehavior = inttmux.PopupCloseBehavior
+var (
+	ErrPopupCommandRequired      = errors.New("tmux popup command is required")
+	ErrPopupCloseBehaviorInvalid = errors.New("tmux popup close behavior is invalid")
+)
+
+type PopupCloseBehavior string
 
 const (
-	PopupCloseOnExit = inttmux.PopupCloseOnExit
-	PopupKeepOpen    = inttmux.PopupKeepOpen
+	PopupCloseOnExit PopupCloseBehavior = "close-on-exit"
+	PopupKeepOpen    PopupCloseBehavior = "keep-open"
 )
+
+type PopupOptions struct {
+	Client        string
+	Target        string
+	Cwd           string
+	Env           map[string]string
+	NoBorder      bool
+	X             string
+	Y             string
+	Width         string
+	Height        string
+	Title         string
+	CloseBehavior PopupCloseBehavior
+}
 
 // ClosePopupOptions describes a scoped `display-popup -C` close command.
 type ClosePopupOptions struct {
@@ -84,11 +101,59 @@ func SelectWindow(ctx context.Context, opts SelectWindowOptions) error {
 
 // DisplayPopup opens a tmux popup and executes the provided shell command.
 func (r Runner) DisplayPopup(ctx context.Context, command string, options PopupOptions) error {
-	args, err := inttmux.BuildDisplayPopupArgs(command, options)
+	args, err := BuildDisplayPopupArgs(command, options)
 	if err != nil {
 		return err
 	}
 	return r.Run(ctx, args...)
+}
+
+// BuildDisplayPopupArgs maps structured popup options to tmux display-popup args.
+func BuildDisplayPopupArgs(command string, options PopupOptions) ([]string, error) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return nil, ErrPopupCommandRequired
+	}
+
+	resolved, err := resolvePopupOptions(options)
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{"display-popup"}
+	if resolved.Client != "" {
+		args = append(args, "-c", resolved.Client)
+	}
+	if resolved.Target != "" {
+		args = append(args, "-t", resolved.Target)
+	}
+	if resolved.CloseBehavior == PopupCloseOnExit {
+		args = append(args, "-E")
+	}
+	if resolved.NoBorder {
+		args = append(args, "-B")
+	}
+	if resolved.Cwd != "" {
+		args = append(args, "-d", resolved.Cwd)
+	}
+	args = appendEnvArgs(args, resolved.Env)
+	if resolved.X != "" {
+		args = append(args, "-x", resolved.X)
+	}
+	if resolved.Y != "" {
+		args = append(args, "-y", resolved.Y)
+	}
+	if resolved.Width != "" {
+		args = append(args, "-w", resolved.Width)
+	}
+	if resolved.Height != "" {
+		args = append(args, "-h", resolved.Height)
+	}
+	if resolved.Title != "" {
+		args = append(args, "-T", resolved.Title)
+	}
+	args = append(args, command)
+	return args, nil
 }
 
 // ClosePopup closes a scoped tmux popup.
@@ -157,4 +222,55 @@ func appendSocketArgs(args []string, socket string) []string {
 		args = append(args, "-S", resolved)
 	}
 	return args
+}
+
+func resolvePopupOptions(options PopupOptions) (PopupOptions, error) {
+	resolved := PopupOptions{
+		Client:        strings.TrimSpace(options.Client),
+		Target:        strings.TrimSpace(options.Target),
+		Cwd:           strings.TrimSpace(options.Cwd),
+		Env:           cleanPopupEnv(options.Env),
+		NoBorder:      options.NoBorder,
+		X:             strings.TrimSpace(options.X),
+		Y:             strings.TrimSpace(options.Y),
+		Width:         strings.TrimSpace(options.Width),
+		Height:        strings.TrimSpace(options.Height),
+		Title:         strings.TrimSpace(options.Title),
+		CloseBehavior: options.CloseBehavior,
+	}
+
+	if resolved.Width == "" {
+		resolved.Width = "80%"
+	}
+	if resolved.Height == "" {
+		resolved.Height = "80%"
+	}
+	if resolved.CloseBehavior == "" {
+		resolved.CloseBehavior = PopupCloseOnExit
+	}
+
+	switch resolved.CloseBehavior {
+	case PopupCloseOnExit, PopupKeepOpen:
+		return resolved, nil
+	default:
+		return PopupOptions{}, ErrPopupCloseBehaviorInvalid
+	}
+}
+
+func cleanPopupEnv(env map[string]string) map[string]string {
+	if len(env) == 0 {
+		return nil
+	}
+	cleaned := make(map[string]string, len(env))
+	for key, value := range env {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		cleaned[key] = value
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	return cleaned
 }

--- a/internal/integrations/mux/lifecycle.go
+++ b/internal/integrations/mux/lifecycle.go
@@ -1,0 +1,291 @@
+package mux
+
+import (
+	"context"
+	"sort"
+	"strings"
+)
+
+// NewSessionOptions describes a `new-session` lifecycle command.
+type NewSessionOptions struct {
+	Socket       string
+	ConfigPath   string
+	Attach       bool
+	Detached     bool
+	Session      string
+	Cwd          string
+	Env          map[string]string
+	ReturnPaneID bool
+	Command      []string
+}
+
+// NewWindowOptions describes a `new-window` command.
+type NewWindowOptions struct {
+	Detached bool
+	Target   string
+	Cwd      string
+	Name     string
+	Command  []string
+}
+
+// SplitWindowOptions describes a `split-window` command.
+type SplitWindowOptions struct {
+	Detached     bool
+	ReturnPaneID bool
+	Direction    string
+	Target       string
+	Cwd          string
+	Command      []string
+}
+
+// SetHookOptions describes a `set-hook` command.
+type SetHookOptions struct {
+	Global  bool
+	Append  bool
+	Unset   bool
+	Hook    string
+	Command string
+}
+
+// SetOptionOptions describes a `set-option` command.
+type SetOptionOptions struct {
+	Global bool
+	Append bool
+	Unset  bool
+	Target string
+	Quiet  bool
+	Option string
+	Value  string
+}
+
+// ShowOptionOptions describes a `show-option` read.
+type ShowOptionOptions struct {
+	Global    bool
+	Quiet     bool
+	ValueOnly bool
+	Target    string
+	Option    string
+}
+
+const (
+	SplitRight = "right"
+	SplitDown  = "down"
+)
+
+// NewSession creates a tmux session and optionally returns the first pane id.
+func NewSession(ctx context.Context, opts NewSessionOptions) (string, error) {
+	return DefaultRunner().NewSession(ctx, opts)
+}
+
+// NewWindow creates a tmux window.
+func NewWindow(ctx context.Context, opts NewWindowOptions) error {
+	return DefaultRunner().NewWindow(ctx, opts)
+}
+
+// SplitWindow creates a tmux pane split and optionally returns the new pane id.
+func SplitWindow(ctx context.Context, opts SplitWindowOptions) (string, error) {
+	return DefaultRunner().SplitWindow(ctx, opts)
+}
+
+// SetHook installs, appends, or unsets a tmux hook.
+func SetHook(ctx context.Context, opts SetHookOptions) error {
+	return DefaultRunner().SetHook(ctx, opts)
+}
+
+// SetOption writes or unsets a tmux option.
+func SetOption(ctx context.Context, opts SetOptionOptions) error {
+	return DefaultRunner().SetOption(ctx, opts)
+}
+
+// ShowOption reads a tmux option.
+func ShowOption(ctx context.Context, opts ShowOptionOptions) (string, error) {
+	return DefaultRunner().ShowOption(ctx, opts)
+}
+
+// NewSession creates a tmux session and optionally returns the first pane id.
+func (r Runner) NewSession(ctx context.Context, opts NewSessionOptions) (string, error) {
+	args := appendSocketArgs(nil, opts.Socket)
+	if config := strings.TrimSpace(opts.ConfigPath); config != "" {
+		args = append(args, "-f", config)
+	}
+	args = append(args, "new-session")
+	if opts.Detached {
+		args = append(args, "-d")
+	}
+	if opts.Attach {
+		args = append(args, "-A")
+	}
+	if sessionName := strings.TrimSpace(opts.Session); sessionName != "" {
+		args = append(args, "-s", sessionName)
+	}
+	if cwd := strings.TrimSpace(opts.Cwd); cwd != "" {
+		args = append(args, "-c", cwd)
+	}
+	args = appendEnvArgs(args, opts.Env)
+	if opts.ReturnPaneID {
+		args = append(args, "-P", "-F", TmuxFormat("pane_id"))
+	}
+	args = append(args, opts.Command...)
+	if opts.ReturnPaneID {
+		return r.ReadTrimmed(ctx, args...)
+	}
+	return "", r.Run(ctx, args...)
+}
+
+// NewWindow creates a tmux window.
+func (r Runner) NewWindow(ctx context.Context, opts NewWindowOptions) error {
+	args := []string{"new-window"}
+	if opts.Detached {
+		args = append(args, "-d")
+	}
+	args = appendPaneTargetArgs(args, opts.Target)
+	if cwd := strings.TrimSpace(opts.Cwd); cwd != "" {
+		args = append(args, "-c", cwd)
+	}
+	if name := strings.TrimSpace(opts.Name); name != "" {
+		args = append(args, "-n", name)
+	}
+	args = append(args, opts.Command...)
+	return r.Run(ctx, args...)
+}
+
+// SplitWindow creates a tmux pane split and optionally returns the new pane id.
+func (r Runner) SplitWindow(ctx context.Context, opts SplitWindowOptions) (string, error) {
+	args := []string{"split-window"}
+	if opts.Detached {
+		args = append(args, "-d")
+	}
+	if opts.ReturnPaneID {
+		args = append(args, "-P", "-F", TmuxFormat("pane_id"))
+	}
+	if flag := splitDirectionFlag(opts.Direction); flag != "" {
+		args = append(args, flag)
+	}
+	args = appendPaneTargetArgs(args, opts.Target)
+	if cwd := strings.TrimSpace(opts.Cwd); cwd != "" {
+		args = append(args, "-c", cwd)
+	}
+	args = append(args, opts.Command...)
+	if opts.ReturnPaneID {
+		return r.ReadTrimmed(ctx, args...)
+	}
+	return "", r.Run(ctx, args...)
+}
+
+// SetHook installs, appends, or unsets a tmux hook.
+func (r Runner) SetHook(ctx context.Context, opts SetHookOptions) error {
+	args := []string{"set-hook"}
+	if flags := hookFlags(opts); flags != "" {
+		args = append(args, flags)
+	}
+	args = append(args, strings.TrimSpace(opts.Hook))
+	if !opts.Unset {
+		args = append(args, opts.Command)
+	}
+	return r.Run(ctx, args...)
+}
+
+// SetOption writes or unsets a tmux option.
+func (r Runner) SetOption(ctx context.Context, opts SetOptionOptions) error {
+	args := []string{"set-option"}
+	if opts.Global {
+		args = append(args, "-g")
+	}
+	if opts.Append {
+		args = append(args, "-a")
+	}
+	if opts.Unset {
+		args = append(args, "-u")
+	}
+	args = appendPaneTargetArgs(args, opts.Target)
+	if opts.Quiet {
+		args = append(args, "-q")
+	}
+	args = append(args, strings.TrimSpace(opts.Option))
+	if !opts.Unset {
+		args = append(args, opts.Value)
+	}
+	return r.Run(ctx, args...)
+}
+
+// ShowOption reads a tmux option.
+func (r Runner) ShowOption(ctx context.Context, opts ShowOptionOptions) (string, error) {
+	args := []string{"show-option"}
+	if flags := showOptionFlags(opts); flags != "" {
+		args = append(args, flags)
+	}
+	args = appendPaneTargetArgs(args, opts.Target)
+	args = append(args, strings.TrimSpace(opts.Option))
+	return r.ReadTrimmed(ctx, args...)
+}
+
+func appendEnvArgs(args []string, env map[string]string) []string {
+	for _, key := range sortedEnvKeys(env) {
+		args = append(args, "-e", key+"="+env[key])
+	}
+	return args
+}
+
+func sortedEnvKeys(env map[string]string) []string {
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		if strings.TrimSpace(key) != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func splitDirectionFlag(direction string) string {
+	switch strings.TrimSpace(direction) {
+	case SplitRight, "horizontal", "-h":
+		return "-h"
+	case SplitDown, "vertical", "-v":
+		return "-v"
+	default:
+		return ""
+	}
+}
+
+func hookFlags(opts SetHookOptions) string {
+	if opts.Global && opts.Append && !opts.Unset {
+		return "-ag"
+	}
+	if opts.Global && opts.Unset && !opts.Append {
+		return "-gu"
+	}
+	var builder strings.Builder
+	builder.WriteByte('-')
+	if opts.Global {
+		builder.WriteByte('g')
+	}
+	if opts.Append {
+		builder.WriteByte('a')
+	}
+	if opts.Unset {
+		builder.WriteByte('u')
+	}
+	if builder.Len() == 1 {
+		return ""
+	}
+	return builder.String()
+}
+
+func showOptionFlags(opts ShowOptionOptions) string {
+	var builder strings.Builder
+	builder.WriteByte('-')
+	if opts.Global {
+		builder.WriteByte('g')
+	}
+	if opts.Quiet {
+		builder.WriteByte('q')
+	}
+	if opts.ValueOnly {
+		builder.WriteByte('v')
+	}
+	if builder.Len() == 1 {
+		return ""
+	}
+	return builder.String()
+}

--- a/internal/integrations/mux/runner.go
+++ b/internal/integrations/mux/runner.go
@@ -5,9 +5,10 @@ package mux
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"os/exec"
 	"strings"
-
-	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
 
 // Backend is the low-level command runner contract used by the mux boundary.
@@ -24,14 +25,14 @@ type Runner struct {
 // backend so production callers can stay concise.
 func NewRunner(backend Backend) Runner {
 	if backend == nil {
-		backend = inttmux.ExecRunner{}
+		backend = execRunner{}
 	}
 	return Runner{backend: backend}
 }
 
 // DefaultRunner returns the production tmux-backed mux runner.
 func DefaultRunner() Runner {
-	return NewRunner(inttmux.ExecRunner{})
+	return NewRunner(execRunner{})
 }
 
 // Run executes tmux with args and discards output.
@@ -145,9 +146,33 @@ func (r Runner) ReadTrimmed(ctx context.Context, args ...string) (string, error)
 
 func (r Runner) runner() Backend {
 	if r.backend == nil {
-		return inttmux.ExecRunner{}
+		return execRunner{}
 	}
 	return r.backend
+}
+
+type execRunner struct{}
+
+func (execRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if name == "tmux" && len(args) > 0 && (args[0] == "attach-session" || args[0] == "switch-client") {
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return nil, fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+		}
+		return nil, nil
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(output))
+		if trimmed != "" {
+			return nil, fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, trimmed)
+		}
+		return nil, fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+	}
+	return output, nil
 }
 
 // PaneOptionFormat renders a tmux format for a pane option.

--- a/internal/integrations/mux/runner_test.go
+++ b/internal/integrations/mux/runner_test.go
@@ -402,6 +402,184 @@ func TestRunnerSelectWindowBuildsSocketScopedArgs(t *testing.T) {
 	}
 }
 
+func TestRunnerNewSessionBuildsDetachedSessionWithEnvAndPaneIDRead(t *testing.T) {
+	backend := &recordingBackend{out: []byte(" %7 \n")}
+	runner := NewRunner(backend)
+
+	paneID, err := runner.NewSession(context.Background(), NewSessionOptions{
+		Detached: true,
+		Session:  " workspace ",
+		Cwd:      " /repo ",
+		Env: map[string]string{
+			"ZED": "last",
+			"FOO": "bar",
+		},
+		ReturnPaneID: true,
+	})
+	if err != nil {
+		t.Fatalf("NewSession returned error: %v", err)
+	}
+
+	wantArgs := []string{"new-session", "-d", "-s", "workspace", "-c", "/repo", "-e", "FOO=bar", "-e", "ZED=last", "-P", "-F", "#{pane_id}"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+	if paneID != "%7" {
+		t.Fatalf("NewSession paneID = %q, want %%7", paneID)
+	}
+}
+
+func TestRunnerNewSessionBuildsAttachSessionWithSocketAndConfig(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	_, err := runner.NewSession(context.Background(), NewSessionOptions{
+		Socket:     " pmx-dev ",
+		ConfigPath: " /tmp/tmux.conf ",
+		Attach:     true,
+		Session:    "dev",
+		Cwd:        "/repo",
+	})
+	if err != nil {
+		t.Fatalf("NewSession returned error: %v", err)
+	}
+
+	wantArgs := []string{"-S", "pmx-dev", "-f", "/tmp/tmux.conf", "new-session", "-A", "-s", "dev", "-c", "/repo"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+}
+
+func TestRunnerNewWindowBuildsDetachedWindowWithNameAndCommand(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	if err := runner.NewWindow(context.Background(), NewWindowOptions{
+		Detached: true,
+		Target:   " home:1 ",
+		Cwd:      "/repo",
+		Name:     "logs",
+		Command:  []string{"/bin/bash", "-l"},
+	}); err != nil {
+		t.Fatalf("NewWindow returned error: %v", err)
+	}
+
+	wantArgs := []string{"new-window", "-d", "-t", "home:1", "-c", "/repo", "-n", "logs", "/bin/bash", "-l"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+}
+
+func TestRunnerSplitWindowBuildsPaneIDReadWithDirectionCwdAndCommand(t *testing.T) {
+	backend := &recordingBackend{out: []byte("%9\n")}
+	runner := NewRunner(backend)
+
+	paneID, err := runner.SplitWindow(context.Background(), SplitWindowOptions{
+		ReturnPaneID: true,
+		Direction:    SplitRight,
+		Target:       " %7 ",
+		Cwd:          "/repo",
+		Command:      []string{"/bin/bash", "-lc", "exec codex"},
+	})
+	if err != nil {
+		t.Fatalf("SplitWindow returned error: %v", err)
+	}
+
+	wantArgs := []string{"split-window", "-P", "-F", "#{pane_id}", "-h", "-t", "%7", "-c", "/repo", "/bin/bash", "-lc", "exec codex"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+	if paneID != "%9" {
+		t.Fatalf("SplitWindow paneID = %q, want %%9", paneID)
+	}
+}
+
+func TestRunnerSplitWindowBuildsDetachedReplayStyleArgs(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	if _, err := runner.SplitWindow(context.Background(), SplitWindowOptions{
+		Detached: true,
+		Target:   "home:0.0",
+		Cwd:      "/repo",
+	}); err != nil {
+		t.Fatalf("SplitWindow returned error: %v", err)
+	}
+
+	wantArgs := []string{"split-window", "-d", "-t", "home:0.0", "-c", "/repo"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+}
+
+func TestRunnerSetHookBuildsAppendAndUnsetArgs(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	if err := runner.SetHook(context.Background(), SetHookOptions{
+		Global:  true,
+		Append:  true,
+		Hook:    " alert-bell ",
+		Command: `run-shell -b 'projmux ai ingest bell --pane "#{pane_id}"'`,
+	}); err != nil {
+		t.Fatalf("SetHook append returned error: %v", err)
+	}
+
+	wantArgs := []string{"set-hook", "-ag", "alert-bell", `run-shell -b 'projmux ai ingest bell --pane "#{pane_id}"'`}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+
+	if err := runner.SetHook(context.Background(), SetHookOptions{
+		Global: true,
+		Unset:  true,
+		Hook:   "alert-bell[2]",
+	}); err != nil {
+		t.Fatalf("SetHook unset returned error: %v", err)
+	}
+
+	wantArgs = []string{"set-hook", "-gu", "alert-bell[2]"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+}
+
+func TestRunnerSetOptionAndShowOptionBuildGlobalArgs(t *testing.T) {
+	backend := &recordingBackend{out: []byte(" on \n")}
+	runner := NewRunner(backend)
+
+	if err := runner.SetOption(context.Background(), SetOptionOptions{
+		Global: true,
+		Option: " allow-passthrough ",
+		Value:  "on",
+	}); err != nil {
+		t.Fatalf("SetOption returned error: %v", err)
+	}
+
+	wantArgs := []string{"set-option", "-g", "allow-passthrough", "on"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+
+	got, err := runner.ShowOption(context.Background(), ShowOptionOptions{
+		Global:    true,
+		Quiet:     true,
+		ValueOnly: true,
+		Option:    "@projmux_app",
+	})
+	if err != nil {
+		t.Fatalf("ShowOption returned error: %v", err)
+	}
+
+	wantArgs = []string{"show-option", "-gqv", "@projmux_app"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+	if got != "on" {
+		t.Fatalf("ShowOption = %q, want on", got)
+	}
+}
+
 func TestParseFormatRowsPinsMalformedAndTrimmingBehavior(t *testing.T) {
 	output := []byte("  one \x1f two \r\nmissing\nthree\x1ffour\x1fextra\n five\\037six \n")
 

--- a/internal/integrations/tmux/client.go
+++ b/internal/integrations/tmux/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/core/lifecycle"
 	"github.com/crevissepartners/projmux/internal/integrations/hooks"
+	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
 )
 
 const SwitchTargetClientEnv = "PROJMUX_SWITCH_TARGET_CLIENT"
@@ -22,8 +23,8 @@ var (
 	errCurrentSessionUnavailable  = errors.New("tmux current session is unavailable")
 	errSessionNameRequired        = errors.New("tmux session name is required")
 	errSessionCWDRequired         = errors.New("tmux session cwd is required")
-	errPopupCommandRequired       = errors.New("tmux popup command is required")
-	errPopupCloseBehaviorInvalid  = errors.New("tmux popup close behavior is invalid")
+	errPopupCommandRequired       = intmux.ErrPopupCommandRequired
+	errPopupCloseBehaviorInvalid  = intmux.ErrPopupCloseBehaviorInvalid
 	errWindowIndexRequired        = errors.New("tmux window index is required when pane index is set")
 	errSessionActivityInvalid     = errors.New("tmux session activity is invalid")
 	errSessionAttachedInvalid     = errors.New("tmux session attached flag is invalid")
@@ -184,26 +185,14 @@ type WindowPane struct {
 	Active bool
 }
 
-type PopupCloseBehavior string
+type PopupCloseBehavior = intmux.PopupCloseBehavior
 
 const (
-	PopupCloseOnExit PopupCloseBehavior = "close-on-exit"
-	PopupKeepOpen    PopupCloseBehavior = "keep-open"
+	PopupCloseOnExit = intmux.PopupCloseOnExit
+	PopupKeepOpen    = intmux.PopupKeepOpen
 )
 
-type PopupOptions struct {
-	Client        string
-	Target        string
-	Cwd           string
-	Env           map[string]string
-	NoBorder      bool
-	X             string
-	Y             string
-	Width         string
-	Height        string
-	Title         string
-	CloseBehavior PopupCloseBehavior
-}
+type PopupOptions = intmux.PopupOptions
 
 // RecentSessionSummary describes one recent tmux session with lightweight row
 // metadata for session pickers.
@@ -504,20 +493,13 @@ func (c *Client) CreateEphemeralSession(ctx context.Context, sessionName, cwd st
 }
 
 func (c *Client) createDetachedSession(ctx context.Context, sessionName, cwd string, env map[string]string) (string, error) {
-	args := []string{"new-session", "-d", "-s", sessionName, "-c", cwd}
-	for _, key := range sortedMapKeys(env) {
-		args = append(args, "-e", key+"="+env[key])
-	}
-	if c.lifecycle == nil {
-		_, err := c.runner.Run(ctx, "tmux", args...)
-		return "", err
-	}
-	args = append(args, "-P", "-F", "#{pane_id}")
-	output, err := c.runner.Run(ctx, "tmux", args...)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(output)), nil
+	return intmux.NewRunner(c.runner).NewSession(ctx, intmux.NewSessionOptions{
+		Detached:     true,
+		Session:      sessionName,
+		Cwd:          cwd,
+		Env:          env,
+		ReturnPaneID: c.lifecycle != nil,
+	})
 }
 
 func (c *Client) projectSessionEnv(cwd string) map[string]string {
@@ -800,52 +782,7 @@ func (c *Client) DisplayPopupWithOptions(ctx context.Context, command string, op
 
 // BuildDisplayPopupArgs maps structured popup options to tmux display-popup args.
 func BuildDisplayPopupArgs(command string, options PopupOptions) ([]string, error) {
-	command = strings.TrimSpace(command)
-	if command == "" {
-		return nil, errPopupCommandRequired
-	}
-
-	resolved, err := resolvePopupOptions(options)
-	if err != nil {
-		return nil, err
-	}
-
-	args := []string{"display-popup"}
-	if resolved.Client != "" {
-		args = append(args, "-c", resolved.Client)
-	}
-	if resolved.Target != "" {
-		args = append(args, "-t", resolved.Target)
-	}
-	if resolved.CloseBehavior == PopupCloseOnExit {
-		args = append(args, "-E")
-	}
-	if resolved.NoBorder {
-		args = append(args, "-B")
-	}
-	if resolved.Cwd != "" {
-		args = append(args, "-d", resolved.Cwd)
-	}
-	for _, key := range sortedEnvKeys(resolved.Env) {
-		args = append(args, "-e", key+"="+resolved.Env[key])
-	}
-	if resolved.X != "" {
-		args = append(args, "-x", resolved.X)
-	}
-	if resolved.Y != "" {
-		args = append(args, "-y", resolved.Y)
-	}
-	if resolved.Width != "" {
-		args = append(args, "-w", resolved.Width)
-	}
-	if resolved.Height != "" {
-		args = append(args, "-h", resolved.Height)
-	}
-	if resolved.Title != "" {
-		args = append(args, "-T", resolved.Title)
-	}
-	args = append(args, command)
-	return args, nil
+	return intmux.BuildDisplayPopupArgs(command, options)
 }
 
 // InsideSession reports whether the caller is already running inside tmux.
@@ -1125,66 +1062,6 @@ func exactSessionTarget(sessionName string) string {
 		return sessionName
 	}
 	return "=" + sessionName
-}
-
-func resolvePopupOptions(options PopupOptions) (PopupOptions, error) {
-	resolved := PopupOptions{
-		Client:        strings.TrimSpace(options.Client),
-		Target:        strings.TrimSpace(options.Target),
-		Cwd:           strings.TrimSpace(options.Cwd),
-		Env:           cleanPopupEnv(options.Env),
-		NoBorder:      options.NoBorder,
-		X:             strings.TrimSpace(options.X),
-		Y:             strings.TrimSpace(options.Y),
-		Width:         strings.TrimSpace(options.Width),
-		Height:        strings.TrimSpace(options.Height),
-		Title:         strings.TrimSpace(options.Title),
-		CloseBehavior: options.CloseBehavior,
-	}
-
-	if resolved.Width == "" {
-		resolved.Width = "80%"
-	}
-	if resolved.Height == "" {
-		resolved.Height = "80%"
-	}
-	if resolved.CloseBehavior == "" {
-		resolved.CloseBehavior = PopupCloseOnExit
-	}
-
-	switch resolved.CloseBehavior {
-	case PopupCloseOnExit, PopupKeepOpen:
-		return resolved, nil
-	default:
-		return PopupOptions{}, errPopupCloseBehaviorInvalid
-	}
-}
-
-func cleanPopupEnv(env map[string]string) map[string]string {
-	if len(env) == 0 {
-		return nil
-	}
-	cleaned := make(map[string]string, len(env))
-	for key, value := range env {
-		key = strings.TrimSpace(key)
-		if key == "" {
-			continue
-		}
-		cleaned[key] = value
-	}
-	if len(cleaned) == 0 {
-		return nil
-	}
-	return cleaned
-}
-
-func sortedEnvKeys(env map[string]string) []string {
-	keys := make([]string, 0, len(env))
-	for key := range env {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	return keys
 }
 
 func tmuxFormat(fields ...string) string {


### PR DESCRIPTION
## Completed Phase

Phase 2D — lifecycle / split / hook slice.

## Surfaces Changed

- Project session create now uses `mux.NewSession` for detached session creation, preserving sorted `-e KEY=VALUE` env injection and lifecycle `-P -F "#{pane_id}"` capture.
- AI agent/shell split now uses `mux.SplitWindow`, preserving right/down flags, target pane, cwd, command tail, and pane id capture for agent splits.
- tmux bell integration install/remove now uses `mux.SetOption` and `mux.SetHook` for the option/hook mutation path.

## Added Semantic Mux API

- `NewSession`
- `NewWindow`
- `SplitWindow`
- `SetHook`
- `SetOption`
- `ShowOption`

The tmux-specific tails for pane id output, cwd, env ordering, split direction, option flags, and hook command argv are centralized in `internal/integrations/mux`.

## Phase 2 Status

Phase 2 is complete after Phase 2D. The active roadmap detail now points to Phase 3B as the next current phase.

## Explicitly Excluded

- No psmux backend implementation.
- No Windows-native process launch redesign.
- No startup/session-state replay rewrite.
- No sessionstate snapshot schema change.
- No project/session lifecycle redesign.
- No popup UI, focus policy, or OS focus adapter changes.
- No all-tmux-callsite rewrite.

## Inventory Docs

Updated `docs/tmux-surface-inventory.md` with the Phase 2D lifecycle/split/hook capability section and psmux audit matrix mappings for `NewSession`, `SplitWindow`, `SetHook`, `SetOption`, and `ShowOption`.

## Private psmux Audit

Updated private Obsidian `Projmux/10.Roadmap/세부 기준 - psmux parity audit`: Phase 2D rows are finalized for the new capability names and left as `unknown` pending Windows/psmux verification.

## Verification

- `GOCACHE=/tmp/projmux-go-cache go test ./internal/integrations/mux ./internal/integrations/tmux ./internal/app`
- `GOCACHE=/tmp/projmux-go-cache make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `git diff --check`
- `git diff --cached --check`

## Unverified / Follow-Up

- Windows Terminal + PowerShell psmux measurement for Phase 2D remains unverified; follow-up is Phase 3B full parity audit.
- Session-state replay intentionally remains on the existing typed tmux path except for the new API availability and public audit mapping.
