### PR TITLE
fix: unblock native windows build

### DIFF
--- a/internal/integrations/osfocus/wt_wsl.go
+++ b/internal/integrations/osfocus/wt_wsl.go
@@ -2,9 +2,7 @@ package osfocus
 
 import (
 	"os"
-	"os/exec"
 	"strings"
-	"syscall"
 )
 
 // WindowsTerminalWSLAdapter raises the Windows Terminal window when projmux
@@ -80,47 +78,6 @@ func (a WindowsTerminalWSLAdapter) Focus(_ Target) error {
 		runner = defaultWTRun
 	}
 	return runner("wt.exe", "-w", "0", "focus-tab", "-t", "0")
-}
-
-// defaultWTRun spawns the command without waiting on it. stdout/stderr are
-// discarded so the spawn cannot leak handles into the projmux process.
-//
-// WSL interop quirk: a direct Go exec of `wt.exe` (the binfmt_misc shim
-// routes us into Windows) spawns the resulting Windows process WITHOUT
-// foreground-window rights. wt.exe runs but cannot raise its window.
-// Wrapping through `bash -c` lets bash set up the process (controlling
-// tty / session) such that foreground rights propagate and the raise
-// actually fires. Verified empirically vs three alternatives during the
-// tier-1 ship.
-//
-// Setsid rationale: `projmux ai notify` is invoked from tmux hooks as a
-// one-shot subprocess; after Notify returns the projmux main goroutine
-// exits and the kernel sends SIGHUP to every member of the parent's
-// process group. cmd.Start("bash", "-c", "wt.exe ...") returns after the
-// fork(2) succeeds but BEFORE bash has exec'd wt.exe — so without
-// detaching, bash dies in the parent's pgroup before the exec can happen
-// and wt.exe never spawns. SysProcAttr{Setsid: true} makes bash a session
-// leader with its own pgroup, so the SIGHUP-on-parent-exit chain does not
-// reach it and the raise fires correctly.
-func defaultWTRun(name string, args ...string) error {
-	quoted := shellQuoteArgs(append([]string{name}, args...))
-	cmd := exec.Command("bash", "-c", quoted)
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	cmd.Stdin = nil
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	// Reap the child in a goroutine so we don't leave a zombie behind. We
-	// don't surface Wait's error because Focus already returned to the
-	// caller — silent fallback policy. If projmux exits first the goroutine
-	// dies too, but the bash child is now in its own session and continues
-	// running detached, so wt.exe still spawns.
-	go func() {
-		_ = cmd.Wait()
-	}()
-	return nil
 }
 
 // shellQuoteArgs joins argv into a single bash command line, quoting each

--- a/internal/integrations/osfocus/wt_wsl_nonunix.go
+++ b/internal/integrations/osfocus/wt_wsl_nonunix.go
@@ -1,0 +1,11 @@
+//go:build !unix
+
+package osfocus
+
+// defaultWTRun is a non-Unix no-op. The WindowsTerminalWSLAdapter is for
+// projmux running inside WSL, where GOOS=linux and wt.exe is launched through
+// WSL interop. Native non-Unix builds must not compile in bash or POSIX
+// process group assumptions.
+func defaultWTRun(_ string, _ ...string) error {
+	return nil
+}

--- a/internal/integrations/osfocus/wt_wsl_posix.go
+++ b/internal/integrations/osfocus/wt_wsl_posix.go
@@ -1,0 +1,49 @@
+//go:build unix
+
+package osfocus
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// defaultWTRun spawns the command without waiting on it. stdout/stderr are
+// discarded so the spawn cannot leak handles into the projmux process.
+//
+// WSL interop quirk: a direct Go exec of `wt.exe` (the binfmt_misc shim
+// routes us into Windows) spawns the resulting Windows process WITHOUT
+// foreground-window rights. wt.exe runs but cannot raise its window.
+// Wrapping through `bash -c` lets bash set up the process (controlling
+// tty / session) such that foreground rights propagate and the raise
+// actually fires. Verified empirically vs three alternatives during the
+// tier-1 ship.
+//
+// Setsid rationale: `projmux ai notify` is invoked from tmux hooks as a
+// one-shot subprocess; after Notify returns the projmux main goroutine
+// exits and the kernel sends SIGHUP to every member of the parent's
+// process group. cmd.Start("bash", "-c", "wt.exe ...") returns after the
+// fork(2) succeeds but BEFORE bash has exec'd wt.exe -- so without
+// detaching, bash dies in the parent's pgroup before the exec can happen
+// and wt.exe never spawns. SysProcAttr{Setsid: true} makes bash a session
+// leader with its own pgroup, so the SIGHUP-on-parent-exit chain does not
+// reach it and the raise fires correctly.
+func defaultWTRun(name string, args ...string) error {
+	quoted := shellQuoteArgs(append([]string{name}, args...))
+	cmd := exec.Command("bash", "-c", quoted)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Stdin = nil
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	// Reap the child in a goroutine so we don't leave a zombie behind. We
+	// don't surface Wait's error because Focus already returned to the
+	// caller -- silent fallback policy. If projmux exits first the goroutine
+	// dies too, but the bash child is now in its own session and continues
+	// running detached, so wt.exe still spawns.
+	go func() {
+		_ = cmd.Wait()
+	}()
+	return nil
+}

--- a/internal/integrations/osfocus/wt_wsl_windows_test.go
+++ b/internal/integrations/osfocus/wt_wsl_windows_test.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package osfocus
+
+import "testing"
+
+func TestWindowsTerminalWSLAdapter_DefaultRunIsNativeWindowsNoop(t *testing.T) {
+	t.Parallel()
+
+	a := WindowsTerminalWSLAdapter{}
+	if err := a.Focus(Target{Session: "native-windows"}); err != nil {
+		t.Fatalf("Focus() with native Windows default runner returned %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Completed Phase: Phase 3A0-1 — Windows build unblock.
- Split the Windows Terminal WSL focus adapter's POSIX `bash`/`setsid` runner behind a Unix build tag.
- Added a native non-Unix no-op runner so Windows builds do not compile WSL-only process assumptions.
- Added a Windows-only compile-path test for the native no-op focus runner.

## User-facing surface

None; build-only. Linux/WSL Windows Terminal WSL focus behavior is intended to remain unchanged.

## Explicitly excluded scope

- Phase 3A0-2 PowerShell runtime smoke.
- Phase 3A0-3 doctor/dependency policy expansion.
- Phase 3A0-4 PowerShell quoting policy.
- Phase 3A0-5 `projmux.exe shell` psmux runtime.
- Phase 3A / Phase 3B / Phase 3C broader psmux audit/backend work.
- Backend/schema/replay/sidecar metadata changes: not touched.

## Verification

```sh
GOCACHE=/tmp/projmux-go-cache GOOS=windows GOARCH=amd64 go build -o /tmp/projmux.exe ./cmd/projmux
GOCACHE=/tmp/projmux-go-cache go test ./internal/integrations/osfocus
GOCACHE=/tmp/projmux-go-cache GOOS=windows GOARCH=amd64 go test -c -o /tmp/osfocus_windows.test ./internal/integrations/osfocus
GOCACHE=/tmp/projmux-go-cache make fmt
GOCACHE=/tmp/projmux-go-cache make fix
GOCACHE=/tmp/projmux-go-cache make test
```

## Unverified

- Native Windows PowerShell runtime smoke. This is intentionally left for Phase 3A0-2.