### PR TITLE
fix: prefer show-options for mux option reads

### DIFF
--- a/docs/tmux-surface-inventory.md
+++ b/docs/tmux-surface-inventory.md
@@ -153,7 +153,77 @@ creation remains on the existing typed tmux path in this phase.
 | `SplitWindow` | `split-window [-d] [-P -F "#{pane_id}"] [-h/-v] [-t <target>] [-c <cwd>] [command...]` | AI agent split, AI shell split |
 | `SetHook` | `set-hook -ag <hook> <command>`, `set-hook -gu <hook[index]>` | `projmux ai integrate tmux-bell` install/remove |
 | `SetOption` | `set-option -g <option> <value>`, `set-option -t <session> -q <option> <value>` | tmux bell integration option install; API available for session-scoped markers |
-| `ShowOption` | `show-option [-g] [-q] [-v] [-t <target>] <option>` | API available for global/session option reads; conversion deferred to low-risk call sites |
+| `ShowOption` | `show-options [-g] [-q] [-v] [-t <target>] <option>` | API available for global/session option reads; converted low-risk call sites use the plural spelling for psmux parity |
+
+## Phase 3 psmux MVP Direction
+
+Phase 3 should bring up a psmux backend before solving rich pane metadata.
+psmux 3.3.4 supports global and session user options, but pane-scoped custom
+`@...` options are not persisted by `set-option -p` in current smoke results.
+The psmux MVP therefore treats pane user options as an unsupported capability
+instead of a launch blocker.
+
+Phase 3A0 should bootstrap native Windows `projmux.exe` execution before the
+psmux backend is wired into product flows. Split it into explicit subphases so
+native PowerShell work does not get conflated with the later psmux backend:
+
+- **Phase 3A0-1: Windows build unblock.** Make `GOOS=windows GOARCH=amd64 go
+  build ./cmd/projmux` succeed. WSL-only focus code, POSIX process attributes,
+  and shell assumptions must be build-tagged, stubbed, or moved behind
+  platform adapters.
+- **Phase 3A0-2: Pure PowerShell CLI smoke.** Run `projmux.exe --version` and
+  other mux-free diagnostics/config commands from PowerShell. This phase should
+  prove that startup, argument parsing, config/state path calculation, and
+  read-only commands do not require tmux, WSL, or POSIX shell tools.
+- **Phase 3A0-3: Windows dependency and path policy.** Teach diagnostics to
+  distinguish native Windows/psmux from WSL/Linux/tmux. `tmux`, `stty`, `/bin/sh`,
+  and WSL-only helpers must not be required for a native psmux track.
+- **Phase 3A0-4: PowerShell process-launch and quoting policy.** Define how
+  generated psmux config invokes `projmux.exe` and child commands without
+  POSIX quoting. This must be settled before hooks, status commands, or popup
+  launchers call back into projmux on Windows.
+- **Phase 3A0-5: Native shell entry smoke.** Add the first limited
+  `projmux.exe shell` PowerShell smoke that reaches a psmux app runtime, with
+  rich pane metadata still disabled.
+
+Phase 3A should add an explicit mux capability contract:
+
+- `PaneUserOptions=false` for psmux until upstream parity or a projmux metadata
+  store exists.
+- `GlobalUserOptions=true` and `SessionUserOptions=true` when backed by
+  `show-options` / `set-option`.
+- Unsupported capabilities must fail or degrade explicitly; they must not
+  silently pretend pane metadata was stored.
+
+Phase 3B should implement the minimal psmux backend and app runtime:
+
+- backend selection for new runtime/session creation only; live session
+  migration between tmux and psmux remains unsupported.
+- `psmux -L <namespace> -f <config>` app runtime isolation, plus
+  `source-file`, `show-options`, and `kill-server` smoke coverage.
+- `projmux.exe shell` on PowerShell should launch the isolated psmux app
+  runtime rather than tmux.
+- core session/window/pane lifecycle: create, list, attach/switch, split, and
+  basic command launch.
+- native field reads such as session/window/pane ids, current path, current
+  command, pane title, and socket path where available.
+
+Phase 3C should ship degraded psmux UX for features that currently depend on
+pane user options:
+
+- AI/shell split can launch commands, but pane topic, AI state, attention ack,
+  notification dedupe, and agent resume metadata are disabled or shown as
+  unsupported.
+- notify/status/session-state code paths should report missing pane metadata
+  capability rather than relying on empty `@projmux_*` reads.
+- `doctor` and settings diagnostics should identify the active backend and its
+  missing metadata capabilities.
+
+Phase 4 should revisit rich metadata after the psmux MVP is usable. The two
+acceptable directions are upstream psmux parity for pane-scoped custom user
+options, or a projmux-owned sidecar pane metadata store with reconcile,
+locking, stale-record cleanup, and pane-id reuse protection. Sidecar metadata
+is intentionally not part of the psmux MVP.
 
 ## Classification Key
 
@@ -214,8 +284,8 @@ creation remains on the existing typed tmux path in this phase.
 | `set-hook -gu alert-bell[...]` | `legacy/cleanup candidate`, `hooks/status` | `projmux ai integrate tmux-bell --remove` | Removes projmux-managed alert-bell entries. Phase 2D mux API: `SetHook`. |
 | `show-hooks -g alert-bell` | `hooks/status` | tmux bell integration planning | Detects existing managed bell fallback. |
 | `run-shell -b <command>` | `hooks/status`, `interactive UI` | generated hooks, generated statusbar binds, AI watch-title | Async hook/status dispatch and title watcher launch. |
-| `show-option -gqv <option>` | `hooks/status`, `legacy/cleanup candidate` | notification mode, statusbar decoration, `@projmux_projdir`, app ownership | Reads global user options and generated app markers. Some call sites still use direct `exec.Command("tmux", ...)`. Phase 2D mux API available: `ShowOption`. |
-| `show-option -gv @projmux_app` | `required MVP` for app quit | `quitCommand` | Confirms a socket is app-owned before `kill-server`. Phase 2D mux API available: `ShowOption`. |
+| `show-options -gqv <option>` | `hooks/status`, `legacy/cleanup candidate` | notification mode, statusbar decoration, `@projmux_projdir`, app ownership | Reads global user options and generated app markers. The plural form works on tmux and psmux; avoid tmux's singular alias in shared surfaces. |
+| `show-options -gv @projmux_app` | `required MVP` for app quit | `quitCommand` | Confirms a socket is app-owned before `kill-server`. Phase 2D mux API available: `ShowOption`. |
 | `set-option -g <option> <value>` | `hooks/status` | settings, notification registration, generated config, tmux bell integration | Writes statusbar decoration, desktop notify mode markers, toast URI markers, and tmux bell options. Phase 2D mux API: `SetOption` for tmux bell integration. |
 | `set-option -g -u <option>` | `legacy/cleanup candidate` | notification URI migration | Unsets older URI registration markers. |
 | `set-option -p [-u] -t <pane> <option> [value]` | `hooks/status`, `required MVP` for AI | AI state, attention, topics, notification dedupe, session-state recipe metadata | Core pane metadata storage. Phase 2A mux API: `SetPaneOption`, `UnsetPaneOption`. |
@@ -240,7 +310,7 @@ creation remains on the existing typed tmux path in this phase.
 | Command | Class | Source | Purpose / notes |
 | --- | --- | --- | --- |
 | `tmux -L <socket> new-session -d ...` | `e2e/support` | integration/install smoke scripts | Creates isolated smoke servers. |
-| `tmux -L <socket> show-option -gqv @projmux_app` | `e2e/support` | install/integration/e2e smoke scripts | Confirms generated app config was sourced. |
+| `tmux -L <socket> show-options -gqv @projmux_app` | `e2e/support` | install/integration/e2e smoke scripts | Confirms generated app config was sourced. |
 | `tmux set-option -p ... @projmux_ai_*` | `e2e/support` | e2e smoke | Seeds AI/status metadata for visual smoke. |
 | `tmux display-message -p ...`, `list-panes`, `list-windows` | `e2e/support` | native picker POC scripts | Verifies tmux state during native picker POC runs. |
 | `set-environment -g PROJMUX_*` in generated POC config | `e2e/support` | native picker POC scripts | Seeds environment for sandboxed native picker tests. |
@@ -406,7 +476,7 @@ Required tmux commands/config:
 - `bind-key -n MouseDown1Status if-shell -F "#{==:#{mouse_status_range},window}" { select-window -t = } { run-shell ... }`
 - `bind-key s switch-client -T projmux-status`
 - `bind-key -T projmux-status <key> run-shell ...`
-- Runtime handlers: `display-message`, `display-popup`, `select-window`, `show-option`, `list-panes`.
+- Runtime handlers: `display-message`, `display-popup`, `select-window`, `show-options`, `list-panes`.
 - Phase 2C mux APIs used by runtime handlers: `DisplayPopup`, `SelectWindow`.
 
 ### Hook
@@ -460,8 +530,9 @@ Required tmux commands:
 These items should not block Phase 1, but they are useful pressure points when
 raw tmux calls are centralized:
 
-- Direct `exec.Command("tmux", "show-option", ...)` remains in
-  `tmuxProjdirOption` and the settings desktop notification resolver.
+- Global option reads should use the mux `ShowOption` helper or spell the
+  command as `show-options`; tmux accepts the singular alias, but psmux 3.3.4
+  does not.
 - Legacy desktop notify option `@projmux_desktop_notify` remains a read alias
   for old boolean state.
 - URI registration markers `@projmux_uri_protocol_registered` through `_v5`
@@ -476,7 +547,7 @@ raw tmux calls are centralized:
 - Native picker POC scripts contain raw tmux setup and assertions; keep them in
   e2e/support unless they graduate into production paths.
 
-## psmux Parity Audit Draft Matrix
+## psmux Parity Audit
 
 Phase 3 can use this section as the initial matrix location. If the table grows
 too large, split it to `docs/psmux-parity-audit.md` and leave a link here.
@@ -500,7 +571,7 @@ Status values for Phase 3: `pass`, `partial`, `missing`, `unknown`.
 | Resize panes | `resize-pane -x/-y` | `interactive UI` | `unknown` | Can be `partial` if MVP can tolerate default split sizing. |
 | Pane title | `select-pane -T` and `#{pane_title}` | `interactive UI`, `hooks/status` | `unknown` | Used by attention and AI labels. Phase 2C mux API: `SelectPane`. |
 | Pane options | `set-option -p`, `display-message -p "#{@...}"` | `required MVP`, `hooks/status`, `session-state` | `unknown` | Needs arbitrary user option storage or replacement metadata store. Phase 2A mux API: `SetPaneOption`, `UnsetPaneOption`, `ShowPaneOption`, `PaneOptionFormat`. |
-| Global/session options | `set-option -g`, `show-option -gqv`, `set-option -t -q` | `hooks/status`, `session-state` | `unknown` | Required for settings, decoration, app markers, session-state source. Phase 2D mux APIs: `SetOption`, `ShowOption`. |
+| Global/session options | `set-option -g`, `show-options -gqv`, `set-option -t -q` | `hooks/status`, `session-state` | `unknown` | Required for settings, decoration, app markers, session-state source. Phase 2D mux APIs: `SetOption`, `ShowOption`. |
 | Generated statusbar | `status`, `status-format`, `#[range=user|...]`, `#(...)`, `#{W:...}` | `hooks/status` | `unknown` | May need a separate psmux-native status model. |
 | Statusbar mouse/key dispatch | `MouseDown1Status`, `if-shell -F`, `switch-client -T`, `run-shell` | `interactive UI`, `hooks/status` | `unknown` | Product UX should degrade explicitly if unsupported. |
 | Hooks | `set-hook`, `show-hooks`, `run-shell -b`, `#{hook_pane}` | `hooks/status` | `unknown` | Alert bell and focus hooks may be unavailable. Phase 2D mux API: `SetHook`. |

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -1354,7 +1354,7 @@ func aiMuxCommandNeedsOutput(args []string) bool {
 		return true
 	}
 	switch args[0] {
-	case "display-message", "list-panes", "list-windows", "capture-pane", "show-option", "show-hooks":
+	case "display-message", "list-panes", "list-windows", "capture-pane", "show-option", "show-options", "show-hooks":
 		return true
 	case "split-window", "new-session":
 		if slices.Contains(args[1:], "-P") {

--- a/internal/app/notification.go
+++ b/internal/app/notification.go
@@ -241,7 +241,7 @@ func (c *aiCommand) ensureWSLURIProtocol() {
 	if !c.isWSL() {
 		return
 	}
-	if strings.TrimSpace(c.readTrimmed("tmux", "show-option", "-gqv", uriProtocolRegisteredTmuxOption)) == "1" {
+	if strings.TrimSpace(c.readTrimmed("tmux", "show-options", "-gqv", uriProtocolRegisteredTmuxOption)) == "1" {
 		return
 	}
 	distro := strings.TrimSpace(c.env("WSL_DISTRO_NAME"))
@@ -293,7 +293,7 @@ func (c *aiCommand) ensureWSLLegacyAppIDCleaned(_ aiNotification) {
 	if !c.isWSL() {
 		return
 	}
-	if strings.TrimSpace(c.readTrimmed("tmux", "show-option", "-gqv", legacyAppIDCleanedTmuxOption)) == "1" {
+	if strings.TrimSpace(c.readTrimmed("tmux", "show-options", "-gqv", legacyAppIDCleanedTmuxOption)) == "1" {
 		return
 	}
 	powerShell := c.resolvePowerShell()

--- a/internal/app/notification_toggle.go
+++ b/internal/app/notification_toggle.go
@@ -101,7 +101,7 @@ const (
 // processes or touching `/proc`.
 type desktopNotifyResolver struct {
 	lookupEnv func(string) string
-	// readTmuxOption reads a global user-option (`tmux show-option -gqv …`).
+	// readTmuxOption reads a global user-option (`tmux show-options -gqv …`).
 	// Must return the trimmed string, or empty when tmux is unavailable or
 	// the option is unset.
 	readTmuxOption func(name string) string
@@ -192,13 +192,13 @@ func (c *aiCommand) desktopNotifyModeResolution() (desktopNotifyMode, desktopNot
 	resolver := desktopNotifyResolver{
 		lookupEnv: c.lookupEnv,
 		readTmuxOption: func(name string) string {
-			// tmux show-option only makes sense inside a tmux client
+			// tmux show-options only makes sense inside a tmux client
 			// (we follow the same TMUX gate used elsewhere in the
 			// codebase — see tmuxProjdirOption in switch.go).
 			if strings.TrimSpace(c.env("TMUX")) == "" {
 				return ""
 			}
-			return c.readTrimmed("tmux", "show-option", "-gqv", name)
+			return c.readTrimmed("tmux", "show-options", "-gqv", name)
 		},
 		isWSL:     c.isWSL(),
 		wtPresent: strings.TrimSpace(c.env("WT_SESSION")) != "",
@@ -226,7 +226,12 @@ func settingsDesktopNotifyResolver(lookupEnv func(string) string) desktopNotifyR
 			if lookupEnv == nil || strings.TrimSpace(lookupEnv("TMUX")) == "" {
 				return ""
 			}
-			out, err := mux.ReadTrimmed(context.Background(), "show-option", "-gqv", name)
+			out, err := mux.ShowOption(context.Background(), mux.ShowOptionOptions{
+				Global:    true,
+				Quiet:     true,
+				ValueOnly: true,
+				Option:    name,
+			})
 			if err != nil {
 				return ""
 			}

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -632,11 +632,11 @@ func (c *notifyCommand) focusNotification(entry notify.Notification, source, kin
 
 func (c *notifyCommand) statusbarDecoration() config.StatusbarDecoration {
 	if envValue(c.lookupEnv, "TMUX") != "" && c.runner != nil {
-		out, err := c.runner.Run(context.Background(), "tmux", "show-option", "-gqv", statusbarDecorationNotifyTmuxOption)
+		out, err := c.runner.Run(context.Background(), "tmux", "show-options", "-gqv", statusbarDecorationNotifyTmuxOption)
 		if err == nil && strings.TrimSpace(string(out)) != "" {
 			return config.NormalizeStatusbarDecoration(string(out))
 		}
-		out, err = c.runner.Run(context.Background(), "tmux", "show-option", "-gqv", statusbarDecorationTmuxOption)
+		out, err = c.runner.Run(context.Background(), "tmux", "show-options", "-gqv", statusbarDecorationTmuxOption)
 		if err == nil && strings.TrimSpace(string(out)) != "" {
 			return config.NormalizeStatusbarDecoration(string(out))
 		}

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -380,7 +380,7 @@ func TestNotifyListSidebarTitleDecoration(t *testing.T) {
 			store := &stubNotifyStore{}
 			picker := &stubNotifyPicker{}
 			runner := &focusFakeRunner{respond: func(args []string) ([]byte, error) {
-				if reflect.DeepEqual(args, []string{"show-option", "-gqv", statusbarDecorationNotifyTmuxOption}) {
+				if reflect.DeepEqual(args, []string{"show-options", "-gqv", statusbarDecorationNotifyTmuxOption}) {
 					return []byte(tt.decoration + "\n"), nil
 				}
 				return nil, errors.New("unexpected runner call")

--- a/internal/app/quit.go
+++ b/internal/app/quit.go
@@ -124,7 +124,7 @@ func (c *quitCommand) shutdownAppRuntime(ctx context.Context, socketName string)
 }
 
 func (c *quitCommand) appRuntimeOwned(ctx context.Context, socketName string) (bool, error) {
-	output, err := c.runner.Run(ctx, "tmux", "-L", socketName, "show-option", "-gv", "@projmux_app")
+	output, err := c.runner.Run(ctx, "tmux", "-L", socketName, "show-options", "-gv", "@projmux_app")
 	if err != nil {
 		if tmuxServerMissing(err) {
 			return false, nil

--- a/internal/app/quit_test.go
+++ b/internal/app/quit_test.go
@@ -46,7 +46,7 @@ func TestQuitCommandSelectionKillsOnlyAppOwnedRuntime(t *testing.T) {
 
 	runner := &recordingTmuxRunner{
 		outputs: map[string]string{
-			strings.Join([]string{"tmux", "-L", defaultAppSocket, "show-option", "-gv", "@projmux_app"}, "\x00"): "1\n",
+			strings.Join([]string{"tmux", "-L", defaultAppSocket, "show-options", "-gv", "@projmux_app"}, "\x00"): "1\n",
 		},
 	}
 	cmd := &quitCommand{
@@ -60,7 +60,7 @@ func TestQuitCommandSelectionKillsOnlyAppOwnedRuntime(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	want := []recordedTmuxCall{
-		{name: "tmux", args: []string{"-L", defaultAppSocket, "show-option", "-gv", "@projmux_app"}},
+		{name: "tmux", args: []string{"-L", defaultAppSocket, "show-options", "-gv", "@projmux_app"}},
 		{name: "tmux", args: []string{"-L", defaultAppSocket, "kill-server"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
@@ -105,7 +105,7 @@ func TestQuitCommandNonAppRuntimeIsNoop(t *testing.T) {
 
 	runner := &recordingTmuxRunner{
 		outputs: map[string]string{
-			strings.Join([]string{"tmux", "-L", defaultAppSocket, "show-option", "-gv", "@projmux_app"}, "\x00"): "0\n",
+			strings.Join([]string{"tmux", "-L", defaultAppSocket, "show-options", "-gv", "@projmux_app"}, "\x00"): "0\n",
 		},
 	}
 	cmd := &quitCommand{runner: runner}
@@ -114,7 +114,7 @@ func TestQuitCommandNonAppRuntimeIsNoop(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	want := []recordedTmuxCall{
-		{name: "tmux", args: []string{"-L", defaultAppSocket, "show-option", "-gv", "@projmux_app"}},
+		{name: "tmux", args: []string{"-L", defaultAppSocket, "show-options", "-gv", "@projmux_app"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("tmux calls = %#v, want only ownership check", runner.calls)
@@ -131,7 +131,7 @@ func TestQuitCommandMissingRuntimeIsNoop(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 	want := []recordedTmuxCall{
-		{name: "tmux", args: []string{"-L", defaultAppSocket, "show-option", "-gv", "@projmux_app"}},
+		{name: "tmux", args: []string{"-L", defaultAppSocket, "show-options", "-gv", "@projmux_app"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("tmux calls = %#v, want only ownership check", runner.calls)

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -177,10 +177,10 @@ func parseGitAheadBehind(line string) (int, int) {
 
 func (c *statusCommand) statusbarDecoration() config.StatusbarDecoration {
 	if c.env("TMUX") != "" {
-		if raw := c.readTrimmed("tmux", "show-option", "-gqv", statusbarDecorationGitTmuxOption); strings.TrimSpace(raw) != "" {
+		if raw := c.readTrimmed("tmux", "show-options", "-gqv", statusbarDecorationGitTmuxOption); strings.TrimSpace(raw) != "" {
 			return config.NormalizeStatusbarDecoration(raw)
 		}
-		if raw := c.readTrimmed("tmux", "show-option", "-gqv", statusbarDecorationTmuxOption); strings.TrimSpace(raw) != "" {
+		if raw := c.readTrimmed("tmux", "show-options", "-gqv", statusbarDecorationTmuxOption); strings.TrimSpace(raw) != "" {
 			return config.NormalizeStatusbarDecoration(raw)
 		}
 	}

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -85,7 +85,7 @@ func TestStatusGitPrintsConfiguredSymbolDecorator(t *testing.T) {
 		switch {
 		case name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "#{pane_current_path}"}):
 			return []byte("/repo\n"), nil
-		case name == "tmux" && reflect.DeepEqual(args, []string{"show-option", "-gqv", statusbarDecorationTmuxOption}):
+		case name == "tmux" && reflect.DeepEqual(args, []string{"show-options", "-gqv", statusbarDecorationTmuxOption}):
 			return []byte("symbol\n"), nil
 		case name == "git" && reflect.DeepEqual(args, []string{"-C", "/repo", "rev-parse", "--is-inside-work-tree"}):
 			return []byte("true\n"), nil

--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -1167,14 +1167,19 @@ func extraProjdirRoots(lookup func(string) string) []string {
 
 // tmuxProjdirOption returns the tmux user-option @projmux_projdir value when
 // running inside a tmux client. The TMUX env gate keeps us off the default
-// socket when projmux runs outside tmux, where show-option may either fail
+// socket when projmux runs outside tmux, where the option read may either fail
 // or return a stale value from another server. Errors are swallowed because
 // the caller falls through to the next priority source.
 func tmuxProjdirOption() string {
 	if os.Getenv("TMUX") == "" {
 		return ""
 	}
-	out, err := mux.ReadTrimmed(context.Background(), "show-option", "-gqv", "@projmux_projdir")
+	out, err := mux.ShowOption(context.Background(), mux.ShowOptionOptions{
+		Global:    true,
+		Quiet:     true,
+		ValueOnly: true,
+		Option:    "@projmux_projdir",
+	})
 	if err != nil {
 		return ""
 	}

--- a/internal/integrations/mux/lifecycle.go
+++ b/internal/integrations/mux/lifecycle.go
@@ -58,7 +58,9 @@ type SetOptionOptions struct {
 	Value  string
 }
 
-// ShowOptionOptions describes a `show-option` read.
+// ShowOptionOptions describes a `show-options` read. Use the plural command
+// form because tmux supports both show-option/show-options while psmux only
+// supports show-options.
 type ShowOptionOptions struct {
 	Global    bool
 	Quiet     bool
@@ -210,7 +212,7 @@ func (r Runner) SetOption(ctx context.Context, opts SetOptionOptions) error {
 
 // ShowOption reads a tmux option.
 func (r Runner) ShowOption(ctx context.Context, opts ShowOptionOptions) (string, error) {
-	args := []string{"show-option"}
+	args := []string{"show-options"}
 	if flags := showOptionFlags(opts); flags != "" {
 		args = append(args, flags)
 	}

--- a/internal/integrations/mux/runner_test.go
+++ b/internal/integrations/mux/runner_test.go
@@ -24,7 +24,7 @@ func TestRunnerReadInvokesTmuxWithExactArgs(t *testing.T) {
 	backend := &recordingBackend{out: []byte("  value \n")}
 	runner := NewRunner(backend)
 
-	out, err := runner.Read(context.Background(), "show-option", "-gqv", "@projmux_projdir")
+	out, err := runner.Read(context.Background(), "display-message", "-p", "#{pane_id}")
 	if err != nil {
 		t.Fatalf("Read returned error: %v", err)
 	}
@@ -32,7 +32,7 @@ func TestRunnerReadInvokesTmuxWithExactArgs(t *testing.T) {
 	if backend.name != "tmux" {
 		t.Fatalf("backend name = %q, want tmux", backend.name)
 	}
-	wantArgs := []string{"show-option", "-gqv", "@projmux_projdir"}
+	wantArgs := []string{"display-message", "-p", "#{pane_id}"}
 	if !reflect.DeepEqual(backend.args, wantArgs) {
 		t.Fatalf("backend args = %#v, want %#v", backend.args, wantArgs)
 	}
@@ -162,6 +162,52 @@ func TestRunnerDisplayMessageAllowsTargetlessRead(t *testing.T) {
 	}
 	if got != "%3" {
 		t.Fatalf("DisplayMessageTrimmed = %q, want %%3", got)
+	}
+}
+
+func TestRunnerShowOptionUsesPluralCommandForPsmuxParity(t *testing.T) {
+	backend := &recordingBackend{out: []byte("value\n")}
+	runner := NewRunner(backend)
+
+	got, err := runner.ShowOption(context.Background(), ShowOptionOptions{
+		Global:    true,
+		Quiet:     true,
+		ValueOnly: true,
+		Option:    " @projmux_projdir ",
+	})
+	if err != nil {
+		t.Fatalf("ShowOption returned error: %v", err)
+	}
+
+	wantArgs := []string{"show-options", "-gqv", "@projmux_projdir"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+	if got != "value" {
+		t.Fatalf("ShowOption = %q, want value", got)
+	}
+}
+
+func TestRunnerShowOptionSupportsTargetedSessionRead(t *testing.T) {
+	backend := &recordingBackend{out: []byte("fresh\n")}
+	runner := NewRunner(backend)
+
+	got, err := runner.ShowOption(context.Background(), ShowOptionOptions{
+		Target:    " workspace ",
+		Quiet:     true,
+		ValueOnly: true,
+		Option:    "@projmux_sessionstate_source",
+	})
+	if err != nil {
+		t.Fatalf("ShowOption returned error: %v", err)
+	}
+
+	wantArgs := []string{"show-options", "-qv", "-t", "workspace", "@projmux_sessionstate_source"}
+	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
+		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
+	}
+	if got != "fresh" {
+		t.Fatalf("ShowOption = %q, want fresh", got)
 	}
 }
 
@@ -571,7 +617,7 @@ func TestRunnerSetOptionAndShowOptionBuildGlobalArgs(t *testing.T) {
 		t.Fatalf("ShowOption returned error: %v", err)
 	}
 
-	wantArgs = []string{"show-option", "-gqv", "@projmux_app"}
+	wantArgs = []string{"show-options", "-gqv", "@projmux_app"}
 	if backend.name != "tmux" || !reflect.DeepEqual(backend.args, wantArgs) {
 		t.Fatalf("backend call = %q %#v, want tmux %#v", backend.name, backend.args, wantArgs)
 	}

--- a/test/e2e/linux-smoke.sh
+++ b/test/e2e/linux-smoke.sh
@@ -22,7 +22,7 @@ tmux split-window -d -t e2e-alpha:0 -c "$project_a" sleep 300
 smoke_assert_file_contains "$PROJMUX_SMOKE_WORKDIR/apply-empty.out" "skipped reload: no live tmux server -L projmux"
 
 tmux source-file "$XDG_CONFIG_HOME/projmux/tmux.conf"
-app_flag="$(tmux show-option -gqv @projmux_app)"
+app_flag="$(tmux show-options -gqv @projmux_app)"
 if [[ "$app_flag" != "1" ]]; then
   echo "expected sourced app config to set @projmux_app=1, got: $app_flag" >&2
   exit 1

--- a/test/install/smoke.sh
+++ b/test/install/smoke.sh
@@ -36,7 +36,7 @@ smoke_assert_file_contains "$PROJMUX_SMOKE_WORKDIR/make-install.out" "reloaded t
 smoke_assert_file_contains "$PROJMUX_SMOKE_WORKDIR/make-install.out" "reconcile:"
 smoke_assert_file_contains "$HOME/.config/projmux/tmux.conf" "status notify --max-width 80"
 
-app_flag="$(tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" show-option -gqv @projmux_app)"
+app_flag="$(tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" show-options -gqv @projmux_app)"
 if [[ "$app_flag" != "1" ]]; then
   echo "expected installed tmux apply to set @projmux_app=1, got: $app_flag" >&2
   exit 1

--- a/test/integration/linux-smoke.sh
+++ b/test/integration/linux-smoke.sh
@@ -34,7 +34,7 @@ tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" new-session -d -s integration-smoke -c "$sm
 apply_out="$("$bin" tmux apply --bin "$bin" --config "$XDG_CONFIG_HOME/projmux/tmux.conf" --socket "$PROJMUX_SMOKE_TMUX_SOCKET")"
 smoke_assert_output_contains "$apply_out" "reloaded tmux server -L $PROJMUX_SMOKE_TMUX_SOCKET: 1 sessions"
 
-app_flag="$(tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" show-option -gqv @projmux_app)"
+app_flag="$(tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" show-options -gqv @projmux_app)"
 if [[ "$app_flag" != "1" ]]; then
   echo "expected tmux apply to set @projmux_app=1, got: $app_flag" >&2
   exit 1


### PR DESCRIPTION
## Summary
- use tmux/psmux-compatible `show-options` spelling for global/session option reads
- route low-risk option reads through the existing mux `ShowOption` helper where available
- document Phase 3 psmux MVP direction and Windows 3A0 subphases without changing backend behavior

## Validation
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`

## Risk
- Low operational impact: tmux supports both `show-option` and `show-options`; psmux 3.3.4 only supports the plural spelling observed in smoke.
- No backend selection, psmux adapter, sidecar metadata, schema, or replay changes.

## Unverified
- Native Windows PowerShell runtime smoke remains a later Phase 3A0 item.