### PR TITLE
fix(keybindings): show readable settings labels

### DIFF
--- a/docs/settings-ia.md
+++ b/docs/settings-ia.md
@@ -17,6 +17,10 @@ view-first layout:
   first, then the edit actions, then the explanatory hints.
 - `Settings > Keybindings` is the single entry point for keybinding work. The
   page is split into four chips: `Bindings`, `Diagnostic`, `Probe`, and `Init`.
+- The launcher checkout policy applies in Settings: the project sidebar is a
+  first-class row, action rows use human-readable labels, internal IDs appear
+  only in detail/source/keymap contexts, and runtime footers are status hints,
+  not key discovery.
 - `Settings > Notifications` owns notification delivery IA. Desktop notification
   mode, AI desktop notification dedupe duration, delivery source diagnostics,
   AI hook quiet policy, in-app queue status, and

--- a/internal/app/keybinding_catalog.go
+++ b/internal/app/keybinding_catalog.go
@@ -91,7 +91,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:              "ProjectSidebarToggle",
 			Description:     "Project sidebar",
-			DisplayName:     "ProjectSidebarToggle",
+			DisplayName:     "Toggle Project Sidebar",
 			LegacyIDs:       []string{"sessionizer-sidebar"},
 			Kind:            keyBindingActionTogglePopup,
 			Tier:            keyBindingTierGuaranteedLaunchDefault,
@@ -120,7 +120,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:             "NotifySidebarToggle",
 			Description:    "Notify sidebar",
-			DisplayName:    "NotifySidebarToggle",
+			DisplayName:    "Toggle Notify Sidebar",
 			LegacyIDs:      []string{"notify-sidebar"},
 			Kind:           keyBindingActionTogglePopup,
 			Tier:           keyBindingTierGuaranteedLaunchDefault,
@@ -147,7 +147,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:              "SessionPopupToggle",
 			Description:     "Existing session popup",
-			DisplayName:     "SessionPopupToggle",
+			DisplayName:     "Toggle Session Popup",
 			LegacyIDs:       []string{"session-popup"},
 			Kind:            keyBindingActionTogglePopup,
 			Tier:            keyBindingTierGuaranteedLaunchDefault,
@@ -176,7 +176,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:             "AISplitPickerToggle",
 			Description:    "AI split picker",
-			DisplayName:    "AISplitPickerToggle",
+			DisplayName:    "Toggle AI Split Picker",
 			LegacyIDs:      []string{"ai-split-picker-right"},
 			Kind:           keyBindingActionTogglePopup,
 			Tier:           keyBindingTierGuaranteedLaunchDefault,
@@ -203,7 +203,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:             "SettingsToggle",
 			Description:    "Settings",
-			DisplayName:    "SettingsToggle",
+			DisplayName:    "Toggle Settings",
 			LegacyIDs:      []string{"ai-split-settings"},
 			Kind:           keyBindingActionTogglePopup,
 			Tier:           keyBindingTierGuaranteedLaunchDefault,
@@ -230,7 +230,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:              "ProjectSwitcherToggle",
 			Description:     "Project switcher popup",
-			DisplayName:     "ProjectSwitcherToggle",
+			DisplayName:     "Toggle Project Switcher",
 			LegacyIDs:       []string{"sessionizer"},
 			Kind:            keyBindingActionTogglePopup,
 			Tier:            keyBindingTierUserConfigurableDirect,
@@ -504,6 +504,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:          "Sidebar:PinProject",
 			Description: "Pin or unpin the focused project",
+			DisplayName: "Pin Project",
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "Sidebar",
@@ -512,6 +513,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:          "Sidebar:KillSession",
 			Description: "Kill the focused existing session",
+			DisplayName: "Kill Session",
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "Sidebar",
@@ -520,6 +522,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:          "SessionPopup:KillSession",
 			Description: "Kill the focused existing session",
+			DisplayName: "Kill Session",
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "SessionPopup",
@@ -528,6 +531,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:          "SessionPopup:OpenState",
 			Description: "Open session state for the focused session",
+			DisplayName: "Open Session State",
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "SessionPopup",
@@ -536,6 +540,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:          "SessionPopup:CyclePreviewWindowPrev",
 			Description: "Preview previous window",
+			DisplayName: "Preview Previous Window",
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "SessionPopup",
@@ -544,6 +549,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:          "SessionPopup:CyclePreviewWindowNext",
 			Description: "Preview next window",
+			DisplayName: "Preview Next Window",
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "SessionPopup",
@@ -552,6 +558,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:          "SessionPopup:CyclePreviewPanePrev",
 			Description: "Preview previous pane",
+			DisplayName: "Preview Previous Pane",
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "SessionPopup",
@@ -560,6 +567,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:          "SessionPopup:CyclePreviewPaneNext",
 			Description: "Preview next pane",
+			DisplayName: "Preview Next Pane",
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "SessionPopup",
@@ -568,6 +576,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:          "NotifySidebar:FocusAndAck",
 			Description: "Focus and acknowledge the selected notification",
+			DisplayName: "Focus and Acknowledge",
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "NotifySidebar",
@@ -576,6 +585,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:          "NotifySidebar:Ack",
 			Description: "Acknowledge the selected notification",
+			DisplayName: "Acknowledge",
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "NotifySidebar",
@@ -584,6 +594,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:          "NotifySidebar:ClearNonCritical",
 			Description: "Clear non-critical notifications",
+			DisplayName: "Clear Non-Critical",
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "NotifySidebar",
@@ -592,6 +603,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:          "NotifySidebar:ClearAll",
 			Description: "Clear all notifications",
+			DisplayName: "Clear All",
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "NotifySidebar",
@@ -600,6 +612,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:          "Settings:SwitchTabPrev",
 			Description: "Switch Settings tab left",
+			DisplayName: "Previous Settings Tab",
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "Settings",
@@ -608,6 +621,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 		{
 			ID:          "Settings:SwitchTabNext",
 			Description: "Switch Settings tab right",
+			DisplayName: "Next Settings Tab",
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "Settings",
@@ -634,7 +648,66 @@ func keyBindingDisplayName(action keyBindingAction) string {
 	if name := strings.TrimSpace(action.DisplayName); name != "" {
 		return name
 	}
-	return action.ID
+	return humanizeKeyBindingActionID(action.ID)
+}
+
+func humanizeKeyBindingActionID(id string) string {
+	if _, local, ok := strings.Cut(id, ":"); ok {
+		id = local
+	}
+	id = strings.ReplaceAll(id, "-", " ")
+	var words []string
+	var current strings.Builder
+	runes := []rune(id)
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		words = append(words, current.String())
+		current.Reset()
+	}
+	for i, r := range runes {
+		if r == ' ' || r == '_' {
+			flush()
+			continue
+		}
+		if i > 0 && current.Len() > 0 && isUpperASCII(r) {
+			prev := runes[i-1]
+			var next rune
+			if i+1 < len(runes) {
+				next = runes[i+1]
+			}
+			if isLowerASCII(prev) || isDigitASCII(prev) || (isUpperASCII(prev) && isLowerASCII(next)) {
+				flush()
+			}
+		}
+		current.WriteRune(r)
+	}
+	flush()
+	for i, word := range words {
+		words[i] = titleASCIIWord(word)
+	}
+	return strings.Join(words, " ")
+}
+
+func titleASCIIWord(word string) string {
+	if word == "" {
+		return ""
+	}
+	lower := strings.ToLower(word)
+	return strings.ToUpper(lower[:1]) + lower[1:]
+}
+
+func isUpperASCII(r rune) bool {
+	return r >= 'A' && r <= 'Z'
+}
+
+func isLowerASCII(r rune) bool {
+	return r >= 'a' && r <= 'z'
+}
+
+func isDigitASCII(r rune) bool {
+	return r >= '0' && r <= '9'
 }
 
 func keyBindingActionAliases(action keyBindingAction) []string {

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -2856,7 +2856,44 @@ func keybindingAliasesSummary(action keyBindingAction) string {
 	if len(keys) == 0 {
 		return "(disabled)"
 	}
-	return strings.Join(keys, ", ")
+	labels := make([]string, 0, len(keys))
+	for _, key := range keys {
+		labels = append(labels, keybindingChordDisplay(key))
+	}
+	return strings.Join(labels, ", ")
+}
+
+func keybindingChordDisplay(chord string) string {
+	chord = strings.TrimSpace(chord)
+	if chord == "" {
+		return ""
+	}
+	readable := keybindingReadableChord(chord)
+	if readable == "" || readable == chord {
+		return chord
+	}
+	return readable + " (" + chord + ")"
+}
+
+func keybindingReadableChord(chord string) string {
+	parts := strings.Split(chord, "-")
+	if len(parts) < 2 {
+		return chord
+	}
+	var out []string
+	for _, part := range parts {
+		switch part {
+		case "M":
+			out = append(out, "Alt")
+		case "C":
+			out = append(out, "Ctrl")
+		case "S":
+			out = append(out, "Shift")
+		default:
+			out = append(out, part)
+		}
+	}
+	return strings.Join(out, "-")
 }
 
 func keybindingSource(current, def keyBindingAction) string {
@@ -3262,29 +3299,41 @@ func (c *settingsCommand) labKeybindingEntries() ([]intpickercompat.Entry, error
 	}
 	terminal := detectTerminal(c.lookupEnv)
 	keys := probeKeysFromActions(actions)
-	entries := make([]intpickercompat.Entry, 0, len(keys)+3)
+	keyByAction := make(map[string]probeKey, len(keys))
+	for _, key := range keys {
+		keyByAction[key.ActionID] = key
+	}
+	entries := make([]intpickercompat.Entry, 0, len(actions)+3)
 	entries = append(entries, settingsBackEntry())
 	entries = append(entries, intpickercompat.Entry{
 		Label: settingsLabelInfo("Terminal", terminal.Display(), labTerminalSupportSummary(terminal)),
 		Value: settingsNoopValue,
 	})
-	for _, key := range keys {
-		action, ok := keyBindingActionByID(actions, key.ActionID)
-		if !ok {
-			continue
-		}
+	for _, action := range actions {
 		defaultAction, _ := keyBindingActionByID(defaultKeyBindingCatalog(), action.ID)
-		desc := strings.TrimSpace(action.Description + "  aliases " + keybindingAliasesSummary(action))
-		if keybindingSource(action, defaultAction) == "keymap.toml" {
-			desc += " (custom)"
+		name := keyBindingDisplayName(action)
+		var detail []string
+		if description := strings.TrimSpace(action.Description); description != "" && description != name {
+			detail = append(detail, description)
 		}
-		if key.UserKey != "" {
-			desc += "  " + key.UserKey
+		detail = append(detail, "aliases "+keybindingAliasesSummary(action))
+		if keybindingSource(action, defaultAction) == "keymap.toml" {
+			detail[len(detail)-1] += " (custom)"
+		}
+		if key, ok := keyByAction[action.ID]; ok {
+			if key.Label != "" {
+				detail = append(detail, "probe "+key.Label)
+			}
+			if key.UserKey != "" {
+				detail = append(detail, key.UserKey)
+			}
+		} else if action.Surface != "" {
+			detail = append(detail, action.Surface+" local")
 		}
 		entries = append(entries, intpickercompat.Entry{
-			Label:     settingsLabel(settingsGlyphOpen, settingsColorType, key.Label, desc),
-			Value:     settingsActionPrefixLabKeymap + key.ActionID,
-			SearchKey: key.ActionID + " " + key.Label + " " + key.Action + " " + action.Description,
+			Label:     settingsLabel(settingsGlyphOpen, settingsColorType, name, strings.Join(detail, "  ")),
+			Value:     settingsActionPrefixLabKeymap + action.ID,
+			SearchKey: action.ID + " " + name + " " + action.Description + " " + strings.Join(keyBindingEffectivePlainChords(action), " "),
 		})
 	}
 	return entries, nil
@@ -3299,21 +3348,18 @@ func (c *settingsCommand) labKeybindingDetailEntries(actionID string) ([]intpick
 	if !ok {
 		return nil, "", fmt.Errorf("unknown keybinding action: %s", actionID)
 	}
-	key, err := c.labProbeKeyFromActions(actionID, actions)
-	if err != nil {
-		return nil, "", err
-	}
 	defaultAction, _ := keyBindingActionByID(defaultKeyBindingCatalog(), actionID)
 	terminal := detectTerminal(c.lookupEnv)
 	prefix := settingsActionPrefixLabKeymap + actionID + ":"
+	displayName := keyBindingDisplayName(action)
 	entries := []intpickercompat.Entry{
 		settingsBackEntry(),
 		{
-			Label: settingsLabelInfo("Action ID", action.ID, ""),
+			Label: settingsLabelInfo("Action", displayName, action.Description),
 			Value: settingsNoopValue,
 		},
 		{
-			Label: settingsLabelInfo("Probe key", key.Label, key.Action),
+			Label: settingsLabelInfo("Action ID", action.ID, ""),
 			Value: settingsNoopValue,
 		},
 		{
@@ -3328,10 +3374,23 @@ func (c *settingsCommand) labKeybindingDetailEntries(actionID string) ([]intpick
 			Label: settingsLabelInfo("Aliases", keybindingAliasesSummary(action), "tmux plain"),
 			Value: settingsNoopValue,
 		},
-		{
-			Label: settingsLabel(settingsGlyphType, settingsColorType, "Press the key", "read one raw keypress from /dev/tty"),
-			Value: prefix + "probe",
-		},
+	}
+	if key, err := c.labProbeKeyFromActions(actionID, actions); err == nil {
+		entries = append(entries,
+			intpickercompat.Entry{
+				Label: settingsLabelInfo("Probe key", key.Label, key.Action),
+				Value: settingsNoopValue,
+			},
+			intpickercompat.Entry{
+				Label: settingsLabel(settingsGlyphType, settingsColorType, "Press the key", "read one raw keypress from /dev/tty"),
+				Value: prefix + "probe",
+			},
+		)
+	} else {
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabelInfo("Probe key", "not available", "picker-local action"),
+			Value: settingsNoopValue,
+		})
 	}
 	if terminal.InitCommand() != "" {
 		entries = append(entries,
@@ -3355,7 +3414,7 @@ func (c *settingsCommand) labKeybindingDetailEntries(actionID string) ([]intpick
 	} else if res, ok := c.lastLabProbe[action.ID]; ok {
 		entries = append(entries, labProbeOutcomeEntries(prefix, action, defaultAction, res, terminal)...)
 	}
-	return entries, "Keybindings - " + action.Description, nil
+	return entries, "Keybindings - " + displayName, nil
 }
 
 func labProbeOutcomeEntries(prefix string, action, defaultAction keyBindingAction, res probeResult, terminal terminalInfo) []intpickercompat.Entry {

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -2596,11 +2596,84 @@ func TestSettingsHubKeybindingsListsCurrentValues(t *testing.T) {
 	if hasEntryValue(keybindingOptions.Entries, settingsActionPrefixKeymap+"Sidebar:PinProject") {
 		t.Fatalf("keybindings entries = %#v, did not want native picker internal action in Settings edit list", keybindingOptions.Entries)
 	}
-	if !hasEntryLabelContaining(keybindingOptions.Entries, "keys M-a (custom)") {
+	if !hasEntryLabelContaining(keybindingOptions.Entries, "keys Alt-a (M-a) (custom)") {
 		t.Fatalf("keybindings entries = %#v, want custom plain value", keybindingOptions.Entries)
 	}
 	if hasEntryLabelContaining(keybindingOptions.Entries, "prefix") {
 		t.Fatalf("keybindings entries = %#v, did not want prefix value", keybindingOptions.Entries)
+	}
+}
+
+func TestSettingsHubKeybindingsUsesReadablePrimaryLabels(t *testing.T) {
+	t.Parallel()
+
+	cmd := &settingsCommand{}
+	entries, err := cmd.keybindingEntries()
+	if err != nil {
+		t.Fatalf("keybindingEntries() error = %v", err)
+	}
+
+	projectIndex := entryIndexValue(entries, settingsActionPrefixKeymap+"ProjectSidebarToggle")
+	if projectIndex < 0 {
+		t.Fatalf("keybindings entries = %#v, want project sidebar row", entries)
+	}
+	notifyIndex := entryIndexValue(entries, settingsActionPrefixKeymap+"NotifySidebarToggle")
+	if notifyIndex < 0 {
+		t.Fatalf("keybindings entries = %#v, want notify sidebar row", entries)
+	}
+	if projectIndex > notifyIndex {
+		t.Fatalf("project sidebar row index = %d, notify row index = %d; want project sidebar listed first", projectIndex, notifyIndex)
+	}
+	projectLabel := entries[projectIndex].Label
+	for _, want := range []string{"Toggle Project Sidebar", "Alt-1", "M-1"} {
+		if !strings.Contains(projectLabel, want) {
+			t.Fatalf("project sidebar label = %q, want %q", projectLabel, want)
+		}
+	}
+	if strings.Contains(projectLabel, "ProjectSidebarToggle") {
+		t.Fatalf("project sidebar label = %q, want primary label without internal action ID", projectLabel)
+	}
+
+	detailEntries, title, err := cmd.keybindingDetailEntries("ProjectSidebarToggle")
+	if err != nil {
+		t.Fatalf("keybindingDetailEntries() error = %v", err)
+	}
+	if got, want := title, "Keybinding - Toggle Project Sidebar"; got != want {
+		t.Fatalf("detail title = %q, want %q", got, want)
+	}
+	if !hasEntryLabelContainingAll(detailEntries, "Aliases", "Alt-1", "M-1") {
+		t.Fatalf("detail entries = %#v, want readable default alias with tmux chord", detailEntries)
+	}
+	if !hasEntryLabelContainingAll(detailEntries, "Action ID", "ProjectSidebarToggle") {
+		t.Fatalf("detail entries = %#v, want internal action ID only in detail/source context", detailEntries)
+	}
+}
+
+func TestKeyBindingDisplayNameSeparatesUserLabelFromInternalID(t *testing.T) {
+	t.Parallel()
+
+	catalog := defaultKeyBindingCatalog()
+	cases := map[string]string{
+		"ProjectSidebarToggle":      "Toggle Project Sidebar",
+		"NotifySidebarToggle":       "Toggle Notify Sidebar",
+		"SessionPopupToggle":        "Toggle Session Popup",
+		"AISplitPickerToggle":       "Toggle AI Split Picker",
+		"SettingsToggle":            "Toggle Settings",
+		"ProjectSwitcherToggle":     "Toggle Project Switcher",
+		"SessionPopup:KillSession":  "Kill Session",
+		"NotifySidebar:FocusAndAck": "Focus and Acknowledge",
+		"Settings:SwitchTabPrev":    "Previous Settings Tab",
+		"rename-window":             "Rename Window",
+		"current-project-session":   "Current Project Session",
+	}
+	for id, want := range cases {
+		action, ok := keyBindingActionByID(catalog, id)
+		if !ok {
+			t.Fatalf("catalog missing %q", id)
+		}
+		if got := keyBindingDisplayName(action); got != want {
+			t.Fatalf("keyBindingDisplayName(%q) = %q, want %q", id, got, want)
+		}
 	}
 }
 
@@ -3001,7 +3074,10 @@ func TestSettingsKeybindingsDiagnosticListsActions(t *testing.T) {
 	if !hasEntryLabelContaining(listOptions.Entries, "Alt-1") {
 		t.Fatalf("keybinding lab entries = %#v, want Alt-1 probe label", listOptions.Entries)
 	}
-	if !hasEntryLabelContaining(listOptions.Entries, "aliases M-a (custom)") {
+	if !hasEntryLabelContaining(listOptions.Entries, "Toggle Project Sidebar") {
+		t.Fatalf("keybinding lab entries = %#v, want readable action label", listOptions.Entries)
+	}
+	if !hasEntryLabelContaining(listOptions.Entries, "aliases Alt-a (M-a) (custom)") {
 		t.Fatalf("keybinding lab entries = %#v, want custom plain summary", listOptions.Entries)
 	}
 }
@@ -3086,8 +3162,8 @@ func TestSettingsLabsKeybindingDetailShowsProbeOutcomes(t *testing.T) {
 			if err != nil {
 				t.Fatalf("labKeybindingDetailEntries() error = %v", err)
 			}
-			if !strings.Contains(title, "Project sidebar") {
-				t.Fatalf("title = %q, want action description", title)
+			if !strings.Contains(title, "Toggle Project Sidebar") {
+				t.Fatalf("title = %q, want readable action label", title)
 			}
 			for _, want := range tc.wantLabel {
 				if !hasEntryLabelContaining(entries, want) {
@@ -3100,6 +3176,46 @@ func TestSettingsLabsKeybindingDetailShowsProbeOutcomes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSettingsKeybindingsDiagnosticSeparatesPopupLocalLabelFromInternalID(t *testing.T) {
+	t.Parallel()
+
+	cmd := &settingsCommand{}
+	entries, err := cmd.labKeybindingEntries()
+	if err != nil {
+		t.Fatalf("labKeybindingEntries() error = %v", err)
+	}
+
+	value := settingsActionPrefixLabKeymap + "SessionPopup:KillSession"
+	index := entryIndexValue(entries, value)
+	if index < 0 {
+		t.Fatalf("keybinding lab entries = %#v, want popup-local action value %q", entries, value)
+	}
+	label := entries[index].Label
+	if !strings.Contains(label, "Kill Session") {
+		t.Fatalf("popup-local label = %q, want readable action label", label)
+	}
+	if strings.Contains(label, "SessionPopup:KillSession") {
+		t.Fatalf("popup-local label = %q, want internal id out of user-facing label", label)
+	}
+
+	detailEntries, title, err := cmd.labKeybindingDetailEntries("SessionPopup:KillSession")
+	if err != nil {
+		t.Fatalf("labKeybindingDetailEntries() error = %v", err)
+	}
+	if got, want := title, "Keybindings - Kill Session"; got != want {
+		t.Fatalf("detail title = %q, want %q", got, want)
+	}
+	if !hasEntryLabelContainingAll(detailEntries, "Action", "Kill Session") {
+		t.Fatalf("detail entries = %#v, want readable action row", detailEntries)
+	}
+	if !hasEntryLabelContainingAll(detailEntries, "Action ID", "SessionPopup:KillSession") {
+		t.Fatalf("detail entries = %#v, want internal id in detail context", detailEntries)
+	}
+	if hasEntryLabelContainingAll(detailEntries, "Kill Session", "SessionPopup:KillSession") {
+		t.Fatalf("detail entries = %#v, did not want internal id beside readable action label", detailEntries)
 	}
 }
 


### PR DESCRIPTION
## 완료한 Phase

Follow-up Phase — Settings Keybindings 표면 label / sidebar binding 가시화

## 수정한 user-facing surface

- `Settings > Keybindings > Bindings` rows now use human-readable primary labels such as `Toggle Project Sidebar` instead of internal IDs such as `ProjectSidebarToggle`.
- The project sidebar binding is a first-class row and shows the default alias in user and tmux terms, e.g. `Alt-1 (M-1)`.
- Toggle popup actions now display readable labels: `Toggle Project Sidebar`, `Toggle Notify Sidebar`, `Toggle Session Popup`, `Toggle AI Split Picker`, `Toggle Settings`, and `Toggle Project Switcher`.
- `Settings > Keybindings > Diagnostic/Probe` also separates readable popup-local labels from internal IDs; for example `SessionPopup:KillSession` is presented as `Kill Session`, with the internal ID retained in detail/source context.
- `docs/settings-ia.md` records that Settings is the source for key discovery, not runtime footers.

## 명시적으로 제외한 범위

- No keybinding schema redesign or destructive migration.
- No native picker engine rewrite.
- No terminal emulator deep rewrite.
- No tmux prefix policy redesign.
- No runtime popup footer key guide reintroduction.
- No psmux, notify, or session-state behavior changes.

## Compatibility constraints kept

- `keymap.toml` schema remains compatible.
- Existing canonical action IDs and legacy action ID aliases are preserved.
- `tmux popup-toggle` mode names are unchanged.
- Native picker engine is unchanged.
- Guaranteed `Alt-1..5` launch defaults are preserved.
- `UserN`/CSI-u fallback remains diagnostic/fallback transport, not a user alias.

## 검증 명령

- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `go test ./internal/app -run 'TestSettings(HubKeybindings|KeybindingsDiagnostic|LabsKeybindingDetail)|TestKeyBindingDisplayName'`
- `git diff --check`
- `rg -n 'Footer:.*(Alt\+5|Alt-5|Alt\+4|Alt-4|Alt-2|Ctrl-X|Alt-P|Alt-Up|Alt-Down|Ctrl\+Alt\+S|Ctrl-S|Alt-1|Alt-3)|projmuxFooter\(".*(Alt\+5|Alt-5|Alt\+4|Alt-4|Alt-2|Ctrl-X|Alt-P|Alt-Up|Alt-Down|Ctrl\+Alt\+S|Ctrl-S|Alt-1|Alt-3)' internal/app --glob '*.go'` — no matches

## 미검증 항목과 후속 Phase

- No live interactive tmux/manual terminal UI session was exercised in this branch beyond the Docker integration/e2e targets.
- No follow-up phase is opened by this PR; further keybinding surface expansion should be tracked as a separate roadmap item.
