### PR TITLE
fix(keybindings): surface picker and movement actions

### DIFF
--- a/internal/app/keybinding_catalog.go
+++ b/internal/app/keybinding_catalog.go
@@ -718,7 +718,7 @@ func keyBindingActionAliases(action keyBindingAction) []string {
 
 func keyBindingEditable(action keyBindingAction) bool {
 	switch action.Tier {
-	case keyBindingTierGuaranteedLaunchDefault, keyBindingTierUserConfigurableDirect:
+	case keyBindingTierGuaranteedLaunchDefault, keyBindingTierUserConfigurableDirect, keyBindingTierNativePickerInternal:
 		return true
 	default:
 		return false

--- a/internal/app/keymap.go
+++ b/internal/app/keymap.go
@@ -166,6 +166,9 @@ func saveKeymapOverride(store keymapStore, actionID, field string, value *string
 	} else {
 		current.Bindings[actionID] = override
 	}
+	if _, err := mergeKeymapOverrides(defaultKeyBindingCatalog(), current); err != nil {
+		return path, err
+	}
 
 	if path == "" {
 		path, err = keymapPath(store.homeDir, store.lookupEnv)
@@ -182,6 +185,52 @@ func saveKeymapOverride(store keymapStore, actionID, field string, value *string
 func saveKeymapKeys(store keymapStore, actionID string, keys []string) (string, error) {
 	joined := strings.Join(keys, ",")
 	return saveKeymapOverride(store, actionID, "keys", &joined)
+}
+
+func resetKeymapKeys(store keymapStore, actionID string) (string, error) {
+	current, _, _, path, err := loadKeymapForEdit(store)
+	if err != nil {
+		return path, err
+	}
+	action, ok := keyBindingActionByID(defaultKeyBindingCatalog(), actionID)
+	if !ok {
+		return path, fmt.Errorf("unknown keybinding action: %s", actionID)
+	}
+	actionID = action.ID
+
+	override := current.Bindings[actionID]
+	if current.Bindings == nil {
+		current.Bindings = map[string]keymapOverride{}
+	}
+	for _, legacy := range action.LegacyIDs {
+		if existing, ok := current.Bindings[legacy]; ok {
+			override = existing
+			delete(current.Bindings, legacy)
+			break
+		}
+	}
+	override.Plain = nil
+	override.Keys = nil
+	override.KeysSet = false
+	if override.Prefix == nil {
+		delete(current.Bindings, actionID)
+	} else {
+		current.Bindings[actionID] = override
+	}
+	if _, err := mergeKeymapOverrides(defaultKeyBindingCatalog(), current); err != nil {
+		return path, err
+	}
+
+	if path == "" {
+		path, err = keymapPath(store.homeDir, store.lookupEnv)
+		if err != nil {
+			return "", err
+		}
+	}
+	if err := writeKeymapFile(path, current, store.writeFile); err != nil {
+		return path, err
+	}
+	return path, nil
 }
 
 func keyBindingActionByID(actions []keyBindingAction, id string) (keyBindingAction, bool) {

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -2576,7 +2576,7 @@ func (c *settingsCommand) runKeybindingDetail(actionID string, stdout, stderr io
 			Entries:    entries,
 			Title:      title,
 			Prompt:     "Settings > Keybindings > Action > ",
-			Footer:     projmuxFooter("Aliases are tmux plain chords. Terminal fallback delivery is diagnostic-only."),
+			Footer:     projmuxFooter("Editable rows write keymap aliases. View-only rows explain transport-dependent keys."),
 			ExpectKeys: []string{"enter"},
 			Bindings:   settingsCloseBindings(),
 		})
@@ -2615,7 +2615,7 @@ func (c *settingsCommand) runKeybindingDetail(actionID string, stdout, stderr io
 				return err
 			}
 		case "reset":
-			if err := c.saveKeymapAndApply(actionID, settingsKeymapFieldPlain, nil, stdout); err != nil {
+			if err := c.resetKeymapKeysAndApply(actionID, stdout); err != nil {
 				return err
 			}
 		default:
@@ -2771,19 +2771,16 @@ func (c *settingsCommand) keybindingEntries() ([]intpickercompat.Entry, error) {
 	entries := make([]intpickercompat.Entry, 0, len(actions)+2)
 	entries = append(entries, settingsBackEntry())
 	entries = append(entries, intpickercompat.Entry{
-		Label: "  " + settingsColorDim + "Only direct tmux plain aliases are editable here. User fallback transport stays diagnostic-only." + settingsColorReset,
+		Label: "  " + settingsColorDim + "All catalog actions are listed. Direct tmux and picker-local keys are editable; transport-dependent rows are view-only." + settingsColorReset,
 		Value: settingsNoopValue,
 	})
 	for _, action := range actions {
-		if !keyBindingEditable(action) {
-			continue
-		}
 		defaultAction, _ := keyBindingActionByID(defaults, action.ID)
 		desc := keybindingCurrentSummary(action, defaultAction)
 		entries = append(entries, intpickercompat.Entry{
 			Label:     settingsLabel(settingsGlyphOpen, settingsColorType, keyBindingDisplayName(action), desc),
 			Value:     settingsActionPrefixKeymap + action.ID,
-			SearchKey: action.ID + " " + action.Description + " " + strings.Join(keyBindingEffectivePlainChords(action), " "),
+			SearchKey: action.ID + " " + action.Surface + " " + action.Description + " " + strings.Join(keybindingVisibleChords(action), " "),
 		})
 	}
 	return entries, nil
@@ -2798,35 +2795,54 @@ func (c *settingsCommand) keybindingDetailEntries(actionID string) ([]intpickerc
 	if !ok {
 		return nil, "", fmt.Errorf("unknown keybinding action: %s", actionID)
 	}
-	if !keyBindingEditable(action) {
-		return nil, "", fmt.Errorf("keybinding action %s is not editable in Settings", action.ID)
-	}
 	defaultAction, _ := keyBindingActionByID(defaultKeyBindingCatalog(), actionID)
 	entries := []intpickercompat.Entry{
 		settingsBackEntry(),
+		{
+			Label: settingsLabelInfo("Action", keyBindingDisplayName(action), action.Description),
+			Value: settingsNoopValue,
+		},
 		{
 			Label: settingsLabelInfo("Action ID", action.ID, ""),
 			Value: settingsNoopValue,
 		},
 		{
-			Label: settingsLabelInfo("Aliases", keybindingAliasesSummary(action), keybindingSource(action, defaultAction)),
+			Label: settingsLabelInfo("Keys", keybindingAliasesSummary(action), keybindingSource(action, defaultAction)),
+			Value: settingsNoopValue,
+		},
+		{
+			Label: settingsLabelInfo("Surface", keybindingSurfaceSummary(action), keybindingKindSummary(action)),
+			Value: settingsNoopValue,
+		},
+		{
+			Label: settingsLabelInfo("Tier", keybindingTierSummary(action), keybindingEditabilitySummary(action)),
 			Value: settingsNoopValue,
 		},
 		{
 			Label: settingsLabelInfo("Delivery path", keybindingDeliveryPath(action), keybindingDeliveryHint(action)),
 			Value: settingsNoopValue,
 		},
-		{
-			Label: "  " + settingsColorDim + "Terminal fallback mappings still require rerunning projmux init and restarting the terminal where applicable." + settingsColorReset,
-			Value: settingsNoopValue,
-		},
 	}
+	if !keyBindingEditable(action) {
+		entries = append(entries, intpickercompat.Entry{
+			Label: settingsLabelInfo("Editing", "view only", keybindingNonEditableReason(action)),
+			Value: settingsNoopValue,
+		})
+		title := "Keybinding - " + keyBindingDisplayName(action)
+		return entries, title, nil
+	}
+	entries = append(entries, intpickercompat.Entry{
+		Label: "  " + settingsColorDim + keybindingEditNote(action) + settingsColorReset,
+		Value: settingsNoopValue,
+	})
 	prefix := settingsActionPrefixKeymap + action.ID + ":"
-	entries = append(entries,
-		intpickercompat.Entry{
+	if keybindingCanCapture(action) {
+		entries = append(entries, intpickercompat.Entry{
 			Label: settingsLabel(settingsGlyphType, settingsColorType, "Add alias", "press new key capture"),
 			Value: prefix + "capture",
-		},
+		})
+	}
+	entries = append(entries,
 		intpickercompat.Entry{
 			Label: settingsLabel(settingsGlyphType, settingsColorType, "Type key chord", "enter C-r, M-a, M-S-Left, or C-Space"),
 			Value: prefix + "type",
@@ -2840,7 +2856,7 @@ func (c *settingsCommand) keybindingDetailEntries(actionID string) ([]intpickerc
 			Value: prefix + "disable",
 		},
 		intpickercompat.Entry{
-			Label: settingsLabel(settingsGlyphBack, settingsColorBack, "Reset default", "remove plain override"),
+			Label: settingsLabel(settingsGlyphBack, settingsColorBack, "Reset default", "remove key override"),
 			Value: prefix + "reset",
 		},
 	)
@@ -2852,9 +2868,9 @@ func (c *settingsCommand) keybindingDetailEntries(actionID string) ([]intpickerc
 }
 
 func keybindingAliasesSummary(action keyBindingAction) string {
-	keys := keyBindingEffectivePlainChords(action)
+	keys := keybindingVisibleChords(action)
 	if len(keys) == 0 {
-		return "(disabled)"
+		return "(unbound)"
 	}
 	labels := make([]string, 0, len(keys))
 	for _, key := range keys {
@@ -2878,10 +2894,13 @@ func keybindingChordDisplay(chord string) string {
 func keybindingReadableChord(chord string) string {
 	parts := strings.Split(chord, "-")
 	if len(parts) < 2 {
+		if len(chord) == 1 && chord[0] >= 'a' && chord[0] <= 'z' {
+			return strings.ToUpper(chord)
+		}
 		return chord
 	}
 	var out []string
-	for _, part := range parts {
+	for i, part := range parts {
 		switch part {
 		case "M":
 			out = append(out, "Alt")
@@ -2890,10 +2909,43 @@ func keybindingReadableChord(chord string) string {
 		case "S":
 			out = append(out, "Shift")
 		default:
+			if i == len(parts)-1 && len(part) == 1 && part[0] >= 'a' && part[0] <= 'z' {
+				part = strings.ToUpper(part)
+			}
 			out = append(out, part)
 		}
 	}
 	return strings.Join(out, "-")
+}
+
+func keybindingVisibleChords(action keyBindingAction) []string {
+	if keys := keyBindingEffectivePlainChords(action); len(keys) != 0 {
+		return keys
+	}
+	if action.Tier == keyBindingTierTransportDependent {
+		if chord := keybindingTransportChord(action); chord != "" {
+			return []string{chord}
+		}
+	}
+	return nil
+}
+
+func keybindingCanCapture(action keyBindingAction) bool {
+	return strings.TrimSpace(action.ProbeLabel) != ""
+}
+
+func keybindingTransportChord(action keyBindingAction) string {
+	label := strings.TrimSpace(action.ProbeLabel)
+	probeAction := strings.TrimSpace(action.ProbeAction)
+	if label == "" || probeAction == "" {
+		return ""
+	}
+	start := strings.LastIndex(probeAction, "(")
+	end := strings.LastIndex(probeAction, ")")
+	if start < 0 || end <= start+1 {
+		return ""
+	}
+	return strings.TrimSpace(probeAction[start+1 : end])
 }
 
 func keybindingSource(current, def keyBindingAction) string {
@@ -2916,17 +2968,27 @@ func sameStringSlice(a, b []string) bool {
 }
 
 func keybindingCurrentSummary(action, defaultAction keyBindingAction) string {
-	plain := "keys " + keybindingAliasesSummary(action)
+	parts := []string{keybindingEditabilitySummary(action), "keys " + keybindingAliasesSummary(action)}
+	keysIndex := len(parts) - 1
+	if action.Surface != "" {
+		parts = append(parts, action.Surface)
+	}
 	if keybindingSource(action, defaultAction) == "keymap.toml" {
-		plain += " (custom)"
+		parts[keysIndex] += " (custom)"
 	}
 	if action.UserSlot != noUserSlot && action.CSIu != "" {
-		return plain + "  fallback " + keyBindingUserKey(action)
+		parts = append(parts, "fallback "+keyBindingUserKey(action))
 	}
-	return plain
+	return strings.Join(parts, "  ")
 }
 
 func keybindingDeliveryPath(action keyBindingAction) string {
+	switch action.Tier {
+	case keyBindingTierNativePickerInternal:
+		return "picker-local"
+	case keyBindingTierTransportDependent:
+		return "transport-dependent tmux chord"
+	}
 	if action.UserSlot != noUserSlot && action.CSIu != "" {
 		if len(keyBindingEffectivePlainChords(action)) != 0 {
 			return "plain tmux + terminal fallback"
@@ -2937,10 +2999,115 @@ func keybindingDeliveryPath(action keyBindingAction) string {
 }
 
 func keybindingDeliveryHint(action keyBindingAction) string {
+	switch action.Tier {
+	case keyBindingTierNativePickerInternal:
+		if action.Surface != "" {
+			return action.Surface + " picker action"
+		}
+		return "native picker action"
+	case keyBindingTierTransportDependent:
+		if chord := keybindingTransportChord(action); chord != "" {
+			return chord + " depends on terminal/tmux transport"
+		}
+		return "no default plain chord; configure a safe tmux alias if needed"
+	}
 	if action.UserSlot != noUserSlot && action.CSIu != "" {
 		return keyBindingUserKey(action) + " ESC[" + action.CSIu + "u"
 	}
 	return "tmux plain chord"
+}
+
+func keybindingSurfaceSummary(action keyBindingAction) string {
+	if surface := strings.TrimSpace(action.Surface); surface != "" {
+		return surface
+	}
+	switch action.Scope {
+	case keyBindingScopeStandalone:
+		return "Standalone tmux"
+	case keyBindingScopeApp:
+		return "App tmux"
+	default:
+		return "Global"
+	}
+}
+
+func keybindingKindSummary(action keyBindingAction) string {
+	switch action.Kind {
+	case keyBindingActionTogglePopup:
+		return "popup toggle"
+	case keyBindingActionCommand:
+		return "tmux command"
+	case keyBindingActionPickerInternal:
+		return "picker-local action"
+	default:
+		if action.Kind != "" {
+			return string(action.Kind)
+		}
+		return "keybinding action"
+	}
+}
+
+func keybindingTierSummary(action keyBindingAction) string {
+	switch action.Tier {
+	case keyBindingTierGuaranteedLaunchDefault:
+		return "Guaranteed launch default"
+	case keyBindingTierUserConfigurableDirect:
+		return "User configurable direct alias"
+	case keyBindingTierTransportDependent:
+		return "Transport dependent"
+	case keyBindingTierCSIuFallback:
+		return "Terminal fallback"
+	case keyBindingTierAmbiguousTerminalChord:
+		return "Ambiguous terminal chord"
+	case keyBindingTierNativePickerInternal:
+		return "Picker local"
+	case keyBindingTierPopupLaunchCloseAlias:
+		return "Popup launch close alias"
+	default:
+		if action.Tier != "" {
+			return string(action.Tier)
+		}
+		return "Unclassified"
+	}
+}
+
+func keybindingEditabilitySummary(action keyBindingAction) string {
+	if keyBindingEditable(action) {
+		if action.Tier == keyBindingTierNativePickerInternal {
+			return "editable picker-local"
+		}
+		return "editable direct alias"
+	}
+	switch action.Tier {
+	case keyBindingTierNativePickerInternal:
+		return "view-only picker-local"
+	case keyBindingTierTransportDependent:
+		return "view-only transport-dependent"
+	case keyBindingTierCSIuFallback:
+		return "view-only terminal fallback"
+	default:
+		return "view-only"
+	}
+}
+
+func keybindingNonEditableReason(action keyBindingAction) string {
+	switch action.Tier {
+	case keyBindingTierNativePickerInternal:
+		return "handled inside the native picker surface, not the direct tmux alias editor"
+	case keyBindingTierTransportDependent:
+		return "depends on terminal/tmux transport or has no default plain chord"
+	case keyBindingTierCSIuFallback:
+		return "delivered through terminal fallback User keys, not stored as aliases"
+	default:
+		return "not part of the direct tmux alias editor"
+	}
+}
+
+func keybindingEditNote(action keyBindingAction) string {
+	if action.Tier == keyBindingTierNativePickerInternal {
+		return "Picker-local keys are written to keymap.toml and stay scoped to their Settings surface."
+	}
+	return "Terminal fallback mappings still require rerunning projmux init and restarting the terminal where applicable."
 }
 
 func keybindingCaptureOutcomeEntries(res probeResult) []intpickercompat.Entry {
@@ -2996,6 +3163,11 @@ func (c *settingsCommand) saveKeymapAndApply(actionID, field string, value *stri
 
 func (c *settingsCommand) saveKeymapKeysAndApply(actionID string, keys []string, stdout io.Writer) error {
 	path, err := saveKeymapKeys(c.keymapStore(), actionID, keys)
+	return c.finishKeymapApply(path, err, stdout)
+}
+
+func (c *settingsCommand) resetKeymapKeysAndApply(actionID string, stdout io.Writer) error {
+	path, err := resetKeymapKeys(c.keymapStore(), actionID)
 	return c.finishKeymapApply(path, err, stdout)
 }
 
@@ -3316,7 +3488,7 @@ func (c *settingsCommand) labKeybindingEntries() ([]intpickercompat.Entry, error
 		if description := strings.TrimSpace(action.Description); description != "" && description != name {
 			detail = append(detail, description)
 		}
-		detail = append(detail, "aliases "+keybindingAliasesSummary(action))
+		detail = append(detail, "keys "+keybindingAliasesSummary(action))
 		if keybindingSource(action, defaultAction) == "keymap.toml" {
 			detail[len(detail)-1] += " (custom)"
 		}

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -2587,16 +2587,22 @@ func TestSettingsHubKeybindingsListsCurrentValues(t *testing.T) {
 	if !hasEntryValue(keybindingOptions.Entries, settingsBackValue) {
 		t.Fatalf("keybindings entries = %#v, want back entry", keybindingOptions.Entries)
 	}
-	if !hasEntryLabelContaining(keybindingOptions.Entries, "Only direct tmux plain aliases are editable here") {
-		t.Fatalf("keybindings entries = %#v, want terminal fallback note", keybindingOptions.Entries)
+	if !hasEntryLabelContaining(keybindingOptions.Entries, "All catalog actions are listed") {
+		t.Fatalf("keybindings entries = %#v, want catalog-complete note", keybindingOptions.Entries)
 	}
 	if !hasEntryValue(keybindingOptions.Entries, settingsActionPrefixKeymap+"ProjectSidebarToggle") {
 		t.Fatalf("keybindings entries = %#v, want canonical ProjectSidebarToggle action", keybindingOptions.Entries)
 	}
-	if hasEntryValue(keybindingOptions.Entries, settingsActionPrefixKeymap+"Sidebar:PinProject") {
-		t.Fatalf("keybindings entries = %#v, did not want native picker internal action in Settings edit list", keybindingOptions.Entries)
+	if !hasEntryValue(keybindingOptions.Entries, settingsActionPrefixKeymap+"Sidebar:PinProject") {
+		t.Fatalf("keybindings entries = %#v, want native picker internal action in Settings list", keybindingOptions.Entries)
 	}
-	if !hasEntryLabelContaining(keybindingOptions.Entries, "keys Alt-a (M-a) (custom)") {
+	if !hasEntryValue(keybindingOptions.Entries, settingsActionPrefixKeymap+"previous-window") {
+		t.Fatalf("keybindings entries = %#v, want previous-window action in Settings list", keybindingOptions.Entries)
+	}
+	if !hasEntryValue(keybindingOptions.Entries, settingsActionPrefixKeymap+"select-pane-left") {
+		t.Fatalf("keybindings entries = %#v, want select-pane-left action in Settings list", keybindingOptions.Entries)
+	}
+	if !hasEntryLabelContaining(keybindingOptions.Entries, "keys Alt-A (M-a) (custom)") {
 		t.Fatalf("keybindings entries = %#v, want custom plain value", keybindingOptions.Entries)
 	}
 	if hasEntryLabelContaining(keybindingOptions.Entries, "prefix") {
@@ -2641,11 +2647,195 @@ func TestSettingsHubKeybindingsUsesReadablePrimaryLabels(t *testing.T) {
 	if got, want := title, "Keybinding - Toggle Project Sidebar"; got != want {
 		t.Fatalf("detail title = %q, want %q", got, want)
 	}
-	if !hasEntryLabelContainingAll(detailEntries, "Aliases", "Alt-1", "M-1") {
+	if !hasEntryLabelContainingAll(detailEntries, "Keys", "Alt-1", "M-1") {
 		t.Fatalf("detail entries = %#v, want readable default alias with tmux chord", detailEntries)
 	}
 	if !hasEntryLabelContainingAll(detailEntries, "Action ID", "ProjectSidebarToggle") {
 		t.Fatalf("detail entries = %#v, want internal action ID only in detail/source context", detailEntries)
+	}
+}
+
+func TestSettingsHubKeybindingsListsPopupLocalAndMovementActions(t *testing.T) {
+	t.Parallel()
+
+	cmd := &settingsCommand{}
+	entries, err := cmd.keybindingEntries()
+	if err != nil {
+		t.Fatalf("keybindingEntries() error = %v", err)
+	}
+
+	cases := []struct {
+		id    string
+		wants []string
+	}{
+		{settingsActionPrefixKeymap + "Sidebar:PinProject", []string{"Pin Project", "Alt-P", "M-p", "Sidebar"}},
+		{settingsActionPrefixKeymap + "Sidebar:KillSession", []string{"Kill Session", "Ctrl-X", "C-x", "Sidebar"}},
+		{settingsActionPrefixKeymap + "SessionPopup:CyclePreviewWindowPrev", []string{"Preview Previous Window", "Left", "SessionPopup"}},
+		{settingsActionPrefixKeymap + "SessionPopup:CyclePreviewPanePrev", []string{"Preview Previous Pane", "Alt-Up", "M-Up", "SessionPopup"}},
+		{settingsActionPrefixKeymap + "NotifySidebar:ClearAll", []string{"Clear All", "Ctrl-X", "C-x", "NotifySidebar"}},
+		{settingsActionPrefixKeymap + "Settings:SwitchTabNext", []string{"Next Settings Tab", "Alt-Shift-Right", "M-S-Right", "Settings"}},
+		{settingsActionPrefixKeymap + "previous-window", []string{"Previous Window", "Alt-Shift-Left", "M-S-Left", "transport-dependent"}},
+		{settingsActionPrefixKeymap + "next-window", []string{"Next Window", "Alt-Shift-Right", "M-S-Right", "transport-dependent"}},
+		{settingsActionPrefixKeymap + "select-pane-left", []string{"Select Pane Left", "(unbound)", "transport-dependent"}},
+		{settingsActionPrefixKeymap + "select-pane-right", []string{"Select Pane Right", "(unbound)", "transport-dependent"}},
+	}
+	for _, tc := range cases {
+		idx := entryIndexValue(entries, tc.id)
+		if idx < 0 {
+			t.Fatalf("keybindings entries missing %q: %#v", tc.id, entries)
+		}
+		label := entries[idx].Label
+		for _, want := range tc.wants {
+			if !strings.Contains(label, want) {
+				t.Fatalf("entry %q label = %q, want substring %q", tc.id, label, want)
+			}
+		}
+		if strings.Contains(label, strings.TrimPrefix(tc.id, settingsActionPrefixKeymap)) {
+			t.Fatalf("entry %q label = %q, want primary label without internal action ID", tc.id, label)
+		}
+	}
+}
+
+func TestSettingsHubKeybindingsPopupLocalDetailIsEditableAndTransportDetailIsViewOnly(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	var calls int
+	var popupDetail, transportDetail intpickercompat.Options
+	cmd := testKeybindingSettingsCommand(t, home, func(options intpickercompat.Options) (intpickercompat.Result, error) {
+		calls++
+		switch calls {
+		case 1:
+			return intpickercompat.Result{Key: "enter", Value: settingsSectionKeybindings}, nil
+		case 2:
+			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixKeymap + "Sidebar:PinProject"}, nil
+		case 3:
+			popupDetail = options
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		case 4:
+			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixKeymap + "previous-window"}, nil
+		case 5:
+			transportDetail = options
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		case 6:
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		case 7:
+			return intpickercompat.Result{}, nil
+		default:
+			t.Fatalf("unexpected settings picker call %d", calls)
+			return intpickercompat.Result{}, nil
+		}
+	})
+
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got, want := popupDetail.UI, "settings-keybinding-detail"; got != want {
+		t.Fatalf("popup detail UI = %q, want %q", got, want)
+	}
+	if !hasEntryLabelContainingAll(popupDetail.Entries, "Action ID", "Sidebar:PinProject") {
+		t.Fatalf("popup detail entries = %#v, want internal action ID in detail", popupDetail.Entries)
+	}
+	if !hasEntryLabelContainingAll(popupDetail.Entries, "Keys", "Alt-P", "M-p") {
+		t.Fatalf("popup detail entries = %#v, want readable picker-local keys", popupDetail.Entries)
+	}
+	if !hasEntryLabelContainingAll(popupDetail.Entries, "Tier", "Picker local", "editable picker-local") {
+		t.Fatalf("popup detail entries = %#v, want editable picker-local tier", popupDetail.Entries)
+	}
+	for _, want := range []string{"Type key chord", "Replace primary", "Disable default", "Reset default"} {
+		if !hasEntryLabelContaining(popupDetail.Entries, want) {
+			t.Fatalf("popup detail entries = %#v, want edit action %q", popupDetail.Entries, want)
+		}
+	}
+	if hasEntryLabelContaining(popupDetail.Entries, "Add alias") {
+		t.Fatalf("popup detail entries = %#v, did not want probe capture action", popupDetail.Entries)
+	}
+
+	if got, want := transportDetail.UI, "settings-keybinding-detail"; got != want {
+		t.Fatalf("transport detail UI = %q, want %q", got, want)
+	}
+	if !hasEntryLabelContainingAll(transportDetail.Entries, "Action ID", "previous-window") {
+		t.Fatalf("transport detail entries = %#v, want internal action ID in detail", transportDetail.Entries)
+	}
+	if !hasEntryLabelContainingAll(transportDetail.Entries, "Keys", "Alt-Shift-Left", "M-S-Left") {
+		t.Fatalf("transport detail entries = %#v, want readable transport keys", transportDetail.Entries)
+	}
+	if !hasEntryLabelContainingAll(transportDetail.Entries, "Editing", "view only", "transport") {
+		t.Fatalf("transport detail entries = %#v, want transport view-only explanation", transportDetail.Entries)
+	}
+	if hasEntryLabelContaining(transportDetail.Entries, "Type key chord") {
+		t.Fatalf("transport detail entries = %#v, did not want edit actions", transportDetail.Entries)
+	}
+}
+
+func TestSettingsHubKeybindingsTypedPopupLocalAliasWritesQuotedKeymap(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	var calls int
+	cmd := testKeybindingSettingsCommand(t, home, func(options intpickercompat.Options) (intpickercompat.Result, error) {
+		calls++
+		switch calls {
+		case 1:
+			return intpickercompat.Result{Key: "enter", Value: settingsSectionKeybindings}, nil
+		case 2:
+			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixKeymap + "Sidebar:PinProject"}, nil
+		case 3:
+			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixKeymap + "Sidebar:PinProject:type"}, nil
+		case 4:
+			if got, want := options.UI, "settings-keybinding-type"; got != want {
+				t.Fatalf("typed keybinding UI = %q, want %q", got, want)
+			}
+			return intpickercompat.Result{Key: "enter", Query: "p"}, nil
+		case 5:
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		case 6:
+			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
+		case 7:
+			return intpickercompat.Result{}, nil
+		default:
+			t.Fatalf("unexpected settings picker call %d", calls)
+			return intpickercompat.Result{}, nil
+		}
+	})
+
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	keymap := readFile(t, filepath.Join(home, ".config", "projmux", "keymap.toml"))
+	if !strings.Contains(keymap, "[bindings.\"Sidebar:PinProject\"]\nkeys = [\"M-p\", \"p\"]\n") {
+		t.Fatalf("keymap = %q, want quoted picker-local keys array", keymap)
+	}
+}
+
+func TestSettingsHubKeybindingsPopupLocalConflictIsRejected(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	var calls int
+	cmd := testKeybindingSettingsCommand(t, home, func(options intpickercompat.Options) (intpickercompat.Result, error) {
+		calls++
+		switch calls {
+		case 1:
+			return intpickercompat.Result{Key: "enter", Value: settingsSectionKeybindings}, nil
+		case 2:
+			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixKeymap + "Sidebar:PinProject"}, nil
+		case 3:
+			return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixKeymap + "Sidebar:PinProject:type"}, nil
+		case 4:
+			return intpickercompat.Result{Key: "enter", Query: "C-x"}, nil
+		default:
+			t.Fatalf("unexpected settings picker call %d", calls)
+			return intpickercompat.Result{}, nil
+		}
+	})
+
+	err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), `key "C-x" is bound to both Sidebar:PinProject and Sidebar:KillSession in Sidebar`) {
+		t.Fatalf("Run() error = %v, want same-surface conflict", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".config", "projmux", "keymap.toml")); !os.IsNotExist(err) {
+		t.Fatalf("keymap stat error = %v, want no invalid keymap written", err)
 	}
 }
 
@@ -3077,7 +3267,7 @@ func TestSettingsKeybindingsDiagnosticListsActions(t *testing.T) {
 	if !hasEntryLabelContaining(listOptions.Entries, "Toggle Project Sidebar") {
 		t.Fatalf("keybinding lab entries = %#v, want readable action label", listOptions.Entries)
 	}
-	if !hasEntryLabelContaining(listOptions.Entries, "aliases Alt-a (M-a) (custom)") {
+	if !hasEntryLabelContaining(listOptions.Entries, "keys Alt-A (M-a) (custom)") {
 		t.Fatalf("keybinding lab entries = %#v, want custom plain summary", listOptions.Entries)
 	}
 }


### PR DESCRIPTION
## 완료한 Phase

Follow-up correction — Settings Keybindings popup-local / pane-window movement action visibility

## 수정한 user-facing surface

- `Settings > Keybindings > Bindings` now lists the full keybinding catalog, not only direct global aliases.
- Popup-local actions are first-class rows with readable labels and scoped keys, including:
  - `Pin Project` / `Kill Session` in the sidebar
  - `Kill Session`, `Open Session State`, preview window/pane actions in the session popup
  - notification sidebar actions
  - Settings tab switch actions
- Popup-local actions are editable through typed key chord / replace / disable / reset, with same-surface conflict validation before writing `keymap.toml`.
- Pane/window movement actions are visible:
  - previous/next window show `Alt-Shift-Left (M-S-Left)` / `Alt-Shift-Right (M-S-Right)`
  - select-pane left/right/up/down show `(unbound)` with transport-dependent context
- Non-editable transport-dependent rows open detail instead of erroring, explaining tier, delivery path, and why they are view-only.
- Internal IDs remain in detail/source/keymap context, not primary labels.

## 명시적으로 제외한 범위

- No keybinding schema redesign or destructive migration.
- No native picker engine rewrite.
- No terminal emulator deep rewrite.
- No tmux prefix policy redesign.
- No runtime popup footer key guide reintroduction.
- No psmux, notify, or session-state behavior changes.

## Compatibility constraints kept

- `keymap.toml` schema remains compatible.
- Existing canonical action IDs and legacy action ID aliases are preserved.
- `tmux popup-toggle` mode names are unchanged.
- Native picker engine is unchanged.
- Guaranteed `Alt-1..5` launch defaults are preserved.
- `UserN`/CSI-u fallback remains diagnostic/fallback transport, not a user alias.

## 검증 명령

- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `go test ./internal/app -run 'Test(SettingsHubKeybindings|SettingsKeybindingsDiagnostic|KeyBindingDisplayName|Keymap)'`
- `git diff --check`
- runtime footer stale-guide guard — no matches

## 미검증 항목과 후속 Phase

- No live manual tmux UI session was exercised beyond Docker integration/e2e targets.
- Further terminal-specific transport policy changes remain separate roadmap work.
