### PR TITLE
docs(keybindings): document settings discovery surface

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -4,7 +4,8 @@ projmux is keyboard-driven, but the guaranteed default contract is small:
 fresh installs bind `Alt-1` through `Alt-5` as plain Meta sequences
 (`M-1`..`M-5`, bytes `\x1b1`..`\x1b5`). Other actions remain discoverable in
 Settings > Keybindings and can be assigned safe tmux plain aliases, but they
-are not installed as terminal-specific User-key fallbacks.
+are not installed as terminal-specific User-key fallbacks. `UserN` and `CSI-u`
+are legacy/removal/unsupported targets, not supported fallback guidance.
 
 The recommended path when a key does not fire:
 
@@ -57,6 +58,20 @@ Pane switching is catalogued as transport-dependent. Previous/next window use
 the xterm modifier sequences for `M-S-Left` and `M-S-Right` when the terminal
 forwards them. Rename actions no longer have a built-in terminal fallback; use
 tmux's prefix rename flow or configure an explicit safe alias.
+
+## Roadmap Requirements
+
+Follow-up Phase 2 keeps Settings > Keybindings as a discovery surface. It must
+continue to expose launch toggles, sidebar keymap actions, picker-local actions,
+pane switching, window switching, and rename actions even when a row is
+view-only. Non-editable rows should explain whether the action is
+transport-dependent, picker-local, or diagnostic-only.
+
+Follow-up Phase 3 removes the `UserN` / `CSI-u` route from the product model.
+Windows Terminal and Ghostty-centered replacements should use plain
+Meta/control chords or xterm modifier sequences where possible. If a key cannot
+be represented that way, leave it as a non-editable unsupported or diagnostic
+row instead of preserving a User-key or CSI-u fallback.
 
 ## Picker Actions
 

--- a/docs/settings-ia.md
+++ b/docs/settings-ia.md
@@ -17,6 +17,17 @@ view-first layout:
   first, then the edit actions, then the explanatory hints.
 - `Settings > Keybindings` is the single entry point for keybinding work. The
   page is split into four chips: `Bindings`, `Diagnostic`, `Probe`, and `Init`.
+- `Settings > Keybindings > Bindings` is a keybinding discovery surface, not
+  only a launch-toggle editor. It must show `Toggle Project Sidebar` with the
+  guaranteed `Alt-1` / `M-1` default, plus sidebar-local commands, picker-local
+  commands, `Pane navigation`, `Window navigation`, and `Rename` groups or
+  equivalent searchable rows.
+- Rows that cannot safely be edited still stay visible. Mark them as
+  `transport-dependent` or `diagnostic-only` with the delivery path and reason
+  instead of hiding them or turning them into unsupported editable aliases.
+- `Alt-1..5` are the only guaranteed zero-config launch defaults. `UserN` and
+  `CSI-u` are legacy/removal/unsupported targets, not supported fallback
+  guidance for Settings, setup, init, or docs.
 - The launcher checkout policy applies in Settings: the project sidebar is a
   first-class row, action rows use human-readable labels, internal IDs appear
   only in detail/source/keymap contexts, and runtime footers are status hints,


### PR DESCRIPTION
## Summary
- Completed the docs-only Keybinding roadmap / Settings IA reflection for Follow-up Phase 2/3.
- Updated the user-facing surface in `docs/settings-ia.md` so Settings > Keybindings is documented as a discovery surface, not just launch toggles.
- Documented that `UserN` / `CSI-u` are removal/legacy/unsupported targets, not a supported fallback layer.

## User-facing surface changed
- `docs/settings-ia.md`
- Supporting roadmap/keybinding copy in `docs/keybindings.md`

## Explicitly excluded
- Go code changes
- Settings UI implementation
- Generated tmux config or terminal init implementation
- Keymap schema, native picker engine, or terminal model design/implementation

## Verification
- `make fmt`
- `git diff --check`
- `rg -n 'Toggle Project Sidebar|Pane navigation|pane switching|Window navigation|window switching|Rename|transport-dependent|diagnostic-only|UserN|CSI-u' docs/settings-ia.md docs/keybindings.md`\n- `rg -n 'UserN|CSI-u|fallback|supported fallback|legacy/removal|unsupported' docs/settings-ia.md docs/keybindings.md`\n\n## Skipped\n- `make fix`, `make test`, `make test-integration`, and `make test-e2e` were skipped because this PR is docs-only and does not touch Go code or runtime behavior.\n\n## Follow-up implementation phases\n- Follow-up Phase 2 implementation remains the Settings coverage requirement: sidebar internal keymap, session popup, notify sidebar, pane/window navigation, and rename rows must stay discoverable with editable or non-editable tiers.\n- Follow-up Phase 3 implementation remains the UserKey / CSI-u removal rule: replace with plain Meta/control chords or xterm modifier sequences where possible; otherwise keep non-editable unsupported/diagnostic rows.