### PR TITLE
fix(ui): align picker and statusbar chrome

### DIFF
--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -1142,7 +1142,7 @@ func tmuxStandaloneConfig(binaryPath string, decoration config.StatusbarDecorati
 const statusbarSettingsIcon = ""
 
 func statusbarSettingsButton(label string) string {
-	return "#[bold,fg=colour230,bg=colour31]#[range=user|settings] " + label + " #[norange]#[default]"
+	return "#[bold,fg=colour230,bg=colour31]#[range=user|settings] " + label + " #[norange]#[default] "
 }
 
 func statusbarStandaloneSessionLeftFormat() string {

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -1119,6 +1119,16 @@ func TestTmuxPrintConfigUsesStandaloneBindings(t *testing.T) {
 	}
 }
 
+func TestStatusbarSettingsButtonKeepsTrailingOutsidePad(t *testing.T) {
+	t.Parallel()
+
+	got := statusbarSettingsButton(statusbarSettingsIcon)
+	want := "#[bold,fg=colour230,bg=colour31]#[range=user|settings]  #[norange]#[default] "
+	if got != want {
+		t.Fatalf("statusbarSettingsButton() = %q, want %q", got, want)
+	}
+}
+
 func TestTmuxPrintConfigMissingKeymapKeepsDefaultOutput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/picker/backend_test.go
+++ b/internal/ui/picker/backend_test.go
@@ -843,7 +843,7 @@ func TestNativeInteractiveRendersOptionalTitlebar(t *testing.T) {
 	if strings.Contains(lines[1], projmuxpicker.TitlebarRule+"─") || strings.Contains(lines[1], strings.Repeat("─", 2)) {
 		t.Fatalf("native titlebar row = %q, want no rule fill after title", lines[1])
 	}
-	if !strings.HasPrefix(lines[2], "├") || !strings.Contains(lines[2], projmuxpicker.TitlebarRule+"─") {
+	if !strings.HasPrefix(lines[2], projmuxpicker.TitlebarRule+"├") || !strings.HasSuffix(lines[2], "┤"+projmuxpicker.Reset) {
 		t.Fatalf("native titlebar divider row = %q, want divider between title and search", lines[2])
 	}
 	if !strings.Contains(lines[3], "Search") {

--- a/internal/ui/projmuxpicker/frame.go
+++ b/internal/ui/projmuxpicker/frame.go
@@ -321,7 +321,7 @@ func frameTitlebarChipsLine(theme Theme, innerWidth int, chips []Chip) string {
 }
 
 func frameTitlebarStyledLine(theme Theme, body string) string {
-	return Reset + theme.Vertical + TitlebarStart + body + Reset + theme.Vertical + Reset
+	return TitlebarRule + theme.Vertical + TitlebarStart + body + TitlebarRule + theme.Vertical + Reset
 }
 
 // renderChipStrip lays out the chip slice into a single visible-width-bound
@@ -385,7 +385,7 @@ func chipGapSegment() string {
 }
 
 func frameTitlebarDivider(theme Theme, innerWidth int) string {
-	return "├" + TitlebarRule + strings.Repeat(theme.Horizontal, innerWidth) + Reset + "┤"
+	return TitlebarRule + "├" + strings.Repeat(theme.Horizontal, innerWidth) + "┤" + Reset
 }
 
 func writeFrameDiff(w io.Writer, previous, next string) {

--- a/internal/ui/projmuxpicker/frame_test.go
+++ b/internal/ui/projmuxpicker/frame_test.go
@@ -88,7 +88,7 @@ func TestRendererRenderFrameWithTitleUsesTitlebarRow(t *testing.T) {
 	if got, want := VisibleLen(lines[1]), 24; got != want {
 		t.Fatalf("titlebar row width = %d, want %d: %q", got, want, lines[1])
 	}
-	if !strings.HasPrefix(lines[2], "├") || !strings.HasSuffix(lines[2], "┤") || !strings.Contains(lines[2], TitlebarRule+"─") {
+	if !strings.HasPrefix(lines[2], TitlebarRule+"├") || !strings.HasSuffix(lines[2], "┤"+Reset) {
 		t.Fatalf("titlebar divider row = %q, want full-width divider below titlebar", lines[2])
 	}
 	if !strings.Contains(lines[3], "hello") {
@@ -102,7 +102,7 @@ func TestFrameTitlebarLineResetsAroundBordersAndPadsBody(t *testing.T) {
 	const innerWidth = 18
 	line := frameTitlebarLine(DefaultTheme, innerWidth, "Projects")
 
-	if got, want := line, Reset+"│"+TitlebarStart+" Projects "+strings.Repeat(" ", 8)+Reset+"│"+Reset; got != want {
+	if got, want := line, TitlebarRule+"│"+TitlebarStart+" Projects "+strings.Repeat(" ", 8)+TitlebarRule+"│"+Reset; got != want {
 		t.Fatalf("frameTitlebarLine() = %q, want %q", got, want)
 	}
 	if got, want := VisibleLen(line), innerWidth+2; got != want {
@@ -128,7 +128,7 @@ func TestFrameTitlebarChipsLineResetsAroundBordersAndPadsBody(t *testing.T) {
 		ChipInactiveStart + " B " + Reset +
 		TitlebarStart +
 		strings.Repeat(" ", 10)
-	if got, want := line, Reset+"│"+TitlebarStart+wantBody+Reset+"│"+Reset; got != want {
+	if got, want := line, TitlebarRule+"│"+TitlebarStart+wantBody+TitlebarRule+"│"+Reset; got != want {
 		t.Fatalf("frameTitlebarChipsLine() = %q, want %q", got, want)
 	}
 	if got, want := VisibleLen(line), innerWidth+2; got != want {
@@ -326,7 +326,7 @@ func TestRendererRenderFrameWithChipsUsesTmuxToneTokens(t *testing.T) {
 	if got, want := VisibleLen(chipRow), 40; got != want {
 		t.Fatalf("chip row width = %d, want %d: %q", got, want, chipRow)
 	}
-	if !strings.HasPrefix(lines[2], "├") || !strings.HasSuffix(lines[2], "┤") {
+	if !strings.HasPrefix(lines[2], TitlebarRule+"├") || !strings.HasSuffix(lines[2], "┤"+Reset) {
 		t.Fatalf("titlebar divider = %q, want full-width divider below chip row", lines[2])
 	}
 	if !strings.Contains(lines[3], "hello") {

--- a/internal/ui/projmuxpicker/surface_test.go
+++ b/internal/ui/projmuxpicker/surface_test.go
@@ -39,7 +39,7 @@ func TestFrameChromeANSIGoldenLines(t *testing.T) {
 		{
 			name:      "title",
 			line:      frameTitlebarLine(DefaultTheme, 18, "\x1b[31mProjects\x1b[0m"),
-			want:      Reset + "│" + TitlebarStart + " \x1b[31mProjects" + Reset + TitlebarStart + strings.Repeat(" ", 9) + Reset + "│" + Reset,
+			want:      TitlebarRule + "│" + TitlebarStart + " \x1b[31mProjects" + Reset + TitlebarStart + strings.Repeat(" ", 9) + TitlebarRule + "│" + Reset,
 			wantWidth: 20,
 		},
 		{


### PR DESCRIPTION
Summary:
- color native picker titlebar borders and divider endpoints with the titlebar rule style
- add a neutral trailing pad after the statusbar settings chip
- update frame and statusbar regression tests

Validation:
- GOCACHE=/tmp/projmux-go-cache make fmt
- GOCACHE=/tmp/projmux-go-cache make fix
- GOCACHE=/tmp/projmux-go-cache make test
- GOCACHE=/tmp/projmux-go-cache make test-integration
- GOCACHE=/tmp/projmux-go-cache make test-e2e