### PR TITLE
fix(ui): style settings chip row right edge

### DIFF
--- a/internal/ui/projmuxpicker/frame.go
+++ b/internal/ui/projmuxpicker/frame.go
@@ -133,7 +133,7 @@ func ChipsHitRegions(chips []Chip, innerWidth int) []ChipHit {
 	// Column 1 is the left border, column 2 is the chip-strip leading
 	// padding cell, so the first chip body starts at column 3.
 	cursor := 3
-	maxBody := innerWidth - 1
+	maxBody := innerWidth - 2
 	used := 0
 	first := true
 	for index, chip := range chips {
@@ -310,7 +310,7 @@ func frameTitlebarChipsLine(theme Theme, innerWidth int, chips []Chip) string {
 	if innerWidth < 4 {
 		return frameTitlebarStyledLine(theme, strings.Repeat(" ", innerWidth))
 	}
-	rendered, used := renderChipStrip(chips, innerWidth-1)
+	rendered, used := renderChipStrip(chips, innerWidth-2)
 	if used == 0 {
 		return frameTitlebarStyledLine(theme, strings.Repeat(" ", innerWidth))
 	}

--- a/internal/ui/projmuxpicker/frame_test.go
+++ b/internal/ui/projmuxpicker/frame_test.go
@@ -139,6 +139,28 @@ func TestFrameTitlebarChipsLineResetsAroundBordersAndPadsBody(t *testing.T) {
 	}
 }
 
+func TestFrameTitlebarChipsLineKeepsRightPadStyledWhenStripFills(t *testing.T) {
+	t.Parallel()
+
+	const innerWidth = 10
+	line := frameTitlebarChipsLine(DefaultTheme, innerWidth, []Chip{
+		{Label: "Project Settings", Active: true},
+	})
+
+	if got, want := VisibleLen(line), innerWidth+2; got != want {
+		t.Fatalf("VisibleLen(chip titlebar line) = %d, want %d: %q", got, want, line)
+	}
+	if !strings.Contains(line, ChipActiveStart+" Projec "+Reset) {
+		t.Fatalf("frameTitlebarChipsLine() = %q, want truncated chip before right pad", line)
+	}
+	if !strings.HasSuffix(line, TitlebarStart+" "+TitlebarRule+"│"+Reset) {
+		t.Fatalf("frameTitlebarChipsLine() = %q, want styled right padding cell before right border", line)
+	}
+	if strings.Contains(line, Reset+TitlebarRule+"│") {
+		t.Fatalf("frameTitlebarChipsLine() = %q, want no reset/default background before right border", line)
+	}
+}
+
 func TestRendererContentLayoutWithTitleReservesTitlebarRow(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Reserve a styled titlebar padding cell before the native picker chip row right border.
- Keep chip click hit regions aligned with the rendered chip strip budget.
- Add a regression test for the filled chip-strip right edge so `Reset` does not leak immediately before the border.

## User-facing surface
- Settings/native picker titlebar chip row, including the Global/Project Settings tabs.
- Visible frame width is unchanged.

## Excluded scope
- Visual palette Phase 1 attention colors.
- notify/usage/AI color redesign.
- git/trust/warning/danger colors.
- theme resolver/config schema.
- Settings IA or keybinding behavior.

## Validation
- `GOCACHE=/tmp/projmux-go-cache go test ./internal/ui/projmuxpicker ./internal/ui/picker ./internal/app -run "Test.*Titlebar|Test.*Chip|Test.*SettingsRoot|TestNativeInteractiveRendersOptionalTitlebar|TestFrameChrome"`
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration` (Docker-backed, escalated for `/var/run/docker.sock`)
- `GOCACHE=/tmp/projmux-go-cache make test-e2e` (Docker-backed, escalated for `/var/run/docker.sock`)

Manual visual confirmation not run; coverage is via targeted ANSI/frame regression and existing native picker tests.