### PR TITLE
feat: add semantic palette foundation

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -50,6 +50,7 @@
 - `make test` also covers `projmux ai ingest log` tail/path rendering and bounded JSONL log trimming for ingest diagnostics.
 - `make test` also covers welcome revisit policy: shell `skip_version` gating, `s` skip vs Enter one-run continue, Settings > About > Welcome native viewer, and attach-popup no-duplicate/no-op behavior.
 - `make test` also covers `projmux quit` action-picker rows, cancel/close no-op behavior, explicit quit of only app-owned mux runtimes marked by `@projmux_app=1` on the selected `tmux`/`psmux -L projmux` backend, missing/default runtime no-ops, dispatcher wiring, and `Settings > About > Quit projmux` routing through the same picker before any shutdown side effect.
+- `make test` also covers the built-in semantic palette foundation: non-empty fallback truecolor/tmux tokens, distinct action/attention/AI/danger roles, native picker chip/current/titlebar render strings, statusbar git/notify/usage/settings palette regressions, and settings/trust/destructive row color guards.
 - Current focused unit coverage also includes strict notify SOT behavior
   (TTL does not remove rows, focus success and target-gone clicks ack,
   reconcile reports stale rows), `notify list --live` queue/live explanations, notify sidebar

--- a/docs/native-picker-no-fzf-poc.md
+++ b/docs/native-picker-no-fzf-poc.md
@@ -16,6 +16,9 @@ The fzf compatibility surface for the native engine is tracked in
   execution, and result contracts, while moving visual composition into
   `projmuxpicker` so projmux can evolve a native picker design without coupling
   every visual tweak to the compatibility option/result shape.
+  Built-in fallback colors are centralized as semantic tokens in
+  `internal/theme/palette.go`; see [theme-palette.md](theme-palette.md) for the
+  current inventory and truecolor to tmux 256-color mapping policy.
 - `internal/ui/pickercompat` remains an internal compatibility mapper between
   the old option/result shape and the backend-neutral `picker.Options`
   contract. It is not a runtime backend. App code should

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -5,6 +5,10 @@ clickable status bar. The same dispatcher (`projmux statusbar click`)
 handles both mouse clicks and the keyboard chord, so adding a new
 segment only requires one wiring point.
 
+The built-in fallback colors used by the statusbar are semantic tokens in
+`internal/theme/palette.go`; see [theme-palette.md](theme-palette.md) for the
+truecolor to tmux 256-color mapping policy and palette inventory.
+
 ## Layout
 
 ```

--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -1,0 +1,101 @@
+# Theme Palette
+
+This document records the built-in fallback palette that native projmux UI
+surfaces use before project or global theme settings exist. The source of
+truth in code is `internal/theme/palette.go`.
+
+## Scope
+
+The fallback palette is a semantic token layer, not a user configuration
+schema. It gives current renderers shared names for the colors stabilized by
+the Visual palette baseline work:
+
+- Native picker truecolor SGR tokens.
+- Native sidebar and chip-strip 256-color SGR tokens.
+- Tmux statusbar and generated-config color tokens.
+- Settings/action/state/trust/attention helper tokens.
+
+Future Theme settings should resolve project/global values into this token
+shape, then keep the built-in values as the final fallback. This phase does not
+add `config.toml` fields, a resolver, a Settings editor, presets, import, or
+export.
+
+## Mapping Policy
+
+Native picker rows can emit truecolor SGR, while tmux statusbar/config strings
+must use tmux color specs. The fallback therefore stores both forms when a
+role crosses surfaces.
+
+Rules:
+
+- Truecolor tokens keep exact SGR strings for native picker chrome and
+  Settings rows.
+- Tmux tokens keep `colourN` strings where tmux owns rendering.
+- Native chip/sidebar badge tokens use 256-color SGR when they intentionally
+  mirror tmux colors.
+- Output compatibility wins inside this baseline. For example, the kube
+  segment keeps tmux's named `red` and `blue` behind semantic tokens until that
+  segment gets a separate redesign.
+- Renderers should reference semantic names instead of spelling color literals
+  directly. Test fixtures may still pin rendered escape strings.
+
+## Fallback Inventory
+
+Chrome and text:
+
+| Role | Native SGR | Tmux |
+| --- | --- | --- |
+| `surface.active` | `48;2;44;56;61` with selected white text | window active `colour240` / `colour231` |
+| `surface.raised` | `48;2;24;34;38` with `216;224;228` text | window inactive `colour235` / `colour245` |
+| `text.primary` | `216;224;228` | `colour231` or `colour254` for identity text |
+| `text.secondary` | `164;176;182` | `colour245` |
+| `text.muted` | `117;132;140` or ANSI dim | `colour244`, `colour238`, `colour240` for low-signal blocks |
+
+Accents and state:
+
+| Role | Native SGR | Tmux |
+| --- | --- | --- |
+| `accent.identity` | not emitted directly today | `colour60` bg / `colour254` fg |
+| `accent.action` | `141;205;142`, strong `122;199;173` | `colour29` bg / `colour230` fg |
+| `accent.attention` | notify sidebar `colour204` family | `colour53`, `colour225`, `colour204`, project `colour90` |
+| `accent.ai` | notify agent `colour37` family | `colour37` bg / `colour121` fg |
+| `state.warning` | usage/status popup ANSI 256 wrapper | `colour214` |
+| `state.danger` | `255;107;107` | `colour160` |
+| `state.success` | settings/trust green families | `colour72`, `colour151` |
+| `state.ahead` | switch/git metadata ANSI 256 wrapper | `colour153` |
+
+Surface-specific tokens:
+
+| Surface | Tokens |
+| --- | --- |
+| Native picker | current row, titlebar, rule, pointer, highlight, muted text, chip active/inactive/disabled |
+| Statusbar row 1 | session identity, cwd secondary text, divider, git branch block, git dirty/staged/ahead/behind, settings action chip, clock |
+| Notify HUD/sidebar | line bg/fg, project badge, info/warn/crit/stale/gone badges, AI agent badge, count/age text |
+| Usage HUD/popup | OK/warning/critical/over-limit bars and numbers, empty cells, muted sync age |
+| Settings | add/type/open action, destructive remove/quit, back/cancel, info/read-only, dim description, root action/dim rows, trust trusted/stale/untrusted |
+| Switch picker cards | path metadata, active/inactive git branch badges, statusbar-like window tabs, inline attention dots |
+
+## Current Literal Inventory
+
+After the Phase 3 token pass, raw color values intentionally remain in:
+
+- `internal/theme/palette.go`, the fallback palette source of truth.
+- Unit and golden fixtures that assert exact rendered output.
+- `internal/app/welcome.go`, which is outside the Visual palette baseline
+  Phase 3 scope and should move only in welcome/update policy work.
+- Older switch picker test fixtures that pin legacy compatibility output.
+
+The converted implementation paths include:
+
+- `internal/ui/projmuxpicker/ansi.go`
+- `internal/app/tmux.go`
+- `internal/app/status.go`
+- `internal/app/statusbar.go`
+- `internal/app/statusbar_decoration.go`
+- `internal/app/notify.go`
+- `internal/app/settings.go`
+- `internal/app/settings_render.go`
+- `internal/app/trust.go`
+- `internal/app/usage.go`
+- `internal/core/usage/hud.go`
+- `internal/ui/render/switch.go`

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/notify"
+	"github.com/crevissepartners/projmux/internal/theme"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
@@ -315,7 +316,7 @@ func (c *notifyCommand) runSidebar(store notifyStore, severities, sources []stri
 		compatOptions := intpickercompat.Options{
 			UI:     "notify-sidebar",
 			Read0:  true,
-			Title:  "\x1b[1;38;5;204m" + notifyHeaderDecorator(c.statusbarDecoration()) + "Pending Notifications\x1b[0m",
+			Title:  theme.ANSINotifyTitleStart + notifyHeaderDecorator(c.statusbarDecoration()) + "Pending Notifications" + theme.ANSIReset,
 			Prompt: "Notify > ",
 			Header: "Newest first",
 			Footer: "Newest first. Critical notifications are kept when clearing non-critical rows.",
@@ -483,19 +484,19 @@ func notifySidebarTarget(e notify.Notification) string {
 }
 
 const (
-	notifySidebarReset   = "\x1b[0m"
-	notifySidebarDimOpen = "\x1b[38;5;245m"
-	notifySidebarProject = "\x1b[1;38;5;231;48;5;90m"
-	notifySidebarInfo    = "\x1b[1;38;5;16;48;5;204m"
-	notifySidebarWarn    = "\x1b[1;38;5;16;48;5;214m"
-	notifySidebarCrit    = "\x1b[1;38;5;231;48;5;160m"
+	notifySidebarReset   = theme.ANSIReset
+	notifySidebarDimOpen = theme.ANSINotifyDimStart
+	notifySidebarProject = theme.ANSINotifyProjectStart
+	notifySidebarInfo    = theme.ANSINotifyInfoStart
+	notifySidebarWarn    = theme.ANSINotifyWarnStart
+	notifySidebarCrit    = theme.ANSINotifyCritStart
 	// Stale/gone badges share a muted grey palette so the ack-only state is
 	// visually distinct from active rows without competing for attention.
 	// STALE keeps the dim italic-equivalent (no italic SGR is universally
 	// supported on tmux palettes, so we lean on the dim attribute), while
 	// GONE adds strikethrough to telegraph "the target no longer exists".
-	notifySidebarStale = "\x1b[2;38;5;231;48;5;240m"
-	notifySidebarGone  = "\x1b[2;9;38;5;231;48;5;238m"
+	notifySidebarStale = theme.ANSINotifyStaleStart
+	notifySidebarGone  = theme.ANSINotifyGoneStart
 )
 
 func notifySidebarAge(age string) string {
@@ -503,7 +504,7 @@ func notifySidebarAge(age string) string {
 	if age == "" {
 		age = "0s"
 	}
-	return "\x1b[1;38;5;204m age " + age + " " + notifySidebarReset
+	return theme.ANSINotifyTitleStart + " age " + age + " " + notifySidebarReset
 }
 
 func notifySidebarProjectBadge(project string) string {
@@ -557,11 +558,11 @@ func notifySidebarAgentBadge(agent string) string {
 func notifySidebarAgentOpen(agent string) string {
 	switch strings.ToLower(strings.TrimSpace(agent)) {
 	case "claude":
-		return "\x1b[1;38;5;16;48;5;37m"
+		return theme.ANSINotifyAgentStart
 	case "codex":
-		return "\x1b[1;38;5;16;48;5;37m"
+		return theme.ANSINotifyAgentStart
 	default:
-		return "\x1b[1;38;5;16;48;5;37m"
+		return theme.ANSINotifyAgentStart
 	}
 }
 

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/config"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+	"github.com/crevissepartners/projmux/internal/theme"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 	"github.com/crevissepartners/projmux/internal/ui/projmuxpicker"
@@ -559,8 +560,8 @@ func (c *settingsCommand) rootEntriesForAxis(axis SettingsAxis) []intpickercompa
 }
 
 const (
-	settingsRootColorOpen = "\x1b[38;2;122;199;173m"
-	settingsRootColorDim  = "\x1b[38;2;117;132;140m"
+	settingsRootColorOpen = theme.ANSIAccentActionStrongStart
+	settingsRootColorDim  = theme.ANSITextMutedStart
 )
 
 func settingsRootLabel(glyph, name, description string) string {

--- a/internal/app/settings_render.go
+++ b/internal/app/settings_render.go
@@ -1,6 +1,10 @@
 package app
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/crevissepartners/projmux/internal/theme"
+)
 
 // settings_render.go centralizes the picker-row formatting used by every
 // settings entry builder. Keeping the glyph + color + padding in one place
@@ -22,14 +26,14 @@ const (
 
 // ANSI color sequences mapped per the design system.
 const (
-	settingsColorAdd    = "\x1b[38;2;141;205;142m" // green: additive / primary action
-	settingsColorType   = "\x1b[38;2;141;205;142m" // green: edit / navigate action
-	settingsColorRemove = "\x1b[38;2;255;107;107m" // red: destructive
-	settingsColorBack   = "\x1b[38;2;164;176;182m" // secondary: back / cancel
-	settingsColorActive = "\x1b[1m"                // bold: active / current value
-	settingsColorDim    = "\x1b[90m"               // dim: descriptions, secondary text
-	settingsColorInfo   = "\x1b[38;2;216;224;228m" // soft foreground: info / read-only label
-	settingsColorReset  = "\x1b[0m"
+	settingsColorAdd    = theme.ANSIAccentActionStart  // additive / primary action
+	settingsColorType   = theme.ANSIAccentActionStart  // edit / navigate action
+	settingsColorRemove = theme.ANSIStateDangerStart   // destructive
+	settingsColorBack   = theme.ANSITextSecondaryStart // back / cancel
+	settingsColorActive = theme.ANSIBold               // active / current value
+	settingsColorDim    = theme.ANSITextDimStart       // descriptions, secondary text
+	settingsColorInfo   = theme.ANSITextPrimaryStart   // info / read-only label
+	settingsColorReset  = theme.ANSIReset
 )
 
 // settingsLabelNameWidth is the byte width the name column is padded to.

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -14,18 +14,19 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/notify"
+	"github.com/crevissepartners/projmux/internal/theme"
 )
 
 const (
 	defaultKubeCacheTTL     = 5 * time.Second
 	defaultKubeCommandLimit = 400 * time.Millisecond
 
-	tmuxGitSegmentBg = "colour30"
-	tmuxGitSegmentFg = "colour231"
-	tmuxGitDirtyFg   = "colour222"
-	tmuxGitStagedFg  = "colour151"
-	tmuxGitAheadFg   = "colour153"
-	tmuxGitBehindFg  = "colour181"
+	tmuxGitSegmentBg = theme.TmuxGitSegmentBg
+	tmuxGitSegmentFg = theme.TmuxGitSegmentFg
+	tmuxGitDirtyFg   = theme.TmuxStateDirtyFg
+	tmuxGitStagedFg  = theme.TmuxStateStagedFg
+	tmuxGitAheadFg   = theme.TmuxStateAheadFg
+	tmuxGitBehindFg  = theme.TmuxStateBehindFg
 )
 
 type statusCommand struct {
@@ -241,7 +242,7 @@ func (c *statusCommand) kubeSegment(sessionName string) string {
 	if ns == "" {
 		ns = "default"
 	}
-	segment := fmt.Sprintf("⎈ #[fg=red]%s#[default]/#[fg=blue]%s#[default]", ctx, ns)
+	segment := fmt.Sprintf("⎈ #[fg=%s]%s#[default]/#[fg=%s]%s#[default]", theme.TmuxKubeContextFg, ctx, theme.TmuxKubeNamespaceFg, ns)
 	_ = os.MkdirAll(filepath.Dir(cacheFile), 0o755)
 	_ = os.WriteFile(cacheFile, []byte(segment), 0o644)
 	return segment
@@ -479,19 +480,19 @@ func (c *statusCommand) notifyStore() (notifyStore, error) {
 // of that same line instead of separate outline glyphs.
 const (
 	notifyLineOpen      = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + tmuxAccentAttentionFg + "]"
-	notifyLineDimOpen   = "#[bg=" + tmuxAccentAttentionBg + ",fg=colour183]"
+	notifyLineDimOpen   = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + theme.TmuxAccentAttentionDimFg + "]"
 	notifyLineCountOpen = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + tmuxAccentAttentionFg + ",bold]"
-	notifyProjectOpen   = "#[bg=colour90,fg=colour231,bold]"
-	notifyBadgeInfoOpen = "#[bg=" + tmuxAccentAttentionStrongBg + ",fg=colour16,bold]"
-	notifyBadgeWarnOpen = "#[bg=" + tmuxStateWarningFg + ",fg=colour16,bold]"
-	notifyBadgeCritOpen = "#[bg=" + tmuxStateCriticalFg + ",fg=colour231,bold]"
+	notifyProjectOpen   = "#[bg=" + theme.TmuxAttentionProjectBg + ",fg=" + theme.TmuxPrimaryFg + ",bold]"
+	notifyBadgeInfoOpen = "#[bg=" + tmuxAccentAttentionStrongBg + ",fg=" + theme.TmuxPaneActiveFg + ",bold]"
+	notifyBadgeWarnOpen = "#[bg=" + tmuxStateWarningFg + ",fg=" + theme.TmuxPaneActiveFg + ",bold]"
+	notifyBadgeCritOpen = "#[bg=" + tmuxStateCriticalFg + ",fg=" + theme.TmuxPrimaryFg + ",bold]"
 	// Stale/gone badges share a muted palette so the ack-only state is
 	// visually distinct from the active NEED/INFO/WARN/CRIT badges without
 	// stealing focus. The colours land in the same neutral grey family the
 	// sidebar uses so users learn a single ack-only affordance.
-	notifyBadgeStaleOpen = "#[bg=colour240,fg=colour231,bold]"
-	notifyBadgeGoneOpen  = "#[bg=colour238,fg=colour231,dim]"
-	notifyAgentOpen      = "#[bg=" + tmuxAccentAIBg + ",fg=colour16,bold]"
+	notifyBadgeStaleOpen = "#[bg=" + theme.TmuxMutedBg + ",fg=" + theme.TmuxPrimaryFg + ",bold]"
+	notifyBadgeGoneOpen  = "#[bg=" + theme.TmuxGoneBg + ",fg=" + theme.TmuxPrimaryFg + ",dim]"
+	notifyAgentOpen      = "#[bg=" + tmuxAccentAIBg + ",fg=" + theme.TmuxPaneActiveFg + ",bold]"
 	notifyAgentClaude    = notifyAgentOpen
 	notifyAgentCodex     = notifyAgentOpen
 	notifySeverityInfo   = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + tmuxAccentAttentionStrongBg + "]"

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -28,6 +28,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/core/notify"
 	coreusage "github.com/crevissepartners/projmux/internal/core/usage"
 	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
+	"github.com/crevissepartners/projmux/internal/theme"
 	"github.com/crevissepartners/projmux/internal/ui/projmuxpicker"
 )
 
@@ -994,15 +995,15 @@ func dimANSI(value string) string {
 }
 
 func amberANSI(value string) string {
-	return "\x1b[38;5;214m" + value + projmuxpicker.Reset
+	return theme.ANSI256FgStart(theme.TmuxStateWarningFg) + value + projmuxpicker.Reset
 }
 
 func redANSI(value string) string {
-	return "\x1b[38;5;160m" + value + projmuxpicker.Reset
+	return theme.ANSI256FgStart(theme.TmuxStateCriticalFg) + value + projmuxpicker.Reset
 }
 
 func tealANSI(value string) string {
-	return "\x1b[38;5;72m" + value + projmuxpicker.Reset
+	return theme.ANSI256FgStart(theme.TmuxStateSuccessFg) + value + projmuxpicker.Reset
 }
 
 func (c *statusbarCommand) statusbarPathMetadata(ctx context.Context, path string) statusbarPathMetadata {

--- a/internal/app/statusbar_decoration.go
+++ b/internal/app/statusbar_decoration.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/theme"
 )
 
 const (
@@ -134,7 +135,7 @@ func statusbarCwdSegmentFormat() string {
 }
 
 func statusbarCwdDecoratorFormat() string {
-	return "#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},},#{?#{==:#{" + statusbarDecorationTmuxOption + "},symbol},#[fg=colour220] ,#{?#{==:#{" + statusbarDecorationTmuxOption + "},emoji},#[fg=colour220]📁 ,}},#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},symbol},#[fg=colour220] ,#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},emoji},#[fg=colour220]📁 ,}}}"
+	return "#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},},#{?#{==:#{" + statusbarDecorationTmuxOption + "},symbol},#[fg=" + theme.TmuxDecorationCwdFg + "] ,#{?#{==:#{" + statusbarDecorationTmuxOption + "},emoji},#[fg=" + theme.TmuxDecorationCwdFg + "]📁 ,}},#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},symbol},#[fg=" + theme.TmuxDecorationCwdFg + "] ,#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},emoji},#[fg=" + theme.TmuxDecorationCwdFg + "]📁 ,}}}"
 }
 
 type gitRemoteProvider string
@@ -150,18 +151,18 @@ func statusbarGitDecorator(mode config.StatusbarDecoration, remoteURL string) st
 	case config.StatusbarDecorationSymbol:
 		switch provider {
 		case gitRemoteProviderGitLab:
-			return "#[fg=colour215] #[fg=" + tmuxGitSegmentFg + "]"
+			return "#[fg=" + theme.TmuxDecorationGitLabFg + "] #[fg=" + tmuxGitSegmentFg + "]"
 		default:
-			return "#[fg=colour153] #[fg=" + tmuxGitSegmentFg + "]"
+			return "#[fg=" + theme.TmuxDecorationGitHubFg + "] #[fg=" + tmuxGitSegmentFg + "]"
 		}
 	case config.StatusbarDecorationEmoji:
 		switch provider {
 		case gitRemoteProviderGitHub:
-			return "#[fg=colour153]🐱 #[fg=" + tmuxGitSegmentFg + "]"
+			return "#[fg=" + theme.TmuxDecorationGitHubFg + "]🐱 #[fg=" + tmuxGitSegmentFg + "]"
 		case gitRemoteProviderGitLab:
-			return "#[fg=colour215]🦊 #[fg=" + tmuxGitSegmentFg + "]"
+			return "#[fg=" + theme.TmuxDecorationGitLabFg + "]🦊 #[fg=" + tmuxGitSegmentFg + "]"
 		default:
-			return "#[fg=colour151]🌿 #[fg=" + tmuxGitSegmentFg + "]"
+			return "#[fg=" + theme.TmuxDecorationGenericGitFg + "]🌿 #[fg=" + tmuxGitSegmentFg + "]"
 		}
 	default:
 		return ""

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -18,6 +18,7 @@ import (
 	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
 	"github.com/crevissepartners/projmux/internal/integrations/sessionstate"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+	"github.com/crevissepartners/projmux/internal/theme"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
 	"github.com/crevissepartners/projmux/internal/ui/projmuxpicker"
 )
@@ -31,19 +32,19 @@ const (
 	tmuxWindowActiveBg   = projmuxpicker.TmuxWindowActiveBg
 	tmuxWindowActiveFg   = projmuxpicker.TmuxWindowActiveFg
 	tmuxWindowTitleWidth = 10
-	tmuxIdentityBg       = "colour60"
-	tmuxIdentityFg       = "colour254"
-	tmuxActionBg         = "colour29"
-	tmuxActionFg         = "colour230"
-	tmuxSecondaryFg      = "colour245"
+	tmuxIdentityBg       = theme.TmuxIdentityBg
+	tmuxIdentityFg       = theme.TmuxIdentityFg
+	tmuxActionBg         = theme.TmuxActionBg
+	tmuxActionFg         = theme.TmuxActionFg
+	tmuxSecondaryFg      = theme.TmuxSecondaryFg
 
-	tmuxAccentAttentionBg       = "colour53"
-	tmuxAccentAttentionFg       = "colour225"
-	tmuxAccentAttentionStrongBg = "colour204"
-	tmuxAccentAIBg              = "colour37"
-	tmuxAccentAIFg              = "colour121"
-	tmuxStateWarningFg          = "colour214"
-	tmuxStateCriticalFg         = "colour160"
+	tmuxAccentAttentionBg       = theme.TmuxAccentAttentionBg
+	tmuxAccentAttentionFg       = theme.TmuxAccentAttentionFg
+	tmuxAccentAttentionStrongBg = theme.TmuxAccentAttentionStrongBg
+	tmuxAccentAIBg              = theme.TmuxAccentAIBg
+	tmuxAccentAIFg              = theme.TmuxAccentAIFg
+	tmuxStateWarningFg          = theme.TmuxStateWarningFg
+	tmuxStateCriticalFg         = theme.TmuxStateCriticalFg
 )
 
 type tmuxPopupClient interface {
@@ -1215,8 +1216,8 @@ func tmuxPaneBorderFormat() string {
 	paneLabelFormat := tmuxVisiblePaneLabelFormat()
 	paneBusyFormat := "#{==:#{@projmux_attention_state},busy}"
 	paneReplyFormat := "#{==:#{@projmux_attention_state},reply}"
-	inactivePaneBorderFormat := "#{?" + paneBusyFormat + ",#[bold#,fg=" + tmuxAccentAIFg + "] ● " + paneLabelFormat + " #[default],#{?" + paneReplyFormat + ",#[bold#,fg=" + tmuxAccentAttentionStrongBg + "] ● " + paneLabelFormat + " #[default],#[fg=colour244] " + paneLabelFormat + " #[default]}}"
-	return "#{?pane_active,#[bold#,fg=colour16#,bg=colour45] > " + paneLabelFormat + " #[default]," + inactivePaneBorderFormat + "}"
+	inactivePaneBorderFormat := "#{?" + paneBusyFormat + ",#[bold#,fg=" + tmuxAccentAIFg + "] ● " + paneLabelFormat + " #[default],#{?" + paneReplyFormat + ",#[bold#,fg=" + tmuxAccentAttentionStrongBg + "] ● " + paneLabelFormat + " #[default],#[fg=" + theme.TmuxMutedFg + "] " + paneLabelFormat + " #[default]}}"
+	return "#{?pane_active,#[bold#,fg=" + theme.TmuxPaneActiveFg + "#,bg=" + theme.TmuxPaneActiveBg + "] > " + paneLabelFormat + " #[default]," + inactivePaneBorderFormat + "}"
 }
 
 func tmuxCenteredWindowNameFormat(width int) string {
@@ -1257,7 +1258,7 @@ func tmuxStandaloneConfigWithKeymap(binaryPath string, decorations statusbarDeco
 		"set -g status-left-length 20",
 		"set -g status-right-length 140",
 		"set -g status-left "+tmuxConfigQuote(statusbarStandaloneSessionLeftFormat()),
-		"set -g status-right "+tmuxConfigQuote(statusbarCwdSegmentFormat()+"#[fg=colour239]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]#[fg="+tmuxSecondaryFg+"]   %Y-%m-%d %H:%M "+statusbarSettingsButton(statusbarSettingsIcon+" projmux")),
+		"set -g status-right "+tmuxConfigQuote(statusbarCwdSegmentFormat()+"#[fg="+theme.TmuxDividerFg+"]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]#[fg="+tmuxSecondaryFg+"]   %Y-%m-%d %H:%M "+statusbarSettingsButton(statusbarSettingsIcon+" projmux")),
 		// Two-line status bar: line 0 is the notify/HUD control row; line 1 is
 		// tmux's native session/window/path row. Setting both rows explicitly is
 		// required because tmux's built-in row otherwise stays at index 0.
@@ -1321,10 +1322,10 @@ func tmuxAppConfigWithKeymap(binaryPath, defaultShell string, decorations status
 		"set -g mode-keys vi",
 		"set -sg escape-time 100",
 		"set -g status-style \"bg=" + tmuxWindowInactiveBg + ",fg=" + tmuxWindowInactiveFg + "\"",
-		"set -g message-style \"bg=colour208,fg=colour16,bold\"",
-		"set -g message-command-style \"bg=colour208,fg=colour16,bold\"",
-		"set -g pane-border-style \"fg=colour236\"",
-		"set -g pane-active-border-style \"fg=colour51,bold\"",
+		"set -g message-style \"bg=" + theme.TmuxMessageBg + ",fg=" + theme.TmuxMessageFg + ",bold\"",
+		"set -g message-command-style \"bg=" + theme.TmuxMessageBg + ",fg=" + theme.TmuxMessageFg + ",bold\"",
+		"set -g pane-border-style \"fg=" + theme.TmuxPaneBorderFg + "\"",
+		"set -g pane-active-border-style \"fg=" + theme.TmuxPaneActiveBorderFg + ",bold\"",
 		"set -g pane-border-status top",
 		"set -g pane-border-format " + tmuxConfigQuote(paneBorderFormat),
 	}
@@ -1347,7 +1348,7 @@ func tmuxAppConfigWithKeymap(binaryPath, defaultShell string, decorations status
 	lines = append(lines,
 		"set -g status 2",
 		"set -g status-left "+tmuxConfigQuote(statusbarAppSessionLeftFormat()),
-		"set -g status-right "+tmuxConfigQuote(statusbarCwdSegmentFormat()+"#[fg=colour239]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]#[fg="+tmuxSecondaryFg+"]   %Y-%m-%d %H:%M "+statusbarSettingsButton(statusbarSettingsIcon)),
+		"set -g status-right "+tmuxConfigQuote(statusbarCwdSegmentFormat()+"#[fg="+theme.TmuxDividerFg+"]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]#[fg="+tmuxSecondaryFg+"]   %Y-%m-%d %H:%M "+statusbarSettingsButton(statusbarSettingsIcon)),
 		"set -g status-format[0] "+tmuxConfigQuote(statusbarAuxLineFormat(bin, true)),
 		"set -g status-format[1] "+tmuxConfigQuote(statusbarWindowLineFormat()),
 		"set -gu status-format[2]",

--- a/internal/app/trust.go
+++ b/internal/app/trust.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/crevissepartners/projmux/internal/integrations/hooks"
+	"github.com/crevissepartners/projmux/internal/theme"
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
 
@@ -74,9 +75,9 @@ func trustBadgeAppearance(state hooks.ProjectConfigTrustState) (string, string, 
 // Trust states use their own small palette so stale/untrusted/trusted rows do
 // not borrow warning, danger, action, or muted tones.
 const (
-	settingsColorTrustTrusted   = "\x1b[38;2;154;191;136m"
-	settingsColorTrustStale     = "\x1b[38;2;177;139;212m"
-	settingsColorTrustUntrusted = "\x1b[38;2;210;139;88m"
+	settingsColorTrustTrusted   = theme.ANSITrustTrustedStart
+	settingsColorTrustStale     = theme.ANSITrustStaleStart
+	settingsColorTrustUntrusted = theme.ANSITrustUntrustedStart
 )
 
 // inspectProjectTrust resolves the trust store path and asks the hooks

--- a/internal/app/usage.go
+++ b/internal/app/usage.go
@@ -18,6 +18,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/core/usage"
 	claudeadapter "github.com/crevissepartners/projmux/internal/core/usage/adapters/claude"
 	codexadapter "github.com/crevissepartners/projmux/internal/core/usage/adapters/codex"
+	"github.com/crevissepartners/projmux/internal/theme"
 )
 
 // usageCommand exposes the `projmux usage` and `projmux status usage`
@@ -643,8 +644,8 @@ func formatLastSyncAge(d time.Duration) string {
 // is missing. Staleness stays muted here so warning/critical colors are
 // reserved for usage thresholds:
 //
-//   - <1h:  dim grey (#[fg=colour245])
-//   - >=1h: muted grey (#[fg=colour244])
+//   - <1h:  secondary text
+//   - >=1h: muted text
 func renderAgeIndicator(m modelDisplay, now time.Time) string {
 	if !m.showAge || now.IsZero() || m.lastSync.IsZero() {
 		return ""
@@ -654,9 +655,9 @@ func renderAgeIndicator(m modelDisplay, now time.Time) string {
 	if text == "" {
 		return ""
 	}
-	color := "colour245"
+	color := theme.TmuxSecondaryFg
 	if age >= ageWarnAfter {
-		color = "colour244"
+		color = theme.TmuxMutedFg
 	}
 	return fmt.Sprintf("#[fg=%s](%s)%s", color, text, statusDefaultReset)
 }

--- a/internal/core/usage/hud.go
+++ b/internal/core/usage/hud.go
@@ -6,6 +6,8 @@ package usage
 
 import (
 	"strings"
+
+	"github.com/crevissepartners/projmux/internal/theme"
 )
 
 // BarCells is the fixed width of the HUD bar widget in cells. The bar is
@@ -94,15 +96,15 @@ func RenderColoredBar(pct float64, fillColor, emptyColor string) string {
 func BarColorForPct(pct float64) string {
 	switch {
 	case pct > 100:
-		return "colour160,bold"
+		return theme.TmuxUsageCriticalBoldFg
 	case pct >= 95:
-		return "colour160"
+		return theme.TmuxUsageCriticalFg
 	case pct >= 80:
-		return "colour214"
+		return theme.TmuxUsageWarningFg
 	default:
-		return "colour72"
+		return theme.TmuxUsageOKFg
 	}
 }
 
 // BarEmptyColor is the tmux color used for empty bar cells across the HUD.
-const BarEmptyColor = "colour238"
+const BarEmptyColor = theme.TmuxUsageEmptyFg

--- a/internal/theme/palette.go
+++ b/internal/theme/palette.go
@@ -1,0 +1,133 @@
+// Package theme contains the built-in fallback palette used by projmux UI
+// renderers. It is intentionally data-only for now: project/global theme
+// resolution will layer on top of these semantic tokens in a later phase.
+package theme
+
+import "strings"
+
+const (
+	ANSIReset   = "\x1b[0m"
+	ANSIBold    = "\x1b[1m"
+	ANSIDim     = "\x1b[2m"
+	ANSIInverse = "\x1b[7m"
+)
+
+// ANSI256FgStart returns an ANSI 256-color foreground SGR for a tmux colourN
+// token. Style suffixes such as ",bold" are intentionally ignored because
+// callers compose attributes separately.
+func ANSI256FgStart(tmuxColor string) string {
+	return "\x1b[38;5;" + strings.TrimPrefix(strings.Split(tmuxColor, ",")[0], "colour") + "m"
+}
+
+const (
+	// Truecolor SGR tokens for native terminal-rendered surfaces.
+	ANSISurfaceActiveStart = "\x1b[48;2;44;56;61m\x1b[38;2;255;255;255m"
+	ANSISurfaceRaisedStart = "\x1b[48;2;24;34;38m\x1b[38;2;216;224;228m"
+	ANSISurfaceRuleStart   = "\x1b[48;2;24;34;38m\x1b[38;2;117;132;140m"
+
+	ANSITextPrimaryStart   = "\x1b[38;2;216;224;228m"
+	ANSITextSecondaryStart = "\x1b[38;2;164;176;182m"
+	ANSITextMutedStart     = "\x1b[38;2;117;132;140m"
+	ANSITextDimStart       = "\x1b[90m"
+
+	ANSIAccentActionStart       = "\x1b[38;2;141;205;142m"
+	ANSIAccentActionStrongStart = "\x1b[38;2;122;199;173m"
+	ANSIAccentHighlightStart    = "\x1b[38;2;255;204;102m"
+	ANSIAccentSettingsStart     = "\x1b[36m"
+
+	ANSIStateDangerStart   = "\x1b[38;2;255;107;107m"
+	ANSIStateExistingStart = "\x1b[32m"
+	ANSIStateTaggedStart   = "\x1b[31m"
+	ANSIStatePinnedStart   = "\x1b[33m"
+	ANSIStateInfoStart     = "\x1b[34m"
+
+	ANSITrustTrustedStart   = "\x1b[38;2;154;191;136m"
+	ANSITrustStaleStart     = "\x1b[38;2;177;139;212m"
+	ANSITrustUntrustedStart = "\x1b[38;2;210;139;88m"
+)
+
+const (
+	// 256-color SGR tokens used by native sidebar badges and chip strips.
+	ANSIChipInactiveStart = "\x1b[48;5;235m\x1b[38;5;245m"
+	ANSIChipActiveStart   = "\x1b[1m\x1b[48;5;240m\x1b[38;5;231m"
+	ANSIChipDisabledStart = "\x1b[2m\x1b[48;5;235m\x1b[38;5;245m"
+
+	ANSINotifyTitleStart   = "\x1b[1;38;5;204m"
+	ANSINotifyDimStart     = "\x1b[38;5;245m"
+	ANSINotifyProjectStart = "\x1b[1;38;5;231;48;5;90m"
+	ANSINotifyInfoStart    = "\x1b[1;38;5;16;48;5;204m"
+	ANSINotifyWarnStart    = "\x1b[1;38;5;16;48;5;214m"
+	ANSINotifyCritStart    = "\x1b[1;38;5;231;48;5;160m"
+	ANSINotifyStaleStart   = "\x1b[2;38;5;231;48;5;240m"
+	ANSINotifyGoneStart    = "\x1b[2;9;38;5;231;48;5;238m"
+	ANSINotifyAgentStart   = "\x1b[1;38;5;16;48;5;37m"
+
+	ANSISwitchPathStart            = "\x1b[38;5;242m"
+	ANSISwitchGitActiveStart       = "\x1b[1;38;5;16;48;5;45m"
+	ANSISwitchGitInactiveStart     = "\x1b[38;5;245;48;5;238m"
+	ANSISwitchWindowTabActiveStart = "\x1b[1;38;5;231;48;5;238m"
+	ANSISwitchWindowTabStart       = "\x1b[38;5;245;48;5;235m"
+	ANSISwitchAttentionNeedsStart  = "\x1b[38;5;220m"
+	ANSISwitchAttentionReadyStart  = "\x1b[38;5;82m"
+)
+
+const (
+	// Tmux 256-color tokens for the statusbar and generated tmux config.
+	TmuxWindowInactiveBg = "colour235"
+	TmuxWindowInactiveFg = "colour245"
+	TmuxWindowActiveBg   = "colour240"
+	TmuxWindowActiveFg   = "colour231"
+
+	TmuxIdentityBg  = "colour60"
+	TmuxIdentityFg  = "colour254"
+	TmuxActionBg    = "colour29"
+	TmuxActionFg    = "colour230"
+	TmuxPrimaryFg   = "colour231"
+	TmuxSecondaryFg = "colour245"
+	TmuxMutedFg     = "colour244"
+	TmuxDividerFg   = "colour239"
+	TmuxMutedBg     = "colour240"
+	TmuxGoneBg      = "colour238"
+
+	TmuxAccentAttentionBg       = "colour53"
+	TmuxAccentAttentionFg       = "colour225"
+	TmuxAccentAttentionDimFg    = "colour183"
+	TmuxAccentAttentionStrongBg = "colour204"
+	TmuxAttentionProjectBg      = "colour90"
+	TmuxAccentAIBg              = "colour37"
+	TmuxAccentAIFg              = "colour121"
+
+	TmuxStateWarningFg  = "colour214"
+	TmuxStateCriticalFg = "colour160"
+	TmuxStateSuccessFg  = "colour72"
+	TmuxStateStagedFg   = "colour151"
+	TmuxStateDirtyFg    = "colour222"
+	TmuxStateAheadFg    = "colour153"
+	TmuxStateBehindFg   = "colour181"
+
+	TmuxGitSegmentBg = "colour30"
+	TmuxGitSegmentFg = TmuxPrimaryFg
+
+	TmuxUsageEmptyFg        = TmuxGoneBg
+	TmuxUsageOKFg           = TmuxStateSuccessFg
+	TmuxUsageWarningFg      = TmuxStateWarningFg
+	TmuxUsageCriticalFg     = TmuxStateCriticalFg
+	TmuxUsageCriticalBoldFg = TmuxStateCriticalFg + ",bold"
+
+	TmuxPaneBorderFg       = "colour236"
+	TmuxPaneActiveBorderFg = "colour51"
+	TmuxPaneActiveBg       = "colour45"
+	TmuxPaneActiveFg       = "colour16"
+	TmuxMessageBg          = "colour208"
+	TmuxMessageFg          = "colour16"
+
+	TmuxDecorationCwdFg        = "colour220"
+	TmuxDecorationGitHubFg     = TmuxStateAheadFg
+	TmuxDecorationGitLabFg     = "colour215"
+	TmuxDecorationGenericGitFg = TmuxStateStagedFg
+
+	// Kube keeps tmux's named red/blue for output compatibility with the
+	// existing status segment until the segment gets a dedicated redesign.
+	TmuxKubeContextFg   = "red"
+	TmuxKubeNamespaceFg = "blue"
+)

--- a/internal/theme/palette_test.go
+++ b/internal/theme/palette_test.go
@@ -1,0 +1,37 @@
+package theme
+
+import "testing"
+
+func TestFallbackPalettePreservesPhaseBaselineTokens(t *testing.T) {
+	checks := map[string]string{
+		"surface active truecolor": ANSISurfaceActiveStart,
+		"text muted truecolor":     ANSITextMutedStart,
+		"action truecolor":         ANSIAccentActionStart,
+		"attention tmux bg":        TmuxAccentAttentionBg,
+		"ai tmux bg":               TmuxAccentAIBg,
+		"warning tmux fg":          TmuxStateWarningFg,
+		"critical tmux fg":         TmuxStateCriticalFg,
+		"window active tmux bg":    TmuxWindowActiveBg,
+		"git staged tmux fg":       TmuxStateStagedFg,
+	}
+	for name, value := range checks {
+		if value == "" {
+			t.Fatalf("%s token is empty", name)
+		}
+	}
+	if TmuxAccentAttentionStrongBg == TmuxAccentAIBg || TmuxAccentAttentionStrongBg == TmuxActionBg {
+		t.Fatalf("attention, ai, and action tokens must remain visually distinct")
+	}
+	if ANSIStateDangerStart == ANSIAccentActionStart || ANSIStateDangerStart == ANSITextDimStart {
+		t.Fatalf("danger truecolor token must not alias action or dim text")
+	}
+}
+
+func TestANSI256FgStart(t *testing.T) {
+	if got, want := ANSI256FgStart(TmuxStateWarningFg), "\x1b[38;5;214m"; got != want {
+		t.Fatalf("ANSI256FgStart(warning) = %q, want %q", got, want)
+	}
+	if got, want := ANSI256FgStart(TmuxUsageCriticalBoldFg), "\x1b[38;5;160m"; got != want {
+		t.Fatalf("ANSI256FgStart(critical,bold) = %q, want %q", got, want)
+	}
+}

--- a/internal/ui/projmuxpicker/ansi.go
+++ b/internal/ui/projmuxpicker/ansi.go
@@ -5,20 +5,22 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/crevissepartners/projmux/internal/theme"
 )
 
 // ANSI/style tokens used by the projmux native picker surface.
 const (
-	CurrentStart   = "\x1b[48;2;44;56;61m\x1b[38;2;255;255;255m"
-	HighlightStart = "\x1b[38;2;255;204;102m"
-	MutedStart     = "\x1b[38;2;117;132;140m"
-	TitlebarStart  = "\x1b[48;2;24;34;38m\x1b[38;2;216;224;228m"
-	TitlebarRule   = "\x1b[48;2;24;34;38m\x1b[38;2;117;132;140m"
-	Pointer        = CurrentStart + "\x1b[38;2;122;199;173m▌" + CurrentStart + " "
-	Continuation   = CurrentStart + "\x1b[38;2;122;199;173m▌" + CurrentStart + " "
-	Reset          = "\x1b[0m"
-	InverseStart   = "\x1b[7m"
-	CursorStart    = "\x1b[7m"
+	CurrentStart   = theme.ANSISurfaceActiveStart
+	HighlightStart = theme.ANSIAccentHighlightStart
+	MutedStart     = theme.ANSITextMutedStart
+	TitlebarStart  = theme.ANSISurfaceRaisedStart
+	TitlebarRule   = theme.ANSISurfaceRuleStart
+	Pointer        = CurrentStart + theme.ANSIAccentActionStrongStart + "▌" + CurrentStart + " "
+	Continuation   = CurrentStart + theme.ANSIAccentActionStrongStart + "▌" + CurrentStart + " "
+	Reset          = theme.ANSIReset
+	InverseStart   = theme.ANSIInverse
+	CursorStart    = theme.ANSIInverse
 	Scrollbar      = "█"
 	GapLine        = "─"
 
@@ -26,19 +28,18 @@ const (
 	// palette entries used both by the tmux status bar (window list) and by
 	// the projmux picker frame chip primitives so the two surfaces stay
 	// visually congruent without re-declaring colour codes.
-	TmuxWindowInactiveBg = "colour235"
-	TmuxWindowInactiveFg = "colour245"
-	TmuxWindowActiveBg   = "colour240"
-	TmuxWindowActiveFg   = "colour231"
+	TmuxWindowInactiveBg = theme.TmuxWindowInactiveBg
+	TmuxWindowInactiveFg = theme.TmuxWindowInactiveFg
+	TmuxWindowActiveBg   = theme.TmuxWindowActiveBg
+	TmuxWindowActiveFg   = theme.TmuxWindowActiveFg
 
 	// Chip ANSI segments (terminal SGR escapes). They mirror the tmux
-	// window-status tone above (colour235/245 inactive, colour240/231 bold
-	// active). Disabled reuses inactive bg with a dimmer foreground to read
-	// as "tab present but not actionable" rather than introducing a third
-	// hue.
-	ChipInactiveStart = "\x1b[48;5;235m\x1b[38;5;245m"
-	ChipActiveStart   = "\x1b[1m\x1b[48;5;240m\x1b[38;5;231m"
-	ChipDisabledStart = "\x1b[2m\x1b[48;5;235m\x1b[38;5;245m"
+	// window-status tone above. Disabled reuses inactive bg with a dimmer
+	// foreground to read as "tab present but not actionable" rather than
+	// introducing a third hue.
+	ChipInactiveStart = theme.ANSIChipInactiveStart
+	ChipActiveStart   = theme.ANSIChipActiveStart
+	ChipDisabledStart = theme.ANSIChipDisabledStart
 )
 
 func PadRight(value string, width int) string {

--- a/internal/ui/render/switch.go
+++ b/internal/ui/render/switch.go
@@ -4,26 +4,27 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/crevissepartners/projmux/internal/theme"
 	"github.com/crevissepartners/projmux/internal/ui/picker"
 )
 
 const (
-	ansiReset  = "\x1b[0m"
-	ansiBold   = "\x1b[1m"
-	ansiDim    = "\x1b[2m"
-	ansiRed    = "\x1b[31m"
-	ansiBlue   = "\x1b[34m"
-	ansiGreen  = "\x1b[32m"
-	ansiYellow = "\x1b[33m"
-	ansiCyan   = "\x1b[36m"
+	ansiReset  = theme.ANSIReset
+	ansiBold   = theme.ANSIBold
+	ansiDim    = theme.ANSIDim
+	ansiRed    = theme.ANSIStateTaggedStart
+	ansiBlue   = theme.ANSIStateInfoStart
+	ansiGreen  = theme.ANSIStateExistingStart
+	ansiYellow = theme.ANSIStatePinnedStart
+	ansiCyan   = theme.ANSIAccentSettingsStart
 )
 
 const (
-	ansiStatusPath        = "\x1b[38;5;242m"
-	ansiStatusGitActive   = "\x1b[1;38;5;16;48;5;45m"
-	ansiStatusGitInactive = "\x1b[38;5;245;48;5;238m"
-	ansiTabActive         = "\x1b[1;38;5;231;48;5;238m"
-	ansiTabInactive       = "\x1b[38;5;245;48;5;235m"
+	ansiStatusPath        = theme.ANSISwitchPathStart
+	ansiStatusGitActive   = theme.ANSISwitchGitActiveStart
+	ansiStatusGitInactive = theme.ANSISwitchGitInactiveStart
+	ansiTabActive         = theme.ANSISwitchWindowTabActiveStart
+	ansiTabInactive       = theme.ANSISwitchWindowTabStart
 )
 
 const (
@@ -294,9 +295,9 @@ func formatSwitchCardStatusBadge(badges []string) string {
 func formatInlineAttentionBadge(rank int) string {
 	switch rank {
 	case 2:
-		return "\x1b[38;5;220m● " + ansiReset
+		return theme.ANSISwitchAttentionNeedsStart + "● " + ansiReset
 	case 1:
-		return "\x1b[38;5;82m● " + ansiReset
+		return theme.ANSISwitchAttentionReadyStart + "● " + ansiReset
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Phase

Completed: Phase 3 — Semantic token foundation.

## Scope

User-facing surface / internal foundation updated:

- Native picker palette tokens: truecolor current row, titlebar/rule, highlight, pointer, muted text, chip active/inactive/disabled tokens now route through `internal/theme`.
- Tmux/statusbar palette tokens: session identity, settings action chip, window tabs, pane borders, statusbar dividers, git state tokens, notify HUD badges, usage HUD colors, cwd/git decorations, and kube compatibility colors route through semantic tmux tokens.
- Settings/action/state/attention helpers: settings action/dim/info/destructive rows, trust state rows, notify sidebar badges/title/agent colors, switch picker card/tab/attention colors, and usage age/ramp colors route through semantic helpers.
- Palette docs/inventory: added `docs/theme-palette.md` and linked it from statusbar/native picker docs; updated the maintained test list.

Explicitly excluded next-phase scope:

- Phase 4 Theme config handoff implementation.
- Theme config resolver/editor/schema.
- Project/global theme resolver.
- Settings theme editor UI.
- External preset/import/export features.

This PR does not add `config.toml` theme schema or user theme settings. It preserves the Phase 0 chrome palette, Phase 1 notify/usage/AI attention palette, and Phase 2 git/trust/warning/danger/action state palette; the change is a semantic-token foundation over the stabilized fallback colors.

## Raw Color Inventory

Converted raw implementation colors in:

- `internal/ui/projmuxpicker/ansi.go`
- `internal/ui/render/switch.go`
- `internal/app/tmux.go`
- `internal/app/status.go`
- `internal/app/statusbar.go`
- `internal/app/statusbar_decoration.go`
- `internal/app/notify.go`
- `internal/app/settings.go`
- `internal/app/settings_render.go`
- `internal/app/trust.go`
- `internal/app/usage.go`
- `internal/core/usage/hud.go`

`rg` implementation inventory now leaves raw color literals in `internal/theme/palette.go` as the source of truth and `internal/app/welcome.go`, which is intentionally outside this Visual palette baseline phase. Tests and golden-style assertions still pin exact rendered escape strings.

## Verification

- `git diff --check`
- `rg -n "colour[0-9]+|fg=red|fg=blue|38;2;|48;2;|38;5;|48;5;|bg=colour|fg=colour" internal -g '*.go' -g '!*_test.go' -g '!internal/theme/*'`
- `GOCACHE=/tmp/projmux-go-cache make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration` (rerun outside sandbox for Docker socket access)
- `GOCACHE=/tmp/projmux-go-cache make test-e2e` (rerun outside sandbox for Docker socket access)

## Not Verified / Follow-up

- Manual tmux visual inspection on a real terminal was not run.
- Phase 4 should consume this built-in fallback token foundation for Theme config handoff without reopening the Phase 0-2 color choices.
