### PR TITLE
feat: complete visual palette theme handoff

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -50,7 +50,7 @@
 - `make test` also covers `projmux ai ingest log` tail/path rendering and bounded JSONL log trimming for ingest diagnostics.
 - `make test` also covers welcome revisit policy: shell `skip_version` gating, `s` skip vs Enter one-run continue, Settings > About > Welcome native viewer, and attach-popup no-duplicate/no-op behavior.
 - `make test` also covers `projmux quit` action-picker rows, cancel/close no-op behavior, explicit quit of only app-owned mux runtimes marked by `@projmux_app=1` on the selected `tmux`/`psmux -L projmux` backend, missing/default runtime no-ops, dispatcher wiring, and `Settings > About > Quit projmux` routing through the same picker before any shutdown side effect.
-- `make test` also covers the built-in semantic palette foundation: non-empty fallback truecolor/tmux tokens, distinct action/attention/AI/danger roles, native picker chip/current/titlebar render strings, statusbar git/notify/usage/settings palette regressions, and settings/trust/destructive row color guards.
+- `make test` also covers the built-in semantic palette foundation: non-empty fallback truecolor/tmux tokens, distinct action/attention/AI/progress/danger roles, native picker chip/current/titlebar render strings, statusbar git/notify/usage/settings palette regressions, attention/pane-border/popup/switch progress color guards, renderer-only lead-mode topic prefix styling, and settings/trust/destructive row color guards.
 - Current focused unit coverage also includes strict notify SOT behavior
   (TTL does not remove rows, focus success and target-gone clicks ack,
   reconcile reports stale rows), `notify list --live` queue/live explanations, notify sidebar

--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -59,6 +59,7 @@ Accents and state:
 | `accent.action` | `141;205;142`, strong `122;199;173` | `colour29` bg / `colour230` fg |
 | `accent.attention` | notify sidebar `colour204` family | `colour53`, `colour225`, `colour204`, project `colour90` |
 | `accent.ai` | notify agent `colour37` family | `colour37` bg / `colour121` fg |
+| `state.progress` | `255;204;102`; switch attention/busy dot `colour220` | `colour220` |
 | `state.warning` | usage/status popup ANSI 256 wrapper | `colour214` |
 | `state.danger` | `255;107;107` | `colour160` |
 | `state.success` | settings/trust green families | `colour72`, `colour151` |
@@ -73,7 +74,7 @@ Surface-specific tokens:
 | Notify HUD/sidebar | line bg/fg, project badge, info/warn/crit/stale/gone badges, AI agent badge, count/age text |
 | Usage HUD/popup | OK/warning/critical/over-limit bars and numbers, empty cells, muted sync age |
 | Settings | add/type/open action, destructive remove/quit, back/cancel, info/read-only, dim description, root action/dim rows, trust trusted/stale/untrusted |
-| Switch picker cards | path metadata, active/inactive git branch badges, statusbar-like window tabs, inline attention dots |
+| Switch picker cards | path metadata, active/inactive git branch badges, statusbar-like window tabs, inline attention/progress dots |
 
 ## Current Literal Inventory
 
@@ -99,3 +100,5 @@ The converted implementation paths include:
 - `internal/app/usage.go`
 - `internal/core/usage/hud.go`
 - `internal/ui/render/switch.go`
+- `internal/ui/render/popup.go`
+- `internal/ui/render/switch_preview.go`

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -2360,7 +2360,7 @@ func TestAITopicGetPrintsPaneOptionValue(t *testing.T) {
 	cmd := testAICommand(home)
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
 		if name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%5", "#{@projmux_ai_topic}"}) {
-			return []byte("ship the feature\n"), nil
+			return []byte("[Lead:Roadmap] ship the feature\n"), nil
 		}
 		return nil, os.ErrNotExist
 	}
@@ -2370,8 +2370,11 @@ func TestAITopicGetPrintsPaneOptionValue(t *testing.T) {
 		t.Fatalf("Run topic get error = %v", err)
 	}
 
-	if got, want := stdout.String(), "ship the feature\n"; got != want {
+	if got, want := stdout.String(), "[Lead:Roadmap] ship the feature\n"; got != want {
 		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if strings.Contains(stdout.String(), "\x1b[") || strings.Contains(stdout.String(), "#[") {
+		t.Fatalf("stdout = %q, want plain topic text", stdout.String())
 	}
 }
 

--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -233,7 +233,7 @@ func (c *attentionCommand) runWindow(args []string, stdout, stderr io.Writer) er
 	seenReply := false
 	for _, row := range rows {
 		if row.State == attentionStateBusy || hasBraillePrefix(row.Title) {
-			_, err := fmt.Fprint(stdout, "#[fg="+tmuxAccentAIFg+"]●")
+			_, err := fmt.Fprint(stdout, "#[fg="+tmuxStateProgressFg+"]●")
 			return err
 		}
 		if row.State == attentionStateReply || hasAttentionPrefix(row.Title) {

--- a/internal/app/attention_test.go
+++ b/internal/app/attention_test.go
@@ -261,7 +261,7 @@ func TestAttentionWindowPrefersBusyBadge(t *testing.T) {
 	if err := cmd.Run([]string{"window", "@1"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if got, want := stdout.String(), "#[fg="+tmuxAccentAIFg+"]●"; got != want {
+	if got, want := stdout.String(), "#[fg="+tmuxStateProgressFg+"]●"; got != want {
 		t.Fatalf("stdout = %q, want %q", got, want)
 	}
 }

--- a/internal/app/notify_producer_test.go
+++ b/internal/app/notify_producer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -78,7 +79,7 @@ func TestStoreAttentionNotifyProducerPushReplyReadyWithTopic(t *testing.T) {
 
 	lookup := newFakeAttentionLookup(map[string]string{
 		"%2|@projmux_ai_agent": "Codex",
-		"%2|@projmux_ai_topic": "wire-producer",
+		"%2|@projmux_ai_topic": "[Lead:QA] wire-producer",
 		"%2|#S":                "feat-notify-producer-attention",
 		"%2|#{window_id}":      "@1",
 		"%2|#{pane_id}":        "%2",
@@ -90,9 +91,12 @@ func TestStoreAttentionNotifyProducerPushReplyReadyWithTopic(t *testing.T) {
 		t.Fatalf("push count = %d, want 1", len(store.pushed))
 	}
 	got := store.pushed[0]
-	wantText := "codex: reply ready · wire-producer"
+	wantText := "codex: reply ready · [Lead:QA] wire-producer"
 	if got.Text != wantText {
 		t.Fatalf("Text = %q, want %q", got.Text, wantText)
+	}
+	if strings.Contains(got.Text, "\x1b[") || strings.Contains(got.Text, "#[") {
+		t.Fatalf("Text = %q, want plain notification text", got.Text)
 	}
 	if got.ID != "ai:feat-notify-producer-attention:%2" {
 		t.Fatalf("ID = %q", got.ID)

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -654,7 +654,7 @@ func TestSwitchCommandSidebarRowsIncludeAttentionBadge(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 
-	if got, want := gotRunnerOptions.Entries[0].Label, "\x1b[1m\x1b[32mapp\x1b[0m \x1b[33m●\x1b[0m\n  \x1b[38;5;242m/tmp/app\x1b[0m"; got != want {
+	if got, want := gotRunnerOptions.Entries[0].Label, "\x1b[1m\x1b[32mapp\x1b[0m \x1b[38;2;255;204;102m●\x1b[0m\n  \x1b[38;5;242m/tmp/app\x1b[0m"; got != want {
 		t.Fatalf("runner entry = %q, want %q", got, want)
 	}
 }

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -43,6 +43,7 @@ const (
 	tmuxAccentAttentionStrongBg = theme.TmuxAccentAttentionStrongBg
 	tmuxAccentAIBg              = theme.TmuxAccentAIBg
 	tmuxAccentAIFg              = theme.TmuxAccentAIFg
+	tmuxStateProgressFg         = theme.TmuxStateProgressFg
 	tmuxStateWarningFg          = theme.TmuxStateWarningFg
 	tmuxStateCriticalFg         = theme.TmuxStateCriticalFg
 )
@@ -1208,15 +1209,32 @@ func tmuxVisiblePaneLabelFormat() string {
 	return "#{?#{&&:#{!=:#{@projmux_ai_agent},},#{!=:#{@projmux_ai_topic},}},#{@projmux_ai_topic}," + tmuxShellPaneLabelFormat() + "}"
 }
 
+func tmuxStyledVisiblePaneLabelFormat() string {
+	topic := "#{@projmux_ai_topic}"
+	return "#{?#{&&:#{!=:#{@projmux_ai_agent},},#{!=:" + topic + ",}}," + tmuxStyledAITopicFormat(topic) + "," + tmuxShellPaneLabelFormat() + "}"
+}
+
+func tmuxStyledAITopicFormat(topic string) string {
+	return "#{?" + tmuxLeadModeTopicMatchFormat(topic) + ",#[push-default]#[bold#,fg=" + tmuxStateProgressFg + "]" + topic + "#[pop-default]," + topic + "}"
+}
+
+func tmuxLeadModeTopicMatchFormat(topic string) string {
+	qa := "#{m/r:^\\[[Ll]ead:[Qq][Aa]\\]," + topic + "}"
+	poc := "#{m/r:^\\[[Ll]ead:[Pp][Oo][Cc]\\]," + topic + "}"
+	ship := "#{m/r:^\\[[Ll]ead:[Ss]hip\\]," + topic + "}"
+	roadmap := "#{m/r:^\\[[Ll]ead:[Rr]oadmap\\]," + topic + "}"
+	return "#{||:#{||:" + qa + "," + poc + "},#{||:" + ship + "," + roadmap + "}}"
+}
+
 func tmuxShellPaneLabelFormat() string {
 	return "#{?#{||:#{||:#{||:#{==:#{pane_current_command},zsh},#{==:#{pane_current_command},bash}},#{||:#{==:#{pane_current_command},fish},#{==:#{pane_current_command},sh}}},#{||:#{==:#{pane_current_command},nu},#{==:#{pane_current_command},xonsh}}},#{pane_current_command},#{pane_title}}"
 }
 
 func tmuxPaneBorderFormat() string {
-	paneLabelFormat := tmuxVisiblePaneLabelFormat()
+	paneLabelFormat := tmuxStyledVisiblePaneLabelFormat()
 	paneBusyFormat := "#{==:#{@projmux_attention_state},busy}"
 	paneReplyFormat := "#{==:#{@projmux_attention_state},reply}"
-	inactivePaneBorderFormat := "#{?" + paneBusyFormat + ",#[bold#,fg=" + tmuxAccentAIFg + "] ● " + paneLabelFormat + " #[default],#{?" + paneReplyFormat + ",#[bold#,fg=" + tmuxAccentAttentionStrongBg + "] ● " + paneLabelFormat + " #[default],#[fg=" + theme.TmuxMutedFg + "] " + paneLabelFormat + " #[default]}}"
+	inactivePaneBorderFormat := "#{?" + paneBusyFormat + ",#[bold#,fg=" + tmuxStateProgressFg + "] ● " + paneLabelFormat + " #[default],#{?" + paneReplyFormat + ",#[bold#,fg=" + tmuxAccentAttentionStrongBg + "] ● " + paneLabelFormat + " #[default],#[fg=" + theme.TmuxMutedFg + "] " + paneLabelFormat + " #[default]}}"
 	return "#{?pane_active,#[bold#,fg=" + theme.TmuxPaneActiveFg + "#,bg=" + theme.TmuxPaneActiveBg + "] > " + paneLabelFormat + " #[default]," + inactivePaneBorderFormat + "}"
 }
 

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -1475,7 +1475,7 @@ func TestTmuxPrintAppConfigUsesIsolatedAppSettings(t *testing.T) {
 		"set -g pane-active-border-style \"fg=colour51,bold\"",
 		"set -g pane-border-status top",
 		"set -g pane-border-format \"#{?pane_active,#[bold#,fg=colour16#,bg=colour45] > ",
-		"#[bold#,fg=" + tmuxAccentAIFg + "] ● ",
+		"#[bold#,fg=" + tmuxStateProgressFg + "] ● ",
 		"#[bold#,fg=" + tmuxAccentAttentionStrongBg + "] ● ",
 		"#[fg=colour244] ",
 		"#{@projmux_ai_topic}",
@@ -1554,6 +1554,7 @@ func TestTmuxAppNamingFormatsUseVisiblePaneLabel(t *testing.T) {
 	t.Parallel()
 
 	visibleLabel := tmuxVisiblePaneLabelFormat()
+	styledVisibleLabel := tmuxStyledVisiblePaneLabelFormat()
 	shellLabel := tmuxShellPaneLabelFormat()
 	paneBorder := tmuxPaneBorderFormat()
 	configText := tmuxAppConfig("/tmp/projmux", "/bin/sh", config.StatusbarDecorationOff)
@@ -1573,8 +1574,14 @@ func TestTmuxAppNamingFormatsUseVisiblePaneLabel(t *testing.T) {
 	if topicIndex, shellIndex := strings.Index(visibleLabel, "#{@projmux_ai_topic}"), strings.Index(visibleLabel, shellLabel); topicIndex < 0 || shellIndex < 0 || topicIndex > shellIndex {
 		t.Fatalf("visible pane label format = %q, want @projmux_ai_topic before shell/current-command fallback", visibleLabel)
 	}
-	if !strings.Contains(paneBorder, visibleLabel) {
-		t.Fatalf("pane border format = %q, want visible label %q", paneBorder, visibleLabel)
+	if !strings.Contains(paneBorder, styledVisibleLabel) {
+		t.Fatalf("pane border format = %q, want styled visible label %q", paneBorder, styledVisibleLabel)
+	}
+	if !strings.Contains(paneBorder, "#[bold#,fg="+tmuxStateProgressFg+"] ● ") {
+		t.Fatalf("pane border format = %q, want busy marker to use state.progress", paneBorder)
+	}
+	if !strings.Contains(styledVisibleLabel, "#[bold#,fg="+tmuxStateProgressFg+"]#{@projmux_ai_topic}#[pop-default]") {
+		t.Fatalf("styled visible label format = %q, want renderer-level lead topic styling", styledVisibleLabel)
 	}
 
 	wantPaneBorderLine := "set -g pane-border-format " + tmuxConfigQuote(paneBorder)

--- a/internal/integrations/sessionstate/store_test.go
+++ b/internal/integrations/sessionstate/store_test.go
@@ -373,8 +373,8 @@ func TestRecipeJSONForms(t *testing.T) {
 		},
 		{
 			name: "agent",
-			in:   AgentRecipeWithResumeMetadata("claude", "abcdef-1234", "keybinding in-app", "session-id", "2026-05-12T03:04:05Z"),
-			want: `{"kind":"agent","agent":"claude","resume_id":"abcdef-1234","resume_source":"session-id","resume_updated_at":"2026-05-12T03:04:05Z","topic":"keybinding in-app"}`,
+			in:   AgentRecipeWithResumeMetadata("claude", "abcdef-1234", "[Lead:QA] keybinding in-app", "session-id", "2026-05-12T03:04:05Z"),
+			want: `{"kind":"agent","agent":"claude","resume_id":"abcdef-1234","resume_source":"session-id","resume_updated_at":"2026-05-12T03:04:05Z","topic":"[Lead:QA] keybinding in-app"}`,
 		},
 		{
 			name: "startup",

--- a/internal/theme/palette.go
+++ b/internal/theme/palette.go
@@ -35,6 +35,7 @@ const (
 	ANSIAccentHighlightStart    = "\x1b[38;2;255;204;102m"
 	ANSIAccentSettingsStart     = "\x1b[36m"
 
+	ANSIStateProgressStart = "\x1b[38;2;255;204;102m"
 	ANSIStateDangerStart   = "\x1b[38;2;255;107;107m"
 	ANSIStateExistingStart = "\x1b[32m"
 	ANSIStateTaggedStart   = "\x1b[31m"
@@ -97,6 +98,7 @@ const (
 	TmuxAccentAIBg              = "colour37"
 	TmuxAccentAIFg              = "colour121"
 
+	TmuxStateProgressFg = "colour220"
 	TmuxStateWarningFg  = "colour214"
 	TmuxStateCriticalFg = "colour160"
 	TmuxStateSuccessFg  = "colour72"

--- a/internal/theme/palette_test.go
+++ b/internal/theme/palette_test.go
@@ -9,6 +9,8 @@ func TestFallbackPalettePreservesPhaseBaselineTokens(t *testing.T) {
 		"action truecolor":         ANSIAccentActionStart,
 		"attention tmux bg":        TmuxAccentAttentionBg,
 		"ai tmux bg":               TmuxAccentAIBg,
+		"progress truecolor":       ANSIStateProgressStart,
+		"progress tmux fg":         TmuxStateProgressFg,
 		"warning tmux fg":          TmuxStateWarningFg,
 		"critical tmux fg":         TmuxStateCriticalFg,
 		"window active tmux bg":    TmuxWindowActiveBg,
@@ -24,6 +26,9 @@ func TestFallbackPalettePreservesPhaseBaselineTokens(t *testing.T) {
 	}
 	if ANSIStateDangerStart == ANSIAccentActionStart || ANSIStateDangerStart == ANSITextDimStart {
 		t.Fatalf("danger truecolor token must not alias action or dim text")
+	}
+	if TmuxStateProgressFg == TmuxAccentAIFg || TmuxStateProgressFg == TmuxStateCriticalFg {
+		t.Fatalf("progress tmux token must not alias AI or danger tokens")
 	}
 }
 

--- a/internal/ui/render/lead_topic.go
+++ b/internal/ui/render/lead_topic.go
@@ -1,0 +1,26 @@
+package render
+
+import "strings"
+
+func styleLeadTopicPrefix(topic string) string {
+	prefix, rest, ok := splitLeadTopicPrefix(topic)
+	if !ok {
+		return topic
+	}
+	return ansiBold + ansiProgress + prefix + ansiReset + rest
+}
+
+func splitLeadTopicPrefix(topic string) (string, string, bool) {
+	lower := strings.ToLower(topic)
+	for _, prefix := range []string{
+		"[lead:qa]",
+		"[lead:poc]",
+		"[lead:ship]",
+		"[lead:roadmap]",
+	} {
+		if strings.HasPrefix(lower, prefix) {
+			return topic[:len(prefix)], topic[len(prefix):], true
+		}
+	}
+	return "", "", false
+}

--- a/internal/ui/render/popup.go
+++ b/internal/ui/render/popup.go
@@ -146,7 +146,7 @@ func formatWindowSummary(window preview.Window, panes []preview.Pane) string {
 }
 
 func formatPaneSummary(pane preview.Pane) string {
-	title := displayPaneTitle(pane)
+	title := displayPaneTitlePlain(pane)
 	if title == "" {
 		title = "-"
 	}
@@ -154,14 +154,23 @@ func formatPaneSummary(pane preview.Pane) string {
 	if command == "" {
 		command = "-"
 	}
-	line := "[" + sanitizeCell(pane.WindowIndex) + "." + sanitizeCell(pane.Index) + "] " + padRight(truncateText(title, 18), 18) + " " + truncateText(command, 10)
+	titleCell := styleLeadTopicPrefix(padRight(truncateText(title, 18), 18))
+	line := "[" + sanitizeCell(pane.WindowIndex) + "." + sanitizeCell(pane.Index) + "] " + titleCell + " " + truncateText(command, 10)
 	if status := formatPaneStatus(pane); status != "" {
-		line += "  " + ansiDim + status + ansiReset
+		if strings.Contains(status, "\x1b[") {
+			line += "  " + status
+		} else {
+			line += "  " + ansiDim + status + ansiReset
+		}
 	}
 	return line
 }
 
 func displayPaneTitle(pane preview.Pane) string {
+	return styleLeadTopicPrefix(displayPaneTitlePlain(pane))
+}
+
+func displayPaneTitlePlain(pane preview.Pane) string {
 	if strings.TrimSpace(pane.AIAgent) != "" {
 		if topic := sanitizeCell(pane.AITopic); topic != "" {
 			return topic
@@ -197,16 +206,16 @@ func isShellCommand(command string) bool {
 func formatPaneStatus(pane preview.Pane) string {
 	parts := make([]string, 0, 6)
 	if state := sanitizeCell(pane.AttentionState); state != "" {
-		parts = append(parts, "badge="+humanAttentionState(state))
+		parts = append(parts, formatPaneStatusPart("badge", humanAttentionState(state), state == "busy"))
 	}
 	if state := sanitizeCell(pane.AIState); state != "" {
-		parts = append(parts, "state="+humanAIState(state))
+		parts = append(parts, formatPaneStatusPart("state", humanAIState(state), state == "thinking"))
 	}
 	if agent := sanitizeCell(pane.AIAgent); agent != "" {
 		parts = append(parts, "assistant="+agent)
 	}
 	if topic := truncateText(pane.AITopic, 24); topic != "" {
-		parts = append(parts, "topic="+topic)
+		parts = append(parts, "topic="+styleLeadTopicPrefix(topic))
 	}
 	if ack := sanitizeCell(pane.AttentionAck); ack != "" {
 		parts = append(parts, "seen="+humanBoolOption(ack))
@@ -215,6 +224,13 @@ func formatPaneStatus(pane preview.Pane) string {
 		parts = append(parts, "clears-on-focus="+humanBoolOption(armed))
 	}
 	return strings.Join(parts, " ")
+}
+
+func formatPaneStatusPart(key, value string, progress bool) string {
+	if !progress {
+		return key + "=" + value
+	}
+	return key + "=" + ansiProgress + value + ansiReset
 }
 
 func windowAttentionRank(windowIndex string, panes []preview.Pane) int {
@@ -236,7 +252,7 @@ func windowAttentionRank(windowIndex string, panes []preview.Pane) int {
 func formatWindowAttentionPrefix(rank int) string {
 	switch rank {
 	case 2:
-		return ansiYellow + "●" + ansiReset
+		return ansiProgress + "●" + ansiReset
 	case 1:
 		return ansiGreen + "●" + ansiReset
 	default:

--- a/internal/ui/render/popup_test.go
+++ b/internal/ui/render/popup_test.go
@@ -76,6 +76,36 @@ func TestRenderPopupPreviewShowsShellCommandAsShellPaneTitle(t *testing.T) {
 	}
 }
 
+func TestRenderPopupPreviewStylesProgressAndLeadPrefixOnlyInRenderer(t *testing.T) {
+	t.Parallel()
+
+	got := RenderPopupPreview(preview.PopupReadModel{
+		SessionName:         "app",
+		HasSelection:        true,
+		SelectedWindowIndex: "1",
+		SelectedPaneIndex:   "0",
+		Windows: []preview.Window{
+			{Index: "1", Name: "app", PaneCount: 1},
+		},
+		Panes: []preview.Pane{
+			{WindowIndex: "1", Index: "0", Title: "agent", AttentionState: "busy", AIState: "thinking", AIAgent: "codex", AITopic: "[Lead:Ship] release", Command: "node", Path: "~rp/app"},
+		},
+	})
+
+	for _, want := range []string{
+		"  \x1b[2mtitle\x1b[0m  \x1b[1m\x1b[38;2;255;204;102m[Lead:Ship]\x1b[0m release\n",
+		"badge=\x1b[38;2;255;204;102mworking\x1b[0m state=\x1b[38;2;255;204;102mworking\x1b[0m assistant=codex topic=\x1b[1m\x1b[38;2;255;204;102m[Lead:Ship]\x1b[0m release",
+		"\x1b[1m\x1b[32m[1.0] \x1b[1m\x1b[38;2;255;204;102m[Lead:Ship]\x1b[0m relea",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("RenderPopupPreview() = %q, want substring %q", got, want)
+		}
+	}
+	if strings.Contains(got, "@projmux_ai_topic") || strings.Contains(got, "#[") {
+		t.Fatalf("RenderPopupPreview() = %q, want ANSI renderer styling only", got)
+	}
+}
+
 func TestRenderPopupPreviewWithWindowOnlySelection(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/render/switch.go
+++ b/internal/ui/render/switch.go
@@ -9,14 +9,15 @@ import (
 )
 
 const (
-	ansiReset  = theme.ANSIReset
-	ansiBold   = theme.ANSIBold
-	ansiDim    = theme.ANSIDim
-	ansiRed    = theme.ANSIStateTaggedStart
-	ansiBlue   = theme.ANSIStateInfoStart
-	ansiGreen  = theme.ANSIStateExistingStart
-	ansiYellow = theme.ANSIStatePinnedStart
-	ansiCyan   = theme.ANSIAccentSettingsStart
+	ansiReset    = theme.ANSIReset
+	ansiBold     = theme.ANSIBold
+	ansiDim      = theme.ANSIDim
+	ansiRed      = theme.ANSIStateTaggedStart
+	ansiBlue     = theme.ANSIStateInfoStart
+	ansiGreen    = theme.ANSIStateExistingStart
+	ansiYellow   = theme.ANSIStatePinnedStart
+	ansiProgress = theme.ANSIStateProgressStart
+	ansiCyan     = theme.ANSIAccentSettingsStart
 )
 
 const (
@@ -280,7 +281,7 @@ func formatSwitchCardStatusBadge(badges []string) string {
 	for _, badge := range badges {
 		switch sanitizeCell(badge) {
 		case "needs review":
-			parts = append(parts, ansiYellow+"●"+ansiReset)
+			parts = append(parts, ansiProgress+"●"+ansiReset)
 		case "ready":
 			parts = append(parts, ansiGreen+"●"+ansiReset)
 		case "tagged":
@@ -410,7 +411,7 @@ func formatSidebarSwitchLabel(candidate SwitchCandidate) string {
 func formatAttentionBadge(rank int) string {
 	switch rank {
 	case 2:
-		return ansiYellow + "●" + ansiReset
+		return ansiProgress + "●" + ansiReset
 	case 1:
 		return ansiGreen + "●" + ansiReset
 	default:

--- a/internal/ui/render/switch_preview.go
+++ b/internal/ui/render/switch_preview.go
@@ -172,16 +172,16 @@ func formatSidebarPaneTitle(pane corepreview.Pane) string {
 	case strings.HasPrefix(title, "✳"), strings.HasPrefix(title, "✔"):
 		return ansiGreen + "●" + ansiReset + " " + trimSidebarPaneTitleMarker(title)
 	case hasBraillePrefix(title):
-		return ansiYellow + "●" + ansiReset + " " + trimSidebarPaneTitleMarker(title)
+		return ansiProgress + "●" + ansiReset + " " + trimSidebarPaneTitleMarker(title)
 	default:
-		return title
+		return styleLeadTopicPrefix(title)
 	}
 }
 
 func sidebarPaneLabel(pane corepreview.Pane) string {
 	if strings.TrimSpace(pane.AIAgent) != "" {
 		if topic := sanitizeCell(pane.AITopic); topic != "" {
-			return topic
+			return styleLeadTopicPrefix(topic)
 		}
 	}
 	return sanitizeCell(pane.Title)
@@ -190,7 +190,7 @@ func sidebarPaneLabel(pane corepreview.Pane) string {
 func sidebarPaneBadge(pane corepreview.Pane) string {
 	switch paneAttentionRank(pane) {
 	case 2:
-		return ansiYellow + "●" + ansiReset
+		return ansiProgress + "●" + ansiReset
 	case 1:
 		return ansiGreen + "●" + ansiReset
 	default:

--- a/internal/ui/render/switch_preview_test.go
+++ b/internal/ui/render/switch_preview_test.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"strings"
 	"testing"
 
 	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
@@ -106,9 +107,36 @@ func TestRenderSwitchPreviewForSidebarMatchesLegacySections(t *testing.T) {
 		"k8s:\x1b[31mkind-dev\x1b[0m/\x1b[34mdefault\x1b[0m\n\n" +
 		"\x1b[1m\x1b[36mWindows\x1b[0m\n" +
 		"[1] shell\n" +
-		"[2] server | \x1b[33m●\x1b[0m tests | \x1b[32m●\x1b[0m projmux-2\n"
+		"[2] server | \x1b[38;2;255;204;102m●\x1b[0m tests | \x1b[32m●\x1b[0m projmux-2\n"
 	if got != want {
 		t.Fatalf("RenderSwitchPreview() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderSwitchPreviewStylesLeadTopicPrefixOnlyInRenderer(t *testing.T) {
+	t.Parallel()
+
+	got := RenderSwitchPreview(corepreview.SwitchReadModel{
+		SessionMode: "existing",
+		Windows: []corepreview.Window{
+			{Index: "1", Name: "app"},
+		},
+		Panes: []corepreview.Pane{
+			{WindowIndex: "1", Index: "0", Title: "agent", AIAgent: "codex", AITopic: "[Lead:QA] review topic"},
+			{WindowIndex: "1", Index: "1", Title: "agent", AIAgent: "codex", AITopic: "[lead:poc] measure"},
+		},
+	}, "sidebar")
+
+	for _, want := range []string{
+		"\x1b[1m\x1b[38;2;255;204;102m[Lead:QA]\x1b[0m review topic",
+		"\x1b[1m\x1b[38;2;255;204;102m[lead:poc]\x1b[0m measure",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("RenderSwitchPreview() = %q, want styled lead prefix %q", got, want)
+		}
+	}
+	if strings.Contains(got, "@projmux_ai_topic") || strings.Contains(got, "#[") {
+		t.Fatalf("RenderSwitchPreview() = %q, want ANSI renderer styling only", got)
 	}
 }
 

--- a/internal/ui/render/switch_test.go
+++ b/internal/ui/render/switch_test.go
@@ -162,12 +162,30 @@ func TestBuildSwitchRowsSidebarShowsAttentionBadge(t *testing.T) {
 		AttentionRank: 2,
 	}})
 
-	const want = "\x1b[33m●\x1b[0m \x1b[1m\x1b[32mapp\x1b[0m \x1b[2m~rp/app\x1b[0m"
+	const want = "\x1b[38;2;255;204;102m●\x1b[0m \x1b[1m\x1b[32mapp\x1b[0m \x1b[2m~rp/app\x1b[0m"
 	if got := rows[0].Label; got != want {
 		t.Fatalf("label = %q, want %q", got, want)
 	}
 	if got, want := rows[0].Item.Badges, []string{"needs review"}; !equalStringSlices(got, want) {
 		t.Fatalf("item badges = %q, want %q", got, want)
+	}
+}
+
+func TestFormatSwitchCardLabelUsesProgressForBusyBadge(t *testing.T) {
+	t.Parallel()
+
+	rows := BuildSwitchRows([]SwitchCandidate{{
+		Path:          "/home/tester/source/repos/app",
+		DisplayName:   "app",
+		ModeLabel:     "existing",
+		UI:            "popup",
+		AttentionRank: 2,
+	}})
+
+	got := FormatSwitchCardLabel(rows[0].Item)
+	const want = "\x1b[1m\x1b[32mapp\x1b[0m \x1b[38;2;255;204;102m●\x1b[0m\n  \x1b[38;5;242m/home/tester/source/repos/app\x1b[0m"
+	if got != want {
+		t.Fatalf("card label = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Completed phase

Phase 4 — Theme config handoff.

## User-facing surface changed

- Attention dot: busy/thinking attention window dot now uses semantic `state.progress` amber (`TmuxStateProgressFg`).
- Pane border busy marker: busy pane border marker now uses `state.progress`; lead-mode AI topic prefixes are styled at render time in the pane border.
- AI pane topic/progress display: popup/switch preview topic and busy/thinking status renderers use `state.progress`; lead-mode prefixes are visually emphasized in renderers only.
- Popup/switch preview busy marker: busy/working dots moved from the old yellow helper to `state.progress`.
- Statusbar/sidebar badge synchronization: statusbar git/gid badge colors were not changed. Existing statusbar git tokens and sidebar/switch git badge tokens remain separate unchanged semantic paths, so this PR does not introduce one-sided drift.

## Explicitly excluded Theme settings scope

- Did not implement Theme settings Phase 0+ resolver-facing token inventory.
- Did not add user config schema, project/global theme resolver, Theme Settings editor, hex input, preset picker, font UX, or external preset import/export.
- Did not redesign semantic token foundation, config schema, resolver, or editor.
- Did not reopen Phase 0–3 fallback palette choices.

## Semantic contract

- `accent.ai` remains agent/brain identity.
- `state.progress` is now the explicit thinking/busy/working amber token.
- `state.danger` remains destructive/error.
- Lead-mode prefix styling is renderer-level only. Stored `@projmux_ai_topic`, session-state topic JSON, notification text, and `projmux ai topic get` output remain plain text with no raw ANSI or tmux `#[...]` styling.

## Verification

- `GOCACHE=/tmp/projmux-go-cache make fmt` — pass.
- `GOCACHE=/tmp/projmux-go-cache make fix` — pass.
- `GOCACHE=/tmp/projmux-go-cache make test` — pass.
- `GOCACHE=/tmp/projmux-go-cache make test-integration` — initial sandbox Docker socket denial, rerun with host Docker access pass.
- `GOCACHE=/tmp/projmux-go-cache make test-e2e` — initial sandbox Docker socket denial, rerun with host Docker access pass.
- `git diff --check` — pass.
- `rg` checked progress/AI/danger token paths, topic storage/render paths, raw color paths, and git/sidebar badge paths.

## Unverified / follow-up

- Live tmux visual confirmation was not performed in this PR. The tmux/popup visual pass remains an e2e/manual candidate.
- Follow-up phase: Theme 설정 Phase 0+ should start from `internal/theme/palette.go` and `docs/theme-palette.md` as the built-in fallback, without reselecting Phase 0–3 colors.