### PR TITLE
fix: preserve lead topic pane color

### DIFF
--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -1219,10 +1219,10 @@ func tmuxStyledAITopicFormat(topic string) string {
 }
 
 func tmuxLeadModeTopicMatchFormat(topic string) string {
-	qa := "#{m/r:^\\[[Ll]ead:[Qq][Aa]\\]," + topic + "}"
-	poc := "#{m/r:^\\[[Ll]ead:[Pp][Oo][Cc]\\]," + topic + "}"
-	ship := "#{m/r:^\\[[Ll]ead:[Ss]hip\\]," + topic + "}"
-	roadmap := "#{m/r:^\\[[Ll]ead:[Rr]oadmap\\]," + topic + "}"
+	qa := "#{m/r:^\\\\[[Ll]ead:[Qq][Aa]\\\\]," + topic + "}"
+	poc := "#{m/r:^\\\\[[Ll]ead:[Pp][Oo][Cc]\\\\]," + topic + "}"
+	ship := "#{m/r:^\\\\[[Ll]ead:[Ss]hip\\\\]," + topic + "}"
+	roadmap := "#{m/r:^\\\\[[Ll]ead:[Rr]oadmap\\\\]," + topic + "}"
 	return "#{||:#{||:" + qa + "," + poc + "},#{||:" + ship + "," + roadmap + "}}"
 }
 

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -1583,6 +1583,9 @@ func TestTmuxAppNamingFormatsUseVisiblePaneLabel(t *testing.T) {
 	if !strings.Contains(styledVisibleLabel, "#[bold#,fg="+tmuxStateProgressFg+"]#{@projmux_ai_topic}#[pop-default]") {
 		t.Fatalf("styled visible label format = %q, want renderer-level lead topic styling", styledVisibleLabel)
 	}
+	if !strings.Contains(styledVisibleLabel, `^\\[[Ll]ead:[Ss]hip\\]`) {
+		t.Fatalf("styled visible label format = %q, want literal bracket escapes to survive tmux config parsing", styledVisibleLabel)
+	}
 
 	wantPaneBorderLine := "set -g pane-border-format " + tmuxConfigQuote(paneBorder)
 	if !strings.Contains(configText, wantPaneBorderLine+"\n") {


### PR DESCRIPTION
## Summary

- Fix tmux pane-border lead topic matching so literal `[` / `]` survive tmux config parsing.
- Keep lead-mode topic renderer styling on `state.progress` amber instead of falling through to the surrounding reply/muted pane style.
- Add a regression assertion for the double-escaped literal bracket pattern.

## Why

Phase 4 added renderer-level lead topic styling, but the tmux regex used in `pane-border-format` only escaped brackets for the Go string layer. The tmux config parser consumed that escape when applying the live option, so the live regex became `^[[Ll]ead...` and did not match literal `[lead:ship]` topics. Busy dots were already amber; the lead topic label itself could still inherit the surrounding pane style.

Reply/waiting dots remain `accent.attention`; only thinking/busy/working progress surfaces use `state.progress`.

## Verification

- `GOCACHE=/tmp/projmux-go-cache go test ./internal/app -run 'TestTmuxAppNamingFormatsUseVisiblePaneLabel|TestTmuxPrintAppConfigUsesIsolatedAppSettings'` — pass.
- `GOCACHE=/tmp/projmux-go-cache make fmt` — pass.
- `GOCACHE=/tmp/projmux-go-cache make fix` — pass.
- `GOCACHE=/tmp/projmux-go-cache make test` — pass.
- `git diff --check` — pass.