### PR TITLE
fix: render ready pane border green

### DIFF
--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -44,6 +44,7 @@ const (
 	tmuxAccentAIBg              = theme.TmuxAccentAIBg
 	tmuxAccentAIFg              = theme.TmuxAccentAIFg
 	tmuxStateProgressFg         = theme.TmuxStateProgressFg
+	tmuxStateSuccessFg          = theme.TmuxStateSuccessFg
 	tmuxStateWarningFg          = theme.TmuxStateWarningFg
 	tmuxStateCriticalFg         = theme.TmuxStateCriticalFg
 )
@@ -1234,7 +1235,7 @@ func tmuxPaneBorderFormat() string {
 	paneLabelFormat := tmuxStyledVisiblePaneLabelFormat()
 	paneBusyFormat := "#{==:#{@projmux_attention_state},busy}"
 	paneReplyFormat := "#{==:#{@projmux_attention_state},reply}"
-	inactivePaneBorderFormat := "#{?" + paneBusyFormat + ",#[bold#,fg=" + tmuxStateProgressFg + "] ● " + paneLabelFormat + " #[default],#{?" + paneReplyFormat + ",#[bold#,fg=" + tmuxAccentAttentionStrongBg + "] ● " + paneLabelFormat + " #[default],#[fg=" + theme.TmuxMutedFg + "] " + paneLabelFormat + " #[default]}}"
+	inactivePaneBorderFormat := "#{?" + paneBusyFormat + ",#[bold#,fg=" + tmuxStateProgressFg + "] ● " + paneLabelFormat + " #[default],#{?" + paneReplyFormat + ",#[bold#,fg=" + tmuxStateSuccessFg + "] ● " + paneLabelFormat + " #[default],#[fg=" + theme.TmuxMutedFg + "] " + paneLabelFormat + " #[default]}}"
 	return "#{?pane_active,#[bold#,fg=" + theme.TmuxPaneActiveFg + "#,bg=" + theme.TmuxPaneActiveBg + "] > " + paneLabelFormat + " #[default]," + inactivePaneBorderFormat + "}"
 }
 

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -1476,7 +1476,7 @@ func TestTmuxPrintAppConfigUsesIsolatedAppSettings(t *testing.T) {
 		"set -g pane-border-status top",
 		"set -g pane-border-format \"#{?pane_active,#[bold#,fg=colour16#,bg=colour45] > ",
 		"#[bold#,fg=" + tmuxStateProgressFg + "] ● ",
-		"#[bold#,fg=" + tmuxAccentAttentionStrongBg + "] ● ",
+		"#[bold#,fg=" + tmuxStateSuccessFg + "] ● ",
 		"#[fg=colour244] ",
 		"#{@projmux_ai_topic}",
 		"#{pane_current_command},#{pane_title}",
@@ -1579,6 +1579,9 @@ func TestTmuxAppNamingFormatsUseVisiblePaneLabel(t *testing.T) {
 	}
 	if !strings.Contains(paneBorder, "#[bold#,fg="+tmuxStateProgressFg+"] ● ") {
 		t.Fatalf("pane border format = %q, want busy marker to use state.progress", paneBorder)
+	}
+	if !strings.Contains(paneBorder, "#[bold#,fg="+tmuxStateSuccessFg+"] ● ") {
+		t.Fatalf("pane border format = %q, want reply/ready marker to use state.success", paneBorder)
 	}
 	if !strings.Contains(styledVisibleLabel, "#[bold#,fg="+tmuxStateProgressFg+"]#{@projmux_ai_topic}#[pop-default]") {
 		t.Fatalf("styled visible label format = %q, want renderer-level lead topic styling", styledVisibleLabel)


### PR DESCRIPTION
## Summary

- Render pane-border `reply` / ready markers with `state.success` green instead of `accent.attention` pink.
- Keep `busy` / thinking markers on `state.progress` amber.
- Add/update tmux app config regression assertions so pane border ready and progress colors stay distinct.

## Why

Popup/switch preview already treat rank-1 ready/reply panes as green, but pane borders still used the stronger attention color. Completed AI panes therefore looked like unresolved alert panes even after work was done.

## Verification

- `GOCACHE=/tmp/projmux-go-cache go test ./internal/app -run 'TestTmuxAppNamingFormatsUseVisiblePaneLabel|TestTmuxPrintAppConfigUsesIsolatedAppSettings'` — pass.
- `GOCACHE=/tmp/projmux-go-cache make fmt` — pass.
- `GOCACHE=/tmp/projmux-go-cache make fix` — pass.
- `GOCACHE=/tmp/projmux-go-cache make test` — pass.
- `git diff --check` — pass.