### PR TITLE
fix: separate AI notification body labels

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -376,7 +376,8 @@ precedence over catalog `action` during ingest, including known events such as
 `install` field used by `projmux ai integrate codex`. A runtime `notify`
 override for a known Codex event without a specialized handler, such as
 `PreToolUse` or `PostToolUse`, pushes a short generic in-app row like
-`Codex · PreToolUse · Bash`. Generic rows are queue/sidebar/statusbar only and
+`PreToolUse · Bash` with agent/category metadata. Generic rows are
+queue/sidebar/statusbar only and
 do not dispatch OS desktop notifications, `PROJMUX_NOTIFY_HOOK`, or
 `[hooks.send-noti]`.
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -169,9 +169,11 @@ stdin receives one JSON object:
   "topic": "worker loop",
   "pane": "%9",
   "session": "main",
-  "message": "claude: reply ready · worker loop",
+  "message": "worker loop",
   "metadata": {
-    "agent": "claude"
+    "agent": "claude",
+    "category": "response_complete",
+    "state": "need"
   },
   "created_at": "2026-05-12T02:03:04Z"
 }
@@ -346,9 +348,9 @@ events, so `Stop` or `PermissionRequest` can be made state-only or quiet
 without changing which hook commands are installed. When a known Codex event
 without a specialized handler, such as `PreToolUse` or `PostToolUse`, is set to
 runtime `notify`, projmux pushes a generic in-app notify row such as
-`Codex · PreToolUse · Bash`. That generic path is queue/sidebar/statusbar only:
-it does not dispatch `[hooks.send-noti]`, `PROJMUX_NOTIFY_HOOK`, `notify-send`,
-or Windows toast.
+`PreToolUse · Bash` with agent/category metadata. That generic path is
+queue/sidebar/statusbar only: it does not dispatch `[hooks.send-noti]`,
+`PROJMUX_NOTIFY_HOOK`, `notify-send`, or Windows toast.
 Generic metadata is limited to safe summary fields such as provider, event,
 tool, cwd, thread, session, turn, and model; raw payloads and tool input are
 not stored.

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -302,10 +302,14 @@ func (c *aiCommand) notifyAIWithInput(paneID string, in attentionNotifyInput) er
 	if strings.TrimSpace(in.Text) == "" {
 		return c.notifyAI(paneID)
 	}
-	return c.notifyAIText(paneID, in.Text, in.Severity, in.Force)
+	return c.notifyAITextWithMetadata(paneID, in.Text, in.Severity, in.Force, in.Metadata)
 }
 
 func (c *aiCommand) notifyAIText(paneID, text, severity string, force bool) error {
+	return c.notifyAITextWithMetadata(paneID, text, severity, force, nil)
+}
+
+func (c *aiCommand) notifyAITextWithMetadata(paneID, text, severity string, force bool, metadata map[string]string) error {
 	paneID = strings.TrimSpace(paneID)
 	text = strings.TrimSpace(text)
 	if paneID == "" || text == "" {
@@ -316,7 +320,7 @@ func (c *aiCommand) notifyAIText(paneID, text, severity string, force bool) erro
 		c.recordAINotification(paneID, key)
 		return nil
 	}
-	notification := c.aiTextNotification(paneID, text, severity)
+	notification := c.aiTextNotificationWithMetadata(paneID, text, severity, metadata)
 	if err := c.notificationNotifier().Notify(notification); err != nil {
 		return nil
 	}
@@ -325,13 +329,26 @@ func (c *aiCommand) notifyAIText(paneID, text, severity string, force bool) erro
 }
 
 func (c *aiCommand) aiTextNotification(paneID, text, severity string) aiNotification {
+	return c.aiTextNotificationWithMetadata(paneID, text, severity, nil)
+}
+
+func (c *aiCommand) aiTextNotificationWithMetadata(paneID, text, severity string, metadata map[string]string) aiNotification {
 	sessionName := c.readTrimmed("tmux", "display-message", "-p", "-t", paneID, "#S")
 	windowName := c.readTrimmed("tmux", "display-message", "-p", "-t", paneID, "#W")
 	panePath := c.readTrimmed("tmux", "display-message", "-p", "-t", paneID, "#{pane_current_path}")
-	agent := aiNotificationTextAgent(text)
+	agent := aiNotificationTextAgentWithMetadata(text, metadata)
+	summary := strings.TrimSpace(text)
+	bodyTitle := ""
+	if parts := parseAITextNotificationParts(text); parts.Category != "" {
+		summary = joinAINotifyText(parts.Agent, titleCaseAINotifyCategory(parts.Category))
+		bodyTitle = parts.Detail
+	} else if category := aiNotificationMetadataCategory(metadata); category != "" {
+		summary = joinAINotifyText(defaultString(agent, "AI"), titleCaseAINotifyCategory(category))
+		bodyTitle = text
+	}
 	return aiNotification{
-		Summary:  strings.TrimSpace(text),
-		Body:     aiNotificationBody("", aiProjectName(panePath), c.gitBranchForPath(panePath), sessionName, windowName),
+		Summary:  summary,
+		Body:     aiNotificationBody(bodyTitle, aiProjectName(panePath), c.gitBranchForPath(panePath), sessionName, windowName),
 		Urgency:  aiOSNotificationUrgency(severity),
 		ExpireMS: c.notificationExpireMS(),
 		AppName:  desktopAppID,
@@ -2174,10 +2191,7 @@ func aiSummaryForKind(kind, agentName, topic string) string {
 		summary = "Input required"
 	}
 	if strings.TrimSpace(agentName) != "" {
-		summary = strings.TrimSpace(agentName) + " " + summary
-	}
-	if strings.TrimSpace(topic) != "" {
-		summary += " · " + topic
+		summary = joinAINotifyText(strings.TrimSpace(agentName), titleCaseAINotifyCategory(summary))
 	}
 	return summary
 }
@@ -2187,6 +2201,16 @@ func aiOSNotificationUrgency(string) string {
 }
 
 func aiNotificationTextAgent(text string) string {
+	return aiNotificationTextAgentWithMetadata(text, nil)
+}
+
+func aiNotificationTextAgentWithMetadata(text string, metadata map[string]string) string {
+	if agent := aiNotificationMetadataAgent(metadata); agent != "" {
+		return agent
+	}
+	if parts := parseAITextNotificationParts(text); parts.Agent != "" {
+		return parts.Agent
+	}
 	switch {
 	case strings.HasPrefix(strings.TrimSpace(text), "Codex"):
 		return "Codex"
@@ -2195,6 +2219,68 @@ func aiNotificationTextAgent(text string) string {
 	default:
 		return "AI"
 	}
+}
+
+func aiNotificationMetadataAgent(metadata map[string]string) string {
+	switch strings.ToLower(strings.TrimSpace(metadata["agent"])) {
+	case "codex":
+		return "Codex"
+	case "claude":
+		return "Claude"
+	default:
+		return ""
+	}
+}
+
+func aiNotificationMetadataCategory(metadata map[string]string) string {
+	category := strings.TrimSpace(metadata["category"])
+	if category == "" {
+		return ""
+	}
+	return strings.ReplaceAll(category, "_", " ")
+}
+
+type aiTextNotificationParts struct {
+	Agent    string
+	Category string
+	Detail   string
+}
+
+func parseAITextNotificationParts(text string) aiTextNotificationParts {
+	fields := strings.Split(strings.TrimSpace(text), " · ")
+	if len(fields) < 2 {
+		return aiTextNotificationParts{}
+	}
+	agent := strings.TrimSpace(fields[0])
+	if !isKnownAgent(strings.ToLower(agent)) {
+		return aiTextNotificationParts{}
+	}
+	category := strings.TrimSpace(fields[1])
+	if !isFixedAINotificationCategory(category) {
+		return aiTextNotificationParts{}
+	}
+	return aiTextNotificationParts{
+		Agent:    agent,
+		Category: category,
+		Detail:   strings.TrimSpace(strings.Join(fields[2:], " · ")),
+	}
+}
+
+func isFixedAINotificationCategory(category string) bool {
+	switch strings.ToLower(strings.TrimSpace(category)) {
+	case "approval required", "response complete", "input required":
+		return true
+	default:
+		return false
+	}
+}
+
+func titleCaseAINotifyCategory(category string) string {
+	words := strings.Fields(strings.ToLower(strings.TrimSpace(category)))
+	for i, word := range words {
+		words[i] = strings.ToUpper(word[:1]) + word[1:]
+	}
+	return strings.Join(words, " ")
 }
 
 func aiProjectName(path string) string {
@@ -2207,7 +2293,7 @@ func aiProjectName(path string) string {
 
 func aiNotificationBody(title, project, branch, sessionName, windowName string) string {
 	context := displayAITopic(title)
-	if isGenericAITopic(context) {
+	if isGenericAITopic(context) || aiReplyKindForTitle(context) != "response_ready" {
 		context = ""
 	}
 	projectPart := ""
@@ -2219,23 +2305,14 @@ func aiNotificationBody(title, project, branch, sessionName, windowName string) 
 	case branch != "":
 		projectPart = branch
 	}
-	location := ""
-	if sessionName != "" || windowName != "" {
-		location = sessionName + ":" + windowName
-	}
 	switch {
 	case context != "" && projectPart != "":
-		return "Review pending: " + context + " · " + projectPart
+		return context + " · " + projectPart
 	case context != "":
-		return "Review pending: " + context
-	case projectPart != "" && location != "":
-		return "Review pending: " + projectPart + " · " + location
+		return context
 	case projectPart != "":
-		return "Review pending: " + projectPart
+		return projectPart
 	default:
-		if location != "" {
-			return "Review pending: " + location
-		}
 		return ""
 	}
 }

--- a/internal/app/ai_ingest.go
+++ b/internal/app/ai_ingest.go
@@ -411,7 +411,7 @@ func (c *aiCommand) ingestCodexHook(data []byte) error {
 				ID:       codexHookNotifyID(payload, "stop"),
 				Text:     body.Text,
 				Severity: body.Severity,
-				Metadata: metadata,
+				Metadata: mergeAINotifyBodyMetadata(metadata, body),
 				Force:    true,
 			}); err != nil {
 				c.appendAIIngestLog(aiIngestLogEntry{Source: "codex-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, ThreadID: payload.matchThreadID(), SessionID: payload.SessionID, TurnID: payload.TurnID})
@@ -424,7 +424,7 @@ func (c *aiCommand) ingestCodexHook(data []byte) error {
 			ID:       codexHookNotifyID(payload, "stop"),
 			Text:     body.Text,
 			Severity: body.Severity,
-			Metadata: metadata,
+			Metadata: mergeAINotifyBodyMetadata(metadata, body),
 			Force:    true,
 		}); err != nil {
 			c.appendAIIngestLog(aiIngestLogEntry{Source: "codex-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, ThreadID: payload.matchThreadID(), SessionID: payload.SessionID, TurnID: payload.TurnID})
@@ -444,7 +444,7 @@ func (c *aiCommand) ingestCodexHook(data []byte) error {
 				ID:       codexHookNotifyID(payload, "permission"),
 				Text:     body.Text,
 				Severity: body.Severity,
-				Metadata: metadata,
+				Metadata: mergeAINotifyBodyMetadata(metadata, body),
 				Force:    true,
 			}); err != nil {
 				c.appendAIIngestLog(aiIngestLogEntry{Source: "codex-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, ThreadID: payload.matchThreadID(), SessionID: payload.SessionID, TurnID: payload.TurnID})
@@ -457,7 +457,7 @@ func (c *aiCommand) ingestCodexHook(data []byte) error {
 			ID:       codexHookNotifyID(payload, "permission"),
 			Text:     body.Text,
 			Severity: body.Severity,
-			Metadata: metadata,
+			Metadata: mergeAINotifyBodyMetadata(metadata, body),
 			Force:    true,
 		}); err != nil {
 			c.appendAIIngestLog(aiIngestLogEntry{Source: "codex-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, ThreadID: payload.matchThreadID(), SessionID: payload.SessionID, TurnID: payload.TurnID})
@@ -527,7 +527,7 @@ func (c *aiCommand) ingestClaudeHook(data []byte) error {
 				ID:       claudeNotifyID(payload),
 				Text:     body.Text,
 				Severity: body.Severity,
-				Metadata: metadata,
+				Metadata: mergeAINotifyBodyMetadata(metadata, body),
 				Force:    true,
 			}); err != nil {
 				c.appendAIIngestLog(aiIngestLogEntry{Source: "claude-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, SessionID: payload.SessionID})
@@ -540,7 +540,7 @@ func (c *aiCommand) ingestClaudeHook(data []byte) error {
 			ID:       claudeNotifyID(payload),
 			Text:     body.Text,
 			Severity: body.Severity,
-			Metadata: metadata,
+			Metadata: mergeAINotifyBodyMetadata(metadata, body),
 			Force:    true,
 		}); err != nil {
 			c.appendAIIngestLog(aiIngestLogEntry{Source: "claude-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, SessionID: payload.SessionID})
@@ -559,7 +559,7 @@ func (c *aiCommand) ingestClaudeHook(data []byte) error {
 				ID:       claudePermissionNotifyID(payload),
 				Text:     body.Text,
 				Severity: body.Severity,
-				Metadata: metadata,
+				Metadata: mergeAINotifyBodyMetadata(metadata, body),
 				Force:    true,
 			}); err != nil {
 				c.appendAIIngestLog(aiIngestLogEntry{Source: "claude-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, SessionID: payload.SessionID})
@@ -572,7 +572,7 @@ func (c *aiCommand) ingestClaudeHook(data []byte) error {
 			ID:       claudePermissionNotifyID(payload),
 			Text:     body.Text,
 			Severity: body.Severity,
-			Metadata: metadata,
+			Metadata: mergeAINotifyBodyMetadata(metadata, body),
 			Force:    true,
 		}); err != nil {
 			c.appendAIIngestLog(aiIngestLogEntry{Source: "claude-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, SessionID: payload.SessionID})
@@ -592,7 +592,7 @@ func (c *aiCommand) ingestClaudeHook(data []byte) error {
 				ID:       claudeStopNotifyID(payload),
 				Text:     body.Text,
 				Severity: body.Severity,
-				Metadata: metadata,
+				Metadata: mergeAINotifyBodyMetadata(metadata, body),
 				Force:    true,
 			}); err != nil {
 				c.appendAIIngestLog(aiIngestLogEntry{Source: "claude-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, SessionID: payload.SessionID})
@@ -605,7 +605,7 @@ func (c *aiCommand) ingestClaudeHook(data []byte) error {
 			ID:       claudeStopNotifyID(payload),
 			Text:     body.Text,
 			Severity: body.Severity,
-			Metadata: metadata,
+			Metadata: mergeAINotifyBodyMetadata(metadata, body),
 			Force:    true,
 		}); err != nil {
 			c.appendAIIngestLog(aiIngestLogEntry{Source: "claude-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, SessionID: payload.SessionID})
@@ -624,7 +624,7 @@ func (c *aiCommand) ingestClaudeHook(data []byte) error {
 				ID:       claudeExtraNotifyID(payload, "stop-failure", payload.ErrorType, payload.ErrorMessage),
 				Text:     body.Text,
 				Severity: body.Severity,
-				Metadata: metadata,
+				Metadata: mergeAINotifyBodyMetadata(metadata, body),
 				Force:    true,
 			}); err != nil {
 				c.appendAIIngestLog(aiIngestLogEntry{Source: "claude-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, SessionID: payload.SessionID})
@@ -637,7 +637,7 @@ func (c *aiCommand) ingestClaudeHook(data []byte) error {
 			ID:       claudeExtraNotifyID(payload, "stop-failure", payload.ErrorType, payload.ErrorMessage),
 			Text:     body.Text,
 			Severity: body.Severity,
-			Metadata: metadata,
+			Metadata: mergeAINotifyBodyMetadata(metadata, body),
 			Force:    true,
 		}); err != nil {
 			c.appendAIIngestLog(aiIngestLogEntry{Source: "claude-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, SessionID: payload.SessionID})
@@ -652,7 +652,7 @@ func (c *aiCommand) ingestClaudeHook(data []byte) error {
 				ID:       claudeExtraNotifyID(payload, "subagent-stop", payload.SubagentType, payload.SubagentID),
 				Text:     body.Text,
 				Severity: body.Severity,
-				Metadata: metadata,
+				Metadata: mergeAINotifyBodyMetadata(metadata, body),
 				Force:    true,
 			}); err != nil {
 				c.appendAIIngestLog(aiIngestLogEntry{Source: "claude-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, SessionID: payload.SessionID})
@@ -666,7 +666,7 @@ func (c *aiCommand) ingestClaudeHook(data []byte) error {
 				ID:       claudeExtraNotifyID(payload, "subagent-stop", payload.SubagentType, payload.SubagentID),
 				Text:     formatClaudeSubagentStopNotifyBody(payload).Text,
 				Severity: notify.SeverityInfo,
-				Metadata: metadata,
+				Metadata: mergeAINotifyBodyMetadata(metadata, formatClaudeSubagentStopNotifyBody(payload)),
 				Force:    true,
 			}); err != nil {
 				c.appendAIIngestLog(aiIngestLogEntry{Source: "claude-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, SessionID: payload.SessionID})
@@ -691,7 +691,7 @@ func (c *aiCommand) ingestClaudeHook(data []byte) error {
 				ID:       claudeExtraNotifyID(payload, "teammate-idle", payload.TeammateName, payload.TeammateID, payload.TeammateContext),
 				Text:     body.Text,
 				Severity: body.Severity,
-				Metadata: metadata,
+				Metadata: mergeAINotifyBodyMetadata(metadata, body),
 				Force:    true,
 			}); err != nil {
 				c.appendAIIngestLog(aiIngestLogEntry{Source: "claude-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, SessionID: payload.SessionID})
@@ -704,7 +704,7 @@ func (c *aiCommand) ingestClaudeHook(data []byte) error {
 			ID:       claudeExtraNotifyID(payload, "teammate-idle", payload.TeammateName, payload.TeammateID, payload.TeammateContext),
 			Text:     body.Text,
 			Severity: body.Severity,
-			Metadata: metadata,
+			Metadata: mergeAINotifyBodyMetadata(metadata, body),
 			Force:    true,
 		}); err != nil {
 			c.appendAIIngestLog(aiIngestLogEntry{Source: "claude-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, SessionID: payload.SessionID})
@@ -734,7 +734,7 @@ func (c *aiCommand) pushGenericCodexHookNotify(paneID string, payload codexHookP
 		ID:            codexHookNotifyID(payload, "generic"),
 		Text:          body.Text,
 		Severity:      body.Severity,
-		Metadata:      payload.codexGenericHookMetadata(),
+		Metadata:      mergeAINotifyBodyMetadata(payload.codexGenericHookMetadata(), body),
 		Force:         true,
 		SuppressHooks: true,
 	})

--- a/internal/app/ai_ingest_test.go
+++ b/internal/app/ai_ingest_test.go
@@ -133,13 +133,13 @@ func TestIngestCodexHookPermissionPushesCriticalQueueEntryAndMetadata(t *testing
 	if got.ID != "ai:codex:permission:codex-session:turn-456:Bash:go test ./internal/app" {
 		t.Fatalf("ID = %q", got.ID)
 	}
-	if got.Text != "Codex · Approval required · Bash: go test ./internal/app" {
+	if got.Text != "Bash: go test ./internal/app" {
 		t.Fatalf("Text = %q", got.Text)
 	}
 	if got.Severity != notify.SeverityCritical {
 		t.Fatalf("Severity = %q", got.Severity)
 	}
-	if got.Metadata["agent"] != "codex" || got.Metadata["event"] != "PermissionRequest" || got.Metadata["model"] != "gpt-5.1-codex" || got.Metadata["tool_input.command"] != "go test ./internal/app" {
+	if got.Metadata["agent"] != "codex" || got.Metadata["category"] != "approval_required" || got.Metadata["event"] != "PermissionRequest" || got.Metadata["model"] != "gpt-5.1-codex" || got.Metadata["tool_input.command"] != "go test ./internal/app" {
 		t.Fatalf("Metadata = %#v", got.Metadata)
 	}
 	assertNoAIPaneTopicWrite(t, cmdRecorder(cmd).commands)
@@ -165,7 +165,7 @@ func TestIngestCodexHookStopPushesInfoQueueEntry(t *testing.T) {
 		t.Fatalf("push count = %d, want 1", len(store.pushed))
 	}
 	got := store.pushed[0]
-	if got.ID != "ai:codex:stop:codex-session:turn-456" || got.Text != "Codex · Response complete" || got.Severity != notify.SeverityInfo {
+	if got.ID != "ai:codex:stop:codex-session:turn-456" || got.Text != "Ready" || got.Severity != notify.SeverityInfo || got.Metadata["category"] != "response_complete" {
 		t.Fatalf("pushed = %#v", got)
 	}
 }
@@ -294,7 +294,7 @@ func TestIngestCodexHookRuntimeNotifyPushesGenericQueueOnlyRow(t *testing.T) {
 		t.Fatalf("push count = %d, want 1: %#v", len(store.pushed), store.pushed)
 	}
 	got := store.pushed[0]
-	if got.Text != "Codex · PreToolUse · Bash" || got.Severity != notify.SeverityInfo {
+	if got.Text != "PreToolUse · Bash" || got.Severity != notify.SeverityInfo {
 		t.Fatalf("pushed = %#v", got)
 	}
 	if got.Metadata["provider"] != "codex" || got.Metadata["event"] != "PreToolUse" || got.Metadata["tool"] != "Bash" || got.Metadata["cwd"] != "/repo/projmux" || got.Metadata["session_id"] != "codex-session" || got.Metadata["turn_id"] != "turn-456" {
@@ -361,7 +361,7 @@ func TestIngestCodexHookRuntimeNotifySuppressesSendNotiHook(t *testing.T) {
 	if len(store.pushed) != 1 {
 		t.Fatalf("push count = %d, want 1: %#v", len(store.pushed), store.pushed)
 	}
-	if got := store.pushed[0].Text; got != "Codex · PostToolUse · Edit" {
+	if got := store.pushed[0].Text; got != "PostToolUse · Edit" {
 		t.Fatalf("Text = %q", got)
 	}
 	if runner.calls != 0 {
@@ -738,12 +738,12 @@ func TestAIHookNotifyBodyCatalog(t *testing.T) {
 				ToolName:  "Bash",
 				ToolInput: map[string]any{"command": "go test ./internal/app"},
 			}),
-			want: aiNotifyBody{Text: "Codex · Approval required · Bash: go test ./internal/app", Severity: notify.SeverityCritical},
+			want: aiNotifyBody{Text: "Bash: go test ./internal/app", Severity: notify.SeverityCritical, Agent: "codex", Category: "approval_required"},
 		},
 		{
 			name: "codex hook stop",
 			body: formatCodexHookStopNotifyBody(codexHookPayload{}),
-			want: aiNotifyBody{Text: "Codex · Response complete", Severity: notify.SeverityInfo},
+			want: aiNotifyBody{Text: "Ready", Severity: notify.SeverityInfo, Agent: "codex", Category: "response_complete"},
 		},
 		{
 			name: "claude notification permission prompt",
@@ -751,7 +751,7 @@ func TestAIHookNotifyBodyCatalog(t *testing.T) {
 				NotificationType: "permission_prompt",
 				Message:          "Approve Bash?",
 			}),
-			want: aiNotifyBody{Text: "Claude · Approval required · Approve Bash?", Severity: notify.SeverityCritical},
+			want: aiNotifyBody{Text: "Approve Bash?", Severity: notify.SeverityCritical, Agent: "claude", Category: "approval_required"},
 		},
 		{
 			name: "claude notification idle",
@@ -759,7 +759,7 @@ func TestAIHookNotifyBodyCatalog(t *testing.T) {
 				NotificationType: "idle_prompt",
 				Message:          "Waiting for your next request",
 			}),
-			want: aiNotifyBody{Text: "Claude · Response complete · Waiting for your next request", Severity: notify.SeverityInfo},
+			want: aiNotifyBody{Text: "Waiting for your next request", Severity: notify.SeverityInfo, Agent: "claude", Category: "response_complete"},
 		},
 		{
 			name: "claude permission request bash command",
@@ -768,12 +768,12 @@ func TestAIHookNotifyBodyCatalog(t *testing.T) {
 				ToolUseID: "tool-123",
 				ToolInput: map[string]any{"command": "rm -rf /tmp/old-cache"},
 			}),
-			want: aiNotifyBody{Text: "Claude · Approval required · Bash: rm -rf /tmp/old-cache", Severity: notify.SeverityCritical},
+			want: aiNotifyBody{Text: "Bash: rm -rf /tmp/old-cache", Severity: notify.SeverityCritical, Agent: "claude", Category: "approval_required"},
 		},
 		{
 			name: "claude stop transcript summary",
 			body: formatClaudeStopNotifyBody("implemented and verified"),
-			want: aiNotifyBody{Text: "Claude · Response complete · implemented and verified", Severity: notify.SeverityInfo},
+			want: aiNotifyBody{Text: "implemented and verified", Severity: notify.SeverityInfo, Agent: "claude", Category: "response_complete"},
 		},
 		{
 			name: "claude stop failure error labels",
@@ -781,7 +781,7 @@ func TestAIHookNotifyBodyCatalog(t *testing.T) {
 				ErrorType:    "timeout",
 				ErrorMessage: "tool call exceeded deadline",
 			}),
-			want: aiNotifyBody{Text: "Claude · Error · timeout · tool call exceeded deadline", Severity: notify.SeverityCritical},
+			want: aiNotifyBody{Text: "timeout · tool call exceeded deadline", Severity: notify.SeverityCritical, Agent: "claude", Category: "error"},
 		},
 		{
 			name: "claude subagent stop labels",
@@ -789,7 +789,7 @@ func TestAIHookNotifyBodyCatalog(t *testing.T) {
 				SubagentType: "reviewer",
 				SubagentID:   "sub-7",
 			}),
-			want: aiNotifyBody{Text: "Claude · Subagent stopped · reviewer · sub-7", Severity: notify.SeverityInfo},
+			want: aiNotifyBody{Text: "reviewer · sub-7", Severity: notify.SeverityInfo, Agent: "claude", Category: "subagent_stopped"},
 		},
 		{
 			name: "claude teammate idle labels",
@@ -798,7 +798,7 @@ func TestAIHookNotifyBodyCatalog(t *testing.T) {
 				TeammateID:      "team-3",
 				TeammateContext: "waiting for review",
 			}),
-			want: aiNotifyBody{Text: "Claude · Teammate waiting · sam · team-3 · waiting for review", Severity: notify.SeverityInfo},
+			want: aiNotifyBody{Text: "sam · team-3 · waiting for review", Severity: notify.SeverityInfo, Agent: "claude", Category: "teammate_waiting"},
 		},
 	}
 
@@ -843,19 +843,20 @@ func TestAIHookDesktopNotificationUsesQueueTextPayload(t *testing.T) {
 		}
 	}
 
-	text := "Codex · Approval required · Bash: go test ./internal/app"
-	notification := cmd.aiTextNotification("%7", text, notify.SeverityCritical)
-	if notification.Summary != text {
-		t.Fatalf("Summary = %q, want queue text %q", notification.Summary, text)
+	text := "Bash: go test ./internal/app"
+	metadata := map[string]string{"agent": "codex", "category": "approval_required"}
+	notification := cmd.aiTextNotificationWithMetadata("%7", text, notify.SeverityCritical, metadata)
+	if notification.Summary != "Codex · Approval Required" {
+		t.Fatalf("Summary = %q", notification.Summary)
 	}
 	if notification.Urgency != "normal" {
 		t.Fatalf("Urgency = %q, want OS urgency normal for critical queue text", notification.Urgency)
 	}
-	if !strings.Contains(notification.Body, "projmux/feat/hooks") || !strings.Contains(notification.Body, "workspace:editor") {
-		t.Fatalf("Body = %q, want project/session context", notification.Body)
+	if !strings.Contains(notification.Body, text) || !strings.Contains(notification.Body, "projmux/feat/hooks") || strings.Contains(notification.Body, "workspace:editor") {
+		t.Fatalf("Body = %q, want actionable text and project context only", notification.Body)
 	}
 
-	if err := cmd.notifyAIText("%7", text, notify.SeverityCritical, true); err != nil {
+	if err := cmd.notifyAITextWithMetadata("%7", text, notify.SeverityCritical, true, metadata); err != nil {
 		t.Fatalf("notifyAIText error = %v", err)
 	}
 	var notifySend recordedAICommand
@@ -868,7 +869,7 @@ func TestAIHookDesktopNotificationUsesQueueTextPayload(t *testing.T) {
 	if notifySend.name == "" {
 		t.Fatalf("commands = %#v, want notify-send dispatch", cmdRecorder(cmd).commands)
 	}
-	if !reflect.DeepEqual(notifySend.args[len(notifySend.args)-2:], []string{text, notification.Body}) {
+	if !reflect.DeepEqual(notifySend.args[len(notifySend.args)-2:], []string{notification.Summary, notification.Body}) {
 		t.Fatalf("notify-send args = %#v, want summary/body from shared payload", notifySend.args)
 	}
 	for _, want := range []string{"--urgency=normal", "--expire-time=5000"} {
@@ -961,13 +962,13 @@ func TestIngestClaudePermissionPushesCriticalQueueEntryAndHookMarker(t *testing.
 	if got.ID != "ai:claude:permission:claude-session:tool-123" {
 		t.Fatalf("ID = %q", got.ID)
 	}
-	if got.Text != "Claude · Approval required · Bash: go test ./internal/app" {
+	if got.Text != "Bash: go test ./internal/app" {
 		t.Fatalf("Text = %q", got.Text)
 	}
 	if got.Severity != notify.SeverityCritical {
 		t.Fatalf("Severity = %q", got.Severity)
 	}
-	if got.Metadata["agent"] != "claude" || got.Metadata["event"] != "PermissionRequest" || got.Metadata["tool_input.command"] != "go test ./internal/app" {
+	if got.Metadata["agent"] != "claude" || got.Metadata["category"] != "approval_required" || got.Metadata["event"] != "PermissionRequest" || got.Metadata["tool_input.command"] != "go test ./internal/app" {
 		t.Fatalf("Metadata = %#v", got.Metadata)
 	}
 	assertNoAIPaneTopicWrite(t, cmdRecorder(cmd).commands)
@@ -993,7 +994,7 @@ func TestIngestClaudeStopUsesTranscriptOrGenericFallback(t *testing.T) {
 	if err := cmd.Run([]string{"ingest", "claude-hook"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run ingest claude-hook Stop error = %v", err)
 	}
-	if len(store.pushed) != 1 || store.pushed[0].Text != "Claude · Response complete · implemented and verified" {
+	if len(store.pushed) != 1 || store.pushed[0].Text != "implemented and verified" || store.pushed[0].Metadata["category"] != "response_complete" {
 		t.Fatalf("pushed = %#v", store.pushed)
 	}
 
@@ -1009,7 +1010,7 @@ func TestIngestClaudeStopUsesTranscriptOrGenericFallback(t *testing.T) {
 	if err := cmd.Run([]string{"ingest", "claude-hook"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run ingest claude-hook Stop without transcript error = %v", err)
 	}
-	if len(store.pushed) != 1 || store.pushed[0].Text != "Claude · Response complete" {
+	if len(store.pushed) != 1 || store.pushed[0].Text != "Ready" || store.pushed[0].Metadata["category"] != "response_complete" {
 		t.Fatalf("fallback pushed = %#v", store.pushed)
 	}
 }
@@ -1035,7 +1036,7 @@ func TestIngestClaudeNotificationMapsInputReady(t *testing.T) {
 		t.Fatalf("push count = %d, want 1", len(store.pushed))
 	}
 	got := store.pushed[0]
-	if got.Text != "Claude · Input required · Need deployment target" || got.Severity != notify.SeverityCritical {
+	if got.Text != "Need deployment target" || got.Severity != notify.SeverityCritical || got.Metadata["category"] != "input_required" {
 		t.Fatalf("pushed = %#v", got)
 	}
 }
@@ -1060,7 +1061,7 @@ func TestIngestClaudeExtraEvents(t *testing.T) {
 				"error_message": "tool call exceeded deadline"
 			}`,
 			wantID:       "ai:claude:stop-failure:claude-session:timeout:tool call exceeded deadline",
-			wantText:     "Claude · Error · timeout · tool call exceeded deadline",
+			wantText:     "timeout · tool call exceeded deadline",
 			wantSeverity: notify.SeverityCritical,
 			wantPush:     true,
 			wantMetadata: map[string]string{
@@ -1088,7 +1089,7 @@ func TestIngestClaudeExtraEvents(t *testing.T) {
 				"teammate": {"name": "sam", "id": "team-3", "context": "waiting for review"}
 			}`,
 			wantID:       "ai:claude:teammate-idle:claude-session:sam:team-3:waiting for review",
-			wantText:     "Claude · Teammate waiting · sam · team-3 · waiting for review",
+			wantText:     "sam · team-3 · waiting for review",
 			wantSeverity: notify.SeverityInfo,
 			wantPush:     true,
 			wantMetadata: map[string]string{
@@ -1197,7 +1198,7 @@ func TestIngestClaudeRuntimeNotifyAppliesToKnownQuietEvent(t *testing.T) {
 	if len(store.pushed) != 1 {
 		t.Fatalf("push count = %d, want 1", len(store.pushed))
 	}
-	if got := store.pushed[0].Text; got != "Claude · Subagent stopped · reviewer · sub-7" {
+	if got := store.pushed[0].Text; got != "reviewer · sub-7" {
 		t.Fatalf("Text = %q", got)
 	}
 }

--- a/internal/app/ai_notify_body.go
+++ b/internal/app/ai_notify_body.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"maps"
 	"strings"
 
 	"github.com/crevissepartners/projmux/internal/core/notify"
@@ -9,6 +10,8 @@ import (
 type aiNotifyBody struct {
 	Text     string
 	Severity string
+	Agent    string
+	Category string
 }
 
 func formatCodexHookPermissionNotifyBody(p codexHookPayload) aiNotifyBody {
@@ -16,35 +19,43 @@ func formatCodexHookPermissionNotifyBody(p codexHookPayload) aiNotifyBody {
 	if toolName == "" {
 		toolName = "Tool"
 	}
-	text := joinAINotifyText("Codex", "Approval required", toolName)
+	text := toolName
 	if summary := formatCodexToolInputSummary(toolName, p.ToolInput); summary != "" {
 		text += ": " + summary
 	}
 	return aiNotifyBody{
 		Text:     text,
 		Severity: notify.SeverityCritical,
+		Agent:    "codex",
+		Category: "approval_required",
 	}
 }
 
 func formatCodexHookStopNotifyBody(codexHookPayload) aiNotifyBody {
 	return aiNotifyBody{
-		Text:     joinAINotifyText("Codex", "Response complete"),
+		Text:     "Ready",
 		Severity: notify.SeverityInfo,
+		Agent:    "codex",
+		Category: "response_complete",
 	}
 }
 
 func formatCodexGenericHookNotifyBody(p codexHookPayload) aiNotifyBody {
 	return aiNotifyBody{
-		Text:     joinAINotifyText("Codex", p.EventName, p.ToolName),
+		Text:     joinAINotifyText("", p.EventName, p.ToolName),
 		Severity: notify.SeverityInfo,
+		Agent:    "codex",
+		Category: strings.TrimSpace(p.EventName),
 	}
 }
 
 func formatClaudeNotificationNotifyBody(p claudeHookPayload) aiNotifyBody {
 	label, severity := claudeNotificationLabelSeverity(p.NotificationType)
 	return aiNotifyBody{
-		Text:     joinAINotifyText("Claude", label, p.Message),
+		Text:     defaultString(strings.TrimSpace(p.Message), "Ready"),
 		Severity: severity,
+		Agent:    "claude",
+		Category: aiNotifyCategoryKey(label),
 	}
 }
 
@@ -53,46 +64,62 @@ func formatClaudePermissionNotifyBody(p claudeHookPayload) aiNotifyBody {
 	if toolName == "" {
 		toolName = "Tool"
 	}
-	text := joinAINotifyText("Claude", "Approval required", toolName)
+	text := toolName
 	if summary := formatClaudeToolInputSummary(toolName, p.ToolInput, p.ToolUseID); summary != "" {
 		text += ": " + summary
 	}
 	return aiNotifyBody{
 		Text:     text,
 		Severity: notify.SeverityCritical,
+		Agent:    "claude",
+		Category: "approval_required",
 	}
 }
 
 func formatClaudeStopNotifyBody(message string) aiNotifyBody {
 	return aiNotifyBody{
-		Text:     joinAINotifyText("Claude", "Response complete", message),
+		Text:     defaultString(strings.TrimSpace(message), "Ready"),
 		Severity: notify.SeverityInfo,
+		Agent:    "claude",
+		Category: "response_complete",
 	}
 }
 
 func formatClaudeStopFailureNotifyBody(p claudeHookPayload) aiNotifyBody {
 	return aiNotifyBody{
-		Text:     joinAINotifyText("Claude", "Error", p.ErrorType, p.ErrorMessage),
+		Text:     joinAINotifyText(p.ErrorType, p.ErrorMessage),
 		Severity: notify.SeverityCritical,
+		Agent:    "claude",
+		Category: "error",
 	}
 }
 
 func formatClaudeSubagentStopNotifyBody(p claudeHookPayload) aiNotifyBody {
 	return aiNotifyBody{
-		Text:     joinAINotifyText("Claude", "Subagent stopped", p.SubagentType, p.SubagentID),
+		Text:     joinAINotifyText(p.SubagentType, p.SubagentID),
 		Severity: notify.SeverityInfo,
+		Agent:    "claude",
+		Category: "subagent_stopped",
 	}
 }
 
 func formatClaudeTeammateIdleNotifyBody(p claudeHookPayload) aiNotifyBody {
 	return aiNotifyBody{
-		Text:     joinAINotifyText("Claude", "Teammate waiting", p.TeammateName, p.TeammateID, p.TeammateContext),
+		Text:     joinAINotifyText(p.TeammateName, p.TeammateID, p.TeammateContext),
 		Severity: notify.SeverityInfo,
+		Agent:    "claude",
+		Category: "teammate_waiting",
 	}
 }
 
 func joinAINotifyText(agent, category string, values ...string) string {
-	parts := []string{strings.TrimSpace(agent), strings.TrimSpace(category)}
+	parts := []string{}
+	if trimmed := strings.TrimSpace(agent); trimmed != "" {
+		parts = append(parts, trimmed)
+	}
+	if trimmed := strings.TrimSpace(category); trimmed != "" {
+		parts = append(parts, trimmed)
+	}
 	for _, value := range values {
 		if trimmed := truncateRunes(value, 80); trimmed != "" {
 			parts = append(parts, trimmed)
@@ -112,6 +139,22 @@ func claudeNotificationLabelSeverity(notificationType string) (string, string) {
 	default:
 		return "Response complete", notify.SeverityInfo
 	}
+}
+
+func aiNotifyCategoryKey(label string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(label)), " ", "_")
+}
+
+func mergeAINotifyBodyMetadata(metadata map[string]string, body aiNotifyBody) map[string]string {
+	merged := make(map[string]string, len(metadata)+2)
+	maps.Copy(merged, metadata)
+	if body.Agent != "" {
+		merged["agent"] = body.Agent
+	}
+	if body.Category != "" {
+		merged["category"] = body.Category
+	}
+	return merged
 }
 
 func formatCodexToolInputSummary(toolName string, input map[string]any) string {

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -1161,8 +1161,8 @@ func TestAIStatusSetWaitingMarksPaneReplyAndNotifies(t *testing.T) {
 		"--app-name=" + desktopAppID,
 		desktopAppID,
 		filepath.Join(home, ".local", "share", "projmux", "icons", "projmux.png"),
-		"Codex Approval required · approval needed",
-		"Review pending: approval needed · projmux/main",
+		"Codex · Approval Required",
+		"projmux/main",
 	} {
 		if !containsAICommandArgSubstring(commands, want) {
 			t.Fatalf("commands = %#v, want notification shell containing %q", commands, want)
@@ -1232,8 +1232,8 @@ func TestAIStatusSetWaitingUsesNotificationHook(t *testing.T) {
 
 	commands := cmdRecorder(cmd).commands
 	if !containsAICommandArgs(commands, hook, []string{
-		"Codex Input required · answer ready",
-		"Review pending: answer ready · projmux/main",
+		"Codex · Input Required",
+		"projmux/main",
 		"normal",
 		desktopAppID,
 		"%9",
@@ -1379,8 +1379,8 @@ func TestAIStatusSetWaitingInWSLRegistersToastAppIDAndDispatchesToast(t *testing
 		"$toast.Group = 'repo'",
 		`<toast duration="short">`,
 		"$toast.ExpirationTime = [DateTimeOffset]::Now.AddMilliseconds(5000)",
-		"Codex Approval required · approval needed",
-		"Review pending: approval needed · projmux/main",
+		"Codex · Approval Required",
+		"projmux/main",
 		iconWin,
 		"appLogoOverride",
 	} {
@@ -1502,9 +1502,10 @@ func TestAIStatusSetWaitingForceDoesNotSetBadgeWhenVisible(t *testing.T) {
 	}
 
 	if err := cmd.applyAIStatusWithNotify("waiting", "%21", attentionNotifyInput{
-		ID:    "ai:test:%21",
-		Text:  "claude: reply ready · forced hook",
-		Force: true,
+		ID:       "ai:test:%21",
+		Text:     "forced hook",
+		Metadata: map[string]string{"agent": "claude", "category": "response_complete"},
+		Force:    true,
 	}); err != nil {
 		t.Fatalf("applyAIStatusWithNotify error = %v", err)
 	}
@@ -1693,7 +1694,7 @@ func TestAINotifyUsesPaneMetadataBeforeMutableTitle(t *testing.T) {
 	for _, want := range []string{
 		desktopAppID,
 		filepath.Join(home, ".local", "share", "projmux", "icons", "projmux.png"),
-		"Claude Approval required · approval needed",
+		"Claude · Approval Required",
 	} {
 		if !containsAICommandArgSubstring(commands, want) {
 			t.Fatalf("commands = %#v, want metadata-derived Claude notification containing %q", commands, want)
@@ -2067,16 +2068,16 @@ func TestAINotificationMessageLabelsClaudeAndAvoidsRootProject(t *testing.T) {
 	if got := aiProjectName("/"); got != "" {
 		t.Fatalf("aiProjectName(/) = %q, want empty", got)
 	}
-	if got, want := aiSummaryForKind("input_required", "Claude", "waiting for input"), "Claude Input required · waiting for input"; got != want {
+	if got, want := aiSummaryForKind("input_required", "Claude", "waiting for input"), "Claude · Input Required"; got != want {
 		t.Fatalf("aiSummaryForKind = %q, want %q", got, want)
 	}
-	if got, want := aiNotificationBody("waiting for input", "", "", "home", "dev"), "Review pending: waiting for input"; got != want {
+	if got, want := aiNotificationBody("waiting for input", "", "", "home", "dev"), ""; got != want {
 		t.Fatalf("aiNotificationBody = %q, want %q", got, want)
 	}
-	if got, want := aiNotificationBody("", "projmux", "main", "home", "dev"), "Review pending: projmux/main · home:dev"; got != want {
+	if got, want := aiNotificationBody("", "projmux", "main", "home", "dev"), "projmux/main"; got != want {
 		t.Fatalf("aiNotificationBody = %q, want %q", got, want)
 	}
-	if got, want := aiNotificationBody("Codex", "projmux", "main", "", ""), "Review pending: projmux/main"; got != want {
+	if got, want := aiNotificationBody("Codex", "projmux", "main", "", ""), "projmux/main"; got != want {
 		t.Fatalf("aiNotificationBody = %q, want %q", got, want)
 	}
 }

--- a/internal/app/notify_classify_test.go
+++ b/internal/app/notify_classify_test.go
@@ -21,13 +21,13 @@ func TestClassifyNotifyRowStateMatchesLiveReport(t *testing.T) {
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	entries := []notify.Notification{
 		{
-			ID: "ai:main:%2", Text: "codex: reply ready",
+			ID: "ai:main:%2", Text: "Ready", Metadata: map[string]string{"agent": "codex", "category": "response_complete", "state": "need"},
 			Severity: notify.SeverityInfo, Source: notify.SourceAI,
 			Session: "main", Window: "@1", Pane: "%2",
 			CreatedAt: now, ExpiresAt: now.Add(time.Hour),
 		},
 		{
-			ID: "ai:gone:%9", Text: "claude: reply ready",
+			ID: "ai:gone:%9", Text: "Ready", Metadata: map[string]string{"agent": "claude", "category": "response_complete", "state": "need"},
 			Severity: notify.SeverityInfo, Source: notify.SourceAI,
 			Session: "gone", Pane: "%9",
 			CreatedAt: now, ExpiresAt: now.Add(time.Hour),
@@ -110,7 +110,7 @@ func TestClassifyNotifyRowStateFallsBackToLiveWhenLiveUnavailable(t *testing.T) 
 	entry := notify.Notification{
 		ID: "ai:main:%2", Session: "main", Pane: "%2",
 		Source: notify.SourceAI, Severity: notify.SeverityInfo,
-		Text: "codex: reply ready",
+		Text: "Ready", Metadata: map[string]string{"agent": "codex", "category": "response_complete", "state": "need"},
 	}
 	if got := classifyNotifyRowState(entry, nil); got != notifyDisplayLive {
 		t.Fatalf("classify with nil live map = %v, want live", got)
@@ -175,7 +175,8 @@ func TestNotifySidebarLabelDimsStaleAndGoneText(t *testing.T) {
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	entry := notify.Notification{
 		ID:        "ai:gone:%2",
-		Text:      "codex: reply ready",
+		Text:      "Ready",
+		Metadata:  map[string]string{"agent": "codex", "category": "response_complete", "state": "need"},
 		Severity:  notify.SeverityInfo,
 		Source:    notify.SourceAI,
 		Session:   "main",
@@ -191,7 +192,7 @@ func TestNotifySidebarLabelDimsStaleAndGoneText(t *testing.T) {
 	if !strings.Contains(live, " NEED ") {
 		t.Fatalf("live label = %q, want NEED badge", live)
 	}
-	if strings.Contains(live, notifySidebarDimOpen+"reply ready") {
+	if strings.Contains(live, notifySidebarDimOpen+"Ready") {
 		t.Fatalf("live label = %q, must not dim its text", live)
 	}
 	if !strings.Contains(stale, " STALE ") || !strings.Contains(stale, notifySidebarDimOpen) {
@@ -210,8 +211,8 @@ func TestNotifySidebarEntriesWithLivePassesClassification(t *testing.T) {
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	entries := []notify.Notification{
-		{ID: "ai:live:%1", Text: "claude: reply ready", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "live", Pane: "%1", CreatedAt: now},
-		{ID: "ai:stale:%2", Text: "codex: reply ready", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "stale", Pane: "%2", CreatedAt: now},
+		{ID: "ai:live:%1", Text: "Ready", Severity: notify.SeverityInfo, Source: notify.SourceAI, Metadata: map[string]string{"agent": "claude", "category": "response_complete", "state": "need"}, Session: "live", Pane: "%1", CreatedAt: now},
+		{ID: "ai:stale:%2", Text: "Ready", Severity: notify.SeverityInfo, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex", "category": "response_complete", "state": "need"}, Session: "stale", Pane: "%2", CreatedAt: now},
 	}
 	liveByID := map[string]notifyLivePane{
 		"ai:live:%1": {ID: "ai:live:%1", Session: "live", Pane: "%1", ShouldQueue: true},
@@ -238,7 +239,8 @@ func TestFormatStatusNotifyWithLiveSubstitutesStaleBadge(t *testing.T) {
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	entries := []notify.Notification{{
 		ID:        "ai:gone:%9",
-		Text:      "codex: reply ready",
+		Text:      "Ready",
+		Metadata:  map[string]string{"agent": "codex", "category": "response_complete", "state": "need"},
 		Severity:  notify.SeverityInfo,
 		Source:    notify.SourceAI,
 		Session:   "gone",
@@ -289,7 +291,8 @@ func TestFormatStatusNotifyLiveEntryKeepsExistingNeedBadge(t *testing.T) {
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	entries := []notify.Notification{{
 		ID:        "ai:s:%1",
-		Text:      "claude: reply ready",
+		Text:      "Ready",
+		Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need"},
 		Severity:  notify.SeverityInfo,
 		Source:    notify.SourceAI,
 		Session:   "s",
@@ -339,7 +342,8 @@ func TestStatusbarClickNotifyStaleHeadSkipsFocus(t *testing.T) {
 	store := &stubNotifyStore{listEntries: []notify.Notification{
 		{
 			ID:        "ai:main:%2",
-			Text:      "codex: reply ready",
+			Text:      "Ready",
+			Metadata:  map[string]string{"agent": "codex", "category": "response_complete", "state": "need"},
 			Severity:  notify.SeverityCritical,
 			Source:    notify.SourceAI,
 			Session:   "main",
@@ -445,11 +449,12 @@ func TestStatusbarClickNotifyEmptyLiveResultFallsBackToFocus(t *testing.T) {
 		},
 	}
 	store := &stubNotifyStore{listEntries: []notify.Notification{{
-		ID:      "ai:e2e-alpha:%0",
-		Text:    "codex: reply ready · docker e2e",
-		Source:  notify.SourceAI,
-		Session: "e2e-alpha",
-		Pane:    "%0",
+		ID:       "ai:e2e-alpha:%0",
+		Text:     "docker e2e",
+		Metadata: map[string]string{"agent": "codex", "category": "response_complete", "state": "need"},
+		Source:   notify.SourceAI,
+		Session:  "e2e-alpha",
+		Pane:     "%0",
 	}}}
 	cmd := newStatusbarTestCommand(runner, store)
 

--- a/internal/app/notify_hook_test.go
+++ b/internal/app/notify_hook_test.go
@@ -46,8 +46,9 @@ func TestSendNotiHookDispatcherDispatchesPayloadAndEnv(t *testing.T) {
 
 	dispatcher.Dispatch(notify.Notification{
 		ID:        "n_123",
-		Text:      "claude: reply ready",
+		Text:      "Ready",
 		Source:    notify.SourceAI,
+		Metadata:  map[string]string{"agent": "claude", "category": "response_complete"},
 		Socket:    "/tmp/tmux.sock",
 		Session:   "main",
 		Pane:      "%9",
@@ -56,7 +57,7 @@ func TestSendNotiHookDispatcherDispatchesPayloadAndEnv(t *testing.T) {
 		Type:    "ai-reply-ready",
 		Agent:   "claude",
 		Topic:   "worker loop",
-		Message: "claude: reply ready",
+		Message: "Ready",
 	})
 
 	if runner.calls != 1 {

--- a/internal/app/notify_producer.go
+++ b/internal/app/notify_producer.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -119,6 +120,7 @@ func (p *storeAttentionNotifyProducer) PushReplyReady(in attentionNotifyInput) {
 	if severity == "" {
 		severity = notify.SeverityInfo
 	}
+	metadata := mergeAttentionNotifyMetadata(in.Metadata, agent, severity)
 	id := strings.TrimSpace(in.ID)
 	if id == "" {
 		id = buildAttentionNotifyID(session, resolvedPane)
@@ -134,7 +136,7 @@ func (p *storeAttentionNotifyProducer) PushReplyReady(in attentionNotifyInput) {
 		Text:     text,
 		Severity: severity,
 		Source:   notify.SourceAI,
-		Metadata: in.Metadata,
+		Metadata: metadata,
 		TTL:      ttl,
 		Target: notify.Target{
 			Socket:  socket,
@@ -173,19 +175,31 @@ func buildAttentionNotifyID(session, paneID string) string {
 	return fmt.Sprintf("ai:%s:%s", strings.TrimSpace(session), strings.TrimSpace(paneID))
 }
 
-// composeAttentionReplyText renders the queue-row text. The agent label is
-// lower-cased to match the existing AI desktop notification convention
-// (`claude:` / `codex:`), and the optional topic is appended after a
-// middle-dot separator. The store truncates to 80 runes; we let it do that
-// rather than duplicating the rule here.
+// composeAttentionReplyText renders the queue-row body text. Agent/category
+// information is carried in metadata so rendered notification bodies stay
+// focused on actionable context.
 func composeAttentionReplyText(agent, topic string) string {
-	label := strings.ToLower(strings.TrimSpace(agent))
-	if label == "" {
-		label = "agent"
-	}
-	text := label + ": reply ready"
 	if t := strings.TrimSpace(topic); t != "" {
-		text += " · " + t
+		return t
 	}
-	return text
+	return "Ready"
+}
+
+func mergeAttentionNotifyMetadata(metadata map[string]string, agent, severity string) map[string]string {
+	merged := make(map[string]string, len(metadata)+2)
+	maps.Copy(merged, metadata)
+	if strings.TrimSpace(merged["agent"]) == "" {
+		merged["agent"] = strings.ToLower(strings.TrimSpace(agent))
+	}
+	if strings.TrimSpace(merged["category"]) == "" {
+		if severity == notify.SeverityCritical {
+			merged["category"] = "approval_required"
+		} else {
+			merged["category"] = "response_complete"
+		}
+	}
+	if strings.TrimSpace(merged["state"]) == "" {
+		merged["state"] = "need"
+	}
+	return merged
 }

--- a/internal/app/notify_producer_test.go
+++ b/internal/app/notify_producer_test.go
@@ -54,8 +54,11 @@ func TestStoreAttentionNotifyProducerPushReplyReadyHappyPath(t *testing.T) {
 	if got.ID != "ai:main:%9" {
 		t.Fatalf("ID = %q, want ai:main:%%9", got.ID)
 	}
-	if got.Text != "claude: reply ready" {
-		t.Fatalf("Text = %q, want %q", got.Text, "claude: reply ready")
+	if got.Text != "Ready" {
+		t.Fatalf("Text = %q, want %q", got.Text, "Ready")
+	}
+	if got.Metadata["agent"] != "claude" || got.Metadata["category"] != "response_complete" || got.Metadata["state"] != "need" {
+		t.Fatalf("Metadata = %#v", got.Metadata)
 	}
 	if got.Source != notify.SourceAI {
 		t.Fatalf("Source = %q, want %q", got.Source, notify.SourceAI)
@@ -91,9 +94,12 @@ func TestStoreAttentionNotifyProducerPushReplyReadyWithTopic(t *testing.T) {
 		t.Fatalf("push count = %d, want 1", len(store.pushed))
 	}
 	got := store.pushed[0]
-	wantText := "codex: reply ready · [Lead:QA] wire-producer"
+	wantText := "[Lead:QA] wire-producer"
 	if got.Text != wantText {
 		t.Fatalf("Text = %q, want %q", got.Text, wantText)
+	}
+	if got.Metadata["agent"] != "codex" || got.Metadata["category"] != "response_complete" || got.Metadata["state"] != "need" {
+		t.Fatalf("Metadata = %#v", got.Metadata)
 	}
 	if strings.Contains(got.Text, "\x1b[") || strings.Contains(got.Text, "#[") {
 		t.Fatalf("Text = %q, want plain notification text", got.Text)
@@ -120,9 +126,10 @@ func TestStoreAttentionNotifyProducerPushReplyReadyWithOverrides(t *testing.T) {
 		PaneID: "%2",
 		Lookup: lookup,
 		ID:     "ai:codex:thread:turn",
-		Text:   "Codex · Response complete · done",
+		Text:   "done",
 		Metadata: map[string]string{
 			"agent":     "codex",
+			"category":  "response_complete",
 			"thread_id": "thread",
 		},
 	})
@@ -131,10 +138,10 @@ func TestStoreAttentionNotifyProducerPushReplyReadyWithOverrides(t *testing.T) {
 		t.Fatalf("push count = %d, want 1", len(store.pushed))
 	}
 	got := store.pushed[0]
-	if got.ID != "ai:codex:thread:turn" || got.Text != "Codex · Response complete · done" {
+	if got.ID != "ai:codex:thread:turn" || got.Text != "done" {
 		t.Fatalf("PushInput = %+v", got)
 	}
-	if got.Metadata["agent"] != "codex" || got.Metadata["thread_id"] != "thread" {
+	if got.Metadata["agent"] != "codex" || got.Metadata["category"] != "response_complete" || got.Metadata["state"] != "need" || got.Metadata["thread_id"] != "thread" {
 		t.Fatalf("Metadata = %#v", got.Metadata)
 	}
 }
@@ -268,13 +275,13 @@ func TestStoreAttentionNotifyProducerAckSkipsBlankInput(t *testing.T) {
 func TestComposeAttentionReplyTextDefaultsAgent(t *testing.T) {
 	t.Parallel()
 
-	if got := composeAttentionReplyText("", ""); got != "agent: reply ready" {
+	if got := composeAttentionReplyText("", ""); got != "Ready" {
 		t.Fatalf("default = %q", got)
 	}
-	if got := composeAttentionReplyText("CLAUDE", ""); got != "claude: reply ready" {
+	if got := composeAttentionReplyText("CLAUDE", ""); got != "Ready" {
 		t.Fatalf("uppercase = %q", got)
 	}
-	if got := composeAttentionReplyText("codex", "  refactor split  "); got != "codex: reply ready · refactor split" {
+	if got := composeAttentionReplyText("codex", "  refactor split  "); got != "refactor split" {
 		t.Fatalf("topic trim = %q", got)
 	}
 }
@@ -314,9 +321,12 @@ func TestAttentionToggleNotifiesQueueOnReply(t *testing.T) {
 	if got.ID != "ai:main:%1" {
 		t.Fatalf("ID = %q", got.ID)
 	}
-	wantText := "claude: reply ready · worker loop"
+	wantText := "worker loop"
 	if got.Text != wantText {
 		t.Fatalf("Text = %q, want %q", got.Text, wantText)
+	}
+	if got.Metadata["agent"] != "claude" || got.Metadata["category"] != "response_complete" || got.Metadata["state"] != "need" {
+		t.Fatalf("Metadata = %#v", got.Metadata)
 	}
 	if got.Source != notify.SourceAI {
 		t.Fatalf("Source = %q", got.Source)
@@ -467,9 +477,12 @@ func TestAIStatusSetWaitingPushesQueueWhenInactive(t *testing.T) {
 	if got.ID != "ai:main:%30" {
 		t.Fatalf("ID = %q, want ai:main:%%30", got.ID)
 	}
-	wantText := "claude: reply ready · notify wiring"
+	wantText := "notify wiring"
 	if got.Text != wantText {
 		t.Fatalf("Text = %q, want %q", got.Text, wantText)
+	}
+	if got.Metadata["agent"] != "claude" || got.Metadata["category"] != "response_complete" || got.Metadata["state"] != "need" {
+		t.Fatalf("Metadata = %#v", got.Metadata)
 	}
 	if got.Source != notify.SourceAI {
 		t.Fatalf("Source = %q", got.Source)

--- a/internal/app/notify_reconcile.go
+++ b/internal/app/notify_reconcile.go
@@ -153,6 +153,7 @@ func (c *notifyCommand) runReconcile(args []string, stdout, stderr io.Writer) er
 			Text:     want,
 			Severity: notify.SeverityInfo,
 			Source:   notify.SourceAI,
+			Metadata: mergeAttentionNotifyMetadata(nil, pane.Agent, notify.SeverityInfo),
 			TTL:      attentionNotifyTTL,
 			Target: notify.Target{
 				Socket:  pane.Socket,

--- a/internal/app/notify_reconcile_test.go
+++ b/internal/app/notify_reconcile_test.go
@@ -117,8 +117,11 @@ func TestNotifyReconcilePushesMissingEntryForReplyPane(t *testing.T) {
 	if in.ID != "ai:main:%16" {
 		t.Fatalf("ID = %q, want ai:main:%%16", in.ID)
 	}
-	if in.Text != "claude: reply ready · notify wiring" {
+	if in.Text != "notify wiring" {
 		t.Fatalf("Text = %q", in.Text)
+	}
+	if in.Metadata["agent"] != "claude" || in.Metadata["category"] != "response_complete" {
+		t.Fatalf("Metadata = %#v", in.Metadata)
 	}
 	if in.Source != notify.SourceAI || in.Severity != notify.SeverityInfo {
 		t.Fatalf("Source/Severity = %q/%q", in.Source, in.Severity)
@@ -168,7 +171,7 @@ func TestNotifyReconcileReportsStaleEntryWhenPaneNoLongerReply(t *testing.T) {
 		entries: []notify.Notification{
 			{
 				ID:        "ai:main:%16",
-				Text:      "claude: reply ready",
+				Text:      "Ready",
 				Severity:  notify.SeverityInfo,
 				Source:    notify.SourceAI,
 				Session:   "main",
@@ -205,7 +208,7 @@ func TestNotifyReconcileReportsStaleEntryWhenPaneGone(t *testing.T) {
 		entries: []notify.Notification{
 			{
 				ID:        "ai:main:%99",
-				Text:      "codex: reply ready",
+				Text:      "Ready",
 				Severity:  notify.SeverityInfo,
 				Source:    notify.SourceAI,
 				Session:   "main",
@@ -240,7 +243,7 @@ func TestNotifyReconcileKeepsMatchingEntryWithoutDuplicatePush(t *testing.T) {
 		entries: []notify.Notification{
 			{
 				ID:        "ai:main:%16",
-				Text:      "claude: reply ready · notify wiring",
+				Text:      "notify wiring",
 				Severity:  notify.SeverityInfo,
 				Source:    notify.SourceAI,
 				Session:   "main",
@@ -279,7 +282,7 @@ func TestNotifyReconcileRefreshesEntryWithStaleText(t *testing.T) {
 		entries: []notify.Notification{
 			{
 				ID:        "ai:main:%16",
-				Text:      "claude: reply ready · old topic",
+				Text:      "old topic",
 				Severity:  notify.SeverityInfo,
 				Source:    notify.SourceAI,
 				Session:   "main",
@@ -298,7 +301,7 @@ func TestNotifyReconcileRefreshesEntryWithStaleText(t *testing.T) {
 	if len(store.pushed) != 1 {
 		t.Fatalf("push count = %d, want 1", len(store.pushed))
 	}
-	if got := store.pushed[0].Text; got != "claude: reply ready · new topic" {
+	if got := store.pushed[0].Text; got != "new topic" {
 		t.Fatalf("Text = %q", got)
 	}
 	if got := stdout.String(); got != "reconcile: pushed 1, acked 0, kept 0, stale 0\n" {

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -282,9 +282,10 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 		listEntries: []notify.Notification{
 			{
 				ID:        "abc",
-				Text:      "codex: reply ready",
+				Text:      "Ready",
 				Severity:  notify.SeverityWarn,
 				Source:    notify.SourceAI,
+				Metadata:  map[string]string{"agent": "codex", "category": "response_complete", "state": "need"},
 				Socket:    "projmux",
 				Session:   "main",
 				Window:    "1",
@@ -337,7 +338,7 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if len(labelLines) != 2 {
 		t.Fatalf("sidebar label = %q, want two-line card", entry.Label)
 	}
-	if labelLines[0] != "reply ready" {
+	if labelLines[0] != "Ready" {
 		t.Fatalf("sidebar first line = %q, want notification text", labelLines[0])
 	}
 	if meta := labelLines[1]; !strings.Contains(meta, " age 30s ") || !strings.Contains(meta, " main ") || !strings.Contains(meta, " codex ") || !strings.Contains(meta, " WARN ") || !strings.Contains(meta, "window 1") || !strings.Contains(meta, "pane 0") || strings.Contains(meta, " queued ") || strings.Contains(meta, " ai ") {
@@ -443,9 +444,10 @@ func TestNotifySidebarNativeBackendDoesNotCallCompatRunner(t *testing.T) {
 	store := &stubNotifyStore{
 		listEntries: []notify.Notification{{
 			ID:        "abc",
-			Text:      "codex: deploy ok",
+			Text:      "deploy ok",
 			Severity:  notify.SeverityWarn,
 			Source:    notify.SourceAI,
+			Metadata:  map[string]string{"agent": "codex"},
 			Socket:    "projmux",
 			Session:   "main",
 			Window:    "1",
@@ -793,8 +795,8 @@ func TestNotifyListSidebarAAckRefreshesLiveStateEachLoop(t *testing.T) {
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	store := &stubNotifyStore{
 		listEntries: []notify.Notification{
-			{ID: "ai:main:%2", Text: "codex: first", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main", Window: "@1", Pane: "%2", CreatedAt: now},
-			{ID: "ai:main:%3", Text: "codex: second", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main", Window: "@1", Pane: "%3", CreatedAt: now},
+			{ID: "ai:main:%2", Text: "first", Severity: notify.SeverityInfo, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex"}, Session: "main", Window: "@1", Pane: "%2", CreatedAt: now},
+			{ID: "ai:main:%3", Text: "second", Severity: notify.SeverityInfo, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex"}, Session: "main", Window: "@1", Pane: "%3", CreatedAt: now},
 		},
 	}
 	picker := &recordingNotifyPicker{
@@ -951,9 +953,10 @@ func TestNotifyListLiveJSONExplainsQueueAndLiveStates(t *testing.T) {
 		listEntries: []notify.Notification{
 			{
 				ID:        "ai:main:%2",
-				Text:      "codex: reply ready · topic",
+				Text:      "topic",
 				Severity:  notify.SeverityInfo,
 				Source:    notify.SourceAI,
+				Metadata:  map[string]string{"agent": "codex", "category": "response_complete", "state": "need"},
 				Session:   "main",
 				Window:    "@1",
 				Pane:      "%2",

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -761,7 +761,11 @@ func notifyStateLabelFor(n notify.Notification, text string, display notifyRowDi
 		return "CRIT"
 	}
 	normalized := strings.ToLower(strings.TrimSpace(text))
-	if n.Source == notify.SourceAI && (strings.Contains(normalized, "reply ready") ||
+	category := strings.ToLower(strings.TrimSpace(n.Metadata["category"]))
+	state := strings.ToLower(strings.TrimSpace(n.Metadata["state"]))
+	if n.Source == notify.SourceAI && (state == "need" ||
+		category == "approval_required" || category == "input_required" ||
+		strings.Contains(normalized, "reply ready") ||
 		strings.Contains(normalized, "needs reply") ||
 		strings.Contains(normalized, "approval needed") ||
 		strings.Contains(normalized, "waiting for input")) {
@@ -822,6 +826,16 @@ func splitAgentPrefix(n notify.Notification) (string, string) {
 	text := strings.TrimSpace(n.Text)
 	if n.Source != notify.SourceAI {
 		return "", text
+	}
+	if parts := parseAITextNotificationParts(text); parts.Agent != "" {
+		agent := strings.ToLower(parts.Agent)
+		if parts.Detail == "" {
+			return agent, ""
+		}
+		return agent, parts.Detail
+	}
+	if agent := strings.ToLower(strings.TrimSpace(n.Metadata["agent"])); isKnownAgent(agent) {
+		return agent, text
 	}
 	idx := strings.Index(text, ":")
 	if idx <= 0 {

--- a/internal/app/status_notify_test.go
+++ b/internal/app/status_notify_test.go
@@ -79,8 +79,8 @@ func TestStatusNotifyExternalEntryRendersInfoBadge(t *testing.T) {
 	}
 }
 
-// AI-source entry whose text begins with `claude:` strips the prefix and
-// renders project, reply-needed state, and agent badges.
+// AI-source entry renders project, reply-needed state, and agent badges from
+// metadata without requiring an agent prefix in the body.
 func TestStatusNotifyAIEntryRendersAgentBadge(t *testing.T) {
 	t.Parallel()
 
@@ -88,9 +88,10 @@ func TestStatusNotifyAIEntryRendersAgentBadge(t *testing.T) {
 	store := &stubNotifyStore{listEntries: []notify.Notification{
 		{
 			ID:        "a",
-			Text:      "claude: reply ready · review",
+			Text:      "review needed before shipping",
 			Severity:  notify.SeverityInfo,
 			Source:    notify.SourceAI,
+			Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need"},
 			Session:   "s",
 			Window:    "1",
 			Pane:      "0",
@@ -113,11 +114,11 @@ func TestStatusNotifyAIEntryRendersAgentBadge(t *testing.T) {
 			t.Fatalf("stdout = %q, want badge %q", got, want)
 		}
 	}
-	if strings.Contains(got, "claude:") {
-		t.Fatalf("stdout = %q, agent prefix should have been stripped from text", got)
+	if strings.Contains(got, "claude:") || strings.Contains(got, "reply ready") {
+		t.Fatalf("stdout = %q, body should not include agent/category prefix", got)
 	}
-	if !strings.Contains(got, "reply ready · review") {
-		t.Fatalf("stdout = %q, want body 'reply ready · review'", got)
+	if !strings.Contains(got, "review") {
+		t.Fatalf("stdout = %q, want body 'review'", got)
 	}
 	if strings.Contains(got, "w1.p0") {
 		t.Fatalf("stdout = %q, must not include pane target", got)
@@ -133,9 +134,10 @@ func TestStatusNotifyPaletteSeparatesAttentionAndAI(t *testing.T) {
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	out := formatStatusNotify([]notify.Notification{{
 		ID:        "a",
-		Text:      "codex: reply ready · review",
+		Text:      "review needed before shipping",
 		Severity:  notify.SeverityInfo,
 		Source:    notify.SourceAI,
+		Metadata:  map[string]string{"agent": "codex", "category": "response_complete", "state": "need"},
 		Session:   "s",
 		CreatedAt: now,
 	}}, 80, now)
@@ -273,9 +275,10 @@ func fixtureAIEntry(now time.Time) []notify.Notification {
 	return []notify.Notification{
 		{
 			ID:        "a",
-			Text:      "claude: reply ready · review",
+			Text:      "review needed before shipping",
 			Severity:  notify.SeverityInfo,
 			Source:    notify.SourceAI,
+			Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need"},
 			Session:   "s",
 			Window:    "1",
 			Pane:      "0",
@@ -283,9 +286,10 @@ func fixtureAIEntry(now time.Time) []notify.Notification {
 		},
 		{
 			ID:        "b",
-			Text:      "claude: another",
+			Text:      "another",
 			Severity:  notify.SeverityInfo,
 			Source:    notify.SourceAI,
+			Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need"},
 			Session:   "s",
 			Window:    "1",
 			Pane:      "0",
@@ -301,9 +305,10 @@ func TestStatusNotifyLongBodyClipsBeforeDroppingAge(t *testing.T) {
 	entries := []notify.Notification{
 		{
 			ID:        "a",
-			Text:      "claude: reply ready with a very long body that should clip before metadata disappears",
+			Text:      "reply ready with a very long body that should clip before metadata disappears",
 			Severity:  notify.SeverityInfo,
 			Source:    notify.SourceAI,
+			Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need"},
 			Session:   "project",
 			CreatedAt: now,
 		},
@@ -340,7 +345,7 @@ func TestStatusNotifyWidthTier1Long(t *testing.T) {
 		notifyLineOpen + renderNotifyProjectBadge("s"),
 		renderNotifyBadge("NEED", notify.SeverityInfo),
 		renderNotifyAgentBadge("claude"),
-		"reply ready",
+		"review needed before shipping",
 		"2m",
 		"+1",
 	} {
@@ -364,7 +369,7 @@ func TestStatusNotifyWidthTier2ClipsTextBeforeAge(t *testing.T) {
 		notifyLineOpen + renderNotifyProjectBadge("s"),
 		renderNotifyBadge("NEED", notify.SeverityInfo),
 		renderNotifyAgentBadge("claude"),
-		"reply ready",
+		"review",
 		"2m",
 		"+1",
 		"…",


### PR DESCRIPTION
## Summary
- Move AI notification agent/category labels out of stored queue/body text and into summary/badge metadata.
- Default approval/input bodies now carry actionable context such as tool command or prompt text, while response-complete fallbacks use `Ready` or the topic/message directly.
- Desktop summaries preserve agent + category, for example `Codex · Approval Required`, while desktop bodies avoid repeating those fixed labels.

## Body / Metadata Contract
- Removed low-signal default body details such as `window 2`, `pane 4`, and `session:window` location strings from AI desktop bodies.
- Removed body prefixes like `Codex · ...`, `Claude · ...`, `codex: reply ready`, and `claude: reply ready` from default AI notification queue/body text.
- Preserved focus/targeting metadata: desktop `Tag`/`Group` behavior remains pane/session based, and queue `Target` still carries socket/session/window/pane.
- Added/preserved structured metadata for agent/category/state so statusbar/sidebar badges can render without depending on body text.

## Explicitly Out Of Scope
- No globalization/i18n catalog, locale resolver, formatter, or runtime language switching.
- No Visual palette Phase 4 work and no changes to `internal/theme/palette.go`, `docs/theme-palette.md`, or visual renderer palette code.

## Verification
- `make fmt`
- `make fix`
- `make test`
- `make test-integration` (rerun outside sandbox for Docker socket access)
- `make test-e2e` (rerun outside sandbox for Docker socket access)
- `git diff --check`
- `rg -n "Approval Required|Response Complete|Input Required|window [0-9]|pane [0-9]|검토 대기|승인 필요|응답 완료|입력 필요" internal/app docs`
- `rg -n "Codex ·|Claude ·|codex: reply ready|claude: reply ready" internal/app docs`

## Unverified
- No manual desktop notification click-through was performed; covered behavior is validated through unit/integration/e2e tests and unchanged targeting fields.
