### PR TITLE
fix: render sidebar footer key guides from keymap

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -95,8 +95,8 @@ by different picker surfaces, while conflicts inside one surface are rejected.
 | `SessionPopup:CyclePreviewPanePrev` / `SessionPopup:CyclePreviewPaneNext` | Preview panes |
 | `NotifySidebar:Ack` / `NotifySidebar:ClearNonCritical` / `NotifySidebar:ClearAll` | Manage notifications |
 
-Runtime picker footers avoid hardcoded key guides so custom aliases do not make
-on-screen copy stale.
+Runtime picker footers render key guides from the merged keymap, preferring the
+default alias when it is present and otherwise using the first configured alias.
 
 ## Keymap File
 

--- a/docs/notify-queue.md
+++ b/docs/notify-queue.md
@@ -98,8 +98,9 @@ pane and acks the row after focus succeeds. The surface actions
 `NotifySidebar:Ack`, `NotifySidebar:ClearNonCritical`, and
 `NotifySidebar:ClearAll` are internal picker actions; direct launch aliases
 are edited in Settings, while internal picker aliases are adjusted in
-`keymap.toml` when needed. Runtime footer copy stays status-oriented instead
-of listing literal keys, so custom aliases do not make the UI stale. Rows are intentionally compact: the visible label keeps
+`keymap.toml` when needed. Runtime footer key guides read the merged keymap
+and show the default alias when present, otherwise the first configured alias,
+so custom aliases do not make the UI stale. Rows are intentionally compact: the visible label keeps
 notification text first, then age, project, window, and pane metadata; hidden
 queue ids remain action values but the sidebar has no search input and
 intentionally does not expose a separate metadata detail view.

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -118,8 +118,8 @@ attention-tinted title. When notification icon decoration is `symbol` or
 `emoji`, the bell appears before the title text.
 Selecting a row still focuses and acknowledges that notification. Internal
 notify commands use `NotifySidebar:*` IDs in `keymap.toml`; runtime footers
-avoid hardcoded key guides so custom aliases do not make the visible copy
-stale.
+render key guides from the merged keymap and prefer the default alias when it
+is still configured.
 
 Empty `#{mouse_status_range}` (a click on whitespace) falls through to
 `select-window -t @<mouse_window>` when `--mouse-window` is non-empty,

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -319,7 +319,12 @@ func (c *notifyCommand) runSidebar(store notifyStore, severities, sources []stri
 			Title:  theme.ANSINotifyTitleStart + notifyHeaderDecorator(c.statusbarDecoration()) + "Pending Notifications" + theme.ANSIReset,
 			Prompt: "Notify > ",
 			Header: "Newest first",
-			Footer: "Newest first. Critical notifications are kept when clearing non-critical rows.",
+			Footer: pickerActionKeyGuide(c.homeDir, c.lookupEnv, []pickerActionKeyGuideItem{
+				{ActionID: "NotifySidebar:FocusAndAck", Label: "focus/ack"},
+				{ActionID: "NotifySidebar:Ack", Label: "ack"},
+				{ActionID: "NotifySidebar:ClearNonCritical", Label: "clear non-critical"},
+				{ActionID: "NotifySidebar:ClearAll", Label: "clear all"},
+			}),
 			ExpectKeys: append(
 				append(
 					effectivePickerKeysForActions(c.homeDir, c.lookupEnv, []string{"NotifySidebar:Ack"}, []string{"a"}),

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -324,7 +326,7 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if got, want := picker.options.Header, "Newest first"; got != want {
 		t.Fatalf("picker header = %q, want %q", got, want)
 	}
-	if got, want := picker.options.Footer, "Newest first. Critical notifications are kept when clearing non-critical rows."; got != want {
+	if got, want := picker.options.Footer, "Enter: focus/ack  |  A: ack  |  X: clear non-critical  |  Ctrl-X: clear all"; got != want {
 		t.Fatalf("picker footer = %q, want %q", got, want)
 	}
 	if got, want := picker.options.ExpectKeys, []string{"a", "x", "ctrl-x"}; !reflect.DeepEqual(got, want) {
@@ -360,6 +362,48 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	wantArgs := []string{"focus", "--target", "main:1.0", "--source", "notify-sidebar", "--kind", "row-select", "--socket", "projmux", "--client", "/dev/pts/7"}
 	if !equalStringSlices(focusCalls[0].args, wantArgs) {
 		t.Fatalf("focus args = %#v, want %#v", focusCalls[0].args, wantArgs)
+	}
+}
+
+func TestNotifyListSidebarFooterReadsKeymapGuide(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	keymapPath := filepath.Join(home, ".config", "projmux", "keymap.toml")
+	if err := os.MkdirAll(filepath.Dir(keymapPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(keymapPath, []byte(`[bindings."NotifySidebar:FocusAndAck"]
+keys = ["o", "Enter"]
+
+[bindings."NotifySidebar:Ack"]
+keys = ["b", "a"]
+
+[bindings."NotifySidebar:ClearNonCritical"]
+keys = ["c"]
+
+[bindings."NotifySidebar:ClearAll"]
+keys = ["C-y"]
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	store := &stubNotifyStore{
+		listEntries: []notify.Notification{{ID: "abc", Text: "deploy ok", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"}},
+	}
+	picker := &stubNotifyPicker{result: intpickercompat.Result{}}
+	cmd := newCmd(store)
+	cmd.homeDir = func() (string, error) { return home, nil }
+	cmd.lookupEnv = func(string) string { return "" }
+	cmd.picker = picker
+	cmd.native = nativePickerFromCompatRunner(picker)
+
+	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	want := "Enter: focus/ack  |  A: ack  |  C: clear non-critical  |  Ctrl-Y: clear all"
+	if got := picker.options.Footer; got != want {
+		t.Fatalf("picker footer = %q, want %q", got, want)
 	}
 }
 

--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -1832,7 +1832,7 @@ func (c *switchCommand) runPicker(plan switchPlan) (intpicker.Result, error) {
 		Items:        plan.Items,
 		MultiLine:    true,
 		Prompt:       "› ",
-		Footer:       switchPickerFooter(plan.UI, plan.StatusMessage),
+		Footer:       switchPickerFooter(plan.UI, plan.StatusMessage, c.homeDir, c.lookupEnv),
 		InitialQuery: plan.InitialQuery,
 		Actions: append(
 			pickerCloseActionsForToggles(c.homeDir, c.lookupEnv, []string{"ProjectSidebarToggle", "NotifySidebarToggle", "SessionPopupToggle"}, "esc", "ctrl-n", "alt-1", "alt-2", "alt-3"),
@@ -2031,10 +2031,13 @@ func switchPreviewWindow(ui string) string {
 	}
 }
 
-func switchPickerFooter(ui, status string) string {
+func switchPickerFooter(ui, status string, homeDir func() (string, error), lookupEnv func(string) string) string {
 	status = strings.TrimSpace(status)
 	if ui == switchUISidebar {
-		footer := "Pinned rows stay near the top."
+		footer := pickerActionKeyGuide(homeDir, lookupEnv, []pickerActionKeyGuideItem{
+			{ActionID: "Sidebar:PinProject", Label: "pin project"},
+			{ActionID: "Sidebar:KillSession", Label: "kill session"},
+		})
 		if status != "" {
 			footer += " | " + status
 		}
@@ -2052,6 +2055,49 @@ func switchPickerFooter(ui, status string) string {
 
 func projmuxFooter(text string) string {
 	return strings.TrimSpace(text)
+}
+
+type pickerActionKeyGuideItem struct {
+	ActionID string
+	Label    string
+}
+
+func pickerActionKeyGuide(homeDir func() (string, error), lookupEnv func(string) string, items []pickerActionKeyGuideItem) string {
+	actions := defaultKeyBindingCatalog()
+	if homeDir != nil {
+		if merged, _, err := loadMergedKeyBindingCatalog(keymapLoader{homeDir: homeDir, lookupEnv: lookupEnv}); err == nil {
+			actions = merged
+		}
+	}
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		chord := pickerActionGuideChord(actions, item.ActionID)
+		if chord == "" {
+			continue
+		}
+		label := strings.TrimSpace(item.Label)
+		if label == "" {
+			label = item.ActionID
+		}
+		parts = append(parts, keybindingReadableChord(chord)+": "+label)
+	}
+	return strings.Join(parts, "  |  ")
+}
+
+func pickerActionGuideChord(actions []keyBindingAction, actionID string) string {
+	action, ok := keyBindingActionByID(actions, actionID)
+	if !ok {
+		return ""
+	}
+	chords := keyBindingEffectivePlainChords(action)
+	defaultAction, ok := keyBindingActionByID(defaultKeyBindingCatalog(), actionID)
+	if ok {
+		defaultChord := firstNonEmptyString(keyBindingEffectivePlainChords(defaultAction))
+		if defaultChord != "" && slices.Contains(chords, defaultChord) {
+			return defaultChord
+		}
+	}
+	return firstNonEmptyString(chords)
 }
 
 func switchSidebarInitialPos(plan switchPlan) int {

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -555,7 +555,7 @@ func TestSwitchCommandSupportsSidebarUI(t *testing.T) {
 	if got, want := gotRunnerOptions.Prompt, "› "; got != want {
 		t.Fatalf("runner prompt = %q, want %q", got, want)
 	}
-	if got, want := gotRunnerOptions.Footer, "Pinned rows stay near the top."; got != want {
+	if got, want := gotRunnerOptions.Footer, "Alt-P: pin project  |  Ctrl-X: kill session"; got != want {
 		t.Fatalf("runner footer = %q, want %q", got, want)
 	}
 	if got, want := gotRunnerOptions.PreviewCommand, "exec '/tmp/projmux' 'switch' 'preview' '--ui=sidebar' {2}"; got != want {
@@ -578,6 +578,30 @@ func TestSwitchCommandSupportsSidebarUI(t *testing.T) {
 		{Label: "\x1b[1m\x1b[32mapp\x1b[0m\n  \x1b[38;5;242m/tmp/app\x1b[0m", Value: "/tmp/app"},
 	}; !equalEntries(got, want) {
 		t.Fatalf("runner entries = %#v, want %#v", got, want)
+	}
+}
+
+func TestSwitchSidebarFooterReadsKeymapGuide(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	keymapPath := filepath.Join(home, ".config", "projmux", "keymap.toml")
+	if err := os.MkdirAll(filepath.Dir(keymapPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(keymapPath, []byte(`[bindings."Sidebar:PinProject"]
+keys = ["p", "M-p"]
+
+[bindings."Sidebar:KillSession"]
+keys = ["K"]
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	got := switchPickerFooter(switchUISidebar, "", func() (string, error) { return home, nil }, func(string) string { return "" })
+	want := "Alt-P: pin project  |  K: kill session"
+	if got != want {
+		t.Fatalf("switchPickerFooter() = %q, want %q", got, want)
 	}
 }
 
@@ -1427,7 +1451,7 @@ func TestNewSwitchCommandUsesEnvAndDefaultPinStore(t *testing.T) {
 	if got, want := fakeRunner.last.UI, switchUISidebar; got != want {
 		t.Fatalf("runner UI = %q, want %q", got, want)
 	}
-	if got, want := fakeRunner.last.Footer, "Pinned rows stay near the top."; got != want {
+	if got, want := fakeRunner.last.Footer, "Alt-P: pin project  |  Ctrl-X: kill session"; got != want {
 		t.Fatalf("runner footer = %q, want %q", got, want)
 	}
 	if got := fakeExecutor.ensureSessionName; got != "" {


### PR DESCRIPTION
## Summary
- Replace the project sidebar pinned-row footer copy with keymap-backed action guides.
- Replace the pending notification sidebar footer copy with keymap-backed action guides.
- Prefer the default alias when it remains configured, otherwise show the first configured alias.

## Verification
- GOCACHE=/tmp/projmux-go-cache make fmt
- GOCACHE=/tmp/projmux-go-cache make fix
- GOCACHE=/tmp/projmux-go-cache make test
- GOCACHE=/tmp/projmux-go-cache make test-integration
- GOCACHE=/tmp/projmux-go-cache make test-e2e