### PR TITLE
fix: hide AI notify target labels

### DIFF
--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -441,6 +441,15 @@ func notifySidebarLabelFor(e notify.Notification, now time.Time, display notifyR
 	if display != notifyDisplayLive {
 		text = notifySidebarDimText(text)
 	}
+	if topic := notifySidebarTopicBadge(e); topic != "" {
+		if notifySidebarLabelCell(e.Metadata["topic"]) == notifySidebarLabelCell(e.Text) {
+			text = "Ready"
+			if display != notifyDisplayLive {
+				text = notifySidebarDimText(text)
+			}
+		}
+		text = topic + " " + text
+	}
 	metaParts := []string{
 		notifySidebarAge(age),
 		notifySidebarProjectBadge(notifyProjectName(e.Session)),
@@ -449,13 +458,19 @@ func notifySidebarLabelFor(e notify.Notification, now time.Time, display notifyR
 		metaParts = append(metaParts, notifySidebarAgentBadge(agent))
 	}
 	metaParts = append(metaParts, notifySidebarStateBadge(notifyStateLabelFor(e, text, display)))
-	if window := notifySidebarTargetPart("window", e.Window); window != "" {
-		metaParts = append(metaParts, window)
-	}
-	if pane := notifySidebarTargetPart("pane", e.Pane); pane != "" {
-		metaParts = append(metaParts, pane)
+	if notifySidebarShowTargetParts(e) {
+		if window := notifySidebarTargetPart("window", e.Window); window != "" {
+			metaParts = append(metaParts, window)
+		}
+		if pane := notifySidebarTargetPart("pane", e.Pane); pane != "" {
+			metaParts = append(metaParts, pane)
+		}
 	}
 	return text + "\n  " + strings.Join(metaParts, " ")
+}
+
+func notifySidebarShowTargetParts(e notify.Notification) bool {
+	return e.Source != notify.SourceAI
 }
 
 // notifySidebarDimText wraps the row's body text in the dim foreground so
@@ -518,6 +533,17 @@ func notifySidebarProjectBadge(project string) string {
 		project = "project"
 	}
 	return notifySidebarProject + " " + project + " " + notifySidebarReset
+}
+
+func notifySidebarTopicBadge(e notify.Notification) string {
+	if e.Source != notify.SourceAI {
+		return ""
+	}
+	topic := notifySidebarLabelCell(e.Metadata["topic"])
+	if topic == "" {
+		return ""
+	}
+	return theme.ANSIChipInactiveStart + " " + topic + " " + notifySidebarReset
 }
 
 func notifySidebarTargetPart(label, value string) string {

--- a/internal/app/notify_producer.go
+++ b/internal/app/notify_producer.go
@@ -120,7 +120,7 @@ func (p *storeAttentionNotifyProducer) PushReplyReady(in attentionNotifyInput) {
 	if severity == "" {
 		severity = notify.SeverityInfo
 	}
-	metadata := mergeAttentionNotifyMetadata(in.Metadata, agent, severity)
+	metadata := mergeAttentionNotifyMetadata(in.Metadata, agent, topic, severity)
 	id := strings.TrimSpace(in.ID)
 	if id == "" {
 		id = buildAttentionNotifyID(session, resolvedPane)
@@ -185,11 +185,14 @@ func composeAttentionReplyText(agent, topic string) string {
 	return "Ready"
 }
 
-func mergeAttentionNotifyMetadata(metadata map[string]string, agent, severity string) map[string]string {
-	merged := make(map[string]string, len(metadata)+2)
+func mergeAttentionNotifyMetadata(metadata map[string]string, agent, topic, severity string) map[string]string {
+	merged := make(map[string]string, len(metadata)+3)
 	maps.Copy(merged, metadata)
 	if strings.TrimSpace(merged["agent"]) == "" {
 		merged["agent"] = strings.ToLower(strings.TrimSpace(agent))
+	}
+	if strings.TrimSpace(merged["topic"]) == "" {
+		merged["topic"] = strings.TrimSpace(topic)
 	}
 	if strings.TrimSpace(merged["category"]) == "" {
 		if severity == notify.SeverityCritical {

--- a/internal/app/notify_producer_test.go
+++ b/internal/app/notify_producer_test.go
@@ -98,7 +98,7 @@ func TestStoreAttentionNotifyProducerPushReplyReadyWithTopic(t *testing.T) {
 	if got.Text != wantText {
 		t.Fatalf("Text = %q, want %q", got.Text, wantText)
 	}
-	if got.Metadata["agent"] != "codex" || got.Metadata["category"] != "response_complete" || got.Metadata["state"] != "need" {
+	if got.Metadata["agent"] != "codex" || got.Metadata["category"] != "response_complete" || got.Metadata["state"] != "need" || got.Metadata["topic"] != "[Lead:QA] wire-producer" {
 		t.Fatalf("Metadata = %#v", got.Metadata)
 	}
 	if strings.Contains(got.Text, "\x1b[") || strings.Contains(got.Text, "#[") {
@@ -325,7 +325,7 @@ func TestAttentionToggleNotifiesQueueOnReply(t *testing.T) {
 	if got.Text != wantText {
 		t.Fatalf("Text = %q, want %q", got.Text, wantText)
 	}
-	if got.Metadata["agent"] != "claude" || got.Metadata["category"] != "response_complete" || got.Metadata["state"] != "need" {
+	if got.Metadata["agent"] != "claude" || got.Metadata["category"] != "response_complete" || got.Metadata["state"] != "need" || got.Metadata["topic"] != "worker loop" {
 		t.Fatalf("Metadata = %#v", got.Metadata)
 	}
 	if got.Source != notify.SourceAI {
@@ -481,7 +481,7 @@ func TestAIStatusSetWaitingPushesQueueWhenInactive(t *testing.T) {
 	if got.Text != wantText {
 		t.Fatalf("Text = %q, want %q", got.Text, wantText)
 	}
-	if got.Metadata["agent"] != "claude" || got.Metadata["category"] != "response_complete" || got.Metadata["state"] != "need" {
+	if got.Metadata["agent"] != "claude" || got.Metadata["category"] != "response_complete" || got.Metadata["state"] != "need" || got.Metadata["topic"] != "notify wiring" {
 		t.Fatalf("Metadata = %#v", got.Metadata)
 	}
 	if got.Source != notify.SourceAI {

--- a/internal/app/notify_reconcile.go
+++ b/internal/app/notify_reconcile.go
@@ -144,7 +144,8 @@ func (c *notifyCommand) runReconcile(args []string, stdout, stderr io.Writer) er
 	// Push pass: for every pane that should be in the queue, add or refresh.
 	for id, pane := range wantByID {
 		want := pane.text()
-		if cur, ok := existingByID[id]; ok && cur.Text == want {
+		metadata := mergeAttentionNotifyMetadata(nil, pane.Agent, pane.Topic, notify.SeverityInfo)
+		if cur, ok := existingByID[id]; ok && cur.Text == want && attentionNotifyMetadataMatches(cur.Metadata, metadata) {
 			result.Kept++
 			continue
 		}
@@ -153,7 +154,7 @@ func (c *notifyCommand) runReconcile(args []string, stdout, stderr io.Writer) er
 			Text:     want,
 			Severity: notify.SeverityInfo,
 			Source:   notify.SourceAI,
-			Metadata: mergeAttentionNotifyMetadata(nil, pane.Agent, notify.SeverityInfo),
+			Metadata: metadata,
 			TTL:      attentionNotifyTTL,
 			Target: notify.Target{
 				Socket:  pane.Socket,
@@ -183,6 +184,15 @@ func (c *notifyCommand) runReconcile(args []string, stdout, stderr io.Writer) er
 	}
 
 	return writeReconcileSummary(stdout, result, *asJSON)
+}
+
+func attentionNotifyMetadataMatches(got, want map[string]string) bool {
+	for _, key := range []string{"agent", "category", "state", "topic"} {
+		if strings.TrimSpace(got[key]) != strings.TrimSpace(want[key]) {
+			return false
+		}
+	}
+	return true
 }
 
 // listReconcilePanes shells out to `tmux list-panes -a -F ...` and parses

--- a/internal/app/notify_reconcile_test.go
+++ b/internal/app/notify_reconcile_test.go
@@ -48,6 +48,7 @@ func (s *memNotifyStore) Push(in notify.PushInput) (notify.Notification, notify.
 		Text:      in.Text,
 		Severity:  in.Severity,
 		Source:    in.Source,
+		Metadata:  in.Metadata,
 		Socket:    in.Target.Socket,
 		Session:   in.Target.Session,
 		Window:    in.Target.Window,
@@ -120,7 +121,7 @@ func TestNotifyReconcilePushesMissingEntryForReplyPane(t *testing.T) {
 	if in.Text != "notify wiring" {
 		t.Fatalf("Text = %q", in.Text)
 	}
-	if in.Metadata["agent"] != "claude" || in.Metadata["category"] != "response_complete" {
+	if in.Metadata["agent"] != "claude" || in.Metadata["category"] != "response_complete" || in.Metadata["topic"] != "notify wiring" {
 		t.Fatalf("Metadata = %#v", in.Metadata)
 	}
 	if in.Source != notify.SourceAI || in.Severity != notify.SeverityInfo {
@@ -171,7 +172,7 @@ func TestNotifyReconcileReportsStaleEntryWhenPaneNoLongerReply(t *testing.T) {
 		entries: []notify.Notification{
 			{
 				ID:        "ai:main:%16",
-				Text:      "Ready",
+				Text:      "notify wiring",
 				Severity:  notify.SeverityInfo,
 				Source:    notify.SourceAI,
 				Session:   "main",
@@ -208,7 +209,7 @@ func TestNotifyReconcileReportsStaleEntryWhenPaneGone(t *testing.T) {
 		entries: []notify.Notification{
 			{
 				ID:        "ai:main:%99",
-				Text:      "Ready",
+				Text:      "notify wiring",
 				Severity:  notify.SeverityInfo,
 				Source:    notify.SourceAI,
 				Session:   "main",
@@ -246,6 +247,7 @@ func TestNotifyReconcileKeepsMatchingEntryWithoutDuplicatePush(t *testing.T) {
 				Text:      "notify wiring",
 				Severity:  notify.SeverityInfo,
 				Source:    notify.SourceAI,
+				Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need", "topic": "notify wiring"},
 				Session:   "main",
 				Pane:      "%16",
 				CreatedAt: now,
@@ -303,6 +305,9 @@ func TestNotifyReconcileRefreshesEntryWithStaleText(t *testing.T) {
 	}
 	if got := store.pushed[0].Text; got != "new topic" {
 		t.Fatalf("Text = %q", got)
+	}
+	if got := store.pushed[0].Metadata["topic"]; got != "new topic" {
+		t.Fatalf("topic metadata = %q", got)
 	}
 	if got := stdout.String(); got != "reconcile: pushed 1, acked 0, kept 0, stale 0\n" {
 		t.Fatalf("stdout = %q", got)

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/crevissepartners/projmux/internal/core/notify"
+	"github.com/crevissepartners/projmux/internal/theme"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
@@ -287,7 +288,7 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 				Text:      "Ready",
 				Severity:  notify.SeverityWarn,
 				Source:    notify.SourceAI,
-				Metadata:  map[string]string{"agent": "codex", "category": "response_complete", "state": "need"},
+				Metadata:  map[string]string{"agent": "codex", "category": "response_complete", "state": "need", "topic": "worker loop"},
 				Socket:    "projmux",
 				Session:   "main",
 				Window:    "1",
@@ -340,11 +341,11 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if len(labelLines) != 2 {
 		t.Fatalf("sidebar label = %q, want two-line card", entry.Label)
 	}
-	if labelLines[0] != "Ready" {
-		t.Fatalf("sidebar first line = %q, want notification text", labelLines[0])
+	if got := stripANSI(labelLines[0]); got != " worker loop  Ready" {
+		t.Fatalf("sidebar first line = %q, want topic badge before notification text", labelLines[0])
 	}
-	if meta := labelLines[1]; !strings.Contains(meta, " age 30s ") || !strings.Contains(meta, " main ") || !strings.Contains(meta, " codex ") || !strings.Contains(meta, " WARN ") || !strings.Contains(meta, "window 1") || !strings.Contains(meta, "pane 0") || strings.Contains(meta, " queued ") || strings.Contains(meta, " ai ") {
-		t.Fatalf("sidebar metadata = %q, want age/project/agent/status/window/pane without queued/source", meta)
+	if meta := labelLines[1]; !strings.Contains(meta, " age 30s ") || !strings.Contains(meta, " main ") || !strings.Contains(meta, " codex ") || !strings.Contains(meta, " WARN ") || strings.Contains(meta, "window 1") || strings.Contains(meta, "pane 0") || strings.Contains(meta, " queued ") || strings.Contains(meta, " ai ") {
+		t.Fatalf("sidebar metadata = %q, want age/project/agent/status without target/source", meta)
 	}
 	if strings.Contains(entry.Label, "abc") {
 		t.Fatalf("sidebar label = %q, want hidden queue id", entry.Label)
@@ -404,6 +405,24 @@ keys = ["C-y"]
 	want := "Enter: focus/ack  |  A: ack  |  C: clear non-critical  |  Ctrl-Y: clear all"
 	if got := picker.options.Footer; got != want {
 		t.Fatalf("picker footer = %q, want %q", got, want)
+	}
+}
+
+func TestNotifySidebarProjectBadgeMatchesStatusbarProjectPalette(t *testing.T) {
+	t.Parallel()
+
+	sidebar := notifySidebarProjectBadge("main")
+	for _, want := range []string{"\x1b[1;", "38;5;231", "48;5;90"} {
+		if !strings.Contains(sidebar, want) {
+			t.Fatalf("sidebar project badge = %q, want ANSI token %q", sidebar, want)
+		}
+	}
+
+	statusbar := renderNotifyProjectBadge("main")
+	for _, want := range []string{"bg=" + theme.TmuxAttentionProjectBg, "fg=" + theme.TmuxPrimaryFg, "bold"} {
+		if !strings.Contains(statusbar, want) {
+			t.Fatalf("statusbar project badge = %q, want tmux token %q", statusbar, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Hide visible `window N` / `pane N` target labels from AI notify sidebar rows.
- Preserve internal targeting fields for focus/URI behavior.
- Render AI topic as a first-line sidebar badge before the body text when topic metadata is available.
- Keep statusbar notify text unchanged so compact lower-bar notifications can still show the topic as the body.

## Badge / Display Shape
- Statusbar remains: project badge, state badge, agent badge, body text, age/count.
- AI sidebar first line becomes topic badge + body text, e.g. topic badge `worker loop` followed by `Ready`.
- AI sidebar second line remains age/project/agent/state.
- External/non-AI sidebar rows keep readable window/pane target labels.
- Project badge palette is covered by a regression test so sidebar ANSI badge colors stay aligned with the statusbar project badge colors.

## Metadata
- AI reply-ready/reconcile rows keep `agent`, `category`, `state`, and now `topic` metadata.
- Queue `Target` socket/session/window/pane fields remain intact for focusing.

## Verification
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test` (rerun outside sandbox once for local httptest socket access)
- `make test-integration` (rerun outside sandbox for Docker socket access)
- `make test-e2e` (rerun outside sandbox for Docker socket access)
- `git diff --check`
- `rg -n "window [0-9]|pane [0-9]|codex: reply ready|claude: reply ready|Codex ·|Claude ·" internal/app docs`

## Notes
- Remaining `rg` hits are summary/title tests, unrelated usage `--window` docs, non-notification pane/window UI tests, and non-AI sidebar target coverage.
