### PR TITLE
fix: improve AI notify sidebar layout

### DIFF
--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -441,14 +441,14 @@ func notifySidebarLabelFor(e notify.Notification, now time.Time, display notifyR
 	if display != notifyDisplayLive {
 		text = notifySidebarDimText(text)
 	}
-	if topic := notifySidebarTopicBadge(e); topic != "" {
+	if e.Source == notify.SourceAI {
 		if notifySidebarLabelCell(e.Metadata["topic"]) == notifySidebarLabelCell(e.Text) {
 			text = "Ready"
 			if display != notifyDisplayLive {
 				text = notifySidebarDimText(text)
 			}
 		}
-		text = topic + " " + text
+		return notifySidebarAILabel(e, age, agent, text, display)
 	}
 	metaParts := []string{
 		notifySidebarAge(age),
@@ -467,6 +467,24 @@ func notifySidebarLabelFor(e notify.Notification, now time.Time, display notifyR
 		}
 	}
 	return text + "\n  " + strings.Join(metaParts, " ")
+}
+
+func notifySidebarAILabel(e notify.Notification, age, agent, text string, display notifyRowDisplayState) string {
+	firstLineParts := []string{notifySidebarProjectBadge(notifyProjectName(e.Session))}
+	if text != "" {
+		firstLineParts = append(firstLineParts, text)
+	}
+	firstLine := strings.Join(firstLineParts, " ")
+
+	metaParts := []string{notifySidebarAge(age)}
+	if topic := notifySidebarTopicBadge(e); topic != "" {
+		metaParts = append(metaParts, topic)
+	}
+	metaParts = append(metaParts, notifySidebarStateBadge(notifyStateLabelFor(e, text, display)))
+	if agent != "" {
+		metaParts = append(metaParts, notifySidebarAgentBadge(agent))
+	}
+	return firstLine + "\n  " + strings.Join(metaParts, " ")
 }
 
 func notifySidebarShowTargetParts(e notify.Notification) bool {
@@ -543,7 +561,7 @@ func notifySidebarTopicBadge(e notify.Notification) string {
 	if topic == "" {
 		return ""
 	}
-	return theme.ANSIChipInactiveStart + " " + topic + " " + notifySidebarReset
+	return theme.ANSIChipActiveStart + " " + topic + " " + notifySidebarReset
 }
 
 func notifySidebarTargetPart(label, value string) string {

--- a/internal/app/notify_classify_test.go
+++ b/internal/app/notify_classify_test.go
@@ -239,17 +239,17 @@ func TestNotifySidebarEntriesWithLivePassesClassification(t *testing.T) {
 	}
 }
 
-// TestFormatStatusNotifyWithLiveSubstitutesStaleBadge pins that the
-// statusbar segment swaps NEED → STL and uses the muted palette when the
-// head entry has no matching live pane.
-func TestFormatStatusNotifyWithLiveSubstitutesStaleBadge(t *testing.T) {
+// TestFormatStatusNotifyWithLiveHidesAIStaleBadge pins that the statusbar
+// keeps AI rows to project/topic/body metadata instead of adding STL/NEED
+// state badges.
+func TestFormatStatusNotifyWithLiveHidesAIStaleBadge(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	entries := []notify.Notification{{
 		ID:        "ai:gone:%9",
 		Text:      "Ready",
-		Metadata:  map[string]string{"agent": "codex", "category": "response_complete", "state": "need"},
+		Metadata:  map[string]string{"agent": "codex", "category": "response_complete", "state": "need", "topic": "docker e2e"},
 		Severity:  notify.SeverityInfo,
 		Source:    notify.SourceAI,
 		Session:   "gone",
@@ -257,14 +257,11 @@ func TestFormatStatusNotifyWithLiveSubstitutesStaleBadge(t *testing.T) {
 		CreatedAt: now.Add(-30 * time.Second),
 	}}
 	out := formatStatusNotifyWithLive(entries, 80, now, map[string]notifyLivePane{})
-	if !strings.Contains(out, " STL ") {
-		t.Fatalf("stale status segment = %q, want STL abbreviation", out)
+	if !strings.Contains(out, renderNotifyTopicBadge(entries[0])) {
+		t.Fatalf("stale status segment = %q, want topic badge", out)
 	}
-	if !strings.Contains(out, notifyBadgeStaleOpen) {
-		t.Fatalf("stale status segment = %q, want stale palette", out)
-	}
-	if strings.Contains(out, " NEED ") {
-		t.Fatalf("stale status segment must not still carry the live NEED label: %q", out)
+	if strings.Contains(out, " STL ") || strings.Contains(out, " NEED ") || strings.Contains(out, " codex ") {
+		t.Fatalf("stale AI status segment must not carry state/agent badges: %q", out)
 	}
 }
 
@@ -291,17 +288,16 @@ func TestFormatStatusNotifyWithLiveSubstitutesGoneBadge(t *testing.T) {
 	}
 }
 
-// TestFormatStatusNotifyLiveEntryKeepsExistingNeedBadge guards the
-// regression contract: live entries keep their original NEED/INFO/WARN/CRIT
-// labels.
-func TestFormatStatusNotifyLiveEntryKeepsExistingNeedBadge(t *testing.T) {
+// TestFormatStatusNotifyLiveAIEntryUsesTopicBadge guards the AI statusbar
+// contract: project/topic/body replace state and agent badges.
+func TestFormatStatusNotifyLiveAIEntryUsesTopicBadge(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	entries := []notify.Notification{{
 		ID:        "ai:s:%1",
 		Text:      "Ready",
-		Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need"},
+		Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need", "topic": "review"},
 		Severity:  notify.SeverityInfo,
 		Source:    notify.SourceAI,
 		Session:   "s",
@@ -312,11 +308,11 @@ func TestFormatStatusNotifyLiveEntryKeepsExistingNeedBadge(t *testing.T) {
 		"ai:s:%1": {ID: "ai:s:%1", Session: "s", Pane: "%1", ShouldQueue: true},
 	}
 	out := formatStatusNotifyWithLive(entries, 80, now, liveByID)
-	if !strings.Contains(out, " NEED ") {
-		t.Fatalf("live status segment = %q, want NEED badge", out)
+	if !strings.Contains(out, renderNotifyTopicBadge(entries[0])) {
+		t.Fatalf("live status segment = %q, want topic badge", out)
 	}
-	if strings.Contains(out, " STL ") || strings.Contains(out, " GON ") {
-		t.Fatalf("live status segment must not carry stale/gone abbreviations: %q", out)
+	if strings.Contains(out, " NEED ") || strings.Contains(out, " STL ") || strings.Contains(out, " GON ") || strings.Contains(out, " claude ") {
+		t.Fatalf("live AI status segment must not carry state/agent abbreviations: %q", out)
 	}
 }
 

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -341,11 +341,22 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if len(labelLines) != 2 {
 		t.Fatalf("sidebar label = %q, want two-line card", entry.Label)
 	}
-	if got := stripANSI(labelLines[0]); got != " worker loop  Ready" {
-		t.Fatalf("sidebar first line = %q, want topic badge before notification text", labelLines[0])
+	if got := stripANSI(labelLines[0]); got != " main  Ready" {
+		t.Fatalf("sidebar first line = %q, want project badge before notification text", labelLines[0])
 	}
-	if meta := labelLines[1]; !strings.Contains(meta, " age 30s ") || !strings.Contains(meta, " main ") || !strings.Contains(meta, " codex ") || !strings.Contains(meta, " WARN ") || strings.Contains(meta, "window 1") || strings.Contains(meta, "pane 0") || strings.Contains(meta, " queued ") || strings.Contains(meta, " ai ") {
-		t.Fatalf("sidebar metadata = %q, want age/project/agent/status without target/source", meta)
+	if !strings.Contains(labelLines[1], theme.ANSIChipActiveStart+" worker loop ") {
+		t.Fatalf("sidebar metadata = %q, want prominent topic badge", labelLines[1])
+	}
+	metaText := stripANSI(labelLines[1])
+	ageIndex := strings.Index(metaText, "age 30s")
+	topicIndex := strings.Index(metaText, "worker loop")
+	statusIndex := strings.Index(metaText, "WARN")
+	agentIndex := strings.Index(metaText, "codex")
+	if !(ageIndex >= 0 && ageIndex < topicIndex && topicIndex < statusIndex && statusIndex < agentIndex) {
+		t.Fatalf("sidebar metadata = %q, want age/topic/status/agent order", labelLines[1])
+	}
+	if meta := labelLines[1]; !strings.Contains(meta, " age 30s ") || strings.Contains(meta, " main ") || !strings.Contains(meta, " codex ") || !strings.Contains(meta, " WARN ") || strings.Contains(meta, "window 1") || strings.Contains(meta, "pane 0") || strings.Contains(meta, " queued ") || strings.Contains(meta, " ai ") {
+		t.Fatalf("sidebar metadata = %q, want age/topic/status/agent without project/target/source", meta)
 	}
 	if strings.Contains(entry.Label, "abc") {
 		t.Fatalf("sidebar label = %q, want hidden queue id", entry.Label)

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -545,10 +545,13 @@ func formatStatusNotifyWithLive(entries []notify.Notification, maxWidth int, now
 
 	display := classifyNotifyRowState(head, liveByID)
 	agent, text := splitAgentPrefix(head)
+	if head.Source == notify.SourceAI {
+		text = notifyAIStatusBodyText(head, text)
+	}
 	badge := assembleNotifyBadges(
 		renderNotifyProjectBadge(notifyProjectName(head.Session)),
-		renderNotifyStateBadgeFor(head, text, display),
-		renderNotifyAgentBadge(agent),
+		renderNotifyStatusMiddleBadge(head, text, display),
+		renderNotifyStatusAgentBadge(head, agent),
 	)
 	icon := renderNotifyIcon(head.Severity)
 	age := ""
@@ -670,6 +673,39 @@ func renderNotifyProjectBadge(project string) string {
 
 func renderNotifyBadge(label, severity string) string {
 	return renderNotifyBlockBadge(label, notifyBadgeOpen(severity))
+}
+
+func renderNotifyStatusMiddleBadge(n notify.Notification, text string, display notifyRowDisplayState) string {
+	if n.Source == notify.SourceAI {
+		return renderNotifyTopicBadge(n)
+	}
+	return renderNotifyStateBadgeFor(n, text, display)
+}
+
+func renderNotifyStatusAgentBadge(n notify.Notification, agent string) string {
+	if n.Source == notify.SourceAI {
+		return ""
+	}
+	return renderNotifyAgentBadge(agent)
+}
+
+func renderNotifyTopicBadge(n notify.Notification) string {
+	if n.Source != notify.SourceAI {
+		return ""
+	}
+	topic := strings.TrimSpace(n.Metadata["topic"])
+	if topic == "" {
+		return ""
+	}
+	return renderNotifyBlockBadge(topic, notifyAgentOpen)
+}
+
+func notifyAIStatusBodyText(n notify.Notification, text string) string {
+	topic := strings.TrimSpace(n.Metadata["topic"])
+	if topic != "" && topic == strings.TrimSpace(text) {
+		return "Ready"
+	}
+	return text
 }
 
 // renderNotifyStateBadgeFor renders the head-entry state badge using the

--- a/internal/app/status_notify_test.go
+++ b/internal/app/status_notify_test.go
@@ -80,9 +80,9 @@ func TestStatusNotifyExternalEntryRendersInfoBadge(t *testing.T) {
 	}
 }
 
-// AI-source entry renders project, reply-needed state, and agent badges from
-// metadata without requiring an agent prefix in the body.
-func TestStatusNotifyAIEntryRendersAgentBadge(t *testing.T) {
+// AI-source entry renders project and topic badges from metadata without
+// repeating state or agent badges in the statusbar body.
+func TestStatusNotifyAIEntryRendersTopicBadge(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
@@ -92,7 +92,7 @@ func TestStatusNotifyAIEntryRendersAgentBadge(t *testing.T) {
 			Text:      "review needed before shipping",
 			Severity:  notify.SeverityInfo,
 			Source:    notify.SourceAI,
-			Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need"},
+			Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need", "topic": "shipping"},
 			Session:   "s",
 			Window:    "1",
 			Pane:      "0",
@@ -108,8 +108,7 @@ func TestStatusNotifyAIEntryRendersAgentBadge(t *testing.T) {
 	got := stdout.String()
 	for _, want := range []string{
 		notifyLineOpen + renderNotifyProjectBadge("s"),
-		renderNotifyBadge("NEED", notify.SeverityInfo),
-		renderNotifyAgentBadge("claude"),
+		renderNotifyTopicBadge(notify.Notification{Source: notify.SourceAI, Metadata: map[string]string{"topic": "shipping"}}),
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stdout = %q, want badge %q", got, want)
@@ -120,6 +119,9 @@ func TestStatusNotifyAIEntryRendersAgentBadge(t *testing.T) {
 	}
 	if !strings.Contains(got, "review") {
 		t.Fatalf("stdout = %q, want body 'review'", got)
+	}
+	if strings.Contains(got, " NEED ") || strings.Contains(got, " claude ") {
+		t.Fatalf("stdout = %q, must not include state/agent badges for AI statusbar", got)
 	}
 	if strings.Contains(got, "w1.p0") {
 		t.Fatalf("stdout = %q, must not include pane target", got)
@@ -138,15 +140,14 @@ func TestStatusNotifyPaletteSeparatesAttentionAndAI(t *testing.T) {
 		Text:      "review needed before shipping",
 		Severity:  notify.SeverityInfo,
 		Source:    notify.SourceAI,
-		Metadata:  map[string]string{"agent": "codex", "category": "response_complete", "state": "need"},
+		Metadata:  map[string]string{"agent": "codex", "category": "response_complete", "state": "need", "topic": "review"},
 		Session:   "s",
 		CreatedAt: now,
 	}}, 80, now)
 
 	for _, want := range []string{
 		"#[bg=" + tmuxAccentAttentionBg + ",fg=" + tmuxStateProgressFg + "]",
-		"#[bg=" + tmuxStateProgressFg + ",fg=colour16,bold] NEED ",
-		"#[bg=" + tmuxAccentAIBg + ",fg=colour16,bold] codex ",
+		"#[bg=" + tmuxAccentAIBg + ",fg=colour16,bold] review ",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("status notify palette output = %q, want %q", out, want)
@@ -282,7 +283,7 @@ func fixtureAIEntry(now time.Time) []notify.Notification {
 			Text:      "review needed before shipping",
 			Severity:  notify.SeverityInfo,
 			Source:    notify.SourceAI,
-			Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need"},
+			Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need", "topic": "shipping"},
 			Session:   "s",
 			Window:    "1",
 			Pane:      "0",
@@ -293,7 +294,7 @@ func fixtureAIEntry(now time.Time) []notify.Notification {
 			Text:      "another",
 			Severity:  notify.SeverityInfo,
 			Source:    notify.SourceAI,
-			Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need"},
+			Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need", "topic": "shipping"},
 			Session:   "s",
 			Window:    "1",
 			Pane:      "0",
@@ -312,7 +313,7 @@ func TestStatusNotifyLongBodyClipsBeforeDroppingAge(t *testing.T) {
 			Text:      "reply ready with a very long body that should clip before metadata disappears",
 			Severity:  notify.SeverityInfo,
 			Source:    notify.SourceAI,
-			Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need"},
+			Metadata:  map[string]string{"agent": "claude", "category": "response_complete", "state": "need", "topic": "long"},
 			Session:   "project",
 			CreatedAt: now,
 		},
@@ -325,8 +326,7 @@ func TestStatusNotifyLongBodyClipsBeforeDroppingAge(t *testing.T) {
 	}
 	for _, want := range []string{
 		notifyLineOpen + renderNotifyProjectBadge("project"),
-		renderNotifyBadge("NEED", notify.SeverityInfo),
-		renderNotifyAgentBadge("claude"),
+		renderNotifyTopicBadge(notify.Notification{Source: notify.SourceAI, Metadata: map[string]string{"topic": "long"}}),
 		"just now",
 		"+2",
 		"…",
@@ -347,8 +347,7 @@ func TestStatusNotifyWidthTier1Long(t *testing.T) {
 	}
 	for _, want := range []string{
 		notifyLineOpen + renderNotifyProjectBadge("s"),
-		renderNotifyBadge("NEED", notify.SeverityInfo),
-		renderNotifyAgentBadge("claude"),
+		renderNotifyTopicBadge(notify.Notification{Source: notify.SourceAI, Metadata: map[string]string{"topic": "shipping"}}),
 		"review needed before shipping",
 		"2m",
 		"+1",
@@ -371,8 +370,7 @@ func TestStatusNotifyWidthTier2ClipsTextBeforeAge(t *testing.T) {
 	}
 	for _, want := range []string{
 		notifyLineOpen + renderNotifyProjectBadge("s"),
-		renderNotifyBadge("NEED", notify.SeverityInfo),
-		renderNotifyAgentBadge("claude"),
+		renderNotifyTopicBadge(notify.Notification{Source: notify.SourceAI, Metadata: map[string]string{"topic": "shipping"}}),
 		"review",
 		"2m",
 		"+1",
@@ -388,14 +386,13 @@ func TestStatusNotifyWidthTier3DropsAgeAfterClippingText(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
-	out := formatStatusNotify(fixtureAIEntry(now), 28, now)
-	if visualLen(out) > 28 {
-		t.Fatalf("tier3 visualLen=%d > 28: %q", visualLen(out), out)
+	out := formatStatusNotify(fixtureAIEntry(now), 24, now)
+	if visualLen(out) > 24 {
+		t.Fatalf("tier3 visualLen=%d > 24: %q", visualLen(out), out)
 	}
 	for _, want := range []string{
 		notifyLineOpen + renderNotifyProjectBadge("s"),
-		renderNotifyBadge("NEED", notify.SeverityInfo),
-		renderNotifyAgentBadge("claude"),
+		renderNotifyTopicBadge(notify.Notification{Source: notify.SourceAI, Metadata: map[string]string{"topic": "shipping"}}),
 		"+1",
 		"…",
 	} {
@@ -472,17 +469,15 @@ func TestStatusNotifyAgentPrefixGracefulFallback(t *testing.T) {
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	cases := []struct {
-		name      string
-		text      string
-		wantAgent string // "" means INFO label badge
-		wantState string
+		name string
+		text string
 	}{
-		{name: "no colon", text: "reply ready", wantAgent: "", wantState: "NEED"},
-		{name: "unknown agent", text: "gpt: reply ready", wantAgent: "", wantState: "NEED"},
-		{name: "empty body after colon", text: "claude:", wantAgent: "", wantState: "INFO"},
-		{name: "leading colon", text: ":hello", wantAgent: "", wantState: "INFO"},
-		{name: "codex prefix", text: "codex: thought", wantAgent: "codex", wantState: "INFO"},
-		{name: "claude prefix uppercase", text: "Claude: ready", wantAgent: "claude", wantState: "INFO"},
+		{name: "no colon", text: "reply ready"},
+		{name: "unknown agent", text: "gpt: reply ready"},
+		{name: "empty body after colon", text: "claude:"},
+		{name: "leading colon", text: ":hello"},
+		{name: "codex prefix", text: "codex: thought"},
+		{name: "claude prefix uppercase", text: "Claude: ready"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -494,16 +489,8 @@ func TestStatusNotifyAgentPrefixGracefulFallback(t *testing.T) {
 			if !strings.HasPrefix(out, notifyLineOpen+renderNotifyProjectBadge("s")) {
 				t.Fatalf("expected project badge at start of %q", out)
 			}
-			wantStateBadge := renderNotifyBadge(tc.wantState, notify.SeverityInfo)
-			if !strings.Contains(out, wantStateBadge) {
-				t.Fatalf("expected state badge %q in %q", wantStateBadge, out)
-			}
-			wantAgentBadge := renderNotifyAgentBadge(tc.wantAgent)
-			if tc.wantAgent != "" && !strings.Contains(out, wantAgentBadge) {
-				t.Fatalf("expected agent badge %q in %q", wantAgentBadge, out)
-			}
-			if tc.wantAgent == "" && (strings.Contains(out, notifyAgentOpen) || strings.Contains(out, notifyAgentClaude) || strings.Contains(out, notifyAgentCodex)) {
-				t.Fatalf("did not expect agent badge in %q", out)
+			if strings.Contains(out, " NEED ") || strings.Contains(out, " INFO ") || strings.Contains(out, " codex ") || strings.Contains(out, " claude ") {
+				t.Fatalf("did not expect state/agent badge in AI statusbar output %q", out)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Rework AI notify sidebar rows into the requested two-line layout.
- First sidebar line now shows project badge followed by body text.
- Second sidebar line now shows age, a more prominent AI topic badge, status, then agent.
- Rework AI notify statusbar badges to project + AI topic only, followed by body text, age, and count.

## Visible Layout
- AI sidebar line 1: `project badge` + `text`
- AI sidebar line 2: `age` + `ai_topic badge` + `status` + `agent`
- AI statusbar: `project badge` + `ai_topic badge` + `text` + `age` + `+N`
- AI statusbar no longer shows state badges such as `NEED`/`STL`/`GON` or agent badges such as `codex`/`claude`.
- `window N` / `pane N` remain hidden for AI sidebar rows.
- The topic badge now uses the active chip/AI badge palette for better visibility.

## Metadata / Targeting
- No focus/URI target fields were removed.
- Queue `Target` still carries socket/session/window/pane.
- Changes are render-only for AI notify sidebar/statusbar layout.

## Verification
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test` (rerun outside sandbox when local httptest socket access was needed)
- `make test-integration` (rerun outside sandbox for Docker socket access)
- `make test-e2e` (rerun outside sandbox for Docker socket access)
- `git diff --check`
- `rg -n "window [0-9]|pane [0-9]|codex: reply ready|claude: reply ready|Codex ·|Claude ·" internal/app docs`

## Notes
- Remaining audit hits are summary/title tests, unrelated usage `--window` docs, non-notification pane/window UI tests, and non-AI sidebar target coverage.
