### PR TITLE
docs: add host-only smoke checklist

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -54,3 +54,125 @@ desktop shell, or OS integration:
 
 Keep those checks as manual or host-run smoke validation until a dedicated
 host harness exists.
+
+Use this smoke checklist when a change touches terminal delivery, host desktop
+notifications, or reviewer confidence around those boundaries. If the change
+does not touch those areas, copy the PR-note block below and mark the relevant
+rows `not run`.
+
+### Terminal Key Delivery
+
+Run the raw key probe outside tmux, in the terminal emulator being claimed:
+
+```sh
+projmux setup --timeout 10s
+```
+
+Observe:
+
+- `Alt-1` through `Alt-5` report `OK plain`. These are the guaranteed
+  zero-config launch defaults.
+- If a guaranteed key reports `MISS timeout`, preview a supported terminal
+  mapping with `projmux init ghostty` or `projmux init windows-terminal`,
+  apply it with the same command plus `--apply`, restart that terminal if
+  required, and rerun `projmux setup --timeout 10s`.
+- Optional direct aliases and transport-dependent chords may be reported by
+  the probe, but they are not part of the guaranteed host smoke unless the PR
+  explicitly changes them.
+
+Then run the app in the same terminal:
+
+```sh
+projmux shell
+```
+
+Observe:
+
+- `Alt-1` opens the project sidebar.
+- `Alt-2` opens the notification sidebar.
+- `Alt-3` opens the existing-session picker.
+- `Alt-4` opens the AI split picker.
+- `Alt-5` opens Settings.
+- Pressing the same launch key again closes the popup instead of typing escape
+  bytes into the shell or picker input.
+
+### WSL Toast
+
+Run this from WSL with Windows Terminal available. The detached tmux server is
+intentional: `projmux focus` falls back to the product desktop notification
+path when there is no attached client to switch.
+
+```sh
+sock="${TMPDIR:-/tmp}/projmux-host-smoke.sock"
+tmux -S "$sock" kill-server 2>/dev/null || true
+tmux -S "$sock" new-session -d -s projmux-host-smoke 'sleep 600'
+PROJMUX_DESKTOP_NOTIFY_MODE=notify \
+  projmux focus --socket "$sock" --target projmux-host-smoke --json
+tmux -S "$sock" kill-server
+```
+
+Observe:
+
+- The JSON includes `"ok":true`, `"dispatch":"notify-only"`, and
+  `"reason":"no-attached-client"`.
+- Windows shows a short projmux toast with `session ready:
+  projmux-host-smoke`.
+- No visible PowerShell or console window remains open after the toast.
+
+If the PR changes click-to-focus behavior, repeat with
+`PROJMUX_DESKTOP_NOTIFY_MODE=raise`, click the toast, and record whether the
+host terminal returns to the target. Otherwise leave click callbacks marked as
+manual/not run.
+
+### macOS GUI Notification
+
+The built-in desktop sender is Linux/WSL-oriented. On macOS, smoke the
+documented `PROJMUX_NOTIFY_HOOK` escape hatch with an `osascript` sender:
+
+```sh
+hook="${TMPDIR:-/tmp}/projmux-macos-notify.sh"
+cat >"$hook" <<'SH'
+#!/bin/sh
+title=${1:-projmux}
+body=${2:-}
+osascript \
+  -e 'on run argv' \
+  -e 'display notification (item 2 of argv) with title (item 1 of argv)' \
+  -e 'end run' \
+  "$title" "$body"
+SH
+chmod 0755 "$hook"
+
+sock="${TMPDIR:-/tmp}/projmux-host-smoke.sock"
+tmux -S "$sock" kill-server 2>/dev/null || true
+tmux -S "$sock" new-session -d -s projmux-host-smoke 'sleep 600'
+PROJMUX_NOTIFY_HOOK="$hook" \
+  projmux focus --socket "$sock" --target projmux-host-smoke --json
+tmux -S "$sock" kill-server
+```
+
+Observe:
+
+- The JSON includes `"ok":true`, `"dispatch":"notify-only"`, and
+  `"reason":"no-attached-client"`.
+- macOS shows a Notification Center banner with `session ready:
+  projmux-host-smoke`.
+- If macOS prompts for notification permission, record that state in the PR
+  instead of treating the product command as verified.
+
+### PR Note Template
+
+```markdown
+Host-only smoke validation:
+
+- Docker-covered checks: `make test-integration`, `make test-install-smoke`,
+  and `make test-e2e` cover portable Linux tmux/config/notify behavior only.
+- Terminal key delivery: not run / run on <terminal>; `projmux setup --timeout
+  10s` showed <result>; `Alt-1..5` app popup smoke <passed/failed/not run>.
+- WSL toast: not run / run on <Windows + WSL distro>; detached-focus smoke
+  produced `dispatch=notify-only`; observed <toast/no toast/notes>.
+- macOS GUI notification: not run / run on <macOS version>; hook smoke
+  produced `dispatch=notify-only`; observed <banner/permission prompt/notes>.
+- Desktop notification click callbacks: not run unless this PR changes
+  click-to-focus behavior; result <notes>.
+```


### PR DESCRIPTION
## Summary

- Completed Phase: Phase 2 - Host-only smoke checklist consolidation
- Updated `docs/testing.md` with executable manual smoke steps for terminal key delivery, WSL toast fallback, macOS notification hook smoke, and a copyable PR note template
- Clarified Docker-covered checks vs host-only checks without changing product behavior

## Explicitly excluded

- Phase 0 welcome locale-safe test work
- Phase 1 npm metadata cleanup
- Session State unused live overwrite primitive Backlog item
- New WSL/macOS GUI automation
- Terminal emulator key transport adapter implementation
- Desktop notification click callback feature changes

## Validation

- `make fmt-check`
- `git diff --check`
- `projmux --help`
- `projmux focus --help`
- `projmux setup --help`
- `projmux init ghostty --dry-run --config /tmp/projmux-smoke-ghostty-config`
- `rg -n "projmux init (ghostty|windows-terminal)|projmux setup --timeout 10s|projmux focus --socket|PROJMUX_NOTIFY_HOOK|PROJMUX_DESKTOP_NOTIFY_MODE|dispatch=notify-only|notify-only|no-attached-client" docs internal/app`

## Unverified / follow-up

- Host-only manual smoke was documented but not run interactively in a real terminal emulator, Windows Terminal/WSL toast environment, or macOS Notification Center environment.
- Desktop notification click callbacks remain manual/not run unless a future PR changes click-to-focus behavior.
- Follow-up phases remain Phase 0 and Phase 1 from the Maintainer hygiene quick cleanup roadmap detail.
