### PR TITLE
fix(npm): generate optional package metadata at staging

### DIFF
--- a/docs/npm-distribution.md
+++ b/docs/npm-distribution.md
@@ -31,13 +31,15 @@ make npm-pack
 or:
 
 ```bash
-scripts/package-npm.sh --version 0.4.0 --out /tmp/projmux-npm --pack
+scripts/package-npm.sh --version 1.2.3 --out /tmp/projmux-npm --pack
 ```
 
 The script stages package directories under `dist/npm` by default. It builds
 the Go binary for each supported platform, copies package metadata and docs,
-updates package versions in the staged copies, then runs `npm pack --dry-run`
-when `--pack` is set.
+updates package versions in the staged copies, generates root
+`optionalDependencies` for the supported platform packages using the same
+version, verifies the staged metadata is internally consistent, then runs
+`npm pack --dry-run` when `--pack` is set.
 
 ## Publish Order
 

--- a/package.json
+++ b/package.json
@@ -23,12 +23,6 @@
     "README-ko.md",
     "LICENSE"
   ],
-  "optionalDependencies": {
-    "@projmux/darwin-arm64": "0.4.0",
-    "@projmux/darwin-x64": "0.4.0",
-    "@projmux/linux-arm64": "0.4.0",
-    "@projmux/linux-x64": "0.4.0"
-  },
   "scripts": {
     "package:npm": "scripts/package-npm.sh",
     "package:npm:pack": "scripts/package-npm.sh --pack"

--- a/scripts/package-npm.sh
+++ b/scripts/package-npm.sh
@@ -5,6 +5,12 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 out="$root/dist/npm"
 pack=0
 version=""
+platform_packages=(
+  "@projmux/linux-x64"
+  "@projmux/linux-arm64"
+  "@projmux/darwin-x64"
+  "@projmux/darwin-arm64"
+)
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -56,12 +62,64 @@ const fs = require("fs");
 const [file, version] = process.argv.slice(2);
 const pkg = JSON.parse(fs.readFileSync(file, "utf8"));
 pkg.version = version;
-if (pkg.optionalDependencies) {
-  for (const name of Object.keys(pkg.optionalDependencies)) {
-    pkg.optionalDependencies[name] = version;
+fs.writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
+NODE
+}
+
+patch_root_package() {
+  local file="$1"
+  node - "$file" "$version" "${platform_packages[@]}" <<'NODE'
+const fs = require("fs");
+const [file, version, ...platformPackages] = process.argv.slice(2);
+const pkg = JSON.parse(fs.readFileSync(file, "utf8"));
+pkg.version = version;
+pkg.optionalDependencies = Object.fromEntries(
+  platformPackages.map((name) => [name, version])
+);
+fs.writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
+NODE
+}
+
+assert_staged_versions() {
+  node - "$out" "$version" "${platform_packages[@]}" <<'NODE'
+const fs = require("fs");
+const path = require("path");
+const [out, version, ...platformPackages] = process.argv.slice(2);
+
+function readPackage(packagePath) {
+  return JSON.parse(fs.readFileSync(packagePath, "utf8"));
+}
+
+function fail(message) {
+  console.error(message);
+  process.exitCode = 1;
+}
+
+const rootPackagePath = path.join(out, "projmux", "package.json");
+const rootPackage = readPackage(rootPackagePath);
+if (rootPackage.version !== version) {
+  fail(`expected projmux version ${version}, got ${rootPackage.version}`);
+}
+
+const optionalDependencies = rootPackage.optionalDependencies || {};
+const optionalNames = Object.keys(optionalDependencies).sort();
+const expectedNames = [...platformPackages].sort();
+if (JSON.stringify(optionalNames) !== JSON.stringify(expectedNames)) {
+  fail(`expected root optionalDependencies ${expectedNames.join(", ")}, got ${optionalNames.join(", ")}`);
+}
+for (const name of platformPackages) {
+  if (optionalDependencies[name] !== version) {
+    fail(`expected root optionalDependency ${name}@${version}, got ${optionalDependencies[name]}`);
   }
 }
-fs.writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
+
+for (const name of platformPackages) {
+  const platformPackagePath = path.join(out, name, "package.json");
+  const platformPackage = readPackage(platformPackagePath);
+  if (platformPackage.version !== version) {
+    fail(`expected ${name} version ${version}, got ${platformPackage.version}`);
+  }
+}
 NODE
 }
 
@@ -78,7 +136,7 @@ stage_main() {
     cp "$root"/docs/assets/* "$dir/docs/assets/"
   fi
   chmod 0755 "$dir/npm/projmux.js"
-  patch_version "$dir/package.json"
+  patch_root_package "$dir/package.json"
 }
 
 stage_platform() {
@@ -126,6 +184,8 @@ done
 if [[ "$stage_status" -ne 0 ]]; then
   exit "$stage_status"
 fi
+
+assert_staged_versions
 
 if [[ "$pack" -eq 1 ]]; then
   for dir in \


### PR DESCRIPTION
## Completed Phase

- Phase 1 - npm package metadata source consistency

## Package Metadata / Packaging Surface

- Removed stale root `package.json` optional platform dependency pins from source metadata.
- Updated `scripts/package-npm.sh` so staging generates the root package `optionalDependencies` from the supported platform package list using the staging/release version.
- Added staging metadata assertions so the staged root package, platform package versions, and root optional dependency versions must match.
- Updated `docs/npm-distribution.md` to document generated optional dependencies and staging metadata verification.

## Explicitly Excluded

- Phase 0 welcome locale-safe test work.
- Phase 2 host-only smoke checklist documentation cleanup.
- Session State unused live overwrite primitive Backlog review/removal.

## Contract Preservation

- npm package names and layout are unchanged.
- Release publish credentials are unchanged.
- Platform binary build matrix is unchanged.
- The release workflow tag-version staging contract is preserved: `scripts/package-npm.sh --version "${GITHUB_REF_NAME#v}" --out dist/npm` still drives staged package versions.

## Verification

- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make npm-pack` (passed with sandbox escalation because npm cache under `~/.npm` is read-only in the default sandbox)
- `GOCACHE=/tmp/projmux-go-cache scripts/package-npm.sh --version 9.8.7 --out /tmp/projmux-npm-stage-check-lead`
- `node -p "const root=require('/tmp/projmux-npm-stage-check-lead/projmux/package.json'); const linux=require('/tmp/projmux-npm-stage-check-lead/@projmux/linux-x64/package.json'); JSON.stringify({root:root.version, linuxX64:linux.version, optionalLinuxX64:root.optionalDependencies['@projmux/linux-x64'], optionalDarwinArm64:root.optionalDependencies['@projmux/darwin-arm64'], optionalNames:Object.keys(root.optionalDependencies).sort()})"`

The staging inspection returned root/platform/optional dependency versions all at `9.8.7`.

## Unverified / Follow-up

- `make test-integration` and `make test-e2e` were not run for this npm metadata-only Phase 1 change.
- Follow-up phases remain Phase 0 and Phase 2 from the maintainer hygiene roadmap detail.
