### PR TITLE
test: make welcome assertions locale-safe

### DIFF
--- a/internal/app/shell_test.go
+++ b/internal/app/shell_test.go
@@ -577,12 +577,13 @@ func TestShellWelcomeShowsUntilSkippedForVersion(t *testing.T) {
 		update:       update,
 	}
 
-	var first bytes.Buffer
-	if err := cmd.Run([]string{"--no-install"}, &first, &bytes.Buffer{}); err != nil {
+	var first, stderr bytes.Buffer
+	if err := cmd.Run([]string{"--no-install"}, &first, &stderr); err != nil {
 		t.Fatalf("first Run() error = %v", err)
 	}
-	if !strings.Contains(first.String(), "Welcome to projmux shell "+version.String()) {
-		t.Fatalf("first stdout = %q, want welcome", first.String())
+	assertWelcomeOutput(t, "first stdout", first.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("first stderr = %q, want empty", stderr.String())
 	}
 	path, err := cmd.welcomeStatePath(version.String())
 	if err != nil {
@@ -607,12 +608,13 @@ func TestShellWelcomeShowsUntilSkippedForVersion(t *testing.T) {
 	}
 
 	cmd.welcomeInput = strings.NewReader("\n")
-	var second bytes.Buffer
-	if err := cmd.Run([]string{"--no-install"}, &second, &bytes.Buffer{}); err != nil {
+	var second, secondStderr bytes.Buffer
+	if err := cmd.Run([]string{"--no-install"}, &second, &secondStderr); err != nil {
 		t.Fatalf("second Run() error = %v", err)
 	}
-	if !strings.Contains(second.String(), "Welcome to projmux shell "+version.String()) {
-		t.Fatalf("second stdout = %q, want repeated welcome until skipped", second.String())
+	assertWelcomeOutput(t, "second stdout", second.String())
+	if secondStderr.Len() != 0 {
+		t.Fatalf("second stderr = %q, want empty", secondStderr.String())
 	}
 }
 
@@ -637,7 +639,7 @@ func TestShellWelcomeSkipsWhenSkipVersionMatchesCurrent(t *testing.T) {
 	if err := cmd.Run([]string{"--no-install"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if strings.Contains(stdout.String(), "Welcome to projmux shell") {
+	if strings.Contains(stdout.String(), version.String()) {
 		t.Fatalf("stdout = %q, did not expect skipped welcome", stdout.String())
 	}
 }
@@ -664,9 +666,7 @@ func TestShellWelcomeShowsWhenSkipVersionDiffers(t *testing.T) {
 	if err := cmd.Run([]string{"--no-install"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if !strings.Contains(stdout.String(), "Welcome to projmux shell "+version.String()) {
-		t.Fatalf("stdout = %q, want welcome when skip_version differs", stdout.String())
-	}
+	assertWelcomeOutput(t, "stdout", stdout.String())
 }
 
 func TestShellWelcomeLegacyLastWelcomedVersionIsNotSkip(t *testing.T) {
@@ -689,9 +689,7 @@ func TestShellWelcomeLegacyLastWelcomedVersionIsNotSkip(t *testing.T) {
 	if err := cmd.Run([]string{"--no-install"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if !strings.Contains(stdout.String(), "Welcome to projmux shell "+version.String()) {
-		t.Fatalf("stdout = %q, want legacy last_welcomed_version-only state to show", stdout.String())
-	}
+	assertWelcomeOutput(t, "stdout", stdout.String())
 }
 
 func TestShellWelcomeSkipInputStoresCurrentVersion(t *testing.T) {
@@ -713,8 +711,11 @@ func TestShellWelcomeSkipInputStoresCurrentVersion(t *testing.T) {
 	if got, want := state.SkipVersion, version.String(); got != want {
 		t.Fatalf("skip_version = %q, want %q", got, want)
 	}
-	if !strings.Contains(stdout.String(), "Skipped welcome for projmux "+version.String()) {
-		t.Fatalf("stdout = %q, want welcome skip confirmation", stdout.String())
+	if !strings.Contains(stdout.String(), version.String()) {
+		t.Fatalf("stdout = %q, want current version in skip confirmation", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "projmux") {
+		t.Fatalf("stdout = %q, want projmux marker in skip confirmation", stdout.String())
 	}
 }
 
@@ -787,7 +788,7 @@ func TestShellWelcomeCorruptStateDoesNotBlockStartup(t *testing.T) {
 	if err := cmd.Run([]string{"--no-install"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if strings.Contains(stdout.String(), "Welcome to projmux shell") {
+	if strings.Contains(stdout.String(), version.String()) {
 		t.Fatalf("stdout = %q, did not expect welcome with corrupt state", stdout.String())
 	}
 	if recorder.name != "tmux" {
@@ -844,8 +845,11 @@ func TestShellWelcomeAppliesInlineUpdate(t *testing.T) {
 	if !reflect.DeepEqual(updateCommands, wantCommands) {
 		t.Fatalf("update commands = %#v, want %#v", updateCommands, wantCommands)
 	}
-	if !strings.Contains(stdout.String(), "Continue? [Enter, u=update, s=skip welcome, d=skip update prompts]") {
-		t.Fatalf("stdout = %q, want inline prompt", stdout.String())
+	assertWelcomeOutput(t, "stdout", stdout.String())
+	for _, want := range []string{"u=", "s=", "d="} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want inline prompt token %q", stdout.String(), want)
+		}
 	}
 }
 

--- a/internal/app/welcome_command_test.go
+++ b/internal/app/welcome_command_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/crevissepartners/projmux/internal/i18n"
 	"github.com/crevissepartners/projmux/internal/version"
 )
 
@@ -18,18 +17,12 @@ func TestWelcomeCommandWritesShellGuide(t *testing.T) {
 	t.Parallel()
 
 	cmd := newWelcomeCommand(nil)
-	cmd.lookupEnv = englishWelcomeLookupEnv
 
 	var stdout, stderr bytes.Buffer
 	if err := cmd.Run(nil, &stdout, &stderr); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if !strings.Contains(stdout.String(), "Welcome to projmux shell") {
-		t.Fatalf("stdout = %q, want welcome heading", stdout.String())
-	}
-	if strings.Contains(stdout.String(), "Alt-1") || strings.Contains(stdout.String(), "Alt-3") || strings.Contains(stdout.String(), "Alt-5") {
-		t.Fatalf("stdout = %q, did not want hardcoded welcome key guide", stdout.String())
-	}
+	assertWelcomeOutput(t, "stdout", stdout.String())
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
@@ -57,25 +50,15 @@ func TestAppDispatchesWelcomeCommand(t *testing.T) {
 	t.Parallel()
 
 	app := New()
-	app.welcome.lookupEnv = englishWelcomeLookupEnv
 
 	var stdout, stderr bytes.Buffer
 	if err := app.Run([]string{"welcome"}, &stdout, &stderr); err != nil {
 		t.Fatalf("Run(welcome) error = %v", err)
 	}
-	if !strings.Contains(stdout.String(), "Welcome to projmux shell") {
-		t.Fatalf("stdout = %q, want welcome output", stdout.String())
-	}
+	assertWelcomeOutput(t, "stdout", stdout.String())
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
-}
-
-func englishWelcomeLookupEnv(name string) string {
-	if name == i18n.LocaleEnvName {
-		return string(i18n.FallbackLocale)
-	}
-	return ""
 }
 
 func TestWelcomePopupClaimsPendingAttachWelcomeOnce(t *testing.T) {
@@ -136,9 +119,7 @@ func TestWelcomePopupHonorsEnvSuppression(t *testing.T) {
 	if err := cmd.Run(nil, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if !strings.Contains(stdout.String(), "Welcome to projmux shell") {
-		t.Fatalf("stdout = %q, want manual welcome despite env suppression", stdout.String())
-	}
+	assertWelcomeOutput(t, "stdout", stdout.String())
 }
 
 func TestWelcomePopupForceShowsWithoutPendingState(t *testing.T) {
@@ -226,15 +207,35 @@ func TestWelcomePopupDisplaysWelcomePayloadInTmux(t *testing.T) {
 		}
 	}
 	command := call.args[len(call.args)-1]
+	assertWelcomeOutput(t, "popup command", command)
 	for _, want := range []string{
-		"Welcome to projmux shell",
-		"shell bootstrap",
 		displayOnlyPopupClosePrompt,
 		"popup-wait-key",
 		"'/tmp/proj mux/bin/projmux'",
 	} {
 		if !strings.Contains(command, want) {
 			t.Fatalf("popup command = %q, want substring %q", command, want)
+		}
+	}
+}
+
+func assertWelcomeOutput(t *testing.T, name, output string) {
+	t.Helper()
+
+	for _, want := range []string{"projmux", version.String()} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("%s = %q, want substring %q", name, output, want)
+		}
+	}
+	assertNoHardcodedWelcomeLaunchGuide(t, name, output)
+}
+
+func assertNoHardcodedWelcomeLaunchGuide(t *testing.T, name, output string) {
+	t.Helper()
+
+	for _, unwanted := range []string{"Alt-1", "Alt-3", "Alt-5"} {
+		if strings.Contains(output, unwanted) {
+			t.Fatalf("%s = %q, did not want hardcoded welcome key guide %q", name, output, unwanted)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- 완료한 Phase: Phase 0 - Locale-safe welcome test slice
- Relaxed welcome command and shell welcome unit tests away from full English welcome sentences, using stable behavior markers instead.
- Added shared test assertions for welcome output, absence of hardcoded `Alt-1` / `Alt-3` / `Alt-5` launch-key guide, stderr quiet paths, and inline prompt action tokens.

## User-facing surface
- Test-only change. No visible welcome copy changed.
- Locale/default catalog policy was not changed.
- i18n catalog schema was not redesigned.

## Explicitly excluded
- Phase 1 npm metadata cleanup.
- Phase 2 host-only smoke checklist docs.
- `Session State unused live overwrite primitive` Backlog item.
- Settings About Welcome viewer i18n cleanup.

## Verification
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache LANG=ko_KR.UTF-8 go test ./internal/app -run TestWelcome`
- `GOCACHE=/tmp/projmux-go-cache LANG=ko_KR.UTF-8 go test ./internal/app -run 'Test(Welcome|ShellWelcome)'`

## Unverified / follow-up
- `GOCACHE=/tmp/projmux-go-cache LANG=ko_KR.UTF-8 go test ./...` still fails outside this Phase 0 scope because existing Settings/picker tests assert English labels under ko-KR. I did not expand into that because the requested slice explicitly excludes broader Settings/i18n cleanup.
- Follow-up phase remaining in the active roadmap detail: Phase 2 host-only smoke checklist consolidation.
