### PR TITLE
fix: keep Alt-1 sidebar rows compact

### DIFF
--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/theme"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
+	intrender "github.com/crevissepartners/projmux/internal/ui/render"
 )
 
 func TestAppRunSwitchDefaultsToPopupAndOpensSelectedSession(t *testing.T) {
@@ -581,7 +582,7 @@ func TestSwitchCommandSupportsSidebarUI(t *testing.T) {
 		t.Fatalf("runner bindings = %q, want %q", got, want)
 	}
 	if got, want := gotRunnerOptions.Entries, []intpickercompat.Entry{
-		{Label: "\x1b[1m\x1b[32mapp\x1b[0m      \n\x1b[2m/tmp/app\x1b[0m \x1b[1;38;5;231;48;5;30m                  \x1b[0m\n\x1b[38;5;245;48;5;235m            \x1b[0m \x1b[38;5;245;48;5;235m            \x1b[0m \x1b[38;5;245;48;5;235m            \x1b[0m", Value: "/tmp/app", SearchKey: "app"},
+		expectedSidebarEntry("app", "/tmp/app", "/tmp/app", "existing", false),
 	}; !equalEntries(got, want) {
 		t.Fatalf("runner entries = %#v, want %#v", got, want)
 	}
@@ -690,12 +691,12 @@ func TestSwitchCommandSidebarRowsIncludeAttentionBadge(t *testing.T) {
 	}
 
 	initialLabel := gotNativeOptions.Items[0].EffectiveLabel()
-	if got, want := len(strings.Split(initialLabel, "\n")), 3; got != want {
-		t.Fatalf("initial row line count = %d, want %d: %q", got, want, initialLabel)
+	if strings.Contains(initialLabel, "\n") {
+		t.Fatalf("initial row = %q, want compact single-line sidebar row", initialLabel)
 	}
 	deferredLabel := gotDeferred.Items[0].EffectiveLabel()
-	if got, want := len(strings.Split(deferredLabel, "\n")), 3; got != want {
-		t.Fatalf("deferred row line count = %d, want %d: %q", got, want, deferredLabel)
+	if strings.Contains(deferredLabel, "\n") {
+		t.Fatalf("deferred row = %q, want compact single-line sidebar row", deferredLabel)
 	}
 	if !strings.Contains(deferredLabel, "●") {
 		t.Fatalf("deferred entry = %q, want attention marker", deferredLabel)
@@ -811,8 +812,8 @@ func TestSwitchCommandNativeSidebarDefersGitWindowsAttentionAndPreview(t *testin
 				t.Fatalf("preview command before first paint = %q, want deferred", options.Preview.Command)
 			}
 			initialLabel := options.Items[0].EffectiveLabel()
-			if got, want := len(strings.Split(initialLabel, "\n")), 3; got != want {
-				t.Fatalf("initial row line count = %d, want %d: %q", got, want, initialLabel)
+			if strings.Contains(initialLabel, "\n") {
+				t.Fatalf("initial row = %q, want compact single-line sidebar row", initialLabel)
 			}
 			if strings.Contains(initialLabel, "branch-main") || strings.Contains(initialLabel, " server ") || strings.Contains(initialLabel, "●") {
 				t.Fatalf("initial item = %q, want reserved lanes without metadata", initialLabel)
@@ -3182,12 +3183,21 @@ func pickerItemSearchTexts(items []intpicker.Item) []string {
 }
 
 func expectedCheapSidebarEntry(name, displayPath, value string, pinned bool) intpickercompat.Entry {
-	statusLane := "     "
-	if pinned {
-		statusLane = "    \x1b[33m*\x1b[0m"
-	}
+	return expectedSidebarEntry(name, displayPath, value, "new", pinned)
+}
+
+func expectedSidebarEntry(name, displayPath, value, modeLabel string, pinned bool) intpickercompat.Entry {
+	row := intrender.BuildSwitchRows([]intrender.SwitchCandidate{{
+		Path:        value,
+		DisplayPath: displayPath,
+		DisplayName: name,
+		SessionName: name,
+		ModeLabel:   modeLabel,
+		UI:          "sidebar",
+		Pinned:      pinned,
+	}})[0]
 	return intpickercompat.Entry{
-		Label:     name + " " + statusLane + "\n\x1b[2m" + displayPath + "\x1b[0m \x1b[38;5;231;48;5;30m                  \x1b[0m\n\x1b[38;5;245;48;5;235m            \x1b[0m \x1b[38;5;245;48;5;235m            \x1b[0m \x1b[38;5;245;48;5;235m            \x1b[0m",
+		Label:     row.Item.EffectiveLabel(),
 		Value:     value,
 		SearchKey: name,
 	}

--- a/internal/ui/render/switch.go
+++ b/internal/ui/render/switch.go
@@ -261,7 +261,7 @@ func formatSidebarSwitchWindowTabs(windows []SwitchWindowTab) string {
 		tabs = append(tabs, formatSidebarSwitchWindowTab(name, window.AttentionRank, window.Active))
 	}
 	for len(tabs) < switchSidebarTabSlots {
-		tabs = append(tabs, ansiTabInactive+strings.Repeat(" ", sidebarSwitchWindowTabWidth())+ansiReset)
+		tabs = append(tabs, formatSidebarBlankLane(sidebarSwitchWindowTabWidth()))
 	}
 	return strings.Join(tabs, " ")
 }
@@ -435,12 +435,19 @@ func formatSidebarSwitchLabel(candidate SwitchCandidate) string {
 	if path == "" {
 		path = sanitizeCell(candidate.Path)
 	}
-	lines := []string{
-		title + " " + formatSidebarStatusLane(candidate),
-		ansiDim + path + ansiReset + " " + formatSidebarBranchLane(candidate),
-		formatSidebarSwitchWindowTabs(candidate.WindowTabs),
+	parts := make([]string, 0, 5)
+	if prefix := formatSidebarStatusPrefix(candidate); prefix != "" {
+		parts = append(parts, prefix)
+	} else {
+		parts = append(parts, formatSidebarBlankLane(1))
 	}
-	return strings.Join(lines, "\n")
+	parts = append(parts, title)
+	if path != "" {
+		parts = append(parts, ansiDim+path+ansiReset)
+	}
+	parts = append(parts, formatSidebarBranchLane(candidate))
+	parts = append(parts, formatSidebarSwitchWindowTabs(candidate.WindowTabs))
+	return strings.Join(parts, " ")
 }
 
 func formatAttentionBadge(rank int) string {
@@ -474,6 +481,10 @@ func formatSidebarStatusLane(candidate SwitchCandidate) string {
 	}, " ")
 }
 
+func formatSidebarStatusPrefix(candidate SwitchCandidate) string {
+	return strings.TrimRight(formatSidebarStatusLane(candidate), " ")
+}
+
 func formatSidebarBranchLane(candidate SwitchCandidate) string {
 	branch := truncateSwitchBadge(sanitizeCell(candidate.GitBranch), switchBranchBadgeMax)
 	style := ansiStatusGitInactive
@@ -481,9 +492,16 @@ func formatSidebarBranchLane(candidate SwitchCandidate) string {
 		style = ansiStatusGitActive
 	}
 	if branch == "" {
-		return style + strings.Repeat(" ", switchBranchBadgeMax+2) + ansiReset
+		return formatSidebarBlankLane(switchBranchBadgeMax + 2)
 	}
 	return style + " " + padRight(branch, switchBranchBadgeMax) + " " + ansiReset
+}
+
+func formatSidebarBlankLane(width int) string {
+	if width <= 0 {
+		return ""
+	}
+	return ansiReset + strings.Repeat(" ", width) + ansiReset
 }
 
 func formatTagBadge(tagged bool) string {

--- a/internal/ui/render/switch_test.go
+++ b/internal/ui/render/switch_test.go
@@ -132,12 +132,17 @@ func TestBuildSwitchRowsSidebarUsesAnsiStylingForModeAndToggles(t *testing.T) {
 		Tagged:      true,
 	}})
 
-	const want = "\x1b[1m\x1b[32mapp\x1b[0m   \x1b[31mx\x1b[0m \x1b[33m*\x1b[0m\n\x1b[2m~rp/app\x1b[0m \x1b[1;38;5;231;48;5;30m                  \x1b[0m\n\x1b[38;5;245;48;5;235m            \x1b[0m \x1b[38;5;245;48;5;235m            \x1b[0m \x1b[38;5;245;48;5;235m            \x1b[0m"
-	if got := rows[0].Label; got != want {
-		t.Fatalf("label = %q, want %q", got, want)
+	got := rows[0].Label
+	for _, want := range []string{"\x1b[31mx\x1b[0m", "\x1b[33m*\x1b[0m", "\x1b[1m\x1b[32mapp\x1b[0m", "\x1b[2m~rp/app\x1b[0m"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("label = %q, want token %q", got, want)
+		}
 	}
-	if got := rows[0].Item.EffectiveLabel(); got != want {
-		t.Fatalf("item label = %q, want %q", got, want)
+	if strings.Contains(got, "\n") {
+		t.Fatalf("label = %q, want compact single-line sidebar row", got)
+	}
+	if itemLabel := rows[0].Item.EffectiveLabel(); strings.Contains(itemLabel, "\n") {
+		t.Fatalf("item label = %q, want compact single-line sidebar row", itemLabel)
 	}
 }
 
@@ -152,9 +157,14 @@ func TestBuildSwitchRowsSidebarLeavesNewSessionNameUncolored(t *testing.T) {
 		UI:          "sidebar",
 	}})
 
-	const want = "app      \n\x1b[2m~rp/app\x1b[0m \x1b[38;5;231;48;5;30m                  \x1b[0m\n\x1b[38;5;245;48;5;235m            \x1b[0m \x1b[38;5;245;48;5;235m            \x1b[0m \x1b[38;5;245;48;5;235m            \x1b[0m"
-	if got := rows[0].Label; got != want {
-		t.Fatalf("label = %q, want %q", got, want)
+	got := rows[0].Label
+	for _, want := range []string{"app", "\x1b[2m~rp/app\x1b[0m"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("label = %q, want token %q", got, want)
+		}
+	}
+	if strings.Contains(got, "\n") {
+		t.Fatalf("label = %q, want compact single-line sidebar row", got)
 	}
 }
 
@@ -170,9 +180,14 @@ func TestBuildSwitchRowsSidebarShowsAttentionBadge(t *testing.T) {
 		AttentionRank: 2,
 	}})
 
-	const want = "\x1b[1m\x1b[32mapp\x1b[0m \x1b[38;2;255;204;102m●\x1b[0m    \n\x1b[2m~rp/app\x1b[0m \x1b[1;38;5;231;48;5;30m                  \x1b[0m\n\x1b[38;5;245;48;5;235m            \x1b[0m \x1b[38;5;245;48;5;235m            \x1b[0m \x1b[38;5;245;48;5;235m            \x1b[0m"
-	if got := rows[0].Label; got != want {
-		t.Fatalf("label = %q, want %q", got, want)
+	got := rows[0].Label
+	for _, want := range []string{"\x1b[38;2;255;204;102m●\x1b[0m", "\x1b[1m\x1b[32mapp\x1b[0m", "\x1b[2m~rp/app\x1b[0m"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("label = %q, want token %q", got, want)
+		}
+	}
+	if strings.Contains(got, "\n") {
+		t.Fatalf("label = %q, want compact single-line sidebar row", got)
 	}
 	if got, want := rows[0].Item.Badges, []string{"needs review"}; !equalStringSlices(got, want) {
 		t.Fatalf("item badges = %q, want %q", got, want)
@@ -207,21 +222,19 @@ func TestBuildSwitchRowsSidebarCheapAndEnrichedGeometryIsStable(t *testing.T) {
 		AttentionRank: 2,
 	}})[0]
 
-	cheapLines := strings.Split(cheap.Item.EffectiveLabel(), "\n")
-	enrichedLines := strings.Split(enriched.Item.EffectiveLabel(), "\n")
-	if len(cheapLines) != 3 || len(enrichedLines) != 3 {
-		t.Fatalf("line count cheap/enriched = %d/%d, want fixed 3-line sidebar rows", len(cheapLines), len(enrichedLines))
+	cheapLabel := cheap.Item.EffectiveLabel()
+	enrichedLabel := enriched.Item.EffectiveLabel()
+	if strings.Contains(cheapLabel, "\n") || strings.Contains(enrichedLabel, "\n") {
+		t.Fatalf("sidebar labels must stay single-line\ncheap:    %q\nenriched: %q", cheapLabel, enrichedLabel)
 	}
-	for idx := range cheapLines {
-		if got, want := projmuxpicker.VisibleLen(enrichedLines[idx]), projmuxpicker.VisibleLen(cheapLines[idx]); got != want {
-			t.Fatalf("line %d width changed from %d to %d\ncheap:    %q\nenriched: %q", idx, want, got, cheapLines[idx], enrichedLines[idx])
-		}
+	if got, want := projmuxpicker.VisibleLen(enrichedLabel), projmuxpicker.VisibleLen(cheapLabel); got != want {
+		t.Fatalf("label width changed from %d to %d\ncheap:    %q\nenriched: %q", want, got, cheapLabel, enrichedLabel)
 	}
-	if !strings.Contains(enrichedLines[1], "feature/long-...") {
-		t.Fatalf("enriched path/git lane = %q, want truncated branch in fixed lane", enrichedLines[1])
+	if !strings.Contains(enrichedLabel, "feature/long-...") {
+		t.Fatalf("enriched label = %q, want truncated branch in fixed lane", enrichedLabel)
 	}
-	if strings.Contains(enrichedLines[2], "extra") {
-		t.Fatalf("enriched tabs lane = %q, want fixed sidebar tab slots", enrichedLines[2])
+	if strings.Contains(enrichedLabel, "extra") {
+		t.Fatalf("enriched label = %q, want fixed sidebar tab slots", enrichedLabel)
 	}
 }
 


### PR DESCRIPTION
## Summary
- restore Alt-1 project sidebar rows to compact single-line rendering
- keep delayed branch/window/attention metadata in fixed inline lanes so enrichment does not change row height or width
- pin regression tests for compact sidebar rows and cheap/enriched geometry stability

## Explicit scope
- Alt-1 project sidebar row rendering only
- no Settings, notify sidebar, session popup, discovery, naming, or open/switch semantic changes

## Verification
- make fmt
- make fix
- go test ./internal/ui/render ./internal/app -run 'TestBuildSwitchRowsSidebar|TestSwitchCommand.*Sidebar|Test.*Switch.*Preview|Test.*Switch.*Git|TestNewSwitchCommandUsesEnvAndDefaultPinStore|TestNewSwitchCommandDoesNotInferRepoRootFromHomeSourceRepos'
- make test
- make test-integration
- make test-e2e

## Risk
- metadata that appears past the visible sidebar width may be clipped by the existing renderer; this is intentional for compact stable rows.