### PR TITLE
fix: soften window-list attention badge

### DIFF
--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -33,6 +33,12 @@ row 1  [#S]  #{pane_current_path}  ⎈ <ctx>/<ns>  <git>   %H:%M
   clicks on tmux 3.4+, so a `run-shell` handler can't recover the
   target after the fact — the Go dispatcher's
   `isWindowListRangeToken` fallback is now defense-in-depth only.
+  Each window tab reserves a one-cell live pane attention prefix from
+  `projmux attention window #{window_id}` before the index: busy panes render a
+  progress-colored dot, reply-ready panes render a non-critical ready-colored
+  dot, and idle windows render a blank placeholder so title alignment and click
+  range width stay stable. This live window-list badge is independent from the
+  row-0 notify queue segment.
   The session, pwd, kube, and git segments on this row are wrapped
   in `#[range=user|<id>]` ranges and dispatched through the projmux
   handler. The standalone config also wraps the right-side `projmux`
@@ -97,7 +103,8 @@ and count metadata. If the segment is still too wide, the age is dropped next
 while badges and the `+N` count stay visible when possible. Very narrow widths
 fall back to dotless clipped text plus the `+N` count when it fits; the final
 hard-truncate path still closes with `#[default]` so later status segments do
-not inherit notification styling.
+not inherit notification styling. That dotless narrow fallback applies only to
+the queued notify segment, not to the separate window-list live attention badge.
 `usage` opens a native-framed detail HUD for the compact usage bar. It reads
 the cached usage state in-process, keeps the existing `projmux usage` CLI
 output shape unchanged for external consumers, aligns model/window rows with

--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -242,7 +242,7 @@ func (c *attentionCommand) runWindow(args []string, stdout, stderr io.Writer) er
 	}
 
 	if seenReply {
-		_, err := fmt.Fprint(stdout, "#[fg="+tmuxAccentAttentionStrongBg+"]●")
+		_, err := fmt.Fprint(stdout, "#[fg="+tmuxStateSuccessFg+"]●")
 		return err
 	}
 	_, err = fmt.Fprint(stdout, " ")

--- a/internal/app/attention_test.go
+++ b/internal/app/attention_test.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/crevissepartners/projmux/internal/theme"
 )
 
 func TestAttentionToggleMarksPlainPane(t *testing.T) {
@@ -280,8 +282,13 @@ func TestAttentionWindowShowsReplyBadge(t *testing.T) {
 	if err := cmd.Run([]string{"window", "@2"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if got, want := stdout.String(), "#[fg="+tmuxAccentAttentionStrongBg+"]●"; got != want {
+	if got, want := stdout.String(), "#[fg="+tmuxStateSuccessFg+"]●"; got != want {
 		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	for _, disallowed := range []string{theme.TmuxAccentAttentionStrongBg} {
+		if strings.Contains(stdout.String(), disallowed) {
+			t.Fatalf("stdout = %q, did not expect critical attention token %q", stdout.String(), disallowed)
+		}
 	}
 }
 

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -38,15 +38,14 @@ const (
 	tmuxActionFg         = theme.TmuxActionFg
 	tmuxSecondaryFg      = theme.TmuxSecondaryFg
 
-	tmuxAccentAttentionBg       = theme.TmuxAccentAttentionBg
-	tmuxAccentAttentionFg       = theme.TmuxAccentAttentionFg
-	tmuxAccentAttentionStrongBg = theme.TmuxAccentAttentionStrongBg
-	tmuxAccentAIBg              = theme.TmuxAccentAIBg
-	tmuxAccentAIFg              = theme.TmuxAccentAIFg
-	tmuxStateProgressFg         = theme.TmuxStateProgressFg
-	tmuxStateSuccessFg          = theme.TmuxStateSuccessFg
-	tmuxStateWarningFg          = theme.TmuxStateWarningFg
-	tmuxStateCriticalFg         = theme.TmuxStateCriticalFg
+	tmuxAccentAttentionBg = theme.TmuxAccentAttentionBg
+	tmuxAccentAttentionFg = theme.TmuxAccentAttentionFg
+	tmuxAccentAIBg        = theme.TmuxAccentAIBg
+	tmuxAccentAIFg        = theme.TmuxAccentAIFg
+	tmuxStateProgressFg   = theme.TmuxStateProgressFg
+	tmuxStateSuccessFg    = theme.TmuxStateSuccessFg
+	tmuxStateWarningFg    = theme.TmuxStateWarningFg
+	tmuxStateCriticalFg   = theme.TmuxStateCriticalFg
 )
 
 type tmuxPopupClient interface {


### PR DESCRIPTION
## Summary
- Completed Phase: Phase 0 - window-list red attention dot cleanup
- User-facing surface changed: bottom tmux window-list attention badge before each window name
- Reply-ready window attention now uses the non-critical ready/success foreground instead of the attention-strong red/pink token
- Busy/progress windows keep the existing progress-colored badge, and no-attention windows keep the blank placeholder for alignment and click range stability
- Docs now call out that the notify segment dotless narrow fallback and the window-list live attention badge are separate statusbar surfaces

## Explicitly out of scope
- Did not change notify queue schema/store/ack/focus behavior
- Did not change `projmux status notify` semantics or notification delivery mode
- Did not redesign pane border attention badges
- Did not change the AI watcher, attention state machine, or focus clear semantics
- Did not change tmux window-list click routing
- Did not perform a broader statusbar palette redesign

## Semantics preserved
- Window-list click routing is still handled by tmux's native window range path; the generated `window-status-format` / `window-status-current-format` routing is unchanged
- Notify queue semantics are unchanged; this only adjusts the live `projmux attention window <window>` reply badge color

## Verification
- `go test ./internal/app -run 'TestAttention.*Window|TestTmux.*Window|TestTmuxConfig.*Theme|Test.*Statusbar'`
- `go test ./internal/app -run TestTmuxConfigThemeUsesProject256ColorBackgroundWithoutGlobalLeak`
- `rg -n 'tmuxAccentAttentionStrongBg|colour204|attention window' internal/app docs/statusbar.md`
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `git diff --check`

## Unverified / follow-up
- No manual tmux visual smoke was run in this session.
- No follow-up phase is required for Phase 0; pane border attention badge redesign and broader statusbar palette work remain explicitly excluded.
