### PR TITLE
fix: drop sidebar switch metadata lines

### DIFF
--- a/internal/ui/render/switch.go
+++ b/internal/ui/render/switch.go
@@ -98,6 +98,7 @@ func BuildSwitchRows(candidates []SwitchCandidate) []SwitchRow {
 		item := switchPickerItem(candidate)
 		if candidate.UI == "sidebar" {
 			item.Label = label
+			item.MetaLines = nil
 		}
 		rows = append(rows, SwitchRow{
 			Label: label,

--- a/internal/ui/render/switch_test.go
+++ b/internal/ui/render/switch_test.go
@@ -144,6 +144,9 @@ func TestBuildSwitchRowsSidebarUsesAnsiStylingForModeAndToggles(t *testing.T) {
 	if itemLabel := rows[0].Item.EffectiveLabel(); strings.Contains(itemLabel, "\n") {
 		t.Fatalf("item label = %q, want compact single-line sidebar row", itemLabel)
 	}
+	if got := rows[0].Item.MetaLines; len(got) != 0 {
+		t.Fatalf("item meta lines = %#v, want sidebar metadata folded into compact label", got)
+	}
 }
 
 func TestBuildSwitchRowsSidebarLeavesNewSessionNameUncolored(t *testing.T) {
@@ -226,6 +229,9 @@ func TestBuildSwitchRowsSidebarCheapAndEnrichedGeometryIsStable(t *testing.T) {
 	enrichedLabel := enriched.Item.EffectiveLabel()
 	if strings.Contains(cheapLabel, "\n") || strings.Contains(enrichedLabel, "\n") {
 		t.Fatalf("sidebar labels must stay single-line\ncheap:    %q\nenriched: %q", cheapLabel, enrichedLabel)
+	}
+	if len(cheap.Item.MetaLines) != 0 || len(enriched.Item.MetaLines) != 0 {
+		t.Fatalf("sidebar meta lines cheap/enriched = %#v/%#v, want no extra rendered lines", cheap.Item.MetaLines, enriched.Item.MetaLines)
 	}
 	if got, want := projmuxpicker.VisibleLen(enrichedLabel), projmuxpicker.VisibleLen(cheapLabel); got != want {
 		t.Fatalf("label width changed from %d to %d\ncheap:    %q\nenriched: %q", want, got, cheapLabel, enrichedLabel)


### PR DESCRIPTION
## Summary
- prevent Alt-1 sidebar switch items from carrying native picker MetaLines
- keep delayed path/git/window metadata folded into the compact single-line sidebar label
- add regression assertions that sidebar items do not render extra metadata lines

## Explicit scope
- Alt-1 project sidebar rendering only
- no Settings, notify sidebar, session popup, discovery, naming, or open/switch semantic changes

## Verification
- make fmt
- make fix
- go test ./internal/ui/render ./internal/app -run 'TestBuildSwitchRowsSidebar|TestSwitchCommand.*Sidebar|Test.*Switch.*Preview|Test.*Switch.*Git|TestNewSwitchCommandUsesEnvAndDefaultPinStore|TestNewSwitchCommandDoesNotInferRepoRootFromHomeSourceRepos'
- make test
- make test-integration
- make test-e2e

## Risk
- inline metadata can be clipped at narrow sidebar widths; row height stays compact by design.