### PR TITLE
fix: restore Alt-1 sidebar card rows

### DIFF
--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -691,12 +691,12 @@ func TestSwitchCommandSidebarRowsIncludeAttentionBadge(t *testing.T) {
 	}
 
 	initialLabel := gotNativeOptions.Items[0].EffectiveLabel()
-	if strings.Contains(initialLabel, "\n") {
-		t.Fatalf("initial row = %q, want compact single-line sidebar row", initialLabel)
+	if got, want := len(strings.Split(initialLabel, "\n")), 3; got != want {
+		t.Fatalf("initial row line count = %d, want card-like 3-line sidebar row: %q", got, initialLabel)
 	}
 	deferredLabel := gotDeferred.Items[0].EffectiveLabel()
-	if strings.Contains(deferredLabel, "\n") {
-		t.Fatalf("deferred row = %q, want compact single-line sidebar row", deferredLabel)
+	if got, want := len(strings.Split(deferredLabel, "\n")), 3; got != want {
+		t.Fatalf("deferred row line count = %d, want card-like 3-line sidebar row: %q", got, deferredLabel)
 	}
 	if !strings.Contains(deferredLabel, "●") {
 		t.Fatalf("deferred entry = %q, want attention marker", deferredLabel)
@@ -812,8 +812,8 @@ func TestSwitchCommandNativeSidebarDefersGitWindowsAttentionAndPreview(t *testin
 				t.Fatalf("preview command before first paint = %q, want deferred", options.Preview.Command)
 			}
 			initialLabel := options.Items[0].EffectiveLabel()
-			if strings.Contains(initialLabel, "\n") {
-				t.Fatalf("initial row = %q, want compact single-line sidebar row", initialLabel)
+			if got, want := len(strings.Split(initialLabel, "\n")), 3; got != want {
+				t.Fatalf("initial row line count = %d, want card-like 3-line sidebar row: %q", got, initialLabel)
 			}
 			if strings.Contains(initialLabel, "branch-main") || strings.Contains(initialLabel, " server ") || strings.Contains(initialLabel, "●") {
 				t.Fatalf("initial item = %q, want reserved lanes without metadata", initialLabel)

--- a/internal/ui/render/switch.go
+++ b/internal/ui/render/switch.go
@@ -262,7 +262,7 @@ func formatSidebarSwitchWindowTabs(windows []SwitchWindowTab) string {
 		tabs = append(tabs, formatSidebarSwitchWindowTab(name, window.AttentionRank, window.Active))
 	}
 	for len(tabs) < switchSidebarTabSlots {
-		tabs = append(tabs, formatSidebarBlankLane(sidebarSwitchWindowTabWidth()))
+		tabs = append(tabs, ansiTabInactive+strings.Repeat(" ", sidebarSwitchWindowTabWidth())+ansiReset)
 	}
 	return strings.Join(tabs, " ")
 }
@@ -436,19 +436,16 @@ func formatSidebarSwitchLabel(candidate SwitchCandidate) string {
 	if path == "" {
 		path = sanitizeCell(candidate.Path)
 	}
-	parts := make([]string, 0, 5)
-	if prefix := formatSidebarStatusPrefix(candidate); prefix != "" {
-		parts = append(parts, prefix)
-	} else {
-		parts = append(parts, formatSidebarBlankLane(1))
+	lines := []string{
+		title + " " + formatSidebarStatusLane(candidate),
 	}
-	parts = append(parts, title)
 	if path != "" {
-		parts = append(parts, ansiDim+path+ansiReset)
+		lines = append(lines, ansiDim+path+ansiReset+" "+formatSidebarBranchLane(candidate))
+	} else {
+		lines = append(lines, formatSidebarBranchLane(candidate))
 	}
-	parts = append(parts, formatSidebarBranchLane(candidate))
-	parts = append(parts, formatSidebarSwitchWindowTabs(candidate.WindowTabs))
-	return strings.Join(parts, " ")
+	lines = append(lines, formatSidebarSwitchWindowTabs(candidate.WindowTabs))
+	return strings.Join(lines, "\n")
 }
 
 func formatAttentionBadge(rank int) string {
@@ -482,10 +479,6 @@ func formatSidebarStatusLane(candidate SwitchCandidate) string {
 	}, " ")
 }
 
-func formatSidebarStatusPrefix(candidate SwitchCandidate) string {
-	return strings.TrimRight(formatSidebarStatusLane(candidate), " ")
-}
-
 func formatSidebarBranchLane(candidate SwitchCandidate) string {
 	branch := truncateSwitchBadge(sanitizeCell(candidate.GitBranch), switchBranchBadgeMax)
 	style := ansiStatusGitInactive
@@ -493,16 +486,9 @@ func formatSidebarBranchLane(candidate SwitchCandidate) string {
 		style = ansiStatusGitActive
 	}
 	if branch == "" {
-		return formatSidebarBlankLane(switchBranchBadgeMax + 2)
+		return style + strings.Repeat(" ", switchBranchBadgeMax+2) + ansiReset
 	}
 	return style + " " + padRight(branch, switchBranchBadgeMax) + " " + ansiReset
-}
-
-func formatSidebarBlankLane(width int) string {
-	if width <= 0 {
-		return ""
-	}
-	return ansiReset + strings.Repeat(" ", width) + ansiReset
 }
 
 func formatTagBadge(tagged bool) string {

--- a/internal/ui/render/switch_test.go
+++ b/internal/ui/render/switch_test.go
@@ -138,14 +138,14 @@ func TestBuildSwitchRowsSidebarUsesAnsiStylingForModeAndToggles(t *testing.T) {
 			t.Fatalf("label = %q, want token %q", got, want)
 		}
 	}
-	if strings.Contains(got, "\n") {
-		t.Fatalf("label = %q, want compact single-line sidebar row", got)
+	if got, want := len(strings.Split(got, "\n")), 3; got != want {
+		t.Fatalf("label line count = %d, want card-like 3-line sidebar row: %q", got, got)
 	}
-	if itemLabel := rows[0].Item.EffectiveLabel(); strings.Contains(itemLabel, "\n") {
-		t.Fatalf("item label = %q, want compact single-line sidebar row", itemLabel)
+	if itemLabel := rows[0].Item.EffectiveLabel(); len(strings.Split(itemLabel, "\n")) != 3 {
+		t.Fatalf("item label = %q, want card-like 3-line sidebar row", itemLabel)
 	}
 	if got := rows[0].Item.MetaLines; len(got) != 0 {
-		t.Fatalf("item meta lines = %#v, want sidebar metadata folded into compact label", got)
+		t.Fatalf("item meta lines = %#v, want sidebar card metadata folded into label lines", got)
 	}
 }
 
@@ -166,8 +166,8 @@ func TestBuildSwitchRowsSidebarLeavesNewSessionNameUncolored(t *testing.T) {
 			t.Fatalf("label = %q, want token %q", got, want)
 		}
 	}
-	if strings.Contains(got, "\n") {
-		t.Fatalf("label = %q, want compact single-line sidebar row", got)
+	if got, want := len(strings.Split(got, "\n")), 3; got != want {
+		t.Fatalf("label line count = %d, want card-like 3-line sidebar row: %q", got, got)
 	}
 }
 
@@ -189,8 +189,8 @@ func TestBuildSwitchRowsSidebarShowsAttentionBadge(t *testing.T) {
 			t.Fatalf("label = %q, want token %q", got, want)
 		}
 	}
-	if strings.Contains(got, "\n") {
-		t.Fatalf("label = %q, want compact single-line sidebar row", got)
+	if got, want := len(strings.Split(got, "\n")), 3; got != want {
+		t.Fatalf("label line count = %d, want card-like 3-line sidebar row: %q", got, got)
 	}
 	if got, want := rows[0].Item.Badges, []string{"needs review"}; !equalStringSlices(got, want) {
 		t.Fatalf("item badges = %q, want %q", got, want)
@@ -227,14 +227,18 @@ func TestBuildSwitchRowsSidebarCheapAndEnrichedGeometryIsStable(t *testing.T) {
 
 	cheapLabel := cheap.Item.EffectiveLabel()
 	enrichedLabel := enriched.Item.EffectiveLabel()
-	if strings.Contains(cheapLabel, "\n") || strings.Contains(enrichedLabel, "\n") {
-		t.Fatalf("sidebar labels must stay single-line\ncheap:    %q\nenriched: %q", cheapLabel, enrichedLabel)
+	cheapLines := strings.Split(cheapLabel, "\n")
+	enrichedLines := strings.Split(enrichedLabel, "\n")
+	if len(cheapLines) != 3 || len(enrichedLines) != 3 {
+		t.Fatalf("sidebar labels must stay 3-line card rows\ncheap:    %q\nenriched: %q", cheapLabel, enrichedLabel)
 	}
 	if len(cheap.Item.MetaLines) != 0 || len(enriched.Item.MetaLines) != 0 {
-		t.Fatalf("sidebar meta lines cheap/enriched = %#v/%#v, want no extra rendered lines", cheap.Item.MetaLines, enriched.Item.MetaLines)
+		t.Fatalf("sidebar meta lines cheap/enriched = %#v/%#v, want no extra rendered lines beyond the 3-line card", cheap.Item.MetaLines, enriched.Item.MetaLines)
 	}
-	if got, want := projmuxpicker.VisibleLen(enrichedLabel), projmuxpicker.VisibleLen(cheapLabel); got != want {
-		t.Fatalf("label width changed from %d to %d\ncheap:    %q\nenriched: %q", want, got, cheapLabel, enrichedLabel)
+	for idx := range cheapLines {
+		if got, want := projmuxpicker.VisibleLen(enrichedLines[idx]), projmuxpicker.VisibleLen(cheapLines[idx]); got != want {
+			t.Fatalf("line %d width changed from %d to %d\ncheap:    %q\nenriched: %q", idx, want, got, cheapLines[idx], enrichedLines[idx])
+		}
 	}
 	if !strings.Contains(enrichedLabel, "feature/long-...") {
 		t.Fatalf("enriched label = %q, want truncated branch in fixed lane", enrichedLabel)


### PR DESCRIPTION
## Summary
- restore Alt-1 project sidebar rows to the card-like 3-line layout
- keep path/git/window metadata inside the 3 reserved label lines instead of native picker MetaLines
- preserve delayed enrichment: cheap rows first, branch/window/attention metadata fills the reserved lanes later
- add regression coverage for 3-line card rows, no extra MetaLines, and stable cheap/enriched row widths

## Explicit scope
- Alt-1 project sidebar row rendering only
- no Settings, notify sidebar, session popup, discovery, naming, or open/switch semantic changes

## Verification
- make fmt
- make fix
- go test ./internal/ui/render ./internal/app -run 'TestBuildSwitchRowsSidebar|TestSwitchCommand.*Sidebar|Test.*Switch.*Preview|Test.*Switch.*Git|TestNewSwitchCommandUsesEnvAndDefaultPinStore|TestNewSwitchCommandDoesNotInferRepoRootFromHomeSourceRepos'
- make test
- make test-integration
- make test-e2e

## Risk
- metadata lanes are fixed-width; long branch/tab labels are intentionally truncated.