### PR TITLE
fix: reserve blank Alt-1 sidebar lanes

### DIFF
--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -1883,6 +1883,8 @@ func (c *switchCommand) runPicker(plan switchPlan) (intpicker.Result, error) {
 	options.InitialIndexSet = surface.InitialIndexSet
 	if surface.PreviewCommand != "" {
 		options.Preview = intpicker.Preview{Command: surface.PreviewCommand, Window: switchPreviewWindow(plan.UI)}
+	} else if plan.UI == switchUISidebar && plan.DeferredUpdate != nil {
+		options.Preview = intpicker.Preview{Window: switchPreviewWindow(plan.UI)}
 	}
 
 	compatOptions := intpickercompat.OptionsFromPicker(options)

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -568,8 +568,8 @@ func TestSwitchCommandSupportsSidebarUI(t *testing.T) {
 	if got, want := gotRunnerOptions.PreviewCommand, ""; got != want {
 		t.Fatalf("runner preview command = %q, want deferred preview", got)
 	}
-	if got, want := gotRunnerOptions.PreviewWindow, ""; got != want {
-		t.Fatalf("runner preview window = %q, want deferred preview", got)
+	if got, want := gotRunnerOptions.PreviewWindow, "down,25%,border-top"; got != want {
+		t.Fatalf("runner preview window = %q, want reserved deferred preview frame %q", got, want)
 	}
 	if got, want := gotRunnerOptions.Bindings, []string{
 		"esc:abort",
@@ -810,6 +810,9 @@ func TestSwitchCommandNativeSidebarDefersGitWindowsAttentionAndPreview(t *testin
 			}
 			if options.Preview.Command != "" {
 				t.Fatalf("preview command before first paint = %q, want deferred", options.Preview.Command)
+			}
+			if options.Preview.Window != "down,25%,border-top" {
+				t.Fatalf("preview window before first paint = %q, want reserved deferred preview frame", options.Preview.Window)
 			}
 			initialLabel := options.Items[0].EffectiveLabel()
 			if got, want := len(strings.Split(initialLabel, "\n")), 3; got != want {
@@ -1668,8 +1671,8 @@ func TestNewSwitchCommandUsesEnvAndDefaultPinStore(t *testing.T) {
 	if got, want := fakeRunner.last.PreviewCommand, ""; got != want {
 		t.Fatalf("runner preview command = %q, want deferred preview", got)
 	}
-	if got, want := fakeRunner.last.PreviewWindow, ""; got != want {
-		t.Fatalf("runner preview window = %q, want deferred preview", got)
+	if got, want := fakeRunner.last.PreviewWindow, "down,25%,border-top"; got != want {
+		t.Fatalf("runner preview window = %q, want reserved deferred preview frame %q", got, want)
 	}
 	if got, want := fakeRunner.last.Bindings, []string{
 		"esc:abort",

--- a/internal/ui/picker/backend.go
+++ b/internal/ui/picker/backend.go
@@ -1506,6 +1506,10 @@ func renderNativeInteractiveContent(w io.Writer, options Options, items []Item, 
 		previewLimit = previewHeight
 	}
 	previewLines := nativePreviewLines(options, items, selected, previewOffset, previewLimit)
+	reservePreview := nativeReservePreviewFrame(options, placement)
+	if reservePreview && len(previewLines) == 0 {
+		previewLines = nativeBlankPreviewLines(previewHeight)
+	}
 	listLimit := nativeListLimit(options, layout, placement, previewHeight, len(previewLines) > 0)
 	start, end := nativeVisibleRange(len(items), selected, listLimit)
 	if options.MultiLine {
@@ -1571,6 +1575,17 @@ func nativeListLimit(options Options, layout nativeLayout, previewPlacement stri
 		return 1
 	}
 	return available
+}
+
+func nativeReservePreviewFrame(options Options, placement string) bool {
+	return strings.TrimSpace(options.UI) == "sidebar" && placement == "down" && strings.TrimSpace(options.Preview.Window) != ""
+}
+
+func nativeBlankPreviewLines(height int) []string {
+	if height <= 0 {
+		return nil
+	}
+	return make([]string, height)
 }
 
 func nativeAppendPartialNextItemLines(items []Item, lines []string, next, selected, limit int) []string {

--- a/internal/ui/picker/backend_test.go
+++ b/internal/ui/picker/backend_test.go
@@ -1718,6 +1718,32 @@ func TestNativeInteractiveRendersPreviewOffset(t *testing.T) {
 	}
 }
 
+func TestNativeSidebarReservesBlankDownPreviewFrame(t *testing.T) {
+	t.Parallel()
+
+	items := []Item{{Title: "api", Value: "/repo/api"}}
+	options := Options{
+		UI:        "sidebar",
+		Preview:   Preview{Window: "down,25%,border-top"},
+		Items:     items,
+		MultiLine: true,
+	}
+	layout := nativeLayout{Rows: 16, Cols: 48}
+	previewHeight := nativePreviewHeight(layout.Rows, options.Preview.Window)
+	listLimit := nativeListLimit(options, layout, "down", previewHeight, true)
+
+	var out bytes.Buffer
+	renderNativeInteractiveContent(&out, options, items, "", 0, 0, 0, layout)
+
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	if got, want := len(lines), nativeChromeLineCount(options)+listLimit+1+previewHeight; got != want {
+		t.Fatalf("rendered line count = %d, want reserved preview frame height %d in %q", got, want, out.String())
+	}
+	if got := strings.Count(out.String(), projmuxpicker.SeparatorLine(layout.Cols)); got < 2 {
+		t.Fatalf("native output = %q, want search separator and reserved down-preview separator", out.String())
+	}
+}
+
 func TestLimitedNativePreviewLinesKeepsLimitWithOverflowNotice(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/render/switch.go
+++ b/internal/ui/render/switch.go
@@ -262,7 +262,7 @@ func formatSidebarSwitchWindowTabs(windows []SwitchWindowTab) string {
 		tabs = append(tabs, formatSidebarSwitchWindowTab(name, window.AttentionRank, window.Active))
 	}
 	for len(tabs) < switchSidebarTabSlots {
-		tabs = append(tabs, ansiTabInactive+strings.Repeat(" ", sidebarSwitchWindowTabWidth())+ansiReset)
+		tabs = append(tabs, formatSidebarBlankLane(sidebarSwitchWindowTabWidth()))
 	}
 	return strings.Join(tabs, " ")
 }
@@ -486,9 +486,16 @@ func formatSidebarBranchLane(candidate SwitchCandidate) string {
 		style = ansiStatusGitActive
 	}
 	if branch == "" {
-		return style + strings.Repeat(" ", switchBranchBadgeMax+2) + ansiReset
+		return formatSidebarBlankLane(switchBranchBadgeMax + 2)
 	}
 	return style + " " + padRight(branch, switchBranchBadgeMax) + " " + ansiReset
+}
+
+func formatSidebarBlankLane(width int) string {
+	if width <= 0 {
+		return ""
+	}
+	return ansiReset + strings.Repeat(" ", width) + ansiReset
 }
 
 func formatTagBadge(tagged bool) string {

--- a/internal/ui/render/switch_test.go
+++ b/internal/ui/render/switch_test.go
@@ -235,6 +235,9 @@ func TestBuildSwitchRowsSidebarCheapAndEnrichedGeometryIsStable(t *testing.T) {
 	if len(cheap.Item.MetaLines) != 0 || len(enriched.Item.MetaLines) != 0 {
 		t.Fatalf("sidebar meta lines cheap/enriched = %#v/%#v, want no extra rendered lines beyond the 3-line card", cheap.Item.MetaLines, enriched.Item.MetaLines)
 	}
+	if strings.Contains(cheapLines[1], "48;5;30m") || strings.Contains(cheapLines[2], "48;5;235m") {
+		t.Fatalf("cheap placeholder lanes must stay visually blank, got lines: %q", cheapLines)
+	}
 	for idx := range cheapLines {
 		if got, want := projmuxpicker.VisibleLen(enrichedLines[idx]), projmuxpicker.VisibleLen(cheapLines[idx]); got != want {
 			t.Fatalf("line %d width changed from %d to %d\ncheap:    %q\nenriched: %q", idx, want, got, cheapLines[idx], enrichedLines[idx])


### PR DESCRIPTION
## Summary
- keep Alt-1 sidebar 3-line card rows but reserve empty lanes as visually blank spaces, not inactive chips
- let branch/window chip UI appear only after delayed enrichment has real metadata
- reserve the sidebar down-preview frame before the preview command is available so list height and scrollbar do not jump when bottom info arrives

## Explicit scope
- Alt-1 project sidebar row and preview-frame stability only
- no Settings, notify sidebar, session popup, discovery, naming, or open/switch semantic changes

## Verification
- make fmt
- make fix
- go test ./internal/ui/render ./internal/app ./internal/ui/picker -run 'TestBuildSwitchRowsSidebar|TestSwitchCommand.*Sidebar|Test.*Switch.*Preview|Test.*Switch.*Git|TestNewSwitchCommandUsesEnvAndDefaultPinStore|TestNewSwitchCommandDoesNotInferRepoRootFromHomeSourceRepos|TestNativeSidebarReservesBlankDownPreviewFrame'
- make test
- make test-integration
- make test-e2e

## Risk
- delayed metadata still truncates to fixed lanes; this is intentional to keep row geometry stable.