### PR TITLE
fix: keep Alt-1 branch chip compact

### DIFF
--- a/internal/ui/render/switch.go
+++ b/internal/ui/render/switch.go
@@ -488,7 +488,7 @@ func formatSidebarBranchLane(candidate SwitchCandidate) string {
 	if branch == "" {
 		return formatSidebarBlankLane(switchBranchBadgeMax + 2)
 	}
-	return style + " " + padRight(branch, switchBranchBadgeMax) + " " + ansiReset
+	return style + " " + branch + " " + ansiReset + formatSidebarBlankLane(switchBranchBadgeMax-len([]rune(branch)))
 }
 
 func formatSidebarBlankLane(width int) string {

--- a/internal/ui/render/switch_test.go
+++ b/internal/ui/render/switch_test.go
@@ -238,6 +238,9 @@ func TestBuildSwitchRowsSidebarCheapAndEnrichedGeometryIsStable(t *testing.T) {
 	if strings.Contains(cheapLines[1], "48;5;30m") || strings.Contains(cheapLines[2], "48;5;235m") {
 		t.Fatalf("cheap placeholder lanes must stay visually blank, got lines: %q", cheapLines)
 	}
+	if strings.Contains(enrichedLines[1], "feature/long-...  ") {
+		t.Fatalf("enriched branch chip = %q, want chip background only around branch text", enrichedLines[1])
+	}
 	for idx := range cheapLines {
 		if got, want := projmuxpicker.VisibleLen(enrichedLines[idx]), projmuxpicker.VisibleLen(cheapLines[idx]); got != want {
 			t.Fatalf("line %d width changed from %d to %d\ncheap:    %q\nenriched: %q", idx, want, got, cheapLines[idx], enrichedLines[idx])


### PR DESCRIPTION
## Summary
- keep the Alt-1 sidebar branch lane width reserved for stable geometry
- render the branch chip background only around the actual branch text
- leave remaining reserved width as plain blank space

## Explicit scope
- Alt-1 project sidebar branch chip rendering only
- no discovery, naming, open/switch, preview, Settings, notify sidebar, or session popup changes

## Verification
- make fmt
- make fix
- go test ./internal/ui/render ./internal/app -run 'TestBuildSwitchRowsSidebar|TestSwitchCommand.*Sidebar|Test.*Switch.*Preview|Test.*Switch.*Git|TestNewSwitchCommandUsesEnvAndDefaultPinStore|TestNewSwitchCommandDoesNotInferRepoRootFromHomeSourceRepos'
- make test
- make test-integration
- make test-e2e