### PR TITLE
fix: reuse palette warning for AI badges

### DIFF
--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -967,6 +967,35 @@ func TestSwitchCommandSidebarAggregatesSemanticBadgePriority(t *testing.T) {
 	}
 }
 
+func TestSwitchCommandPopupRowsUseSemanticSessionBadge(t *testing.T) {
+	t.Parallel()
+
+	cmd := &switchCommand{
+		sessions: &capturingSwitchSessionExecutor{exists: map[string]bool{"tmp-app": true}},
+		inventory: &stubPreviewInventory{
+			windows: []corepreview.Window{{Index: "0", Name: "main", Active: true}},
+			panes: []corepreview.Pane{
+				{SessionName: "tmp-app", WindowIndex: "0", Title: "work", AIBadgeKind: aiBadgeKindInProgress},
+				{SessionName: "tmp-app", WindowIndex: "0", Title: "approve", AIBadgeKind: aiBadgeKindInputRequired},
+			},
+		},
+		identity: stubSwitchIdentityResolver{name: "tmp-app"},
+		pinStore: func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
+		homeDir:  func() (string, error) { return "/home/tester", nil },
+	}
+
+	rows, _, _, err := cmd.renderRows(context.Background(), switchUIPopup, []string{"/tmp/app"})
+	if err != nil {
+		t.Fatalf("renderRows() error = %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %#v, want one existing popup row", rows)
+	}
+	if !strings.Contains(rows[0].Label, "\x1b[38;5;214m●\x1b[0m") {
+		t.Fatalf("popup label = %q, want semantic prompt warning badge", rows[0].Label)
+	}
+}
+
 func TestSwitchCommandSidebarUsesContextSessionForInitialPosition(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/render/switch.go
+++ b/internal/ui/render/switch.go
@@ -18,9 +18,10 @@ const (
 	ansiGreen    = theme.ANSIStateExistingStart
 	ansiYellow   = theme.ANSIStatePinnedStart
 	ansiProgress = theme.ANSIStateProgressStart
-	ansiWarning  = "\x1b[38;5;214m"
 	ansiCyan     = theme.ANSIAccentSettingsStart
 )
+
+var ansiWarning = theme.ANSI256FgStart(theme.TmuxStateWarningFg)
 
 const (
 	ansiStatusPath        = theme.ANSISwitchPathStart


### PR DESCRIPTION
## Completed Phase

- Phase 1 — renderers + aggregation follow-up hardening after #371 merged the main Phase 1 implementation.

## User-facing Surface Changed

- switch row / popup row: adds focused coverage for semantic session badge priority in popup rows.
- sidebar/window-list/pane/topic behavior remains the Phase 1 behavior merged in #371.
- renderer color source: reuses the existing theme palette adapter for the warning badge instead of a raw ANSI literal; no display style behavior changes.

## Aggregate Priority

- The merged Phase 1 resolver applies approval_required / input_required > response_complete > in_progress > none.
- This follow-up keeps that priority unchanged and adds popup-row test coverage for input_required winning over in_progress.

## Explicitly Excluded

- No Phase 2 badge display style config, emoji/dot/off setting, or Settings UI.
- No Phase 3 theme token schema extension.
- No notify queue ack/focus redesign.
- No session-state restore model changes.
- No desktop notification urgency changes.
- No Antigravity/Gemini provider work.

## Existing Semantics Preserved

- @projmux_ai_badge_kind storage contract from Phase 0 is unchanged.
- Existing @projmux_ai_state, @projmux_attention_state, ack/focus clear behavior, click routing, notify queue severity, and desktop notification urgency are preserved.
- No-state placeholder behavior remains unchanged from #371.

## Verification

Full Phase 1 validation run before the rebase:

- go test ./internal/app -run 'TestAttention.*Window|TestAI.*Topic|Test.*Sidebar|Test.*Switch.*Attention|TestTmux.*Window'
- go test ./internal/ui -run 'Test.*Badge|Test.*Status' failed as expected because internal/ui has no Go files.
- go test ./internal/ui/render -run 'Test.*Badge|Test.*Status'
- go test ./internal/ui/... -run 'Test.*Badge|Test.*Status'
- rg -n "attention window|ai topic|ai_state|attention_state|ai_badge_kind|@projmux_ai_badge_kind" internal/app internal/ui docs/statusbar.md
- make fmt
- GOCACHE=/tmp/projmux-go-cache make fix
- GOCACHE=/tmp/projmux-go-cache make test
- GOCACHE=/tmp/projmux-go-cache make test-integration
- GOCACHE=/tmp/projmux-go-cache make test-e2e
- git diff --check main...HEAD

Post-rebase follow-up validation:

- go test ./internal/app -run 'TestSwitchCommandPopupRowsUseSemanticSessionBadge|TestSwitchCommandSidebarAggregatesSemanticBadgePriority'
- go test ./internal/ui/render -run 'Test.*Badge|Test.*Status'
- GOCACHE=/tmp/projmux-go-cache make test
- git diff --check origin/main..HEAD

## Unverified / Follow-up Phases

- Manual tmux visual smoke was not run.
- Phase 2 remains responsible for display style compatibility and user-selectable emoji/dot/off behavior.
- Phase 3 remains responsible for final theme token schema/docs hardening around status badge colors versus notify severity.