### PR TITLE
fix: preserve legacy attention window rows

### DIFF
--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -337,6 +337,9 @@ func (c *attentionCommand) windowAttentionRows(windowID string) []attentionWindo
 	if err != nil {
 		return nil
 	}
+	if len(rows) == 0 {
+		return c.legacyWindowAttentionRows(windowID)
+	}
 
 	out := make([]attentionWindowRow, 0, len(rows))
 	for _, fields := range rows {
@@ -345,6 +348,28 @@ func (c *attentionCommand) windowAttentionRows(windowID string) []attentionWindo
 			State:       fields[1],
 			AIState:     fields[2],
 			AIBadgeKind: fields[3],
+		})
+	}
+	return out
+}
+
+func (c *attentionCommand) legacyWindowAttentionRows(windowID string) []attentionWindowRow {
+	rows, err := intmux.NewRunner(c.runner).ListPanes(context.Background(), intmux.ListPanesOptions{
+		Target: windowID,
+		Formats: []string{
+			intmux.TmuxFormat("pane_title"),
+			intmux.PaneOptionFormat(attentionStateOption),
+		},
+	})
+	if err != nil {
+		return nil
+	}
+
+	out := make([]attentionWindowRow, 0, len(rows))
+	for _, fields := range rows {
+		out = append(out, attentionWindowRow{
+			Title: fields[0],
+			State: fields[1],
 		})
 	}
 	return out

--- a/internal/app/attention_test.go
+++ b/internal/app/attention_test.go
@@ -330,6 +330,25 @@ func TestAttentionWindowSemanticProgressOnlyUsesProgressBadge(t *testing.T) {
 	}
 }
 
+func TestAttentionWindowLegacyStubRowsStillRenderBadge(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingAttentionRunner{
+		outputs: map[string][]byte{
+			"tmux list-panes -t @6 -F #{pane_title}" + attentionListSeparator + "#{@projmux_attention_state}": []byte("plain" + attentionListSeparator + "\n✳ ready" + attentionListSeparator + "reply\n"),
+		},
+	}
+	cmd := &attentionCommand{runner: runner}
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"window", "@6"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got, want := stdout.String(), "#[fg="+tmuxStateSuccessFg+"]●"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
 func TestAttentionWindowFallsBackToBlank(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Fixes the Phase 1 attention-window verification failure where legacy two-field list-pane stubs parsed as no rows after adding the semantic ai_badge_kind field.
- Adds a narrow fallback read for attention window rows using the pre-Phase-1 pane_title + attention_state format only when the semantic read returns no rows.
- Adds regression coverage for the legacy stub shape so reply badges no longer collapse to the blank placeholder.

## Phase 1 Scope

- Keeps @projmux_ai_badge_kind unchanged.
- Keeps Phase 1 aggregate behavior for semantic rows unchanged.
- Preserves no-state blank placeholder behavior when both semantic and legacy reads return no rows.
- Does not touch Phase 2 display style settings, Phase 3 theme schema, notify urgency/severity, ack/focus, or session-state behavior.

## Verification

- go test ./internal/app -count=1 -run "TestAttention.*Window|TestAI.*Topic|Test.*Sidebar|Test.*Switch.*Attention|TestTmux.*Window"
- go test ./internal/app -count=1 -run "TestAttentionWindowLegacyStubRowsStillRenderBadge"