### PR TITLE
refactor: remove legacy keybinding fallback model

### DIFF
--- a/internal/app/keybinding_catalog.go
+++ b/internal/app/keybinding_catalog.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-const noUserSlot = -1
-
 type keyBindingScope string
 
 const (
@@ -59,8 +57,6 @@ type keyBindingAction struct {
 	PlainChord  string
 	PlainChords []string
 	PrefixChord string
-	UserSlot    int
-	CSIu        string
 
 	TmuxKind       tmuxBindingKind
 	TmuxBody       string
@@ -68,7 +64,6 @@ type keyBindingAction struct {
 	Toggleable     bool
 
 	PlainBindOrder  int
-	UserBindOrder   int
 	PrefixBindOrder int
 
 	GhosttyTrigger string
@@ -83,7 +78,6 @@ type keyBindingAction struct {
 	ProbeLabel  string
 	ProbeAction string
 	ProbePlain  string
-	ProbeCSIu   string
 }
 
 func defaultKeyBindingCatalog() []keyBindingAction {
@@ -98,7 +92,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Scope:           keyBindingScopeStandalone,
 			PlainChord:      "M-1",
 			PrefixChord:     "F",
-			UserSlot:        noUserSlot,
 			TmuxKind:        tmuxBindingPopupToggle,
 			TmuxBody:        "sessionizer-sidebar",
 			Toggleable:      true,
@@ -125,7 +118,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Tier:           keyBindingTierGuaranteedLaunchDefault,
 			Scope:          keyBindingScopeStandalone,
 			PlainChord:     "M-2",
-			UserSlot:       noUserSlot,
 			TmuxKind:       tmuxBindingPopupToggle,
 			TmuxBody:       "notify-sidebar",
 			Toggleable:     true,
@@ -152,7 +144,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Scope:           keyBindingScopeStandalone,
 			PlainChord:      "M-3",
 			PrefixChord:     "b",
-			UserSlot:        noUserSlot,
 			TmuxKind:        tmuxBindingPopupToggle,
 			TmuxBody:        "session-popup",
 			Toggleable:      true,
@@ -179,7 +170,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Tier:           keyBindingTierGuaranteedLaunchDefault,
 			Scope:          keyBindingScopeStandalone,
 			PlainChord:     "M-4",
-			UserSlot:       noUserSlot,
 			TmuxKind:       tmuxBindingPopupToggle,
 			TmuxBody:       "ai-split-picker-right",
 			Toggleable:     true,
@@ -205,7 +195,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Tier:           keyBindingTierGuaranteedLaunchDefault,
 			Scope:          keyBindingScopeStandalone,
 			PlainChord:     "M-5",
-			UserSlot:       noUserSlot,
 			TmuxKind:       tmuxBindingPopupToggle,
 			TmuxBody:       "ai-split-settings",
 			Toggleable:     true,
@@ -232,7 +221,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Scope:           keyBindingScopeStandalone,
 			PlainChord:      "",
 			PrefixChord:     "f",
-			UserSlot:        noUserSlot,
 			TmuxKind:        tmuxBindingPopupToggle,
 			TmuxBody:        "sessionizer",
 			Toggleable:      true,
@@ -251,7 +239,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Scope:           keyBindingScopeStandalone,
 			PlainChord:      "",
 			PrefixChord:     "R",
-			UserSlot:        noUserSlot,
 			TmuxKind:        tmuxBindingCommandPrompt,
 			TmuxBody:        "rename-window -- '%%'",
 			TmuxPromptArgs:  "-I \"#{window_name}\"",
@@ -268,7 +255,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Kind:           keyBindingActionCommand,
 			Tier:           keyBindingTierTransportDependent,
 			Scope:          keyBindingScopeStandalone,
-			UserSlot:       noUserSlot,
 			TmuxKind:       tmuxBindingCommandPrompt,
 			TmuxBody:       "select-pane -T '%1' \\; set-option -p " + aiPaneTopicOption + " '%1' \\; if-shell -F '#{==:#{" + aiPaneTopicOption + "},}' 'set-option -p -u " + aiPaneTopicManualOption + "' 'set-option -p " + aiPaneTopicManualOption + " 1'",
 			TmuxPromptArgs: "-p \"ai topic:\" -I \"#{pane_title}\"",
@@ -283,7 +269,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Tier:            keyBindingTierUserConfigurableDirect,
 			Scope:           keyBindingScopeStandalone,
 			PrefixChord:     "r",
-			UserSlot:        noUserSlot,
 			TmuxKind:        tmuxBindingRunProjmux,
 			TmuxBody:        "ai split right",
 			PrefixBindOrder: 50,
@@ -294,7 +279,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			ProbeOrder:      80,
 			ProbeLabel:      "Ctrl-Shift-R",
 			ProbeAction:     "No projmux binding by default",
-			ProbeCSIu:       "-",
 		},
 		{
 			ID:              "ai-split-down",
@@ -303,7 +287,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Tier:            keyBindingTierUserConfigurableDirect,
 			Scope:           keyBindingScopeStandalone,
 			PrefixChord:     "l",
-			UserSlot:        noUserSlot,
 			TmuxKind:        tmuxBindingRunProjmux,
 			TmuxBody:        "ai split down",
 			PrefixBindOrder: 60,
@@ -314,7 +297,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			ProbeOrder:      90,
 			ProbeLabel:      "Ctrl-Shift-L",
 			ProbeAction:     "No projmux binding by default",
-			ProbeCSIu:       "-",
 		},
 		{
 			ID:              "current-project-session",
@@ -323,7 +305,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Tier:            keyBindingTierUserConfigurableDirect,
 			Scope:           keyBindingScopeStandalone,
 			PrefixChord:     "g",
-			UserSlot:        noUserSlot,
 			TmuxKind:        tmuxBindingRunProjmux,
 			TmuxBody:        "current",
 			PrefixBindOrder: 40,
@@ -335,7 +316,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Tier:           keyBindingTierUserConfigurableDirect,
 			Scope:          keyBindingScopeApp,
 			PlainChord:     "",
-			UserSlot:       noUserSlot,
 			TmuxKind:       tmuxBindingCommand,
 			TmuxBody:       "new-window -c \"#{pane_current_path}\"",
 			PlainBindOrder: 50,
@@ -362,7 +342,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Tier:           keyBindingTierTransportDependent,
 			Scope:          keyBindingScopeApp,
 			PlainChord:     "M-S-Left",
-			UserSlot:       noUserSlot,
 			TmuxKind:       tmuxBindingCommand,
 			TmuxBody:       "previous-window",
 			PlainBindOrder: 60,
@@ -374,7 +353,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			ProbeLabel:     "Alt-Shift-Left",
 			ProbeAction:    "Previous window (M-S-Left)",
 			ProbePlain:     "\x1b[1;4D",
-			ProbeCSIu:      "-",
 		},
 		{
 			// See `previous-window` above — the same reasoning applies to the
@@ -385,7 +363,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Tier:           keyBindingTierTransportDependent,
 			Scope:          keyBindingScopeApp,
 			PlainChord:     "M-S-Right",
-			UserSlot:       noUserSlot,
 			TmuxKind:       tmuxBindingCommand,
 			TmuxBody:       "next-window",
 			PlainBindOrder: 70,
@@ -397,7 +374,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			ProbeLabel:     "Alt-Shift-Right",
 			ProbeAction:    "Next window (M-S-Right)",
 			ProbePlain:     "\x1b[1;4C",
-			ProbeCSIu:      "-",
 		},
 		{
 			ID:             "select-pane-left",
@@ -406,7 +382,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Tier:           keyBindingTierTransportDependent,
 			Scope:          keyBindingScopeApp,
 			PlainChord:     "M-Left",
-			UserSlot:       noUserSlot,
 			TmuxKind:       tmuxBindingCommand,
 			TmuxBody:       "select-pane -L",
 			PlainBindOrder: 10,
@@ -418,7 +393,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Tier:           keyBindingTierTransportDependent,
 			Scope:          keyBindingScopeApp,
 			PlainChord:     "M-Right",
-			UserSlot:       noUserSlot,
 			TmuxKind:       tmuxBindingCommand,
 			TmuxBody:       "select-pane -R",
 			PlainBindOrder: 20,
@@ -430,7 +404,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Tier:           keyBindingTierTransportDependent,
 			Scope:          keyBindingScopeApp,
 			PlainChord:     "M-Up",
-			UserSlot:       noUserSlot,
 			TmuxKind:       tmuxBindingCommand,
 			TmuxBody:       "select-pane -U",
 			PlainBindOrder: 30,
@@ -442,7 +415,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Tier:           keyBindingTierTransportDependent,
 			Scope:          keyBindingScopeApp,
 			PlainChord:     "M-Down",
-			UserSlot:       noUserSlot,
 			TmuxKind:       tmuxBindingCommand,
 			TmuxBody:       "select-pane -D",
 			PlainBindOrder: 40,
@@ -454,7 +426,6 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Tier:            keyBindingTierUserConfigurableDirect,
 			Scope:           keyBindingScopeApp,
 			PrefixChord:     "M",
-			UserSlot:        noUserSlot,
 			TmuxKind:        tmuxBindingCommand,
 			TmuxBody:        "if -F \"#{mouse}\" \"set -g mouse off \\; display-message 'tmux mouse: off'\" \"set -g mouse on \\; display-message 'tmux mouse: on'\"",
 			PrefixBindOrder: 10,
@@ -916,19 +887,11 @@ func probeKeysFromActions(catalog []keyBindingAction) []probeKey {
 
 	keys := make([]probeKey, 0, len(actions))
 	for _, action := range actions {
-		csiu := action.ProbeCSIu
-		if csiu == "" && action.CSIu != "" {
-			csiu = "\x1b[" + action.CSIu + "u"
-		}
-		if csiu == "-" {
-			csiu = ""
-		}
 		keys = append(keys, probeKey{
 			ActionID:   action.ID,
 			Label:      action.ProbeLabel,
 			Action:     action.ProbeAction,
 			Plain:      action.ProbePlain,
-			CSIu:       csiu,
 			PlainChord: firstNonEmptyString(keyBindingEffectivePlainChords(action)),
 		})
 	}

--- a/internal/app/setup.go
+++ b/internal/app/setup.go
@@ -66,12 +66,6 @@ type probeKey struct {
 	// (e.g. "\x1b1" for Alt-1). Empty means projmux does not have a
 	// direct plain bind for this key (Ctrl-Shift-{R,L}, etc).
 	Plain string
-	// CSIu is retained only for legacy/archive tests that exercise raw
-	// app-specific escape captures. It is no longer a success path.
-	CSIu string
-	// UserKey is retained only for older fixtures; product flows no longer
-	// surface tmux User keys.
-	UserKey string
 	// PlainChord is the current tmux plain chord for the action after keymap
 	// overrides have been merged. It is for reporting/saving, not raw bytes.
 	PlainChord string

--- a/internal/app/setup_test.go
+++ b/internal/app/setup_test.go
@@ -12,7 +12,7 @@ import (
 func TestClassifyProbeInput(t *testing.T) {
 	t.Parallel()
 
-	keyAlt1 := probeKey{Label: "Alt-1", Action: "Open sidebar", Plain: "\x1b1", CSIu: "\x1b[9900u"}
+	keyAlt1 := probeKey{Label: "Alt-1", Action: "Open sidebar", Plain: "\x1b1"}
 	keyCtrlShiftR := probeKey{Label: "Ctrl-Shift-R", Action: "No projmux binding by default"}
 
 	cases := []struct {
@@ -50,7 +50,7 @@ func TestClassifyProbeInput(t *testing.T) {
 func TestClassifyProbeInputDoesNotAliasInput(t *testing.T) {
 	t.Parallel()
 
-	key := probeKey{Label: "Alt-1", Plain: "\x1b1", CSIu: "\x1b[9900u"}
+	key := probeKey{Label: "Alt-1", Plain: "\x1b1"}
 	src := []byte("\x1b1")
 	res := classifyProbeInput(key, src)
 	src[0] = 'X'
@@ -62,7 +62,7 @@ func TestClassifyProbeInputDoesNotAliasInput(t *testing.T) {
 func TestRenderProbeStatusContainsSequence(t *testing.T) {
 	t.Parallel()
 
-	res := classifyProbeInput(probeKey{Label: "Alt-1", Plain: "\x1b1", CSIu: "\x1b[9900u"}, []byte("\x1b[9900u"))
+	res := classifyProbeInput(probeKey{Label: "Alt-1", Plain: "\x1b1"}, []byte("\x1b[9900u"))
 	rendered := renderProbeStatus(res)
 	if !strings.Contains(rendered, "MISS unknown") {
 		t.Fatalf("expected unknown marker, got %q", rendered)
@@ -362,7 +362,7 @@ func TestSetupCommandRunInteractivePropagatesReadError(t *testing.T) {
 	t.Parallel()
 
 	keys := []probeKey{
-		{Label: "Alt-1", Plain: "\x1b1", CSIu: "\x1b[9900u"},
+		{Label: "Alt-1", Plain: "\x1b1"},
 	}
 	cmd := newSetupCommand()
 	cmd.defaultKeys = keys
@@ -436,9 +436,17 @@ func TestDefaultProbeKeysCoverSpec(t *testing.T) {
 			t.Fatalf("default probe key[%d] = %q, want %q (full got=%v)", i, got[i], want[i], got)
 		}
 	}
-	for _, key := range keys {
-		if key.CSIu != "" || key.UserKey != "" {
-			t.Fatalf("default probe key %s has legacy escape/UserKey route: %#v", key.Label, key)
+	cmd := newSetupCommand()
+	cmd.defaultKeys = keys
+	cmd.lookupEnv = func(string) string { return "" }
+	var stdout, stderr bytes.Buffer
+	if err := cmd.Run([]string{"--non-interactive"}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run --non-interactive error = %v", err)
+	}
+	out := stdout.String()
+	for _, banned := range []string{"9900u", "User", "CSI-u"} {
+		if strings.Contains(out, banned) {
+			t.Fatalf("default probe key output should not include legacy route %q:\n%s", banned, out)
 		}
 	}
 }


### PR DESCRIPTION
## Completed Phase

Phase 3 — legacy CSI-u/User-key model 제거

## Code / Docs / Tests Surface

- Removed the legacy CSI-u/User-key catalog fields and sentinel from `internal/app/keybinding_catalog.go`: `noUserSlot`, `UserSlot`, `CSIu`, `UserBindOrder`, `ProbeCSIu`, and setup-probe CSI-u projection.
- Removed legacy `probeKey.CSIu` / `probeKey.UserKey` fields and comments from `internal/app/setup.go`.
- Updated setup tests so app-specific CSI-u raw input remains `MISS unknown`, default probes expose only plain delivery expectations, and `setup --non-interactive` does not print app escape/User-key expected routes.
- Audited docs and tests: remaining `UserN` / `CSI-u` / `User-key` references are unsupported/legacy boundary notes, negative generated-config assertions, native-parser parity context, or Windows Terminal `User.projmux*` JSON action IDs.

## Explicitly Excluded

- No new terminal adapters such as WezTerm, kitty, or iTerm2.
- No keymap-to-terminal projection and no terminal adapter rewrite from keymap data.
- No `keymap.toml` schema redesign.
- No Settings terminal mapping preview/apply/init row restoration.
- No native picker engine or generated app tmux runtime redesign.

## Preserved Model Constraints

- `Alt-1..5` guaranteed launch defaults remain unchanged.
- `keymap.toml` remains the generated tmux config input schema.
- `projmux setup` and `projmux init` CLI surfaces remain present.
- Ghostty and Windows Terminal init adapter behavior remains unchanged, including Windows Terminal `User.projmux*` action IDs.

## Verification

- `rg -n "CSIu|ProbeCSIu|UserKey|UserSlot|UserBindOrder|noUserSlot" internal/app`
- `rg -n "CSI-u|UserN|User-key|User key|app csi-u|fallback guidance|set -s user-keys" docs internal/app -S`
- `go test ./internal/app -count=1 -run 'Test(ClassifyProbeInput|RenderProbeStatus|SetupCommand|DefaultProbeKeys|Keymap|Shell|GhosttyInit|WindowsTerminal)'`
- `GOCACHE=/tmp/projmux-go-cache make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `GOCACHE=/tmp/projmux-go-cache go run ./cmd/projmux setup --non-interactive`
- `GOCACHE=/tmp/projmux-go-cache go run ./cmd/projmux tmux print-config | rg "set -s user-keys|bind-key -n User|9009u|9010u"` — no matches (exit 1 from `rg`).
- `git diff --check`

## Unverified / Follow-up

None locally. After CI passes and this PR merges, the roadmap item is a Done-move candidate because Phase 1, Phase 2, and Phase 3 criteria are complete.
