### PR TITLE
fix: gate focus osfocus by desktop notify mode

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -152,6 +152,10 @@ client is attached on that socket, it emits the configured desktop
 notification instead. `--socket` is explicit; when omitted, the socket is
 derived from `$TMUX`.
 
+After a successful tmux focus, `projmux focus` dispatches host-terminal
+osfocus only when Desktop notification mode is `raise`. Modes `off` /
+`none` and `notify` keep focus in tmux without a host-window raise.
+
 `--client` is a preferred origin tmux client. In-app consumers such as the
 status bar and notify sidebar pass the clicked client so focus redirects that
 display first. If that client is gone, focus falls back to an attached client

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -410,7 +410,9 @@ only a generic in-app queue/sidebar/statusbar row; it does not fire OS toast,
 The OS-level dispatch carries three modes. The in-app notify queue, the
 statusbar segment, and the attention badge stay live regardless of which
 mode is active — only the toast / notify-send / auto-raise fan-out is
-gated here.
+gated here. The same mode also gates `projmux focus` post-switch osfocus
+dispatch: only `raise` asks the host terminal to come forward after a
+successful tmux focus.
 
 | Mode | On push | On click |
 | --- | --- | --- |
@@ -422,7 +424,8 @@ Click activation is wired only for `raise`. The `projmux://` URI handler is
 registered on the first `raise` Notify of each tmux server (gated by the
 `@projmux_uri_protocol_registered_v6` marker). The
 mode only controls whether a toast fires at all and whether to follow it
-up with an on-push auto-raise.
+up with an on-push auto-raise. `off` / `none` and `notify` also suppress
+the focus-triggered osfocus raise after `projmux focus`.
 
 Resolution order (highest priority first):
 

--- a/docs/notify-queue.md
+++ b/docs/notify-queue.md
@@ -230,6 +230,8 @@ Outcomes:
 
 The same consume policy is shared by notify-sidebar Enter and OS
 click-to-focus Toast callbacks after a real tmux focus dispatch succeeds.
+OS Toast click-to-focus is only registered when Desktop notification mode is
+`raise`; the in-app sidebar/statusbar consume path works in every mode.
 Pane focus hooks and attention clear paths remain live-attention-only and do
 not ack the notify queue. Non-critical AI completion producers also compact
 older same-pane non-critical AI rows after replacing/pushing their latest row,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -117,12 +117,15 @@ Observe:
   `"reason":"no-attached-client"`.
 - Windows shows a short projmux toast with `session ready:
   projmux-host-smoke`.
+- In `notify` mode, the toast has no click-to-focus action and should not
+  auto-raise the host terminal.
 - No visible PowerShell or console window remains open after the toast.
 
 If the PR changes click-to-focus behavior, repeat with
 `PROJMUX_DESKTOP_NOTIFY_MODE=raise`, click the toast, and record whether the
-host terminal returns to the target. Otherwise leave click callbacks marked as
-manual/not run.
+host terminal returns to the target. `raise` should also be the only mode where
+`projmux focus` performs post-switch osfocus. Otherwise leave click callbacks
+marked as manual/not run.
 
 ### macOS GUI Notification
 

--- a/internal/app/focus.go
+++ b/internal/app/focus.go
@@ -40,6 +40,7 @@ type focusNotifier interface {
 type focusCommand struct {
 	runner        focusCommandRunner
 	lookupEnv     func(string) string
+	homeDir       func() (string, error)
 	stdout        io.Writer
 	stderr        io.Writer
 	notifierOnce  func(stderr io.Writer) focusNotifier
@@ -80,6 +81,7 @@ func newFocusCommand() *focusCommand {
 	return &focusCommand{
 		runner:        focusExecRunner{},
 		lookupEnv:     os.Getenv,
+		homeDir:       os.UserHomeDir,
 		notifyStoreFn: defaultStatusNotifyStore,
 		notifierOnce: func(stderr io.Writer) focusNotifier {
 			// Reuse the existing notifier chain (WSL toast, notify-send, hook).

--- a/internal/app/osfocus.go
+++ b/internal/app/osfocus.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"context"
+	"strings"
+
 	"github.com/crevissepartners/projmux/internal/core/focus"
 	"github.com/crevissepartners/projmux/internal/integrations/osfocus"
 )
@@ -32,6 +35,9 @@ func defaultOSFocusChain() osFocusDispatcher {
 // detects (the common case until the user is on a measured terminal × OS
 // combo), this is a no-op.
 func (c *focusCommand) dispatchOSFocus(target focus.Target, socket string) {
+	if c.desktopNotifyMode(socket) != desktopNotifyModeRaise {
+		return
+	}
 	chain := c.osFocusChain
 	if chain == nil {
 		chain = defaultOSFocusChain()
@@ -42,4 +48,33 @@ func (c *focusCommand) dispatchOSFocus(target focus.Target, socket string) {
 		Window:  target.WindowSelector(),
 		Pane:    target.PaneSelector(),
 	})
+}
+
+func (c *focusCommand) desktopNotifyMode(socket string) desktopNotifyMode {
+	lookupEnv := c.lookupEnv
+	resolver := desktopNotifyResolver{
+		lookupEnv: lookupEnv,
+		readConfigMode: func() (desktopNotifyMode, bool) {
+			return loadSavedDesktopNotifyMode(c.homeDir, lookupEnv)
+		},
+		readTmuxOption: func(name string) string {
+			if c.runner == nil {
+				return ""
+			}
+			if strings.TrimSpace(socket) == "" {
+				if lookupEnv == nil || strings.TrimSpace(lookupEnv("TMUX")) == "" {
+					return ""
+				}
+			}
+			out, err := c.runner.Run(context.Background(), "tmux", c.tmuxArgs(socket, "show-options", "-gqv", name)...)
+			if err != nil {
+				return ""
+			}
+			return strings.TrimSpace(string(out))
+		},
+		isWSL:     lookupEnv != nil && strings.TrimSpace(lookupEnv("WSL_DISTRO_NAME")) != "",
+		wtPresent: lookupEnv != nil && strings.TrimSpace(lookupEnv("WT_SESSION")) != "",
+	}
+	mode, _ := resolver.resolveMode()
+	return mode
 }

--- a/internal/app/osfocus_test.go
+++ b/internal/app/osfocus_test.go
@@ -30,7 +30,7 @@ func (f *fakeOSFocusChain) snapshot() []osfocus.Target {
 	return append([]osfocus.Target(nil), f.calls...)
 }
 
-func TestFocus_DispatchesOSFocusOnSuccess(t *testing.T) {
+func TestFocus_DispatchesOSFocusOnSuccessWhenDesktopNotifyRaise(t *testing.T) {
 	t.Parallel()
 
 	listSessions := []byte("100\tworkspace\t1\n")
@@ -48,7 +48,7 @@ func TestFocus_DispatchesOSFocusOnSuccess(t *testing.T) {
 		},
 	}
 	chain := &fakeOSFocusChain{}
-	cmd := newFocusTestCommand(runner, nil, nil)
+	cmd := newFocusTestCommand(runner, map[string]string{desktopNotifyModeEnv: "raise"}, nil)
 	cmd.osFocusChain = chain
 
 	stdout := &bytes.Buffer{}
@@ -73,6 +73,51 @@ func TestFocus_DispatchesOSFocusOnSuccess(t *testing.T) {
 	}
 }
 
+func TestFocus_DoesNotDispatchOSFocusWhenDesktopNotifyModeIsNotRaise(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		mode string
+	}{
+		{name: "off", mode: "off"},
+		{name: "none", mode: "none"},
+		{name: "notify", mode: "notify"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			listSessions := []byte("100\tworkspace\t1\n")
+			listClients := []byte("/dev/pts/0\tworkspace\n")
+
+			runner := &focusFakeRunner{
+				respond: func(args []string) ([]byte, error) {
+					switch {
+					case containsArg(args, "list-sessions"):
+						return listSessions, nil
+					case containsArg(args, "list-clients"):
+						return listClients, nil
+					}
+					return nil, nil
+				},
+			}
+			chain := &fakeOSFocusChain{}
+			cmd := newFocusTestCommand(runner, map[string]string{desktopNotifyModeEnv: tc.mode}, nil)
+			cmd.osFocusChain = chain
+
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			if err := cmd.Run([]string{"--target", "workspace:1.0"}, stdout, stderr); err != nil {
+				t.Fatalf("Run returned error: %v (stderr=%s)", err, stderr.String())
+			}
+
+			if calls := chain.snapshot(); len(calls) != 0 {
+				t.Fatalf("expected no os-focus dispatch in mode %q, got %v", tc.mode, calls)
+			}
+		})
+	}
+}
+
 func TestFocus_DoesNotDispatchOSFocusWhenNoClientAttached(t *testing.T) {
 	t.Parallel()
 
@@ -94,7 +139,7 @@ func TestFocus_DoesNotDispatchOSFocusWhenNoClientAttached(t *testing.T) {
 	}
 	notifier := &focusFakeNotifier{}
 	chain := &fakeOSFocusChain{}
-	cmd := newFocusTestCommand(runner, nil, notifier)
+	cmd := newFocusTestCommand(runner, map[string]string{desktopNotifyModeEnv: "raise"}, notifier)
 	cmd.osFocusChain = chain
 
 	stdout := &bytes.Buffer{}
@@ -124,7 +169,7 @@ func TestFocus_DoesNotDispatchOSFocusOnUnresolvedSession(t *testing.T) {
 		},
 	}
 	chain := &fakeOSFocusChain{}
-	cmd := newFocusTestCommand(runner, nil, nil)
+	cmd := newFocusTestCommand(runner, map[string]string{desktopNotifyModeEnv: "raise"}, nil)
 	cmd.osFocusChain = chain
 
 	stdout := &bytes.Buffer{}


### PR DESCRIPTION
## Completed Phase

Phase 0 — mode semantics and focus gate alignment

## User-facing semantics

- `Desktop notifications = off` / `none`: in-app notifications only. No OS toast / notify-send, no notification push auto-raise, no toast click-to-focus, and no focus-triggered `osfocus` after `projmux focus`.
- `Desktop notifications = notify`: OS notification only. Toast / notify-send may appear, but click action and all auto-raise paths stay disabled.
- `Desktop notifications = raise`: OS notification plus notification push auto-raise, toast click-to-focus, and focus-triggered `osfocus` after successful tmux focus.

## Focus gate change

`projmux focus` now resolves the existing desktop notification mode cascade and dispatches post-switch `osfocus` only when the effective mode is `raise`. The existing notification push gate remains intact.

## Preserved behavior

The in-app notify queue, statusbar notify segment, Alt-2 notify sidebar, and attention badge remain active in all three modes.

## Explicitly out of scope

- No new OS focus adapter was added.
- The Windows Terminal `osfocus` adapter was not redesigned.
- Notify queue schema was not changed.
- `PROJMUX_NOTIFY_HOOK` semantics were not changed.

## Validation

- `go test ./internal/app -run 'Test.*DesktopNotify|Test.*Focus.*OSFocus|Test.*Notify.*Raise|Test.*Notification.*Mode'`
- `go test ./internal/integrations/osfocus/...`
- `rg -n "Desktop notification mode|auto-raise|click-to-focus|focus-triggered|osfocus" docs`
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
- `git diff --check`

## Unverified

- Manual WSL toast click / host-window smoke was not run.
