### PR TITLE
feat(ai): add antigravity notify ingest

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -129,9 +129,9 @@ with `--json`. Doctor does not diagnose terminal key delivery; use `projmux
 setup` for that.
 
 `Settings > Notifications > Delivery sources` shows active Codex hooks, Claude,
-and tmux statuses, conflicts, config paths, and copyable AI integration
-install/remove/dry-run commands. Settings does not install or remove external
-Codex, Claude, or tmux notify wiring.
+Antigravity manual hook ingest, and tmux statuses, conflicts, config paths, and
+copyable AI integration commands where available. Settings does not install or
+remove external Codex, Claude, Antigravity, or tmux notify wiring.
 
 ## focus
 
@@ -333,6 +333,7 @@ projmux ai notify   <reset|notify> [--pane <id>]
 projmux ai watch-title [--pane <id>]
 projmux ai ingest   codex-hook < payload.json
 projmux ai ingest   claude-hook < payload.json
+projmux ai ingest   antigravity-hook < payload.json
 projmux ai ingest   bell --pane <pane_id>
 projmux ai ingest   log [--tail N] [--json] [--path]
 projmux ai integrate codex [--dry-run] [--remove]
@@ -429,6 +430,25 @@ Runtime action overrides from
 precedence over catalog `action` for known Claude events too; for example a
 noisy notify event can be made state-only or quiet without changing installed
 Claude hook commands.
+
+`ingest antigravity-hook` is the manual hook/statusline entrypoint for
+Antigravity CLI `agy` payloads observed in the Phase 0b smoke. Projmux does not
+provide `projmux ai integrate antigravity`, does not install Antigravity hooks,
+and does not mutate Antigravity user config. If users wire Antigravity manually,
+the hook/statusline command should call an absolute `projmux` path or run from a
+known cwd because relative command paths failed smoke.
+
+The default known Antigravity catalog is intentionally narrow:
+`PostInvocation` is quiet/log-only, `Stop` is notify, and `Statusline` is notify
+only when manually wired and `tool_confirmation_pending=true`. `Stop` with
+`error` or a non-normal `terminationReason` pushes a critical error row; `Stop`
+without those error signals pushes an info completion row. Accepted identity
+fields include `conversationId`/`conversation_id`, `cwd` or `workspace.path`,
+`transcriptPath`, `fullyIdle`, `agent_state`, and `context_window`.
+Antigravity notify metadata uses `agent=antigravity`. Phase 3 session-state
+restore and usage/quota HUD support are not included; Antigravity ingest stores
+`conversationId` as pane thread metadata for matching, does not write resume
+metadata, and does not read transcript contents.
 
 `ingest bell --pane <pane_id>` is the narrow tmux-bell fallback ingest path.
 It does not require the pane to be AI-managed. Projmux resolves session,

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -606,6 +606,36 @@ Codex and are managed from `Settings > Notifications > Hook quiet policy`.
 They only affect ingest delivery; `projmux ai integrate claude` still uses the
 catalog `install` field for installed hook events.
 
+## Antigravity Hook Ingest
+
+`projmux ai ingest antigravity-hook < payload.json` is available for manual
+Antigravity CLI `agy` hook/statusline payloads. Projmux does not provide
+`projmux ai integrate antigravity`, does not install Antigravity hooks, and
+does not mutate Antigravity user config. The Delivery sources diagnostic
+therefore reports Antigravity as a read-only unsupported/manual row. If users
+wire it by hand, use an absolute `projmux` command path or a known cwd because
+relative command paths failed the Phase 0b smoke.
+
+The default known Antigravity catalog records only observed Phase 0b signals
+and marks them `install: false`:
+
+| Event/signal | Behavior |
+| --- | --- |
+| `PostInvocation` | marks the matched pane hook-active and writes a quiet ingest diagnostic; no notify queue entry is pushed |
+| `Stop` | pushes a completion row, or a critical error row when `error` is present or `terminationReason` is non-normal |
+| `Statusline` with `tool_confirmation_pending=true` | pushes a critical approval row; this is only active when a statusline/manual status payload is wired to ingest |
+| `Statusline` without `tool_confirmation_pending=true` | marks the matched pane hook-active and writes a quiet ingest diagnostic |
+| unknown events | mark the matched pane hook-active and write quiet ingest diagnostics only |
+
+Antigravity notify rows use `agent=antigravity` metadata. Accepted fields
+include `conversationId`/`conversation_id`, `cwd`, `workspace.path`,
+`transcriptPath`, `terminationReason`, `error`, `fullyIdle`, `agent_state`,
+`context_window`, and nested `statusline.tool_confirmation_pending`.
+Antigravity ingest uses `conversationId` as pane thread metadata for matching
+and does not write resume/session-state metadata. Phase 3 session-state restore
+and usage/quota HUD support are not included, and raw payloads or transcript
+contents are not stored.
+
 ## Ingest Debug Log
 
 Every `projmux ai ingest ...` path appends compact JSONL diagnostics to

--- a/docs/notify-queue.md
+++ b/docs/notify-queue.md
@@ -58,11 +58,15 @@ exit code 2.
 routing/debug context such as `agent`, `thread_id`, `turn_id`, `cwd`,
 `model`, and `client`; Claude hook rows also carry event-specific keys such as
 `tool_name`, `tool_input.command`, `error_type`, `subagent_type`, and
-`teammate_name`. Tmux bell fallback rows carry `agent=bell`, `event=bell`,
-and tmux target context such as pane title, command, session, window, pane, and
-socket. `notify list --json` includes this metadata as the structured data
-channel while human table/sidebar output keeps the compact text body. Existing
-entries without metadata remain valid.
+`teammate_name`. Antigravity manual hook rows carry `agent=antigravity`,
+`conversation_id`, `termination_reason`, `fully_idle`,
+`tool_confirmation_pending`, `agent_state`, and `context_window` when present;
+Phase 3 session-state restore and usage/quota HUD support are not included.
+Tmux bell fallback rows carry `agent=bell`, `event=bell`, and tmux target
+context such as pane title, command, session, window, pane, and socket.
+`notify list --json` includes this metadata as the structured data channel
+while human table/sidebar output keeps the compact text body. Existing entries
+without metadata remain valid.
 
 ## CLI surface
 

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -3471,6 +3471,7 @@ func printAIUsage(w io.Writer) {
 	fmt.Fprintln(w, "  projmux ai watch-title [pane]")
 	fmt.Fprintln(w, "  projmux ai ingest codex-hook < payload.json")
 	fmt.Fprintln(w, "  projmux ai ingest claude-hook < payload.json")
+	fmt.Fprintln(w, "  projmux ai ingest antigravity-hook < payload.json")
 	fmt.Fprintln(w, "  projmux ai ingest bell --pane <pane_id>")
 	fmt.Fprintln(w, "  projmux ai ingest log [--tail N] [--json] [--path]")
 	fmt.Fprintln(w, "  projmux ai integrate codex [--dry-run] [--remove]")

--- a/internal/app/ai_hook_catalog.go
+++ b/internal/app/ai_hook_catalog.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	aiHookProviderClaude = "claude"
-	aiHookProviderCodex  = "codex"
+	aiHookProviderClaude      = "claude"
+	aiHookProviderCodex       = "codex"
+	aiHookProviderAntigravity = "antigravity"
 
 	aiHookActionNotify = "notify"
 	aiHookActionQuiet  = "quiet"
@@ -24,6 +25,9 @@ var defaultClaudeHookCatalogJSON string
 
 //go:embed ai_hook_catalogs/codex.json
 var defaultCodexHookCatalogJSON string
+
+//go:embed ai_hook_catalogs/antigravity.json
+var defaultAntigravityHookCatalogJSON string
 
 type aiHookCatalog struct {
 	Provider        string               `json:"provider"`
@@ -127,6 +131,8 @@ func defaultAIHookCatalog(provider string) (aiHookCatalog, error) {
 		raw = defaultClaudeHookCatalogJSON
 	case aiHookProviderCodex:
 		raw = defaultCodexHookCatalogJSON
+	case aiHookProviderAntigravity:
+		raw = defaultAntigravityHookCatalogJSON
 	default:
 		return aiHookCatalog{}, fmt.Errorf("unknown AI hook catalog provider %q", provider)
 	}

--- a/internal/app/ai_hook_catalogs/antigravity.json
+++ b/internal/app/ai_hook_catalogs/antigravity.json
@@ -1,0 +1,9 @@
+{
+  "provider": "antigravity",
+  "observed_version": "Antigravity CLI agy Phase 0b smoke",
+  "events": [
+    { "name": "PostInvocation", "install": false, "action": "quiet" },
+    { "name": "Stop", "install": false, "action": "notify" },
+    { "name": "Statusline", "install": false, "action": "notify" }
+  ]
+}

--- a/internal/app/ai_ingest.go
+++ b/internal/app/ai_ingest.go
@@ -107,6 +107,21 @@ type claudeHookPayload struct {
 	TeammateContext  string
 }
 
+type antigravityHookPayload struct {
+	EventName                  string
+	CWD                        string
+	ConversationID             string
+	TranscriptPath             string
+	TerminationReason          string
+	Error                      string
+	FullyIdle                  bool
+	FullyIdleSet               bool
+	ToolConfirmationPending    bool
+	ToolConfirmationPendingSet bool
+	AgentState                 string
+	ContextWindow              string
+}
+
 func (c *aiCommand) runIngest(args []string, stdout, stderr io.Writer) error {
 	if len(args) < 1 {
 		printAIUsage(stderr)
@@ -147,6 +162,23 @@ func (c *aiCommand) runIngest(args []string, stdout, stderr io.Writer) error {
 			return errors.New("claude hook payload exceeds 1 MiB")
 		}
 		return c.ingestClaudeHook(data)
+	case "antigravity-hook":
+		if len(args) != 1 {
+			printAIUsage(stderr)
+			return errors.New("ai ingest antigravity-hook reads JSON from stdin and accepts no payload arguments")
+		}
+		reader := c.stdin
+		if reader == nil {
+			reader = os.Stdin
+		}
+		data, err := io.ReadAll(io.LimitReader(reader, 1024*1024+1))
+		if err != nil {
+			return fmt.Errorf("read antigravity hook payload: %w", err)
+		}
+		if len(data) > 1024*1024 {
+			return errors.New("antigravity hook payload exceeds 1 MiB")
+		}
+		return c.ingestAntigravityHook(data)
 	case "bell":
 		return c.runIngestBell(args[1:], stderr)
 	case "log":
@@ -733,6 +765,108 @@ func (c *aiCommand) ingestClaudeHook(data []byte) error {
 	}
 }
 
+func (c *aiCommand) ingestAntigravityHook(data []byte) error {
+	payload, err := parseAntigravityHookPayload(data)
+	if err != nil {
+		c.appendAIIngestLog(aiIngestLogEntry{Source: "antigravity-hook", Result: "error", Reason: err.Error()})
+		return err
+	}
+
+	paneID := c.matchAIPane(aiPaneMatchInput{
+		CWD:      payload.CWD,
+		ThreadID: payload.ConversationID,
+	})
+	if paneID == "" {
+		c.appendAIIngestLog(aiIngestLogEntry{Source: "antigravity-hook", Event: payload.EventName, Result: "ignored", Reason: "no matching pane", CWD: payload.CWD, ThreadID: payload.ConversationID})
+		return nil
+	}
+
+	c.markAIHookPane(paneID, aiModeAntigravity, payload.CWD, payload.ConversationID, "", payload.TranscriptPath)
+	metadata := payload.antigravityMetadata()
+	action := c.aiHookEffectiveAction(aiHookProviderAntigravity, payload.EventName)
+
+	switch payload.EventName {
+	case "Stop":
+		if action.Action == aiHookActionQuiet {
+			c.quietAntigravityHook(paneID, payload, aiHookQuietReason(action))
+			return nil
+		}
+		body := formatAntigravityStopNotifyBody(payload)
+		if action.Action == aiHookActionState {
+			if err := c.applyAIStatusStateOnly("waiting", paneID, attentionNotifyInput{
+				ID:        antigravityNotifyID(payload, "stop"),
+				Text:      body.Text,
+				Severity:  body.Severity,
+				Metadata:  mergeAINotifyBodyMetadata(metadata, body),
+				Force:     true,
+				BadgeKind: aiBadgeKindForNotifyCategory(body.Category),
+			}); err != nil {
+				c.appendAIIngestLog(aiIngestLogEntry{Source: "antigravity-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, ThreadID: payload.ConversationID})
+				return err
+			}
+			c.appendAIIngestLog(aiIngestLogEntry{Source: "antigravity-hook", Event: payload.EventName, Result: "state", Reason: aiHookStateReason(action), Pane: paneID, CWD: payload.CWD, ThreadID: payload.ConversationID})
+			return nil
+		}
+		if err := c.applyAIStatusWithNotify("waiting", paneID, attentionNotifyInput{
+			ID:        antigravityNotifyID(payload, "stop"),
+			Text:      body.Text,
+			Severity:  body.Severity,
+			Metadata:  mergeAINotifyBodyMetadata(metadata, body),
+			Force:     true,
+			BadgeKind: aiBadgeKindForNotifyCategory(body.Category),
+		}); err != nil {
+			c.appendAIIngestLog(aiIngestLogEntry{Source: "antigravity-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, ThreadID: payload.ConversationID})
+			return err
+		}
+		c.appendAIIngestLog(aiIngestLogEntry{Source: "antigravity-hook", Event: payload.EventName, Result: "notify", Pane: paneID, CWD: payload.CWD, ThreadID: payload.ConversationID})
+		return nil
+	case "Statusline":
+		if !payload.ToolConfirmationPending {
+			c.quietAntigravityHook(paneID, payload, "statusline has no pending tool confirmation")
+			return nil
+		}
+		if action.Action == aiHookActionQuiet {
+			c.quietAntigravityHook(paneID, payload, aiHookQuietReason(action))
+			return nil
+		}
+		body := formatAntigravityApprovalNotifyBody(payload)
+		if action.Action == aiHookActionState {
+			if err := c.applyAIStatusStateOnly("waiting", paneID, attentionNotifyInput{
+				ID:        antigravityNotifyID(payload, "approval"),
+				Text:      body.Text,
+				Severity:  body.Severity,
+				Metadata:  mergeAINotifyBodyMetadata(metadata, body),
+				Force:     true,
+				BadgeKind: aiBadgeKindApprovalRequired,
+			}); err != nil {
+				c.appendAIIngestLog(aiIngestLogEntry{Source: "antigravity-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, ThreadID: payload.ConversationID})
+				return err
+			}
+			c.appendAIIngestLog(aiIngestLogEntry{Source: "antigravity-hook", Event: payload.EventName, Result: "state", Reason: aiHookStateReason(action), Pane: paneID, CWD: payload.CWD, ThreadID: payload.ConversationID})
+			return nil
+		}
+		if err := c.applyAIStatusWithNotify("waiting", paneID, attentionNotifyInput{
+			ID:        antigravityNotifyID(payload, "approval"),
+			Text:      body.Text,
+			Severity:  body.Severity,
+			Metadata:  mergeAINotifyBodyMetadata(metadata, body),
+			Force:     true,
+			BadgeKind: aiBadgeKindApprovalRequired,
+		}); err != nil {
+			c.appendAIIngestLog(aiIngestLogEntry{Source: "antigravity-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, CWD: payload.CWD, ThreadID: payload.ConversationID})
+			return err
+		}
+		c.appendAIIngestLog(aiIngestLogEntry{Source: "antigravity-hook", Event: payload.EventName, Result: "notify", Pane: paneID, CWD: payload.CWD, ThreadID: payload.ConversationID})
+		return nil
+	case "PostInvocation":
+		c.quietAntigravityHook(paneID, payload, aiHookNoHandlerReason(action))
+		return nil
+	default:
+		c.quietAntigravityHook(paneID, payload, aiHookNoHandlerReason(action))
+		return nil
+	}
+}
+
 func (c *aiCommand) quietCodexHook(paneID string, payload codexHookPayload, reason string) {
 	c.markAIHookPane(paneID, aiModeCodex, payload.CWD, payload.matchThreadID(), payload.SessionID, "")
 	c.appendAIIngestLog(aiIngestLogEntry{Source: "codex-hook", Event: payload.EventName, Result: "quiet", Reason: reason, Pane: paneID, CWD: payload.CWD, ThreadID: payload.matchThreadID(), SessionID: payload.SessionID, TurnID: payload.TurnID})
@@ -758,6 +892,11 @@ func (c *aiCommand) pushGenericCodexHookNotify(paneID string, payload codexHookP
 func (c *aiCommand) quietClaudeHook(paneID string, payload claudeHookPayload, reason string) {
 	c.markAIHookPane(paneID, aiModeClaude, payload.CWD, "", payload.SessionID, payload.TranscriptPath)
 	c.appendAIIngestLog(aiIngestLogEntry{Source: "claude-hook", Event: payload.EventName, Result: "quiet", Reason: reason, Pane: paneID, CWD: payload.CWD, SessionID: payload.SessionID})
+}
+
+func (c *aiCommand) quietAntigravityHook(paneID string, payload antigravityHookPayload, reason string) {
+	c.markAIHookPane(paneID, aiModeAntigravity, payload.CWD, payload.ConversationID, "", payload.TranscriptPath)
+	c.appendAIIngestLog(aiIngestLogEntry{Source: "antigravity-hook", Event: payload.EventName, Result: "quiet", Reason: reason, Pane: paneID, CWD: payload.CWD, ThreadID: payload.ConversationID})
 }
 
 func (c *aiCommand) aiHookFallbackReason(provider, event string) string {
@@ -987,6 +1126,78 @@ func parseClaudeHookPayload(data []byte) (claudeHookPayload, error) {
 	return payload, nil
 }
 
+func parseAntigravityHookPayload(data []byte) (antigravityHookPayload, error) {
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return antigravityHookPayload{}, fmt.Errorf("parse antigravity hook payload: %w", err)
+	}
+	eventName := firstString(raw, "hook_event_name", "event_name", "eventName", "event", "type")
+	payload := antigravityHookPayload{
+		EventName:         eventName,
+		CWD:               firstString(raw, "cwd", "workspace", "project_dir", "projectDir"),
+		ConversationID:    firstString(raw, "conversation_id", "conversationId", "session_id", "sessionId"),
+		TranscriptPath:    firstString(raw, "transcript_path", "transcriptPath"),
+		TerminationReason: firstString(raw, "termination_reason", "terminationReason"),
+		Error:             antigravityErrorString(raw["error"]),
+		AgentState:        firstString(raw, "agent_state", "agentState"),
+		ContextWindow:     stringFromAny(firstAny(raw, "context_window", "contextWindow")),
+	}
+	if payload.CWD == "" {
+		payload.CWD = firstNestedString(raw["workspace"], "cwd", "path")
+	}
+	if payload.TranscriptPath == "" {
+		payload.TranscriptPath = firstNestedString(raw["transcript"], "path", "transcriptPath")
+	}
+	statusline := firstAny(raw, "statusline", "status_line", "statusLine", "status")
+	if payload.AgentState == "" {
+		payload.AgentState = firstNestedString(statusline, "agent_state", "agentState")
+	}
+	if payload.ContextWindow == "" {
+		payload.ContextWindow = stringFromAny(firstNestedAny(statusline, "context_window", "contextWindow"))
+	}
+	if value, ok := firstBool(raw, "fully_idle", "fullyIdle"); ok {
+		payload.FullyIdle = value
+		payload.FullyIdleSet = true
+	}
+	if value, ok := firstBool(raw, "tool_confirmation_pending", "toolConfirmationPending"); ok {
+		payload.ToolConfirmationPending = value
+		payload.ToolConfirmationPendingSet = true
+	}
+	if value, ok := firstNestedBool(statusline, "tool_confirmation_pending", "toolConfirmationPending"); ok {
+		payload.ToolConfirmationPending = value
+		payload.ToolConfirmationPendingSet = true
+	}
+	payload.EventName = normalizeAntigravityEventName(payload.EventName)
+	if payload.EventName == "" && antigravityStatuslineShapedPayload(statusline, payload) {
+		payload.EventName = "Statusline"
+	}
+	if payload.EventName == "" {
+		payload.EventName = "Unknown"
+	}
+	return payload, nil
+}
+
+func antigravityStatuslineShapedPayload(statusline any, payload antigravityHookPayload) bool {
+	return statusline != nil ||
+		strings.TrimSpace(payload.AgentState) != "" ||
+		strings.TrimSpace(payload.ContextWindow) != "" ||
+		payload.ToolConfirmationPendingSet
+}
+
+func normalizeAntigravityEventName(name string) string {
+	trimmed := strings.TrimSpace(name)
+	switch strings.ToLower(strings.ReplaceAll(trimmed, "_", "")) {
+	case "postinvocation":
+		return "PostInvocation"
+	case "stop":
+		return "Stop"
+	case "statusline", "status":
+		return "Statusline"
+	default:
+		return trimmed
+	}
+}
+
 func (p codexHookPayload) codexHookMetadata() map[string]string {
 	metadata := map[string]string{
 		"agent":           aiModeCodex,
@@ -1065,6 +1276,33 @@ func (p claudeHookPayload) claudeMetadata() map[string]string {
 		if text := stringFromAny(value); text != "" {
 			metadata["tool_input."+key] = truncateRunes(text, 160)
 		}
+	}
+	out := make(map[string]string, len(metadata))
+	for k, v := range metadata {
+		if value := strings.TrimSpace(v); value != "" {
+			out[k] = value
+		}
+	}
+	return out
+}
+
+func (p antigravityHookPayload) antigravityMetadata() map[string]string {
+	metadata := map[string]string{
+		"agent":              aiModeAntigravity,
+		"event":              p.EventName,
+		"conversation_id":    p.ConversationID,
+		"cwd":                p.CWD,
+		"transcript_path":    p.TranscriptPath,
+		"termination_reason": p.TerminationReason,
+		"error":              truncateRunes(p.Error, 160),
+		"agent_state":        p.AgentState,
+		"context_window":     p.ContextWindow,
+	}
+	if p.FullyIdleSet {
+		metadata["fully_idle"] = boolMetadataValue(p.FullyIdle)
+	}
+	if p.ToolConfirmationPendingSet {
+		metadata["tool_confirmation_pending"] = boolMetadataValue(p.ToolConfirmationPending)
 	}
 	out := make(map[string]string, len(metadata))
 	for k, v := range metadata {
@@ -1219,6 +1457,19 @@ func claudeStopNotifyID(p claudeHookPayload) string {
 	return ""
 }
 
+func antigravityNotifyID(p antigravityHookPayload, kind string) string {
+	parts := []string{"ai", "antigravity", kind}
+	if value := strings.TrimSpace(p.ConversationID); value != "" {
+		parts = append(parts, value)
+	}
+	if kind == "approval" {
+		if value := strings.TrimSpace(p.AgentState); value != "" {
+			parts = append(parts, value)
+		}
+	}
+	return strings.Join(parts, ":")
+}
+
 func claudeExtraNotifyID(p claudeHookPayload, kind string, values ...string) string {
 	parts := []string{"ai", "claude", kind}
 	if value := strings.TrimSpace(p.SessionID); value != "" {
@@ -1319,6 +1570,40 @@ func firstNestedString(value any, keys ...string) string {
 	return firstString(nested, keys...)
 }
 
+func firstAny(raw map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := raw[key]; ok && value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
+func firstNestedAny(value any, keys ...string) any {
+	nested, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	return firstAny(nested, keys...)
+}
+
+func firstBool(raw map[string]any, keys ...string) (bool, bool) {
+	for _, key := range keys {
+		if value, ok := boolFromAny(raw[key]); ok {
+			return value, true
+		}
+	}
+	return false, false
+}
+
+func firstNestedBool(value any, keys ...string) (bool, bool) {
+	nested, ok := value.(map[string]any)
+	if !ok {
+		return false, false
+	}
+	return firstBool(nested, keys...)
+}
+
 func mapFromAny(value any) map[string]any {
 	if raw, ok := value.(map[string]any); ok {
 		out := make(map[string]any, len(raw))
@@ -1326,6 +1611,42 @@ func mapFromAny(value any) map[string]any {
 		return out
 	}
 	return map[string]any{}
+}
+
+func antigravityErrorString(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(v)
+	case map[string]any:
+		if text := firstString(v, "message", "text", "reason", "type", "code"); text != "" {
+			return text
+		}
+	}
+	return stringFromAny(value)
+}
+
+func boolFromAny(value any) (bool, bool) {
+	switch v := value.(type) {
+	case bool:
+		return v, true
+	case string:
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "true", "1", "yes":
+			return true, true
+		case "false", "0", "no":
+			return false, true
+		}
+	}
+	return false, false
+}
+
+func boolMetadataValue(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
 }
 
 func stringFromAny(value any) string {

--- a/internal/app/ai_ingest_test.go
+++ b/internal/app/ai_ingest_test.go
@@ -1390,6 +1390,261 @@ func TestIngestClaudeUnknownEventFallsBackToQuiet(t *testing.T) {
 	}
 }
 
+func TestParseAntigravityHookPayloadObservedFields(t *testing.T) {
+	t.Parallel()
+
+	payload, err := parseAntigravityHookPayload([]byte(`{
+		"eventName": "Stop",
+		"conversationId": "ag-conv-123",
+		"workspace": {"path": "/repo/projmux"},
+		"transcriptPath": "/tmp/ag.jsonl",
+		"terminationReason": "completed",
+		"fullyIdle": true,
+		"statusline": {
+			"agent_state": "idle",
+			"tool_confirmation_pending": false,
+			"context_window": "42%"
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("parseAntigravityHookPayload() error = %v", err)
+	}
+	if payload.EventName != "Stop" || payload.ConversationID != "ag-conv-123" || payload.CWD != "/repo/projmux" || payload.TranscriptPath != "/tmp/ag.jsonl" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if payload.TerminationReason != "completed" || !payload.FullyIdle || !payload.FullyIdleSet || payload.ToolConfirmationPending || payload.AgentState != "idle" || payload.ContextWindow != "42%" {
+		t.Fatalf("observed fields = %+v", payload)
+	}
+
+	payload, err = parseAntigravityHookPayload([]byte(`{"conversation_id":"ag-conv-123","tool_confirmation_pending":true}`))
+	if err != nil {
+		t.Fatalf("parseAntigravityHookPayload() statusline-only error = %v", err)
+	}
+	if payload.EventName != "Statusline" || !payload.ToolConfirmationPending {
+		t.Fatalf("statusline payload = %+v, want Statusline approval signal", payload)
+	}
+
+	payload, err = parseAntigravityHookPayload([]byte(`{"conversation_id":"ag-conv-123","agent_state":"idle","context_window":"38%"}`))
+	if err != nil {
+		t.Fatalf("parseAntigravityHookPayload() statusline-shaped error = %v", err)
+	}
+	if payload.EventName != "Statusline" || payload.ToolConfirmationPending || payload.ToolConfirmationPendingSet {
+		t.Fatalf("statusline-shaped payload = %+v, want Statusline without pending metadata", payload)
+	}
+	if metadata := payload.antigravityMetadata(); metadata["tool_confirmation_pending"] != "" {
+		t.Fatalf("metadata = %#v, want absent tool_confirmation_pending when field was absent", metadata)
+	}
+
+	payload, err = parseAntigravityHookPayload([]byte(`{"conversation_id":"ag-conv-123","toolConfirmationPending":false}`))
+	if err != nil {
+		t.Fatalf("parseAntigravityHookPayload() explicit false statusline error = %v", err)
+	}
+	if payload.EventName != "Statusline" || payload.ToolConfirmationPending || !payload.ToolConfirmationPendingSet {
+		t.Fatalf("explicit false statusline payload = %+v, want Statusline with pending=false", payload)
+	}
+}
+
+func TestIngestAntigravityStopPushesCompletionMetadataWithoutResumeState(t *testing.T) {
+	home := t.TempDir()
+	store := &stubNotifyStore{}
+	cmd := testAICommand(home)
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+	cmd.stdin = strings.NewReader(`{
+		"eventName": "Stop",
+		"conversationId": "ag-conv-123",
+		"cwd": "/repo/projmux",
+		"transcriptPath": "/tmp/ag.jsonl",
+		"terminationReason": "completed",
+		"fullyIdle": true
+	}`)
+	cmd.readCommand = antigravityIngestReadCommand("%7")
+
+	if err := cmd.Run([]string{"ingest", "antigravity-hook"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run ingest antigravity-hook Stop error = %v", err)
+	}
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1", len(store.pushed))
+	}
+	got := store.pushed[0]
+	if got.ID != "ai:antigravity:stop:ag-conv-123" || got.Text != "Ready" || got.Severity != notify.SeverityInfo {
+		t.Fatalf("pushed = %#v", got)
+	}
+	for key, want := range map[string]string{
+		"agent":              "antigravity",
+		"event":              "Stop",
+		"conversation_id":    "ag-conv-123",
+		"cwd":                "/repo/projmux",
+		"transcript_path":    "/tmp/ag.jsonl",
+		"termination_reason": "completed",
+		"fully_idle":         "true",
+		"category":           "response_complete",
+	} {
+		if got.Metadata[key] != want {
+			t.Fatalf("metadata[%s] = %q, want %q in %#v", key, got.Metadata[key], want, got.Metadata)
+		}
+	}
+	for _, want := range []recordedAICommand{
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiPaneHookActiveOption, "1"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiPaneAgentOption, aiModeAntigravity}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiPaneThreadIDOption, "ag-conv-123"}},
+	} {
+		if !hasRecordedAICommand(cmdRecorder(cmd).commands, want) {
+			t.Fatalf("commands = %#v, missing %#v", cmdRecorder(cmd).commands, want)
+		}
+	}
+	if hasRecordedAISetOption(cmdRecorder(cmd).commands, aiPaneResumeIDOption) || hasRecordedAISetOption(cmdRecorder(cmd).commands, aiPaneSessionIDOption) {
+		t.Fatalf("commands = %#v, want no session-state resume writes for Antigravity", cmdRecorder(cmd).commands)
+	}
+}
+
+func TestIngestAntigravityStopIgnoresToolConfirmationPendingForApproval(t *testing.T) {
+	home := t.TempDir()
+	store := &stubNotifyStore{}
+	cmd := testAICommand(home)
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+	cmd.stdin = strings.NewReader(`{
+		"eventName": "Stop",
+		"conversationId": "ag-conv-123",
+		"cwd": "/repo/projmux",
+		"tool_confirmation_pending": true,
+		"terminationReason": "completed"
+	}`)
+	cmd.readCommand = antigravityIngestReadCommand("%7")
+
+	if err := cmd.Run([]string{"ingest", "antigravity-hook"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run ingest antigravity-hook Stop error = %v", err)
+	}
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1", len(store.pushed))
+	}
+	got := store.pushed[0]
+	if got.ID != "ai:antigravity:stop:ag-conv-123" || got.Metadata["category"] != "response_complete" || got.Severity != notify.SeverityInfo {
+		t.Fatalf("pushed = %#v, want Stop completion mapping", got)
+	}
+}
+
+func TestIngestAntigravityStopErrorPushesCritical(t *testing.T) {
+	home := t.TempDir()
+	store := &stubNotifyStore{}
+	cmd := testAICommand(home)
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+	cmd.stdin = strings.NewReader(`{
+		"eventName": "Stop",
+		"conversationId": "ag-conv-123",
+		"cwd": "/repo/projmux",
+		"terminationReason": "error",
+		"error": {"message": "tool failed"}
+	}`)
+	cmd.readCommand = antigravityIngestReadCommand("%7")
+
+	if err := cmd.Run([]string{"ingest", "antigravity-hook"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run ingest antigravity-hook Stop error = %v", err)
+	}
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1", len(store.pushed))
+	}
+	got := store.pushed[0]
+	if got.Severity != notify.SeverityCritical || got.Metadata["category"] != "error" || got.Metadata["error"] != "tool failed" {
+		t.Fatalf("pushed = %#v", got)
+	}
+}
+
+func TestIngestAntigravityStatuslineApprovalPushesCritical(t *testing.T) {
+	home := t.TempDir()
+	store := &stubNotifyStore{}
+	cmd := testAICommand(home)
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+	cmd.stdin = strings.NewReader(`{
+		"conversationId": "ag-conv-123",
+		"cwd": "/repo/projmux",
+		"statusline": {
+			"agent_state": "waiting_for_tool",
+			"tool_confirmation_pending": true
+		}
+	}`)
+	cmd.readCommand = antigravityIngestReadCommand("%7")
+
+	if err := cmd.Run([]string{"ingest", "antigravity-hook"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run ingest antigravity-hook Statusline error = %v", err)
+	}
+	if len(store.pushed) != 1 {
+		t.Fatalf("push count = %d, want 1", len(store.pushed))
+	}
+	got := store.pushed[0]
+	if got.ID != "ai:antigravity:approval:ag-conv-123:waiting_for_tool" || got.Severity != notify.SeverityCritical || got.Metadata["category"] != "approval_required" {
+		t.Fatalf("pushed = %#v", got)
+	}
+	if got.Metadata["agent"] != "antigravity" || got.Metadata["tool_confirmation_pending"] != "true" || got.Metadata["agent_state"] != "waiting_for_tool" {
+		t.Fatalf("metadata = %#v", got.Metadata)
+	}
+}
+
+func TestIngestAntigravityStatuslineWithoutPendingQuietLogsReason(t *testing.T) {
+	home := t.TempDir()
+	store := &stubNotifyStore{}
+	cmd := testAICommand(home)
+	cmd.readFile = os.ReadFile
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+	cmd.stdin = strings.NewReader(`{
+		"conversationId": "ag-conv-123",
+		"cwd": "/repo/projmux",
+		"agent_state": "idle",
+		"context_window": "38%"
+	}`)
+	cmd.readCommand = antigravityIngestReadCommand("%7")
+
+	if err := cmd.Run([]string{"ingest", "antigravity-hook"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run ingest antigravity-hook Statusline quiet error = %v", err)
+	}
+	if len(store.pushed) != 0 {
+		t.Fatalf("push count = %d, want 0: %#v", len(store.pushed), store.pushed)
+	}
+	var out bytes.Buffer
+	if err := cmd.Run([]string{"ingest", "log", "--json"}, &out, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run ingest log --json error = %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		`"source":"antigravity-hook"`,
+		`"event":"Statusline"`,
+		`"result":"quiet"`,
+		`"reason":"statusline has no pending tool confirmation"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("log output = %q, want %s", got, want)
+		}
+	}
+}
+
+func TestIngestAntigravityPostInvocationQuietWithoutNotify(t *testing.T) {
+	home := t.TempDir()
+	store := &stubNotifyStore{}
+	cmd := testAICommand(home)
+	cmd.readFile = os.ReadFile
+	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
+	cmd.stdin = strings.NewReader(`{
+		"eventName": "PostInvocation",
+		"conversationId": "ag-conv-123",
+		"cwd": "/repo/projmux"
+	}`)
+	cmd.readCommand = antigravityIngestReadCommand("%7")
+
+	if err := cmd.Run([]string{"ingest", "antigravity-hook"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run ingest antigravity-hook PostInvocation error = %v", err)
+	}
+	if len(store.pushed) != 0 {
+		t.Fatalf("push count = %d, want 0: %#v", len(store.pushed), store.pushed)
+	}
+	var out bytes.Buffer
+	if err := cmd.Run([]string{"ingest", "log", "--json"}, &out, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run ingest log --json error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, `"source":"antigravity-hook"`) || !strings.Contains(got, `"event":"PostInvocation"`) || !strings.Contains(got, `"result":"quiet"`) {
+		t.Fatalf("log output = %q", got)
+	}
+}
+
 func TestAIWatchTitleSkipsHookActivePane(t *testing.T) {
 	home := t.TempDir()
 	cmd := testAICommand(home)
@@ -1456,6 +1711,29 @@ func codexHookIngestReadCommand(paneID string) func(context.Context, string, ...
 			return []byte(paneID + "\x1f/repo/projmux\x1f\x1fcodex-session\n"), nil
 		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", paneID, "#{@projmux_ai_agent}"}):
 			return []byte("codex\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", paneID, "#S"}):
+			return []byte("workspace\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", paneID, "#{window_id}"}):
+			return []byte("@1\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", paneID, "#{pane_id}"}):
+			return []byte(paneID + "\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", paneID, "#{socket_path}"}):
+			return []byte("/tmp/tmux-1000/projmux\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+}
+
+func antigravityIngestReadCommand(paneID string) func(context.Context, string, ...string) ([]byte, error) {
+	return func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name != "tmux" {
+			return nil, os.ErrNotExist
+		}
+		switch {
+		case reflect.DeepEqual(args, []string{"list-panes", "-a", "-F", aiIngestListPanesFormat}):
+			return []byte(paneID + "\x1f/repo/projmux\x1f\x1f\n"), nil
+		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", paneID, "#{@projmux_ai_agent}"}):
+			return []byte("antigravity\n"), nil
 		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", paneID, "#S"}):
 			return []byte("workspace\n"), nil
 		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", paneID, "#{window_id}"}):

--- a/internal/app/ai_notify_body.go
+++ b/internal/app/ai_notify_body.go
@@ -112,6 +112,45 @@ func formatClaudeTeammateIdleNotifyBody(p claudeHookPayload) aiNotifyBody {
 	}
 }
 
+func formatAntigravityApprovalNotifyBody(p antigravityHookPayload) aiNotifyBody {
+	return aiNotifyBody{
+		Text:     defaultString(joinAINotifyText("Approval needed", p.AgentState), "Approval needed"),
+		Severity: notify.SeverityCritical,
+		Agent:    "antigravity",
+		Category: "approval_required",
+	}
+}
+
+func formatAntigravityStopNotifyBody(p antigravityHookPayload) aiNotifyBody {
+	if antigravityHookHasError(p) {
+		return aiNotifyBody{
+			Text:     defaultString(joinAINotifyText(p.TerminationReason, p.Error), "Error"),
+			Severity: notify.SeverityCritical,
+			Agent:    "antigravity",
+			Category: "error",
+		}
+	}
+	return aiNotifyBody{
+		Text:     "Ready",
+		Severity: notify.SeverityInfo,
+		Agent:    "antigravity",
+		Category: "response_complete",
+	}
+}
+
+func antigravityHookHasError(p antigravityHookPayload) bool {
+	if strings.TrimSpace(p.Error) != "" {
+		return true
+	}
+	reason := strings.ToLower(strings.TrimSpace(p.TerminationReason))
+	switch reason {
+	case "", "stop", "stopped", "complete", "completed", "success", "normal":
+		return false
+	default:
+		return true
+	}
+}
+
 func joinAINotifyText(agent, category string, values ...string) string {
 	parts := []string{}
 	if trimmed := strings.TrimSpace(agent); trimmed != "" {

--- a/internal/app/doctor_ai.go
+++ b/internal/app/doctor_ai.go
@@ -43,6 +43,8 @@ func doctorAINotifyDiagnostics(ai *aiCommand) []doctorAINotifyIntegration {
 			diagnostics = append(diagnostics, withProviderDiagnosticMetadata(doctorClaudeIntegrationDiagnostic(ai), provider, enabled))
 		case aiprovider.Codex:
 			diagnostics = append(diagnostics, withProviderDiagnosticMetadata(doctorCodexIntegrationDiagnostic(ai), provider, enabled))
+		case aiprovider.Antigravity:
+			diagnostics = append(diagnostics, withProviderDiagnosticMetadata(doctorAntigravityIntegrationDiagnostic(ai), provider, enabled))
 		}
 	}
 	diagnostics = append(diagnostics, doctorTmuxBellIntegrationDiagnostic(ai))
@@ -126,6 +128,17 @@ func doctorClaudeIntegrationDiagnostic(ai *aiCommand) doctorAINotifyIntegration 
 	}
 	out.Status = doctorAINotifyStatusMissing
 	return out
+}
+
+func doctorAntigravityIntegrationDiagnostic(ai *aiCommand) doctorAINotifyIntegration {
+	provider, _ := aiprovider.Lookup(string(aiprovider.Antigravity))
+	return doctorAINotifyIntegration{
+		ID:            provider.HookDiagnostics.ID,
+		Name:          provider.HookDiagnostics.Name,
+		Status:        doctorAINotifyStatusSkip,
+		TestedVersion: ai.aiHookObservedVersion(aiHookProviderAntigravity),
+		Guidance:      "Antigravity hook payloads support manual projmux ai ingest antigravity-hook wiring only; projmux does not mutate Antigravity user config, and hook commands should use an absolute projmux path or a known cwd because relative hook commands failed smoke.",
+	}
 }
 
 func doctorTmuxBellIntegrationDiagnostic(ai *aiCommand) doctorAINotifyIntegration {

--- a/internal/app/doctor_test.go
+++ b/internal/app/doctor_test.go
@@ -698,6 +698,9 @@ command = "projmux ai ingest codex-hook"
 	if byID["tmux-bell"].Status != doctorAINotifyStatusInstalled {
 		t.Fatalf("tmux bell status = %#v, want installed", byID["tmux-bell"])
 	}
+	if byID["antigravity-hooks"].Status != doctorAINotifyStatusSkip {
+		t.Fatalf("antigravity hooks status = %#v, want skip/manual diagnostic", byID["antigravity-hooks"])
+	}
 	if byID["codex-hooks"].InstallCommand != "projmux ai integrate codex" {
 		t.Fatalf("codex hooks InstallCommand = %q", byID["codex-hooks"].InstallCommand)
 	}
@@ -712,6 +715,12 @@ command = "projmux ai ingest codex-hook"
 	}
 	if byID["claude-hooks"].TestedVersion != "Claude Code 2.1.140" {
 		t.Fatalf("claude hooks TestedVersion = %q", byID["claude-hooks"].TestedVersion)
+	}
+	if byID["antigravity-hooks"].ProviderID != "antigravity" || byID["antigravity-hooks"].InstallCommand != "" || byID["antigravity-hooks"].RemoveCommand != "" || byID["antigravity-hooks"].DryRunCommand != "" {
+		t.Fatalf("antigravity hooks diagnostic = %#v", byID["antigravity-hooks"])
+	}
+	if !strings.Contains(byID["antigravity-hooks"].Guidance, "does not mutate Antigravity user config") || !strings.Contains(byID["antigravity-hooks"].Guidance, "absolute projmux path") {
+		t.Fatalf("antigravity hooks Guidance = %q, want manual/absolute-command notice", byID["antigravity-hooks"].Guidance)
 	}
 	if len(cmdRecorder(cmd).commands) != 0 {
 		t.Fatalf("commands = %#v, want read-only diagnostics", cmdRecorder(cmd).commands)
@@ -741,6 +750,7 @@ func TestDoctorAINotifyDiagnosticsProviderMetadataShowsDisabledProviders(t *test
 	}{
 		{id: "codex-hooks", provider: "codex"},
 		{id: "claude-hooks", provider: "claude"},
+		{id: "antigravity-hooks", provider: "antigravity"},
 	} {
 		diagnostic, ok := byID[tc.id]
 		if !ok {

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -2348,6 +2348,14 @@ func TestSettingsAINotifyDiagnosticsRenderDoctorRowsAndCommandGuidance(t *testin
 			RemoveCommand:  "projmux ai integrate tmux-bell --remove",
 			DryRunCommand:  "projmux ai integrate tmux-bell --dry-run",
 		},
+		{
+			ID:            "antigravity-hooks",
+			Name:          "Antigravity hooks",
+			Status:        doctorAINotifyStatusSkip,
+			ProviderID:    "antigravity",
+			TestedVersion: "Antigravity CLI agy Phase 0b smoke",
+			Guidance:      "Antigravity hook payloads support manual projmux ai ingest antigravity-hook wiring only; projmux does not mutate Antigravity user config.",
+		},
 	}
 
 	var calls int
@@ -2429,6 +2437,11 @@ func TestSettingsAINotifyDiagnosticsRenderDoctorRowsAndCommandGuidance(t *testin
 			t.Fatalf("delivery sources entries = %#v, want %q", listOptions.Entries, want)
 		}
 	}
+	for _, want := range []string{"Antigravity hooks", "skip", "Antigravity CLI agy Phase 0b smoke"} {
+		if !hasEntryLabelContaining(listOptions.Entries, want) {
+			t.Fatalf("delivery sources entries = %#v, want %q", listOptions.Entries, want)
+		}
+	}
 	if got, want := detailOptions.UI, "settings-notifications-delivery-detail"; got != want {
 		t.Fatalf("delivery source detail UI = %q, want %q", got, want)
 	}
@@ -2469,6 +2482,79 @@ func TestSettingsAINotifyDiagnosticsRenderDoctorRowsAndCommandGuidance(t *testin
 	}
 	if len(tmuxRunner.calls) != 0 {
 		t.Fatalf("tmux calls = %#v, want no clipboard copy while opening detail", tmuxRunner.calls)
+	}
+}
+
+func TestSettingsNotificationsDeliveryShowsAntigravityUnsupportedReadOnly(t *testing.T) {
+	t.Parallel()
+
+	diagnostics := []doctorAINotifyIntegration{{
+		ID:            "antigravity-hooks",
+		Name:          "Antigravity hooks",
+		ProviderID:    "antigravity",
+		Status:        doctorAINotifyStatusSkip,
+		TestedVersion: "Antigravity CLI agy Phase 0b smoke",
+		Guidance:      "Antigravity hook payloads support manual projmux ai ingest antigravity-hook wiring only; projmux does not mutate Antigravity user config, and hook commands should use an absolute projmux path or a known cwd.",
+	}}
+
+	var calls int
+	var listOptions intpickercompat.Options
+	var detailOptions intpickercompat.Options
+	cmd := &settingsCommand{
+		ai:                  testAICommand(t.TempDir()),
+		aiNotifyDiagnostics: func() []doctorAINotifyIntegration { return diagnostics },
+		tmuxRunner:          &recordingTmuxRunner{},
+		runner: switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
+			calls++
+			switch calls {
+			case 1:
+				return intpickercompat.Result{Key: "enter", Value: settingsSectionNotifications}, nil
+			case 2:
+				return intpickercompat.Result{Key: "enter", Value: settingsNotificationsDelivery}, nil
+			case 3:
+				listOptions = options
+				return intpickercompat.Result{Key: "enter", Value: settingsActionPrefixAINotifyDiagnostic + "antigravity-hooks"}, nil
+			case 4:
+				detailOptions = options
+				return intpickercompat.Result{Key: "enter", Value: settingsNoopValue}, nil
+			case 5:
+				return intpickercompat.Result{}, nil
+			default:
+				t.Fatalf("unexpected settings picker call %d", calls)
+				return intpickercompat.Result{}, nil
+			}
+		}),
+	}
+	cmd.nativePicker = nativePickerFromCompatRunner(cmd.runner)
+
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil && err != errSettingsClosed {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !hasEntryValue(listOptions.Entries, settingsActionPrefixAINotifyDiagnostic+"antigravity-hooks") {
+		t.Fatalf("delivery sources entries = %#v, want antigravity row", listOptions.Entries)
+	}
+	for _, want := range []string{"Antigravity hooks", "skip", "Antigravity CLI agy Phase 0b smoke"} {
+		if !hasEntryLabelContaining(listOptions.Entries, want) {
+			t.Fatalf("delivery sources entries = %#v, want %q", listOptions.Entries, want)
+		}
+	}
+	for _, want := range []string{
+		"manual projmux ai ingest antigravity-hook",
+		"does not mutate Antigravity user config",
+		"absolute projmux path",
+		"Install command",
+		"unavailable",
+		"Remove command",
+		"Dry-run command",
+	} {
+		if !hasEntryLabelContaining(detailOptions.Entries, want) {
+			t.Fatalf("antigravity detail entries = %#v, want %q", detailOptions.Entries, want)
+		}
+	}
+	for _, entry := range detailOptions.Entries {
+		if strings.HasPrefix(entry.Value, settingsActionPrefixAINotifyCommand) {
+			t.Fatalf("antigravity detail entry = %#v, want no copyable install actions", entry)
+		}
 	}
 }
 

--- a/internal/core/aiprovider/registry.go
+++ b/internal/core/aiprovider/registry.go
@@ -91,10 +91,16 @@ var registry = []Metadata{
 		DisplayName:     "Antigravity",
 		ShortName:       "Antigravity",
 		BinaryName:      "agy",
+		HookProvider:    string(Antigravity),
 		SettingsVisible: true,
 		PickerEligible:  true,
-		SettingsOrder:   30,
-		PickerOrder:     30,
+		HookDiagnostics: SupportMetadata{
+			Supported: true,
+			ID:        "antigravity-hooks",
+			Name:      "Antigravity hooks",
+		},
+		SettingsOrder: 30,
+		PickerOrder:   30,
 	},
 }
 

--- a/internal/core/aiprovider/registry_test.go
+++ b/internal/core/aiprovider/registry_test.go
@@ -17,7 +17,7 @@ func TestProviderRegistryOrdersSurfaces(t *testing.T) {
 	if got, want := providerIDs(UsageSupported()), []ID{Claude, Codex}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("UsageSupported() = %#v, want %#v", got, want)
 	}
-	if got, want := providerIDs(HookDiagnosticSupported()), []ID{Claude, Codex}; !reflect.DeepEqual(got, want) {
+	if got, want := providerIDs(HookDiagnosticSupported()), []ID{Claude, Codex, Antigravity}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("HookDiagnosticSupported() = %#v, want %#v", got, want)
 	}
 }
@@ -61,8 +61,11 @@ func TestProviderRegistryMetadataForCurrentAgents(t *testing.T) {
 	if !ok {
 		t.Fatalf("Lookup(antigravity) missing")
 	}
-	if antigravity.UsageSupported || antigravity.UsageModel != "" || antigravity.HookDiagnostics.Supported || antigravity.Integrate.Supported || antigravity.SessionState.Supported {
-		t.Fatalf("Antigravity metadata = %#v, want launch/settings only in this phase", antigravity)
+	if antigravity.UsageSupported || antigravity.UsageModel != "" || antigravity.Integrate.Supported || antigravity.SessionState.Supported {
+		t.Fatalf("Antigravity metadata = %#v, want no usage/integrate/session-state support in this phase", antigravity)
+	}
+	if !antigravity.HookDiagnostics.Supported || antigravity.HookDiagnostics.ID != "antigravity-hooks" || antigravity.HookProvider != "antigravity" {
+		t.Fatalf("Antigravity hook metadata = %#v, want manual hook diagnostics support", antigravity)
 	}
 }
 


### PR DESCRIPTION
## Completed phase

Phase 2 - notify ingest / fallback.

## Hook/statusline mapping

- Adds `projmux ai ingest antigravity-hook` for manually wired Antigravity CLI `agy` hook/statusline payloads.
- `PostInvocation` is quiet/log-only.
- `Stop` pushes an info completion row when the observed fields are normal, or a critical error row when `error` is present or `terminationReason` is non-normal.
- `Statusline` pushes a critical approval-needed row only when the normalized payload is statusline-shaped and `tool_confirmation_pending=true`; statusline payloads without a pending confirmation stay quiet/log-only.
- Notify metadata uses `agent=antigravity`.

## User-facing surface

- CLI help/docs list `projmux ai ingest antigravity-hook < payload.json`.
- `doctor` and Settings > Notifications > Delivery sources show an Antigravity hooks row as read-only/manual/unsupported for automatic integration.
- Docs call out that Projmux does not provide `projmux ai integrate antigravity` yet and that manual hook/statusline commands should use an absolute `projmux` path or known cwd because relative hook commands failed smoke.

## Explicitly excluded

- No Phase 3 session-state restore work.
- No usage adapter and no mixing Antigravity `context-window-only` data into Claude/Codex quota HUD.
- No Antigravity user config mutation.
- No tracked `.agents/` or `.antigravitycli` files.
- No Codex/Claude hook behavior changes.
- No notify queue schema redesign.

## Validation

- `git diff --check`
- `go test ./internal/app -count=1 -run 'Test(Ingest.*Antigravity|.*Notify.*Antigravity|.*Doctor.*Antigravity|.*Settings.*Delivery)'`
- `go test ./internal/core/aiprovider ./internal/config ./internal/app -count=1 -run 'Test.*Provider|Test.*AI.*Agent|Test.*Hook'`
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix`
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`

## Unverified / follow-up

- No new live `agy` smoke was run in this Phase 2 implementation, so no raw transcript/token/history data was captured.
- Phase 3 remains: Antigravity session-state metadata/restore support and usage/context-window-only UX or unsupported state.
