### PR TITLE
fix(notify): classify gone targets from real tmux inventory

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -218,9 +218,11 @@ projmux notify reconcile [--json]
   `--live` adds a non-mutating explanation table (or JSON report) that
   compares queued entries with live pane attention. It calls out manual
   reply badges that do not queue because no AI agent is attached, live AI
-  reply panes missing a queue entry, matched AI reply entries, and inactive
-  (`queue-stale`) queue entries whose live pane no longer matches reply+agent
-  state. `--ui=sidebar` opens the compact interactive notify list where Enter
+  reply panes missing a queue entry, matched AI reply entries, inactive
+  (`queue-stale`) queue entries whose live pane EXISTS but no longer matches
+  reply+agent state, and gone (`queue-gone`) entries whose pane is absent from
+  the real tmux live pane inventory (or which have no routable target).
+  `--ui=sidebar` opens the compact interactive notify list where Enter
   focuses and acks live or inactive-routable targets, cleans gone/unroutable
   targets without focusing, `a` acks the selected row, `x` clears non-critical
   rows, and `Ctrl-X` clears all; opening or navigating the sidebar does not ack.

--- a/docs/notify-queue.md
+++ b/docs/notify-queue.md
@@ -170,11 +170,19 @@ output becomes `{queue, live, rows, errors}`. Typical states:
 - `live-ai-reply-missing-queue` — a live AI reply pane lacks the derived
   queue entry; run `projmux notify reconcile` to back-fill it.
 - `queue-stale` — preserved machine-readable state for an inactive target:
-  an `ai:` queue entry exists, but the live pane no longer matches reply+agent
-  state. It is not TTL/time age. Surfaced in the sidebar/statusbar as
-  `INACTIVE` / `INA`; Enter still focuses and acks if the target is routable.
-- `queue-gone` — a queue entry has no routable target (empty session). Surfaced
-  as `GONE` / `GON`, and Enter/ack cleans it up without focusing.
+  an `ai:` queue entry whose pane still EXISTS in the live tmux pane inventory,
+  but no longer matches reply+agent state. It is not TTL/time age. Surfaced in
+  the sidebar/statusbar as `INACTIVE` / `INA`; Enter still focuses and acks if
+  the target is routable.
+- `queue-gone` — the queue entry's target is gone. This is now determined two
+  ways: (a) the entry has no routable target (empty session), or (b) the entry
+  carries a pane target whose pane id is absent from the real tmux live pane
+  inventory (`tmux list-panes -a`). Surfaced as `GONE` / `GON`, and Enter/ack
+  cleans it up without focusing. The inventory check is best-effort: when the
+  pane inventory cannot be read (tmux error, or an empty/unrecognized reply),
+  membership-based GONE is skipped so a missing tmux server never falsely
+  dims/gones every row, and only pane-target rows are eligible (window/session-
+  only rows keep the empty-session check only).
 - `queue-only` — a non-AI/external queue entry is pending and has no live AI
   reply-pane requirement.
 

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -151,8 +151,13 @@ inside the native sidebar; Right on a childless group refreshes without adding
 rows. Enter on a group row, whether folded or expanded, focuses the group's
 representative pane and acknowledges every visible notification in that group
 only after focus succeeds. Inactive means an `ai:` queue entry no longer
-matches live reply+agent state, not that the row is old; if the target remains
-routable, Enter and statusbar clicks still focus and then ack. If the
+matches live reply+agent state (its pane still EXISTS in tmux), not that the
+row is old; if the target remains routable, Enter and statusbar clicks still
+focus and then ack. Gone means the target is unroutable (empty session) or the
+row's pane id is absent from the real tmux live pane inventory
+(`tmux list-panes -a`). The inventory check is best-effort: an unreadable or
+empty/unrecognized tmux reply is treated as "unavailable", so a missing tmux
+server never falsely gones routable rows. If the
 representative target is gone/unroutable, Enter cleans up the selected group
 without focusing and acknowledges every visible notification in that group,
 including critical notifications. A

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -503,8 +503,8 @@ func (c *notifyCommand) notifySidebarPickerOptions(store notifyStore, entries []
 	}
 
 	now := c.clock()
-	liveByID := c.notifyLiveByIDBestEffort()
-	model := buildNotifySidebarReadModel(entries, now, liveByID, locale)
+	liveByID, paneSet := c.notifyLiveStateBestEffort()
+	model := buildNotifySidebarReadModel(entries, now, liveByID, paneSet, locale)
 	return intpicker.Options{
 		UI:             "notify-sidebar",
 		MultiLine:      true,
@@ -552,8 +552,8 @@ func (c *notifyCommand) notifySidebarDeferredUpdate(store notifyStore, severitie
 		return intpicker.DeferredUpdate{}, err
 	}
 	now := c.clock()
-	liveByID := c.notifyLiveByIDBestEffort()
-	model := buildNotifySidebarReadModel(entries, now, liveByID, locale)
+	liveByID, paneSet := c.notifyLiveStateBestEffort()
+	model := buildNotifySidebarReadModel(entries, now, liveByID, paneSet, locale)
 	pruneNotifySidebarExpanded(expanded, model)
 	return intpicker.DeferredUpdate{
 		Items: notifySidebarPickerItems(model.ExpandedEntries(expanded)),
@@ -650,7 +650,8 @@ func ackNotifySidebarGroup(store notifyStore, entries []notify.Notification, gro
 }
 
 func (c *notifyCommand) focusAndAckNotifySidebarGroup(store notifyStore, entries []notify.Notification, groupKey, clientTTY string, locale i18n.Locale) error {
-	group, ok := notifySidebarGroupByKey(entries, c.clock(), c.notifyLiveByIDBestEffort(), groupKey, locale)
+	liveByID, paneSet := c.notifyLiveStateBestEffort()
+	group, ok := notifySidebarGroupByKey(entries, c.clock(), liveByID, paneSet, groupKey, locale)
 	if !ok {
 		c.displayNotifySidebarMessage("notify group already gone")
 		return nil
@@ -681,12 +682,12 @@ func (c *notifyCommand) focusAndAckNotifySidebarGroup(store notifyStore, entries
 	return ackNotifySidebarGroup(store, entries, groupKey)
 }
 
-func notifySidebarGroupByKey(entries []notify.Notification, now time.Time, liveByID map[string]notifyLivePane, groupKey string, locale i18n.Locale) (notifySidebarGroup, bool) {
+func notifySidebarGroupByKey(entries []notify.Notification, now time.Time, liveByID map[string]notifyLivePane, paneSet notifyLivePaneSet, groupKey string, locale i18n.Locale) (notifySidebarGroup, bool) {
 	groupKey = strings.TrimSpace(groupKey)
 	if groupKey == "" {
 		return notifySidebarGroup{}, false
 	}
-	model := buildNotifySidebarReadModel(entries, now, liveByID, locale)
+	model := buildNotifySidebarReadModel(entries, now, liveByID, paneSet, locale)
 	for _, group := range model.Groups {
 		if group.Key == groupKey {
 			return group, true
@@ -773,7 +774,10 @@ func notifySidebarEntries(entries []notify.Notification, now time.Time) []intpic
 }
 
 func notifySidebarEntriesWithLiveLocale(entries []notify.Notification, now time.Time, liveByID map[string]notifyLivePane, locale i18n.Locale) []intpickercompat.Entry {
-	return buildNotifySidebarReadModel(entries, now, liveByID, locale).CollapsedEntries()
+	// Legacy collapsed-entry helper: the modern sidebar path builds the read
+	// model directly (with the pane inventory). These helpers keep nil paneSet
+	// (inventory unavailable) so behavior is unchanged for their callers.
+	return buildNotifySidebarReadModel(entries, now, liveByID, nil, locale).CollapsedEntries()
 }
 
 // notifySidebarEntriesWithLive renders sidebar rows with awareness of
@@ -880,7 +884,7 @@ func notifySidebarEmptyEntries() []intpickercompat.Entry {
 	}}
 }
 
-func buildNotifySidebarReadModel(entries []notify.Notification, now time.Time, liveByID map[string]notifyLivePane, locale i18n.Locale) notifySidebarReadModel {
+func buildNotifySidebarReadModel(entries []notify.Notification, now time.Time, liveByID map[string]notifyLivePane, paneSet notifyLivePaneSet, locale i18n.Locale) notifySidebarReadModel {
 	type groupBuild struct {
 		group notifySidebarGroup
 	}
@@ -898,7 +902,7 @@ func buildNotifySidebarReadModel(entries []notify.Notification, now time.Time, l
 			builders[key] = builder
 			order = append(order, key)
 		}
-		display := classifyNotifyRowState(entry, liveByID)
+		display := classifyNotifyRowState(entry, liveByID, paneSet)
 		label := notifySidebarChildLabelForLocale(entry, now, display, locale)
 		builder.group.Rows = append(builder.group.Rows, notifySidebarRow{
 			GroupKey: key,
@@ -1635,7 +1639,7 @@ func (c *notifyCommand) buildNotifyLiveReportLocale(entries []notify.Notificatio
 		Errors: []string{},
 	}
 
-	panes, err := c.listNotifyLivePanes()
+	panes, paneSet, err := c.listNotifyLivePanesAndSet()
 	if err != nil {
 		report.Errors = append(report.Errors, err.Error())
 		for _, entry := range entries {
@@ -1700,7 +1704,7 @@ func (c *notifyCommand) buildNotifyLiveReportLocale(entries []notify.Notificatio
 			continue
 		}
 		state := "queue-only"
-		switch classifyNotifyRowState(entry, liveByID) {
+		switch classifyNotifyRowState(entry, liveByID, paneSet) {
 		case notifyDisplayStale:
 			state = "queue-stale"
 		case notifyDisplayGone:
@@ -1753,6 +1757,21 @@ func (c *notifyCommand) notifyLiveByIDBestEffort() map[string]notifyLivePane {
 	return notifyLiveShouldQueueByID(panes)
 }
 
+// notifyLiveStateBestEffort reads the attention pane rows once and returns
+// both the reply+agent index (for stale detection) and the full pane inventory
+// (for gone detection), swallowing any tmux error into nil/nil. Sidebar
+// renders use this so a single `list-panes` subprocess feeds both classifiers.
+func (c *notifyCommand) notifyLiveStateBestEffort() (map[string]notifyLivePane, notifyLivePaneSet) {
+	if c == nil || c.runner == nil {
+		return nil, nil
+	}
+	panes, paneSet, err := c.listNotifyLivePanesAndSet()
+	if err != nil {
+		return nil, nil
+	}
+	return notifyLiveShouldQueueByID(panes), paneSet
+}
+
 // notifyLiveShouldQueueByID indexes the subset of live panes that satisfy
 // AI reply+agent state (i.e. ShouldQueue). This is the same condition
 // [notifyCommand.buildNotifyLiveReport] uses to decide which queue entries
@@ -1767,12 +1786,82 @@ func notifyLiveShouldQueueByID(panes []notifyLivePane) map[string]notifyLivePane
 	return out
 }
 
+// notifyLivePaneSet is the full live tmux pane inventory (every pane on the
+// server), used to decide whether a queue row's pane target still exists.
+//
+// A nil notifyLivePaneSet means "inventory unavailable" (the tmux read failed
+// or returned an empty/unrecognized result); callers MUST treat nil as
+// best-effort and skip membership-based GONE classification rather than
+// goneing every row. An empty (non-nil) set is also treated as unavailable by
+// the constructor below: it returns nil when no live panes were parsed, which
+// is the same docker-e2e degradation [statusbarCommand.classifyHeadDisplayBestEffort]
+// guards against.
+type notifyLivePaneSet map[string]struct{}
+
+// notifyLivePaneSetKey builds the membership key for a pane target. The notify
+// queue is pane-centric, so we key by pane id scoped within its session: two
+// different sessions can each have a `%0`. Pane ids are unique per tmux server,
+// so session+pane is sufficient.
+//
+// Socket is deliberately NOT part of the key. The notify producer records a
+// socket path, but user-edited and reconciled rows frequently omit it while the
+// tmux-reported pane always carries one; including socket in the key would
+// cause false-gone on socket-empty rows. The (session, pane) pair is precise
+// enough in practice and errs toward "present" (no false gone) when sockets
+// disagree.
+func notifyLivePaneSetKey(session, pane string) string {
+	return strings.TrimSpace(session) + "\x00" + strings.TrimSpace(pane)
+}
+
+// newNotifyLivePaneSet builds a pane-inventory set from the full (unfiltered)
+// attention pane rows. It returns nil when no rows have a usable pane target,
+// so callers uniformly read nil as "inventory unavailable".
+func newNotifyLivePaneSet(rows []attentionPaneRow) notifyLivePaneSet {
+	set := make(notifyLivePaneSet, len(rows))
+	for _, row := range rows {
+		if strings.TrimSpace(row.Pane) == "" {
+			continue
+		}
+		set[notifyLivePaneSetKey(row.Session, row.Pane)] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
+}
+
+// Has reports whether the entry's pane target is present in the live
+// inventory. It is only meaningful for pane-target rows; window/session-only
+// rows should not be tested for membership (see classifyNotifyRowState).
+func (s notifyLivePaneSet) Has(entry notify.Notification) bool {
+	if s == nil {
+		return false
+	}
+	_, ok := s[notifyLivePaneSetKey(entry.Session, entry.Pane)]
+	return ok
+}
+
+// listNotifyLivePanesAndSet reads the attention pane rows once and returns both
+// the attention/reply-filtered notifyLivePane slice (for stale detection) and
+// the full pane-inventory set (for GONE detection), avoiding a second tmux
+// subprocess.
+func (c *notifyCommand) listNotifyLivePanesAndSet() ([]notifyLivePane, notifyLivePaneSet, error) {
+	rows, err := (&attentionCommand{runner: c.runner}).listAttentionPanes()
+	if err != nil {
+		return nil, nil, err
+	}
+	return notifyLivePanesFromRows(rows), newNotifyLivePaneSet(rows), nil
+}
+
 func (c *notifyCommand) listNotifyLivePanes() ([]notifyLivePane, error) {
 	rows, err := (&attentionCommand{runner: c.runner}).listAttentionPanes()
 	if err != nil {
 		return nil, err
 	}
+	return notifyLivePanesFromRows(rows), nil
+}
 
+func notifyLivePanesFromRows(rows []attentionPaneRow) []notifyLivePane {
 	out := make([]notifyLivePane, 0, len(rows))
 	for _, row := range rows {
 		live := notifyLivePane{
@@ -1797,7 +1886,7 @@ func (c *notifyCommand) listNotifyLivePanes() ([]notifyLivePane, error) {
 			out = append(out, live)
 		}
 	}
-	return out, nil
+	return out
 }
 
 func nonNilNotifications(entries []notify.Notification) []notify.Notification {

--- a/internal/app/notify_classify.go
+++ b/internal/app/notify_classify.go
@@ -31,16 +31,48 @@ const (
 )
 
 // classifyNotifyRowState returns the display classification for a single
-// queue entry. `liveByID` is the map of live AI reply-state panes keyed by
-// notify id (the same map [notifyCommand.buildNotifyLiveReport] builds). Pass
-// `nil` when live data is unavailable; the helper then only reports
-// [notifyDisplayGone] for unroutable entries and treats every other entry as
-// [notifyDisplayLive] (best-effort: a missing tmux server must not falsely
-// dim every row).
-func classifyNotifyRowState(entry notify.Notification, liveByID map[string]notifyLivePane) notifyRowDisplayState {
+// queue entry.
+//
+// `liveByID` is the map of live AI reply-state panes keyed by notify id (the
+// same map [notifyCommand.buildNotifyLiveReport] builds). It drives the
+// inactive/stale decision. Pass `nil` when live data is unavailable; the
+// helper then never reports [notifyDisplayStale] (best-effort: a missing tmux
+// server must not falsely dim every row).
+//
+// `paneSet` is the full live tmux pane inventory (every pane on the server,
+// not just attention/reply panes). It drives the real GONE decision: a
+// pane-target queue row whose pane is no longer present in tmux is gone. Pass
+// `nil` to mean "inventory unavailable" — membership-based GONE is then
+// skipped entirely so a missing/empty tmux reply does not falsely gone every
+// row. See [notifyLivePaneSet].
+//
+// Classification order (fixed):
+//
+//  1. GONE — the entry has no routable target (malformed/empty session), OR
+//     the inventory is available AND the entry has a pane target AND that pane
+//     is NOT present in the live inventory. Only pane-target rows are eligible
+//     for membership-based GONE; window/session-only rows keep the routable
+//     string check only (we do not have a reliable pane id to test).
+//  2. STALE/INACTIVE — an `ai:`-prefixed entry whose pane still exists but no
+//     longer satisfies live reply+agent state (a `liveByID` miss).
+//  3. LIVE — everything else.
+func classifyNotifyRowState(entry notify.Notification, liveByID map[string]notifyLivePane, paneSet notifyLivePaneSet) notifyRowDisplayState {
+	// 1. GONE: malformed target, or a real pane-inventory miss.
 	if !notifyEntryIsRoutable(entry) {
 		return notifyDisplayGone
 	}
+	// Pane-first policy: only rows that carry a concrete pane target are
+	// eligible for membership-based GONE. Window/session-only rows have no
+	// pane id to look up, so we leave them to the routable-string check above.
+	// A nil paneSet means the inventory was unavailable (read failed or the
+	// tmux reply was empty/unrecognized); skip membership-based GONE so a
+	// missing tmux server cannot gone every row.
+	if paneSet != nil && strings.TrimSpace(entry.Pane) != "" && !paneSet.Has(entry) {
+		return notifyDisplayGone
+	}
+
+	// 2. STALE: ai-prefixed entry whose pane exists but no longer matches live
+	// reply+agent state.
 	if liveByID == nil {
 		return notifyDisplayLive
 	}

--- a/internal/app/notify_classify_test.go
+++ b/internal/app/notify_classify_test.go
@@ -27,6 +27,16 @@ func TestClassifyNotifyRowStateMatchesLiveReport(t *testing.T) {
 			CreatedAt: now, ExpiresAt: now.Add(time.Hour),
 		},
 		{
+			// Pane %5 EXISTS in tmux (it is in the inventory below) but is no
+			// longer in reply+agent state, so it is INACTIVE/queue-stale, not
+			// gone.
+			ID: "ai:main:%5", Text: "Ready", Metadata: map[string]string{"agent": "claude", "category": "response_complete", "state": "need"},
+			Severity: notify.SeverityInfo, Source: notify.SourceAI,
+			Session: "main", Window: "@1", Pane: "%5",
+			CreatedAt: now, ExpiresAt: now.Add(time.Hour),
+		},
+		{
+			// Pane %9 is NOT present in the live inventory → GONE/queue-gone.
 			ID: "ai:gone:%9", Text: "Ready", Metadata: map[string]string{"agent": "claude", "category": "response_complete", "state": "need"},
 			Severity: notify.SeverityInfo, Source: notify.SourceAI,
 			Session: "gone", Pane: "%9",
@@ -50,7 +60,11 @@ func TestClassifyNotifyRowStateMatchesLiveReport(t *testing.T) {
 		respond: func(args []string) ([]byte, error) {
 			if containsArg(args, "list-panes") {
 				return notifyLivePaneRows(
+					// %2: reply + agent → ShouldQueue (live).
 					[]string{"main", "@1", "%2", "0", "codex", "reply", "waiting", "codex", "topic", "/tmp/tmux/default"},
+					// %5: exists but title-only attention, not reply → in the
+					// pane inventory but NOT in liveByID, so it is stale.
+					[]string{"main", "@1", "%5", "0", "✳ ready", "", "", "", "", "/tmp/tmux/default"},
 				), nil
 			}
 			return nil, nil
@@ -70,6 +84,10 @@ func TestClassifyNotifyRowStateMatchesLiveReport(t *testing.T) {
 	}
 
 	liveByID := notifyLiveShouldQueueByID(report.Live)
+	_, paneSet, err := cmd.listNotifyLivePanesAndSet()
+	if err != nil {
+		t.Fatalf("listNotifyLivePanesAndSet error = %v", err)
+	}
 	cases := []struct {
 		id           string
 		wantDisplay  notifyRowDisplayState
@@ -77,16 +95,19 @@ func TestClassifyNotifyRowStateMatchesLiveReport(t *testing.T) {
 	}{
 		// AI entry matched to a live ShouldQueue pane → live both ways.
 		{"ai:main:%2", notifyDisplayLive, "live-ai-reply-queued"},
-		// AI entry without a live match → inactive display/queue-stale state.
-		{"ai:gone:%9", notifyDisplayStale, "queue-stale"},
-		// External entry with a routable target stays live.
+		// AI entry whose pane EXISTS but no longer matches reply+agent →
+		// inactive display/queue-stale state.
+		{"ai:main:%5", notifyDisplayStale, "queue-stale"},
+		// AI entry whose pane is ABSENT from the live inventory → GONE.
+		{"ai:gone:%9", notifyDisplayGone, "queue-gone"},
+		// External entry with a routable target (no pane) stays live.
 		{"ext:1", notifyDisplayLive, "queue-only"},
 		// Empty session → GONE in both surfaces.
 		{"unroutable", notifyDisplayGone, "queue-gone"},
 	}
 	for _, tc := range cases {
 		entry := findEntryByIDOrFail(t, entries, tc.id)
-		gotDisplay := classifyNotifyRowState(entry, liveByID)
+		gotDisplay := classifyNotifyRowState(entry, liveByID, paneSet)
 		if gotDisplay != tc.wantDisplay {
 			t.Fatalf("classify(%s) = %v, want %v", tc.id, gotDisplay, tc.wantDisplay)
 		}
@@ -112,14 +133,99 @@ func TestClassifyNotifyRowStateFallsBackToLiveWhenLiveUnavailable(t *testing.T) 
 		Source: notify.SourceAI, Severity: notify.SeverityInfo,
 		Text: "Ready", Metadata: map[string]string{"agent": "codex", "category": "response_complete", "state": "need"},
 	}
-	if got := classifyNotifyRowState(entry, nil); got != notifyDisplayLive {
+	if got := classifyNotifyRowState(entry, nil, nil); got != notifyDisplayLive {
 		t.Fatalf("classify with nil live map = %v, want live", got)
 	}
 	// Empty session still classifies as GONE even without live data,
 	// because that decision needs no tmux input.
 	gone := notify.Notification{ID: "x", Text: "no target"}
-	if got := classifyNotifyRowState(gone, nil); got != notifyDisplayGone {
+	if got := classifyNotifyRowState(gone, nil, nil); got != notifyDisplayGone {
 		t.Fatalf("classify gone with nil live map = %v, want gone", got)
+	}
+}
+
+// TestClassifyNotifyRowStatePaneInventoryGone pins the concrete repro: a queue
+// row whose pane id is absent from the live tmux pane inventory classifies as
+// GONE, while a pane that IS present (but stale on reply+agent) stays
+// INACTIVE/stale. This is the core Phase 7 behavior.
+func TestClassifyNotifyRowStatePaneInventoryGone(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.June, 19, 12, 0, 0, 0, time.UTC)
+	// Live inventory has only %84 and %85 in repos-test-sample:@13.
+	paneSet := newNotifyLivePaneSet([]attentionPaneRow{
+		{Session: "repos-test-sample", Window: "@13", Pane: "%84"},
+		{Session: "repos-test-sample", Window: "@13", Pane: "%85"},
+	})
+	if paneSet == nil {
+		t.Fatal("expected non-nil pane inventory")
+	}
+
+	// The repro entry targets %83, which is no longer present in tmux.
+	goneEntry := notify.Notification{
+		ID: "ai:repos-test-sample:%83", Text: "Ready",
+		Severity: notify.SeverityInfo, Source: notify.SourceAI,
+		Session: "repos-test-sample", Window: "@13", Pane: "%83",
+		Metadata:  map[string]string{"agent": "codex", "category": "response_complete"},
+		CreatedAt: now, ExpiresAt: now.Add(time.Hour),
+	}
+	if got := classifyNotifyRowState(goneEntry, nil, paneSet); got != notifyDisplayGone {
+		t.Fatalf("classify(%%83 absent) = %v, want gone", got)
+	}
+	// Even with a live reply map that does not list this id, the pane-set miss
+	// is what makes it gone (membership beats stale in the fixed order).
+	if got := classifyNotifyRowState(goneEntry, map[string]notifyLivePane{}, paneSet); got != notifyDisplayGone {
+		t.Fatalf("classify(%%83 absent, empty liveByID) = %v, want gone", got)
+	}
+
+	// A pane that IS present but no longer in reply+agent state stays stale.
+	presentStale := notify.Notification{
+		ID: "ai:repos-test-sample:%84", Text: "Ready",
+		Severity: notify.SeverityInfo, Source: notify.SourceAI,
+		Session: "repos-test-sample", Window: "@13", Pane: "%84",
+		Metadata:  map[string]string{"agent": "codex", "category": "response_complete"},
+		CreatedAt: now, ExpiresAt: now.Add(time.Hour),
+	}
+	if got := classifyNotifyRowState(presentStale, map[string]notifyLivePane{}, paneSet); got != notifyDisplayStale {
+		t.Fatalf("classify(%%84 present, no reply match) = %v, want stale", got)
+	}
+	// A pane that is present AND in the reply map is live.
+	if got := classifyNotifyRowState(presentStale, map[string]notifyLivePane{presentStale.ID: {}}, paneSet); got != notifyDisplayLive {
+		t.Fatalf("classify(%%84 present + reply match) = %v, want live", got)
+	}
+}
+
+// TestClassifyNotifyRowStateNilInventoryNeverGone pins the best-effort
+// guarantee: when the pane inventory is unavailable (nil set), a routable
+// pane-target row is NOT classified gone just because membership cannot be
+// tested.
+func TestClassifyNotifyRowStateNilInventoryNeverGone(t *testing.T) {
+	t.Parallel()
+
+	entry := notify.Notification{
+		ID: "ai:repos-test-sample:%83", Text: "Ready",
+		Source: notify.SourceAI, Severity: notify.SeverityInfo,
+		Session: "repos-test-sample", Window: "@13", Pane: "%83",
+		Metadata: map[string]string{"agent": "codex", "category": "response_complete"},
+	}
+	// nil inventory + nil liveByID → live (no false gone, no false stale).
+	if got := classifyNotifyRowState(entry, nil, nil); got != notifyDisplayLive {
+		t.Fatalf("classify(nil inventory) = %v, want live", got)
+	}
+	// nil inventory + empty liveByID → stale (pane existence unknown, but the
+	// ai reply map says it is not live). This is the existing inactive path,
+	// unchanged: membership-based gone requires a non-nil inventory.
+	if got := classifyNotifyRowState(entry, map[string]notifyLivePane{}, nil); got != notifyDisplayStale {
+		t.Fatalf("classify(nil inventory, empty liveByID) = %v, want stale", got)
+	}
+	// An empty inventory built from zero usable rows is nil (unavailable), so
+	// it must not turn the row gone either.
+	emptySet := newNotifyLivePaneSet(nil)
+	if emptySet != nil {
+		t.Fatalf("newNotifyLivePaneSet(nil) = %v, want nil (unavailable)", emptySet)
+	}
+	if got := classifyNotifyRowState(entry, nil, emptySet); got != notifyDisplayLive {
+		t.Fatalf("classify(empty inventory) = %v, want live", got)
 	}
 }
 
@@ -335,9 +441,13 @@ func TestStatusbarClickNotifyStaleHeadStillFocuses(t *testing.T) {
 	runner := &statusbarFakeRunner{
 		respond: func(name string, args []string) ([]byte, error) {
 			if name == "tmux" && containsArg(args, "list-panes") {
-				// One unrelated reply-state pane → liveByID is non-empty but
-				// does not contain the head id → ai-prefixed head is stale.
+				// The head pane main:%2 EXISTS in the inventory but is
+				// title-only attention (not reply+agent), so the head is stale
+				// (INACTIVE), not gone. One unrelated reply-state pane keeps
+				// liveByID non-empty so the classifier does not fall back to the
+				// nil/empty best-effort path.
 				return notifyLivePaneRows(
+					[]string{"main", "@1", "%2", "0", "✳ inactive", "", "idle", "codex", "topic", "/tmp/tmux/default"},
 					[]string{"other", "@9", "%9", "0", "claude", "reply", "waiting", "claude", "topic", "/tmp/tmux/default"},
 				), nil
 			}
@@ -437,6 +547,54 @@ func TestStatusbarClickNotifyGoneHeadSkipsFocus(t *testing.T) {
 	}
 	if store.ackedID != "ext:orphan" {
 		t.Fatalf("store.ackedID = %q, want ext:orphan", store.ackedID)
+	}
+	if !sawTmuxDisplayMessage(runner.calls, "notify target gone; cleared") {
+		t.Fatalf("missing gone cleanup toast; calls = %#v", runner.calls)
+	}
+}
+
+// TestStatusbarClickNotifyPaneInventoryGoneHeadSkipsFocus pins Phase 7 on the
+// statusbar click path: an `ai:`-prefixed head whose pane is ABSENT from the
+// live tmux inventory takes the ack-only fast path (no focus subprocess),
+// because the pane really disappeared even though the id is routable.
+func TestStatusbarClickNotifyPaneInventoryGoneHeadSkipsFocus(t *testing.T) {
+	t.Parallel()
+
+	runner := &statusbarFakeRunner{
+		respond: func(name string, args []string) ([]byte, error) {
+			if name == "tmux" && containsArg(args, "list-panes") {
+				// Inventory has %84,%85 but NOT the head's %83. A second
+				// reply-state pane keeps liveByID non-empty so we exercise the
+				// real-inventory gone path rather than the nil/empty fallback.
+				return notifyLivePaneRows(
+					[]string{"repos-test-sample", "@13", "%84", "0", "✳ idle", "", "idle", "codex", "topic", "/tmp/tmux/default"},
+					[]string{"repos-test-sample", "@13", "%85", "0", "codex", "reply", "waiting", "codex", "topic", "/tmp/tmux/default"},
+				), nil
+			}
+			return nil, nil
+		},
+	}
+	store := &stubNotifyStore{listEntries: []notify.Notification{{
+		ID:       "ai:repos-test-sample:%83",
+		Text:     "Ready",
+		Metadata: map[string]string{"agent": "codex", "category": "response_complete", "state": "need"},
+		Source:   notify.SourceAI,
+		Session:  "repos-test-sample",
+		Window:   "@13",
+		Pane:     "%83",
+	}}}
+	cmd := newStatusbarTestCommand(runner, store)
+
+	if err := cmd.Run([]string{"click", "notify"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	for _, call := range runner.calls {
+		if call.name == "/usr/local/bin/projmux" {
+			t.Fatalf("focus subprocess was invoked despite pane-inventory gone head; call = %#v", call)
+		}
+	}
+	if store.ackedID != "ai:repos-test-sample:%83" {
+		t.Fatalf("store.ackedID = %q, want the gone head", store.ackedID)
 	}
 	if !sawTmuxDisplayMessage(runner.calls, "notify target gone; cleared") {
 		t.Fatalf("missing gone cleanup toast; calls = %#v", runner.calls)

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -652,7 +652,7 @@ func TestNotifySidebarGroupedReadModelConstructsCollapsedPaneRows(t *testing.T) 
 		{ID: "old", Text: "background update", Severity: notify.SeverityInfo, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex", "topic": "worker loop"}, Socket: "sock", Session: "main", Window: "@1", Pane: "%2", CreatedAt: now.Add(-5 * time.Minute)},
 	}
 
-	model := buildNotifySidebarReadModel(entries, now, nil, i18n.FallbackLocale)
+	model := buildNotifySidebarReadModel(entries, now, nil, nil, i18n.FallbackLocale)
 	if len(model.Groups) != 1 {
 		t.Fatalf("groups = %#v, want one pane group", model.Groups)
 	}
@@ -720,7 +720,7 @@ func TestNotifySidebarGroupedReadModelTitleUsesOlderRowMetadata(t *testing.T) {
 		{ID: "older", Text: "older rich update", Severity: notify.SeverityInfo, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex", "topic": "worker loop"}, Socket: "sock", Session: "main", Window: "@1", Pane: "%2", CreatedAt: now.Add(-2 * time.Minute)},
 	}
 
-	model := buildNotifySidebarReadModel(entries, now, nil, i18n.FallbackLocale)
+	model := buildNotifySidebarReadModel(entries, now, nil, nil, i18n.FallbackLocale)
 	collapsed := model.CollapsedEntries()
 	if len(collapsed) != 1 || collapsed[0].Value != notifySidebarGroupValue(model.Groups[0].Key) {
 		t.Fatalf("collapsed entries = %#v, want group value", collapsed)
@@ -740,7 +740,7 @@ func TestNotifySidebarGroupedReadModelReducesDuplicateLabelPreview(t *testing.T)
 		{ID: "latest", Text: "worker loop", Severity: notify.SeverityInfo, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex", "topic": "worker loop"}, Session: "main", Pane: "%2", CreatedAt: now},
 	}
 
-	model := buildNotifySidebarReadModel(entries, now, nil, i18n.FallbackLocale)
+	model := buildNotifySidebarReadModel(entries, now, nil, nil, i18n.FallbackLocale)
 	collapsed := model.CollapsedEntries()
 	if len(collapsed) != 1 {
 		t.Fatalf("collapsed entries = %#v, want one group row", collapsed)
@@ -782,7 +782,7 @@ func TestNotifySidebarGroupedReadModelKeepsProjectSlotWhenTopicContainsProject(t
 				{ID: "latest", Text: "done", Severity: notify.SeverityInfo, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex", "topic": tt.topic}, Session: "team-main", Pane: "%2", CreatedAt: now},
 			}
 
-			model := buildNotifySidebarReadModel(entries, now, nil, i18n.FallbackLocale)
+			model := buildNotifySidebarReadModel(entries, now, nil, nil, i18n.FallbackLocale)
 			label := stripANSI(model.CollapsedEntries()[0].Label)
 			lines := strings.Split(label, "\n")
 			if len(lines) != 3 {
@@ -805,7 +805,7 @@ func TestNotifySidebarGroupedReadModelSelectionMarkerKeepsFieldShape(t *testing.
 	model := buildNotifySidebarReadModel([]notify.Notification{
 		{ID: "latest", Text: "done", Severity: notify.SeverityInfo, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex", "topic": "worker loop"}, Session: "main", Pane: "%2", CreatedAt: now},
 		{ID: "older", Text: "older", Severity: notify.SeverityInfo, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex", "topic": "worker loop"}, Session: "main", Pane: "%2", CreatedAt: now.Add(-1 * time.Minute)},
-	}, now, nil, i18n.FallbackLocale)
+	}, now, nil, nil, i18n.FallbackLocale)
 	group := model.Groups[0]
 	folded := stripANSI(notifySidebarGroupEntry(group, false).Label)
 	expanded := stripANSI(notifySidebarGroupEntry(group, true).Label)
@@ -830,7 +830,7 @@ func TestNotifySidebarGroupedReadModelChildlessGroupHasNoFoldMarkerOrCount(t *te
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	model := buildNotifySidebarReadModel([]notify.Notification{
 		{ID: "latest", Text: "done", Severity: notify.SeverityWarn, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex", "topic": "worker loop"}, Session: "main", Pane: "%2", CreatedAt: now},
-	}, now, nil, i18n.FallbackLocale)
+	}, now, nil, nil, i18n.FallbackLocale)
 	group := model.Groups[0]
 	collapsed := stripANSI(notifySidebarGroupEntry(group, false).Label)
 	expanded := stripANSI(notifySidebarGroupEntry(group, true).Label)
@@ -859,7 +859,7 @@ func TestNotifySidebarExpandedChildRowsStayCompactAndPreserveWarnCritical(t *tes
 		{ID: "warn", Text: "tests failed", Severity: notify.SeverityWarn, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex", "topic": "worker loop"}, Session: "main", Pane: "%2", CreatedAt: now.Add(-1 * time.Minute)},
 	}
 
-	model := buildNotifySidebarReadModel(entries, now, nil, i18n.FallbackLocale)
+	model := buildNotifySidebarReadModel(entries, now, nil, nil, i18n.FallbackLocale)
 	expanded := model.ExpandedEntries(map[string]bool{model.Groups[0].Key: true})
 	if len(expanded) != 3 {
 		t.Fatalf("expanded entries = %#v, want group plus two compact child rows", expanded)
@@ -891,7 +891,7 @@ func TestNotifySidebarGroupedReadModelUsesWorstSeverity(t *testing.T) {
 		{ID: "latest", Text: "minor update", Severity: notify.SeverityInfo, Source: notify.SourceExternal, Session: "main", Pane: "%2", CreatedAt: now},
 		{ID: "critical", Text: "approval required", Severity: notify.SeverityCritical, Source: notify.SourceExternal, Session: "main", Pane: "%2", CreatedAt: now.Add(-1 * time.Minute)},
 	}
-	model := buildNotifySidebarReadModel(entries, now, nil, i18n.FallbackLocale)
+	model := buildNotifySidebarReadModel(entries, now, nil, nil, i18n.FallbackLocale)
 	if got := model.Groups[0].Worst; got != notify.SeverityCritical {
 		t.Fatalf("worst severity = %q, want critical", got)
 	}
@@ -908,7 +908,7 @@ func TestNotifySidebarGroupedReadModelDisplaysInactiveAndGoneGroups(t *testing.T
 		{ID: "ai:main:%2", Text: "Ready", Severity: notify.SeverityInfo, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex", "category": "response_complete", "state": "need"}, Session: "main", Pane: "%2", CreatedAt: now},
 		{ID: "external", Text: "orphaned", Severity: notify.SeverityWarn, Source: notify.SourceExternal, Session: "", CreatedAt: now.Add(-1 * time.Minute)},
 	}
-	model := buildNotifySidebarReadModel(entries, now, map[string]notifyLivePane{}, i18n.FallbackLocale)
+	model := buildNotifySidebarReadModel(entries, now, map[string]notifyLivePane{}, nil, i18n.FallbackLocale)
 	if len(model.Groups) != 2 {
 		t.Fatalf("groups = %#v, want inactive and gone groups", model.Groups)
 	}
@@ -932,7 +932,7 @@ func TestNotifySidebarGroupedReadModelDisplaysInactiveAndGoneChildCounts(t *test
 		{ID: "gone-new", Text: "new gone", Severity: notify.SeverityInfo, Source: notify.SourceExternal, CreatedAt: now.Add(-2 * time.Minute)},
 		{ID: "gone-old", Text: "old gone", Severity: notify.SeverityCritical, Source: notify.SourceExternal, CreatedAt: now.Add(-3 * time.Minute)},
 	}
-	model := buildNotifySidebarReadModel(entries, now, map[string]notifyLivePane{}, i18n.FallbackLocale)
+	model := buildNotifySidebarReadModel(entries, now, map[string]notifyLivePane{}, nil, i18n.FallbackLocale)
 	if len(model.Groups) != 2 {
 		t.Fatalf("groups = %#v, want inactive and gone groups", model.Groups)
 	}
@@ -960,6 +960,40 @@ func TestNotifySidebarGroupedReadModelDisplaysInactiveAndGoneChildCounts(t *test
 	}
 }
 
+// TestNotifySidebarReadModelPaneInventoryGoneVsStale pins Phase 7 in the
+// sidebar: a pane-target row whose pane is ABSENT from the live inventory shows
+// the GONE group (cleanup-only), while a pane that EXISTS but no longer matches
+// reply+agent shows the INACTIVE group (focus+ack affordance retained).
+func TestNotifySidebarReadModelPaneInventoryGoneVsStale(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.June, 19, 12, 0, 0, 0, time.UTC)
+	entries := []notify.Notification{
+		// %84 exists in tmux but is not reply+agent → INACTIVE/stale.
+		{ID: "ai:repos-test-sample:%84", Text: "Ready", Severity: notify.SeverityInfo, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex", "category": "response_complete"}, Session: "repos-test-sample", Window: "@13", Pane: "%84", CreatedAt: now},
+		// %83 is absent from tmux → GONE.
+		{ID: "ai:repos-test-sample:%83", Text: "Ready", Severity: notify.SeverityInfo, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex", "category": "response_complete"}, Session: "repos-test-sample", Window: "@13", Pane: "%83", CreatedAt: now.Add(-1 * time.Minute)},
+	}
+	paneSet := newNotifyLivePaneSet([]attentionPaneRow{
+		{Session: "repos-test-sample", Window: "@13", Pane: "%84"},
+		{Session: "repos-test-sample", Window: "@13", Pane: "%85"},
+	})
+	model := buildNotifySidebarReadModel(entries, now, map[string]notifyLivePane{}, paneSet, i18n.FallbackLocale)
+
+	byPane := map[string]notifyRowDisplayState{}
+	for _, group := range model.Groups {
+		for _, row := range group.Rows {
+			byPane[row.Notify.Pane] = row.Display
+		}
+	}
+	if byPane["%83"] != notifyDisplayGone {
+		t.Fatalf("pane %%83 display = %v, want GONE (absent from inventory)", byPane["%83"])
+	}
+	if byPane["%84"] != notifyDisplayStale {
+		t.Fatalf("pane %%84 display = %v, want INACTIVE/stale (present but not reply+agent)", byPane["%84"])
+	}
+}
+
 func TestNotifySidebarGroupedReadModelPaneLessFallbackKeys(t *testing.T) {
 	t.Parallel()
 
@@ -969,7 +1003,7 @@ func TestNotifySidebarGroupedReadModelPaneLessFallbackKeys(t *testing.T) {
 		{ID: "session", Text: "session scoped", Severity: notify.SeverityInfo, Source: notify.SourceExternal, Socket: "sock", Session: "main", CreatedAt: now.Add(-1 * time.Minute)},
 		{ID: "external", Text: "external scoped", Severity: notify.SeverityInfo, Source: notify.SourceExternal, Socket: "sock", CreatedAt: now.Add(-2 * time.Minute)},
 	}
-	model := buildNotifySidebarReadModel(entries, now, nil, i18n.FallbackLocale)
+	model := buildNotifySidebarReadModel(entries, now, nil, nil, i18n.FallbackLocale)
 	got := []string{model.Groups[0].Key, model.Groups[1].Key, model.Groups[2].Key}
 	want := []string{"window\x00sock\x00main\x00@1", "session\x00sock\x00main", "external\x00sock"}
 	if !reflect.DeepEqual(got, want) {
@@ -2005,12 +2039,16 @@ func TestNotifyListLiveJSONExplainsQueueAndLiveStates(t *testing.T) {
 				ExpiresAt: now.Add(time.Hour),
 			},
 			{
-				ID:        "ai:gone:%9",
+				// Pane %5 EXISTS in the inventory below but is title-only
+				// attention (not reply+agent), so this queue row is INACTIVE /
+				// queue-stale, not gone.
+				ID:        "ai:title:%5",
 				Text:      "stale",
 				Severity:  notify.SeverityInfo,
 				Source:    notify.SourceAI,
-				Session:   "gone",
-				Pane:      "%9",
+				Session:   "title",
+				Window:    "@4",
+				Pane:      "%5",
 				CreatedAt: now,
 				ExpiresAt: now.Add(time.Hour),
 			},

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -437,8 +437,8 @@ func (c *statusCommand) runNotify(args []string, stdout, stderr io.Writer) error
 	if c.now != nil {
 		now = c.now()
 	}
-	liveByID := c.notifyLiveByIDBestEffort()
-	out := formatStatusNotifyWithLiveLocale(entries, *maxWidth, now, liveByID, c.locale())
+	liveByID, paneSet := c.notifyLiveStateBestEffort()
+	out := formatStatusNotifyWithLiveLocale(entries, *maxWidth, now, liveByID, paneSet, c.locale())
 	if out == "" {
 		return nil
 	}
@@ -460,6 +460,18 @@ func (c *statusCommand) notifyLiveByIDBestEffort() map[string]notifyLivePane {
 		return nil
 	}
 	return notifyLiveShouldQueueByID(panes)
+}
+
+// notifyLiveStateBestEffort reads the live reply+agent index and the full pane
+// inventory from a single tmux subprocess, swallowing errors into nil/nil. A
+// nil set means "inventory unavailable" so the head entry is never falsely
+// classified GONE during a tmux outage.
+func (c *statusCommand) notifyLiveStateBestEffort() (map[string]notifyLivePane, notifyLivePaneSet) {
+	if c == nil || c.readCommand == nil {
+		return nil, nil
+	}
+	runner := statusCommandRunnerAdapter{read: c.readCommand}
+	return (&notifyCommand{runner: runner}).notifyLiveStateBestEffort()
 }
 
 // statusCommandRunnerAdapter wraps statusCommand.readCommand so the existing
@@ -545,17 +557,20 @@ func formatStatusNotify(entries []notify.Notification, maxWidth int, now time.Ti
 // the caller could not read live tmux pane state; in that case the segment
 // degrades to the legacy NEED/INFO/WARN/CRIT badge set.
 func formatStatusNotifyWithLive(entries []notify.Notification, maxWidth int, now time.Time, liveByID map[string]notifyLivePane) string {
-	return formatStatusNotifyWithLiveLocale(entries, maxWidth, now, liveByID, i18n.FallbackLocale)
+	return formatStatusNotifyWithLiveLocale(entries, maxWidth, now, liveByID, nil, i18n.FallbackLocale)
 }
 
-func formatStatusNotifyWithLiveLocale(entries []notify.Notification, maxWidth int, now time.Time, liveByID map[string]notifyLivePane, locale i18n.Locale) string {
+// formatStatusNotifyWithLiveLocale renders the status segment. `paneSet` is the
+// full live tmux pane inventory used for real GONE classification of the head
+// entry; pass nil when unavailable (membership-based GONE is then skipped).
+func formatStatusNotifyWithLiveLocale(entries []notify.Notification, maxWidth int, now time.Time, liveByID map[string]notifyLivePane, paneSet notifyLivePaneSet, locale i18n.Locale) string {
 	if len(entries) == 0 {
 		return ""
 	}
 	head := entries[0]
 	extras := len(entries) - 1
 
-	display := classifyNotifyRowState(head, liveByID)
+	display := classifyNotifyRowState(head, liveByID, paneSet)
 	agent, text := splitAgentPrefix(head)
 	if head.Source == notify.SourceAI {
 		text = notifyAIStatusBodyTextLocale(head, text, locale)

--- a/internal/app/status_notify_test.go
+++ b/internal/app/status_notify_test.go
@@ -411,7 +411,7 @@ func TestStatusNotifyLocaleFormatsAgeAITextAndCount(t *testing.T) {
 			Session:   "s",
 			CreatedAt: now.Add(-2 * time.Minute),
 		},
-	}, 80, now, nil, i18n.Locale("ko-KR"))
+	}, 80, now, nil, nil, i18n.Locale("ko-KR"))
 
 	for _, want := range []string{
 		renderNotifyProjectBadge("s"),

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -646,17 +646,22 @@ func (c *statusbarCommand) handleNotify(opts statusbarClickOptions, _, stderr io
 // because they have richer context and are not on the click critical path.
 func (c *statusbarCommand) classifyHeadDisplayBestEffort(head notify.Notification) notifyRowDisplayState {
 	if c == nil || c.runner == nil {
-		return classifyNotifyRowState(head, nil)
+		return classifyNotifyRowState(head, nil, nil)
 	}
-	panes, err := (&notifyCommand{runner: c.runner}).listNotifyLivePanes()
+	panes, paneSet, err := (&notifyCommand{runner: c.runner}).listNotifyLivePanesAndSet()
 	if err != nil {
-		return classifyNotifyRowState(head, nil)
+		return classifyNotifyRowState(head, nil, nil)
 	}
+	// Real pane-inventory GONE is honoured even when no panes are in reply
+	// state: a click on a head whose pane truly disappeared takes the ack-only
+	// fast path. newNotifyLivePaneSet already returns nil for an empty/
+	// unrecognized tmux reply, so passing paneSet through preserves the
+	// docker-e2e best-effort fallback (nil paneSet ⇒ no membership GONE).
 	liveByID := notifyLiveShouldQueueByID(panes)
 	if len(liveByID) == 0 {
-		return classifyNotifyRowState(head, nil)
+		return classifyNotifyRowState(head, nil, paneSet)
 	}
-	return classifyNotifyRowState(head, liveByID)
+	return classifyNotifyRowState(head, liveByID, paneSet)
 }
 
 // notifyAckOnlyToast renders the fast-path toast surfaced when a click lands


### PR DESCRIPTION
## 완료한 Phase

- **Phase 7 — real tmux target gone classification**

Phase 6은 stale/inactive 와 gone 의 user-facing 의미를 분리했지만, `gone` 판정이 실제 tmux target 존재 여부를 보지 않았다. 기존 `GONE` 은 session/target 문자열이 비어 있는 malformed row 에 한정됐고, 실제 pane 이 사라진 queue entry 는 `INACTIVE`(`queue-stale`)로 잘못 표시됐다. (`notifyEntryIsRoutable` 이 문자열 비어있음만 검사) 이번 변경은 실제 tmux live pane set membership 으로 gone 을 판정한다.

## 수정한 user-facing surface

- **`notify list --live`**: 실제 tmux 에 없는 pane target → `queue-gone`. pane 은 존재하지만 reply+agent mismatch → `queue-stale` 유지.
- **Notify sidebar**: group/child row 에서 실제 gone target 은 `GONE` badge/metadata + cleanup-only affordance, inactive target 은 `INACTIVE` + focus+ack affordance.
- **Statusbar notify click**: gone head 는 focus subprocess 없이 ack/cleanup fast-path, inactive head 는 focus 시도 (Phase 6 routing 유지).

## 구현 요약

- `notifyLivePaneSet` 추가: full(unfiltered) attention pane inventory 로 구성. `nil`/empty = "inventory unavailable" → membership-based GONE 스킵 (tmux 부재 시 모든 row 를 false-gone 하지 않음).
- `classifyNotifyRowState` 에 pane-set 인자 추가, 분류 순서 고정: **gone target → inactive/stale → live**. pane target 이 있는 row 만 membership 기반 gone 대상 (pane-first policy). window/session-only row 는 기존 routable-string 검사만.
- membership key = `session + pane` (socket 제외: 재조정/사용자 편집 row 는 socket 을 자주 생략하므로 포함 시 false-gone 위험).
- `listNotifyLivePanesAndSet` / `notifyLiveStateBestEffort` 로 stale + gone 분류가 단일 `list-panes` 호출 공유.
- focus race(`focusExitNotResolved`) → gone cleanup 전환 기존 방어 유지.

## 명시적으로 제외한 다음 Phase 범위

- window/session-only(pane 없는) row 의 window/session 존재 여부 판정 — 현재 notify queue 는 pane target 중심이라 pane 기준만 고정. 후속 후보.
- notify store schema 변경 없음.

## 모델 / 스키마 / 엔진 제약 준수

- notify store schema (`internal/core/notify`) 변경 없음.
- `queue-stale` / `queue-gone` JSON state 제거·rename 없음 (이름·emit 동일).
- Phase 6 inactive copy (`INACTIVE`/`INA` + explanation) 재논의·변경 없음.
- fold/unfold state 변경 없음.
- notification producer id format (`ai:<session>:<pane>`) 재설계 없음.
- `notify list --json` default output shape 변경 없음.

## 검증 명령

로컬 (worktree, `GOCACHE=/tmp/projmux-go-cache`):

- `make fmt` — clean
- `make fix` — clean
- `make test` — all packages ok, `internal/app` pass
- `go test ./internal/app/ -run 'Notify|Statusbar|Classify|StatusNotify' -count=1` — ok
- `git diff --check` — clean

추가된 focused tests:

- `TestClassifyNotifyRowStatePaneInventoryGone` — 필수 repro: `repos-test-sample:@13.%83` (inventory `{%84,%85}`) → GONE; `%84` present-but-not-reply → STALE; `%84` + reply match → LIVE.
- `TestClassifyNotifyRowStateNilInventoryNeverGone` — nil/empty inventory → never gone (best-effort).
- `TestNotifySidebarReadModelPaneInventoryGoneVsStale` — sidebar 에서 absent pane GONE, present-but-stale INACTIVE.
- `TestStatusbarClickNotifyPaneInventoryGoneHeadSkipsFocus` — gone head ack-only, no focus subprocess.
- `TestStatusbarClickNotifyStaleHeadStillFocuses` (갱신) — inactive head focus 유지.
- `TestNotifyListLiveJSONExplainsQueueAndLiveStates` / `TestClassifyNotifyRowStateMatchesLiveReport` (갱신) — `queue-stale`/`queue-gone` JSON 호환.

## 미검증 항목 / 후속 Phase

- **실제 tmux 서버 e2e 미검증**: 실제로 window/pane 을 kill 해서 `tmux list-panes -a` 가 해당 pane 을 누락하고 sidebar/statusbar 가 GONE + cleanup-only 로 렌더되는 end-to-end 경로는 unit(fake) 으로만 커버됨. 실제 tmux 수동 smoke / e2e 는 후속 후보.
- docker-e2e 의 empty/unrecognized tmux reply degradation 은 `newNotifyLivePaneSet` 의 nil 정규화로 방어하지만 실서버 확인은 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
