### PR TITLE
feat(recent-windows): Alt-3 card badge visibility and visual polish (Phase 6)

### DIFF
--- a/internal/app/recent_window.go
+++ b/internal/app/recent_window.go
@@ -14,6 +14,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/recentwindows"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+	"github.com/crevissepartners/projmux/internal/theme"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
 )
 
@@ -385,32 +386,52 @@ func recentWindowPickerItems(candidates []recentwindows.Candidate, now time.Time
 	return items, byValue
 }
 
-const recentWindowPaneSummaryMaxRunes = 80
+const (
+	recentWindowPaneSummaryMaxRunes = 80
+	// Per-component construction-time budgets keep the readable window name and
+	// the age badge on line 1 even when project or window names are very long.
+	// TruncateANSI trims at render time for the real terminal width; these
+	// budgets only guarantee the high-priority fields are never pushed out by a
+	// single overlong component before truncation runs.
+	recentWindowProjectBadgeMaxRunes = 24
+	recentWindowNameMaxRunes         = 48
+	recentWindowTopicChipMaxRunes    = 48
+)
 
 func recentWindowPickerItem(candidate recentwindows.Candidate, now time.Time) intpicker.Item {
-	// Title is the readable window name only (never a raw @window_id/%pane_id).
-	// BuildLabel already falls back name -> project -> session -> pane/topic/cmd.
-	title := strings.TrimSpace(candidate.Label.Primary)
-	if title == "" {
-		title = recentWindowTargetLabel(candidate)
+	// The readable window name (never a raw @window_id/%pane_id). BuildLabel
+	// already falls back name -> project -> session -> pane/topic/cmd.
+	name := strings.TrimSpace(candidate.Label.Primary)
+	if name == "" {
+		name = recentWindowTargetLabel(candidate)
 	}
+	name = recentWindowTruncate(name, recentWindowNameMaxRunes)
 
 	age := recentWindowAge(candidate.LastFocusedAt, now)
 	lastVisit := recentWindowLastVisit(age, candidate.LastFocusedAt)
 
+	// Line 1: project badge -> readable window name -> last-focus age badge.
+	// Reuse the notify sidebar helpers so the badges match the notification
+	// sidebar palette and each badge terminates with theme.ANSIReset (so the
+	// selected-row background re-applies cleanly after every badge).
+	badgeText := recentWindowBadgeText(candidate)
+	title := notifySidebarProjectBadge(badgeText) + " " + name + " " + notifySidebarAge(age)
+
+	// Line 2: the window's pane topic/title summary (topic leads).
+	paneSummary := recentWindowPaneSummaryLine(candidate)
+
 	// Display-only context badge (project/session). Never a recency signal.
 	context := joinRecentWindowParts(candidate.Project, candidate.Session)
-	paneSummary := recentWindowPaneSummary(candidate)
 
 	meta := make([]string, 0, 3)
 	if paneSummary != "" {
 		meta = append(meta, paneSummary)
 	}
-	if context != "" && context != title {
-		meta = append(meta, context)
-	}
 	if lastVisit != "" {
 		meta = append(meta, lastVisit)
+	}
+	if context != "" && context != name {
+		meta = append(meta, notifySidebarDim(context))
 	}
 
 	search := joinRecentWindowParts(append([]string{
@@ -432,6 +453,18 @@ func recentWindowPickerItem(candidate recentwindows.Candidate, now time.Time) in
 	}
 }
 
+// recentWindowBadgeText picks the line-1 badge text: real project context when
+// available, else the session, so we show meaningful context instead of an
+// empty "project" placeholder. notifySidebarProjectBadge supplies the default
+// only when both are truly empty.
+func recentWindowBadgeText(candidate recentwindows.Candidate) string {
+	badge := strings.TrimSpace(candidate.Project)
+	if badge == "" {
+		badge = strings.TrimSpace(candidate.Session)
+	}
+	return recentWindowTruncate(badge, recentWindowProjectBadgeMaxRunes)
+}
+
 // recentWindowPaneTitles returns the pane-title list, falling back to the
 // single active pane title for snapshots recorded before PaneTitles existed.
 func recentWindowPaneTitles(candidate recentwindows.Candidate) []string {
@@ -449,14 +482,77 @@ func recentWindowPaneTitles(candidate recentwindows.Candidate) []string {
 	return titles
 }
 
-// recentWindowPaneSummary joins all pane titles with " | " and stably truncates
-// the result so a long summary never causes the row to shift layout.
+// recentWindowPaneSummary joins the window's pane topic/title summary with
+// " | " and stably truncates the plain result so it never shifts layout. Pane
+// topic leads (the user's work context) when present; otherwise pane titles,
+// falling back to LastPaneTitle then LastCommand via recentWindowPaneTitles.
 func recentWindowPaneSummary(candidate recentwindows.Candidate) string {
-	titles := recentWindowPaneTitles(candidate)
-	if len(titles) == 0 {
+	parts := recentWindowPaneSummaryParts(candidate)
+	if len(parts) == 0 {
 		return ""
 	}
-	return recentWindowTruncate(strings.Join(titles, " | "), recentWindowPaneSummaryMaxRunes)
+	return recentWindowTruncate(strings.Join(parts, " | "), recentWindowPaneSummaryMaxRunes)
+}
+
+// recentWindowPaneSummaryParts returns the ordered topic/title parts for the
+// pane summary, with the pane topic leading when set.
+func recentWindowPaneSummaryParts(candidate recentwindows.Candidate) []string {
+	titles := recentWindowPaneTitles(candidate)
+	topic := strings.TrimSpace(candidate.LastPaneTopic)
+	if topic == "" {
+		if len(titles) > 0 {
+			return titles
+		}
+		if cmd := strings.TrimSpace(candidate.LastCommand); cmd != "" {
+			return []string{cmd}
+		}
+		return nil
+	}
+	// Topic leads; append the remaining titles (excluding any that duplicate the
+	// topic) so the user's work context shows first.
+	parts := make([]string, 0, len(titles)+1)
+	parts = append(parts, topic)
+	for _, title := range titles {
+		if title != topic {
+			parts = append(parts, title)
+		}
+	}
+	return parts
+}
+
+// recentWindowPaneSummaryLine renders the line-2 pane summary with notify-level
+// visibility: the leading topic is wrapped in an active chip (like
+// notifySidebarTopicBadge) and the remaining pane titles are dimmed so they
+// read as secondary context rather than blending into plain meta text.
+func recentWindowPaneSummaryLine(candidate recentwindows.Candidate) string {
+	plain := recentWindowPaneSummary(candidate)
+	if plain == "" {
+		return ""
+	}
+	parts := strings.SplitN(plain, " | ", 2)
+	lead := parts[0]
+	rest := ""
+	if len(parts) == 2 {
+		rest = parts[1]
+	}
+	if strings.TrimSpace(candidate.LastPaneTopic) != "" {
+		chip := recentWindowTopicChip(lead)
+		if rest != "" {
+			return chip + " " + notifySidebarDim(rest)
+		}
+		return chip
+	}
+	return notifySidebarDim(plain)
+}
+
+// recentWindowTopicChip wraps the pane topic in the shared active chip palette,
+// terminating with theme.ANSIReset like notifySidebarTopicBadge.
+func recentWindowTopicChip(topic string) string {
+	topic = recentWindowTruncate(strings.TrimSpace(topic), recentWindowTopicChipMaxRunes)
+	if topic == "" {
+		return ""
+	}
+	return theme.ANSIChipActiveStart + " " + topic + " " + theme.ANSIReset
 }
 
 // recentWindowLastVisit labels the relative age so the row reads unambiguously

--- a/internal/app/recent_window_test.go
+++ b/internal/app/recent_window_test.go
@@ -6,14 +6,25 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/crevissepartners/projmux/internal/core/recentwindows"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+	"github.com/crevissepartners/projmux/internal/theme"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	projmuxpicker "github.com/crevissepartners/projmux/internal/ui/projmuxpicker"
 )
+
+var recentWindowANSIPattern = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+// recentWindowStripANSI removes SGR escape sequences so tests can assert on the
+// visible content of badge-decorated rows.
+func recentWindowStripANSI(value string) string {
+	return recentWindowANSIPattern.ReplaceAllString(value, "")
+}
 
 func TestRecentWindowPickerItemEmphasizesNamesAndAge(t *testing.T) {
 	t.Parallel()
@@ -36,13 +47,29 @@ func TestRecentWindowPickerItemEmphasizesNamesAndAge(t *testing.T) {
 		Label:    recentwindows.BuildLabel(snapshot),
 	}, at.Add(12*time.Second))
 
-	if got, want := item.Title, "projmux"; got != want {
-		t.Fatalf("Title = %q, want %q", got, want)
+	// Line 1 reads: project badge -> readable window name -> age badge.
+	visibleTitle := recentWindowStripANSI(item.Title)
+	projectIdx := strings.Index(visibleTitle, "Projmux")
+	nameIdx := strings.Index(visibleTitle, "projmux")
+	ageIdx := strings.Index(visibleTitle, "12s ago")
+	if projectIdx < 0 || nameIdx <= projectIdx || ageIdx <= nameIdx {
+		t.Fatalf("line 1 visible = %q, want project badge -> window name -> age order", visibleTitle)
 	}
 	if strings.Contains(item.Title, "@6") || strings.Contains(item.Title, "%54") {
 		t.Fatalf("Title = %q, want no raw tmux IDs", item.Title)
 	}
-	text := item.Title + "\n" + strings.Join(item.MetaLines, "\n")
+	// Notify badge palette reuse: project + age start tokens, and every badge
+	// terminates with a reset so selected-row background re-applies.
+	if !strings.Contains(item.Title, theme.ANSINotifyProjectStart) {
+		t.Fatalf("Title = %q, want notify project badge palette", item.Title)
+	}
+	if !strings.Contains(item.Title, theme.ANSINotifyAgeStart) {
+		t.Fatalf("Title = %q, want notify age badge palette", item.Title)
+	}
+	if !strings.HasSuffix(item.Title, theme.ANSIReset) {
+		t.Fatalf("Title = %q, want trailing reset", item.Title)
+	}
+	text := recentWindowStripANSI(item.Title + "\n" + strings.Join(item.MetaLines, "\n"))
 	for _, want := range []string{"codex-review", "12s ago", "Projmux", "repos-projmux"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("render text = %q, want %q", text, want)
@@ -63,13 +90,13 @@ func TestRecentWindowPickerItemShowsContextBadgeAsMetaLine(t *testing.T) {
 	}
 	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at)
 
-	if item.Title != "projmux" {
-		t.Fatalf("Title = %q, want readable window name", item.Title)
+	if got := recentWindowStripANSI(item.Title); !strings.Contains(got, "projmux") {
+		t.Fatalf("line 1 visible = %q, want readable window name", got)
 	}
 	wantContext := "Projmux · repos-projmux"
 	found := false
 	for _, line := range item.MetaLines {
-		if line == wantContext {
+		if recentWindowStripANSI(line) == wantContext {
 			found = true
 		}
 	}
@@ -94,8 +121,8 @@ func TestRecentWindowPickerItemFallsBackToNameNeverRawIDs(t *testing.T) {
 	if strings.Contains(item.Title, "@6") || strings.Contains(item.Title, "%54") {
 		t.Fatalf("Title = %q, want fallback name, never raw tmux IDs", item.Title)
 	}
-	if item.Title != "repos-projmux" {
-		t.Fatalf("Title = %q, want session fallback", item.Title)
+	if got := recentWindowStripANSI(item.Title); !strings.Contains(got, "repos-projmux") {
+		t.Fatalf("line 1 visible = %q, want session fallback", got)
 	}
 }
 
@@ -115,7 +142,7 @@ func TestRecentWindowPickerItemJoinsAllPaneTitles(t *testing.T) {
 	want := "zsh | Codex · [lead:roadmap] Projmux | Claude Code"
 	found := false
 	for _, line := range item.MetaLines {
-		if line == want {
+		if recentWindowStripANSI(line) == want {
 			found = true
 		}
 	}
@@ -202,6 +229,102 @@ func TestRecentWindowPickerItemLastVisitFormat(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("MetaLines = %#v, want last-visit line %q", item.MetaLines, want)
+	}
+}
+
+func TestRecentWindowPickerItemPaneTopicLeadsSummary(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	snapshot := recentwindows.Snapshot{
+		Session:       "repos-projmux",
+		WindowID:      "@6",
+		WindowName:    "projmux",
+		LastPaneTopic: "Phase 6 polish",
+		PaneTitles:    []string{"zsh", "Claude Code"},
+	}
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at)
+
+	if len(item.MetaLines) == 0 {
+		t.Fatalf("MetaLines = %#v, want a pane summary line", item.MetaLines)
+	}
+	visible := recentWindowStripANSI(item.MetaLines[0])
+	topicIdx := strings.Index(visible, "Phase 6 polish")
+	zshIdx := strings.Index(visible, "zsh")
+	claudeIdx := strings.Index(visible, "Claude Code")
+	if topicIdx < 0 || zshIdx <= topicIdx || claudeIdx <= zshIdx {
+		t.Fatalf("pane summary line = %q, want topic-led order topic -> zsh -> Claude Code", visible)
+	}
+	if !strings.Contains(visible, "zsh | Claude Code") {
+		t.Fatalf("pane summary line = %q, want remaining titles joined with ' | '", visible)
+	}
+	// The leading topic is wrapped in the shared active chip palette.
+	if !strings.Contains(item.MetaLines[0], theme.ANSIChipActiveStart) {
+		t.Fatalf("pane summary line = %q, want topic chip palette", item.MetaLines[0])
+	}
+	if !strings.HasSuffix(item.MetaLines[0], theme.ANSIReset) {
+		t.Fatalf("pane summary line = %q, want trailing reset", item.MetaLines[0])
+	}
+}
+
+func TestRecentWindowPickerItemTruncatesLongComponentsKeepingNameAndAge(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	snapshot := recentwindows.Snapshot{
+		Session:       "repos-projmux",
+		WindowID:      "@6",
+		WindowName:    strings.Repeat("window-name", 12),
+		Project:       strings.Repeat("project", 12),
+		LastFocusedAt: at,
+	}
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at.Add(2*time.Minute))
+
+	visible := recentWindowStripANSI(item.Title)
+	if !strings.Contains(visible, "2m ago") {
+		t.Fatalf("line 1 visible = %q, want age preserved", visible)
+	}
+	if !strings.Contains(visible, "…") {
+		t.Fatalf("line 1 visible = %q, want long components truncated with ellipsis", visible)
+	}
+	// The window name must remain present (truncated, not dropped).
+	if !strings.Contains(visible, "window-name") {
+		t.Fatalf("line 1 visible = %q, want window name preserved", visible)
+	}
+	// Component budgets bound each piece so the age survives.
+	if got := len([]rune(recentWindowBadgeText(recentWindowCandidate(snapshot)))); got > recentWindowProjectBadgeMaxRunes {
+		t.Fatalf("badge text rune len = %d, want <= %d", got, recentWindowProjectBadgeMaxRunes)
+	}
+}
+
+func TestRecentWindowPickerItemRowRendersWithoutStyleBleed(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	snapshot := recentwindows.Snapshot{
+		Session:       "repos-projmux",
+		WindowID:      "@6",
+		WindowName:    "projmux",
+		Project:       "Projmux",
+		LastPaneTopic: "Phase 6 polish",
+		PaneTitles:    []string{"zsh"},
+		LastFocusedAt: at,
+	}
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at.Add(time.Minute))
+	row := projmuxpicker.Row{Label: item.Title, MetaLines: item.MetaLines}
+
+	for _, selected := range []bool{true, false} {
+		lines := projmuxpicker.InteractiveRowLinesWithTheme(projmuxpicker.DefaultTheme, row, selected, true)
+		if len(lines) == 0 {
+			t.Fatalf("selected=%v rendered no lines", selected)
+		}
+		line1 := lines[0]
+		if !strings.HasSuffix(line1, theme.ANSIReset) {
+			t.Fatalf("selected=%v line 1 = %q, want trailing reset (no orphaned styling)", selected, line1)
+		}
+		if !strings.Contains(recentWindowStripANSI(line1), "projmux") {
+			t.Fatalf("selected=%v line 1 visible = %q, want window name", selected, recentWindowStripANSI(line1))
+		}
 	}
 }
 
@@ -622,7 +745,7 @@ func TestRecentWindowGoneCandidatePrunedBeforePicker(t *testing.T) {
 	if err := cmd.Run(nil, nil, nil); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if len(pickerOptions.Items) != 1 || pickerOptions.Items[0].Title != "alive" {
+	if len(pickerOptions.Items) != 1 || !strings.Contains(recentWindowStripANSI(pickerOptions.Items[0].Title), "alive") {
 		t.Fatalf("picker items = %#v, want only alive candidate", pickerOptions.Items)
 	}
 	if opener.session != "alive" || opener.window != "@3" {


### PR DESCRIPTION
## 완료 Phase

**Phase 6 — Recent Windows badge visibility and visual polish** (로드맵 디테일 - Recent windows queue).

Phase 0~5 로 Recent Windows MRU queue, Alt-3 popup, runtime recorder, 기본 card 정보 구조는 이미 닫혔다. 이번 PR 은 producer/MRU model/switch semantics 를 바꾸지 않는 **시각·가독성 polish** 만 다룬다.

## User-facing surface

`Alt-3` (`RecentWindows:Open`) Recent Windows native picker 의 각 row 카드. 정보가 고정된 우선순위로 읽히도록 다듬었다:

- **Line 1 (Title)**: `project(or session) badge` → readable window name → `last-focus age badge`. notify sidebar 와 같은 badge palette 를 써서 plain meta line 처럼 묻히지 않는다. window name 은 raw `@window_id`/`%pane_id` 로 떨어지지 않는다.
- **Line 2**: 해당 window 의 pane topic/title summary. pane topic 이 있으면 active chip 으로 맨 앞에 오고(작업 맥락 우선), 나머지 pane title 은 dim 처리되어 ` | ` 로 나열된다. topic 이 없으면 pane title, 그다음 `LastPaneTitle`/`LastCommand` fallback.
- **Line 3**: last visit relative+absolute detail(`last visit · {age} · {date}`), 그다음 dim 처리된 `project · session` context line.
- project badge / window name / topic chip 에 construction-time rune budget 을 둬서, 긴 텍스트에서도 render-time `TruncateANSI` 전에 window name 과 age 가 밀려 사라지지 않는다.

## 참고한 notify badge/card surface

`internal/app/notify.go` (동일 `app` 패키지) 의 helper 를 직접 재사용:

- `notifySidebarProjectBadge` — line 1 project/session badge.
- `notifySidebarAge` — line 1 age badge.
- `notifySidebarDim` — dim 처리(remaining pane titles, context line).
- `theme.ANSIChipActiveStart` (`notifySidebarTopicBadge` 와 동일 chip 스타일) — line 2 topic chip.

큰 public shared API 추출 없이 동일 패키지 helper 재사용 + 소수의 local helper(`recentWindowBadgeText`, `recentWindowPaneSummaryParts`, `recentWindowPaneSummaryLine`, `recentWindowTopicChip`)로 제한했다.

## ANSI / selected-row 안전성

모든 badge 가 `theme.ANSIReset` 로 끝나므로 `SelectedLineWithTheme` 의 `ReplaceAll(Reset, Reset+selected)` 패턴에서 selected row 배경이 매 badge 뒤에 재적용되고, 뒤 라인이 오염되지 않는다. selected/unselected 양쪽을 `InteractiveRowLinesWithTheme` 로 렌더해 trailing reset 을 테스트로 고정했다.

## 제외 범위 (이번 PR 에서 건드리지 않음)

- RecentWindows MRU state schema 대규모 재설계.
- window ordering, current-window exclusion, gone prune, max-20 bound.
- selection value / switch semantics.
- historical pane restore / RecentPanes advanced mode.
- keybinding Settings IA.
- notify sidebar 기능 (참고 대상일 뿐 수정 없음).
- Alt-1 Project sidebar ordering/row redesign.

## MRU / switch semantics 유지

`recentWindowValue`(=`session + fieldSep + windowID`)와 search text 구성은 byte-identical. window-level MRU newest-first, current-window exclusion, gone prune 테스트는 그대로 통과한다. cross-session switch 테스트(badge text "Other" + age "2m ago" 부분 문자열)도 유지.

## 검증

- `make fmt` ✅
- `make fix` ✅
- `make test` ✅ (전체 패키지 통과)
- focused: `go test ./internal/app/ -run RecentWindow -count=1` ✅

추가/갱신 테스트: project badge + window name first 순서, notify badge palette(`ANSINotifyProjectStart`/`ANSINotifyAgeStart`) + trailing reset 재사용, pane topic priority over title, ` | ` pane summary, 긴 텍스트 truncation 우선순위(name·age 보존), last focus age badge/date visibility, selected/unselected 무-bleed 렌더, search text/selection value 불변, MRU/current-window/gone-prune 불변.

## 미검증 / 후속

- 실제 tmux 터미널에서의 시각 렌더(chip/badge 색상, 실제 width 에서의 `TruncateANSI`)는 unit test 로만 구조적으로 검증했고 live smoke 는 미실시.
- 후속 후보(이 detail 범위 아님): RecentPanes advanced mode / historical pane restore, `SessionPopupToggle Alt-3 default 제거`(메인 Backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)