### PR TITLE
feat(recent-windows): current window visible CURRENT no-op row (Phase 7)

### DIFF
--- a/internal/app/recent_window.go
+++ b/internal/app/recent_window.go
@@ -161,6 +161,12 @@ func (c *recentWindowCommand) Run(args []string, _ io.Writer, stderr io.Writer) 
 	if !ok {
 		return fmt.Errorf("recent window selection is not recognized: %s", value)
 	}
+	if selected.IsCurrent {
+		// Staying on the current window is a no-op / stay-current: the picker
+		// closes and tmux keeps the user where they already are. Never a switch
+		// or an error.
+		return nil
+	}
 	if err := c.openRecentWindow(ctx, selected); err != nil {
 		c.displayMessage(ctx, stderr, "recent window unavailable: "+recentWindowTargetLabel(selected))
 		c.refreshCandidates(ctx, current, store)
@@ -416,6 +422,9 @@ func recentWindowPickerItem(candidate recentwindows.Candidate, now time.Time) in
 	// selected-row background re-applies cleanly after every badge).
 	badgeText := recentWindowBadgeText(candidate)
 	title := notifySidebarProjectBadge(badgeText) + " " + name + " " + notifySidebarAge(age)
+	if candidate.IsCurrent {
+		title = recentWindowCurrentBadge() + " " + title
+	}
 
 	// Line 2: the window's pane topic/title summary (topic leads).
 	paneSummary := recentWindowPaneSummaryLine(candidate)
@@ -434,17 +443,21 @@ func recentWindowPickerItem(candidate recentwindows.Candidate, now time.Time) in
 		meta = append(meta, notifySidebarDim(context))
 	}
 
-	search := joinRecentWindowParts(append([]string{
-		candidate.WindowName,
-		candidate.Project,
-		candidate.Session,
-	}, append(recentWindowPaneTitles(candidate), []string{
+	searchTail := []string{
 		candidate.LastPaneTopic,
 		candidate.LastCommand,
 		age,
 		recentWindowFocusDate(candidate.LastFocusedAt),
 		candidate.Label.Secondary,
-	}...)...)...)
+	}
+	if candidate.IsCurrent {
+		searchTail = append(searchTail, recentWindowCurrentBadgeLabel)
+	}
+	search := joinRecentWindowParts(append([]string{
+		candidate.WindowName,
+		candidate.Project,
+		candidate.Session,
+	}, append(recentWindowPaneTitles(candidate), searchTail...)...)...)
 
 	return intpicker.Item{
 		Title:      title,
@@ -553,6 +566,16 @@ func recentWindowTopicChip(topic string) string {
 		return ""
 	}
 	return theme.ANSIChipActiveStart + " " + topic + " " + theme.ANSIReset
+}
+
+const recentWindowCurrentBadgeLabel = "CURRENT"
+
+// recentWindowCurrentBadge marks the row the user is already on. It uses the
+// notify info palette (bold dark text on a bright background) so it reads as a
+// distinct "you are here" marker, terminating with theme.ANSIReset like the
+// other badges so the selected-row background re-applies cleanly.
+func recentWindowCurrentBadge() string {
+	return theme.ANSINotifyInfoStart + " " + recentWindowCurrentBadgeLabel + " " + theme.ANSIReset
 }
 
 // recentWindowLastVisit labels the relative age so the row reads unambiguously

--- a/internal/app/recent_window_test.go
+++ b/internal/app/recent_window_test.go
@@ -375,6 +375,155 @@ func TestRecentWindowPickerItemKeepsSelectionValue(t *testing.T) {
 	}
 }
 
+func TestRecentWindowPickerItemMarksCurrentRow(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	snapshot := recentwindows.Snapshot{
+		Session:    "repos-projmux",
+		WindowID:   "@6",
+		WindowName: "projmux",
+		Project:    "Projmux",
+	}
+	current := recentwindows.Candidate{
+		Snapshot:  snapshot,
+		Label:     recentwindows.BuildLabel(snapshot),
+		IsCurrent: true,
+	}
+	item := recentWindowPickerItem(current, at)
+
+	visible := recentWindowStripANSI(item.Title)
+	currentIdx := strings.Index(visible, "CURRENT")
+	nameIdx := strings.Index(visible, "projmux")
+	if currentIdx < 0 {
+		t.Fatalf("Title visible = %q, want CURRENT marker", visible)
+	}
+	if nameIdx <= currentIdx {
+		t.Fatalf("Title visible = %q, want CURRENT marker before the window name", visible)
+	}
+	if !strings.Contains(item.Title, theme.ANSINotifyInfoStart) {
+		t.Fatalf("Title = %q, want notify info palette for the current badge", item.Title)
+	}
+	if !strings.HasSuffix(item.Title, theme.ANSIReset) {
+		t.Fatalf("Title = %q, want trailing reset", item.Title)
+	}
+	for _, want := range []string{"CURRENT", "Projmux", "repos-projmux", "projmux"} {
+		if !strings.Contains(item.SearchText, want) {
+			t.Fatalf("SearchText = %q, want substring %q", item.SearchText, want)
+		}
+	}
+
+	// A non-current candidate must not carry the CURRENT marker.
+	plain := recentWindowPickerItem(recentWindowCandidate(snapshot), at)
+	if strings.Contains(recentWindowStripANSI(plain.Title), "CURRENT") {
+		t.Fatalf("non-current Title = %q, want no CURRENT marker", plain.Title)
+	}
+}
+
+func TestRecentWindowRunCurrentRowIsNoOp(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux,1,0")
+
+	currentCandidate := recentwindows.Candidate{
+		Snapshot: recentwindows.Snapshot{
+			Socket:     "/tmp/tmux",
+			Session:    "current",
+			WindowID:   "@1",
+			WindowName: "current-window",
+		},
+		Label:     recentwindows.BuildLabel(recentwindows.Snapshot{Session: "current", WindowID: "@1", WindowName: "current-window"}),
+		IsCurrent: true,
+	}
+	store := &recentWindowStubStore{candidates: []recentwindows.Candidate{currentCandidate}}
+	runner := &recentWindowFakeRunner{
+		currentOutput: "/tmp/tmux" + recentWindowFieldSep + "current" + recentWindowFieldSep + "@1\n",
+		listOutputs:   "current" + recentWindowFieldSep + "@1\n",
+	}
+	opener := &recentWindowStubOpener{}
+	cmd := &recentWindowCommand{
+		runner: runner,
+		opener: opener,
+		storeFactory: func(string) (recentWindowStore, error) {
+			return store, nil
+		},
+		nativePicker: pickerRunnerFunc(func(intpicker.Options) (intpicker.Result, error) {
+			return intpicker.Result{Key: "enter", Value: recentWindowValue(currentCandidate)}, nil
+		}),
+		now: func() time.Time { return time.Unix(0, 0) },
+	}
+
+	if err := cmd.Run(nil, nil, nil); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	for _, call := range runner.calls {
+		if call.name == "tmux" && len(call.args) >= 1 && call.args[0] == "switch-client" {
+			t.Fatalf("calls = %#v, want no switch-client for the current row", runner.calls)
+		}
+	}
+	if opener.session != "" || opener.window != "" {
+		t.Fatalf("opener = %q %q, want opener never called for the current row", opener.session, opener.window)
+	}
+	if runner.sawDisplayMessage("recent window unavailable: " + recentWindowTargetLabel(currentCandidate)) {
+		t.Fatalf("calls = %#v, want no unavailable display-message for the current row", runner.calls)
+	}
+}
+
+func TestRecentWindowRunCurrentOnlyStateOpensPicker(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux,1,0")
+
+	currentCandidate := recentwindows.Candidate{
+		Snapshot: recentwindows.Snapshot{
+			Socket:     "/tmp/tmux",
+			Session:    "current",
+			WindowID:   "@1",
+			WindowName: "current-window",
+		},
+		Label:     recentwindows.BuildLabel(recentwindows.Snapshot{Session: "current", WindowID: "@1", WindowName: "current-window"}),
+		IsCurrent: true,
+	}
+	store := &recentWindowStubStore{candidates: []recentwindows.Candidate{currentCandidate}}
+	runner := &recentWindowFakeRunner{
+		currentOutput: "/tmp/tmux" + recentWindowFieldSep + "current" + recentWindowFieldSep + "@1\n",
+		listOutputs:   "current" + recentWindowFieldSep + "@1\n",
+	}
+	opener := &recentWindowStubOpener{}
+	var pickerOptions intpicker.Options
+	var pickerCalled bool
+	cmd := &recentWindowCommand{
+		runner: runner,
+		opener: opener,
+		storeFactory: func(string) (recentWindowStore, error) {
+			return store, nil
+		},
+		nativePicker: pickerRunnerFunc(func(options intpicker.Options) (intpicker.Result, error) {
+			pickerCalled = true
+			pickerOptions = options
+			return intpicker.Result{Key: "enter", Value: recentWindowValue(currentCandidate)}, nil
+		}),
+		now: func() time.Time { return time.Unix(0, 0) },
+	}
+
+	if err := cmd.Run(nil, nil, nil); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !pickerCalled {
+		t.Fatal("picker was not called for the current-only state")
+	}
+	if len(pickerOptions.Items) != 1 {
+		t.Fatalf("picker items = %#v, want exactly the current candidate", pickerOptions.Items)
+	}
+	if runner.sawDisplayMessage("no recent windows") {
+		t.Fatalf("calls = %#v, want no 'no recent windows' message for current-only state", runner.calls)
+	}
+	for _, call := range runner.calls {
+		if call.name == "tmux" && len(call.args) >= 1 && call.args[0] == "switch-client" {
+			t.Fatalf("calls = %#v, want no switch for the current-only state", runner.calls)
+		}
+	}
+	if opener.session != "" {
+		t.Fatalf("opener = %q, want opener never called", opener.session)
+	}
+}
+
 func TestRecentWindowRunEmptyQueueShowsMessage(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/recentwindows/model.go
+++ b/internal/core/recentwindows/model.go
@@ -53,7 +53,8 @@ type Label struct {
 
 type Candidate struct {
 	Snapshot
-	Label Label
+	Label     Label
+	IsCurrent bool
 }
 
 func NewState(entries []Snapshot) State {
@@ -89,12 +90,10 @@ func (s State) Candidates(current WindowKey, live []LiveWindow, limit int) ([]Ca
 			continue
 		}
 		kept = append(kept, entry)
-		if key == current {
-			continue
-		}
 		candidates = append(candidates, Candidate{
-			Snapshot: entry,
-			Label:    BuildLabel(entry),
+			Snapshot:  entry,
+			Label:     BuildLabel(entry),
+			IsCurrent: key == current,
 		})
 	}
 	return candidates, State{Version: Version, Entries: kept}

--- a/internal/core/recentwindows/model_test.go
+++ b/internal/core/recentwindows/model_test.go
@@ -91,7 +91,7 @@ func TestRecordRequiresWindowKey(t *testing.T) {
 	}
 }
 
-func TestCandidatesExcludeCurrentAndRetainCrossSession(t *testing.T) {
+func TestCandidatesIncludeCurrentAsMarkedRowAndRetainCrossSession(t *testing.T) {
 	t.Parallel()
 
 	state := NewState([]Snapshot{
@@ -106,14 +106,44 @@ func TestCandidatesExcludeCurrentAndRetainCrossSession(t *testing.T) {
 	}
 
 	candidates, pruned := state.Candidates(WindowKey{Socket: "/tmp/tmux", Session: "current", WindowID: "@1"}, live, 0)
-	if got, want := len(candidates), 2; got != want {
+	if got, want := len(candidates), 3; got != want {
 		t.Fatalf("candidates len = %d, want %d", got, want)
 	}
-	if candidates[0].Session != "other-project" || candidates[1].Session != "third-project" {
-		t.Fatalf("candidates = %+v, want cross-session entries retained", candidates)
+	if candidates[0].Session != "current" || candidates[1].Session != "other-project" || candidates[2].Session != "third-project" {
+		t.Fatalf("candidates = %+v, want MRU order [current, other-project, third-project]", candidates)
+	}
+	if !candidates[0].IsCurrent {
+		t.Fatalf("candidates[0] = %+v, want IsCurrent true for the current window", candidates[0])
+	}
+	if candidates[1].IsCurrent || candidates[2].IsCurrent {
+		t.Fatalf("candidates = %+v, want only the current row marked IsCurrent", candidates)
 	}
 	if got, want := len(pruned.Entries), 3; got != want {
 		t.Fatalf("pruned len = %d, want %d", got, want)
+	}
+}
+
+func TestCandidatesIncludeCurrentForSameSessionMultiWindow(t *testing.T) {
+	t.Parallel()
+
+	state := NewState([]Snapshot{
+		snap("/tmp/tmux", "repos-projmux", "@9", "zsh", time.Unix(2, 0)),
+		snap("/tmp/tmux", "repos-projmux", "@6", "projmux", time.Unix(1, 0)),
+	})
+	live := []LiveWindow{
+		{Socket: "/tmp/tmux", Session: "repos-projmux", WindowID: "@9"},
+		{Socket: "/tmp/tmux", Session: "repos-projmux", WindowID: "@6"},
+	}
+
+	candidates, _ := state.Candidates(WindowKey{Socket: "/tmp/tmux", Session: "repos-projmux", WindowID: "@6"}, live, 0)
+	if got, want := len(candidates), 2; got != want {
+		t.Fatalf("candidates len = %d, want %d (same-session multi-window history retained)", got, want)
+	}
+	if candidates[0].WindowID != "@9" || candidates[0].IsCurrent {
+		t.Fatalf("candidates[0] = %+v, want @9 as a normal (non-current) switch target", candidates[0])
+	}
+	if candidates[1].WindowID != "@6" || !candidates[1].IsCurrent {
+		t.Fatalf("candidates[1] = %+v, want @6 marked IsCurrent", candidates[1])
 	}
 }
 
@@ -135,6 +165,9 @@ func TestCandidatesPruneGoneWindowsAgainstSameSocketInventory(t *testing.T) {
 	}
 	if candidates[0].WindowName != "alive" {
 		t.Fatalf("candidate = %+v, want alive", candidates[0])
+	}
+	if candidates[0].IsCurrent {
+		t.Fatalf("candidate = %+v, want IsCurrent false when no current window is given", candidates[0])
 	}
 	if got, want := len(pruned.Entries), 1; got != want {
 		t.Fatalf("pruned len = %d, want %d", got, want)


### PR DESCRIPTION
## Phase 7 — current window visible no-op row

Recent Windows state already records the current window, but the picker excluded it entirely. That made same-session multi-window history (e.g. `repos-projmux @6` and `repos-projmux @9`) look like only one window was ever recorded. This phase surfaces the current window as a `CURRENT` row while keeping selection inert.

### User-facing surface
- **Alt-3 Recent Windows picker** now shows the current window as a `CURRENT` row instead of hiding it. The row leads with a `CURRENT` badge (notify info palette), then the project badge → readable window name → last-focus age.
- Same-session multi-window history is now visible: the current window shows as `CURRENT`, other windows in the same session remain normal switch targets.
- Search text for the current row includes `CURRENT` plus the existing project / session / window name / pane titles / topic / command / last-focus fields.

### Current row no-op policy
- Selecting the `CURRENT` row is a **no-op / stay-current**: the picker closes (same as any selection) and tmux keeps the user where they are. No `switch-client`, no error, no "unavailable" message. Locked by test.

### Current-only state
- When the only live recorded window is the current one, the picker opens showing the single `CURRENT` row rather than falling to the `no recent windows` empty state or a `returned 1`-style confusion. Genuinely empty state (nothing recorded) still shows `no recent windows`.

### Out of scope (unchanged)
- RecentWindows MRU state schema (no redesign).
- Record hook / producers.
- Window-level MRU ordering, max-20 bound, gone prune.
- Session/project recency model.
- Historical pane restore / RecentPanes advanced mode.
- Keybinding Settings IA.
- Notify sidebar integration.

### Preserved semantics
- State record/dedupe key remains `socket + session + window_id`.
- Non-current rows still switch to the target window (no historical pane restore).
- `kept` / gone-prune behavior in `State.Candidates` is identical; `IsCurrent` lives only on the in-memory `Candidate`, not persisted state.
- Selection value remains `session + sep + window_id`.

### Verification
- `make fmt`
- `make fix`
- `make test`
- Focused tests: same-session multi-window candidates include current + other windows; current row badge/style/palette; current row Enter no-op (no switch/opener call); non-current switch unchanged; current-only state opens picker; search text includes current row fields; gone prune unchanged; record dedupe remains `socket + session + window_id`.

### Not verified / follow-up
- No manual tmux smoke test in this session (lead session has a dirty `?? .antigravitycli/` in the primary checkout, untouched). Behavior is covered by unit tests.
- Follow-up tracks (separate, out of this detail): RecentPanes advanced mode / historical pane restore; `SessionPopupToggle Alt-3 default 제거` (main Backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)