### PR TITLE
feat(recent-windows): drop CURRENT badge, dedupe card context, richer pane preview (Phase 8)

### DIFF
--- a/internal/app/recent_window.go
+++ b/internal/app/recent_window.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/core/aibadge"
 	"github.com/crevissepartners/projmux/internal/core/recentwindows"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 	"github.com/crevissepartners/projmux/internal/theme"
@@ -85,6 +86,7 @@ type recentWindowCommand struct {
 	storeFactory recentWindowStoreFactory
 	nativePicker intpicker.Runner
 	lookupEnv    func(string) string
+	homeDir      func() (string, error)
 	now          func() time.Time
 }
 
@@ -96,8 +98,19 @@ func newRecentWindowCommand() *recentWindowCommand {
 		storeFactory: defaultRecentWindowStore,
 		nativePicker: intpicker.NativeRunner{In: os.Stdin, Out: os.Stdout},
 		lookupEnv:    os.Getenv,
+		homeDir:      os.UserHomeDir,
 		now:          time.Now,
 	}
+}
+
+// recentWindowAIBadgeStyle resolves the configured AI badge glyph style for the
+// picker, mirroring how switch.go reads it. It falls back to the dot style when
+// the home dir resolver is unset (e.g. in tests that do not exercise badges).
+func (c *recentWindowCommand) recentWindowAIBadgeStyle() string {
+	if c.homeDir == nil {
+		return aibadge.StyleDot
+	}
+	return aibadge.NormalizeStyle(string(loadAIBadgeStyle(c.homeDir, c.lookupEnv)))
 }
 
 func defaultRecentWindowStore(socket string) (recentWindowStore, error) {
@@ -148,7 +161,7 @@ func (c *recentWindowCommand) Run(args []string, _ io.Writer, stderr io.Writer) 
 		return fmt.Errorf("native picker is not configured")
 	}
 
-	items, byValue := recentWindowPickerItems(candidates, c.currentTime())
+	items, byValue := recentWindowPickerItems(candidates, c.currentTime(), c.recentWindowAIBadgeStyle())
 	result, err := c.nativePicker.Run(recentWindowPickerOptions(items))
 	if err != nil {
 		return fmt.Errorf("run recent windows picker: %w", err)
@@ -264,43 +277,52 @@ func (c *recentWindowCommand) currentSnapshot(ctx context.Context) (recentwindow
 	if len(fields) != 9 || fields[1] == "" || fields[2] == "" {
 		return recentwindows.Snapshot{}, fmt.Errorf("snapshot current tmux window: tmux returned incomplete metadata")
 	}
+	titles, badgeKinds := c.windowPaneMetadata(ctx, fields[2])
 	return recentwindows.Snapshot{
-		Socket:        fields[0],
-		Session:       fields[1],
-		WindowID:      fields[2],
-		WindowName:    fields[3],
-		Project:       recentWindowProjectName(fields[8]),
-		LastPaneID:    fields[4],
-		LastPaneTitle: fields[5],
-		PaneTitles:    c.windowPaneTitles(ctx, fields[2]),
-		LastPaneTopic: fields[6],
-		LastCommand:   fields[7],
-		LastFocusedAt: c.currentTime().UTC(),
+		Socket:         fields[0],
+		Session:        fields[1],
+		WindowID:       fields[2],
+		WindowName:     fields[3],
+		Project:        recentWindowProjectName(fields[8]),
+		LastPaneID:     fields[4],
+		LastPaneTitle:  fields[5],
+		PaneTitles:     titles,
+		PaneBadgeKinds: badgeKinds,
+		LastPaneTopic:  fields[6],
+		LastCommand:    fields[7],
+		LastFocusedAt:  c.currentTime().UTC(),
 	}, nil
 }
 
-// windowPaneTitles collects the pane titles of every pane in the given window
-// so the picker can render a multi-pane summary. Failures degrade gracefully:
-// an empty result falls back to LastPaneTitle at display time.
-func (c *recentWindowCommand) windowPaneTitles(ctx context.Context, windowID string) []string {
+// windowPaneMetadata collects every pane's title and AI badge kind for the given
+// window so the picker can render a multi-pane summary with per-pane status. The
+// returned slices are positionally aligned. Failures degrade gracefully: an
+// empty result falls back to LastPaneTitle at display time, and missing badge
+// kinds simply render the title without a status glyph.
+func (c *recentWindowCommand) windowPaneMetadata(ctx context.Context, windowID string) (titles, badgeKinds []string) {
 	if c.runner == nil || strings.TrimSpace(windowID) == "" {
-		return nil
+		return nil, nil
 	}
-	output, err := c.runner.Run(ctx, "tmux", "list-panes", "-t", windowID, "-F", "#{pane_title}")
+	format := strings.Join([]string{"#{pane_title}", "#{@projmux_ai_badge_kind}"}, recentWindowFieldSep)
+	output, err := c.runner.Run(ctx, "tmux", "list-panes", "-t", windowID, "-F", format)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	rows := parseRecentWindowRows(output, 1)
-	titles := make([]string, 0, len(rows))
+	rows := parseRecentWindowRows(output, 2)
+	titles = make([]string, 0, len(rows))
+	badgeKinds = make([]string, 0, len(rows))
 	for _, fields := range rows {
-		if title := strings.TrimSpace(fields[0]); title != "" {
-			titles = append(titles, title)
+		title := strings.TrimSpace(fields[0])
+		if title == "" {
+			continue
 		}
+		titles = append(titles, title)
+		badgeKinds = append(badgeKinds, strings.TrimSpace(fields[1]))
 	}
 	if len(titles) == 0 {
-		return nil
+		return nil, nil
 	}
-	return titles
+	return titles, badgeKinds
 }
 
 func (c *recentWindowCommand) liveWindows(ctx context.Context, socket string) ([]recentwindows.LiveWindow, error) {
@@ -376,7 +398,7 @@ func recentWindowPickerOptions(items []intpicker.Item) intpicker.Options {
 	return options
 }
 
-func recentWindowPickerItems(candidates []recentwindows.Candidate, now time.Time) ([]intpicker.Item, map[string]recentwindows.Candidate) {
+func recentWindowPickerItems(candidates []recentwindows.Candidate, now time.Time, badgeStyle string) ([]intpicker.Item, map[string]recentwindows.Candidate) {
 	items := make([]intpicker.Item, 0, len(candidates))
 	byValue := make(map[string]recentwindows.Candidate, len(candidates))
 	for _, candidate := range candidates {
@@ -384,7 +406,7 @@ func recentWindowPickerItems(candidates []recentwindows.Candidate, now time.Time
 		if value == "" {
 			continue
 		}
-		item := recentWindowPickerItem(candidate, now)
+		item := recentWindowPickerItem(candidate, now, badgeStyle)
 		item.Value = value
 		items = append(items, item)
 		byValue[value] = candidate
@@ -402,9 +424,12 @@ const (
 	recentWindowProjectBadgeMaxRunes = 24
 	recentWindowNameMaxRunes         = 48
 	recentWindowTopicChipMaxRunes    = 48
+	// recentWindowMaxPanes caps how many pane titles render on line 2 before the
+	// remainder collapses into a compact "+N" count (the Alt-1 sidebar pattern).
+	recentWindowMaxPanes = 3
 )
 
-func recentWindowPickerItem(candidate recentwindows.Candidate, now time.Time) intpicker.Item {
+func recentWindowPickerItem(candidate recentwindows.Candidate, now time.Time, badgeStyle string) intpicker.Item {
 	// The readable window name (never a raw @window_id/%pane_id). BuildLabel
 	// already falls back name -> project -> session -> pane/topic/cmd.
 	name := strings.TrimSpace(candidate.Label.Primary)
@@ -419,28 +444,23 @@ func recentWindowPickerItem(candidate recentwindows.Candidate, now time.Time) in
 	// Line 1: project badge -> readable window name -> last-focus age badge.
 	// Reuse the notify sidebar helpers so the badges match the notification
 	// sidebar palette and each badge terminates with theme.ANSIReset (so the
-	// selected-row background re-applies cleanly after every badge).
+	// selected-row background re-applies cleanly after every badge). The current
+	// window stays in history as a normal card with NO CURRENT badge.
 	badgeText := recentWindowBadgeText(candidate)
 	title := notifySidebarProjectBadge(badgeText) + " " + name + " " + notifySidebarAge(age)
-	if candidate.IsCurrent {
-		title = recentWindowCurrentBadge() + " " + title
-	}
 
-	// Line 2: the window's pane topic/title summary (topic leads).
-	paneSummary := recentWindowPaneSummaryLine(candidate)
+	// Line 2: the window's pane topic/title summary (topic leads, per-pane AI
+	// badges). Line 3: last-visit metadata. We deliberately do NOT add a context
+	// (project · session) line: the project already leads line 1 and the session
+	// unique id stays in SearchText/debug only.
+	paneSummary := recentWindowPaneSummaryLine(candidate, badgeStyle)
 
-	// Display-only context badge (project/session). Never a recency signal.
-	context := joinRecentWindowParts(candidate.Project, candidate.Session)
-
-	meta := make([]string, 0, 3)
+	meta := make([]string, 0, 2)
 	if paneSummary != "" {
 		meta = append(meta, paneSummary)
 	}
 	if lastVisit != "" {
 		meta = append(meta, lastVisit)
-	}
-	if context != "" && context != name {
-		meta = append(meta, notifySidebarDim(context))
 	}
 
 	searchTail := []string{
@@ -450,9 +470,8 @@ func recentWindowPickerItem(candidate recentwindows.Candidate, now time.Time) in
 		recentWindowFocusDate(candidate.LastFocusedAt),
 		candidate.Label.Secondary,
 	}
-	if candidate.IsCurrent {
-		searchTail = append(searchTail, recentWindowCurrentBadgeLabel)
-	}
+	// SearchText still carries the session unique id and pane metadata even though
+	// they are dropped from the visible card lines, so search stays comprehensive.
 	search := joinRecentWindowParts(append([]string{
 		candidate.WindowName,
 		candidate.Project,
@@ -533,29 +552,144 @@ func recentWindowPaneSummaryParts(candidate recentwindows.Candidate) []string {
 	return parts
 }
 
+// recentWindowPaneCell pairs a pane title with its own AI badge kind so the two
+// never desync as the summary is reordered (topic-prepend), deduped, or
+// overflow-collapsed. The topic chip is NOT a paneCell: it leads the line as a
+// chip with no per-pane badge.
+type recentWindowPaneCell struct {
+	title string
+	kind  string
+}
+
 // recentWindowPaneSummaryLine renders the line-2 pane summary with notify-level
 // visibility: the leading topic is wrapped in an active chip (like
-// notifySidebarTopicBadge) and the remaining pane titles are dimmed so they
-// read as secondary context rather than blending into plain meta text.
-func recentWindowPaneSummaryLine(candidate recentwindows.Candidate) string {
-	plain := recentWindowPaneSummary(candidate)
-	if plain == "" {
+// notifySidebarTopicBadge), each remaining pane title is prefixed with ITS OWN
+// per-pane AI badge glyph (when available) and dimmed, and panes beyond
+// recentWindowMaxPanes collapse into a compact "+N" count. Layout stays stable
+// because every visible pane title is rune-truncated identically to the plain
+// recentWindowPaneSummary path.
+func recentWindowPaneSummaryLine(candidate recentwindows.Candidate, badgeStyle string) string {
+	// recentWindowPaneSummary owns the canonical plain text (and its stable
+	// truncation); bail early when there is nothing to render so the no-summary
+	// path matches exactly.
+	if recentWindowPaneSummary(candidate) == "" {
 		return ""
 	}
-	parts := strings.SplitN(plain, " | ", 2)
-	lead := parts[0]
-	rest := ""
-	if len(parts) == 2 {
-		rest = parts[1]
-	}
-	if strings.TrimSpace(candidate.LastPaneTopic) != "" {
-		chip := recentWindowTopicChip(lead)
-		if rest != "" {
-			return chip + " " + notifySidebarDim(rest)
+
+	topic := strings.TrimSpace(candidate.LastPaneTopic)
+	cells := recentWindowPaneCells(candidate)
+
+	chip := ""
+	if topic != "" {
+		chip = recentWindowTopicChip(topic)
+		// The topic leads as a chip; drop any pane title that merely duplicates it
+		// so the same context is not shown twice. The badge kind travels with each
+		// title, so dropping a cell never shifts the remaining title↔badge binding.
+		filtered := cells[:0]
+		for _, cell := range cells {
+			if cell.title == topic {
+				continue
+			}
+			filtered = append(filtered, cell)
 		}
-		return chip
+		cells = filtered
 	}
-	return notifySidebarDim(plain)
+
+	visible := cells
+	overflow := 0
+	if len(cells) > recentWindowMaxPanes {
+		visible = cells[:recentWindowMaxPanes]
+		overflow = len(cells) - recentWindowMaxPanes
+	}
+
+	// Pane cells join with " | " so the visible separator survives ANSI stripping;
+	// the topic chip (when present) leads the line with a plain space gap.
+	rendered := make([]string, 0, len(visible)+1)
+	for _, cell := range visible {
+		// Truncate identically to the plain summary path so layout never shifts.
+		title := recentWindowTruncate(cell.title, recentWindowPaneSummaryMaxRunes)
+		body := notifySidebarDim(title)
+		if glyph := recentWindowPaneKindGlyph(cell.kind, badgeStyle); glyph != "" {
+			body = glyph + " " + body
+		}
+		rendered = append(rendered, body)
+	}
+	if overflow > 0 {
+		rendered = append(rendered, notifySidebarDim(fmt.Sprintf("+%d", overflow)))
+	}
+
+	body := strings.Join(rendered, " | ")
+	switch {
+	case chip != "" && body != "":
+		return chip + " " + body
+	case chip != "":
+		return chip
+	default:
+		return body
+	}
+}
+
+// recentWindowPaneCells builds the per-pane (title, badge kind) units, keeping
+// each title bound to its own kind regardless of later reordering or dedup. It
+// mirrors recentWindowPaneTitles' fallbacks: when no PaneTitles exist it falls
+// back to a single LastPaneTitle (then LastCommand) cell with no badge kind.
+func recentWindowPaneCells(candidate recentwindows.Candidate) []recentWindowPaneCell {
+	kinds := candidate.PaneBadgeKinds
+	cells := make([]recentWindowPaneCell, 0, len(candidate.PaneTitles))
+	for i, title := range candidate.PaneTitles {
+		if title = strings.TrimSpace(title); title == "" {
+			continue
+		}
+		kind := ""
+		if i < len(kinds) {
+			kind = strings.TrimSpace(kinds[i])
+		}
+		cells = append(cells, recentWindowPaneCell{title: title, kind: kind})
+	}
+	if len(cells) == 0 {
+		if title := strings.TrimSpace(candidate.LastPaneTitle); title != "" {
+			cells = append(cells, recentWindowPaneCell{title: title})
+		} else if cmd := strings.TrimSpace(candidate.LastCommand); cmd != "" {
+			cells = append(cells, recentWindowPaneCell{title: cmd})
+		}
+	}
+	return cells
+}
+
+// recentWindowPaneKindGlyph renders the themed AI badge glyph for a single
+// pane's badge kind, honoring the configured style (dot/emoji/off). It
+// terminates with theme.ANSIReset so the selected-row background re-applies
+// cleanly. Returns "" when the kind is unrecognized or the style is off.
+func recentWindowPaneKindGlyph(kind, badgeStyle string) string {
+	kind = aibadge.Normalize(kind)
+	if kind == "" {
+		return ""
+	}
+	glyph := aibadge.Glyph(kind, badgeStyle)
+	if strings.TrimSpace(glyph) == "" {
+		return ""
+	}
+	style := recentWindowAIBadgeKindStart(kind)
+	if style == "" {
+		return ""
+	}
+	return style + glyph + theme.ANSIReset
+}
+
+// recentWindowAIBadgeKindStart maps an AI badge kind to its themed ANSI start
+// sequence, mirroring the sidebar's ansiAIBadgeKindStart so the picker reuses
+// the same per-role palette.
+func recentWindowAIBadgeKindStart(kind string) string {
+	switch aibadge.ThemeRole(kind) {
+	case aibadge.RoleActionRequired:
+		return theme.ANSIAIBadgeActionRequiredStart
+	case aibadge.RoleSuccess:
+		return theme.ANSIAIBadgeSuccessStart
+	case aibadge.RoleProgress:
+		return theme.ANSIAIBadgeProgressStart
+	default:
+		return ""
+	}
 }
 
 // recentWindowTopicChip wraps the pane topic in the shared active chip palette,
@@ -566,16 +700,6 @@ func recentWindowTopicChip(topic string) string {
 		return ""
 	}
 	return theme.ANSIChipActiveStart + " " + topic + " " + theme.ANSIReset
-}
-
-const recentWindowCurrentBadgeLabel = "CURRENT"
-
-// recentWindowCurrentBadge marks the row the user is already on. It uses the
-// notify info palette (bold dark text on a bright background) so it reads as a
-// distinct "you are here" marker, terminating with theme.ANSIReset like the
-// other badges so the selected-row background re-applies cleanly.
-func recentWindowCurrentBadge() string {
-	return theme.ANSINotifyInfoStart + " " + recentWindowCurrentBadgeLabel + " " + theme.ANSIReset
 }
 
 // recentWindowLastVisit labels the relative age so the row reads unambiguously

--- a/internal/app/recent_window_test.go
+++ b/internal/app/recent_window_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/crevissepartners/projmux/internal/core/aibadge"
 	"github.com/crevissepartners/projmux/internal/core/recentwindows"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 	"github.com/crevissepartners/projmux/internal/theme"
@@ -45,7 +46,7 @@ func TestRecentWindowPickerItemEmphasizesNamesAndAge(t *testing.T) {
 	item := recentWindowPickerItem(recentwindows.Candidate{
 		Snapshot: snapshot,
 		Label:    recentwindows.BuildLabel(snapshot),
-	}, at.Add(12*time.Second))
+	}, at.Add(12*time.Second), aibadge.StyleDot)
 
 	// Line 1 reads: project badge -> readable window name -> age badge.
 	visibleTitle := recentWindowStripANSI(item.Title)
@@ -70,14 +71,22 @@ func TestRecentWindowPickerItemEmphasizesNamesAndAge(t *testing.T) {
 		t.Fatalf("Title = %q, want trailing reset", item.Title)
 	}
 	text := recentWindowStripANSI(item.Title + "\n" + strings.Join(item.MetaLines, "\n"))
-	for _, want := range []string{"codex-review", "12s ago", "Projmux", "repos-projmux"} {
+	for _, want := range []string{"codex-review", "12s ago", "Projmux"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("render text = %q, want %q", text, want)
 		}
 	}
+	// The session unique id is dropped from the visible card (deduped against the
+	// project badge) but must remain searchable.
+	if strings.Contains(text, "repos-projmux") {
+		t.Fatalf("render text = %q, want no visible session id line", text)
+	}
+	if !strings.Contains(item.SearchText, "repos-projmux") {
+		t.Fatalf("SearchText = %q, want session id searchable", item.SearchText)
+	}
 }
 
-func TestRecentWindowPickerItemShowsContextBadgeAsMetaLine(t *testing.T) {
+func TestRecentWindowPickerItemHasNoContextLine(t *testing.T) {
 	t.Parallel()
 
 	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
@@ -88,20 +97,25 @@ func TestRecentWindowPickerItemShowsContextBadgeAsMetaLine(t *testing.T) {
 		Project:    "Projmux",
 		PaneTitles: []string{"zsh"},
 	}
-	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at)
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
 
 	if got := recentWindowStripANSI(item.Title); !strings.Contains(got, "projmux") {
 		t.Fatalf("line 1 visible = %q, want readable window name", got)
 	}
-	wantContext := "Projmux · repos-projmux"
-	found := false
-	for _, line := range item.MetaLines {
-		if recentWindowStripANSI(line) == wantContext {
-			found = true
-		}
+	// The default card ends at three lines: title + at most two MetaLines (pane
+	// preview, last-visit). The deduped "project · session" context line and any
+	// session-id line must be gone.
+	if len(item.MetaLines) > 2 {
+		t.Fatalf("MetaLines = %#v, want at most two lines (pane preview, last visit)", item.MetaLines)
 	}
-	if !found {
-		t.Fatalf("MetaLines = %#v, want context badge %q on its own line", item.MetaLines, wantContext)
+	for _, line := range item.MetaLines {
+		visible := recentWindowStripANSI(line)
+		if visible == "Projmux · repos-projmux" {
+			t.Fatalf("MetaLines = %#v, want no repeated project/session context line", item.MetaLines)
+		}
+		if strings.Contains(visible, "repos-projmux") {
+			t.Fatalf("MetaLines = %#v, want no visible session id", item.MetaLines)
+		}
 	}
 }
 
@@ -116,7 +130,7 @@ func TestRecentWindowPickerItemFallsBackToNameNeverRawIDs(t *testing.T) {
 		LastPaneID:    "%54",
 		LastPaneTopic: "roadmap",
 	}
-	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at)
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
 
 	if strings.Contains(item.Title, "@6") || strings.Contains(item.Title, "%54") {
 		t.Fatalf("Title = %q, want fallback name, never raw tmux IDs", item.Title)
@@ -137,7 +151,7 @@ func TestRecentWindowPickerItemJoinsAllPaneTitles(t *testing.T) {
 		LastPaneTitle: "zsh",
 		PaneTitles:    []string{"zsh", "Codex · [lead:roadmap] Projmux", "Claude Code"},
 	}
-	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at)
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
 
 	want := "zsh | Codex · [lead:roadmap] Projmux | Claude Code"
 	found := false
@@ -162,7 +176,7 @@ func TestRecentWindowPickerItemFallsBackToLastPaneTitleSummary(t *testing.T) {
 		WindowName:    "projmux",
 		LastPaneTitle: "legacy-pane",
 	}
-	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at)
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
 
 	if got := recentWindowPaneSummary(recentWindowCandidate(snapshot)); got != "legacy-pane" {
 		t.Fatalf("pane summary = %q, want LastPaneTitle fallback", got)
@@ -218,7 +232,7 @@ func TestRecentWindowPickerItemLastVisitFormat(t *testing.T) {
 		WindowName:    "projmux",
 		LastFocusedAt: at,
 	}
-	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at.Add(3*time.Minute))
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at.Add(3*time.Minute), aibadge.StyleDot)
 
 	want := "last visit · 3m ago · 2026-06-18 01:02"
 	found := false
@@ -243,7 +257,7 @@ func TestRecentWindowPickerItemPaneTopicLeadsSummary(t *testing.T) {
 		LastPaneTopic: "Phase 6 polish",
 		PaneTitles:    []string{"zsh", "Claude Code"},
 	}
-	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at)
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
 
 	if len(item.MetaLines) == 0 {
 		t.Fatalf("MetaLines = %#v, want a pane summary line", item.MetaLines)
@@ -267,6 +281,192 @@ func TestRecentWindowPickerItemPaneTopicLeadsSummary(t *testing.T) {
 	}
 }
 
+func TestRecentWindowPickerItemRendersPerPaneAIBadges(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	snapshot := recentwindows.Snapshot{
+		Session:        "repos-projmux",
+		WindowID:       "@6",
+		WindowName:     "projmux",
+		PaneTitles:     []string{"Claude Code", "Codex", "zsh"},
+		PaneBadgeKinds: []string{"in_progress", "response_complete", ""},
+	}
+
+	// Dot style: recognized kinds render a themed "●" glyph in front of the pane.
+	dot := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
+	if len(dot.MetaLines) == 0 {
+		t.Fatalf("MetaLines = %#v, want a pane summary line", dot.MetaLines)
+	}
+	line := dot.MetaLines[0]
+	if !strings.Contains(line, theme.ANSIAIBadgeProgressStart+"●") {
+		t.Fatalf("pane summary = %q, want in_progress dot badge", line)
+	}
+	if !strings.Contains(line, theme.ANSIAIBadgeSuccessStart+"●") {
+		t.Fatalf("pane summary = %q, want response_complete dot badge", line)
+	}
+	visible := recentWindowStripANSI(line)
+	if !strings.Contains(visible, "Claude Code") || !strings.Contains(visible, "Codex") || !strings.Contains(visible, "zsh") {
+		t.Fatalf("pane summary visible = %q, want all pane titles", visible)
+	}
+
+	// Emoji style: recognized kinds render their emoji glyph instead of the dot.
+	emoji := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleEmoji)
+	emojiLine := recentWindowStripANSI(emoji.MetaLines[0])
+	if !strings.Contains(emojiLine, "🔄") || !strings.Contains(emojiLine, "✅") {
+		t.Fatalf("pane summary emoji = %q, want in_progress and response_complete emoji glyphs", emojiLine)
+	}
+
+	// Off style: no glyph is rendered, only the plain dimmed titles.
+	off := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleOff)
+	offVisible := recentWindowStripANSI(off.MetaLines[0])
+	if strings.ContainsAny(offVisible, "●🔄✅") {
+		t.Fatalf("pane summary off = %q, want no badge glyphs", offVisible)
+	}
+	if want := "Claude Code | Codex | zsh"; !strings.Contains(offVisible, want) {
+		t.Fatalf("pane summary off = %q, want plain titles %q", offVisible, want)
+	}
+}
+
+// recentWindowPaneCellFor splits the ANSI-stripped pane summary line on " | "
+// and returns the cell containing substr, so tests can assert badge↔pane
+// correspondence per cell.
+func recentWindowPaneCellFor(t *testing.T, line, substr string) string {
+	t.Helper()
+	for cell := range strings.SplitSeq(recentWindowStripANSI(line), " | ") {
+		if strings.Contains(cell, substr) {
+			return cell
+		}
+	}
+	t.Fatalf("pane summary line = %q, want a cell containing %q", line, substr)
+	return ""
+}
+
+func TestRecentWindowPickerItemBindsBadgeToOwnPaneWithLeadingTopic(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	// The bug: with a leading topic, the in_progress dot was painted on "zsh"
+	// (pane 0) instead of "Codex" (pane 1) because the badge lookup used a +1
+	// offset against a positionally-aligned slice. Each pane title must carry its
+	// own badge kind through the topic-prepend/dedup logic.
+	snapshot := recentwindows.Snapshot{
+		Session:        "repos-projmux",
+		WindowID:       "@6",
+		WindowName:     "projmux",
+		PaneTitles:     []string{"zsh", "Codex"},
+		PaneBadgeKinds: []string{"", "in_progress"},
+		LastPaneTopic:  "Phase 8",
+	}
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
+	if len(item.MetaLines) == 0 {
+		t.Fatalf("MetaLines = %#v, want a pane summary line", item.MetaLines)
+	}
+	line := item.MetaLines[0]
+
+	// Topic chip leads, then the pane cells in order.
+	visible := recentWindowStripANSI(line)
+	topicIdx := strings.Index(visible, "Phase 8")
+	zshIdx := strings.Index(visible, "zsh")
+	codexIdx := strings.Index(visible, "Codex")
+	if topicIdx < 0 || zshIdx <= topicIdx || codexIdx <= zshIdx {
+		t.Fatalf("pane summary line = %q, want order topic -> zsh -> Codex", visible)
+	}
+
+	// The in_progress themed glyph belongs to Codex, NOT zsh.
+	dot := theme.ANSIAIBadgeProgressStart + "●"
+	codexCell := recentWindowPaneCellFor(t, line, "Codex")
+	zshCell := recentWindowPaneCellFor(t, line, "zsh")
+	// Operate on the ANSI-bearing cells to confirm the themed glyph placement.
+	codexFull, zshFull := "", ""
+	for cell := range strings.SplitSeq(line, " | ") {
+		switch {
+		case strings.Contains(recentWindowStripANSI(cell), "Codex"):
+			codexFull = cell
+		case strings.Contains(recentWindowStripANSI(cell), "zsh"):
+			zshFull = cell
+		}
+	}
+	if !strings.Contains(codexFull, dot) {
+		t.Fatalf("Codex cell = %q, want in_progress dot %q before Codex", codexFull, dot)
+	}
+	if strings.Contains(zshFull, dot) || strings.Contains(zshCell, "●") {
+		t.Fatalf("zsh cell = %q, want NO badge glyph", zshFull)
+	}
+	if strings.Contains(codexCell, "●") == false {
+		t.Fatalf("Codex cell (stripped) = %q, want a ● glyph", codexCell)
+	}
+}
+
+func TestRecentWindowPickerItemTopicDedupKeepsBadgeBinding(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	// A pane title equal to the topic is deduped (dropped) from the cells. The
+	// remaining pane's badge must stay bound to it and not shift.
+	snapshot := recentwindows.Snapshot{
+		Session:        "repos-projmux",
+		WindowID:       "@6",
+		WindowName:     "projmux",
+		PaneTitles:     []string{"Phase 8", "Codex"},
+		PaneBadgeKinds: []string{"", "in_progress"},
+		LastPaneTopic:  "Phase 8",
+	}
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
+	if len(item.MetaLines) == 0 {
+		t.Fatalf("MetaLines = %#v, want a pane summary line", item.MetaLines)
+	}
+	line := item.MetaLines[0]
+
+	// "Phase 8" appears once (as the leading chip), not duplicated as a pane cell.
+	visible := recentWindowStripANSI(line)
+	if strings.Count(visible, "Phase 8") != 1 {
+		t.Fatalf("pane summary line = %q, want topic shown once (chip), pane title deduped", visible)
+	}
+
+	dot := theme.ANSIAIBadgeProgressStart + "●"
+	codexFull := ""
+	for cell := range strings.SplitSeq(line, " | ") {
+		if strings.Contains(recentWindowStripANSI(cell), "Codex") {
+			codexFull = cell
+		}
+	}
+	if !strings.Contains(codexFull, dot) {
+		t.Fatalf("Codex cell = %q, want in_progress dot %q to stay bound after dedup", codexFull, dot)
+	}
+}
+
+func TestRecentWindowPickerItemCollapsesExtraPanesIntoCount(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	snapshot := recentwindows.Snapshot{
+		Session:    "repos-projmux",
+		WindowID:   "@6",
+		WindowName: "projmux",
+		PaneTitles: []string{"one", "two", "three", "four", "five"},
+	}
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
+
+	if len(item.MetaLines) == 0 {
+		t.Fatalf("MetaLines = %#v, want a pane summary line", item.MetaLines)
+	}
+	visible := recentWindowStripANSI(item.MetaLines[0])
+	// First recentWindowMaxPanes (3) render; the remaining two collapse into "+2".
+	if want := "one | two | three | +2"; !strings.Contains(visible, want) {
+		t.Fatalf("pane summary = %q, want first %d panes then %q", visible, recentWindowMaxPanes, "+2")
+	}
+	if strings.Contains(visible, "four") || strings.Contains(visible, "five") {
+		t.Fatalf("pane summary = %q, want overflow panes collapsed, not listed", visible)
+	}
+	// All pane titles must still be searchable even when collapsed on screen.
+	for _, want := range []string{"four", "five"} {
+		if !strings.Contains(item.SearchText, want) {
+			t.Fatalf("SearchText = %q, want overflow pane %q searchable", item.SearchText, want)
+		}
+	}
+}
+
 func TestRecentWindowPickerItemTruncatesLongComponentsKeepingNameAndAge(t *testing.T) {
 	t.Parallel()
 
@@ -278,7 +478,7 @@ func TestRecentWindowPickerItemTruncatesLongComponentsKeepingNameAndAge(t *testi
 		Project:       strings.Repeat("project", 12),
 		LastFocusedAt: at,
 	}
-	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at.Add(2*time.Minute))
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at.Add(2*time.Minute), aibadge.StyleDot)
 
 	visible := recentWindowStripANSI(item.Title)
 	if !strings.Contains(visible, "2m ago") {
@@ -310,7 +510,7 @@ func TestRecentWindowPickerItemRowRendersWithoutStyleBleed(t *testing.T) {
 		PaneTitles:    []string{"zsh"},
 		LastFocusedAt: at,
 	}
-	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at.Add(time.Minute))
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at.Add(time.Minute), aibadge.StyleDot)
 	row := projmuxpicker.Row{Label: item.Title, MetaLines: item.MetaLines}
 
 	for _, selected := range []bool{true, false} {
@@ -342,7 +542,7 @@ func TestRecentWindowPickerItemSearchTextIncludesPaneTitlesAndDate(t *testing.T)
 		LastCommand:   "codex",
 		LastFocusedAt: at,
 	}
-	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at.Add(time.Minute))
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at.Add(time.Minute), aibadge.StyleDot)
 
 	for _, want := range []string{"projmux", "Projmux", "repos-projmux", "zsh", "Claude Code", "Codex", "roadmap", "codex", "2026-06-18 01:02"} {
 		if !strings.Contains(item.SearchText, want) {
@@ -361,7 +561,7 @@ func TestRecentWindowPickerItemKeepsSelectionValue(t *testing.T) {
 		WindowName: "projmux",
 	}
 	candidate := recentWindowCandidate(snapshot)
-	items, byValue := recentWindowPickerItems([]recentwindows.Candidate{candidate}, at)
+	items, byValue := recentWindowPickerItems([]recentwindows.Candidate{candidate}, at, aibadge.StyleDot)
 
 	if len(items) != 1 {
 		t.Fatalf("items = %#v, want one", items)
@@ -375,7 +575,7 @@ func TestRecentWindowPickerItemKeepsSelectionValue(t *testing.T) {
 	}
 }
 
-func TestRecentWindowPickerItemMarksCurrentRow(t *testing.T) {
+func TestRecentWindowPickerItemHasNoCurrentBadge(t *testing.T) {
 	t.Parallel()
 
 	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
@@ -390,31 +590,29 @@ func TestRecentWindowPickerItemMarksCurrentRow(t *testing.T) {
 		Label:     recentwindows.BuildLabel(snapshot),
 		IsCurrent: true,
 	}
-	item := recentWindowPickerItem(current, at)
+	item := recentWindowPickerItem(current, at, aibadge.StyleDot)
 
-	visible := recentWindowStripANSI(item.Title)
-	currentIdx := strings.Index(visible, "CURRENT")
-	nameIdx := strings.Index(visible, "projmux")
-	if currentIdx < 0 {
-		t.Fatalf("Title visible = %q, want CURRENT marker", visible)
+	// Agreed policy: the current window stays in history as a normal card with NO
+	// CURRENT badge — neither in the visible Title nor in SearchText.
+	if strings.Contains(recentWindowStripANSI(item.Title), "CURRENT") {
+		t.Fatalf("current Title = %q, want no CURRENT marker", item.Title)
 	}
-	if nameIdx <= currentIdx {
-		t.Fatalf("Title visible = %q, want CURRENT marker before the window name", visible)
+	if strings.Contains(item.SearchText, "CURRENT") {
+		t.Fatalf("current SearchText = %q, want no CURRENT marker", item.SearchText)
 	}
-	if !strings.Contains(item.Title, theme.ANSINotifyInfoStart) {
-		t.Fatalf("Title = %q, want notify info palette for the current badge", item.Title)
+	// The card still renders the readable window name and stays searchable by the
+	// session unique id.
+	if !strings.Contains(recentWindowStripANSI(item.Title), "projmux") {
+		t.Fatalf("current Title = %q, want readable window name", item.Title)
 	}
-	if !strings.HasSuffix(item.Title, theme.ANSIReset) {
-		t.Fatalf("Title = %q, want trailing reset", item.Title)
-	}
-	for _, want := range []string{"CURRENT", "Projmux", "repos-projmux", "projmux"} {
+	for _, want := range []string{"Projmux", "repos-projmux", "projmux"} {
 		if !strings.Contains(item.SearchText, want) {
 			t.Fatalf("SearchText = %q, want substring %q", item.SearchText, want)
 		}
 	}
 
-	// A non-current candidate must not carry the CURRENT marker.
-	plain := recentWindowPickerItem(recentWindowCandidate(snapshot), at)
+	// A non-current candidate also carries no CURRENT marker.
+	plain := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
 	if strings.Contains(recentWindowStripANSI(plain.Title), "CURRENT") {
 		t.Fatalf("non-current Title = %q, want no CURRENT marker", plain.Title)
 	}
@@ -697,7 +895,9 @@ func TestRecentWindowRecordSnapshotsCurrentTmuxWindow(t *testing.T) {
 			"codex",
 			filepath.Join(project, "internal", "app"),
 		}, recentWindowFieldSep) + "\n",
-		listPanesOutput: "codex-review\nClaude Code\nzsh\n",
+		listPanesOutput: strings.Join([]string{"codex-review", "in_progress"}, recentWindowFieldSep) + "\n" +
+			strings.Join([]string{"Claude Code", "response_complete"}, recentWindowFieldSep) + "\n" +
+			strings.Join([]string{"zsh", ""}, recentWindowFieldSep) + "\n",
 	}
 	store := &recentWindowStubStore{}
 	cmd := &recentWindowCommand{
@@ -726,6 +926,9 @@ func TestRecentWindowRecordSnapshotsCurrentTmuxWindow(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.PaneTitles, []string{"codex-review", "Claude Code", "zsh"}) {
 		t.Fatalf("snapshot pane titles = %+v, want all panes of the window", got.PaneTitles)
+	}
+	if !reflect.DeepEqual(got.PaneBadgeKinds, []string{"in_progress", "response_complete", ""}) {
+		t.Fatalf("snapshot pane badge kinds = %+v, want per-pane AI badge kinds aligned with titles", got.PaneBadgeKinds)
 	}
 	if got.Project != filepath.Base(project) {
 		t.Fatalf("snapshot project = %q, want %q", got.Project, filepath.Base(project))
@@ -971,7 +1174,7 @@ func (r *recentWindowFakeRunner) Run(_ context.Context, name string, args ...str
 	if name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-F", strings.Join([]string{"#{socket_path}", "#{session_name}", "#{window_id}", "#{window_name}", "#{pane_id}", "#{pane_title}", "#{@projmux_ai_topic}", "#{pane_current_command}", "#{pane_current_path}"}, recentWindowFieldSep)}) {
 		return []byte(r.recordOutput), nil
 	}
-	if name == "tmux" && len(args) == 5 && args[0] == "list-panes" && args[1] == "-t" && args[3] == "-F" && args[4] == "#{pane_title}" {
+	if name == "tmux" && len(args) == 5 && args[0] == "list-panes" && args[1] == "-t" && args[3] == "-F" && args[4] == strings.Join([]string{"#{pane_title}", "#{@projmux_ai_badge_kind}"}, recentWindowFieldSep) {
 		return []byte(r.listPanesOutput), nil
 	}
 	if name == "tmux" && reflect.DeepEqual(args, []string{"list-windows", "-a", "-F", strings.Join([]string{"#{session_name}", "#{window_id}"}, recentWindowFieldSep)}) {

--- a/internal/core/recentwindows/model.go
+++ b/internal/core/recentwindows/model.go
@@ -5,6 +5,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/aibadge"
 )
 
 const (
@@ -21,17 +23,21 @@ type WindowKey struct {
 }
 
 type Snapshot struct {
-	Socket        string    `json:"socket"`
-	Session       string    `json:"session"`
-	WindowID      string    `json:"window_id"`
-	WindowName    string    `json:"window_name,omitempty"`
-	Project       string    `json:"project,omitempty"`
-	LastPaneID    string    `json:"last_pane_id,omitempty"`
-	LastPaneTitle string    `json:"last_pane_title,omitempty"`
-	PaneTitles    []string  `json:"pane_titles,omitempty"`
-	LastPaneTopic string    `json:"last_pane_topic,omitempty"`
-	LastCommand   string    `json:"last_command,omitempty"`
-	LastFocusedAt time.Time `json:"last_focused_at"`
+	Socket        string   `json:"socket"`
+	Session       string   `json:"session"`
+	WindowID      string   `json:"window_id"`
+	WindowName    string   `json:"window_name,omitempty"`
+	Project       string   `json:"project,omitempty"`
+	LastPaneID    string   `json:"last_pane_id,omitempty"`
+	LastPaneTitle string   `json:"last_pane_title,omitempty"`
+	PaneTitles    []string `json:"pane_titles,omitempty"`
+	// PaneBadgeKinds carries the per-pane AI badge kind parallel to PaneTitles
+	// (same length/order when available). Additive and backward compatible: old
+	// state files omit it, so the picker falls back to titles-only rendering.
+	PaneBadgeKinds []string  `json:"pane_badge_kinds,omitempty"`
+	LastPaneTopic  string    `json:"last_pane_topic,omitempty"`
+	LastCommand    string    `json:"last_command,omitempty"`
+	LastFocusedAt  time.Time `json:"last_focused_at"`
 }
 
 type State struct {
@@ -186,6 +192,7 @@ func normalizeSnapshot(snapshot Snapshot) Snapshot {
 	snapshot.LastPaneID = strings.TrimSpace(snapshot.LastPaneID)
 	snapshot.LastPaneTitle = strings.TrimSpace(snapshot.LastPaneTitle)
 	snapshot.PaneTitles = normalizePaneTitles(snapshot.PaneTitles)
+	snapshot.PaneBadgeKinds = normalizePaneBadgeKinds(snapshot.PaneBadgeKinds)
 	snapshot.LastPaneTopic = strings.TrimSpace(snapshot.LastPaneTopic)
 	snapshot.LastCommand = strings.TrimSpace(snapshot.LastCommand)
 	if !snapshot.LastFocusedAt.IsZero() {
@@ -208,6 +215,29 @@ func normalizePaneTitles(titles []string) []string {
 		return nil
 	}
 	return out
+}
+
+// normalizePaneBadgeKinds normalizes each per-pane AI badge kind while keeping
+// positional alignment with PaneTitles: a pane with no/unknown badge keeps an
+// empty slot rather than shifting later panes. Trailing empties are trimmed and
+// an all-empty slice collapses to nil so backward-compatible state stays clean.
+func normalizePaneBadgeKinds(kinds []string) []string {
+	if len(kinds) == 0 {
+		return nil
+	}
+	out := make([]string, len(kinds))
+	last := -1
+	for i, kind := range kinds {
+		normalized := aibadge.Normalize(kind)
+		out[i] = normalized
+		if normalized != "" {
+			last = i
+		}
+	}
+	if last < 0 {
+		return nil
+	}
+	return out[:last+1]
 }
 
 func normalizeKey(key WindowKey) WindowKey {

--- a/internal/core/recentwindows/model_test.go
+++ b/internal/core/recentwindows/model_test.go
@@ -253,6 +253,48 @@ func TestRecordPreservesPaneTitlesRoundTrip(t *testing.T) {
 	}
 }
 
+func TestNormalizeSnapshotPaneBadgeKinds(t *testing.T) {
+	t.Parallel()
+
+	// Per-pane badge kinds keep positional alignment with PaneTitles: an
+	// unrecognized or empty kind becomes an empty slot rather than shifting later
+	// panes, and trailing empties are trimmed.
+	snapshot := normalizeSnapshot(Snapshot{
+		Session:        "s",
+		WindowID:       "@1",
+		PaneTitles:     []string{"a", "b", "c"},
+		PaneBadgeKinds: []string{"", "  in_progress ", "bogus"},
+	})
+	if got := snapshot.PaneBadgeKinds; len(got) != 2 || got[0] != "" || got[1] != "in_progress" {
+		t.Fatalf("pane badge kinds = %#v, want empty slot preserved, kind kept, unknown/trailing trimmed", got)
+	}
+
+	// An all-empty/unknown slice collapses to nil for backward-compatible state.
+	if got := normalizeSnapshot(Snapshot{Session: "s", WindowID: "@1", PaneBadgeKinds: []string{"", "nope"}}).PaneBadgeKinds; got != nil {
+		t.Fatalf("pane badge kinds = %#v, want nil for all-empty", got)
+	}
+}
+
+func TestRecordPreservesPaneBadgeKindsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	state, err := NewState(nil).Record(Snapshot{
+		Session:        "s",
+		WindowID:       "@1",
+		WindowName:     "main",
+		PaneTitles:     []string{"zsh", "Claude Code"},
+		PaneBadgeKinds: []string{"", "in_progress"},
+		LastFocusedAt:  now,
+	}, 0)
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if got := state.Entries[0].PaneBadgeKinds; len(got) != 2 || got[0] != "" || got[1] != "in_progress" {
+		t.Fatalf("pane badge kinds = %#v, want preserved round-trip", got)
+	}
+}
+
 func TestRecordWindowMRUDoesNotReorderBeyondWindowList(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Phase 8 — current-row badge correction, dedupe card context, richer pane preview

Roadmap track: **Recent windows queue** (`Alt-3` cross-project window MRU picker). Source of truth: Obsidian `로드맵 디테일 - Recent windows queue`.

### Completed phase
- **Phase 8** — and only Phase 8.

### User-facing surface changed
Recent Windows **Alt-3 picker card** only:
1. **`CURRENT` badge removed** (Phase 7 drift correction). Agreed policy restored: the current window stays in history as a normal card with **no** badge; initial selection is the first non-current row; Enter on the current row is a no-op/stay-current; Enter on a non-current row switches. Dead helpers `recentWindowCurrentBadge` / `recentWindowCurrentBadgeLabel` deleted; `CURRENT` token dropped from SearchText.
2. **De-duplicated card context.** The card is now exactly 3 lines: (1) project badge + readable window name + last-focus age, (2) rich pane preview, (3) `last visit · {age} · {date}`. The repeated `project · session` context line and the visible session-id line are gone. The session unique id (`repos-*`) stays in **SearchText/debug only**, so search remains comprehensive.
3. **Richer pane preview.** Pane topic/name list joined with ` | ` (Alt-1 sidebar pattern), each pane prefixed with its **own** per-pane AI status badge glyph, capped at 3 panes with a compact `+N` overflow. AI badge **style is honored live** (dot/emoji/off) via `@projmux_ai_badge_style` (same `loadAIBadgeStyle` path as switch.go); themed per badge-kind role (`in_progress`/`response_complete`/`approval_required`/`input_required`).

### Explicitly out of scope (unchanged)
- RecentPanes advanced mode / historical pane restore.
- keybinding Settings IA changes; SessionPopupToggle deletion; notify sidebar integration.
- Alt-1 Project sidebar itself (reference only).
- No large shared-renderer extraction.

### Model / schema / engine constraints respected
- RecentWindows **MRU ordering**, current-row **no-op semantics**, **max-20** bound: unchanged.
- Record **dedupe key** stays `socket + session + window_id`.
- Session/project recency model unchanged; Recent Windows MRU does **not** propagate to Alt-1 / session/project ordering.
- Only an **additive** `Snapshot.PaneBadgeKinds []string` field (`json:"pane_badge_kinds,omitempty"`, positionally parallel to `PaneTitles`), populated at record time from `#{@projmux_ai_badge_kind}`. **No state Version bump**; old state files render titles-only. Selection value (`session\x1fwindow_id`) and switch semantics unchanged.

### Validation
- `make fmt` — clean (no residual diff).
- `make fix` — clean.
- `make test` — all packages ok, no failures.
- `go test ./internal/app/ -run RecentWindow -count=1` — ok.
- `go test ./internal/core/recentwindows/ -count=1` — ok.
- Focused tests: no `CURRENT` marker on current/non-current rows; no repeated project/session line; no 4th-line session id; per-pane AI badge **bound to the correct pane** including the topic-leading and topic-dedup cases (regression test added); dot/emoji/off style behavior; `+N` overflow; SearchText still includes session id + pane metadata; current-row no-op and first-non-current initial selection unchanged.

### Unverified / follow-up candidates
- No live `Alt-3` interactive tmux smoke (badge color/position, `+N` collapse, emoji/off reflection, current-row Enter no-op). The item builder is terminal-width-agnostic; structure/palette/handling are unit-tested. Live `Alt-3` visual check recommended after install — **e2e candidate**.
- Per-pane badge kind is a record-time snapshot (like `PaneTitles`), so it reflects state at last focus, not live — acceptable for an MRU recency picker; documented tradeoff.
- Out-of-track follow-ups: RecentPanes advanced mode / historical pane restore; `SessionPopupToggle Alt-3 default 제거` (main Backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
