### PR TITLE
feat(recent-windows): default cursor to first non-current row, flat line-2 perceived titles (Phase 9)

### DIFF
--- a/internal/app/recent_window.go
+++ b/internal/app/recent_window.go
@@ -161,8 +161,8 @@ func (c *recentWindowCommand) Run(args []string, _ io.Writer, stderr io.Writer) 
 		return fmt.Errorf("native picker is not configured")
 	}
 
-	items, byValue := recentWindowPickerItems(candidates, c.currentTime(), c.recentWindowAIBadgeStyle())
-	result, err := c.nativePicker.Run(recentWindowPickerOptions(items))
+	items, byValue, initialIndex := recentWindowPickerItems(candidates, c.currentTime(), c.recentWindowAIBadgeStyle())
+	result, err := c.nativePicker.Run(recentWindowPickerOptions(items, initialIndex))
 	if err != nil {
 		return fmt.Errorf("run recent windows picker: %w", err)
 	}
@@ -277,7 +277,7 @@ func (c *recentWindowCommand) currentSnapshot(ctx context.Context) (recentwindow
 	if len(fields) != 9 || fields[1] == "" || fields[2] == "" {
 		return recentwindows.Snapshot{}, fmt.Errorf("snapshot current tmux window: tmux returned incomplete metadata")
 	}
-	titles, badgeKinds := c.windowPaneMetadata(ctx, fields[2])
+	titles, badgeKinds, topics := c.windowPaneMetadata(ctx, fields[2])
 	return recentwindows.Snapshot{
 		Socket:         fields[0],
 		Session:        fields[1],
@@ -288,29 +288,32 @@ func (c *recentWindowCommand) currentSnapshot(ctx context.Context) (recentwindow
 		LastPaneTitle:  fields[5],
 		PaneTitles:     titles,
 		PaneBadgeKinds: badgeKinds,
+		PaneTopics:     topics,
 		LastPaneTopic:  fields[6],
 		LastCommand:    fields[7],
 		LastFocusedAt:  c.currentTime().UTC(),
 	}, nil
 }
 
-// windowPaneMetadata collects every pane's title and AI badge kind for the given
-// window so the picker can render a multi-pane summary with per-pane status. The
-// returned slices are positionally aligned. Failures degrade gracefully: an
-// empty result falls back to LastPaneTitle at display time, and missing badge
-// kinds simply render the title without a status glyph.
-func (c *recentWindowCommand) windowPaneMetadata(ctx context.Context, windowID string) (titles, badgeKinds []string) {
+// windowPaneMetadata collects every pane's title, AI badge kind, and AI topic
+// for the given window so the picker can render a multi-pane summary with
+// per-pane status and per-pane perceived title. The returned slices are
+// positionally aligned. Failures degrade gracefully: an empty result falls back
+// to LastPaneTitle at display time, missing badge kinds render the title without
+// a status glyph, and missing topics fall back to the pane title then command.
+func (c *recentWindowCommand) windowPaneMetadata(ctx context.Context, windowID string) (titles, badgeKinds, topics []string) {
 	if c.runner == nil || strings.TrimSpace(windowID) == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
-	format := strings.Join([]string{"#{pane_title}", "#{@projmux_ai_badge_kind}"}, recentWindowFieldSep)
+	format := strings.Join([]string{"#{pane_title}", "#{@projmux_ai_badge_kind}", "#{@projmux_ai_topic}"}, recentWindowFieldSep)
 	output, err := c.runner.Run(ctx, "tmux", "list-panes", "-t", windowID, "-F", format)
 	if err != nil {
-		return nil, nil
+		return nil, nil, nil
 	}
-	rows := parseRecentWindowRows(output, 2)
+	rows := parseRecentWindowRows(output, 3)
 	titles = make([]string, 0, len(rows))
 	badgeKinds = make([]string, 0, len(rows))
+	topics = make([]string, 0, len(rows))
 	for _, fields := range rows {
 		title := strings.TrimSpace(fields[0])
 		if title == "" {
@@ -318,11 +321,12 @@ func (c *recentWindowCommand) windowPaneMetadata(ctx context.Context, windowID s
 		}
 		titles = append(titles, title)
 		badgeKinds = append(badgeKinds, strings.TrimSpace(fields[1]))
+		topics = append(topics, strings.TrimSpace(fields[2]))
 	}
 	if len(titles) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
-	return titles, badgeKinds
+	return titles, badgeKinds, topics
 }
 
 func (c *recentWindowCommand) liveWindows(ctx context.Context, socket string) ([]recentwindows.LiveWindow, error) {
@@ -385,7 +389,11 @@ func (c *recentWindowCommand) currentTime() time.Time {
 	return c.now()
 }
 
-func recentWindowPickerOptions(items []intpicker.Item) intpicker.Options {
+// recentWindowPickerOptions builds the picker options for the recent-windows UI.
+// initialIndex lands the cursor on the first non-current row (the most recent
+// switch target) instead of the current-window row; a negative index means there
+// is no non-current row (current-only state), so the cursor stays on index 0.
+func recentWindowPickerOptions(items []intpicker.Item, initialIndex int) intpicker.Options {
 	options := intpicker.Options{
 		UI:        "recent-windows",
 		Title:     "Recent Windows",
@@ -394,24 +402,38 @@ func recentWindowPickerOptions(items []intpicker.Item) intpicker.Options {
 		MultiLine: true,
 		Actions:   pickerCloseActionsForToggles(nil, nil, []string{"ProjectSidebarToggle", "NotifySidebarToggle", "RecentWindows:Open", "SessionPopupToggle"}, "esc", "ctrl-n", "alt-1", "alt-2", "alt-3"),
 	}
+	if initialIndex > 0 {
+		options.InitialIndex = initialIndex
+		options.InitialIndexSet = true
+	}
 	options = fallbackRenderThemeSource().pickerOptions(options)
 	return options
 }
 
-func recentWindowPickerItems(candidates []recentwindows.Candidate, now time.Time, badgeStyle string) ([]intpicker.Item, map[string]recentwindows.Candidate) {
+// recentWindowPickerItems builds the picker items in display (MRU) order and
+// returns the index of the first non-current row in that final item order so the
+// cursor can default to the most recent switch target rather than the
+// current-window row. The index is computed against the FINAL items slice (rows
+// with an empty value are skipped), and is -1 when every row is the current
+// window (current-only state) so the caller leaves the cursor on index 0.
+func recentWindowPickerItems(candidates []recentwindows.Candidate, now time.Time, badgeStyle string) ([]intpicker.Item, map[string]recentwindows.Candidate, int) {
 	items := make([]intpicker.Item, 0, len(candidates))
 	byValue := make(map[string]recentwindows.Candidate, len(candidates))
+	firstNonCurrent := -1
 	for _, candidate := range candidates {
 		value := recentWindowValue(candidate)
 		if value == "" {
 			continue
+		}
+		if firstNonCurrent < 0 && !candidate.IsCurrent {
+			firstNonCurrent = len(items)
 		}
 		item := recentWindowPickerItem(candidate, now, badgeStyle)
 		item.Value = value
 		items = append(items, item)
 		byValue[value] = candidate
 	}
-	return items, byValue
+	return items, byValue, firstNonCurrent
 }
 
 const (
@@ -423,7 +445,6 @@ const (
 	// single overlong component before truncation runs.
 	recentWindowProjectBadgeMaxRunes = 24
 	recentWindowNameMaxRunes         = 48
-	recentWindowTopicChipMaxRunes    = 48
 	// recentWindowMaxPanes caps how many pane titles render on line 2 before the
 	// remainder collapses into a compact "+N" count (the Alt-1 sidebar pattern).
 	recentWindowMaxPanes = 3
@@ -463,13 +484,13 @@ func recentWindowPickerItem(candidate recentwindows.Candidate, now time.Time, ba
 		meta = append(meta, lastVisit)
 	}
 
-	searchTail := []string{
-		candidate.LastPaneTopic,
+	searchTail := append([]string{candidate.LastPaneTopic}, candidate.PaneTopics...)
+	searchTail = append(searchTail,
 		candidate.LastCommand,
 		age,
 		recentWindowFocusDate(candidate.LastFocusedAt),
 		candidate.Label.Secondary,
-	}
+	)
 	// SearchText still carries the session unique id and pane metadata even though
 	// they are dropped from the visible card lines, so search stays comprehensive.
 	search := joinRecentWindowParts(append([]string{
@@ -526,47 +547,51 @@ func recentWindowPaneSummary(candidate recentwindows.Candidate) string {
 	return recentWindowTruncate(strings.Join(parts, " | "), recentWindowPaneSummaryMaxRunes)
 }
 
-// recentWindowPaneSummaryParts returns the ordered topic/title parts for the
-// pane summary, with the pane topic leading when set.
+// recentWindowPaneSummaryParts returns the ordered perceived-title parts for the
+// pane summary, one per pane in display order. Each part is a pane's perceived
+// title (an AI pane's own topic > its title; a non-AI pane's title), with the
+// recentWindowPaneCells title->command fallback for legacy snapshots.
 func recentWindowPaneSummaryParts(candidate recentwindows.Candidate) []string {
-	titles := recentWindowPaneTitles(candidate)
-	topic := strings.TrimSpace(candidate.LastPaneTopic)
-	if topic == "" {
-		if len(titles) > 0 {
-			return titles
-		}
-		if cmd := strings.TrimSpace(candidate.LastCommand); cmd != "" {
-			return []string{cmd}
-		}
-		return nil
-	}
-	// Topic leads; append the remaining titles (excluding any that duplicate the
-	// topic) so the user's work context shows first.
-	parts := make([]string, 0, len(titles)+1)
-	parts = append(parts, topic)
-	for _, title := range titles {
-		if title != topic {
+	cells := recentWindowPaneCells(candidate)
+	parts := make([]string, 0, len(cells))
+	for _, cell := range cells {
+		if title := strings.TrimSpace(cell.perceivedTitle()); title != "" {
 			parts = append(parts, title)
 		}
 	}
 	return parts
 }
 
-// recentWindowPaneCell pairs a pane title with its own AI badge kind so the two
-// never desync as the summary is reordered (topic-prepend), deduped, or
-// overflow-collapsed. The topic chip is NOT a paneCell: it leads the line as a
-// chip with no per-pane badge.
+// recentWindowPaneCell pairs a pane's perceived title with its own AI badge kind
+// (and the pane's own AI topic) so the three never desync as the summary is
+// overflow-collapsed. Each pane renders at the same hierarchy on line 2:
+// "<status glyph> <perceived title>".
 type recentWindowPaneCell struct {
 	title string
 	kind  string
+	topic string
 }
 
-// recentWindowPaneSummaryLine renders the line-2 pane summary with notify-level
-// visibility: the leading topic is wrapped in an active chip (like
-// notifySidebarTopicBadge), each remaining pane title is prefixed with ITS OWN
-// per-pane AI badge glyph (when available) and dimmed, and panes beyond
-// recentWindowMaxPanes collapse into a compact "+N" count. Layout stays stable
-// because every visible pane title is rune-truncated identically to the plain
+// perceivedTitle returns the pane's display title for line 2: its own AI topic
+// when the pane is an AI pane (non-empty badge kind), else the pane title, with
+// the cell already carrying the title->command fallback.
+func (cell recentWindowPaneCell) perceivedTitle() string {
+	if aibadge.Normalize(cell.kind) != "" {
+		if topic := strings.TrimSpace(cell.topic); topic != "" {
+			return topic
+		}
+	}
+	return cell.title
+}
+
+// recentWindowPaneSummaryLine renders the line-2 pane summary as a flat list of
+// every pane at the same hierarchy, joined by " | ". Each pane reads as
+// "<AI status glyph> <perceived title>": an AI pane (non-empty badge kind) leads
+// with its themed status glyph and shows its own AI topic; a non-AI pane shows
+// its title with no glyph. Panes beyond recentWindowMaxPanes collapse into a
+// compact "+N" count. The AI status glyph is the only remaining visual signal —
+// no active chip, no grey dim decoration. Layout stays stable because every
+// visible title is rune-truncated identically to the plain
 // recentWindowPaneSummary path.
 func recentWindowPaneSummaryLine(candidate recentwindows.Candidate, badgeStyle string) string {
 	// recentWindowPaneSummary owns the canonical plain text (and its stable
@@ -576,24 +601,7 @@ func recentWindowPaneSummaryLine(candidate recentwindows.Candidate, badgeStyle s
 		return ""
 	}
 
-	topic := strings.TrimSpace(candidate.LastPaneTopic)
 	cells := recentWindowPaneCells(candidate)
-
-	chip := ""
-	if topic != "" {
-		chip = recentWindowTopicChip(topic)
-		// The topic leads as a chip; drop any pane title that merely duplicates it
-		// so the same context is not shown twice. The badge kind travels with each
-		// title, so dropping a cell never shifts the remaining title↔badge binding.
-		filtered := cells[:0]
-		for _, cell := range cells {
-			if cell.title == topic {
-				continue
-			}
-			filtered = append(filtered, cell)
-		}
-		cells = filtered
-	}
 
 	visible := cells
 	overflow := 0
@@ -602,39 +610,31 @@ func recentWindowPaneSummaryLine(candidate recentwindows.Candidate, badgeStyle s
 		overflow = len(cells) - recentWindowMaxPanes
 	}
 
-	// Pane cells join with " | " so the visible separator survives ANSI stripping;
-	// the topic chip (when present) leads the line with a plain space gap.
+	// Pane cells join with " | " so the visible separator survives ANSI stripping.
 	rendered := make([]string, 0, len(visible)+1)
 	for _, cell := range visible {
 		// Truncate identically to the plain summary path so layout never shifts.
-		title := recentWindowTruncate(cell.title, recentWindowPaneSummaryMaxRunes)
-		body := notifySidebarDim(title)
+		body := recentWindowTruncate(cell.perceivedTitle(), recentWindowPaneSummaryMaxRunes)
 		if glyph := recentWindowPaneKindGlyph(cell.kind, badgeStyle); glyph != "" {
 			body = glyph + " " + body
 		}
 		rendered = append(rendered, body)
 	}
 	if overflow > 0 {
-		rendered = append(rendered, notifySidebarDim(fmt.Sprintf("+%d", overflow)))
+		rendered = append(rendered, fmt.Sprintf("+%d", overflow))
 	}
 
-	body := strings.Join(rendered, " | ")
-	switch {
-	case chip != "" && body != "":
-		return chip + " " + body
-	case chip != "":
-		return chip
-	default:
-		return body
-	}
+	return strings.Join(rendered, " | ")
 }
 
-// recentWindowPaneCells builds the per-pane (title, badge kind) units, keeping
-// each title bound to its own kind regardless of later reordering or dedup. It
-// mirrors recentWindowPaneTitles' fallbacks: when no PaneTitles exist it falls
-// back to a single LastPaneTitle (then LastCommand) cell with no badge kind.
+// recentWindowPaneCells builds the per-pane (title, badge kind, topic) units,
+// keeping each title bound to its own kind and topic regardless of later
+// overflow collapse. It mirrors recentWindowPaneTitles' fallbacks: when no
+// PaneTitles exist it falls back to a single LastPaneTitle (then LastCommand)
+// cell with no badge kind.
 func recentWindowPaneCells(candidate recentwindows.Candidate) []recentWindowPaneCell {
 	kinds := candidate.PaneBadgeKinds
+	topics := candidate.PaneTopics
 	cells := make([]recentWindowPaneCell, 0, len(candidate.PaneTitles))
 	for i, title := range candidate.PaneTitles {
 		if title = strings.TrimSpace(title); title == "" {
@@ -644,7 +644,11 @@ func recentWindowPaneCells(candidate recentwindows.Candidate) []recentWindowPane
 		if i < len(kinds) {
 			kind = strings.TrimSpace(kinds[i])
 		}
-		cells = append(cells, recentWindowPaneCell{title: title, kind: kind})
+		topic := ""
+		if i < len(topics) {
+			topic = strings.TrimSpace(topics[i])
+		}
+		cells = append(cells, recentWindowPaneCell{title: title, kind: kind, topic: topic})
 	}
 	if len(cells) == 0 {
 		if title := strings.TrimSpace(candidate.LastPaneTitle); title != "" {
@@ -690,16 +694,6 @@ func recentWindowAIBadgeKindStart(kind string) string {
 	default:
 		return ""
 	}
-}
-
-// recentWindowTopicChip wraps the pane topic in the shared active chip palette,
-// terminating with theme.ANSIReset like notifySidebarTopicBadge.
-func recentWindowTopicChip(topic string) string {
-	topic = recentWindowTruncate(strings.TrimSpace(topic), recentWindowTopicChipMaxRunes)
-	if topic == "" {
-		return ""
-	}
-	return theme.ANSIChipActiveStart + " " + topic + " " + theme.ANSIReset
 }
 
 // recentWindowLastVisit labels the relative age so the row reads unambiguously

--- a/internal/app/recent_window_test.go
+++ b/internal/app/recent_window_test.go
@@ -246,16 +246,20 @@ func TestRecentWindowPickerItemLastVisitFormat(t *testing.T) {
 	}
 }
 
-func TestRecentWindowPickerItemPaneTopicLeadsSummary(t *testing.T) {
+func TestRecentWindowPickerItemPaneSummaryIsFlatNoChip(t *testing.T) {
 	t.Parallel()
 
 	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	// Each pane lists at the same hierarchy joined by " | " in display order.
+	// An AI pane shows its OWN topic; non-AI panes show their title. There is no
+	// leading topic chip and no grey dim decoration.
 	snapshot := recentwindows.Snapshot{
-		Session:       "repos-projmux",
-		WindowID:      "@6",
-		WindowName:    "projmux",
-		LastPaneTopic: "Phase 6 polish",
-		PaneTitles:    []string{"zsh", "Claude Code"},
+		Session:        "repos-projmux",
+		WindowID:       "@6",
+		WindowName:     "projmux",
+		PaneTitles:     []string{"zsh", "Claude Code"},
+		PaneBadgeKinds: []string{"", "in_progress"},
+		PaneTopics:     []string{"", "Phase 6 polish"},
 	}
 	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
 
@@ -263,21 +267,22 @@ func TestRecentWindowPickerItemPaneTopicLeadsSummary(t *testing.T) {
 		t.Fatalf("MetaLines = %#v, want a pane summary line", item.MetaLines)
 	}
 	visible := recentWindowStripANSI(item.MetaLines[0])
-	topicIdx := strings.Index(visible, "Phase 6 polish")
-	zshIdx := strings.Index(visible, "zsh")
-	claudeIdx := strings.Index(visible, "Claude Code")
-	if topicIdx < 0 || zshIdx <= topicIdx || claudeIdx <= zshIdx {
-		t.Fatalf("pane summary line = %q, want topic-led order topic -> zsh -> Claude Code", visible)
+	// zsh (non-AI, its title) leads; the AI pane shows its own topic, not "Claude Code".
+	if want := "zsh | "; !strings.HasPrefix(visible, want) {
+		t.Fatalf("pane summary line = %q, want display-order panes joined with ' | '", visible)
 	}
-	if !strings.Contains(visible, "zsh | Claude Code") {
-		t.Fatalf("pane summary line = %q, want remaining titles joined with ' | '", visible)
+	if !strings.Contains(visible, "Phase 6 polish") {
+		t.Fatalf("pane summary line = %q, want AI pane shown by its own topic", visible)
 	}
-	// The leading topic is wrapped in the shared active chip palette.
-	if !strings.Contains(item.MetaLines[0], theme.ANSIChipActiveStart) {
-		t.Fatalf("pane summary line = %q, want topic chip palette", item.MetaLines[0])
+	if strings.Contains(visible, "Claude Code") {
+		t.Fatalf("pane summary line = %q, want AI pane's topic preferred over its title", visible)
 	}
-	if !strings.HasSuffix(item.MetaLines[0], theme.ANSIReset) {
-		t.Fatalf("pane summary line = %q, want trailing reset", item.MetaLines[0])
+	// No active chip palette and no grey dim decoration on line 2.
+	if strings.Contains(item.MetaLines[0], theme.ANSIChipActiveStart) {
+		t.Fatalf("pane summary line = %q, want NO topic chip palette", item.MetaLines[0])
+	}
+	if strings.Contains(item.MetaLines[0], theme.ANSINotifyDimStart) {
+		t.Fatalf("pane summary line = %q, want NO grey dim decoration", item.MetaLines[0])
 	}
 }
 
@@ -342,21 +347,19 @@ func recentWindowPaneCellFor(t *testing.T, line, substr string) string {
 	return ""
 }
 
-func TestRecentWindowPickerItemBindsBadgeToOwnPaneWithLeadingTopic(t *testing.T) {
+func TestRecentWindowPickerItemBindsBadgeToOwnPane(t *testing.T) {
 	t.Parallel()
 
 	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
-	// The bug: with a leading topic, the in_progress dot was painted on "zsh"
-	// (pane 0) instead of "Codex" (pane 1) because the badge lookup used a +1
-	// offset against a positionally-aligned slice. Each pane title must carry its
-	// own badge kind through the topic-prepend/dedup logic.
+	// Phase 8 binding guarantee preserved in the flat model: the in_progress glyph
+	// must attach to "Codex" (pane 1), never to "zsh" (pane 0). Each pane cell
+	// carries its own badge kind, so a glyph can never desync to the wrong pane.
 	snapshot := recentwindows.Snapshot{
 		Session:        "repos-projmux",
 		WindowID:       "@6",
 		WindowName:     "projmux",
 		PaneTitles:     []string{"zsh", "Codex"},
 		PaneBadgeKinds: []string{"", "in_progress"},
-		LastPaneTopic:  "Phase 8",
 	}
 	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
 	if len(item.MetaLines) == 0 {
@@ -364,20 +367,18 @@ func TestRecentWindowPickerItemBindsBadgeToOwnPaneWithLeadingTopic(t *testing.T)
 	}
 	line := item.MetaLines[0]
 
-	// Topic chip leads, then the pane cells in order.
+	// Display order: zsh -> Codex, flat, joined by " | ".
 	visible := recentWindowStripANSI(line)
-	topicIdx := strings.Index(visible, "Phase 8")
 	zshIdx := strings.Index(visible, "zsh")
 	codexIdx := strings.Index(visible, "Codex")
-	if topicIdx < 0 || zshIdx <= topicIdx || codexIdx <= zshIdx {
-		t.Fatalf("pane summary line = %q, want order topic -> zsh -> Codex", visible)
+	if zshIdx < 0 || codexIdx <= zshIdx {
+		t.Fatalf("pane summary line = %q, want order zsh -> Codex", visible)
 	}
 
 	// The in_progress themed glyph belongs to Codex, NOT zsh.
 	dot := theme.ANSIAIBadgeProgressStart + "●"
 	codexCell := recentWindowPaneCellFor(t, line, "Codex")
 	zshCell := recentWindowPaneCellFor(t, line, "zsh")
-	// Operate on the ANSI-bearing cells to confirm the themed glyph placement.
 	codexFull, zshFull := "", ""
 	for cell := range strings.SplitSeq(line, " | ") {
 		switch {
@@ -398,41 +399,52 @@ func TestRecentWindowPickerItemBindsBadgeToOwnPaneWithLeadingTopic(t *testing.T)
 	}
 }
 
-func TestRecentWindowPickerItemTopicDedupKeepsBadgeBinding(t *testing.T) {
+func TestRecentWindowPickerItemAIPaneShowsOwnTopicWithBoundBadge(t *testing.T) {
 	t.Parallel()
 
 	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
-	// A pane title equal to the topic is deduped (dropped) from the cells. The
-	// remaining pane's badge must stay bound to it and not shift.
+	// The AI pane (pane 1) renders its OWN ai_topic as its perceived title, with
+	// its own in_progress glyph still bound to it. The non-AI pane keeps its title
+	// and gets no glyph. No off-by-one: the glyph stays on the AI pane's cell.
 	snapshot := recentwindows.Snapshot{
 		Session:        "repos-projmux",
 		WindowID:       "@6",
 		WindowName:     "projmux",
-		PaneTitles:     []string{"Phase 8", "Codex"},
+		PaneTitles:     []string{"zsh", "Codex"},
 		PaneBadgeKinds: []string{"", "in_progress"},
-		LastPaneTopic:  "Phase 8",
+		PaneTopics:     []string{"", "Phase 8 binding"},
 	}
 	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
 	if len(item.MetaLines) == 0 {
 		t.Fatalf("MetaLines = %#v, want a pane summary line", item.MetaLines)
 	}
 	line := item.MetaLines[0]
-
-	// "Phase 8" appears once (as the leading chip), not duplicated as a pane cell.
 	visible := recentWindowStripANSI(line)
-	if strings.Count(visible, "Phase 8") != 1 {
-		t.Fatalf("pane summary line = %q, want topic shown once (chip), pane title deduped", visible)
+
+	// The AI pane shows its topic instead of "Codex"; the non-AI pane shows "zsh".
+	if !strings.Contains(visible, "zsh") || !strings.Contains(visible, "Phase 8 binding") {
+		t.Fatalf("pane summary line = %q, want zsh and the AI pane's topic", visible)
+	}
+	if strings.Contains(visible, "Codex") {
+		t.Fatalf("pane summary line = %q, want AI pane's topic preferred over its title", visible)
 	}
 
+	// The in_progress glyph stays bound to the AI pane's (topic) cell, not zsh.
 	dot := theme.ANSIAIBadgeProgressStart + "●"
-	codexFull := ""
+	topicFull, zshFull := "", ""
 	for cell := range strings.SplitSeq(line, " | ") {
-		if strings.Contains(recentWindowStripANSI(cell), "Codex") {
-			codexFull = cell
+		switch {
+		case strings.Contains(recentWindowStripANSI(cell), "Phase 8 binding"):
+			topicFull = cell
+		case strings.Contains(recentWindowStripANSI(cell), "zsh"):
+			zshFull = cell
 		}
 	}
-	if !strings.Contains(codexFull, dot) {
-		t.Fatalf("Codex cell = %q, want in_progress dot %q to stay bound after dedup", codexFull, dot)
+	if !strings.Contains(topicFull, dot) {
+		t.Fatalf("AI topic cell = %q, want in_progress dot %q bound to the AI pane", topicFull, dot)
+	}
+	if strings.Contains(zshFull, dot) {
+		t.Fatalf("zsh cell = %q, want NO badge glyph", zshFull)
 	}
 }
 
@@ -561,7 +573,7 @@ func TestRecentWindowPickerItemKeepsSelectionValue(t *testing.T) {
 		WindowName: "projmux",
 	}
 	candidate := recentWindowCandidate(snapshot)
-	items, byValue := recentWindowPickerItems([]recentwindows.Candidate{candidate}, at, aibadge.StyleDot)
+	items, byValue, _ := recentWindowPickerItems([]recentwindows.Candidate{candidate}, at, aibadge.StyleDot)
 
 	if len(items) != 1 {
 		t.Fatalf("items = %#v, want one", items)
@@ -572,6 +584,93 @@ func TestRecentWindowPickerItemKeepsSelectionValue(t *testing.T) {
 	}
 	if _, ok := byValue[wantValue]; !ok {
 		t.Fatalf("byValue missing %q", wantValue)
+	}
+}
+
+func TestRecentWindowPickerItemsInitialIndexFirstNonCurrentRow(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	// Display (MRU) order: current row leads, then two non-current rows. The
+	// cursor must default to the FIRST non-current row (index 1 here), not the
+	// current row at index 0.
+	current := recentwindows.Candidate{
+		Snapshot:  recentwindows.Snapshot{Session: "current", WindowID: "@1", WindowName: "current"},
+		IsCurrent: true,
+	}
+	other := recentWindowCandidate(recentwindows.Snapshot{Session: "other", WindowID: "@2", WindowName: "other"})
+	third := recentWindowCandidate(recentwindows.Snapshot{Session: "third", WindowID: "@3", WindowName: "third"})
+
+	_, _, initialIndex := recentWindowPickerItems([]recentwindows.Candidate{current, other, third}, at, aibadge.StyleDot)
+	if initialIndex != 1 {
+		t.Fatalf("initialIndex = %d, want 1 (first non-current row)", initialIndex)
+	}
+
+	options := recentWindowPickerOptions(make([]intpicker.Item, 3), initialIndex)
+	if !options.InitialIndexSet || options.InitialIndex != 1 {
+		t.Fatalf("options InitialIndex = %d/%t, want 1/true", options.InitialIndex, options.InitialIndexSet)
+	}
+}
+
+func TestRecentWindowPickerItemsInitialIndexCurrentOnlyStaysOnCurrent(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	current := recentwindows.Candidate{
+		Snapshot:  recentwindows.Snapshot{Session: "current", WindowID: "@1", WindowName: "current"},
+		IsCurrent: true,
+	}
+
+	_, _, initialIndex := recentWindowPickerItems([]recentwindows.Candidate{current}, at, aibadge.StyleDot)
+	if initialIndex != -1 {
+		t.Fatalf("initialIndex = %d, want -1 (no non-current row)", initialIndex)
+	}
+
+	// A negative index leaves the cursor on index 0 and does NOT set InitialIndexSet.
+	options := recentWindowPickerOptions(make([]intpicker.Item, 1), initialIndex)
+	if options.InitialIndexSet || options.InitialIndex != 0 {
+		t.Fatalf("options InitialIndex = %d/%t, want 0/false (stay on current row)", options.InitialIndex, options.InitialIndexSet)
+	}
+}
+
+func TestRecentWindowPickerItemFallsBackToTitleWhenTopicAbsent(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	// Old snapshot: an AI pane with a badge kind but no PaneTopics entry falls back
+	// to its pane title (then command) for the perceived title.
+	snapshot := recentwindows.Snapshot{
+		Session:        "repos-projmux",
+		WindowID:       "@6",
+		WindowName:     "projmux",
+		PaneTitles:     []string{"Codex"},
+		PaneBadgeKinds: []string{"in_progress"},
+	}
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
+	if len(item.MetaLines) == 0 {
+		t.Fatalf("MetaLines = %#v, want a pane summary line", item.MetaLines)
+	}
+	if visible := recentWindowStripANSI(item.MetaLines[0]); !strings.Contains(visible, "Codex") {
+		t.Fatalf("pane summary line = %q, want pane-title fallback when topic absent", visible)
+	}
+}
+
+func TestRecentWindowPickerItemSearchTextIncludesPaneTopics(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	snapshot := recentwindows.Snapshot{
+		Session:       "repos-projmux",
+		WindowID:      "@6",
+		WindowName:    "projmux",
+		Project:       "Projmux",
+		PaneTitles:    []string{"zsh", "Codex"},
+		PaneTopics:    []string{"", "Phase 9 search"},
+		LastFocusedAt: at,
+	}
+	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at, aibadge.StyleDot)
+	if !strings.Contains(item.SearchText, "Phase 9 search") {
+		t.Fatalf("SearchText = %q, want per-pane topic searchable", item.SearchText)
 	}
 }
 
@@ -895,9 +994,9 @@ func TestRecentWindowRecordSnapshotsCurrentTmuxWindow(t *testing.T) {
 			"codex",
 			filepath.Join(project, "internal", "app"),
 		}, recentWindowFieldSep) + "\n",
-		listPanesOutput: strings.Join([]string{"codex-review", "in_progress"}, recentWindowFieldSep) + "\n" +
-			strings.Join([]string{"Claude Code", "response_complete"}, recentWindowFieldSep) + "\n" +
-			strings.Join([]string{"zsh", ""}, recentWindowFieldSep) + "\n",
+		listPanesOutput: strings.Join([]string{"codex-review", "in_progress", "Phase 9 picker"}, recentWindowFieldSep) + "\n" +
+			strings.Join([]string{"Claude Code", "response_complete", "Recent windows queue"}, recentWindowFieldSep) + "\n" +
+			strings.Join([]string{"zsh", "", ""}, recentWindowFieldSep) + "\n",
 	}
 	store := &recentWindowStubStore{}
 	cmd := &recentWindowCommand{
@@ -929,6 +1028,9 @@ func TestRecentWindowRecordSnapshotsCurrentTmuxWindow(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.PaneBadgeKinds, []string{"in_progress", "response_complete", ""}) {
 		t.Fatalf("snapshot pane badge kinds = %+v, want per-pane AI badge kinds aligned with titles", got.PaneBadgeKinds)
+	}
+	if !reflect.DeepEqual(got.PaneTopics, []string{"Phase 9 picker", "Recent windows queue", ""}) {
+		t.Fatalf("snapshot pane topics = %+v, want per-pane AI topics aligned with titles", got.PaneTopics)
 	}
 	if got.Project != filepath.Base(project) {
 		t.Fatalf("snapshot project = %q, want %q", got.Project, filepath.Base(project))
@@ -1174,7 +1276,7 @@ func (r *recentWindowFakeRunner) Run(_ context.Context, name string, args ...str
 	if name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-F", strings.Join([]string{"#{socket_path}", "#{session_name}", "#{window_id}", "#{window_name}", "#{pane_id}", "#{pane_title}", "#{@projmux_ai_topic}", "#{pane_current_command}", "#{pane_current_path}"}, recentWindowFieldSep)}) {
 		return []byte(r.recordOutput), nil
 	}
-	if name == "tmux" && len(args) == 5 && args[0] == "list-panes" && args[1] == "-t" && args[3] == "-F" && args[4] == strings.Join([]string{"#{pane_title}", "#{@projmux_ai_badge_kind}"}, recentWindowFieldSep) {
+	if name == "tmux" && len(args) == 5 && args[0] == "list-panes" && args[1] == "-t" && args[3] == "-F" && args[4] == strings.Join([]string{"#{pane_title}", "#{@projmux_ai_badge_kind}", "#{@projmux_ai_topic}"}, recentWindowFieldSep) {
 		return []byte(r.listPanesOutput), nil
 	}
 	if name == "tmux" && reflect.DeepEqual(args, []string{"list-windows", "-a", "-F", strings.Join([]string{"#{session_name}", "#{window_id}"}, recentWindowFieldSep)}) {

--- a/internal/core/recentwindows/model.go
+++ b/internal/core/recentwindows/model.go
@@ -34,10 +34,14 @@ type Snapshot struct {
 	// PaneBadgeKinds carries the per-pane AI badge kind parallel to PaneTitles
 	// (same length/order when available). Additive and backward compatible: old
 	// state files omit it, so the picker falls back to titles-only rendering.
-	PaneBadgeKinds []string  `json:"pane_badge_kinds,omitempty"`
-	LastPaneTopic  string    `json:"last_pane_topic,omitempty"`
-	LastCommand    string    `json:"last_command,omitempty"`
-	LastFocusedAt  time.Time `json:"last_focused_at"`
+	PaneBadgeKinds []string `json:"pane_badge_kinds,omitempty"`
+	// PaneTopics carries each pane's own AI topic parallel to PaneTitles (same
+	// length/order when available). Additive and backward compatible: old state
+	// files omit it, so the picker falls back to pane title then command.
+	PaneTopics    []string  `json:"pane_topics,omitempty"`
+	LastPaneTopic string    `json:"last_pane_topic,omitempty"`
+	LastCommand   string    `json:"last_command,omitempty"`
+	LastFocusedAt time.Time `json:"last_focused_at"`
 }
 
 type State struct {
@@ -193,6 +197,7 @@ func normalizeSnapshot(snapshot Snapshot) Snapshot {
 	snapshot.LastPaneTitle = strings.TrimSpace(snapshot.LastPaneTitle)
 	snapshot.PaneTitles = normalizePaneTitles(snapshot.PaneTitles)
 	snapshot.PaneBadgeKinds = normalizePaneBadgeKinds(snapshot.PaneBadgeKinds)
+	snapshot.PaneTopics = normalizePaneTopics(snapshot.PaneTopics)
 	snapshot.LastPaneTopic = strings.TrimSpace(snapshot.LastPaneTopic)
 	snapshot.LastCommand = strings.TrimSpace(snapshot.LastCommand)
 	if !snapshot.LastFocusedAt.IsZero() {
@@ -231,6 +236,29 @@ func normalizePaneBadgeKinds(kinds []string) []string {
 		normalized := aibadge.Normalize(kind)
 		out[i] = normalized
 		if normalized != "" {
+			last = i
+		}
+	}
+	if last < 0 {
+		return nil
+	}
+	return out[:last+1]
+}
+
+// normalizePaneTopics trims each per-pane AI topic while keeping positional
+// alignment with PaneTitles: a pane with no topic keeps an empty slot rather
+// than shifting later panes. Trailing empties are trimmed and an all-empty
+// slice collapses to nil so backward-compatible state stays clean.
+func normalizePaneTopics(topics []string) []string {
+	if len(topics) == 0 {
+		return nil
+	}
+	out := make([]string, len(topics))
+	last := -1
+	for i, topic := range topics {
+		trimmed := strings.TrimSpace(topic)
+		out[i] = trimmed
+		if trimmed != "" {
 			last = i
 		}
 	}

--- a/internal/core/recentwindows/model_test.go
+++ b/internal/core/recentwindows/model_test.go
@@ -295,6 +295,48 @@ func TestRecordPreservesPaneBadgeKindsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestNormalizeSnapshotPaneTopics(t *testing.T) {
+	t.Parallel()
+
+	// Per-pane topics keep positional alignment with PaneTitles: an empty topic
+	// becomes an empty slot rather than shifting later panes, and trailing empties
+	// are trimmed.
+	snapshot := normalizeSnapshot(Snapshot{
+		Session:    "s",
+		WindowID:   "@1",
+		PaneTitles: []string{"a", "b", "c"},
+		PaneTopics: []string{"", "  Phase 9 ", ""},
+	})
+	if got := snapshot.PaneTopics; len(got) != 2 || got[0] != "" || got[1] != "Phase 9" {
+		t.Fatalf("pane topics = %#v, want empty slot preserved, topic trimmed, trailing trimmed", got)
+	}
+
+	// An all-empty slice collapses to nil for backward-compatible state.
+	if got := normalizeSnapshot(Snapshot{Session: "s", WindowID: "@1", PaneTopics: []string{"", "  "}}).PaneTopics; got != nil {
+		t.Fatalf("pane topics = %#v, want nil for all-empty", got)
+	}
+}
+
+func TestRecordPreservesPaneTopicsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	state, err := NewState(nil).Record(Snapshot{
+		Session:       "s",
+		WindowID:      "@1",
+		WindowName:    "main",
+		PaneTitles:    []string{"zsh", "Claude Code"},
+		PaneTopics:    []string{"", "Phase 9 polish"},
+		LastFocusedAt: now,
+	}, 0)
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if got := state.Entries[0].PaneTopics; len(got) != 2 || got[0] != "" || got[1] != "Phase 9 polish" {
+		t.Fatalf("pane topics = %#v, want preserved round-trip", got)
+	}
+}
+
 func TestRecordWindowMRUDoesNotReorderBeyondWindowList(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 완료한 Phase

**Phase 9 — default selection fix and line-2 perceived-title simplification** (Recent windows queue 트랙).

## 수정한 user-facing surface (Recent Windows `Alt-3` picker)

1. **기본 커서 위치 fix.** picker 를 열면 커서가 current window(index 0)가 아니라 **첫 non-current row** 에 간다. `recentWindowPickerItems` 가 최종 표시(MRU) 순서 기준 첫 non-current row 의 index 를 계산해 `recentWindowPickerOptions` 가 `InitialIndex`+`InitialIndexSet` 로 넘긴다(picker 백엔드 기존 지원 사용, 새 기능 없음). non-current row 가 없으면(current-only) 커서는 current row 에 남는다. Enter 한 번으로 직전/다른 window 로 전환되는 흐름.
2. **2행 perceived-title 단순화.** active topic chip(`recentWindowTopicChip`)과 회색 dim(`notifySidebarDim`) per-pane 장식 제거. 각 pane 을 동일 위계의 평범한 텍스트 `<AI 상태 이모지> <체감 제목>` 로 ` | ` 나열. 체감 제목 우선순위: AI pane = 그 pane 의 ai_topic > title > command, 비-AI pane = title > command. AI 상태 이모지(glyph)만 유일한 시각 신호로 유지. 예: `zsh | ⠂ [lead:roadmap] Projmux | ✳ Recent windows queue Phase 8`.
3. **per-pane ai_topic 기록.** `recentwindows.Snapshot` 에 `PaneTopics []string`(`json:"pane_topics,omitempty"`) 최소 필드만 추가(PaneTitles/PaneBadgeKinds 와 평행). `window record` 가 `list-panes` 3-field 포맷(`#{pane_title}\x1f#{@projmux_ai_badge_kind}\x1f#{@projmux_ai_topic}`)으로 per-pane topic 을 채운다. 구버전 snapshot(`pane_topics[]` 없음)은 pane title/command 로 graceful fallback.

## 명시적으로 제외한 범위

- historical pane restore / RecentPanes advanced mode.
- keybinding Settings IA 변경.
- notify sidebar / Alt-1 sidebar 자체 변경.
- AI badge style(dot/emoji/off) 설정 모델 재설계 (단 2행 회색 badge chip 장식 제거는 포함).
- SessionPopupToggle 삭제.

## 모델/스키마/엔진 제약 준수

- **RecentWindows MRU ordering** 변경 없음 (render order 그대로, InitialIndex 만 표시 순서 기준 계산).
- **current row no-op/stay-current semantics** 유지, non-current Enter = switch 유지.
- **max-20 bound** 변경 없음.
- **record dedupe key = `socket + session + window_id`** 유지.
- **session/project recency model** 변경 없음.
- **MRU state schema**: `PaneTopics []string` 최소 필드 1개만 additive 추가, `Version` bump 없음, 완전 backward compatible.
- **Phase 8 badge↔pane binding 보장 유지**: 각 `recentWindowPaneCell` 이 자신의 title+kind+topic 을 함께 들고 다녀 glyph 가 다른 pane 으로 새지 않음.

## 검증 명령

- `make fmt` — pass (잔여 diff 없음).
- `GOCACHE=/tmp/projmux-go-cache make fix` — pass.
- `GOCACHE=/tmp/projmux-go-cache make test` — pass (전 패키지 ok).
- `go test ./internal/app/ -run RecentWindow -count=1` — ok.
- `go test ./internal/core/recentwindows/ -count=1` — ok.
- `go vet ./internal/app/ ./internal/core/recentwindows/` — clean.

추가/갱신 focused/snapshot tests: `TestRecentWindowPickerItemsInitialIndexFirstNonCurrentRow`(InitialIndex=1), `...InitialIndexCurrentOnlyStaysOnCurrent`(-1, not set), `TestRecentWindowPickerItemPaneSummaryIsFlatNoChip`(chip/dim 부재, AI pane 자기 topic), `TestRecentWindowPickerItemBindsBadgeToOwnPane` + `...AIPaneShowsOwnTopicWithBoundBadge`(badge↔pane binding), `TestRecentWindowPickerItemFallsBackToTitleWhenTopicAbsent`(fallback), `TestRecentWindowPickerItemSearchTextIncludesPaneTopics`, `TestRecentWindowRecordSnapshotsCurrentTmuxWindow`(3-field list-panes + PaneTopics), core `TestNormalizeSnapshotPaneTopics` + `TestRecordPreservesPaneTopicsRoundTrip`. 기존 no-op/current-only/cross-session switch/truncation/`+N` overflow 테스트는 green 유지.

## 미검증 항목 / 후속 후보

- **실제 `Alt-3` interactive tmux smoke 미실행** (e2e 후보): 커서가 두 번째 행(첫 non-current)에 있는지, 2행이 `zsh | ⠂ ai_topic | …` 형태로 보이는지, AI 상태 이모지 색/위치는 item builder 가 terminal width 를 모르므로 unit test 로 구조만 검증. 설치 후 live 확인 권장.
- 후속 후보(이 detail 범위 아님, 별도 트랙): RecentPanes advanced mode / historical pane restore, `SessionPopupToggle Alt-3 default 제거`(메인 Backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)