### PR TITLE
chore(legacy): dead-code removal + detection tooling (Phase 0/1/2)

### DIFF
--- a/.deadcode-allowlist.txt
+++ b/.deadcode-allowlist.txt
@@ -1,0 +1,340 @@
+# .deadcode-allowlist.txt
+#
+# Allowlist for `make deadcode` (golang.org/x/tools/cmd/deadcode).
+#
+# Each non-comment, non-blank line is the EXACT fully-qualified symbol name as
+# emitted by deadcode after "unreachable func: " (e.g. "aiCommand.notifyAIText"
+# or "tmuxTruthy"). A finding is suppressed only when its symbol matches a line
+# here exactly; matching is on the symbol, not the file:line, so the baseline
+# survives line-number drift. New dead code that is NOT listed here makes
+# `make deadcode` exit non-zero.
+#
+# Lines starting with '#' are comments; blank lines are ignored.
+#
+# This baseline was captured from `go tool deadcode ./...` at the time the
+# detector was introduced. The goal of this phase is to STAND UP detection so
+# only NEW dead code shows up red -- NOT to remove the existing findings.
+# Entries are grouped by intent below.
+
+# ---------------------------------------------------------------------------
+# MUST-KEEP: deliberately retained legacy / migration / planned-consumer
+# symbols. These read old persisted state, clean stale bindings, or are
+# planned future consumers. deadcode may flag them as unreachable in some
+# builds, but they MUST NOT be removed. Listed explicitly even when not
+# currently flagged, so a future refactor that makes them unreachable does
+# not turn the baseline red and tempt their removal.
+# ---------------------------------------------------------------------------
+MigrateProjectLegacyScripts
+MigrateGlobalLegacyScripts
+legacyDesktopAppID
+CleanupLegacyArtifacts
+legacyWindowAttentionRows
+formatLegacyPaneSummary
+tmuxRetiredKeyUnbindLines
+# "last-pane" action handler: audit shows it as dead but it is a PLANNED
+# consumer and must stay (it is a keybinding catalog string ID, not a func,
+# so deadcode does not flag it by name -- recorded here for intent).
+
+# ---------------------------------------------------------------------------
+# Baseline findings captured at detector introduction. Intentional / false
+# positive / not-yet-wired surfaces; retained as the clean baseline so only
+# NEW dead code is reported. Grouped loosely by package.
+# ---------------------------------------------------------------------------
+
+# internal/i18n -- string-audit and catalog helpers (audit tooling surface)
+All
+AuditGoStringLiterals
+AuditGoStringLiteralsInDir
+AuditGoStrings
+RuntimeKoreanStringAuditOptions
+StringAuditFinding.IsCandidate
+auditGoStringLiteralsInFile
+classifyStringLiteral
+containsASCIILetter
+containsHangul
+isDataStringLiteral
+isDebugStringContext
+isDebugStringLiteral
+isEnglishUserFacingCandidate
+isPreservedLiteralString
+shouldKeepStringAuditFinding
+sortStringAuditFindings
+Catalog.Keys
+Catalog.LocaleKeys
+Catalog.MissingFallbackKeys
+Catalog.MissingLocaleKeys
+FoundationKeys
+Localizer.Locale
+Localizer.Styled
+StyledFragment.IsANSI
+StyledFragment.IsStyledKind
+StyledFragment.IsTmuxStyle
+StyledFragment.Key
+StyledFragment.Kind
+StyledFragment.Locale
+StyledFragment.String
+Text.Key
+Text.Locale
+FormatList
+firstRune
+runeLen
+
+# internal/ui/picker, pickercompat, projmuxpicker, render -- native picker
+# rendering surface kept for parity with the legacy fzf backend.
+BuildSwitchPickerItems
+ChromeLine
+FooterBlockLines
+HeaderLine
+InteractiveListLines
+InteractiveRowLines
+InverseSelectedContent
+InverseSelectedContentWithTheme
+ListLinesWithScrollbar
+PromptLine
+PromptLineWithCursor
+PromptLineWithCursorLabel
+PromptLineWithRenderedQuery
+PromptLineWithRenderedQueryLabel
+QueryWithCursor
+RenderBar
+RenderFullFrameUpdate
+RenderInlinePreview
+RenderSplitPreview
+RenderSwitchPreview
+RenderWindowsCommandLine
+RenderableListLine
+RenderableListLines
+RenderableListLinesWithTheme
+Renderer.ContentLayout
+Renderer.RenderFrame
+ResolveBackend
+ResultToPicker
+SelectedContent
+SelectedContentWithTheme
+SelectedLine
+WriteContentWithFooter
+nativeAppendPartialNextItemLines
+nativeFooterBlockLines
+nativeHeaderLine
+nativeHighlightANSIVisiblePositions
+nativeHighlightSimpleItems
+nativeInteractiveItemLines
+nativeInteractiveListLines
+nativeInverseSelectedContent
+nativeLinesBeforeItem
+nativeListLinesWithScrollbar
+nativeListLinesWithScrollbarRows
+nativeLocalizedText
+nativePadRight
+nativePadStyledLine
+nativePartialNextItemLines
+nativePrependPartialPreviousItemLines
+nativePromptLine
+nativePromptLineWithCursor
+nativePromptLineWithCursorAndTheme
+nativePromptLineWithRenderedQuery
+nativeQueryWithCursor
+nativeRenderableListLine
+nativeRenderableListLines
+nativeSearchSeparatorLine
+nativeSelectedContent
+nativeTruncateANSI
+nativeVisibleLen
+renderNativeFrame
+renderNativeInteractive
+renderNativeInteractiveWithCursor
+padsInsideFinalStyle
+joinFinal
+selectionMarker
+writeNativeContentWithFooter
+formatPopupSummary
+formatSelectedSummary
+formatTargetSummary
+sanitizeSwitchPreviewPath
+
+# internal/integrations/mux, psmux, tmux -- mux abstraction methods kept for
+# the pluggable backend surface (not all wired by the live tmux path).
+Command.WindowsCommandLine
+Run
+CapturePane
+ClosePopup
+DisplayMessage
+DisplayMessageTrimmed
+DisplayPaneFields
+DisplayPopup
+ListPanes
+ListWindows
+NewSession
+NewWindow
+NextPane
+NextWindow
+PreviousPane
+PreviousWindow
+Read
+ReadTrimmed
+Runner.ListWindows
+Runner.NewWindow
+SelectPane
+SelectWindow
+SetHook
+SetOption
+SetPaneOption
+ShowPaneOption
+SplitWindow
+SwitchClient
+UnsetPaneOption
+NewWithConfig
+NewWithRoot
+NewWithSocketName
+WithFileReader
+WithSocketName
+newClientWithEnv
+RenderWindowsCommandLine
+windowsCommandLineArg
+effectivePaneCount
+
+# internal/config -- config readers / trust helpers retained for callers.
+IsProjectConfigTrusted
+LoadSessionStateToggleFile
+Paths.PostCreateHookPath
+Paths.ProjdirFile
+Paths.WorkdirsFile
+PostCreateRunner.Run
+PostCreateRunner.runner
+WithPostCreateRunner
+
+# internal/core/usage -- adapter / store / registry surface.
+NewState
+Registry.Lookup
+Registry.Names
+Registry.Replace
+RedactToken
+Store.BaseDir
+Store.Remove
+Store.SaveAll
+Store.Show
+UsageSupported
+
+# internal/core/layout, preview, recentwindows
+RenderFullFrameUpdate
+
+# internal/integrations/hooks -- hook install / trust helpers.
+
+# internal/app -- AI / notify / status / settings / tmux / switch surfaces
+# that are not currently reachable from the wired command paths.
+aiCommand.agentLaunchCommand
+aiCommand.aiHookFallbackReason
+aiCommand.aiTextNotification
+aiCommand.notifyAIText
+aiNotificationTextAgent
+aiNotifyDiagnosticCommandEntry
+aiNotifyDiagnosticDetailEntries
+aiNotifyDiagnosticEntry
+aiSummaryForKind
+callName
+codexHooksBlock
+defaultAIHookInstallEvents
+flagWasProvided
+formatAge
+formatAttentionBadge
+formatRelativeAge
+formatStatusNotify
+formatStatusNotifyWithLive
+formatWindowAttentionPrefix
+buildPopupToggle
+buildPopupToggleWithPickerBackend
+keybindingAdvancedDeliveryHint
+keybindingCanCapture
+keybindingDeliveryHint
+keybindingDeliveryPath
+keybindingEditabilitySummary
+keybindingKindSummary
+keybindingNonEditableReason
+keybindingPlainAliasesSummary
+keybindingPrimaryAndAdditional
+keybindingSource
+keybindingSourceDetail
+keybindingSurfaceSummary
+keybindingTierSummary
+keybindingTransportAliasSource
+notifyAIStatusBodyText
+notifyCommand.buildNotifyLiveReport
+notifyCommand.listNotifyLivePanes
+notifyCommand.notifyLiveByIDBestEffort
+notifySeverityOpen
+notifySidebarAILabel
+notifySidebarAgentBadge
+notifySidebarAgentOpen
+notifySidebarEntries
+notifySidebarEntriesWithLive
+notifySidebarEntriesWithLiveLocale
+notifySidebarLabel
+notifySidebarLabelFor
+notifySidebarLabelForLocale
+notifySidebarReadModel.CollapsedEntries
+notifySidebarShowTargetParts
+notifySidebarStateBadge
+notifySidebarTarget
+notifySidebarTopicBadge
+notifyStateLabel
+pickerCloseBindingsForToggle
+pickerCommandFromCompatBinding
+pickerOptionsFromCompatPicker
+printSessionStateReplayWarnings
+renderNotifyBadge
+renderNotifyIcon
+renderThemeSource.tmuxAppConfig
+renderThemeSource.tmuxAppConfigWithAIBadgeStyle
+renderThemeSource.tmuxStandaloneConfig
+renderThemeSource.tmuxStandaloneConfigWithAIBadgeStyle
+sessionStateToggleEnabled
+sessionStateToggleState
+settingsCommand.addCurrentProjectEntry
+settingsCommand.confirmSessionStateDelete
+settingsCommand.currentSessionStateToggle
+settingsCommand.projectRootEntry
+settingsCommand.projectRootHintEntry
+settingsCommand.projectSessionStateRootLabel
+settingsCommand.projectSessionStateSnapshotEntriesForSession
+settingsCommand.rootEntries
+settingsCommand.rootEntriesForAxis
+settingsCommand.rootEntriesForTab
+settingsCommand.saveKeymapAndApply
+settingsCommand.sessionStateDeleteEntry
+settingsCommand.sessionStateRootLabel
+settingsCommand.sessionStateSettingsRootLabel
+settingsCommand.sessionStateSnapshotEntries
+settingsCommand.sessionStateSnapshotEntriesForSession
+settingsCommand.sessionStateToggleDetailEntries
+settingsCommand.setCurrentProjectRootEntry
+settingsPassiveRootTabChips
+settingsRootLabelWithColor
+settingsRootPrompt
+settingsRootTabChips
+settingsRootTabFromResult
+settingsWorkdirTypedEntry
+shellAppTmuxRunner.Run
+shellCommand.nowTime
+shellCommand.skipWelcomeVersion
+sortedProbeLabels
+statusCommand.notifyLiveByIDBestEffort
+statusbarDecorationSetFromGlobal
+statusbarSessionStatePreviewLines
+switchCommand.candidateInputsNoMemoize
+switchCommand.loadTaggedSet
+switchCommand.prepareSidebarTrustPopup
+switchCommand.switchAttentionRanks
+switchWindowAttentionRanks
+terminalRegistry.reset
+tmuxAppConfig
+tmuxAppConfigWithKeymap
+tmuxAppConfigWithKeymapTheme
+tmuxAppConfigWithKeymapThemeAndAIBadgeStyle
+tmuxPaneBorderFormat
+tmuxStandaloneConfig
+tmuxStandaloneConfigWithKeymap
+tmuxStandaloneConfigWithKeymapTheme
+tmuxStandaloneConfigWithKeymapThemeAndAIBadgeStyle
+tmuxStyledVisiblePaneLabelFormat
+tmuxTruthy
+windowAttentionRank

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ GO_FILES := $(shell find . -type f -name '*.go' \
 	-not -path './.git/*' \
 	-not -path './.wt/*')
 
-.PHONY: fmt fmt-check fix build install npm-pack test test-integration test-install-smoke test-e2e e2e verify
+DEADCODE_ALLOWLIST ?= .deadcode-allowlist.txt
+
+.PHONY: fmt fmt-check fix build install npm-pack test test-integration test-install-smoke test-e2e e2e verify deadcode
 
 build:
 	@mkdir -p $(BUILD_DIR)
@@ -56,6 +58,36 @@ fmt-check:
 
 fix:
 	$(GO) fix ./...
+	@$(MAKE) --no-print-directory deadcode
+
+# deadcode runs golang.org/x/tools/cmd/deadcode (pinned via the go.mod tool
+# directive) over the module and filters findings against an allowlist of
+# intentional / MUST-KEEP symbols. It exits non-zero only when a NEW
+# (non-allowlisted) unreachable function appears, so the checked-in baseline
+# stays green while genuinely new dead code is surfaced.
+deadcode:
+	@findings="$$( $(GO) tool deadcode ./... )"; \
+	if [ -z "$$findings" ]; then \
+		echo ">> deadcode: no unreachable functions reported"; \
+		exit 0; \
+	fi; \
+	allow="$$(mktemp)"; \
+	grep -v '^[[:space:]]*#' $(DEADCODE_ALLOWLIST) | grep -v '^[[:space:]]*$$' > "$$allow"; \
+	remaining="$$( printf '%s\n' "$$findings" | while IFS= read -r line; do \
+		sym="$${line##*unreachable func: }"; \
+		if grep -Fxq -- "$$sym" "$$allow"; then \
+			continue; \
+		fi; \
+		printf '%s\n' "$$line"; \
+	done )"; \
+	rm -f "$$allow"; \
+	if [ -n "$$remaining" ]; then \
+		echo ">> deadcode: NEW unreachable functions (not in $(DEADCODE_ALLOWLIST)):"; \
+		printf '%s\n' "$$remaining"; \
+		exit 1; \
+	fi; \
+	echo ">> deadcode: clean (all findings allowlisted in $(DEADCODE_ALLOWLIST))"; \
+	exit 0
 
 test:
 	$(GO) test ./...

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -21,6 +21,10 @@ and humans run the same entrypoints.
   `test/e2e/linux-smoke.sh`. It validates a minimal real-tmux workflow:
   sessions, panes, config sourcing, reply-state notify reconciliation, focus
   notify fallback, and status notify rendering.
+- `make deadcode` runs `go tool deadcode` (pinned via the go.mod tool
+  directive) over the module and reports unreachable functions, filtering out
+  the intentional/MUST-KEEP baseline in `.deadcode-allowlist.txt`; it fails
+  only on NEW dead code, and `make fix` runs it after `go fix`.
 
 ## Docker-Covered Checks
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,13 @@
 module github.com/crevissepartners/projmux
 
-go 1.24.2
+go 1.25.0
+
+tool golang.org/x/tools/cmd/deadcode
+
+require (
+	golang.org/x/mod v0.37.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/telemetry v0.0.0-20260610154732-fb80ec83bdd9 // indirect
+	golang.org/x/tools v0.46.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/telemetry v0.0.0-20260610154732-fb80ec83bdd9 h1:FjUup8XrRy7lv+XHONi6KKUSizeF2NnVrTnz/HhbohQ=
+golang.org/x/telemetry v0.0.0-20260610154732-fb80ec83bdd9/go.mod h1:3AWMyWHS+caVoiEXpiq6+tzKA40J4vQT3MYr80ZtQpc=
+golang.org/x/tools v0.46.0 h1:7jTurBkPZu4moS/Uy4OQT1M+QBlsj3wejyZwsT8Z7rk=
+golang.org/x/tools v0.46.0/go.mod h1:FrD85F8l+NWL+9XWBSyVSHO6Ne4jutsfIFba7AWQ5Ys=

--- a/internal/core/usage/usage.go
+++ b/internal/core/usage/usage.go
@@ -33,11 +33,6 @@ const (
 	WindowWeekly Window = "weekly"
 )
 
-// AllWindows returns the canonical ordered window list used by the CLI.
-func AllWindows() []Window {
-	return []Window{Window5h, WindowWeekly}
-}
-
 // Duration is the rolling window length used when describing windows. The
 // weekly window's duration is approximate — actual rollover follows the
 // vendor's published reset cadence (Anthropic returns an explicit

--- a/internal/integrations/sessionstate/replay.go
+++ b/internal/integrations/sessionstate/replay.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/crevissepartners/projmux/internal/core/aiprovider"
 	antigravityagent "github.com/crevissepartners/projmux/internal/integrations/agents/antigravity"
@@ -34,16 +33,6 @@ type ReplayOptions struct {
 
 	// CommandShell overrides the POSIX shell used for direct-start wrappers.
 	CommandShell string
-}
-
-// ApplyToExistingSessionOptions controls destructive replay into an
-// already-running tmux session.
-type ApplyToExistingSessionOptions struct {
-	ReplayOptions
-
-	// TempSession overrides the internal staging session name. It is intended
-	// for tests; production callers should leave it empty.
-	TempSession string
 }
 
 // ReplayResult reports non-fatal restore decisions.
@@ -170,96 +159,6 @@ func replay(ctx context.Context, runner Runner, snap Snapshot, opts ReplayOption
 		}
 	}
 
-	return result, nil
-}
-
-// ApplyToExistingSession destructively replaces the windows in snap.Session
-// while keeping that tmux session identity. It stages the snapshot in a
-// temporary session using Replay, moves the staged windows into the live
-// session by window ID, then removes any live windows that were not part of the
-// staged snapshot.
-func ApplyToExistingSession(ctx context.Context, runner Runner, snap Snapshot, opts ApplyToExistingSessionOptions) (ReplayResult, error) {
-	var result ReplayResult
-	if runner == nil {
-		return result, fmt.Errorf("sessionstate: replay runner is required")
-	}
-	if err := snap.Validate(); err != nil {
-		return result, err
-	}
-
-	windows := sortedWindows(snap.Windows)
-	if len(windows) == 0 {
-		return result, fmt.Errorf("sessionstate: live replay requires at least one window")
-	}
-
-	tempSession := strings.TrimSpace(opts.TempSession)
-	if tempSession == "" {
-		tempSession = defaultLiveReplayTempSession(snap.Session)
-	}
-	if err := validateSessionName(tempSession); err != nil {
-		return result, fmt.Errorf("sessionstate: invalid live replay temp session: %w", err)
-	}
-	if tempSession == snap.Session {
-		return result, fmt.Errorf("sessionstate: live replay temp session must differ from target session")
-	}
-
-	staged := snap
-	staged.Session = tempSession
-	cleanupTemp := false
-	defer func() {
-		if cleanupTemp {
-			_, _ = runner.Run(ctx, "tmux", "kill-session", "-t", tempSession)
-		}
-	}()
-
-	var err error
-	result, err = replay(ctx, runner, staged, opts.ReplayOptions, replayOptions{})
-	if err != nil {
-		cleanupTemp = true
-		return result, err
-	}
-	cleanupTemp = true
-
-	stagedWindows, err := listIndexedWindowIDs(ctx, runner, tempSession)
-	if err != nil {
-		return result, err
-	}
-
-	moved := make(map[string]struct{}, len(windows))
-	for _, window := range windows {
-		windowID, ok := stagedWindows[window.Index]
-		if !ok {
-			return result, fmt.Errorf("sessionstate: staged window %d not found", window.Index)
-		}
-		if _, err := runner.Run(ctx, "tmux", "move-window", "-d", "-k", "-s", windowID, "-t", windowTarget(snap.Session, window.Index)); err != nil {
-			return result, fmt.Errorf("live replay tmux window %d move: %w", window.Index, err)
-		}
-		moved[windowID] = struct{}{}
-	}
-	cleanupTemp = false
-
-	liveWindows, err := listWindowIDs(ctx, runner, snap.Session)
-	if err != nil {
-		return result, err
-	}
-	for _, windowID := range liveWindows {
-		if _, keep := moved[windowID]; keep {
-			continue
-		}
-		if _, err := runner.Run(ctx, "tmux", "kill-window", "-t", windowID); err != nil {
-			return result, fmt.Errorf("live replay tmux extra window %s: %w", windowID, err)
-		}
-	}
-
-	for _, window := range windows {
-		if err := replayPaneRecipes(ctx, runner, snap.Session, window, sortedPanes(window.Panes), &result, replayOptions{replayPaneRecipes: true}); err != nil {
-			return result, err
-		}
-	}
-
-	if _, err := runner.Run(ctx, "tmux", "select-window", "-t", windowTarget(snap.Session, windows[0].Index)); err != nil {
-		return result, fmt.Errorf("live replay tmux active window %d: %w", windows[0].Index, err)
-	}
 	return result, nil
 }
 
@@ -409,54 +308,6 @@ func replayStartupRecipe(ctx context.Context, runner Runner, target string, wind
 		return fmt.Errorf("replay tmux window %d pane %d startup: %w", windowIndex, pane.Index, err)
 	}
 	return nil
-}
-
-func listWindowIDs(ctx context.Context, runner Runner, session string) ([]string, error) {
-	output, err := runner.Run(ctx, "tmux", "list-windows", "-t", session, "-F", "#{window_id}")
-	if err != nil {
-		return nil, fmt.Errorf("sessionstate: list tmux windows for %q: %w", session, err)
-	}
-	var ids []string
-	for raw := range strings.SplitSeq(string(output), "\n") {
-		id := strings.TrimSpace(raw)
-		if id != "" {
-			ids = append(ids, id)
-		}
-	}
-	return ids, nil
-}
-
-func listIndexedWindowIDs(ctx context.Context, runner Runner, session string) (map[int]string, error) {
-	output, err := runner.Run(ctx, "tmux", "list-windows", "-t", session, "-F", "#{window_id}\t#{window_index}")
-	if err != nil {
-		return nil, fmt.Errorf("sessionstate: list staged tmux windows for %q: %w", session, err)
-	}
-	out := make(map[int]string)
-	for raw := range strings.SplitSeq(string(output), "\n") {
-		line := strings.TrimSpace(raw)
-		if line == "" {
-			continue
-		}
-		fields := strings.Split(line, "\t")
-		if len(fields) != 2 {
-			return nil, fmt.Errorf("sessionstate: parse tmux window row %q", raw)
-		}
-		index, err := strconv.Atoi(strings.TrimSpace(fields[1]))
-		if err != nil {
-			return nil, fmt.Errorf("sessionstate: parse tmux window index %q: %w", fields[1], err)
-		}
-		id := strings.TrimSpace(fields[0])
-		if id == "" {
-			return nil, fmt.Errorf("sessionstate: parse tmux window row %q: missing window id", raw)
-		}
-		out[index] = id
-	}
-	return out, nil
-}
-
-func defaultLiveReplayTempSession(session string) string {
-	name := strings.NewReplacer(":", "_", ".", "_").Replace(session)
-	return "__projmux_apply_" + name + "_" + strconv.Itoa(os.Getpid()) + "_" + strconv.FormatInt(time.Now().UnixNano(), 10)
 }
 
 func appendReplayWarning(result *ReplayResult, warning ReplayWarning) {

--- a/internal/integrations/sessionstate/replay_test.go
+++ b/internal/integrations/sessionstate/replay_test.go
@@ -625,7 +625,7 @@ func TestReplayDoesNotResumeUnsupportedAgent(t *testing.T) {
 			Name:            "agent",
 			ActivePaneIndex: 0,
 			Panes: []Pane{
-				{Index: 0, CWD: cwd, Recipe: AgentRecipe("gemini", "abcdef-1234", "topic")},
+				{Index: 0, CWD: cwd, Recipe: AgentRecipe("unsupported-agent", "abcdef-1234", "topic")},
 			},
 		},
 	}
@@ -642,97 +642,6 @@ func TestReplayDoesNotResumeUnsupportedAgent(t *testing.T) {
 		if len(command.args) > 0 && command.args[0] == "send-keys" {
 			t.Fatalf("Replay() resumed unsupported agent: %#v", command)
 		}
-	}
-}
-
-func TestApplyToExistingSessionMovesStagedWindowsAndKillsExtras(t *testing.T) {
-	t.Parallel()
-
-	cwd := t.TempDir()
-	snap := replaySnapshot(cwd)
-	snap.Windows = []Window{
-		{
-			Index:           0,
-			Name:            "main",
-			ActivePaneIndex: 0,
-			Panes: []Pane{
-				{Index: 0, CWD: cwd, Recipe: ShellRecipe()},
-			},
-		},
-		{
-			Index:           1,
-			Name:            "logs",
-			ActivePaneIndex: 0,
-			Panes: []Pane{
-				{Index: 0, CWD: cwd, Recipe: StartupRecipe("tail -f app.log")},
-			},
-		},
-		{
-			Index:           2,
-			Name:            "agent",
-			ActivePaneIndex: 0,
-			Panes: []Pane{
-				{Index: 0, CWD: cwd, Recipe: AgentRecipe("claude", "abcdef-1234", "topic")},
-			},
-		},
-	}
-	runner := &recordingReplayRunner{outputs: map[string]string{
-		replayOutputKey("tmux", "list-windows", "-t", "tmp-home", "-F", "#{window_id}\t#{window_index}"): "@10\t0\n@11\t1\n@12\t2\n",
-		replayOutputKey("tmux", "list-windows", "-t", "home", "-F", "#{window_id}"):                      "@10\n@11\n@12\n@2\n",
-	}}
-
-	result, err := ApplyToExistingSession(context.Background(), runner, snap, ApplyToExistingSessionOptions{
-		ReplayOptions: ReplayOptions{},
-		TempSession:   "tmp-home",
-	})
-	if err != nil {
-		t.Fatalf("ApplyToExistingSession() error = %v", err)
-	}
-	if len(result.Warnings) != 0 {
-		t.Fatalf("ApplyToExistingSession() warnings = %#v, want none", result.Warnings)
-	}
-
-	want := [][]string{
-		{"new-session", "-d", "-s", "tmp-home", "-c", cwd},
-		{"rename-window", "-t", "tmp-home:0", "main"},
-		{"new-window", "-d", "-t", "tmp-home:1", "-c", cwd, "-n", "logs"},
-		{"new-window", "-d", "-t", "tmp-home:2", "-c", cwd, "-n", "agent"},
-		{"list-windows", "-t", "tmp-home", "-F", "#{window_id}\t#{window_index}"},
-		{"move-window", "-d", "-k", "-s", "@10", "-t", "home:0"},
-		{"move-window", "-d", "-k", "-s", "@11", "-t", "home:1"},
-		{"move-window", "-d", "-k", "-s", "@12", "-t", "home:2"},
-		{"list-windows", "-t", "home", "-F", "#{window_id}"},
-		{"kill-window", "-t", "@2"},
-		{"send-keys", "-t", "home:1.0", "tail -f app.log", "Enter"},
-		{"send-keys", "-t", "home:2.0", "claude --resume abcdef-1234", "Enter"},
-		{"select-window", "-t", "home:0"},
-	}
-	if !replayCommandsContainInOrder(runner.commands, want) {
-		t.Fatalf("commands = %#v, want ordered subsequence %#v", runner.commands, want)
-	}
-	for _, command := range runner.commands {
-		if reflect.DeepEqual(command.args, []string{"send-keys", "-t", "tmp-home:1.0", "tail -f app.log", "Enter"}) ||
-			reflect.DeepEqual(command.args, []string{"send-keys", "-t", "tmp-home:2.0", "claude --resume abcdef-1234", "Enter"}) {
-			t.Fatalf("ApplyToExistingSession() replayed pane recipe in staging session: %#v", command)
-		}
-	}
-}
-
-func TestApplyToExistingSessionRejectsEmptySnapshot(t *testing.T) {
-	t.Parallel()
-
-	snap := replaySnapshot(t.TempDir())
-	runner := &recordingReplayRunner{}
-
-	_, err := ApplyToExistingSession(context.Background(), runner, snap, ApplyToExistingSessionOptions{TempSession: "tmp-home"})
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if !strings.Contains(err.Error(), "requires at least one window") {
-		t.Fatalf("error = %v, want empty snapshot failure", err)
-	}
-	if len(runner.commands) != 0 {
-		t.Fatalf("commands = %#v, want no tmux calls", runner.commands)
 	}
 }
 
@@ -777,24 +686,6 @@ func replayCommandIndex(commands []replayCommand, args []string) int {
 		}
 	}
 	return -1
-}
-
-func replayCommandsContainInOrder(commands []replayCommand, want [][]string) bool {
-	last := -1
-	for _, args := range want {
-		next := -1
-		for i := last + 1; i < len(commands); i++ {
-			if reflect.DeepEqual(commands[i].args, args) {
-				next = i
-				break
-			}
-		}
-		if next < 0 {
-			return false
-		}
-		last = next
-	}
-	return true
 }
 
 func replayAgentOptions(agentBin string) ReplayOptions {


### PR DESCRIPTION
## Summary

Legacy dead-code roadmap — **Phase 0 + Phase 1 + Phase 2**. Pure dead-symbol removal, dead-code **detection tooling**, and removal of an unused session-state live-overwrite primitive. No config-alias or keybinding-legacy work (those are Phase 3/4).

## Completed phases

- **Phase 0** — Truly-dead symbol removal (with one documented carve-out, see below)
- **Phase 1** — Dead-code detection tooling
- **Phase 2** — Session-state unused live-overwrite primitive removal

## Symbols removed / modified

**Phase 0**
- ❌ `internal/core/usage/usage.go` — removed `AllWindows()` (+ doc). `Window5h` / `WindowWeekly` constants kept. Zero residual refs.
- ✏️ `internal/integrations/sessionstate/replay_test.go` — hardcoded `AgentRecipe("gemini", …)` unsupported-agent fixture → `"unsupported-agent"`. `"gemini"` appeared only at this one line in the Go tree (no special-casing); the test's intent (unsupported-agent resume is refused) is preserved.
- ⚠️ **Carve-out: `settingsCompatSidebarStartupPicker` / `runSidebarStartupPickerDetail()` / the `settings.go:4120` switch case were NOT removed.** The audit premise was **stale**. These are a **live, tested Labs→Session State compat redirect**, not dead code:
  - `runSidebarStartupPickerDetail()` is called from `sessionstate_settings.go:78` via the reachable Session State menu (`sessionStateEntries()`, line 279).
  - The `settings.go:4120-4121` case is exercised by `TestSettingsLabsSidebarStartupPickerRedirectsToSessionStateDetail` (settings_test.go:3488), which injects the compat value into the labs picker and asserts it redirects to the Session State detail.
  - The constant is also asserted-absent-from-labs-entries by `settings_test.go:1585`.
  Removing them breaks the build + 2 tests and deletes a **config-value compat alias** — explicitly out of scope (Phase 3) and protected by MUST-KEEP intent. The sidebar-startup-picker was *moved* Labs→Session State, leaving an intentional redirect; the audit assumed deletion. → reclassify to Phase 3 / drop.

**Phase 2**
- ❌ `internal/integrations/sessionstate/replay.go` — removed `ApplyToExistingSession()`, `ApplyToExistingSessionOptions`, and the helpers used **only** by it (`listWindowIDs`, `listIndexedWindowIDs`, `defaultLiveReplayTempSession`) + now-unused `time` import.
- ❌ `replay_test.go` — removed `TestApplyToExistingSessionMovesStagedWindowsAndKillsExtras`, `TestApplyToExistingSessionRejectsEmptySnapshot`, and the helper `replayCommandsContainInOrder` (used only by them).
- ✅ `Replay`, `validateSessionName`, `sortedWindows`/`sortedPanes`, `replayPaneRecipes`, `windowTarget` and all shared infra **kept intact**. Zero residual `ApplyToExistingSession` refs.

**Phase 1**
- Pinned `golang.org/x/tools/cmd/deadcode @ v0.46.0` via the go.mod **`tool` directive** (runs as `go tool deadcode`). New `go.sum` (module was stdlib-only before).
- `Makefile`: new `deadcode` target — runs `go tool deadcode ./...`, exact-matches each finding against `.deadcode-allowlist.txt`, prints + exits 1 only on **non-allowlisted (new)** dead code, else exits 0. **Wired into `make fix`**.
- `.deadcode-allowlist.txt`: checked-in baseline (276 findings captured at introduction) with an explicit MUST-KEEP section at top.
- `docs/testing.md`: one-line usage note.

## Phase 2 — `session-state restore --dry-run` decision: **KEEP** (option a)

Decided to **keep** `restore --dry-run` as the documented preview surface, because:
1. It is **reachable CLI code**, not dead — `deadcode` does not flag it, and removing it is outside the "pure dead" scope of this bundle.
2. `restore` rejects non-dry-run with *"only supports --dry-run in this release"* — a deliberate forward-looking placeholder for real restore wiring (a planned consumer, analogous to `last-pane`).
3. It shares `printRestorePreview` with the `session-state preview` subcommand; keeping `restore --dry-run` as a discoverable alias costs nothing and preserves the planned surface.

## Explicitly excluded scope

- **Config-value legacy aliases** (Phase 3) — incl. the sidebar-startup-picker compat redirect carve-out above.
- **Keybinding `LegacyIDs` / `PrefixChord` legacy** (Phase 4).
- **MUST-KEEP sunset commenting** (Phase 5).
- No new config values / UI added.

## `last-pane` & MUST-KEEP — untouched ✅

`last-pane` action and the full MUST-KEEP set (`MigrateProjectLegacyScripts`, `MigrateGlobalLegacyScripts`, `legacyDesktopAppID` + tmux option markers, `CleanupLegacyArtifacts`, `legacyWindowAttentionRows`, `formatLegacyPaneSummary`, `tmuxRetiredKeyUnbindLines`, schema `Version=1` constants) are unchanged in product code (confirmed by rg). They are additionally listed in the deadcode allowlist so a future refactor that makes them unreachable won't tempt removal.

## ⚠️ Notable side-effect — `go` directive bump

`go.mod` `go 1.24.2 → 1.25.0` (required by `x/tools v0.46.0`). **No operational breakage**: CI uses `go-version-file: go.mod` with `setup-go@v6` (auto-fetches), local toolchain is go1.26. The only implication is the minimum *build-from-source* Go version. Accepted in preference to pinning an older, potentially-buggier x/tools just to hold 1.24.2.

## Verification

```
make fmt        # clean (no changes)
make fix        # go fix ./... + deadcode → ">> deadcode: clean (all findings allowlisted)"
make test       # all packages ok
make deadcode   # ">> deadcode: clean (all findings allowlisted in .deadcode-allowlist.txt)" (exit 0)
```

Residual-reference checks:
- `rg "AllWindows|ApplyToExistingSession" --type go` → **0** ✅
- `rg "settingsCompatSidebarStartupPicker|runSidebarStartupPickerDetail"` → still present (deliberate carve-out)
- `last-pane` + MUST-KEEP set → still present in product code ✅

## Unverified / follow-up

- **Docker integration / e2e** (`make test-integration`, `test-e2e`) not run locally (Docker harness) — not gating for this change; covered in CI.
- **Phase 0.1** reclassified to Phase 3 (config alias) or drop — not done here.
- **Phase 3** (config-value legacy aliases), **Phase 4** (keybinding legacy), **Phase 5** (MUST-KEEP sunset) — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
