### PR TITLE
chore(legacy): config-value legacy alias hard-drop (Phase 3)

### DIFF
--- a/docs/settings-ia.md
+++ b/docs/settings-ia.md
@@ -70,8 +70,7 @@ view-first layout:
   edit catalog `install` values or run agent install/remove commands.
 - `Settings > Session State > Sidebar startup picker` controls the Alt-1
   project-open startup selector. The saved file remains
-  `${XDG_CONFIG_HOME:-$HOME/.config}/projmux/sidebar-startup-picker`, and the
-  stale `labs:sidebar-startup-picker` action opens this Session State detail.
+  `${XDG_CONFIG_HOME:-$HOME/.config}/projmux/sidebar-startup-picker`.
 - `Settings > Labs` keeps experimental toggles, but keybindings no longer have a
   visible Labs row. The hidden compatibility action redirects to the
   `Settings > Keybindings` action list, not to a diagnostic default.

--- a/internal/app/sessionstate_settings.go
+++ b/internal/app/sessionstate_settings.go
@@ -74,7 +74,7 @@ func (c *settingsCommand) runSessionStateSection(stdout, stderr io.Writer) error
 			}, stdout, stderr); err != nil {
 				return err
 			}
-		case settingsSessionStateSidebarStartupPickerDetail, settingsCompatSidebarStartupPicker:
+		case settingsSessionStateSidebarStartupPickerDetail:
 			if err := c.runSidebarStartupPickerDetail(stdout, stderr); err != nil {
 				return err
 			}

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -116,7 +116,6 @@ var settingsEntryCatalog = map[string]settingsEntryMeta{
 	settingsNotificationsHookOverride:  {Name: "Notification hook override", Axis: settingsAxisGlobal},
 	settingsAppearanceLanguage:         {Name: "Language / Locale", Axis: settingsAxisGlobal},
 	settingsLabsProjectHooks:           {Name: "Project Hooks", Axis: settingsAxisGlobal},
-	settingsCompatSidebarStartupPicker: {Name: "Sidebar startup picker", Axis: settingsAxisGlobal},
 	settingsSessionStateDelete:         {Name: "Delete session snapshot", Axis: settingsAxisGlobal},
 	settingsLabKeybindings:             {Name: "Keybindings", Axis: settingsAxisGlobal},
 	settingsUpdateApply:                {Name: "Update Now", Axis: settingsAxisGlobal},
@@ -244,7 +243,6 @@ const (
 	settingsNotificationsHookOverride      = "notifications:hook-override"
 	settingsAppearanceLanguage             = "appearance:language"
 	settingsLabsProjectHooks               = "labs:project-hooks"
-	settingsCompatSidebarStartupPicker     = "labs:sidebar-startup-picker"
 	settingsLabKeybindings                 = "labs:keybindings"
 	settingsSessionStateDelete             = "sessionstate:delete"
 	settingsWelcomeShow                    = "welcome:show"
@@ -4117,8 +4115,6 @@ func (c *settingsCommand) runLabsSection(stdout, stderr io.Writer) error {
 			}
 		case action == settingsLabsProjectHooks:
 			return c.runLabsProjectHooksSection(stdout, stderr)
-		case action == settingsCompatSidebarStartupPicker:
-			return c.runSidebarStartupPickerDetail(stdout, stderr)
 		case strings.HasPrefix(action, settingsActionPrefixHooks):
 			if err := c.execute(action, stdout, stderr); err != nil {
 				return err

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -1581,8 +1581,7 @@ func TestSettingsHubKeepsLabsSectionWithoutPickerBackendChoices(t *testing.T) {
 	if !hasEntryValue(labsOptions.Entries, settingsLabsProjectHooks) {
 		t.Fatalf("labs settings entries = %#v, want project hooks overview row", labsOptions.Entries)
 	}
-	if hasEntryLabelContaining(labsOptions.Entries, "Sidebar startup picker") ||
-		hasEntryValue(labsOptions.Entries, settingsCompatSidebarStartupPicker) {
+	if hasEntryLabelContaining(labsOptions.Entries, "Sidebar startup picker") {
 		t.Fatalf("labs settings entries = %#v, want sidebar startup picker moved to Session State", labsOptions.Entries)
 	}
 	if hasEntryValue(labsOptions.Entries, settingsActionPrefixSessionState+"sidebar-startup:off") ||
@@ -3482,48 +3481,6 @@ func TestSettingsSessionStateSidebarStartupPickerDetailPersistsExistingFile(t *t
 	}
 	if got := filepath.Base(paths.SidebarStartupPickerFile()); got != config.SidebarStartupPickerFileName {
 		t.Fatalf("sidebar startup picker file name = %q, want %q", got, config.SidebarStartupPickerFileName)
-	}
-}
-
-func TestSettingsLabsSidebarStartupPickerRedirectsToSessionStateDetail(t *testing.T) {
-	t.Parallel()
-
-	home := t.TempDir()
-	var calls int
-	runner := switchRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
-		calls++
-		switch calls {
-		case 1:
-			if got, want := options.UI, "settings-labs"; got != want {
-				t.Fatalf("labs UI = %q, want %q", got, want)
-			}
-			return intpickercompat.Result{Key: "enter", Value: settingsCompatSidebarStartupPicker}, nil
-		case 2:
-			if got, want := options.UI, "settings-sessionstate-detail"; got != want {
-				t.Fatalf("redirect detail UI = %q, want %q", got, want)
-			}
-			if strings.Contains(options.Title, "Labs") || strings.Contains(options.Prompt, "Labs") {
-				t.Fatalf("redirect detail chrome = title %q prompt %q, want Session State path", options.Title, options.Prompt)
-			}
-			if got, want := options.Title, "Session State - Sidebar startup picker"; got != want {
-				t.Fatalf("redirect detail title = %q, want %q", got, want)
-			}
-			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
-		case 3:
-			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil
-		default:
-			t.Fatalf("unexpected picker call %d", calls)
-			return intpickercompat.Result{}, nil
-		}
-	})
-	cmd := &settingsCommand{
-		nativePicker: nativePickerFromCompatRunner(runner),
-		homeDir:      func() (string, error) { return home, nil },
-		lookupEnv:    func(string) string { return "" },
-	}
-
-	if err := cmd.runLabsSection(&bytes.Buffer{}, &bytes.Buffer{}); err != nil {
-		t.Fatalf("runLabsSection() error = %v", err)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -286,6 +286,7 @@ func TestDesktopNotifyModeNormalizesInvalidValues(t *testing.T) {
 		t.Fatalf("LoadDesktopNotifyModeFile() = %q, want %q", got, DefaultDesktopNotifyMode)
 	}
 
+	// "none" is a dropped legacy alias; it now absorbs into the default.
 	if err := SaveDesktopNotifyModeFile(path, DesktopNotifyMode("none")); err != nil {
 		t.Fatalf("SaveDesktopNotifyModeFile() error = %v", err)
 	}
@@ -293,8 +294,8 @@ func TestDesktopNotifyModeNormalizesInvalidValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadDesktopNotifyModeFile() error = %v", err)
 	}
-	if got != DesktopNotifyModeOff {
-		t.Fatalf("LoadDesktopNotifyModeFile() after save = %q, want %q", got, DesktopNotifyModeOff)
+	if got != DefaultDesktopNotifyMode {
+		t.Fatalf("LoadDesktopNotifyModeFile() after save = %q, want %q", got, DefaultDesktopNotifyMode)
 	}
 }
 
@@ -444,9 +445,11 @@ func TestSessionStateToggleRoundtrip(t *testing.T) {
 	}
 }
 
-func TestSessionStateToggleNormalizesBooleanValues(t *testing.T) {
+func TestSessionStateToggleDropsBooleanAliases(t *testing.T) {
 	t.Parallel()
 
+	// "false" was a legacy boolean-ish alias; it is now dropped and absorbs
+	// into the default (On).
 	path := filepath.Join(t.TempDir(), SessionStateAutosaveFileName)
 	if err := os.WriteFile(path, []byte("false\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -455,8 +458,20 @@ func TestSessionStateToggleNormalizesBooleanValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSessionStateToggleFile() error = %v", err)
 	}
+	if got != SessionStateToggleOn {
+		t.Fatalf("LoadSessionStateToggleFile(false) = %q, want %q", got, SessionStateToggleOn)
+	}
+
+	// The canonical "off" value still resolves to Off.
+	if err := os.WriteFile(path, []byte("off\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err = LoadSessionStateToggleFile(path)
+	if err != nil {
+		t.Fatalf("LoadSessionStateToggleFile() error = %v", err)
+	}
 	if got != SessionStateToggleOff {
-		t.Fatalf("LoadSessionStateToggleFile() = %q, want %q", got, SessionStateToggleOff)
+		t.Fatalf("LoadSessionStateToggleFile(off) = %q, want %q", got, SessionStateToggleOff)
 	}
 }
 
@@ -538,8 +553,9 @@ func TestAIBadgeStyleNormalizesInvalidValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadAIBadgeStyleFile() error = %v", err)
 	}
-	if got != AIBadgeStyleOff {
-		t.Fatalf("LoadAIBadgeStyleFile(minimal) = %q, want %q", got, AIBadgeStyleOff)
+	// "minimal" is a dropped legacy alias; it now absorbs into the default (dot).
+	if got != AIBadgeStyleDot {
+		t.Fatalf("LoadAIBadgeStyleFile(minimal) = %q, want %q", got, AIBadgeStyleDot)
 	}
 
 	if err := SaveAIBadgeStyleFile(path, AIBadgeStyle("also-broken")); err != nil {

--- a/internal/config/notification.go
+++ b/internal/config/notification.go
@@ -46,11 +46,11 @@ func (p Paths) DesktopNotifyModeFile() string {
 
 func NormalizeDesktopNotifyMode(value string) DesktopNotifyMode {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case string(DesktopNotifyModeOff), "none", "disabled":
+	case string(DesktopNotifyModeOff):
 		return DesktopNotifyModeOff
-	case string(DesktopNotifyModeRaise), "auto-raise", "autoraise":
+	case string(DesktopNotifyModeRaise):
 		return DesktopNotifyModeRaise
-	case string(DesktopNotifyModeNotify), "toast":
+	case string(DesktopNotifyModeNotify):
 		return DesktopNotifyModeNotify
 	default:
 		return DefaultDesktopNotifyMode

--- a/internal/config/sessionstate.go
+++ b/internal/config/sessionstate.go
@@ -28,7 +28,7 @@ type SessionStateProjectToggle string
 
 func NormalizeSessionStateToggle(value string) SessionStateToggle {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "0", "false", "no", "off", "disabled", "disable":
+	case string(SessionStateToggleOff):
 		return SessionStateToggleOff
 	default:
 		return SessionStateToggleOn
@@ -41,9 +41,9 @@ func (t SessionStateToggle) Enabled() bool {
 
 func NormalizeSessionStateProjectToggle(value string) SessionStateProjectToggle {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "1", "true", "yes", "on", "enabled", "enable":
+	case string(SessionStateProjectOn):
 		return SessionStateProjectOn
-	case "0", "false", "no", "off", "disabled", "disable":
+	case string(SessionStateProjectOff):
 		return SessionStateProjectOff
 	default:
 		return SessionStateProjectInherit

--- a/internal/config/statusbar.go
+++ b/internal/config/statusbar.go
@@ -39,7 +39,7 @@ func NormalizeAIBadgeStyle(value string) AIBadgeStyle {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case string(AIBadgeStyleEmoji):
 		return AIBadgeStyleEmoji
-	case string(AIBadgeStyleOff), "minimal":
+	case string(AIBadgeStyleOff):
 		return AIBadgeStyleOff
 	default:
 		return AIBadgeStyleDot

--- a/internal/core/aibadge/badge.go
+++ b/internal/core/aibadge/badge.go
@@ -40,7 +40,7 @@ func NormalizeStyle(style string) string {
 	switch strings.ToLower(strings.TrimSpace(style)) {
 	case StyleEmoji:
 		return StyleEmoji
-	case StyleOff, "minimal":
+	case StyleOff:
 		return StyleOff
 	default:
 		return StyleDot

--- a/internal/core/aibadge/badge_test.go
+++ b/internal/core/aibadge/badge_test.go
@@ -31,8 +31,18 @@ func TestAggregatePriorityContract(t *testing.T) {
 func TestStyleAndThemeRoleContracts(t *testing.T) {
 	t.Parallel()
 
-	if got := NormalizeStyle("minimal"); got != StyleOff {
-		t.Fatalf("NormalizeStyle(minimal) = %q, want %q", got, StyleOff)
+	// "minimal" is a dropped legacy alias; it now absorbs into the default (dot).
+	if got := NormalizeStyle("minimal"); got != StyleDot {
+		t.Fatalf("NormalizeStyle(minimal) = %q, want %q", got, StyleDot)
+	}
+	if got := NormalizeStyle("off"); got != StyleOff {
+		t.Fatalf("NormalizeStyle(off) = %q, want %q", got, StyleOff)
+	}
+	if got := NormalizeStyle("emoji"); got != StyleEmoji {
+		t.Fatalf("NormalizeStyle(emoji) = %q, want %q", got, StyleEmoji)
+	}
+	if got := NormalizeStyle("dot"); got != StyleDot {
+		t.Fatalf("NormalizeStyle(dot) = %q, want %q", got, StyleDot)
 	}
 	if got := NormalizeStyle("unknown"); got != StyleDot {
 		t.Fatalf("NormalizeStyle(unknown) = %q, want %q", got, StyleDot)

--- a/internal/ui/render/switch_test.go
+++ b/internal/ui/render/switch_test.go
@@ -260,8 +260,8 @@ func TestSwitchBadgeEmojiStyleCompatibilityGlyphs(t *testing.T) {
 			t.Fatalf("Glyph(%q, emoji) = %q, want %q", kind, got, want)
 		}
 	}
-	if got := aibadge.Glyph(aibadge.ApprovalRequired, "minimal"); got != " " {
-		t.Fatalf("Glyph(approval_required, minimal) = %q, want blank alignment glyph", got)
+	if got := aibadge.Glyph(aibadge.ApprovalRequired, aibadge.StyleOff); got != " " {
+		t.Fatalf("Glyph(approval_required, off) = %q, want blank alignment glyph", got)
 	}
 }
 


### PR DESCRIPTION
## 완료한 Phase

**Phase 3 — config-value legacy alias 하드 드롭** (Legacy dead-code 전수조사 & 0.7 제거 트랙, ungated).

정책: **릴리스 노트 + 하드 드롭.** UX 에서 도달 불가한 옛 config 문자열 alias 를 삭제하고, dropped value 는 release note 로만 고지한다. 마이그레이션 코드 없음. 각 normalizer 의 unknown→default fallback 으로 옛 값이 자연 흡수된다.

## 드롭한 config alias 값 목록 (release note 용)

| 설정 | 드롭된 alias | 흡수 결과 |
| --- | --- | --- |
| AI badge style (`NormalizeAIBadgeStyle` / `aibadge.NormalizeStyle`) | `minimal` | → 기본값 `dot` |
| Desktop notify mode (`NormalizeDesktopNotifyMode`) | `none`, `disabled`, `auto-raise`, `autoraise`, `toast` | → 기본값 `notify` |
| Session state toggle (`NormalizeSessionStateToggle`) | `0`, `false`, `no`, `disabled`, `disable` | → 기본값 `on` (canonical `off` 는 그대로 Off) |
| Session state project toggle (`NormalizeSessionStateProjectToggle`) | `1`/`true`/`yes`/`enabled`/`enable`, `0`/`false`/`no`/`disabled`/`disable` | → 기본값 `inherit` (canonical `on`/`off` 유지) |
| Sidebar startup picker Labs alias | action `labs:sidebar-startup-picker` (`settingsCompatSidebarStartupPicker`) | 상수/메타데이터/redirect/테스트 완전 제거 |

canonical 값(dot/emoji/off, off/raise/notify, on/off, inherit)은 회귀 없음.

## Sidebar startup picker redirect 처리

- **`runSidebarStartupPickerDetail()` 함수는 유지.** canonical Session State 경로(`settingsSessionStateSidebarStartupPickerDetail`, `sessionstate_settings.go:77`)에서 계속 dispatch 되므로 compat alias 전용이 아니다. `make deadcode` clean 으로 도달 가능 확인.
- 제거한 것: 상수 `settingsCompatSidebarStartupPicker`(`settings.go:247`), 메타데이터 엔트리(`settings.go:119`), Labs dispatch 분기(`settings.go:4120-4121`), `sessionstate_settings.go:77` 의 compat alias case, `TestSettingsLabsSidebarStartupPickerRedirectsToSessionStateDetail` 테스트, Labs 섹션 테스트의 compat-value 절(`settings_test.go:1585`), `docs/settings-ia.md` 의 stale alias 문장.
- 잔여 참조 `rg "settingsCompatSidebarStartupPicker|labs:sidebar-startup-picker"` → **0**.

## 명시적으로 제외한 범위

- **keybinding legacy (Phase 4)**: LegacyIDs / PrefixChord / `tmuxRetiredKeyUnbindLines` — Must 키바인딩 cleanup 머지 후 진행. 미변경.
- **MUST-KEEP 세트**: persisted-state `Version` 상수, hook migration, `legacyDesktopAppID`, `CleanupLegacyArtifacts`, `legacyWindowAttentionRows`, `formatLegacyPaneSummary` 등 전부 미변경.
- **`last-pane` action**: planned consumer, 미변경.
- **deadcode allowlist baseline 축소/triage**: 별도 후속. `.deadcode-allowlist.txt` 미변경(신규 dead 없음).
- **`parseDesktopNotifyMode`** (`internal/app/notification_toggle.go`): env-var/tmux-option 3-way 런타임 resolver. config-file normalizer 와 별개의 live 입력 surface 이고 audit 인벤토리(섹션 B)에 없음 → 이번 범위 제외, 후속 검토 항목.

## 모델/스키마 제약 준수

- persisted state schema(`Version` 상수 등) 변경 없음.
- 각 normalizer 의 unknown-value → default fallback 동작 유지 (옛 값은 에러/경고 없이 default 로 흡수).
- `last-pane` action / MUST-KEEP 세트 전부 보존.
- 새 config 값/UI 추가 없음.

## 검증

워크트리에서 실행, 전부 통과:

- `make fmt` — clean (no reformatting)
- `make fix` — `go fix ./...` + `>> deadcode: clean (all findings allowlisted)`
- `make test` — 전체 패키지 `ok`, FAIL 없음
- `make deadcode` — `>> deadcode: clean (all findings allowlisted in .deadcode-allowlist.txt)` (신규 dead 없음)
- normalizer 테스트 고정: 제거된 alias 가 더 이상 canonical 로 매핑되지 않고 unknown→default fallback 으로 떨어짐을 assert (`config_test.go`, `badge_test.go`). canonical 값 회귀 없음 assert 추가.

## 미검증 / 후속

- 런타임 동작(앱 실제 실행) 수동 검증은 안 함 — 변경이 normalizer 분기 축소 + dead alias 제거라 단위 테스트로 커버.
- **Phase 4** (keybinding legacy 제거): Must "Keybinding alias coverage cleanup" 머지 후.
- **Phase 5** (MUST-KEEP sunset 주석화).
- `parseDesktopNotifyMode` env/tmux alias 정리 여부 결정(별도).

🤖 Generated with [Claude Code](https://claude.com/claude-code)