### PR TITLE
fix(recent-windows): show last-visit absolute time in local timezone (Phase 0)

### DIFF
--- a/internal/app/recent_window.go
+++ b/internal/app/recent_window.go
@@ -713,7 +713,7 @@ func recentWindowFocusDate(focused time.Time) string {
 	if focused.IsZero() {
 		return ""
 	}
-	return focused.UTC().Format("2006-01-02 15:04")
+	return focused.Local().Format("2006-01-02 15:04")
 }
 
 // recentWindowTruncate shortens value to at most maxRunes runes (rune-aware),

--- a/internal/app/recent_window_test.go
+++ b/internal/app/recent_window_test.go
@@ -234,7 +234,8 @@ func TestRecentWindowPickerItemLastVisitFormat(t *testing.T) {
 	}
 	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at.Add(3*time.Minute), aibadge.StyleDot)
 
-	want := "last visit · 3m ago · 2026-06-18 01:02"
+	wantDate := at.Local().Format("2006-01-02 15:04")
+	want := "last visit · 3m ago · " + wantDate
 	found := false
 	for _, line := range item.MetaLines {
 		if line == want {
@@ -243,6 +244,23 @@ func TestRecentWindowPickerItemLastVisitFormat(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("MetaLines = %#v, want last-visit line %q", item.MetaLines, want)
+	}
+}
+
+func TestRecentWindowFocusDateUsesLocalTimezone(t *testing.T) {
+	// No t.Parallel(): this mutates the global time.Local.
+	loc, err := time.LoadLocation("Asia/Seoul")
+	if err != nil {
+		t.Skipf("Asia/Seoul tzdata unavailable: %v", err)
+	}
+	orig := time.Local
+	time.Local = loc
+	t.Cleanup(func() { time.Local = orig })
+
+	// 01:02 UTC == 10:02 KST.
+	at := time.Date(2026, 6, 18, 1, 2, 3, 0, time.UTC)
+	if got, want := recentWindowFocusDate(at), "2026-06-18 10:02"; got != want {
+		t.Fatalf("recentWindowFocusDate(%s) = %q, want %q (local TZ)", at, got, want)
 	}
 }
 
@@ -556,7 +574,8 @@ func TestRecentWindowPickerItemSearchTextIncludesPaneTitlesAndDate(t *testing.T)
 	}
 	item := recentWindowPickerItem(recentWindowCandidate(snapshot), at.Add(time.Minute), aibadge.StyleDot)
 
-	for _, want := range []string{"projmux", "Projmux", "repos-projmux", "zsh", "Claude Code", "Codex", "roadmap", "codex", "2026-06-18 01:02"} {
+	wantDate := at.Local().Format("2006-01-02 15:04")
+	for _, want := range []string{"projmux", "Projmux", "repos-projmux", "zsh", "Claude Code", "Codex", "roadmap", "codex", wantDate} {
 		if !strings.Contains(item.SearchText, want) {
 			t.Fatalf("SearchText = %q, want substring %q", item.SearchText, want)
 		}
@@ -1037,6 +1056,13 @@ func TestRecentWindowRecordSnapshotsCurrentTmuxWindow(t *testing.T) {
 	}
 	if got.LastFocusedAt != now {
 		t.Fatalf("snapshot time = %s, want %s", got.LastFocusedAt, now)
+	}
+	// Persisted state must stay UTC regardless of display-time local conversion.
+	if loc := got.LastFocusedAt.Location(); loc != time.UTC {
+		t.Fatalf("snapshot time location = %v, want UTC", loc)
+	}
+	if formatted := got.LastFocusedAt.Format(time.RFC3339); !strings.HasSuffix(formatted, "Z") {
+		t.Fatalf("snapshot time RFC3339 = %q, want UTC 'Z' suffix", formatted)
 	}
 	if got, want := store.recordLimits[0], recentwindows.DefaultLimit; got != want {
 		t.Fatalf("record limit = %d, want %d", got, want)


### PR DESCRIPTION
## Completed Phase
Phase 0

## Modified surface
Recent Windows (Alt-3) picker card **last-visit absolute time display**.

`recentWindowFocusDate` previously formatted `focused.UTC()`, so the card always rendered the last-visit time in UTC regardless of the environment's timezone. It now formats `focused.Local()`, following Go's `time.Local` (TZ env / system).

## Explicit scope notes
- **Storage format (UTC) unchanged** — the persisted `LastFocusedAt: c.currentTime().UTC()` write is untouched. Only the display converts to local.
- **Age (duration) unchanged** — `recentWindowAge` is timezone-independent and was not modified.
- **No TZ config added** — display follows `time.Local` only; no setting introduced.
- Date format string `2006-01-02 15:04` unchanged.

## Tests
- Added `TestRecentWindowFocusDateUsesLocalTimezone`: loads `Asia/Seoul` (skips if tzdata missing), swaps/restores global `time.Local`, and asserts `01:02 UTC` renders as `2026-06-18 10:02` KST — proving display follows local TZ with a hardcoded expected value.
- Added a real UTC-persistence assertion to `TestRecentWindowRecordSnapshotsCurrentTmuxWindow`: the stored `LastFocusedAt.Location()` is `time.UTC` and its RFC3339 form ends in `Z`.
- Fixed two previously hard-coded UTC literals (`2026-06-18 01:02`) in `TestRecentWindowPickerItemLastVisitFormat` and `TestRecentWindowPickerItemSearchTextIncludesPaneTitlesAndDate` to derive `wantDate` from `at.Local()`, keeping them deterministic on any machine TZ.

## Verification
- `make fmt` — clean (no output)
- `make fix` — `go fix ./...`; `deadcode: clean (all findings allowlisted in .deadcode-allowlist.txt)`
- `make deadcode` — `deadcode: clean (all findings allowlisted in .deadcode-allowlist.txt)`
- `make test` — all packages `ok`
- `TZ=Asia/Seoul go test ./internal/app/ -run 'RecentWindow' -count=1` — `ok`
- `TZ=UTC go test ./internal/app/ -run 'RecentWindow' -count=1` — `ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)