### PR TITLE
feat(keybindings): preview-only action list hierarchy (Phase 0.7)

### DIFF
--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -3717,7 +3717,7 @@ func keybindingListKeysSummary(action keyBindingAction) string {
 	}
 	summary := keybindingChordDisplay(keys[0])
 	if len(keys) > 1 {
-		summary += fmt.Sprintf(" +%d", len(keys)-1)
+		summary += fmt.Sprintf(", +%d", len(keys)-1)
 	}
 	return summary
 }
@@ -3734,16 +3734,15 @@ func keybindingActionsSummary(keymap keymapFile, action, defaultAction keyBindin
 		return "view only"
 	}
 	var actions []string
-	actions = append(actions, "Add key")
-	if len(removableKeybindingKeys(keymap, action, defaultAction)) != 0 {
-		actions = append(actions, "Remove key")
-	}
 	if len(keybindingVisibleChords(action)) != 0 {
 		actions = append(actions, "Unbind")
 	}
 	state := keybindingState(keymap, action, defaultAction)
 	if keybindingShowResetAction(state) {
 		actions = append(actions, keybindingResetActionLabel(state, defaultAction))
+	}
+	if len(actions) == 0 {
+		return "no action-level options"
 	}
 	return strings.Join(actions, ", ")
 }

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -4255,6 +4255,170 @@ func TestSettingsHubKeybindingsUsesReadableKeyLabels(t *testing.T) {
 	}
 }
 
+func TestSettingsKeybindingsActionListIsPreviewOnly(t *testing.T) {
+	t.Parallel()
+
+	// (a) Action LIST rows expose no mutation: every navigable row is a plain
+	// keymap:<actionID> link with no mutation suffix, and no row label carries a
+	// mutation verb. The list can only navigate into detail.
+	cmd := &settingsCommand{}
+	listEntries, err := cmd.keybindingEntries()
+	if err != nil {
+		t.Fatalf("keybindingEntries() error = %v", err)
+	}
+
+	mutationSuffixes := []string{":add", ":capture", ":type", ":advanced", ":unbind", ":reset", ":key:", ":remove:", ":test:"}
+	var navigableRows int
+	for _, entry := range listEntries {
+		value := entry.Value
+		if value == settingsBackValue || value == settingsNoopValue || value == "" {
+			continue
+		}
+		if !strings.HasPrefix(value, settingsActionPrefixKeymap) {
+			t.Fatalf("list row value = %q, want %s<actionID> link", value, settingsActionPrefixKeymap)
+		}
+		navigableRows++
+		actionID := strings.TrimPrefix(value, settingsActionPrefixKeymap)
+		if want := settingsActionPrefixKeymap + actionID; value != want {
+			t.Fatalf("list row value = %q, want exactly %q (no mutation suffix)", value, want)
+		}
+		for _, suffix := range mutationSuffixes {
+			if strings.Contains(value, suffix) {
+				t.Fatalf("list row value = %q, must not contain mutation marker %q", value, suffix)
+			}
+		}
+	}
+	if navigableRows == 0 {
+		t.Fatalf("keybinding list = %#v, want at least one navigable action row", listEntries)
+	}
+	for _, mutationWord := range []string{"Add key", "Remove", "Unbind", "Reset"} {
+		if hasEntryLabelContaining(listEntries, mutationWord) {
+			t.Fatalf("list entries = %#v, must not surface mutation word %q in a row label", listEntries, mutationWord)
+		}
+	}
+
+	// (d) Phase 0.6 invariants preserved in the list: no primary/alias/additional
+	// role labels reintroduced.
+	for _, role := range []string{"Primary", "Alias", "Additional"} {
+		if hasEntryLabelContaining(listEntries, role) {
+			t.Fatalf("list entries = %#v, must not surface role word %q", listEntries, role)
+		}
+	}
+}
+
+func TestSettingsKeybindingsListKeysPreviewCompression(t *testing.T) {
+	t.Parallel()
+
+	// (b) Keys preview compression: a multi-key custom binding renders as
+	// "<first key>, +N" with the comma; an unbound action shows "Not bound".
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "projmux", "keymap.toml"),
+		"[bindings.ProjectSidebarToggle]\nkeys = [\"M-a\", \"M-b\"]\n[bindings.NotifySidebarToggle]\nplain = \"\"\n")
+
+	cmd := testKeybindingSettingsCommand(t, home, func(intpickercompat.Options) (intpickercompat.Result, error) {
+		return intpickercompat.Result{}, nil
+	})
+
+	entries, err := cmd.keybindingEntries()
+	if err != nil {
+		t.Fatalf("keybindingEntries() error = %v", err)
+	}
+
+	idx := entryIndexValue(entries, settingsActionPrefixKeymap+"ProjectSidebarToggle")
+	if idx < 0 {
+		t.Fatalf("entries = %#v, want ProjectSidebarToggle row", entries)
+	}
+	if got := entries[idx].Label; !strings.Contains(got, "Alt-A (M-a), +1") {
+		t.Fatalf("multi-key row label = %q, want compressed %q form", got, "Alt-A (M-a), +1")
+	}
+
+	notifyIdx := entryIndexValue(entries, settingsActionPrefixKeymap+"NotifySidebarToggle")
+	if notifyIdx < 0 {
+		t.Fatalf("entries = %#v, want NotifySidebarToggle row", entries)
+	}
+	if got := entries[notifyIdx].Label; !strings.Contains(got, "Not bound") {
+		t.Fatalf("unbound row label = %q, want %q", got, "Not bound")
+	}
+}
+
+func TestSettingsKeybindingsMutationLivesInDetailNotList(t *testing.T) {
+	t.Parallel()
+
+	// (c) Mutating values appear only in detail / key-detail / add-key entry
+	// sets, never in the action list. ProjectSidebarToggle is an editable plain
+	// action with a custom multi-key binding so every mutation row is present.
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "projmux", "keymap.toml"),
+		"[bindings.ProjectSidebarToggle]\nkeys = [\"M-a\", \"M-b\"]\n")
+	cmd := testKeybindingSettingsCommand(t, home, func(intpickercompat.Options) (intpickercompat.Result, error) {
+		return intpickercompat.Result{}, nil
+	})
+
+	const actionID = "ProjectSidebarToggle"
+	prefix := settingsActionPrefixKeymap + actionID + ":"
+
+	listEntries, err := cmd.keybindingEntries()
+	if err != nil {
+		t.Fatalf("keybindingEntries() error = %v", err)
+	}
+	detailEntries, _, err := cmd.keybindingDetailEntries(actionID)
+	if err != nil {
+		t.Fatalf("keybindingDetailEntries() error = %v", err)
+	}
+	keyDetailEntries, _, err := cmd.keybindingKeyDetailEntries(actionID, "M-a")
+	if err != nil {
+		t.Fatalf("keybindingKeyDetailEntries() error = %v", err)
+	}
+	addEntries, _, err := cmd.keybindingAddEntries(actionID)
+	if err != nil {
+		t.Fatalf("keybindingAddEntries() error = %v", err)
+	}
+	addAdvancedEntries, _, err := cmd.keybindingAddAdvancedEntries(actionID)
+	if err != nil {
+		t.Fatalf("keybindingAddAdvancedEntries() error = %v", err)
+	}
+
+	// Action-level mutations live in detail.
+	for _, value := range []string{prefix + "add", prefix + "unbind", prefix + "key:M-a"} {
+		if !hasEntryValue(detailEntries, value) {
+			t.Fatalf("detail entries = %#v, want mutation/navigation value %q", detailEntries, value)
+		}
+		if hasEntryValue(listEntries, value) {
+			t.Fatalf("list entries must not contain detail value %q", value)
+		}
+	}
+	// Key removal lives in key detail.
+	if !hasEntryValue(keyDetailEntries, prefix+"remove:M-a") {
+		t.Fatalf("key detail entries = %#v, want remove value %q", keyDetailEntries, prefix+"remove:M-a")
+	}
+	if hasEntryValue(listEntries, prefix+"remove:M-a") {
+		t.Fatalf("list entries must not contain key-remove value")
+	}
+	// Capture/type live in the add-key flow.
+	if !hasEntryValue(addEntries, prefix+"capture") {
+		t.Fatalf("add entries = %#v, want capture value %q", addEntries, prefix+"capture")
+	}
+	if !hasEntryValue(addAdvancedEntries, prefix+"type") {
+		t.Fatalf("add advanced entries = %#v, want type value %q", addAdvancedEntries, prefix+"type")
+	}
+	for _, value := range []string{prefix + "capture", prefix + "type"} {
+		if hasEntryValue(listEntries, value) {
+			t.Fatalf("list entries must not contain add-flow value %q", value)
+		}
+	}
+
+	// (d) Phase 0.6 invariants preserved in detail: no role words, flat key
+	// list (a per-key navigable row exists, no nested grouping copy).
+	for _, role := range []string{"Primary", "Alias", "Additional"} {
+		if hasEntryLabelContaining(detailEntries, role) {
+			t.Fatalf("detail entries = %#v, must not surface role word %q", detailEntries, role)
+		}
+	}
+	if !hasEntryValue(detailEntries, prefix+"key:M-a") || !hasEntryValue(detailEntries, prefix+"key:M-b") {
+		t.Fatalf("detail entries = %#v, want a flat per-key row for each active chord", detailEntries)
+	}
+}
+
 func TestSettingsHubKeybindingsListsPopupLocalAndMovementActions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 완료한 Phase

- **Phase 0.7 — Preview-only action list hierarchy slice** (Keybinding alias coverage cleanup 트랙)

Source of truth: `로드맵 디테일 - Keybinding alias coverage cleanup` Phase 0.7. Phase 0.6 (flat key list, #410) 위에 list/detail 책임을 더 명확히 나눈 locking 슬라이스.

## 수정한 user-facing surface (Settings > Keybindings)

- **Action list (overview)**: action row 는 preview/navigation 전용. label + keys preview + state 만 보여주고, row 자체에는 `Add`/`Remove`/`Reset`/`Unbind` 같은 mutation 을 노출하지 않는다 (row value 는 `keymap:<actionID>` detail 링크뿐).
- **Keys preview 압축**: action row 의 keys preview 를 `<first key>, +N` (콤마 포함) / `Not bound` 형태로 압축 (`keybindingListKeysSummary`).
- **Action detail `Options` 정리**: detail 의 `Options` summary 를 action-level 옵션(`Unbind`, `Reset`/`Use default`)만 반영하도록 트림. `+ Add key` 는 별도 Keys row, `Remove key` 는 key detail 소관이므로 Options summary 텍스트에서 제외. 실제 `+ Add key`/`Unbind`/`Reset` row 자체는 그대로 유지.
- create/update/delete 는 action detail / key detail / add-key flow 안쪽에서만 수행 (구조는 Phase 0.6 유지).

## 모델 제약 준수

- Phase 0.6 **flat key list** 모델 유지, **primary/alias** 구분 미도입 (테스트로 `Primary`/`Alias`/`Additional` 미노출 고정).
- `keymap.toml` **schema 미변경**.
- 새 default key 선정 없음, immediate split action default 지정 없음.

## 명시적으로 제외한 범위

- Phase 1 (keymap/apply coupling 구현 확장) — 미포함.
- Phase 2 (delivery diagnostics / UserSequence / adapter) — 미포함.
- notify sidebar pane grouping — 미포함.
- sidebar-startup-picker / Session State 영역 (dead-code Phase 3 소관) — 미접촉.

## 검증

- `make fmt` — clean
- `make fix` — clean; `>> deadcode: clean (all findings allowlisted in .deadcode-allowlist.txt)` (allowlist 추가 없음)
- `make test` — 전 패키지 `ok`
- focused 테스트 신규 추가:
  - `TestSettingsKeybindingsActionListIsPreviewOnly` — (a) list row mutation 부재 + preview-only, (d) list 측 primary/alias 부재
  - `TestSettingsKeybindingsListKeysPreviewCompression` — (b) `<first key>, +N` / `Not bound` 압축
  - `TestSettingsKeybindingsMutationLivesInDetailNotList` — (c) mutation 이 detail/key-detail/add flow 안쪽에서만, (d) detail flat key list + role 워드 부재

## 미검증 항목 / 후속 Phase

- live tmux source/reload, generated config apply 경로는 본 슬라이스 범위 밖 → **Phase 1**.
- delivery diagnostics / capture normalization 수동검증(Ghostty/tmux) → **Phase 2**.
- 빌드/유닛 테스트는 통과했으나 실제 TUI 수동 e2e 는 미수행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)