### PR TITLE
fix: derive popup close aliases from keybinding catalog

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -128,6 +128,17 @@ uppercase `A`, distinct from `NotifySidebar:Ack` on lowercase `a`.
 Runtime picker footers render key guides from the merged keymap, using the
 first active key as the representative key.
 
+In Settings > Keybindings, **Add key** appends a key to the selected action's
+`keys = [...]` list. For catalog popup toggle actions, those keys are used both
+by generated tmux open bindings and by popup-internal close bindings, so the
+same key can close the corresponding already-open popup. This same-key close
+behavior is only for actions cataloged as popup toggles, such as
+`ProjectSidebarToggle`, `NotifySidebarToggle`, `RecentWindows:Open`,
+`AISplitPickerToggle`, `SettingsToggle`, `ProjectSwitcherToggle`, and
+`SessionPopupToggle`. Direct command actions such as `new-window`, pane/window
+navigation, and direct AI split actions remain command bindings and are not
+treated as popup close keys.
+
 ## Keymap File
 
 Settings writes the action-centered multi-alias schema:

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -794,7 +794,7 @@ func (c *aiCommand) runSettings(args []string, stdout, stderr io.Writer) error {
 		Prompt:     "AI Setting > ",
 		Footer:     projmuxFooter("Choose the default split mode for future AI launches."),
 		ExpectKeys: []string{"enter"},
-		Bindings:   pickerCloseBindings("esc", "ctrl-c", "alt-5", "ctrl-alt-s", "alt-4"),
+		Bindings:   pickerCloseBindingsForPopupToggleMode(c.homeDir, c.lookupEnv, "ai-split-settings", "esc", "ctrl-c", "ctrl-alt-s"),
 	})
 	if err != nil {
 		if isNoSelectionExit(err) {
@@ -819,8 +819,15 @@ func (c *aiCommand) runAgentPicker(direction string) (intpickercompat.Result, er
 		Prompt:     "AI Launch > ",
 		Footer:     projmuxFooter("Choose an agent or shell target to launch."),
 		ExpectKeys: []string{"enter"},
-		Bindings:   pickerCloseBindings("esc", "ctrl-c", "alt-4", "alt-5", "ctrl-alt-s"),
+		Bindings:   pickerCloseBindingsForPopupToggleMode(c.homeDir, c.lookupEnv, aiSplitPickerPopupMode(direction), "esc", "ctrl-c", "ctrl-alt-s"),
 	})
+}
+
+func aiSplitPickerPopupMode(direction string) string {
+	if direction == "down" {
+		return "ai-split-picker-down"
+	}
+	return "ai-split-picker-right"
 }
 
 func (c *aiCommand) settingsRows() []intpickercompat.Entry {

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -103,6 +103,40 @@ func TestAISettingsPickerSetsSelectedMode(t *testing.T) {
 	}
 }
 
+func TestAISplitPickerCloseBindingsUseAISplitPickerAlias(t *testing.T) {
+	home := t.TempDir()
+	keymapPath := filepath.Join(home, ".config", "projmux", "keymap.toml")
+	if err := os.MkdirAll(filepath.Dir(keymapPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keymapPath, []byte(`[bindings.AISplitPickerToggle]
+keys = ["M-a"]
+[bindings.SettingsToggle]
+keys = ["M-s"]
+[bindings.new-window]
+keys = ["M-t"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runner := &capturingAIRunner{}
+	cmd := testAICommand(home)
+	cmd.runner = runner
+	cmd.nativePicker = nativePickerFromCompatRunner(runner)
+
+	if _, err := cmd.runAgentPicker("right"); err != nil {
+		t.Fatalf("runAgentPicker() error = %v", err)
+	}
+	if !containsString(runner.options.Bindings, "alt-a:abort") {
+		t.Fatalf("AI picker bindings = %#v, want custom AISplitPickerToggle alias close", runner.options.Bindings)
+	}
+	if containsString(runner.options.Bindings, "alt-s:abort") {
+		t.Fatalf("AI picker bindings = %#v, SettingsToggle alias must not close AI picker", runner.options.Bindings)
+	}
+	if containsString(runner.options.Bindings, "alt-t:abort") {
+		t.Fatalf("AI picker bindings = %#v, direct command alias must not close popup", runner.options.Bindings)
+	}
+}
+
 func TestAISettingsRowsHideDisabledAgentDefaults(t *testing.T) {
 	home := t.TempDir()
 	if err := config.SaveAIEnabledAgentsFile(filepath.Join(home, ".config", "projmux", config.AIEnabledAgentsFileName), []config.AIAgentProvider{config.AIAgentClaude}); err != nil {

--- a/internal/app/keybinding_catalog.go
+++ b/internal/app/keybinding_catalog.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -57,10 +58,11 @@ type keyBindingAction struct {
 	PlainChords []string
 	PrefixChord string
 
-	TmuxKind       tmuxBindingKind
-	TmuxBody       string
-	TmuxPromptArgs string
-	Toggleable     bool
+	TmuxKind        tmuxBindingKind
+	TmuxBody        string
+	TmuxBodyAliases []string
+	TmuxPromptArgs  string
+	Toggleable      bool
 
 	PlainBindOrder  int
 	PrefixBindOrder int
@@ -167,28 +169,29 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			ProbePlain:     "\x1b3",
 		},
 		{
-			ID:             "AISplitPickerToggle",
-			Description:    "Toggle the popup picker for choosing an AI split mode",
-			DisplayName:    "Toggle AI Split Picker Popup",
-			Kind:           keyBindingActionTogglePopup,
-			Tier:           keyBindingTierGuaranteedLaunchDefault,
-			Scope:          keyBindingScopeStandalone,
-			PlainChord:     "M-4",
-			TmuxKind:       tmuxBindingPopupToggle,
-			TmuxBody:       "ai-split-picker-right",
-			Toggleable:     true,
-			PlainBindOrder: 40,
-			GhosttyTrigger: "alt+4",
-			GhosttyAction:  `text:\x1b4`,
-			GhosttyOrder:   40,
-			WTID:           "User.projmuxAIPicker",
-			WTKeys:         "alt+4",
-			WTInput:        "\x1b4",
-			WTOrder:        40,
-			ProbeOrder:     40,
-			ProbeLabel:     "Alt-4",
-			ProbeAction:    "AI split picker right",
-			ProbePlain:     "\x1b4",
+			ID:              "AISplitPickerToggle",
+			Description:     "Toggle the popup picker for choosing an AI split mode",
+			DisplayName:     "Toggle AI Split Picker Popup",
+			Kind:            keyBindingActionTogglePopup,
+			Tier:            keyBindingTierGuaranteedLaunchDefault,
+			Scope:           keyBindingScopeStandalone,
+			PlainChord:      "M-4",
+			TmuxKind:        tmuxBindingPopupToggle,
+			TmuxBody:        "ai-split-picker-right",
+			TmuxBodyAliases: []string{"ai-split-picker-down"},
+			Toggleable:      true,
+			PlainBindOrder:  40,
+			GhosttyTrigger:  "alt+4",
+			GhosttyAction:   `text:\x1b4`,
+			GhosttyOrder:    40,
+			WTID:            "User.projmuxAIPicker",
+			WTKeys:          "alt+4",
+			WTInput:         "\x1b4",
+			WTOrder:         40,
+			ProbeOrder:      40,
+			ProbeLabel:      "Alt-4",
+			ProbeAction:     "AI split picker right",
+			ProbePlain:      "\x1b4",
 		},
 		{
 			ID:             "SettingsToggle",
@@ -719,6 +722,37 @@ func isDigitASCII(r rune) bool {
 
 func keyBindingActionAliases(action keyBindingAction) []string {
 	return []string{action.ID}
+}
+
+func keyBindingActionIsPopupToggle(action keyBindingAction) bool {
+	return action.Kind == keyBindingActionTogglePopup &&
+		action.TmuxKind == tmuxBindingPopupToggle &&
+		action.Toggleable
+}
+
+func popupToggleModesForAction(action keyBindingAction) []string {
+	if !keyBindingActionIsPopupToggle(action) {
+		return nil
+	}
+	modes := append([]string{action.TmuxBody}, action.TmuxBodyAliases...)
+	return uniqueNonEmptyStrings(modes)
+}
+
+func popupToggleActionIDByModeFromCatalog(actions []keyBindingAction, mode string) (string, bool) {
+	mode = strings.TrimSpace(mode)
+	if mode == "" {
+		return "", false
+	}
+	for _, action := range actions {
+		if slices.Contains(popupToggleModesForAction(action), mode) {
+			return action.ID, true
+		}
+	}
+	return "", false
+}
+
+func popupToggleActionIDForMode(mode string) (string, bool) {
+	return popupToggleActionIDByModeFromCatalog(defaultKeyBindingCatalog(), mode)
 }
 
 func keyBindingEditable(action keyBindingAction) bool {

--- a/internal/app/keymap_test.go
+++ b/internal/app/keymap_test.go
@@ -103,6 +103,151 @@ keys = ["M-1", "M-a"]
 	}
 }
 
+func TestPopupToggleModeActionMappingCoversCatalog(t *testing.T) {
+	t.Parallel()
+
+	want := map[string][]string{
+		"ProjectSidebarToggle":  {"sessionizer-sidebar"},
+		"NotifySidebarToggle":   {"notify-sidebar"},
+		"RecentWindows:Open":    {"recent-windows"},
+		"AISplitPickerToggle":   {"ai-split-picker-right", "ai-split-picker-down"},
+		"SettingsToggle":        {"ai-split-settings"},
+		"ProjectSwitcherToggle": {"sessionizer"},
+		"SessionPopupToggle":    {"session-popup"},
+	}
+	catalog := defaultKeyBindingCatalog()
+	var gotIDs []string
+	for _, action := range catalog {
+		if keyBindingActionIsPopupToggle(action) {
+			gotIDs = append(gotIDs, action.ID)
+		}
+	}
+	if got := uniqueNonEmptyStrings(gotIDs); len(got) != len(want) {
+		t.Fatalf("popup toggle action ids = %#v, want exactly %#v", got, want)
+	}
+	for id, modes := range want {
+		action, ok := keyBindingActionByID(catalog, id)
+		if !ok {
+			t.Fatalf("catalog missing popup toggle action %s", id)
+		}
+		if !keyBindingActionIsPopupToggle(action) {
+			t.Fatalf("%s metadata = kind %s tmux %s toggleable %v, want catalog popup toggle", id, action.Kind, action.TmuxKind, action.Toggleable)
+		}
+		if got := popupToggleModesForAction(action); !equalStrings(got, modes) {
+			t.Fatalf("%s popup modes = %#v, want %#v", id, got, modes)
+		}
+		for _, mode := range modes {
+			got, ok := popupToggleActionIDForMode(mode)
+			if !ok || got != id {
+				t.Fatalf("popupToggleActionIDForMode(%q) = %q, %v; want %s, true", mode, got, ok, id)
+			}
+		}
+	}
+}
+
+func TestKeymapPopupToggleAliasesEmitTmuxBindingsForCatalogActions(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := parseKeymapFile("/tmp/keymap.toml", `[bindings.ProjectSidebarToggle]
+keys = ["M-a"]
+[bindings.NotifySidebarToggle]
+keys = ["M-b"]
+[bindings."RecentWindows:Open"]
+keys = ["M-c"]
+[bindings.AISplitPickerToggle]
+keys = ["M-d"]
+[bindings.SettingsToggle]
+keys = ["M-e"]
+[bindings.ProjectSwitcherToggle]
+keys = ["M-f"]
+[bindings.SessionPopupToggle]
+keys = ["M-g"]
+`)
+	if err != nil {
+		t.Fatalf("parseKeymapFile() error = %v", err)
+	}
+	merged, err := mergeKeymapOverrides(defaultKeyBindingCatalog(), parsed)
+	if err != nil {
+		t.Fatalf("mergeKeymapOverrides() error = %v", err)
+	}
+	lines := strings.Join(tmuxBindLines("/bin/projmux", keyBindingCatalogForScopeFrom(merged, keyBindingScopeStandalone)), "\n")
+	for chord, mode := range map[string]string{
+		"M-a": "sessionizer-sidebar",
+		"M-b": "notify-sidebar",
+		"M-c": "recent-windows",
+		"M-d": "ai-split-picker-right",
+		"M-e": "ai-split-settings",
+		"M-f": "sessionizer",
+		"M-g": "session-popup",
+	} {
+		for _, want := range []string{"bind-key -n " + chord + " run-shell", "tmux popup-toggle --client #{client_tty} " + mode} {
+			if !strings.Contains(lines, want) {
+				t.Fatalf("tmux bind lines =\n%s\nwant %q", lines, want)
+			}
+		}
+	}
+}
+
+func TestPopupToggleModeCloseKeysUseMappedActionKeymapAndIgnoreDirectCommands(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	keymapPath := filepath.Join(home, ".config", "projmux", "keymap.toml")
+	if err := os.MkdirAll(filepath.Dir(keymapPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keymapPath, []byte(`[bindings."RecentWindows:Open"]
+keys = ["M-r"]
+[bindings.AISplitPickerToggle]
+keys = ["M-a"]
+[bindings.SettingsToggle]
+keys = ["M-s"]
+[bindings.ProjectSidebarToggle]
+keys = ["M-p"]
+[bindings.NotifySidebarToggle]
+keys = ["M-n"]
+[bindings.ProjectSwitcherToggle]
+keys = ["M-j"]
+[bindings.SessionPopupToggle]
+keys = ["M-u"]
+[bindings.new-window]
+keys = ["M-t"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	homeDir := func() (string, error) { return home, nil }
+	lookupEnv := func(string) string { return "" }
+	for _, tc := range []struct {
+		mode string
+		want string
+	}{
+		{mode: "sessionizer-sidebar", want: "alt-p"},
+		{mode: "notify-sidebar", want: "alt-n"},
+		{mode: "recent-windows", want: "alt-r"},
+		{mode: "ai-split-picker-right", want: "alt-a"},
+		{mode: "ai-split-picker-down", want: "alt-a"},
+		{mode: "ai-split-settings", want: "alt-s"},
+		{mode: "sessionizer", want: "alt-j"},
+		{mode: "session-popup", want: "alt-u"},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			keys := effectivePickerKeysForPopupToggleMode(homeDir, lookupEnv, tc.mode, []string{"esc"})
+			if !containsString(keys, "esc") || !containsString(keys, tc.want) {
+				t.Fatalf("%s close keys = %#v, want esc and %s", tc.mode, keys, tc.want)
+			}
+			for _, leaked := range []string{"alt-p", "alt-n", "alt-r", "alt-a", "alt-s", "alt-j", "alt-u", "alt-t"} {
+				if leaked == tc.want {
+					continue
+				}
+				if containsString(keys, leaked) {
+					t.Fatalf("%s close keys = %#v, did not want leaked key %s", tc.mode, keys, leaked)
+				}
+			}
+		})
+	}
+}
+
 func TestKeymapTransportAliasesKeepDefaultTransportChord(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -484,7 +484,7 @@ func (c *notifyCommand) notifySidebarPickerOptions(store notifyStore, entries []
 		return intpicker.DeferredUpdate{Result: &intpicker.Result{Key: ctx.Key, Value: ctx.Value, Query: ctx.Query}}, nil
 	}
 	actions := append(
-		pickerCloseActionsForToggles(c.homeDir, c.lookupEnv, []string{"NotifySidebarToggle"}, "esc", "alt-2"),
+		pickerCloseActionsForPopupToggleMode(c.homeDir, c.lookupEnv, "notify-sidebar", "esc"),
 		notifySidebarMutableActions(effectivePickerKeysForActions(c.homeDir, c.lookupEnv, []string{"NotifySidebar:FocusAndAck"}, []string{"enter"}), focusOrAckGroup)...,
 	)
 	actions = append(actions,

--- a/internal/app/recent_window.go
+++ b/internal/app/recent_window.go
@@ -162,7 +162,7 @@ func (c *recentWindowCommand) Run(args []string, _ io.Writer, stderr io.Writer) 
 	}
 
 	items, byValue, initialIndex := recentWindowPickerItems(candidates, c.currentTime(), c.recentWindowAIBadgeStyle())
-	result, err := c.nativePicker.Run(recentWindowPickerOptions(items, initialIndex))
+	result, err := c.nativePicker.Run(recentWindowPickerOptions(items, initialIndex, c.homeDir, c.lookupEnv))
 	if err != nil {
 		return fmt.Errorf("run recent windows picker: %w", err)
 	}
@@ -393,14 +393,14 @@ func (c *recentWindowCommand) currentTime() time.Time {
 // initialIndex lands the cursor on the first non-current row (the most recent
 // switch target) instead of the current-window row; a negative index means there
 // is no non-current row (current-only state), so the cursor stays on index 0.
-func recentWindowPickerOptions(items []intpicker.Item, initialIndex int) intpicker.Options {
+func recentWindowPickerOptions(items []intpicker.Item, initialIndex int, homeDir func() (string, error), lookupEnv func(string) string) intpicker.Options {
 	options := intpicker.Options{
 		UI:        "recent-windows",
 		Title:     "Recent Windows",
 		Prompt:    "› ",
 		Items:     items,
 		MultiLine: true,
-		Actions:   pickerCloseActionsForToggles(nil, nil, []string{"ProjectSidebarToggle", "NotifySidebarToggle", "RecentWindows:Open", "SessionPopupToggle"}, "esc", "ctrl-n", "alt-1", "alt-2", "alt-3"),
+		Actions:   pickerCloseActionsForPopupToggleMode(homeDir, lookupEnv, "recent-windows", "esc", "ctrl-n"),
 	}
 	if initialIndex > 0 {
 		options.InitialIndex = initialIndex

--- a/internal/app/recent_window_test.go
+++ b/internal/app/recent_window_test.go
@@ -16,6 +16,7 @@ import (
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 	"github.com/crevissepartners/projmux/internal/theme"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 	projmuxpicker "github.com/crevissepartners/projmux/internal/ui/projmuxpicker"
 )
 
@@ -625,7 +626,7 @@ func TestRecentWindowPickerItemsInitialIndexFirstNonCurrentRow(t *testing.T) {
 		t.Fatalf("initialIndex = %d, want 1 (first non-current row)", initialIndex)
 	}
 
-	options := recentWindowPickerOptions(make([]intpicker.Item, 3), initialIndex)
+	options := recentWindowPickerOptions(make([]intpicker.Item, 3), initialIndex, nil, nil)
 	if !options.InitialIndexSet || options.InitialIndex != 1 {
 		t.Fatalf("options InitialIndex = %d/%t, want 1/true", options.InitialIndex, options.InitialIndexSet)
 	}
@@ -646,9 +647,40 @@ func TestRecentWindowPickerItemsInitialIndexCurrentOnlyStaysOnCurrent(t *testing
 	}
 
 	// A negative index leaves the cursor on index 0 and does NOT set InitialIndexSet.
-	options := recentWindowPickerOptions(make([]intpicker.Item, 1), initialIndex)
+	options := recentWindowPickerOptions(make([]intpicker.Item, 1), initialIndex, nil, nil)
 	if options.InitialIndexSet || options.InitialIndex != 0 {
 		t.Fatalf("options InitialIndex = %d/%t, want 0/false (stay on current row)", options.InitialIndex, options.InitialIndexSet)
+	}
+}
+
+func TestRecentWindowPickerCloseBindingsUseRecentWindowsAlias(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	keymapPath := filepath.Join(home, ".config", "projmux", "keymap.toml")
+	if err := os.MkdirAll(filepath.Dir(keymapPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keymapPath, []byte(`[bindings."RecentWindows:Open"]
+keys = ["M-r"]
+[bindings.AISplitPickerToggle]
+keys = ["M-a"]
+[bindings.new-window]
+keys = ["M-t"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	options := recentWindowPickerOptions(nil, -1, func() (string, error) { return home, nil }, func(string) string { return "" })
+	bindings := intpickercompat.OptionsFromPicker(options).Bindings
+	if !containsString(bindings, "alt-r:abort") {
+		t.Fatalf("recent windows bindings = %#v, want custom RecentWindows:Open alias close", bindings)
+	}
+	if containsString(bindings, "alt-a:abort") {
+		t.Fatalf("recent windows bindings = %#v, AI picker alias must not close recent windows popup", bindings)
+	}
+	if containsString(bindings, "alt-t:abort") {
+		t.Fatalf("recent windows bindings = %#v, direct command alias must not close popup", bindings)
 	}
 }
 

--- a/internal/app/sessions.go
+++ b/internal/app/sessions.go
@@ -166,7 +166,7 @@ func (c *sessionsCommand) Run(args []string, stdout, stderr io.Writer) error {
 			),
 			PreviewCommand: previewCommand,
 			PreviewWindow:  sessionsPreviewWindow(*ui),
-			Bindings: append(pickerCloseBindingsForToggles(c.homeDir, c.lookupEnv, []string{"ProjectSidebarToggle", "NotifySidebarToggle", "RecentWindows:Open", "SessionPopupToggle"}, "esc", "ctrl-n", "alt-1", "alt-2", "alt-3"),
+			Bindings: append(pickerCloseBindingsForPopupToggleMode(c.homeDir, c.lookupEnv, "session-popup", "esc", "ctrl-n"),
 				"left:execute-silent("+cycleWindowPrev+")+refresh-preview",
 				"right:execute-silent("+cycleWindowNext+")+refresh-preview",
 				"alt-up:execute-silent("+cyclePanePrev+")+refresh-preview",
@@ -221,7 +221,7 @@ func (c *sessionsCommand) runSessionStateOverview(sessionName string, summaries 
 		Prompt:        "Projects > Sessions > State > ",
 		Footer:        projmuxFooter("Session state overview is read-only here."),
 		ExpectKeys:    []string{"enter"},
-		Bindings:      pickerCloseBindingsForToggles(c.homeDir, c.lookupEnv, []string{"SessionPopupToggle"}, "esc", "alt-3"),
+		Bindings:      pickerCloseBindingsForPopupToggleMode(c.homeDir, c.lookupEnv, "session-popup", "esc"),
 		DisableSearch: true,
 	})
 	if err != nil {

--- a/internal/app/sessions_test.go
+++ b/internal/app/sessions_test.go
@@ -83,9 +83,6 @@ func TestAppRunSessionsDefaultsToPopupAndOpensSelectedSession(t *testing.T) {
 	if got, want := gotOptions.Bindings, []string{
 		"esc:abort",
 		"ctrl-n:abort",
-		"alt-1:abort",
-		"alt-2:abort",
-		"alt-3:abort",
 		"left:execute-silent(exec '/tmp/proj mux/bin/projmux' 'session-popup' 'cycle-window' {2} 'prev')+refresh-preview",
 		"right:execute-silent(exec '/tmp/proj mux/bin/projmux' 'session-popup' 'cycle-window' {2} 'next')+refresh-preview",
 		"alt-up:execute-silent(exec '/tmp/proj mux/bin/projmux' 'session-popup' 'cycle-pane' {2} 'prev')+refresh-preview",

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -472,7 +472,7 @@ func (c *settingsCommand) rootOptions(tab settingsRootTab) intpickercompat.Optio
 		Header:     settingsRootContextHeader(tab, ctx),
 		Footer:     localizeText(locale, i18n.KeySettingsRootFooter, "Open rows or click a scope chip to switch tabs."),
 		ExpectKeys: []string{"enter", "ctrl-g", "ctrl-p", "alt-shift-left", "alt-shift-right"},
-		Bindings:   settingsCloseBindings(),
+		Bindings:   c.settingsCloseBindings(),
 	}
 }
 
@@ -895,7 +895,7 @@ func (c *settingsCommand) sectionOptions(section string) (intpickercompat.Option
 			Prompt:     "Settings > AI Settings > ",
 			Footer:     projmuxFooter("Enter: open  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		}, nil
 	case settingsSectionNotifications:
 		return intpickercompat.Options{
@@ -905,7 +905,7 @@ func (c *settingsCommand) sectionOptions(section string) (intpickercompat.Option
 			Prompt:     "Settings > Notifications > ",
 			Footer:     projmuxFooter("Enter: open  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		}, nil
 	case settingsSectionGlobalHooks:
 		return intpickercompat.Options{
@@ -915,7 +915,7 @@ func (c *settingsCommand) sectionOptions(section string) (intpickercompat.Option
 			Prompt:     "Settings > Hooks > ",
 			Footer:     projmuxFooter("Enter: edit/add  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		}, nil
 	case settingsSectionProjectHooks:
 		ctx := c.resolveSettingsProjectContext()
@@ -926,7 +926,7 @@ func (c *settingsCommand) sectionOptions(section string) (intpickercompat.Option
 			Prompt:     "Settings > Project > Hooks > ",
 			Footer:     projmuxFooter("Enter: edit/add  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		}, nil
 	case settingsSectionProject:
 		return intpickercompat.Options{
@@ -936,7 +936,7 @@ func (c *settingsCommand) sectionOptions(section string) (intpickercompat.Option
 			Prompt:     "Settings > Project Picker > ",
 			Footer:     projmuxFooter("Enter: apply  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		}, nil
 	case settingsSectionStatusbar:
 		ctx := c.resolveSettingsProjectContext()
@@ -948,7 +948,7 @@ func (c *settingsCommand) sectionOptions(section string) (intpickercompat.Option
 			Prompt:     "Settings > Appearance > ",
 			Footer:     projmuxFooter("Enter: open  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		}, nil
 	case settingsSectionSessionState:
 		return intpickercompat.Options{
@@ -958,7 +958,7 @@ func (c *settingsCommand) sectionOptions(section string) (intpickercompat.Option
 			Prompt:     "Settings > Session State > ",
 			Footer:     projmuxFooter("Enter: apply  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		}, nil
 	case settingsSectionProjectSessionState:
 		return intpickercompat.Options{
@@ -968,7 +968,7 @@ func (c *settingsCommand) sectionOptions(section string) (intpickercompat.Option
 			Prompt:     "Settings > Project > Session State > ",
 			Footer:     projmuxFooter("Enter: apply  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		}, nil
 	case settingsSectionKeybindings:
 		return c.keybindingsOptions(settingsKeybindingsBindings), nil
@@ -980,7 +980,7 @@ func (c *settingsCommand) sectionOptions(section string) (intpickercompat.Option
 			Prompt:     "Settings > Labs > ",
 			Footer:     projmuxFooter("Enter: apply  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		}, nil
 	case settingsSectionAbout:
 		return intpickercompat.Options{
@@ -990,7 +990,7 @@ func (c *settingsCommand) sectionOptions(section string) (intpickercompat.Option
 			Prompt:     "Settings > About > ",
 			Footer:     projmuxFooter("Enter: action  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		}, nil
 	default:
 		return intpickercompat.Options{}, fmt.Errorf("unknown settings section: %s", section)
@@ -1076,7 +1076,7 @@ func (c *settingsCommand) runAddProject(stdout, stderr io.Writer) error {
 		Prompt:     "Settings > Project Picker > Add Project > ",
 		Footer:     projmuxFooter("Enter: add  |  Back row: parent "),
 		ExpectKeys: []string{"enter"},
-		Bindings:   settingsCloseBindings(),
+		Bindings:   c.settingsCloseBindings(),
 	})
 	if err != nil {
 		return err
@@ -1105,7 +1105,7 @@ func (c *settingsCommand) runProjectRootSettings(stdout, stderr io.Writer) error
 			Prompt:     "Settings > Project Picker > Project Root > ",
 			Footer:     projmuxFooter("Enter: apply  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -1147,7 +1147,7 @@ func (c *settingsCommand) runSetProjectRootTyped(stdout, stderr io.Writer) error
 		Prompt:       "Type project root path > ",
 		Footer:       projmuxFooter("Enter: save "),
 		ExpectKeys:   []string{"enter"},
-		Bindings:     settingsCloseBindings(),
+		Bindings:     c.settingsCloseBindings(),
 	})
 	if err != nil {
 		return err
@@ -1207,7 +1207,7 @@ func (c *settingsCommand) runAddWorkdir(stdout, stderr io.Writer) error {
 		Prompt:     "Settings > Project Picker > Add Workdir > ",
 		Footer:     projmuxFooter("Enter: add  |  Back row: parent "),
 		ExpectKeys: []string{"enter"},
-		Bindings:   settingsCloseBindings(),
+		Bindings:   c.settingsCloseBindings(),
 	})
 	if err != nil {
 		return err
@@ -1257,7 +1257,7 @@ func (c *settingsCommand) runAddWorkdirTyped(stdout, stderr io.Writer) error {
 		Prompt:      "Type workdir path > ",
 		Footer:      projmuxFooter("Enter: add "),
 		ExpectKeys:  []string{"enter"},
-		Bindings:    settingsCloseBindings(),
+		Bindings:    c.settingsCloseBindings(),
 	})
 	if err != nil {
 		return err
@@ -1327,7 +1327,7 @@ func (c *settingsCommand) runWorkdirsList(stdout, stderr io.Writer) error {
 			Prompt:     "Settings > Project Picker > Workdirs > ",
 			Footer:     projmuxFooter("Enter: open/add/remove  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -1417,7 +1417,7 @@ func (c *settingsCommand) runPinnedProjects(stdout, stderr io.Writer) error {
 			Prompt:     "Settings > Project Picker > Pinned Projects > ",
 			Footer:     projmuxFooter("Enter: apply  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -1746,7 +1746,7 @@ func (c *settingsCommand) runAIEnabledAgentsSection(stdout, stderr io.Writer) er
 			Prompt:     "Settings > AI Settings > Enabled agents > ",
 			Footer:     projmuxFooter("Enter: toggle  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -1821,7 +1821,7 @@ func (c *settingsCommand) runNotificationsAIDedupeSection(stdout, stderr io.Writ
 			Prompt:     "Settings > Notifications > AI dedupe > ",
 			Footer:     projmuxFooter("Enter: apply  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -1864,7 +1864,7 @@ func (c *settingsCommand) runNotificationsAIDedupeCustom(stdout, stderr io.Write
 		Prompt:       "AI dedupe seconds > ",
 		Footer:       projmuxFooter("Enter: save  |  Example: 120 "),
 		ExpectKeys:   []string{"enter"},
-		Bindings:     settingsCloseBindings(),
+		Bindings:     c.settingsCloseBindings(),
 	})
 	if err != nil {
 		return err
@@ -1890,7 +1890,7 @@ func (c *settingsCommand) runNotificationsDesktopSection(stdout, stderr io.Write
 			Prompt:     settingsNotificationsDesktopPrompt(locale),
 			Footer:     projmuxFooter("Enter: apply  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -1923,7 +1923,7 @@ func (c *settingsCommand) runAIDefaultModeSection(stdout, stderr io.Writer) erro
 			Prompt:     "Settings > AI Settings > Default split mode > ",
 			Footer:     projmuxFooter("Enter: apply  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -2038,7 +2038,7 @@ func (c *settingsCommand) runNotificationsHookActionsSection(stdout, stderr io.W
 			Prompt:     "Settings > Notifications > Hook quiet policy > ",
 			Footer:     projmuxFooter("Enter: view hooks  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -2072,7 +2072,7 @@ func (c *settingsCommand) runAIHookProviderActionSection(provider string, stdout
 			Prompt:     "Settings > Notifications > Hook quiet policy > " + aiHookProviderLabel(provider) + " > ",
 			Footer:     projmuxFooter("Enter: change action  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -2109,7 +2109,7 @@ func (c *settingsCommand) runAIHookEventActionSection(provider, event string, st
 			Prompt:     "Settings > Notifications > Hook quiet policy > " + aiHookProviderLabel(provider) + " > " + event + " > ",
 			Footer:     projmuxFooter("Enter: save  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -2153,7 +2153,7 @@ func (c *settingsCommand) runNotificationsDeliverySourcesSection(stdout, stderr 
 			Prompt:     "Settings > Notifications > Delivery sources > ",
 			Footer:     projmuxFooter("Enter: view details  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -2195,7 +2195,7 @@ func (c *settingsCommand) runAINotifyDiagnosticDetail(id string, stderr io.Write
 			Prompt:     "Settings > Notifications > Delivery sources > " + diag.Name + " > ",
 			Footer:     projmuxFooter("Enter: copy command  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -2716,7 +2716,7 @@ func (c *settingsCommand) aiBadgeStyleOptions() intpickercompat.Options {
 		Prompt:     "Settings > Appearance > AI badge style > ",
 		Footer:     projmuxFooter("Enter: apply  |  Back row: parent "),
 		ExpectKeys: []string{"enter"},
-		Bindings:   settingsCloseBindings(),
+		Bindings:   c.settingsCloseBindings(),
 	}
 }
 
@@ -2832,7 +2832,7 @@ func (c *settingsCommand) statusbarDecorationTargetOptions(target statusbarDecor
 		Prompt:     "Settings > Appearance > " + meta.Name + " > ",
 		Footer:     projmuxFooter("Enter: apply  |  Back row: parent "),
 		ExpectKeys: []string{"enter"},
-		Bindings:   settingsCloseBindings(),
+		Bindings:   c.settingsCloseBindings(),
 	}, nil
 }
 
@@ -2969,7 +2969,7 @@ func (c *settingsCommand) keybindingsOptions(active string) intpickercompat.Opti
 		Prompt:     "Settings > Keybindings > ",
 		Footer:     projmuxFooter("Actions show their active keys and current state."),
 		ExpectKeys: []string{"enter"},
-		Bindings:   settingsCloseBindings(),
+		Bindings:   c.settingsCloseBindings(),
 	}
 }
 
@@ -3026,7 +3026,7 @@ func (c *settingsCommand) runKeybindingDetail(actionID string, stdout, stderr io
 			Prompt:     "Settings > Keybindings > Action > ",
 			Footer:     projmuxFooter("Manage the active keys for this action."),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -3128,7 +3128,7 @@ func (c *settingsCommand) runKeybindingAdd(actionID string, stdout, stderr io.Wr
 			Prompt:     "Settings > Keybindings > Action > Add key > ",
 			Footer:     projmuxFooter("Press a key to add it to this action."),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -3177,7 +3177,7 @@ func (c *settingsCommand) runKeybindingAddAdvanced(actionID string, stdout, stde
 			Prompt:     "Settings > Keybindings > Action > Add key > Advanced > ",
 			Footer:     projmuxFooter("Typed key names and raw diagnostics stay advanced."),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return false, err
@@ -3218,7 +3218,7 @@ func (c *settingsCommand) runKeybindingKeyDetail(actionID, chord string, stdout,
 			Prompt:     "Settings > Keybindings > Action > Key > ",
 			Footer:     projmuxFooter("Manage this active key."),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -3309,7 +3309,7 @@ func (c *settingsCommand) runKeybindingTyped(actionID string, replace bool, stdo
 		Prompt:        "Enter key > ",
 		Footer:        projmuxFooter("Enter a key such as C-r, M-a, M-S-Left, or C-Space."),
 		ExpectKeys:    []string{"enter"},
-		Bindings:      settingsCloseBindings(),
+		Bindings:      c.settingsCloseBindings(),
 		AcceptQuery:   true,
 		DisableSearch: true,
 	})
@@ -4133,7 +4133,7 @@ func (c *settingsCommand) runLabsProjectHooksSection(stdout, stderr io.Writer) e
 			Prompt:     "Settings > Labs > Project Hooks > ",
 			Footer:     projmuxFooter("Enter: apply  |  Back row: parent "),
 			ExpectKeys: []string{"enter"},
-			Bindings:   settingsCloseBindings(),
+			Bindings:   c.settingsCloseBindings(),
 		})
 		if err != nil {
 			return err
@@ -4938,7 +4938,7 @@ func (c *settingsCommand) welcomeSettingsViewerOptions() intpickercompat.Options
 		Prompt:        settingsCatalogTextLocale(locale, "Settings") + " > " + settingsCatalogTextLocale(locale, "About") + " > " + settingsCatalogTextLocale(locale, "Welcome") + " > ",
 		Footer:        projmuxFooter("Back row: About  |  Esc: close settings"),
 		DisableSearch: true,
-		Bindings:      settingsCloseBindings(),
+		Bindings:      c.settingsCloseBindings(),
 	}
 }
 
@@ -4953,8 +4953,15 @@ func settingsBackEntryLocale(locale i18n.Locale) intpickercompat.Entry {
 	}
 }
 
+func (c *settingsCommand) settingsCloseBindings() []string {
+	if c == nil {
+		return settingsCloseBindings()
+	}
+	return pickerCloseBindingsForPopupToggleMode(c.homeDir, c.lookupEnv, "ai-split-settings", "esc", "ctrl-c", "ctrl-alt-s")
+}
+
 func settingsCloseBindings() []string {
-	return pickerCloseBindings("esc", "ctrl-c", "alt-5", "ctrl-alt-s")
+	return pickerCloseBindingsForPopupToggleMode(nil, nil, "ai-split-settings", "esc", "ctrl-c", "ctrl-alt-s")
 }
 
 func printSettingsUsage(w io.Writer) {

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -98,7 +98,7 @@ func TestSettingsRootOptionsDefaultGlobalTab(t *testing.T) {
 	if got, want := options.ExpectKeys, []string{"enter", "ctrl-g", "ctrl-p", "alt-shift-left", "alt-shift-right"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("root settings expect keys = %#v, want %#v", got, want)
 	}
-	if got, want := options.Bindings, []string{"esc:abort", "ctrl-c:abort", "alt-5:abort", "ctrl-alt-s:abort"}; !reflect.DeepEqual(got, want) {
+	if got, want := options.Bindings, []string{"esc:abort", "ctrl-c:abort", "ctrl-alt-s:abort", "alt-5:abort"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("root settings close bindings = %#v, want %#v", got, want)
 	}
 	if got, want := entryValues(options.Entries), []string{
@@ -114,6 +114,40 @@ func TestSettingsRootOptionsDefaultGlobalTab(t *testing.T) {
 		settingsSectionAbout,
 	}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("root settings entry order = %#v, want %#v", got, want)
+	}
+}
+
+func TestSettingsCloseBindingsUseSettingsToggleAlias(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	keymapPath := filepath.Join(home, ".config", "projmux", "keymap.toml")
+	if err := os.MkdirAll(filepath.Dir(keymapPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keymapPath, []byte(`[bindings.SettingsToggle]
+keys = ["M-s"]
+[bindings.AISplitPickerToggle]
+keys = ["M-a"]
+[bindings.new-window]
+keys = ["M-t"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &settingsCommand{
+		homeDir:   func() (string, error) { return home, nil },
+		lookupEnv: func(string) string { return "" },
+	}
+
+	options := cmd.rootOptions(settingsRootTabGlobal)
+	if !containsString(options.Bindings, "alt-s:abort") {
+		t.Fatalf("settings bindings = %#v, want custom SettingsToggle alias close", options.Bindings)
+	}
+	if containsString(options.Bindings, "alt-a:abort") {
+		t.Fatalf("settings bindings = %#v, AI picker alias must not close settings popup", options.Bindings)
+	}
+	if containsString(options.Bindings, "alt-t:abort") {
+		t.Fatalf("settings bindings = %#v, direct command alias must not close popup", options.Bindings)
 	}
 }
 

--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -1863,7 +1863,7 @@ func (c *switchCommand) runPicker(plan switchPlan) (intpicker.Result, error) {
 		Footer:         switchPickerFooter(plan.UI, plan.StatusMessage, c.homeDir, c.lookupEnv),
 		InitialQuery:   plan.InitialQuery,
 		DeferredUpdate: plan.DeferredUpdate,
-		Actions:        pickerCloseActionsForToggles(c.homeDir, c.lookupEnv, []string{"ProjectSidebarToggle", "NotifySidebarToggle", "RecentWindows:Open", "SessionPopupToggle"}, "esc", "ctrl-n", "alt-1", "alt-2", "alt-3"),
+		Actions:        pickerCloseActionsForPopupToggleMode(c.homeDir, c.lookupEnv, popupToggleModeForSwitchUI(plan.UI), "esc", "ctrl-n"),
 	}
 	options.Actions = append(options.Actions, sidebarKillActions...)
 	options.Actions = append(options.Actions, intpicker.CustomActions(effectivePickerKeysForActions(c.homeDir, c.lookupEnv, []string{"Sidebar:PinProject"}, []string{switchPinExpectKey})...)...)
@@ -2080,16 +2080,19 @@ func pickerCloseBindings(keys ...string) []string {
 	return bindings
 }
 
-func pickerCloseActionsForToggles(homeDir func() (string, error), lookupEnv func(string) string, actionIDs []string, fallback ...string) []intpicker.Action {
-	return pickerCloseActions(effectivePickerKeysForActions(homeDir, lookupEnv, actionIDs, fallback)...)
+func pickerCloseActionsForPopupToggleMode(homeDir func() (string, error), lookupEnv func(string) string, mode string, fallback ...string) []intpicker.Action {
+	return pickerCloseActions(effectivePickerKeysForPopupToggleMode(homeDir, lookupEnv, mode, fallback)...)
 }
 
-func pickerCloseBindingsForToggle(homeDir func() (string, error), lookupEnv func(string) string, actionID string, fallback ...string) []string {
-	return pickerCloseBindings(effectivePickerKeysForActions(homeDir, lookupEnv, []string{actionID}, fallback)...)
+func pickerCloseBindingsForPopupToggleMode(homeDir func() (string, error), lookupEnv func(string) string, mode string, fallback ...string) []string {
+	return pickerCloseBindings(effectivePickerKeysForPopupToggleMode(homeDir, lookupEnv, mode, fallback)...)
 }
 
-func pickerCloseBindingsForToggles(homeDir func() (string, error), lookupEnv func(string) string, actionIDs []string, fallback ...string) []string {
-	return pickerCloseBindings(effectivePickerKeysForActions(homeDir, lookupEnv, actionIDs, fallback)...)
+func popupToggleModeForSwitchUI(ui string) string {
+	if ui == switchUISidebar {
+		return "sessionizer-sidebar"
+	}
+	return "sessionizer"
 }
 
 func pickerKeyMatchesAction(homeDir func() (string, error), lookupEnv func(string) string, key, actionID string, fallback ...string) bool {
@@ -2098,6 +2101,14 @@ func pickerKeyMatchesAction(homeDir func() (string, error), lookupEnv func(strin
 		return false
 	}
 	return slices.Contains(effectivePickerKeysForActions(homeDir, lookupEnv, []string{actionID}, fallback), key)
+}
+
+func effectivePickerKeysForPopupToggleMode(homeDir func() (string, error), lookupEnv func(string) string, mode string, fallback []string) []string {
+	actionID, ok := popupToggleActionIDForMode(mode)
+	if !ok {
+		return uniqueNonEmptyStrings(fallback)
+	}
+	return effectivePickerKeysForActions(homeDir, lookupEnv, []string{actionID}, fallback)
 }
 
 func effectivePickerKeysForActions(homeDir func() (string, error), lookupEnv func(string) string, actionIDs []string, fallback []string) []string {

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -131,9 +131,6 @@ func TestAppRunSwitchDefaultsToPopupAndOpensSelectedSession(t *testing.T) {
 	if got, want := gotRunnerOptions.Bindings, []string{
 		"esc:abort",
 		"ctrl-n:abort",
-		"alt-1:abort",
-		"alt-2:abort",
-		"alt-3:abort",
 		"left:execute-silent(exec '/tmp/projmux' 'switch' 'cycle-window' {2} 'prev')+refresh-preview",
 		"right:execute-silent(exec '/tmp/projmux' 'switch' 'cycle-window' {2} 'next')+refresh-preview",
 		"alt-up:execute-silent(exec '/tmp/projmux' 'switch' 'cycle-pane' {2} 'prev')+refresh-preview",
@@ -575,8 +572,6 @@ func TestSwitchCommandSupportsSidebarUI(t *testing.T) {
 		"esc:abort",
 		"ctrl-n:abort",
 		"alt-1:abort",
-		"alt-2:abort",
-		"alt-3:abort",
 		"focus:execute-silent(exec '/tmp/projmux' 'switch' 'sidebar-focus' {2})",
 	}; !equalStrings(got, want) {
 		t.Fatalf("runner bindings = %q, want %q", got, want)
@@ -1043,8 +1038,6 @@ func TestSwitchCommandSidebarUsesContextSessionForInitialPosition(t *testing.T) 
 		"esc:abort",
 		"ctrl-n:abort",
 		"alt-1:abort",
-		"alt-2:abort",
-		"alt-3:abort",
 		"focus:execute-silent(exec '/tmp/projmux' 'switch' 'sidebar-focus' {2})",
 		"start:pos(1)",
 	}; !equalStrings(got, want) {
@@ -1754,8 +1747,6 @@ func TestNewSwitchCommandUsesEnvAndDefaultPinStore(t *testing.T) {
 		"esc:abort",
 		"ctrl-n:abort",
 		"alt-1:abort",
-		"alt-2:abort",
-		"alt-3:abort",
 		"focus:execute-silent(exec '/tmp/projmux' 'switch' 'sidebar-focus' {2})",
 		"start:pos(4)",
 	}; !equalStrings(got, want) {

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -472,6 +472,10 @@ func parseTmuxPopupToggleArgs(args []string, stderr io.Writer) (tmuxPopupToggleM
 
 	raw := strings.TrimSpace(fs.Arg(0))
 	client := strings.TrimSpace(*clientKey)
+	if _, ok := popupToggleActionIDForMode(raw); !ok {
+		printTmuxUsage(stderr)
+		return tmuxPopupToggleMode{}, fmt.Errorf("unknown tmux popup-toggle mode: %s", raw)
+	}
 	switch raw {
 	case "session-popup", "sessionizer", "sessionizer-sidebar", "notify-sidebar", "recent-windows", "ai-split-settings":
 		return tmuxPopupToggleMode{Raw: raw, Canonical: raw, ClientKey: client}, nil
@@ -480,7 +484,6 @@ func parseTmuxPopupToggleArgs(args []string, stderr io.Writer) (tmuxPopupToggleM
 	case "ai-split-picker-down":
 		return tmuxPopupToggleMode{Raw: raw, Canonical: "ai-split-picker", Direction: "down", ClientKey: client}, nil
 	default:
-		printTmuxUsage(stderr)
 		return tmuxPopupToggleMode{}, fmt.Errorf("unknown tmux popup-toggle mode: %s", raw)
 	}
 }


### PR DESCRIPTION
## Completed Phase

- Completed Phase 1A — Popup toggle alias close parity slice from the Keybinding alias coverage cleanup roadmap.

## User-facing surfaces changed

- Generated tmux keybindings now continue to bind custom popup toggle action keys to `tmux popup-toggle <mode>`.
- Popup-internal close bindings now use the same custom key for the corresponding popup toggle action:
  - project sidebar
  - notify sidebar
  - recent windows
  - AI split picker
  - settings popup
  - project switcher
  - session popup
- `docs/keybindings.md` now clarifies that Add key edits the action key list, and same-key close applies only to catalog popup toggle actions.

## Scope intentionally excluded

- No Phase 1B saved/generated/live apply state coupling.
- No Phase 2 delivery diagnostics, UserSequence, terminal adapter, `UserN`, or CSI-u fallback work.
- No `Alt-1..5` default expansion.
- No terminal init/setup, Ghostty, or Windows Terminal mapping changes.
- No Settings Keybindings IA redesign or key capture flow rewrite.

## Model constraints kept

- Popup toggle close parity is catalog-driven: popup modes map back to canonical actions using catalog popup-toggle metadata instead of surface-local `alt-N` hardcoding.
- Direct command actions were not promoted to toggles. `new-window`, pane/window navigation, and direct AI split actions remain command bindings and are not treated as popup close keys.
- Phase 0 through 0.7 assumptions remain intact: preview-only action list, flat key list, no primary/alias user-facing split, and no keymap schema change.

## Verification

- `GOCACHE=/tmp/projmux-go-cache go test ./internal/app -run 'Test.*Keymap|Test.*Keybinding|Test.*Recent|Test.*Settings|Test.*AISplit|Test.*PopupToggle'` — passed
- `GOCACHE=/tmp/projmux-go-cache make fmt` — passed
- `GOCACHE=/tmp/projmux-go-cache make fix` — passed
- `GOCACHE=/tmp/projmux-go-cache make test` — sandbox failed on Unix socket bind permission in `TestNotifyQueueRefreshTransportPublishesToSubscriber`; escalated run passed

## Not verified

- Live terminal/tmux key delivery was not manually verified because it is terminal/environment dependent. Coverage is through generated tmux config and popup picker close-binding tests.
