### PR TITLE
docs: simplify theme source contract

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,26 +169,35 @@ configured key opens and closes the popup.
 
 ## Theme Resolver Foundation
 
-Theme settings are resolved against the same project/global axes as
-declarative hooks and project recipe fields:
+The Phase 0 target theme contract is a global user theme plus a built-in
+fallback. Theme settings resolve from:
 
 ```text
-<project>/.projmux/config.toml
 ~/.config/projmux/config.toml
+built-in fallback preset
 ```
 
-Settings can edit the global `[theme]` in `~/.config/projmux/config.toml` and
-the current project override in `<project>/.projmux/config.toml`. The Effective
-theme view shows the final project > global > built-in fallback value for each
-field with source labels: `project`, `global`, or `fallback`.
+Settings can edit the global `[theme]` in `~/.config/projmux/config.toml`. The
+Effective theme view shows the final global > built-in fallback value for each
+field with source labels: `global` or `fallback`.
+
+Project `.projmux/config.toml` `[theme]` is deprecated migration data and is
+removed from the intended effective theme source. It should be ignored by the
+future resolver contract rather than surfaced as a warning path. Phase 1
+Settings cleanup should remove the Project theme tab, project override editor,
+project theme reset action, and project/source labels from theme UI.
 
 Renderer adapters can apply an already resolved `EffectiveTheme` to native
 picker frame background/foreground SGR and tmux status/window `colourN`
-background tokens. Settings and native project picker surfaces load global and
-project `[theme]` values through the shared effective-theme source. Native
-picker frames also apply the built-in fallback `background`/`foreground` tokens
-so picker-owned padding, empty rows, footer rows, and preview gaps do not
-inherit the terminal default background.
+background tokens. Settings and native project picker surfaces load global
+`[theme]` values through the shared effective-theme source. Native picker
+frames also apply the built-in fallback `background`/`foreground` tokens so
+picker-owned padding, empty rows, footer rows, and preview gaps do not inherit
+the terminal default background.
+
+Active pane focus affordance belongs to Theme app chrome Phase 2, not the
+resolver foundation. That work must preserve `pane-border-status top`, pane
+topics, AI badges, and visible pane labels.
 
 Native picker popups launched through `projmux tmux popup-toggle` also pass a
 per-popup tmux 3.4 `display-popup -s` body style using the effective theme

--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -1,14 +1,17 @@
 # Theme Palette
 
-This document records the built-in fallback palette that native projmux UI
-surfaces use before project or global theme settings exist. The source of
-truth in code is `internal/theme/palette.go`.
+This document records the Phase 0 target theme contract and the built-in
+fallback palette that native projmux UI surfaces use when no global user theme
+is configured. The source of truth for current fallback values in code is
+`internal/theme/palette.go`.
 
 ## Scope
 
-The fallback palette is a semantic token layer. Theme settings resolve project
-and global config into the resolver-facing token inventory below, then fall
-back to the built-in values from `internal/theme/palette.go`.
+The fallback palette is a semantic token layer. The intended theme contract is
+a global user theme resolved from `~/.config/projmux/config.toml`, followed by
+the built-in fallback values from `internal/theme/palette.go`. Phase 0 records
+that product contract for later implementation phases; it does not require a
+product-code change by itself.
 
 - Native picker truecolor SGR tokens.
 - Native sidebar and chip-strip 256-color SGR tokens.
@@ -19,8 +22,9 @@ Renderer adapters apply resolver-backed background/foreground colors to native
 picker frame chrome and to tmux status/window background tokens when an
 `EffectiveTheme` is supplied by the caller. Fallback-sourced fields still
 render through the historical constants so built-in default output remains
-byte-identical. Settings and native project picker surfaces load `[theme]`
-values from global and project config through the shared effective-theme source.
+byte-identical. Project `.projmux/config.toml` `[theme]` is deprecated and is
+removed from the intended effective theme source; future resolver and Settings
+work should treat it as ignored migration data rather than as a target source.
 Theme marketplace/import/export and Visual palette reselection remain out of
 scope.
 
@@ -88,24 +92,23 @@ Rules:
 
 ## Resolver Contract
 
-Theme resolution is field-by-field after validating each layer:
+The Phase 0 target contract resolves theme fields from:
 
-1. Project `.projmux/config.toml`
-2. Global `~/.config/projmux/config.toml`
-3. Built-in fallback preset `projmux-dark`
+1. Global `~/.config/projmux/config.toml`
+2. Built-in fallback preset `projmux-dark`
 
 Rules:
 
-- Project values override global values for the same field.
-- Missing or `inherit` project values fall back to global values.
 - Missing global values fall back to built-in values.
-- A preset fills missing color tokens in its own layer.
-- Explicit color tokens in the same layer override preset colors.
-- An unknown preset invalidates only that layer and emits a warning.
-- An invalid color, `font_family`, or `font_size` invalidates only that layer
-  and emits a warning.
-- Every effective field reports `project`, `global`, or `fallback` as its
-  source label.
+- A preset fills missing color tokens in the global layer.
+- Explicit global color tokens override preset colors.
+- An unknown preset invalidates only the global layer.
+- An invalid color, `font_family`, or `font_size` invalidates only the global
+  layer.
+- Every effective field reports `global` or `fallback` as its source label.
+
+Historical project `[theme]` values in `.projmux/config.toml` are migration
+data only. They are not a current or target source in this contract.
 
 Built-in preset config values are:
 


### PR DESCRIPTION
## Completed Phase

- Phase 0 — Global-only theme contract slice

## Modified Docs / Roadmap Surface

- `docs/theme-palette.md`
- `docs/configuration.md`
- Obsidian roadmap notes updated separately:
  - `Projmux/10.Roadmap/로드맵.md`
  - `Projmux/10.Roadmap/로드맵 디테일 - Theme model simplification and app chrome`
  - `Projmux/10.Roadmap/로드맵 디테일 - Active pane focus border geometry`
  - `Projmux/11.Done/2026-05-22/로드맵 디테일 - Theme 설정`
  - `Projmux/12.Archive/2026-06-20/로드맵 진행 기록 - Theme model simplification and app chrome`

## Scope

- Documents the Theme source contract as global user theme + built-in fallback.
- Marks project `.projmux/config.toml` `[theme]` as deprecated migration data that should be ignored by the future effective theme resolver, with docs/migration note as the first policy.
- Lists the Phase 1 Settings cleanup surface: remove Project theme tab, project override editor/reset, and `project` source labels.
- Absorbs active pane focus affordance into Theme Phase 2 app chrome scope while preserving `pane-border-status top`, pane topics, AI badges, and visible pane labels.

## Explicitly Excluded Phase 1/2/3 Work

- No global-only resolver/settings implementation.
- No active pane tint implementation.
- No theme color palette reselection.
- No theme config schema expansion.
- No external theme import/export/marketplace.
- No terminal font adapter work.
- No `pane-border-status off` direction and no pane topic / AI badge / visible pane label removal.

## Verification

- `rg -n "project > global|Project theme|project theme|프로젝트 theme|프로젝트별 theme" docs internal /home/es5h/Obsidian/30.Projects.Design/Projmux/10.Roadmap`
  - Remaining hits are expected buckets: active roadmap historical/current phase notes, Phase 1 implementation references in `internal`, and intentional docs migration wording.
- `make fmt`
- `make fix`
  - Initial sandbox run failed on read-only Go build cache; rerun outside sandbox passed.
- `make test`
  - Initial sandbox run failed on local Unix/TCP socket restrictions; rerun outside sandbox passed.
- `make test-integration`
  - Initial sandbox run failed on Docker socket access; rerun outside sandbox passed.
- `make test-e2e`
  - Initial sandbox run failed on Docker socket access; rerun outside sandbox passed.

## Unverified / Follow-up Phases

- No unverified local gates remain for this docs-only slice.
- Phase 1: implement global-only resolver and Settings cleanup.
- Phase 2: implement theme-derived app active pane chrome token/tint while preserving top pane labels.
- Phase 3: post-implementation docs and migration cleanup.
