### PR TITLE
docs(legacy): annotate retained sunset paths

### DIFF
--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -376,6 +376,9 @@ func (c *attentionCommand) windowAttentionRows(windowID string) []attentionWindo
 }
 
 func (c *attentionCommand) legacyWindowAttentionRows(windowID string) []attentionWindowRow {
+	// Legacy: retained for old pane option format fallback; sunset when the
+	// new window-attention format has a versioned migration/expiry policy and
+	// old pane options are intentionally dropped.
 	rows, err := intmux.NewRunner(c.runner).ListPanes(context.Background(), intmux.ListPanesOptions{
 		Target: windowID,
 		Formats: []string{

--- a/internal/app/keybinding_catalog.go
+++ b/internal/app/keybinding_catalog.go
@@ -860,6 +860,10 @@ func tmuxRetiredKeyUnbindLines() []string {
 		// Historical direct defaults removed during the keybinding surface
 		// cleanup. Keep unbinding them so a live tmux server sourced from an
 		// older projmux build does not retain stale behavior after reload.
+		// Legacy: retained for cleaning stale tmux keybindings from live tmux
+		// after reload; sunset when retired bindings from the 0.7/keybinding
+		// cleanup era have aged out and live stale-binding cleanup is
+		// intentionally stopped.
 		"unbind-key -q -n M-6",
 		"unbind-key -q -n C-n",
 		"unbind-key -q -n M-r",

--- a/internal/app/notification_appid.go
+++ b/internal/app/notification_appid.go
@@ -13,6 +13,11 @@ package app
 //     shortcut and the AppUserModelID registry key tied to the legacy
 //     value. Keeping the constant alongside the new one makes the
 //     migration footprint discoverable in one place.
+//
+// Legacy: retained for Windows AppUserModelID migration and idempotent stale
+// marker cleanup; sunset when a post-0.7 review after two minor releases or 90
+// days confirms stale tmux markers from pre-cleanup installs are no longer
+// supported.
 
 const (
 	desktopAppID       = "com.crevisse.projmux"

--- a/internal/core/recentwindows/model.go
+++ b/internal/core/recentwindows/model.go
@@ -10,6 +10,9 @@ import (
 )
 
 const (
+	// Legacy: retained for persisted recent-windows state; sunset when a schema
+	// version bump plus migration window makes v1 compatibility intentionally
+	// droppable.
 	Version      = 1
 	DefaultLimit = 20
 )

--- a/internal/core/usage/manager.go
+++ b/internal/core/usage/manager.go
@@ -99,6 +99,9 @@ func (m *Manager) collect(ctx context.Context, perAdapterFloor time.Duration, fo
 
 	now := m.now().UTC()
 	// Best-effort cleanup of v1 artifacts. Cheap; safe to retry.
+	// Legacy: retained for usage v1/v2 cleanup; sunset when a post-0.7 review
+	// after two minor releases or 90 days intentionally ignores or removes v1
+	// artifacts.
 	m.store.CleanupLegacyArtifacts()
 
 	priorState, _ := m.store.LoadState()

--- a/internal/integrations/hooks/migration.go
+++ b/internal/integrations/hooks/migration.go
@@ -2,6 +2,11 @@
 // [hooks.<event>] config.toml entry. The runner no longer executes script
 // files directly; this code path drains the historical layout so users do not
 // silently lose hook behaviour after upgrading.
+//
+// Legacy: retained for draining legacy `.projmux/<event>` scripts into
+// declarative config without data loss; sunset when a post-0.7 review after
+// two minor releases or 90 days confirms legacy script migration has had
+// enough release/time coverage.
 package hooks
 
 import (

--- a/internal/integrations/sessionstate/store.go
+++ b/internal/integrations/sessionstate/store.go
@@ -16,6 +16,9 @@ import (
 
 const (
 	// Version is the current on-disk session snapshot schema version.
+	// Legacy: retained for validating and reading persisted session-state
+	// snapshots; sunset when a schema version bump plus migration window makes
+	// v1 snapshot compatibility intentionally droppable.
 	Version = 1
 
 	sessionDirName = "sessions"

--- a/internal/ui/render/popup.go
+++ b/internal/ui/render/popup.go
@@ -374,6 +374,9 @@ func highlightPreviewLine(line string) string {
 }
 
 func formatLegacyPaneSummary(model preview.PopupReadModel) string {
+	// Legacy: retained for old popup pane summary formatting shim; sunset when
+	// popup state/summary producers no longer emit the legacy shape and the
+	// compatibility window is closed.
 	pane := sanitizeCell(model.SelectedPaneIndex)
 	if pane == "" {
 		pane = "?"


### PR DESCRIPTION
## Completed phase

- Phase 5 — MUST-KEEP legacy sunset annotation

## Annotated MUST-KEEP legacy targets

- `internal/integrations/sessionstate/store.go`: session-state `Version = 1`
- `internal/core/recentwindows/model.go`: recent-windows `Version = 1`
- `internal/integrations/hooks/migration.go`: legacy hook migration package
- `internal/app/notification_appid.go`: `legacyDesktopAppID` / tmux option marker cleanup
- `internal/app/attention.go`: `legacyWindowAttentionRows`
- `internal/core/usage/manager.go`: `CleanupLegacyArtifacts()` call
- `internal/ui/render/popup.go`: `formatLegacyPaneSummary`
- `internal/app/keybinding_catalog.go`: `tmuxRetiredKeyUnbindLines()`

## Behavior

- Comment/documentation-only change.
- No behavior change or legacy removal.
- No state schema version bump.
- No hook migration behavior change.
- No stale-binding cleanup removal.

## Explicitly excluded

- Legacy code removal.
- Config alias or keybinding alias add/remove work.
- Deadcode allowlist baseline shrink.
- Deadcode tooling policy changes.
- Behavior-changing refactors.
- `new-window` WT adapter-only remnant.

## Validation

- `make fmt`
- `make fix`
- `make test`
- focused `rg -n -C 2 "Legacy: retained for|sunset when" ...` across the MUST-KEEP target files

## Remaining follow-up candidates

- deadcode baseline shrink
- `new-window` WT adapter-only remnant
