### PR TITLE
feat(theme): state/severity + AI status role migration (Phase 3)

### DIFF
--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -13,6 +13,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/core/aibadge"
 	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+	"github.com/crevissepartners/projmux/internal/theme"
 )
 
 const (
@@ -243,7 +244,7 @@ func (c *attentionCommand) runWindow(args []string, stdout, stderr io.Writer) er
 			_, err := fmt.Fprint(stdout, " ")
 			return err
 		}
-		_, err := fmt.Fprint(stdout, "#[fg="+tmuxAIBadgeKindFg(badgeKind)+"]"+glyph)
+		_, err := fmt.Fprint(stdout, "#[fg="+tmuxAIBadgeKindFg(badgeKind, theme.RenderRolesFromEffective(theme.EffectiveTheme{}))+"]"+glyph)
 		return err
 	}
 	_, err = fmt.Fprint(stdout, " ")
@@ -437,16 +438,16 @@ func isResponseCompleteLiveBadgeKind(kind string) bool {
 	return normalizeAIBadgeKind(kind) == aiBadgeKindResponseComplete || kind == "response_ready"
 }
 
-func tmuxAIBadgeKindFg(kind string) string {
+func tmuxAIBadgeKindFg(kind string, roles theme.RenderRoles) string {
 	switch aibadge.ThemeRole(kind) {
 	case aibadge.RoleActionRequired:
-		return tmuxAIBadgeActionRequiredFg
+		return roles.AIActionRequired
 	case aibadge.RoleSuccess:
-		return tmuxAIBadgeSuccessFg
+		return roles.AISuccess
 	case aibadge.RoleProgress:
-		return tmuxAIBadgeProgressFg
+		return roles.AIProgress
 	default:
-		return tmuxAIBadgeProgressFg
+		return roles.AIProgress
 	}
 }
 

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -499,13 +499,8 @@ func (c *statusCommand) notifyStore() (notifyStore, error) {
 // carries a notification-colored background; badges are stronger blocks on top
 // of that same line instead of separate outline glyphs.
 const (
-	notifyLineOpen      = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + tmuxStateProgressFg + "]"
-	notifyLineDimOpen   = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + theme.TmuxStateAheadFg + "]"
-	notifyLineCountOpen = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + tmuxStateProgressFg + ",bold]"
-	notifyProjectOpen   = "#[bg=" + theme.TmuxAttentionProjectBg + ",fg=" + theme.TmuxPrimaryFg + ",bold]"
-	notifyBadgeInfoOpen = "#[bg=" + tmuxStateProgressFg + ",fg=" + theme.TmuxPaneActiveFg + ",bold]"
-	notifyBadgeWarnOpen = "#[bg=" + tmuxStateWarningFg + ",fg=" + theme.TmuxPaneActiveFg + ",bold]"
-	notifyBadgeCritOpen = "#[bg=" + tmuxStateCriticalFg + ",fg=" + theme.TmuxPrimaryFg + ",bold]"
+	notifyLineDimOpen = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + theme.TmuxStateAheadFg + "]"
+	notifyProjectOpen = "#[bg=" + theme.TmuxAttentionProjectBg + ",fg=" + theme.TmuxPrimaryFg + ",bold]"
 	// Inactive/gone badges share a muted palette so target-state hints are
 	// visually distinct from the active NEED/INFO/WARN/CRIT badges without
 	// stealing focus. The colours land in the same neutral grey family the
@@ -515,13 +510,29 @@ const (
 	notifyAgentOpen      = "#[bg=" + tmuxAccentAIBg + ",fg=" + theme.TmuxPaneActiveFg + ",bold]"
 	notifyAgentClaude    = notifyAgentOpen
 	notifyAgentCodex     = notifyAgentOpen
-	notifySeverityInfo   = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + tmuxStateProgressFg + "]"
-	notifySeverityWarn   = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + tmuxStateWarningFg + "]"
-	notifySeverityCrit   = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + tmuxStateCriticalFg + ",bold]"
 	notifyIcon           = "●"
 	notifyMidDot         = "·"
 	notifyEllipsis       = "…"
 	notifyReset          = "#[default]"
+)
+
+// State/severity-colored notify tokens. These source their state colors from
+// the semantic role map (single source shared with statusbar/usage HUD) instead
+// of the bare tmux literal aliases. The status/notify render path carries no
+// explicit EffectiveTheme today, so the fallback role map is used here; full
+// subprocess theme plumbing is a later phase. The fallback role values equal the
+// historical literals, so the generated strings are byte-identical.
+var (
+	notifyStateRoles = theme.RenderRolesFromEffective(theme.EffectiveTheme{})
+
+	notifyLineOpen      = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + notifyStateRoles.StateProgress + "]"
+	notifyLineCountOpen = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + notifyStateRoles.StateProgress + ",bold]"
+	notifyBadgeInfoOpen = "#[bg=" + notifyStateRoles.StateProgress + ",fg=" + theme.TmuxPaneActiveFg + ",bold]"
+	notifyBadgeWarnOpen = "#[bg=" + notifyStateRoles.StateWarning + ",fg=" + theme.TmuxPaneActiveFg + ",bold]"
+	notifyBadgeCritOpen = "#[bg=" + notifyStateRoles.StateCritical + ",fg=" + theme.TmuxPrimaryFg + ",bold]"
+	notifySeverityInfo  = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + notifyStateRoles.StateProgress + "]"
+	notifySeverityWarn  = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + notifyStateRoles.StateWarning + "]"
+	notifySeverityCrit  = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + notifyStateRoles.StateCritical + ",bold]"
 )
 
 // known agent prefixes recognised when stripping a leading `<agent>:` from

--- a/internal/app/status_notify_test.go
+++ b/internal/app/status_notify_test.go
@@ -197,16 +197,17 @@ func TestCriticalNotifySeverityDoesNotDriveAIStatusBadgePalette(t *testing.T) {
 	if got := notifyBadgeOpen(entry.Severity); got != notifyBadgeCritOpen {
 		t.Fatalf("notify severity palette = %q, want critical queue palette %q", got, notifyBadgeCritOpen)
 	}
-	if got := tmuxAIBadgeKindFg(aiBadgeKindApprovalRequired); got != theme.TmuxAIBadgeActionRequiredFg {
+	fallbackRoles := theme.RenderRolesFromEffective(theme.EffectiveTheme{})
+	if got := tmuxAIBadgeKindFg(aiBadgeKindApprovalRequired, fallbackRoles); got != theme.TmuxAIBadgeActionRequiredFg {
 		t.Fatalf("approval-required status badge fg = %q, want action-required %q", got, theme.TmuxAIBadgeActionRequiredFg)
 	}
-	if got := tmuxAIBadgeKindFg(aiBadgeKindApprovalRequired); got == tmuxStateCriticalFg {
+	if got := tmuxAIBadgeKindFg(aiBadgeKindApprovalRequired, fallbackRoles); got == tmuxStateCriticalFg {
 		t.Fatalf("approval-required status badge fg = %q, must not follow critical notify severity", got)
 	}
-	if got := tmuxAIBadgeKindFg(aiBadgeKindResponseComplete); got != theme.TmuxAIBadgeSuccessFg {
+	if got := tmuxAIBadgeKindFg(aiBadgeKindResponseComplete, fallbackRoles); got != theme.TmuxAIBadgeSuccessFg {
 		t.Fatalf("response-complete status badge fg = %q, want success %q", got, theme.TmuxAIBadgeSuccessFg)
 	}
-	if got := tmuxAIBadgeKindFg(aiBadgeKindInProgress); got != theme.TmuxAIBadgeProgressFg {
+	if got := tmuxAIBadgeKindFg(aiBadgeKindInProgress, fallbackRoles); got != theme.TmuxAIBadgeProgressFg {
 		t.Fatalf("in-progress status badge fg = %q, want progress %q", got, theme.TmuxAIBadgeProgressFg)
 	}
 }

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -1013,16 +1013,20 @@ func dimANSI(value string) string {
 	return projmuxpicker.MutedStart + value + projmuxpicker.Reset
 }
 
+// amberANSI/redANSI/tealANSI tint the native usage statusbar text from the
+// semantic state role map (single source shared with the notify/usage tmux
+// severity cluster). ANSI256FgStart adapts the role's tmux colourN to the
+// 256-color SGR; the fallback role values keep this byte-identical.
 func amberANSI(value string) string {
-	return theme.ANSI256FgStart(theme.TmuxStateWarningFg) + value + projmuxpicker.Reset
+	return theme.ANSI256FgStart(theme.RenderRolesFromEffective(theme.EffectiveTheme{}).StateWarning) + value + projmuxpicker.Reset
 }
 
 func redANSI(value string) string {
-	return theme.ANSI256FgStart(theme.TmuxStateCriticalFg) + value + projmuxpicker.Reset
+	return theme.ANSI256FgStart(theme.RenderRolesFromEffective(theme.EffectiveTheme{}).StateCritical) + value + projmuxpicker.Reset
 }
 
 func tealANSI(value string) string {
-	return theme.ANSI256FgStart(theme.TmuxStateSuccessFg) + value + projmuxpicker.Reset
+	return theme.ANSI256FgStart(theme.RenderRolesFromEffective(theme.EffectiveTheme{}).StateSuccess) + value + projmuxpicker.Reset
 }
 
 func (c *statusbarCommand) statusbarPathMetadata(ctx context.Context, path string) statusbarPathMetadata {

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -1252,7 +1252,7 @@ func tmuxVisiblePaneLabelFormat() string {
 }
 
 func tmuxStyledVisiblePaneLabelFormat() string {
-	return tmuxStyledVisiblePaneLabelFormatFor(tmuxStateProgressFg)
+	return tmuxStyledVisiblePaneLabelFormatFor(theme.RenderRolesFromEffective(theme.EffectiveTheme{}).StateProgress)
 }
 
 func tmuxStyledVisiblePaneLabelFormatFor(styleFg string) string {
@@ -1283,16 +1283,16 @@ func tmuxPaneBorderFormat() string {
 func tmuxPaneBorderFormatWithAIBadgeStyle(badgeStyle config.AIBadgeStyle, roles theme.RenderRoles) string {
 	badgeStyle = config.NormalizeAIBadgeStyle(string(badgeStyle))
 	activePaneLabelFormat := tmuxVisiblePaneLabelFormat()
-	promptPaneLabelFormat := tmuxStyledVisiblePaneLabelFormatFor(tmuxAIBadgeActionRequiredFg)
-	busyPaneLabelFormat := tmuxStyledVisiblePaneLabelFormatFor(tmuxAIBadgeProgressFg)
-	replyPaneLabelFormat := tmuxStyledVisiblePaneLabelFormatFor(tmuxAIBadgeSuccessFg)
+	promptPaneLabelFormat := tmuxStyledVisiblePaneLabelFormatFor(roles.AIActionRequired)
+	busyPaneLabelFormat := tmuxStyledVisiblePaneLabelFormatFor(roles.AIProgress)
+	replyPaneLabelFormat := tmuxStyledVisiblePaneLabelFormatFor(roles.AISuccess)
 	mutedPaneLabelFormat := tmuxStyledVisiblePaneLabelFormatFor(theme.TmuxMutedFg)
 	panePromptFormat := "#{||:#{==:#{@projmux_ai_badge_kind}," + aiBadgeKindApprovalRequired + "},#{==:#{@projmux_ai_badge_kind}," + aiBadgeKindInputRequired + "}}"
 	paneCompleteFormat := "#{==:#{@projmux_ai_badge_kind}," + aiBadgeKindResponseComplete + "}"
 	paneProgressFormat := "#{==:#{@projmux_ai_badge_kind}," + aiBadgeKindInProgress + "}"
 	paneBusyFormat := "#{==:#{@projmux_attention_state},busy}"
 	paneReplyFormat := "#{==:#{@projmux_attention_state},reply}"
-	inactivePaneBorderFormat := "#{?" + panePromptFormat + ",#[bold#,fg=" + tmuxAIBadgeActionRequiredFg + "]" + tmuxAIBadgeMarker(aiBadgeKindApprovalRequired, badgeStyle) + promptPaneLabelFormat + " #[default],#{?" + paneCompleteFormat + ",#[bold#,fg=" + tmuxAIBadgeSuccessFg + "]" + tmuxAIBadgeMarker(aiBadgeKindResponseComplete, badgeStyle) + replyPaneLabelFormat + " #[default],#{?#{||:" + paneProgressFormat + "," + paneBusyFormat + "},#[bold#,fg=" + tmuxAIBadgeProgressFg + "]" + tmuxAIBadgeMarker(aiBadgeKindInProgress, badgeStyle) + busyPaneLabelFormat + " #[default],#{?" + paneReplyFormat + ",#[bold#,fg=" + tmuxAIBadgeSuccessFg + "]" + tmuxAIBadgeMarker(aiBadgeKindResponseComplete, badgeStyle) + replyPaneLabelFormat + " #[default],#[fg=" + theme.TmuxMutedFg + "] " + mutedPaneLabelFormat + " #[default]}}}}"
+	inactivePaneBorderFormat := "#{?" + panePromptFormat + ",#[bold#,fg=" + roles.AIActionRequired + "]" + tmuxAIBadgeMarker(aiBadgeKindApprovalRequired, badgeStyle) + promptPaneLabelFormat + " #[default],#{?" + paneCompleteFormat + ",#[bold#,fg=" + roles.AISuccess + "]" + tmuxAIBadgeMarker(aiBadgeKindResponseComplete, badgeStyle) + replyPaneLabelFormat + " #[default],#{?#{||:" + paneProgressFormat + "," + paneBusyFormat + "},#[bold#,fg=" + roles.AIProgress + "]" + tmuxAIBadgeMarker(aiBadgeKindInProgress, badgeStyle) + busyPaneLabelFormat + " #[default],#{?" + paneReplyFormat + ",#[bold#,fg=" + roles.AISuccess + "]" + tmuxAIBadgeMarker(aiBadgeKindResponseComplete, badgeStyle) + replyPaneLabelFormat + " #[default],#[fg=" + theme.TmuxMutedFg + "] " + mutedPaneLabelFormat + " #[default]}}}}"
 	return "#{?pane_active,#[bold#,fg=" + roles.PaneTopicChipFg + "#,bg=" + roles.PaneTopicChipBg + "] > " + activePaneLabelFormat + " #[default]," + inactivePaneBorderFormat + "}"
 }
 

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -1954,6 +1954,32 @@ func TestTmuxAppNamingFormatsUseVisiblePaneLabel(t *testing.T) {
 	}
 }
 
+func TestTmuxPaneBorderAIBadgeRepaintsFromExplicitThemeKeepingActionRequiredSeparate(t *testing.T) {
+	t.Parallel()
+
+	fallbackRoles := theme.RenderRolesFromEffective(theme.EffectiveTheme{})
+	fallbackBorder := tmuxPaneBorderFormatWithAIBadgeStyle(config.AIBadgeStyleDot, fallbackRoles)
+
+	// Fallback border keeps the historical literals (byte-identity).
+	if !strings.Contains(fallbackBorder, "#[bold#,fg="+fallbackRoles.AIProgress+"]") {
+		t.Fatalf("fallback pane border = %q, want progress role %q", fallbackBorder, fallbackRoles.AIProgress)
+	}
+
+	// An explicit critical/warning theme must NOT repaint action_required
+	// (Tier C, independent of critical) — its color stays the literal.
+	explicitRoles := theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{
+		Critical: "#0000ff",
+		Warning:  "#00ff00",
+	}))
+	if explicitRoles.AIActionRequired != fallbackRoles.AIActionRequired {
+		t.Fatalf("ai.action_required repainted to %q, must stay independent of critical at %q", explicitRoles.AIActionRequired, fallbackRoles.AIActionRequired)
+	}
+	explicitBorder := tmuxPaneBorderFormatWithAIBadgeStyle(config.AIBadgeStyleDot, explicitRoles)
+	if !strings.Contains(explicitBorder, "#[bold#,fg="+fallbackRoles.AIActionRequired+"]") {
+		t.Fatalf("explicit pane border = %q, want action_required marker to keep literal %q", explicitBorder, fallbackRoles.AIActionRequired)
+	}
+}
+
 func TestTmuxAppShellTitlePolicyDisablesProgramWindowRename(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/usage.go
+++ b/internal/app/usage.go
@@ -824,8 +824,13 @@ func renderTextPair(m modelDisplay, label string) string {
 // renderHUDPair renders a single `<window> [bar] N%` substring with color
 // escapes. Used for both 5h and weekly pairs in the HUD tiers.
 func renderHUDPair(window string, pct float64) string {
-	color := usage.BarColorForPct(pct)
-	bar := usage.RenderColoredBar(pct, color, usage.BarEmptyColor)
+	// State/severity colors come from the semantic role map (single source
+	// shared with notify/statusbar). The status subprocess does not yet thread
+	// an explicit EffectiveTheme, so the fallback role map is used here; full
+	// runtime theme plumbing for the usage HUD is a later phase.
+	roles := theme.RenderRolesFromEffective(theme.EffectiveTheme{})
+	color := usage.BarColorForPct(pct, roles)
+	bar := usage.RenderColoredBar(pct, color, usage.BarEmptyColorForRoles(roles))
 	// `#[default]` after the bar restores label fg before the weekly text. The
 	// percent number then re-applies the same color as the bar fill so the
 	// numeric matches visually (a red bar's 90% reads red too).

--- a/internal/core/usage/hud.go
+++ b/internal/core/usage/hud.go
@@ -87,23 +87,31 @@ func RenderColoredBar(pct float64, fillColor, emptyColor string) string {
 }
 
 // BarColorForPct returns the tmux color spec for the bar fill at the
-// supplied percentage. Ramps:
+// supplied percentage, sourced from the semantic state role map (single
+// source shared with the notify/statusbar severity cluster). Ramps:
 //
-//	<80%   → muted teal
-//	80-95% → amber warning
-//	95%+   → red critical
-//	>100%  → red,bold (over-limit)
-func BarColorForPct(pct float64) string {
+//	<80%   → state.success (muted teal)
+//	80-95% → state.warning (amber)
+//	95%+   → state.critical (red)
+//	>100%  → state.critical,bold (over-limit)
+func BarColorForPct(pct float64, roles theme.RenderRoles) string {
 	switch {
 	case pct > 100:
-		return theme.TmuxUsageCriticalBoldFg
+		return roles.StateCritical + ",bold"
 	case pct >= 95:
-		return theme.TmuxUsageCriticalFg
+		return roles.StateCritical
 	case pct >= 80:
-		return theme.TmuxUsageWarningFg
+		return roles.StateWarning
 	default:
-		return theme.TmuxUsageOKFg
+		return roles.StateSuccess
 	}
+}
+
+// BarEmptyColorForRoles returns the tmux color used for empty bar cells. It is
+// the muted/gone bg literal (TmuxUsageEmptyFg = TmuxGoneBg) carried as the
+// usage-empty role; not yet runtime-derived (Phase 6 candidate).
+func BarEmptyColorForRoles(_ theme.RenderRoles) string {
+	return theme.TmuxUsageEmptyFg
 }
 
 // BarEmptyColor is the tmux color used for empty bar cells across the HUD.

--- a/internal/core/usage/hud_test.go
+++ b/internal/core/usage/hud_test.go
@@ -3,6 +3,8 @@ package usage
 import (
 	"strings"
 	"testing"
+
+	"github.com/crevissepartners/projmux/internal/theme"
 )
 
 func TestBarFillCountBoundaryCases(t *testing.T) {
@@ -93,10 +95,40 @@ func TestBarColorForPctRamp(t *testing.T) {
 		{101, "colour160,bold"},
 		{300, "colour160,bold"},
 	}
+	roles := theme.RenderRolesFromEffective(theme.EffectiveTheme{})
 	for _, tc := range cases {
-		if got := BarColorForPct(tc.pct); got != tc.want {
+		if got := BarColorForPct(tc.pct, roles); got != tc.want {
 			t.Fatalf("BarColorForPct(%v) = %q, want %q", tc.pct, got, tc.want)
 		}
+	}
+}
+
+func TestBarColorForPctRepaintsFromExplicitThemeWarningCritical(t *testing.T) {
+	t.Parallel()
+
+	fallback := theme.RenderRolesFromEffective(theme.EffectiveTheme{})
+	explicit := theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{
+		Warning:  "#00ff00",
+		Critical: "#0000ff",
+	}))
+
+	// Warning ramp (80-95%) follows the explicit warning token.
+	if BarColorForPct(85, explicit) == BarColorForPct(85, fallback) {
+		t.Fatalf("usage warning color did not repaint from explicit theme")
+	}
+	if BarColorForPct(85, explicit) != explicit.StateWarning {
+		t.Fatalf("usage warning color = %q, want explicit state.warning %q", BarColorForPct(85, explicit), explicit.StateWarning)
+	}
+	// Critical ramp (95%+) follows the explicit critical token.
+	if BarColorForPct(96, explicit) == BarColorForPct(96, fallback) {
+		t.Fatalf("usage critical color did not repaint from explicit theme")
+	}
+	if BarColorForPct(96, explicit) != explicit.StateCritical {
+		t.Fatalf("usage critical color = %q, want explicit state.critical %q", BarColorForPct(96, explicit), explicit.StateCritical)
+	}
+	// Over-limit keeps the ,bold suffix on the repainted critical.
+	if BarColorForPct(150, explicit) != explicit.StateCritical+",bold" {
+		t.Fatalf("usage over-limit color = %q, want explicit critical,bold", BarColorForPct(150, explicit))
 	}
 }
 

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -198,6 +198,20 @@ type RenderRoles struct {
 	// tint(surface_active) / blend(background, surface_active). Fallback is the
 	// spike-decided colour235 (window-active-style tint).
 	FocusPaneActiveBg string
+
+	// state / severity cluster (Phase 3). Single source for the notify HUD,
+	// usage HUD, and statusbar severity tints on the tmux side.
+	StateWarning  string // state.warning  Tier A <- warning   (colour214)
+	StateCritical string // state.critical Tier A <- critical  (colour160)
+	StateProgress string // state.progress Tier C renderer-only (colour220) — Phase 6 candidate, carries literal
+	StateSuccess  string // state.success  Tier C renderer-only (colour72)  — Phase 6 candidate, carries literal
+
+	// AI-status cluster (Phase 3). One logical color per AI badge role.
+	// AIProgress/AISuccess reuse the state.progress/success colors; action
+	// required is kept as its OWN role and must NEVER merge into critical.
+	AIProgress       string // ai.progress        <- StateProgress (colour220)
+	AISuccess        string // ai.success         <- StateSuccess  (colour72)
+	AIActionRequired string // ai.action_required Tier C renderer-only (colour214) — Phase 6 candidate; independent of critical
 }
 
 // RenderRolesFromEffective derives the semantic role map from an effective
@@ -221,6 +235,22 @@ func RenderRolesFromEffective(effective EffectiveTheme) RenderRoles {
 		// colour235 (matching surface.base / window-inactive bg) so the
 		// generated window-active-style line is byte-stable.
 		FocusPaneActiveBg: tmuxColorOrFallback(effective.SurfaceActive, TmuxWindowInactiveBg),
+
+		// Tier A: warning/critical follow the explicit public token so an
+		// explicit theme repaints the notify/usage/statusbar severity tints.
+		StateWarning:  tmuxColorOrFallback(effective.Warning, TmuxStateWarningFg),
+		StateCritical: tmuxColorOrFallback(effective.Critical, TmuxStateCriticalFg),
+		// Tier C: renderer-only state colors with no public token yet. The
+		// literal is carried under the role; no derivation until Phase 6.
+		StateProgress: TmuxStateProgressFg,
+		StateSuccess:  TmuxStateSuccessFg,
+
+		// AI-status: progress/success reuse the state colors (same logical
+		// color). action_required is its OWN Tier C role — keep it independent
+		// of StateCritical; never merge.
+		AIProgress:       TmuxStateProgressFg,
+		AISuccess:        TmuxStateSuccessFg,
+		AIActionRequired: TmuxAIBadgeActionRequiredFg,
 	}
 }
 

--- a/internal/theme/resolve_test.go
+++ b/internal/theme/resolve_test.go
@@ -87,9 +87,87 @@ func TestRenderRolesFallbackPreservesBuiltInPalette(t *testing.T) {
 		PaneTopicChipBg:   TmuxPaneActiveBg,
 		PaneTopicChipFg:   TmuxPaneActiveFg,
 		FocusPaneActiveBg: TmuxWindowInactiveBg, // spike-fixed colour235
+		StateWarning:      TmuxStateWarningFg,
+		StateCritical:     TmuxStateCriticalFg,
+		StateProgress:     TmuxStateProgressFg,
+		StateSuccess:      TmuxStateSuccessFg,
+		AIProgress:        TmuxStateProgressFg,
+		AISuccess:         TmuxStateSuccessFg,
+		AIActionRequired:  TmuxAIBadgeActionRequiredFg,
 	}
 	if got != want {
 		t.Fatalf("fallback render roles = %#v, want %#v", got, want)
+	}
+}
+
+func TestRenderRolesStateAIFallbackEqualHistoricalLiterals(t *testing.T) {
+	t.Parallel()
+
+	got := RenderRolesFromEffective(ResolveTheme(ThemeConfig{}))
+
+	// State/severity cluster fallback must equal the historical palette
+	// literals so generated fallback output stays byte-identical.
+	if got.StateWarning != "colour214" {
+		t.Fatalf("state.warning = %q, want colour214", got.StateWarning)
+	}
+	if got.StateCritical != "colour160" {
+		t.Fatalf("state.critical = %q, want colour160", got.StateCritical)
+	}
+	if got.StateProgress != "colour220" {
+		t.Fatalf("state.progress = %q, want colour220", got.StateProgress)
+	}
+	if got.StateSuccess != "colour72" {
+		t.Fatalf("state.success = %q, want colour72", got.StateSuccess)
+	}
+
+	// AI cluster: progress/success reuse the state colors; action_required is
+	// its OWN role and must remain colour214 (NOT merged into critical).
+	if got.AIProgress != got.StateProgress {
+		t.Fatalf("ai.progress = %q, want = state.progress %q", got.AIProgress, got.StateProgress)
+	}
+	if got.AISuccess != got.StateSuccess {
+		t.Fatalf("ai.success = %q, want = state.success %q", got.AISuccess, got.StateSuccess)
+	}
+	if got.AIActionRequired != "colour214" {
+		t.Fatalf("ai.action_required = %q, want colour214", got.AIActionRequired)
+	}
+	if got.AIActionRequired == got.StateCritical {
+		t.Fatalf("ai.action_required = %q must never equal state.critical %q", got.AIActionRequired, got.StateCritical)
+	}
+}
+
+func TestRenderRolesExplicitThemeRepaintsStateTierAButNotTierC(t *testing.T) {
+	t.Parallel()
+
+	got := RenderRolesFromEffective(ResolveTheme(ThemeConfig{
+		Warning:  "#00ff00",
+		Critical: "#0000ff",
+		Accent:   "#ffff00",
+	}))
+	fallback := RenderRolesFromEffective(ResolveTheme(ThemeConfig{}))
+
+	// Tier A: warning/critical repaint from the explicit public tokens.
+	if got.StateWarning == fallback.StateWarning {
+		t.Fatalf("state.warning = %q, want repainted from explicit warning, not literal", got.StateWarning)
+	}
+	if got.StateCritical == fallback.StateCritical {
+		t.Fatalf("state.critical = %q, want repainted from explicit critical, not literal", got.StateCritical)
+	}
+
+	// Tier C: progress/success/action_required have no public token yet, so
+	// they must NOT change. This also proves action_required is independent of
+	// critical — an explicit critical never bleeds into action_required.
+	if got.StateProgress != fallback.StateProgress {
+		t.Fatalf("state.progress = %q, want unchanged literal %q (Tier C)", got.StateProgress, fallback.StateProgress)
+	}
+	if got.StateSuccess != fallback.StateSuccess {
+		t.Fatalf("state.success = %q, want unchanged literal %q (Tier C)", got.StateSuccess, fallback.StateSuccess)
+	}
+	if got.AIActionRequired != fallback.AIActionRequired {
+		t.Fatalf("ai.action_required = %q, want unchanged literal %q (independent of critical)", got.AIActionRequired, fallback.AIActionRequired)
+	}
+	if got.AIActionRequired == got.StateCritical {
+		t.Fatalf("ai.action_required = %q must never equal repainted state.critical %q", got.AIActionRequired, got.StateCritical)
 	}
 }
 


### PR DESCRIPTION
## 완료한 Phase

**Phase 3 — State/severity + AI status role migration slice.** state/severity + AI-status 색 클러스터를 Phase 2 의 semantic role map(`RenderRoles`)으로 옮기고, tmux generated-config 소비자들이 bare literal 대신 role 로 색을 받게 한다.

### Role 추가 (`internal/theme/resolve.go`)
- `StateWarning` — Tier A ← `warning` (fallback colour214)
- `StateCritical` — Tier A ← `critical` (fallback colour160)
- `StateProgress` / `StateSuccess` — Tier C, literal-carried (colour220 / colour72), Phase 6 후보
- `AIProgress` / `AISuccess` — state.progress/success 색 재사용
- `AIActionRequired` — **독립 Tier C role, critical 과 절대 합치지 않음** (fallback colour214)

usage HUD 는 state role 을 재사용 (기존 `TmuxUsage*=TmuxState*` alias 를 role 재사용으로 정식화).

## 수정한 user-facing surface
- **tmux AI badge** (`tmux.go`, `attention.go`): pane-border / visible-pane-label 색이 role 로 결정되며 **explicit theme 에서 실제 repaint** (`settings.go` 의 `RenderRolesFromEffective(source.effective)` 경로).
- **usage HUD** (`core/usage/hud.go`, `app/usage.go`): bar 색이 state role 소비.
- **statusbar severity tint** (`statusbar.go`): warning/critical/success ANSI256 텍스트가 state role 소비.
- **notify HUD severity** (`status.go`): INFO/WARN/CRIT 뱃지/severity 가 state role 소비 (single source).

## 명시적으로 제외한(다음 Phase) 범위
- **Phase 4**: git/decoration/kube statusbar segment (`TmuxStateAhead/Staged/...`, `TmuxDecoration*`, `TmuxKube*`) — 손대지 않음.
- **Phase 5**: native UI ANSI* (notify sidebar `ANSINotify*`, switch `ANSIState*`/`ANSISwitchAttention*`). switch 의 `ANSISwitchAttentionReadyStart`(colour82) ≠ `state.success`(colour72) 라 naive role 재사용 불가 — Phase 5 의 ANSI 통합에서 정리.
- **Phase 6**: public `[theme]` schema 확장 (`success`/`progress`/`action_required` 공개 후보).

## 모델/스키마 제약 준수
- public `[theme]` schema 변경 없음. `EffectiveTheme` 필드 변경 없음.
- **byte-identity 유지**: explicit theme 없을 때 generated config + ANSI 출력이 현재와 동일. 모든 role 의 fallback = 기존 literal. golden test 보존.
- `action_required` ≠ `critical` 분리 유지 (테스트로 강제).
- Phase 2 의 role map 메커니즘 확장만 사용 (새 메커니즘 없음).

## 검증
- `make fmt` / `make fix` (deadcode clean, allowlisted) / `go build ./...` — clean
- `go test ./internal/theme` — ok (신규: `TestRenderRolesStateAIFallbackEqualHistoricalLiterals`, `TestRenderRolesExplicitThemeRepaintsStateTierAButNotTierC`)
- `go test ./internal/core/usage` — ok (신규: `TestBarColorForPctRepaintsFromExplicitThemeWarningCritical`)
- `go test ./internal/ui/render` — ok
- `go test ./internal/app -run "TestNotify|TestUsage|Test.*Badge|Test.*Theme|TestStatus"` — Phase 3 tmux notify/status/badge golden 통과 (신규: `TestTmuxPaneBorderAIBadgeRepaintsFromExplicitThemeKeepingActionRequiredSeparate`)

## 미검증 항목 / 후속
- `internal/app` 의 `TestNotifyList*` 및 `internal/ui/picker` `TestNativeInteractive*` 실패는 `LANG=ko_KR` 로컬 i18n 사전 부재로 **clean main 에서도 동일하게 실패**하는 기존 환경 이슈(색/Phase 3 무관, CI 통과). worktree↔main ANSI 출력 byte-identical 확인.
- usage HUD / statusbar / notify HUD 은 status 서브프로세스가 explicit EffectiveTheme 를 아직 thread 하지 않아 **single-source(role 소비)는 됐지만 runtime repaint 는 fallback** 단계. 서브프로세스 theme plumbing 은 후속(Phase 5/native UI plumbing) 과제.
- ANSI-side state/severity 변형의 role 파생은 Phase 5 로 이관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)