### PR TITLE
feat(theme): statusbar segment role migration (Phase 4)

### DIFF
--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -21,13 +21,22 @@ import (
 const (
 	defaultKubeCacheTTL     = 5 * time.Second
 	defaultKubeCommandLimit = 400 * time.Millisecond
+)
 
-	tmuxGitSegmentBg = theme.TmuxGitSegmentBg
-	tmuxGitSegmentFg = theme.TmuxGitSegmentFg
-	tmuxGitDirtyFg   = theme.TmuxStateDirtyFg
-	tmuxGitStagedFg  = theme.TmuxStateStagedFg
-	tmuxGitAheadFg   = theme.TmuxStateAheadFg
-	tmuxGitBehindFg  = theme.TmuxStateBehindFg
+// statusbar git segment / kube colors source from the semantic role map
+// (single source shared with the decoration renderer) instead of bare tmux
+// literals. The status segment render path carries no explicit EffectiveTheme
+// today, so the fallback role map is used here; the fallback role values equal
+// the historical literals, so the generated strings are byte-identical.
+var (
+	statusSegmentRoles = theme.RenderRolesFromEffective(theme.EffectiveTheme{})
+
+	tmuxGitSegmentBg = statusSegmentRoles.GitSegmentBg
+	tmuxGitSegmentFg = statusSegmentRoles.GitSegmentFg
+	tmuxGitDirtyFg   = statusSegmentRoles.GitDirty
+	tmuxGitStagedFg  = statusSegmentRoles.GitStaged
+	tmuxGitAheadFg   = statusSegmentRoles.GitAhead
+	tmuxGitBehindFg  = statusSegmentRoles.GitBehind
 )
 
 type statusCommand struct {
@@ -243,7 +252,7 @@ func (c *statusCommand) kubeSegment(sessionName string) string {
 	if ns == "" {
 		ns = "default"
 	}
-	segment := fmt.Sprintf("⎈ #[fg=%s]%s#[default]/#[fg=%s]%s#[default]", theme.TmuxKubeContextFg, ctx, theme.TmuxKubeNamespaceFg, ns)
+	segment := fmt.Sprintf("⎈ #[fg=%s]%s#[default]/#[fg=%s]%s#[default]", statusSegmentRoles.KubeContext, ctx, statusSegmentRoles.KubeNamespace, ns)
 	_ = os.MkdirAll(filepath.Dir(cacheFile), 0o755)
 	_ = os.WriteFile(cacheFile, []byte(segment), 0o644)
 	return segment

--- a/internal/app/statusbar_decoration.go
+++ b/internal/app/statusbar_decoration.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/crevissepartners/projmux/internal/config"
-	"github.com/crevissepartners/projmux/internal/theme"
 )
 
 const (
@@ -135,7 +134,7 @@ func statusbarCwdSegmentFormat() string {
 }
 
 func statusbarCwdDecoratorFormat() string {
-	return "#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},},#{?#{==:#{" + statusbarDecorationTmuxOption + "},symbol},#[fg=" + theme.TmuxDecorationCwdFg + "] ,#{?#{==:#{" + statusbarDecorationTmuxOption + "},emoji},#[fg=" + theme.TmuxDecorationCwdFg + "]📁 ,}},#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},symbol},#[fg=" + theme.TmuxDecorationCwdFg + "] ,#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},emoji},#[fg=" + theme.TmuxDecorationCwdFg + "]📁 ,}}}"
+	return "#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},},#{?#{==:#{" + statusbarDecorationTmuxOption + "},symbol},#[fg=" + statusSegmentRoles.DecorationCwd + "] ,#{?#{==:#{" + statusbarDecorationTmuxOption + "},emoji},#[fg=" + statusSegmentRoles.DecorationCwd + "]📁 ,}},#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},symbol},#[fg=" + statusSegmentRoles.DecorationCwd + "] ,#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},emoji},#[fg=" + statusSegmentRoles.DecorationCwd + "]📁 ,}}}"
 }
 
 type gitRemoteProvider string
@@ -151,18 +150,18 @@ func statusbarGitDecorator(mode config.StatusbarDecoration, remoteURL string) st
 	case config.StatusbarDecorationSymbol:
 		switch provider {
 		case gitRemoteProviderGitLab:
-			return "#[fg=" + theme.TmuxDecorationGitLabFg + "] #[fg=" + tmuxGitSegmentFg + "]"
+			return "#[fg=" + statusSegmentRoles.DecorationGitLab + "] #[fg=" + tmuxGitSegmentFg + "]"
 		default:
-			return "#[fg=" + theme.TmuxDecorationGitHubFg + "] #[fg=" + tmuxGitSegmentFg + "]"
+			return "#[fg=" + statusSegmentRoles.GitAhead + "] #[fg=" + tmuxGitSegmentFg + "]"
 		}
 	case config.StatusbarDecorationEmoji:
 		switch provider {
 		case gitRemoteProviderGitHub:
-			return "#[fg=" + theme.TmuxDecorationGitHubFg + "]🐱 #[fg=" + tmuxGitSegmentFg + "]"
+			return "#[fg=" + statusSegmentRoles.GitAhead + "]🐱 #[fg=" + tmuxGitSegmentFg + "]"
 		case gitRemoteProviderGitLab:
-			return "#[fg=" + theme.TmuxDecorationGitLabFg + "]🦊 #[fg=" + tmuxGitSegmentFg + "]"
+			return "#[fg=" + statusSegmentRoles.DecorationGitLab + "]🦊 #[fg=" + tmuxGitSegmentFg + "]"
 		default:
-			return "#[fg=" + theme.TmuxDecorationGenericGitFg + "]🌿 #[fg=" + tmuxGitSegmentFg + "]"
+			return "#[fg=" + statusSegmentRoles.GitStaged + "]🌿 #[fg=" + tmuxGitSegmentFg + "]"
 		}
 	default:
 		return ""

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -33,10 +33,6 @@ const (
 	tmuxWindowActiveBg   = projmuxpicker.TmuxWindowActiveBg
 	tmuxWindowActiveFg   = projmuxpicker.TmuxWindowActiveFg
 	tmuxWindowTitleWidth = 10
-	tmuxIdentityBg       = theme.TmuxIdentityBg
-	tmuxIdentityFg       = theme.TmuxIdentityFg
-	tmuxActionBg         = theme.TmuxActionBg
-	tmuxActionFg         = theme.TmuxActionFg
 	tmuxSecondaryFg      = theme.TmuxSecondaryFg
 
 	tmuxAccentAttentionBg = theme.TmuxAccentAttentionBg
@@ -1199,7 +1195,7 @@ func tmuxStandaloneConfig(binaryPath string, decoration config.StatusbarDecorati
 const statusbarSettingsIcon = ""
 
 func statusbarSettingsButton(label string) string {
-	return "#[bold,fg=" + tmuxActionFg + ",bg=" + tmuxActionBg + "]#[range=user|settings]" + statusbarSettingsButtonBody(label) + "#[norange]#[default]"
+	return "#[bold,fg=" + statusSegmentRoles.ActionFg + ",bg=" + statusSegmentRoles.ActionBg + "]#[range=user|settings]" + statusbarSettingsButtonBody(label) + "#[norange]#[default]"
 }
 
 func statusbarSettingsButtonBody(label string) string {
@@ -1214,11 +1210,11 @@ func statusbarSettingsButtonBody(label string) string {
 }
 
 func statusbarStandaloneSessionLeftFormat() string {
-	return "#[range=user|session]#[bold,fg=" + tmuxIdentityFg + ",bg=" + tmuxIdentityBg + "] [#S] #[default]#[norange] "
+	return "#[range=user|session]#[bold,fg=" + statusSegmentRoles.IdentityFg + ",bg=" + statusSegmentRoles.IdentityBg + "] [#S] #[default]#[norange] "
 }
 
 func statusbarAppSessionLeftFormat() string {
-	return "#[range=user|session]#[bold,fg=" + tmuxIdentityFg + ",bg=" + tmuxIdentityBg + "] #{s|^[^-]*-||:session_name} #[default]#[norange] "
+	return "#[range=user|session]#[bold,fg=" + statusSegmentRoles.IdentityFg + ",bg=" + statusSegmentRoles.IdentityBg + "] #{s|^[^-]*-||:session_name} #[default]#[norange] "
 }
 
 func statusbarAuxLineFormat(bin string, autosave bool) string {
@@ -1337,6 +1333,7 @@ func tmuxStandaloneConfigWithKeymapThemeAndAIBadgeStyle(binaryPath string, decor
 
 func tmuxStandaloneConfigWithKeymapThemeAIBadgeStyleAndDesktopNotifyMode(binaryPath string, decorations statusbarDecorationSet, badgeStyle config.AIBadgeStyle, desktopNotifyMode config.DesktopNotifyMode, catalog []keyBindingAction, keymapPresent bool, effective theme.EffectiveTheme) string {
 	bin := tmuxShellQuote(binaryPath)
+	roles := theme.RenderRolesFromEffective(effective)
 	windowStatusFormat, windowStatusCurrentFormat := tmuxWindowStatusFormats(binaryPath, effective)
 	defaultStandaloneKeyBindings := keyBindingCatalogForScope(keyBindingScopeStandalone)
 	standaloneKeyBindings := keyBindingCatalogForScopeFrom(catalog, keyBindingScopeStandalone)
@@ -1366,7 +1363,7 @@ func tmuxStandaloneConfigWithKeymapThemeAIBadgeStyleAndDesktopNotifyMode(binaryP
 		"set -g status-left-length 20",
 		"set -g status-right-length 140",
 		"set -g status-left "+tmuxConfigQuote(statusbarStandaloneSessionLeftFormat()),
-		"set -g status-right "+tmuxConfigQuote(statusbarCwdSegmentFormat()+"#[fg="+theme.TmuxDividerFg+"]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]#[fg="+tmuxSecondaryFg+"]   %Y-%m-%d %H:%M "+statusbarSettingsButton(statusbarSettingsIcon+" projmux")),
+		"set -g status-right "+tmuxConfigQuote(statusbarCwdSegmentFormat()+"#[fg="+roles.DividerFg+"]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]#[fg="+tmuxSecondaryFg+"]   %Y-%m-%d %H:%M "+statusbarSettingsButton(statusbarSettingsIcon+" projmux")),
 		// Two-line status bar: line 0 is the notify/HUD control row; line 1 is
 		// tmux's native session/window/path row. Setting both rows explicitly is
 		// required because tmux's built-in row otherwise stays at index 0.
@@ -1486,7 +1483,7 @@ func tmuxAppConfigWithKeymapThemeAIBadgeStyleAndDesktopNotifyMode(binaryPath, de
 	lines = append(lines,
 		"set -g status 2",
 		"set -g status-left "+tmuxConfigQuote(statusbarAppSessionLeftFormat()),
-		"set -g status-right "+tmuxConfigQuote(statusbarCwdSegmentFormat()+"#[fg="+theme.TmuxDividerFg+"]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]#[fg="+tmuxSecondaryFg+"]   %Y-%m-%d %H:%M "+statusbarSettingsButton(statusbarSettingsIcon)),
+		"set -g status-right "+tmuxConfigQuote(statusbarCwdSegmentFormat()+"#[fg="+roles.DividerFg+"]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]#[fg="+tmuxSecondaryFg+"]   %Y-%m-%d %H:%M "+statusbarSettingsButton(statusbarSettingsIcon)),
 		"set -g status-format[0] "+tmuxConfigQuote(statusbarAuxLineFormat(bin, true)),
 		"set -g status-format[1] "+tmuxConfigQuote(statusbarWindowLineFormat()),
 		"set -gu status-format[2]",

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -212,6 +212,36 @@ type RenderRoles struct {
 	AIProgress       string // ai.progress        <- StateProgress (colour220)
 	AISuccess        string // ai.success         <- StateSuccess  (colour72)
 	AIActionRequired string // ai.action_required Tier C renderer-only (colour214) — Phase 6 candidate; independent of critical
+
+	// statusbar git segment cluster (Phase 4). The segment foreground is the
+	// only foreground-derived role here; the segment bg and the staged/dirty/
+	// ahead/behind state colors are renderer-only literals carried verbatim.
+	GitSegmentFg string // git.segment_fg Tier A <- foreground (colour231 fallback)
+	GitSegmentBg string // git.segment_bg Tier C renderer-only (colour30)
+	GitStaged    string // git.staged     Tier C renderer-only (colour151)
+	GitDirty     string // git.dirty      Tier C renderer-only (colour222)
+	GitAhead     string // git.ahead      Tier C renderer-only (colour153) — also the github-decoration source
+	GitBehind    string // git.behind     Tier C renderer-only (colour181)
+
+	// statusbar decoration cluster (Phase 4). cwd keeps its OWN role even though
+	// it shares colour220 with state.progress; the github/generic-git decoration
+	// colors reuse GitAhead/GitStaged (single source) and so have no field here.
+	DecorationCwd    string // decoration.cwd    Tier C renderer-only (colour220) — independent of state.progress
+	DecorationGitLab string // decoration.gitlab Tier C renderer-only (colour215)
+
+	// statusbar kube cluster (Phase 4). tmux named colors carried verbatim for
+	// output compatibility with the existing segment.
+	KubeContext   string // kube.context   Tier C renderer-only ("red")
+	KubeNamespace string // kube.namespace Tier C renderer-only ("blue")
+
+	// statusbar identity/action chrome (Phase 4). Renderer-only literals.
+	IdentityBg string // identity.bg Tier C renderer-only (colour60)
+	IdentityFg string // identity.fg Tier C renderer-only (colour254)
+	ActionBg   string // action.bg   Tier C renderer-only (colour29)
+	ActionFg   string // action.fg   Tier C renderer-only (colour230)
+
+	// statusbar divider (Phase 4). Renderer-only literal; kept simple, not derived.
+	DividerFg string // divider.fg Tier C renderer-only (colour239)
 }
 
 // RenderRolesFromEffective derives the semantic role map from an effective
@@ -251,6 +281,35 @@ func RenderRolesFromEffective(effective EffectiveTheme) RenderRoles {
 		AIProgress:       TmuxStateProgressFg,
 		AISuccess:        TmuxStateSuccessFg,
 		AIActionRequired: TmuxAIBadgeActionRequiredFg,
+
+		// statusbar git segment: only the segment fg follows the public
+		// foreground token (Tier A). The segment bg and state colors are
+		// Tier C renderer-only literals carried verbatim.
+		GitSegmentFg: tmuxColorOrFallback(effective.Foreground, TmuxGitSegmentFg),
+		GitSegmentBg: TmuxGitSegmentBg,
+		GitStaged:    TmuxStateStagedFg,
+		GitDirty:     TmuxStateDirtyFg,
+		GitAhead:     TmuxStateAheadFg,
+		GitBehind:    TmuxStateBehindFg,
+
+		// statusbar decoration: cwd is its OWN Tier C role (independent of
+		// state.progress). github/generic-git decorations reuse GitAhead/
+		// GitStaged above, so only cwd/gitlab carry their own literal here.
+		DecorationCwd:    TmuxDecorationCwdFg,
+		DecorationGitLab: TmuxDecorationGitLabFg,
+
+		// kube: tmux named colors carried verbatim (Tier C).
+		KubeContext:   TmuxKubeContextFg,
+		KubeNamespace: TmuxKubeNamespaceFg,
+
+		// identity/action chrome: Tier C renderer-only literals.
+		IdentityBg: TmuxIdentityBg,
+		IdentityFg: TmuxIdentityFg,
+		ActionBg:   TmuxActionBg,
+		ActionFg:   TmuxActionFg,
+
+		// divider: Tier C renderer-only literal.
+		DividerFg: TmuxDividerFg,
 	}
 }
 

--- a/internal/theme/resolve_test.go
+++ b/internal/theme/resolve_test.go
@@ -94,6 +94,21 @@ func TestRenderRolesFallbackPreservesBuiltInPalette(t *testing.T) {
 		AIProgress:        TmuxStateProgressFg,
 		AISuccess:         TmuxStateSuccessFg,
 		AIActionRequired:  TmuxAIBadgeActionRequiredFg,
+		GitSegmentFg:      TmuxGitSegmentFg,
+		GitSegmentBg:      TmuxGitSegmentBg,
+		GitStaged:         TmuxStateStagedFg,
+		GitDirty:          TmuxStateDirtyFg,
+		GitAhead:          TmuxStateAheadFg,
+		GitBehind:         TmuxStateBehindFg,
+		DecorationCwd:     TmuxDecorationCwdFg,
+		DecorationGitLab:  TmuxDecorationGitLabFg,
+		KubeContext:       TmuxKubeContextFg,
+		KubeNamespace:     TmuxKubeNamespaceFg,
+		IdentityBg:        TmuxIdentityBg,
+		IdentityFg:        TmuxIdentityFg,
+		ActionBg:          TmuxActionBg,
+		ActionFg:          TmuxActionFg,
+		DividerFg:         TmuxDividerFg,
 	}
 	if got != want {
 		t.Fatalf("fallback render roles = %#v, want %#v", got, want)


### PR DESCRIPTION
## 완료한 Phase

**Phase 4 — Statusbar segment role migration slice.** statusbar segment 클러스터(git/decoration/kube/identity/action/divider)의 renderer 를 Phase 2 `RenderRoles` 골대 소비로 전환. 새 메커니즘 도입 없이 기존 struct 확장.

## 수정한 user-facing surface (statusbar segments)

- **git segment** — staged/dirty/ahead/behind 상태색 + segment bg/fg
- **decoration** — cwd, gitlab, github(→git.ahead 재사용), generic-git(→git.staged 재사용)
- **kube** — context/namespace (named color `red`/`blue` 그대로)
- **identity** — session chip bg/fg
- **action** — settings 버튼 bg/fg
- **divider** — status-right 구분자

## 변경 내용

- `internal/theme/resolve.go`: `RenderRoles` 에 git/decoration/kube/identity/action/divider 필드 추가 + `RenderRolesFromEffective` 매핑. `GitSegmentFg` 만 Tier A(`<- foreground`), 나머지는 Tier C renderer-only literal 보존. GitHub/generic-git decoration 은 `GitAhead`/`GitStaged` 단일 소스 재사용.
- `internal/app/status.go`, `internal/app/statusbar_decoration.go`, `internal/app/tmux.go`: 해당 segment 가 `theme.Tmux*` literal 대신 role 로 색 소비.

## 모델/스키마 제약 준수

- public `[theme]` schema **변경 없음** (Phase 6 범위).
- palette `Tmux*` literal **삭제 없음** — role 이 fallback 으로 참조.
- fallback(empty effective theme) role 값 = 기존 literal 과 동일 → **generated config byte-identical** (golden test 보존).
- `action_required`/`decoration.cwd` 등 **분리 유지**, 병합 없음.

## 명시적으로 제외한 다음 Phase 범위

- native UI `ANSI*` (picker/settings/switch) — Phase 5
- notify HUD const `notifyLineDimOpen` (notify 사이드바 계열) — Phase 5
- public `[theme]` schema 확장 — Phase 6
- Phase 3 에서 이미 옮긴 state/AI role 재변경 없음

## 검증

- `make fmt` (no-op), `make fix` (deadcode clean), `make test`
- focused: `go test ./internal/theme`, `go test ./internal/app -run "TestStatus|TestStatusbar|TestDecoration|TestKube|Test.*Theme"` → **pass**
- byte-identity guard `TestRenderRolesFallbackPreservesBuiltInPalette` + generated-config golden(`TestTmuxConfig*MatchesDefaultOutput`) → **zero diff**
- grep 결과: Phase 4 renderer 가 더 이상 migrated literal 직접 참조 안 함 (유일 잔여 = `notifyLineDimOpen`, Phase 5 범위로 의도적 보존).

## 미검증 항목 / 후속

- statusbar 는 서브프로세스(`projmux status git/kube`)로 렌더되어 effective theme plumbing 이 아직 없다 → 현재 fallback role 소비로 byte-identity 유지. 실제 explicit-theme repaint(서브프로세스 plumbing) 는 **Phase 5(native UI/plumbing)** 범위. `GitSegmentFg` 는 Tier A 라 plumbing 도착 시 자동 repaint 된다.
- real tmux 시각 확인은 e2e 후보(생성 config 문자열은 golden 으로 고정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)