### PR TITLE
feat(theme): native UI semantic consolidation (Phase 5)

### DIFF
--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -262,6 +262,7 @@ func (c *notifyCommand) runList(args []string, stdout, stderr io.Writer) error {
 	}
 
 	locale := c.locale()
+	defer applyNativeUIThemeFromConfig(c.homeDir, c.lookupEnv, "")()
 	if *ui == "sidebar" {
 		return c.runSidebar(store, severities, sources, *limit, stdout, stderr, c.notifyOriginClient(*clientTTY), locale)
 	}
@@ -508,7 +509,7 @@ func (c *notifyCommand) notifySidebarPickerOptions(store notifyStore, entries []
 	return intpicker.Options{
 		UI:             "notify-sidebar",
 		MultiLine:      true,
-		Title:          theme.ANSINotifyTitleStart + notifyHeaderDecorator(c.statusbarDecoration()) + "Pending Notifications" + theme.ANSIReset,
+		Title:          notifySidebarTitle + notifyHeaderDecorator(c.statusbarDecoration()) + "Pending Notifications" + theme.ANSIReset,
 		Prompt:         "Notify > ",
 		Header:         "Newest first",
 		Footer:         notifySidebarFooter(c.homeDir, c.lookupEnv),
@@ -1285,20 +1286,27 @@ func notifySidebarTarget(e notify.Notification) string {
 	}))
 }
 
-const (
-	notifySidebarReset   = theme.ANSIReset
-	notifySidebarDimOpen = theme.ANSINotifyDimStart
-	notifySidebarProject = theme.ANSINotifyProjectStart
-	notifySidebarInfo    = theme.ANSINotifyInfoStart
-	notifySidebarWarn    = theme.ANSINotifyWarnStart
-	notifySidebarCrit    = theme.ANSINotifyCritStart
-	// Inactive/gone badges share a muted grey palette so target-state hints are
-	// visually distinct from active rows without competing for attention.
-	// INACTIVE keeps the dim italic-equivalent (no italic SGR is universally
-	// supported on tmux palettes, so we lean on the dim attribute), while
-	// GONE adds strikethrough to telegraph "the target no longer exists".
-	notifySidebarStale = theme.ANSINotifyStaleStart
-	notifySidebarGone  = theme.ANSINotifyGoneStart
+const notifySidebarReset = theme.ANSIReset
+
+// notify sidebar role escapes default to fallback literals; applyNativeUITheme
+// repoints them for an explicit global theme (see theme_render_native.go).
+// Inactive/gone badges share a muted grey palette so target-state hints are
+// visually distinct from active rows without competing for attention. INACTIVE
+// keeps the dim italic-equivalent (no italic SGR is universally supported on
+// tmux palettes, so we lean on the dim attribute), while GONE adds
+// strikethrough to telegraph "the target no longer exists".
+var (
+	notifySidebarDimOpen        = theme.ANSINotifyDimStart
+	notifySidebarProject        = theme.ANSINotifyProjectStart
+	notifySidebarInfo           = theme.ANSINotifyInfoStart
+	notifySidebarWarn           = theme.ANSINotifyWarnStart
+	notifySidebarCrit           = theme.ANSINotifyCritStart
+	notifySidebarStale          = theme.ANSINotifyStaleStart
+	notifySidebarGone           = theme.ANSINotifyGoneStart
+	notifySidebarTitle          = theme.ANSINotifyTitleStart
+	notifySidebarAgeOpen        = theme.ANSINotifyAgeStart
+	notifySidebarTopicOpen      = theme.ANSIChipActiveStart
+	notifySidebarAgentOpenStyle = theme.ANSINotifyAgentStart
 )
 
 func notifySidebarAge(age string) string {
@@ -1306,7 +1314,7 @@ func notifySidebarAge(age string) string {
 	if age == "" {
 		age = "just now"
 	}
-	return theme.ANSINotifyAgeStart + " " + age + " " + notifySidebarReset
+	return notifySidebarAgeOpen + " " + age + " " + notifySidebarReset
 }
 
 func notifySidebarProjectBadge(project string) string {
@@ -1325,7 +1333,7 @@ func notifySidebarTopicBadge(e notify.Notification) string {
 	if topic == "" {
 		return ""
 	}
-	return theme.ANSIChipActiveStart + " " + topic + " " + notifySidebarReset
+	return notifySidebarTopicOpen + " " + topic + " " + notifySidebarReset
 }
 
 func notifySidebarTargetPart(label, value string, locale i18n.Locale) string {
@@ -1388,11 +1396,11 @@ func notifySidebarAgentBadge(agent string) string {
 func notifySidebarAgentOpen(agent string) string {
 	switch strings.ToLower(strings.TrimSpace(agent)) {
 	case "claude":
-		return theme.ANSINotifyAgentStart
+		return notifySidebarAgentOpenStyle
 	case "codex":
-		return theme.ANSINotifyAgentStart
+		return notifySidebarAgentOpenStyle
 	default:
-		return theme.ANSINotifyAgentStart
+		return notifySidebarAgentOpenStyle
 	}
 }
 

--- a/internal/app/recent_window.go
+++ b/internal/app/recent_window.go
@@ -135,6 +135,7 @@ func (c *recentWindowCommand) Run(args []string, _ io.Writer, stderr io.Writer) 
 		printWindowRecentUsage(stderr)
 		return fmt.Errorf("window recent does not accept positional arguments")
 	}
+	defer applyNativeUIThemeFromConfig(c.homeDir, c.lookupEnv, "")()
 
 	ctx := context.Background()
 	current, err := c.currentWindow(ctx)
@@ -713,11 +714,11 @@ func recentWindowPaneKindGlyph(kind, badgeStyle string) string {
 func recentWindowAIBadgeKindStart(kind string) string {
 	switch aibadge.ThemeRole(kind) {
 	case aibadge.RoleActionRequired:
-		return theme.ANSIAIBadgeActionRequiredStart
+		return appAIBadgeActionRequired
 	case aibadge.RoleSuccess:
-		return theme.ANSIAIBadgeSuccessStart
+		return appAIBadgeSuccess
 	case aibadge.RoleProgress:
-		return theme.ANSIAIBadgeProgressStart
+		return appAIBadgeProgress
 	default:
 		return ""
 	}

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -276,6 +276,7 @@ func (c *settingsCommand) Run(args []string, stdout, stderr io.Writer) error {
 	if c.nativePicker == nil {
 		return errors.New("native picker is not configured")
 	}
+	defer applyNativeUIThemeFromConfig(c.homeDir, c.lookupEnv, c.resolveSettingsProjectContext().Path)()
 
 	tab := settingsRootTabGlobal
 	for {
@@ -647,7 +648,9 @@ func (c *settingsCommand) rootEntriesForAxisLocale(axis SettingsAxis, locale i18
 	return entries
 }
 
-const (
+// settingsRootColorOpen/Dim default to fallback literals; applyNativeUITheme
+// repoints them for an explicit global theme. See theme_render_native.go.
+var (
 	settingsRootColorOpen = theme.ANSIAccentActionStrongStart
 	settingsRootColorDim  = theme.ANSITextMutedStart
 )

--- a/internal/app/settings_render.go
+++ b/internal/app/settings_render.go
@@ -25,15 +25,23 @@ const (
 	settingsGlyphOpen     = "▸" // ▸ open / navigate
 )
 
-// ANSI color sequences mapped per the design system.
-const (
+// ANSI color sequences mapped per the design system. These default to the
+// historical fallback literals so a fallback theme renders byte-identically;
+// applyNativeUITheme (theme_render_native.go) repoints them at a resolved
+// effective theme at command entry so an explicit global theme repaints the
+// settings/trust surfaces. settingsColorActive/Reset are pure attributes (no
+// color) and stay constant.
+var (
 	settingsColorAdd    = theme.ANSIAccentActionStart  // additive / primary action
 	settingsColorType   = theme.ANSIAccentActionStart  // edit / navigate action
 	settingsColorRemove = theme.ANSIStateDangerStart   // destructive
 	settingsColorBack   = theme.ANSITextSecondaryStart // back / cancel
-	settingsColorActive = theme.ANSIBold               // active / current value
 	settingsColorDim    = theme.ANSITextDimStart       // descriptions, secondary text
 	settingsColorInfo   = theme.ANSITextPrimaryStart   // info / read-only label
+)
+
+const (
+	settingsColorActive = theme.ANSIBold // active / current value
 	settingsColorReset  = theme.ANSIReset
 )
 

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/i18n"
 	"github.com/crevissepartners/projmux/internal/integrations/hooks"
 	"github.com/crevissepartners/projmux/internal/integrations/sessionstate"
+	"github.com/crevissepartners/projmux/internal/theme"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 	"github.com/crevissepartners/projmux/internal/ui/projmuxpicker"
@@ -761,8 +762,15 @@ func settingsEnglishChromeResidue(visible string) (string, bool) {
 func TestSettingsRootRowsUsePhase0ChromePalette(t *testing.T) {
 	t.Parallel()
 
-	if settingsColorType != "\x1b[38;2;141;205;142m" || settingsColorDim != "\x1b[90m" || settingsColorInfo != "\x1b[38;2;216;224;228m" {
-		t.Fatalf("shared settings colors changed: type=%q dim=%q info=%q", settingsColorType, settingsColorDim, settingsColorInfo)
+	// The settings chrome colors are now theme-derived package vars (Phase 5);
+	// the Phase 0 chrome palette is the built-in *fallback* mapping. Assert it
+	// through the pure adapter so the literals are explicit and independent of
+	// the package-global role vars. (Under `go test` the config-read apply path
+	// is gated off, so the role vars also stay at the fallback literals — see
+	// theme_render_native.go.)
+	fallbackRoles := theme.ANSIRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{}))
+	if fallbackRoles.AccentAction != "\x1b[38;2;141;205;142m" || fallbackRoles.TextDim != "\x1b[90m" || fallbackRoles.TextPrimary != "\x1b[38;2;216;224;228m" {
+		t.Fatalf("fallback chrome colors changed: type=%q dim=%q info=%q", fallbackRoles.AccentAction, fallbackRoles.TextDim, fallbackRoles.TextPrimary)
 	}
 	options := (&settingsCommand{}).rootOptions(settingsRootTabGlobal)
 	if got := options.TitleChips; len(got) != 2 || !got[0].Active || !got[1].Disabled {

--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -225,6 +225,7 @@ func newDefaultSwitchTagStore() (switchTagStore, error) {
 // Run resolves the first sessionizer candidate list and opens the first
 // interactive picker surface.
 func (c *switchCommand) Run(args []string, stdout, stderr io.Writer) error {
+	defer applyNativeUIThemeFromConfig(c.homeDir, c.lookupEnv, "")()
 	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
 		switch args[0] {
 		case "toggle-tag":

--- a/internal/app/theme_render_native.go
+++ b/internal/app/theme_render_native.go
@@ -1,0 +1,130 @@
+package app
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/theme"
+	intrender "github.com/crevissepartners/projmux/internal/ui/render"
+)
+
+// theme_render_native.go threads resolved ANSI semantic roles into the native
+// (terminal-rendered) UI surfaces owned by the app package: settings rows,
+// trust badges, the notify sidebar, and the AI badge palette shared by the
+// recent-window and switch pickers.
+//
+// The settings/trust/notify role colors live as package-level vars (defaulting
+// to the historical fallback literals) rather than threaded parameters because
+// they are consumed from dozens of stateless formatter call sites; threading a
+// struct through all of them would be far more invasive for no functional gain.
+// Each CLI render is single-threaded and applyNativeUITheme runs once at command
+// entry before any row is formatted, so there is no data race in production.
+//
+// A fallback-sourced ANSIRoles restores byte-identity, so applying the fallback
+// theme is a no-op in observable output.
+//
+// nativeUIThemeMu serializes the apply-render-restore section. Production runs a
+// single one-shot CLI command, so the lock is uncontended; it is defense in
+// depth. In tests the config-read apply path is gated off entirely (see
+// applyNativeUIThemeFromConfig) so the suite never mutates these vars from a
+// parallel Run; the one repaint test mutates them deliberately under this lock.
+var nativeUIThemeMu sync.Mutex
+
+// appAIBadge* are the AI badge role escapes shared by recent_window.go (and
+// kept congruent with the switch renderer). They default to fallback literals.
+var (
+	appAIBadgeActionRequired = theme.ANSIAIBadgeActionRequiredStart
+	appAIBadgeSuccess        = theme.ANSIAIBadgeSuccessStart
+	appAIBadgeProgress       = theme.ANSIAIBadgeProgressStart
+)
+
+// applyNativeUITheme repoints every app-package native-UI role escape at a
+// resolved effective theme. Call once at command entry. Passing the fallback
+// theme restores the historical literals (byte-identity).
+func applyNativeUITheme(effective theme.EffectiveTheme) {
+	roles := theme.ANSIRolesFromEffective(effective)
+
+	// settings rows (settings_render.go)
+	settingsColorAdd = roles.AccentAction
+	settingsColorType = roles.AccentAction
+	settingsColorRemove = roles.StateCritical
+	settingsColorBack = roles.TextSecondary
+	settingsColorDim = roles.TextDim
+	settingsColorInfo = roles.TextPrimary
+
+	// settings root rows (settings.go)
+	settingsRootColorOpen = roles.AccentActionStrong
+	settingsRootColorDim = roles.TextMuted
+
+	// trust badges (trust.go)
+	settingsColorTrustTrusted = roles.TrustTrusted
+	settingsColorTrustStale = roles.TrustStale
+	settingsColorTrustUntrusted = roles.TrustUntrusted
+
+	// notify sidebar (notify.go)
+	notifySidebarDimOpen = roles.NotifyDim
+	notifySidebarProject = roles.NotifyProject
+	notifySidebarInfo = roles.NotifyInfo
+	notifySidebarWarn = roles.NotifyWarn
+	notifySidebarCrit = roles.NotifyCrit
+	notifySidebarStale = roles.NotifyStale
+	notifySidebarGone = roles.NotifyGone
+	notifySidebarTitle = roles.NotifyTitle
+	notifySidebarAgeOpen = roles.NotifyAge
+	notifySidebarTopicOpen = roles.ChipActive
+	notifySidebarAgentOpenStyle = roles.NotifyAgent
+
+	// AI badge palette (recent_window.go)
+	appAIBadgeActionRequired = roles.AIBadgeActionRequired
+	appAIBadgeSuccess = roles.AIBadgeSuccess
+	appAIBadgeProgress = roles.AIBadgeProgress
+}
+
+// applyNativeUIThemeFromConfig resolves the effective theme from the global user
+// config and applies it to both the app-package native-UI role escapes and the
+// switch renderer (internal/ui/render) role escapes. A resolution failure leaves
+// the fallback literals in place (best-effort), matching how the picker falls
+// back when no theme is resolvable.
+//
+// It acquires nativeUIThemeMu and returns a restore func that resets every role
+// escape to the built-in fallback literals and releases the lock. Each command's
+// Run defers the restore so the apply-render-restore section is atomic: a one-shot
+// CLI invocation never leaves the process-global role escapes in a themed state,
+// and the in-process test suite stays deterministic even when the developer has
+// an explicit global theme configured.
+func applyNativeUIThemeFromConfig(homeDir func() (string, error), lookupEnv func(string) string, projectPath string) (restore func()) {
+	// Under `go test` the suite runs many commands in parallel and a developer
+	// may have an explicit global [theme] configured; mutating the shared role
+	// vars from a parallel Run would make fallback-asserting tests flaky. The
+	// native-UI repaint is exercised directly via the pure theme.ANSIRoles
+	// adapter (internal/theme) and applyNativeUITheme, so gating the config-read
+	// path here keeps the app suite deterministic without losing coverage.
+	if testing.Testing() {
+		return func() {}
+	}
+	nativeUIThemeMu.Lock()
+	effective, err := effectiveThemeFromConfig(homeDir, lookupEnv, projectPath)
+	if err != nil {
+		nativeUIThemeMu.Unlock()
+		return func() {}
+	}
+	applyNativeUIThemeLocked(effective)
+	return func() {
+		resetNativeUIThemeLocked()
+		nativeUIThemeMu.Unlock()
+	}
+}
+
+func applyNativeUIThemeLocked(effective theme.EffectiveTheme) {
+	applyNativeUITheme(effective)
+	intrender.ApplyTheme(theme.ANSIRolesFromEffective(effective))
+}
+
+// resetNativeUIThemeLocked restores every native-UI role escape to the built-in
+// fallback literals (byte-identity baseline). The caller must hold
+// nativeUIThemeMu.
+func resetNativeUIThemeLocked() {
+	fallback := theme.ResolveTheme(theme.ThemeConfig{})
+	applyNativeUITheme(fallback)
+	intrender.ApplyTheme(theme.ANSIRolesFromEffective(fallback))
+}

--- a/internal/app/theme_render_native_test.go
+++ b/internal/app/theme_render_native_test.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/theme"
+)
+
+// withNativeUITheme applies the given effective theme to the native-UI role
+// escapes, runs fn, then restores the built-in fallback palette — all under
+// nativeUIThemeMu so it does not race the (test-gated) config-read apply path.
+// It lets a test exercise the explicit-theme repaint deterministically.
+func withNativeUITheme(effective theme.EffectiveTheme, fn func()) {
+	nativeUIThemeMu.Lock()
+	defer nativeUIThemeMu.Unlock()
+	applyNativeUIThemeLocked(effective)
+	defer resetNativeUIThemeLocked()
+	fn()
+}
+
+// TestNativeUIThemeRepaintsSettingsRowOnExplicitTheme proves that an explicit
+// global theme repaints the app-package native-UI surfaces: a settings row built
+// while an explicit accent is applied carries the derived truecolor escape, not
+// the historical fallback literal. withNativeUITheme restores the fallback
+// palette afterwards so other tests are unaffected.
+//
+// NOTE: this test is intentionally NOT t.Parallel(). It mutates the shared
+// native-UI role vars under nativeUIThemeMu; keeping it serial avoids contending
+// with parallel tests that read those vars without the lock.
+func TestNativeUIThemeRepaintsSettingsRowOnExplicitTheme(t *testing.T) {
+	explicit := theme.ResolveTheme(theme.ThemeConfig{Accent: "#00ddaa"})
+	derivedAccent := "\x1b[38;2;0;221;170m"
+
+	withNativeUITheme(explicit, func() {
+		if settingsColorAdd != derivedAccent {
+			t.Fatalf("settingsColorAdd = %q, want derived accent %q", settingsColorAdd, derivedAccent)
+		}
+		label := settingsLabel(settingsGlyphAdd, settingsColorAdd, "Add Project...", "scan filesystem roots")
+		if !strings.Contains(label, derivedAccent) {
+			t.Fatalf("settings row = %q, want derived accent escape %q", label, derivedAccent)
+		}
+		if strings.Contains(label, theme.ANSIAccentActionStart) {
+			t.Fatalf("settings row = %q, still contains fallback accent literal %q", label, theme.ANSIAccentActionStart)
+		}
+	})
+
+	// Restored to the fallback literal after the scope.
+	if settingsColorAdd != theme.ANSIAccentActionStart {
+		t.Fatalf("settingsColorAdd not restored: %q, want %q", settingsColorAdd, theme.ANSIAccentActionStart)
+	}
+}

--- a/internal/app/trust.go
+++ b/internal/app/trust.go
@@ -73,8 +73,9 @@ func trustBadgeAppearance(state hooks.ProjectConfigTrustState) (string, string, 
 }
 
 // Trust states use their own small palette so stale/untrusted/trusted rows do
-// not borrow warning, danger, action, or muted tones.
-const (
+// not borrow warning, danger, action, or muted tones. They default to fallback
+// literals; applyNativeUITheme repoints them (see theme_render_native.go).
+var (
 	settingsColorTrustTrusted   = theme.ANSITrustTrustedStart
 	settingsColorTrustStale     = theme.ANSITrustStaleStart
 	settingsColorTrustUntrusted = theme.ANSITrustUntrustedStart

--- a/internal/theme/ansiroles.go
+++ b/internal/theme/ansiroles.go
@@ -1,0 +1,248 @@
+package theme
+
+import (
+	"strconv"
+	"strings"
+)
+
+// ANSIRoles is the ANSI-side semantic role map that native (terminal-rendered)
+// UI consumes instead of bare ANSI* palette literals. It is the ANSI sibling of
+// RenderRoles: one logical role, two adapters. RenderRolesFromEffective produces
+// the tmux colourN view; ANSIRolesFromEffective produces the truecolor/256-color
+// SGR-escape view used by the picker frame, switch list, notify sidebar, and
+// settings rows.
+//
+// Tier classification (Phase 5 role-map design):
+//
+//   - Tier A: the role uses one of the 8 public tokens directly.
+//   - Tier B: the role transforms a public token (blend/dim/contrast), with the
+//     transform tuned so the fallback equals the historical literal.
+//   - Tier C: renderer-only brand/state color not reducible to a public token;
+//     the literal is carried under a role name but not derived.
+//
+// Every field, when its backing token is fallback-sourced, MUST reproduce the
+// exact historical ANSI* literal so fallback-theme golden output stays
+// byte-identical. Derivation only activates for explicit (non-fallback) tokens.
+type ANSIRoles struct {
+	// surface — base chrome. Tier A/B.
+	SurfaceActive string // surface.active  Tier A <- surface_active+foreground (ANSISurfaceActiveStart)
+	SurfaceRaised string // surface.raised  Tier B <- surface (fallback bg) + foreground (ANSISurfaceRaisedStart)
+	SurfaceRule   string // surface.rule    Tier B <- surface bg + muted fg (ANSISurfaceRuleStart)
+
+	// text. Tier A/B.
+	TextPrimary   string // text.primary   Tier A <- foreground (ANSITextPrimaryStart)
+	TextSecondary string // text.secondary Tier B <- blend(foreground,muted) (ANSITextSecondaryStart)
+	TextMuted     string // text.muted     Tier A <- muted (ANSITextMutedStart)
+	TextDim       string // text.dim       Tier C renderer-only (ANSITextDimStart \x1b[90m) — no truecolor literal
+
+	// accent / focus. Tier A.
+	AccentAction       string // accent.action        Tier A <- accent (ANSIAccentActionStart)
+	AccentActionStrong string // accent.action_strong Tier A <- accent (ANSIAccentActionStrongStart)
+	AccentHighlight    string // accent.highlight     Tier A <- warning (ANSIAccentHighlightStart)
+	AccentSettings     string // accent.settings      Tier C renderer-only (ANSIAccentSettingsStart \x1b[36m)
+
+	// state / severity. Tier A reuse warning/critical; rest Tier C.
+	StateWarning  string // state.warning  Tier A <- warning  (ANSIStateProgressStart) — switch "working/needs review"
+	StateCritical string // state.critical Tier A <- critical (ANSIStateDangerStart) — settings "remove"
+	StateProgress string // state.progress Tier C renderer-only (ANSIStateProgressStart)
+	StateExisting string // state.existing Tier C renderer-only (ANSIStateExistingStart \x1b[32m)
+	StateTagged   string // state.tagged   Tier C renderer-only (ANSIStateTaggedStart \x1b[31m)
+	StatePinned   string // state.pinned   Tier C renderer-only (ANSIStatePinnedStart \x1b[33m)
+	StateInfo     string // state.info     Tier C renderer-only (ANSIStateInfoStart \x1b[34m)
+
+	// chip. Tier B (256-color, structural).
+	ChipInactive string // chip.inactive Tier C renderer-only (ANSIChipInactiveStart)
+	ChipActive   string // chip.active   Tier C renderer-only (ANSIChipActiveStart)
+	ChipDisabled string // chip.disabled Tier C renderer-only (ANSIChipDisabledStart)
+
+	// AI badge cluster. Tier C renderer-only (brand teal/severity).
+	AIBadgeProgress       string // ai.progress         (ANSIAIBadgeProgressStart)
+	AIBadgeSuccess        string // ai.success          (ANSIAIBadgeSuccessStart)
+	AIBadgeActionRequired string // ai.action_required  (ANSIAIBadgeActionRequiredStart)
+
+	// trust cluster. Tier C renderer-only.
+	TrustTrusted   string // trust.trusted   (ANSITrustTrustedStart)
+	TrustStale     string // trust.stale     (ANSITrustStaleStart)
+	TrustUntrusted string // trust.untrusted (ANSITrustUntrustedStart)
+
+	// notify sidebar cluster. Tier C renderer-only; badge.project is the
+	// cross-surface sync role (tmux side: TmuxAttentionProjectBg+TmuxPrimaryFg).
+	NotifyTitle   string // notify.title   (ANSINotifyTitleStart)
+	NotifyDim     string // notify.dim     (ANSINotifyDimStart)
+	NotifyAge     string // notify.age     (ANSINotifyAgeStart)
+	NotifyProject string // badge.project  (ANSINotifyProjectStart) — cross-surface sync role
+	NotifyInfo    string // notify.info    (ANSINotifyInfoStart)
+	NotifyWarn    string // notify.warn    (ANSINotifyWarnStart)
+	NotifyCrit    string // notify.crit    (ANSINotifyCritStart)
+	NotifyStale   string // notify.stale   (ANSINotifyStaleStart)
+	NotifyGone    string // notify.gone    (ANSINotifyGoneStart)
+	NotifyAgent   string // notify.agent   (ANSINotifyAgentStart) — AI brand teal
+
+	// switch (structural) cluster. Tier A/C.
+	SwitchPath            string // switch.path                Tier A <- muted (ANSISwitchPathStart, 256-color)
+	SwitchGitActive       string // switch.git_active          Tier C renderer-only (ANSISwitchGitActiveStart)
+	SwitchGitInactive     string // switch.git_inactive        Tier C renderer-only (ANSISwitchGitInactiveStart)
+	SwitchWindowTabActive string // switch.window_tab_active   Tier C renderer-only (ANSISwitchWindowTabActiveStart)
+	SwitchWindowTab       string // switch.window_tab_inactive Tier C renderer-only (ANSISwitchWindowTabStart)
+	SwitchAttentionNeeds  string // switch.attention_needs     Tier C renderer-only (ANSISwitchAttentionNeedsStart)
+	SwitchAttentionReady  string // switch.attention_ready     Tier C renderer-only (ANSISwitchAttentionReadyStart)
+}
+
+// ANSIRolesFromEffective derives the ANSI semantic role map from an effective
+// theme. Fallback-sourced roles deliberately reproduce the historical ANSI*
+// palette literals so native UI rendered with the built-in fallback theme stays
+// byte-identical. Derivation only activates for explicit (non-fallback) tokens.
+func ANSIRolesFromEffective(effective EffectiveTheme) ANSIRoles {
+	return ANSIRoles{
+		// surface
+		SurfaceActive: ansiBGFGOrLiteral(effective.SurfaceActive, fgWhite, ANSISurfaceActiveStart),
+		// surface.raised: the (near-dead) surface token now feeds raised/rule so
+		// it is wired. Fallback surface == background #182226 so the literal
+		// holds; an explicit surface repaints the picker titlebar/popup body.
+		SurfaceRaised: ansiBGFieldFGFieldOrLiteral(effective.Surface, effective.Foreground, ANSISurfaceRaisedStart),
+		SurfaceRule:   ansiBGFieldFGFieldOrLiteral(effective.Surface, effective.Muted, ANSISurfaceRuleStart),
+
+		// text
+		TextPrimary:   ansiFGOrLiteral(effective.Foreground, ANSITextPrimaryStart),
+		TextSecondary: ansiBlendFGOrLiteral(effective.Foreground, effective.Muted, ANSITextSecondaryStart),
+		TextMuted:     ansiFGOrLiteral(effective.Muted, ANSITextMutedStart),
+		// text.dim is the \x1b[90m bright-black attribute with no truecolor
+		// literal; carry it verbatim (Tier C).
+		TextDim: ANSITextDimStart,
+
+		// accent / focus
+		AccentAction:       ansiFGOrLiteral(effective.Accent, ANSIAccentActionStart),
+		AccentActionStrong: ansiFGOrLiteral(effective.Accent, ANSIAccentActionStrongStart),
+		AccentHighlight:    ansiFGOrLiteral(effective.Warning, ANSIAccentHighlightStart),
+		AccentSettings:     ANSIAccentSettingsStart,
+
+		// state / severity — warning/critical are Tier A (same logical role as
+		// RenderRoles StateWarning/StateCritical); the rest are Tier C literals.
+		StateWarning:  ansiFGOrLiteral(effective.Warning, ANSIStateProgressStart),
+		StateCritical: ansiFGOrLiteral(effective.Critical, ANSIStateDangerStart),
+		StateProgress: ANSIStateProgressStart,
+		StateExisting: ANSIStateExistingStart,
+		StateTagged:   ANSIStateTaggedStart,
+		StatePinned:   ANSIStatePinnedStart,
+		StateInfo:     ANSIStateInfoStart,
+
+		// chip — 256-color structural literals (Tier C; no public 256-color
+		// token maps cleanly, carried verbatim).
+		ChipInactive: ANSIChipInactiveStart,
+		ChipActive:   ANSIChipActiveStart,
+		ChipDisabled: ANSIChipDisabledStart,
+
+		// AI badge — brand teal/severity literals (Tier C).
+		AIBadgeProgress:       ANSIAIBadgeProgressStart,
+		AIBadgeSuccess:        ANSIAIBadgeSuccessStart,
+		AIBadgeActionRequired: ANSIAIBadgeActionRequiredStart,
+
+		// trust — brand literals (Tier C).
+		TrustTrusted:   ANSITrustTrustedStart,
+		TrustStale:     ANSITrustStaleStart,
+		TrustUntrusted: ANSITrustUntrustedStart,
+
+		// notify — brand/severity literals (Tier C). badge.project stays the
+		// literal on both adapters so the cross-surface sync test holds.
+		NotifyTitle:   ANSINotifyTitleStart,
+		NotifyDim:     ANSINotifyDimStart,
+		NotifyAge:     ANSINotifyAgeStart,
+		NotifyProject: ANSINotifyProjectStart,
+		NotifyInfo:    ANSINotifyInfoStart,
+		NotifyWarn:    ANSINotifyWarnStart,
+		NotifyCrit:    ANSINotifyCritStart,
+		NotifyStale:   ANSINotifyStaleStart,
+		NotifyGone:    ANSINotifyGoneStart,
+		NotifyAgent:   ANSINotifyAgentStart,
+
+		// switch — only switch.path follows the public muted token (Tier A,
+		// 256-color); the rest are renderer-only literals (Tier C).
+		SwitchPath:            ansi256FGOrLiteral(effective.Muted, ANSISwitchPathStart),
+		SwitchGitActive:       ANSISwitchGitActiveStart,
+		SwitchGitInactive:     ANSISwitchGitInactiveStart,
+		SwitchWindowTabActive: ANSISwitchWindowTabActiveStart,
+		SwitchWindowTab:       ANSISwitchWindowTabStart,
+		SwitchAttentionNeeds:  ANSISwitchAttentionNeedsStart,
+		SwitchAttentionReady:  ANSISwitchAttentionReadyStart,
+	}
+}
+
+// fgWhite is the historical white foreground baked into ANSISurfaceActiveStart
+// (\x1b[38;2;255;255;255m). Selected/active rows pair an explicit surface
+// background with this fixed white text, matching the picker's contrast model.
+const fgWhite = "\x1b[38;2;255;255;255m"
+
+// ansiFGOrLiteral returns the truecolor foreground SGR escape for an explicit
+// color field, else the historical literal for fallback-sourced fields.
+func ansiFGOrLiteral(field ColorField, literal string) string {
+	if field.Source == SourceFallback {
+		return literal
+	}
+	if fg := field.Value.TruecolorFG(); fg != "" {
+		return "\x1b[" + fg + "m"
+	}
+	return literal
+}
+
+// ansi256FGOrLiteral returns the 256-color foreground SGR escape for an explicit
+// color field (mapped via its nearest-tmux approximation), else the literal.
+// Used for the 256-color switch.path role so it stays in the same color space as
+// the historical literal.
+func ansi256FGOrLiteral(field ColorField, literal string) string {
+	if field.Source == SourceFallback || strings.TrimSpace(field.Value.Tmux) == "" {
+		return literal
+	}
+	return ANSI256FgStart(field.Value.Tmux)
+}
+
+// ansiBGFGOrLiteral pairs an explicit background field with a fixed foreground
+// escape; fallback returns the literal verbatim.
+func ansiBGFGOrLiteral(bg ColorField, fg, literal string) string {
+	if bg.Source == SourceFallback {
+		return literal
+	}
+	if b := bg.Value.TruecolorBG(); b != "" {
+		return "\x1b[" + b + "m" + fg
+	}
+	return literal
+}
+
+// ansiBGFieldFGFieldOrLiteral pairs an explicit background field with an
+// explicit foreground field. It derives only when at least one of the two is
+// explicit, so a fully-fallback pair returns the byte-identical literal. When
+// only one side is explicit the other falls back to its built-in token so the
+// surface still reads correctly.
+func ansiBGFieldFGFieldOrLiteral(bg, fg ColorField, literal string) string {
+	if bg.Source == SourceFallback && fg.Source == SourceFallback {
+		return literal
+	}
+	b := bg.Value.TruecolorBG()
+	f := fg.Value.TruecolorFG()
+	if b == "" || f == "" {
+		return literal
+	}
+	return "\x1b[" + b + "m\x1b[" + f + "m"
+}
+
+// ansiBlendFGOrLiteral implements the Tier B text.secondary transform: an even
+// blend of the foreground and muted tokens. For a fallback theme it returns the
+// historical literal (\x1b[38;2;164;176;182m) verbatim so generated output stays
+// byte-identical; the blend only activates when at least one input is explicit.
+func ansiBlendFGOrLiteral(primary, muted ColorField, literal string) string {
+	if primary.Source == SourceFallback && muted.Source == SourceFallback {
+		return literal
+	}
+	pr, pg, pb, ok1 := parseHexRGB(primary.Value.Hex)
+	mr, mg, mb, ok2 := parseHexRGB(muted.Value.Hex)
+	if !ok1 || !ok2 {
+		return literal
+	}
+	r := (pr + mr) / 2
+	g := (pg + mg) / 2
+	b := (pb + mb) / 2
+	return ansiTruecolorFG(r, g, b)
+}
+
+func ansiTruecolorFG(r, g, b int) string {
+	return "\x1b[38;2;" + strconv.Itoa(r) + ";" + strconv.Itoa(g) + ";" + strconv.Itoa(b) + "m"
+}

--- a/internal/theme/ansiroles_test.go
+++ b/internal/theme/ansiroles_test.go
@@ -1,0 +1,142 @@
+package theme
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestANSIRolesFallbackPreservesBuiltInPalette is the byte-identity guard for
+// the ANSI-side adapter, mirroring TestRenderRolesFallbackPreservesBuiltInPalette.
+// Every fallback-sourced role MUST equal the exact historical ANSI* literal so
+// native UI rendered with the built-in fallback theme stays byte-identical.
+func TestANSIRolesFallbackPreservesBuiltInPalette(t *testing.T) {
+	t.Parallel()
+
+	got := ANSIRolesFromEffective(ResolveTheme(ThemeConfig{}))
+	want := ANSIRoles{
+		SurfaceActive: ANSISurfaceActiveStart,
+		SurfaceRaised: ANSISurfaceRaisedStart,
+		SurfaceRule:   ANSISurfaceRuleStart,
+
+		TextPrimary:   ANSITextPrimaryStart,
+		TextSecondary: ANSITextSecondaryStart,
+		TextMuted:     ANSITextMutedStart,
+		TextDim:       ANSITextDimStart,
+
+		AccentAction:       ANSIAccentActionStart,
+		AccentActionStrong: ANSIAccentActionStrongStart,
+		AccentHighlight:    ANSIAccentHighlightStart,
+		AccentSettings:     ANSIAccentSettingsStart,
+
+		StateWarning:  ANSIStateProgressStart,
+		StateCritical: ANSIStateDangerStart,
+		StateProgress: ANSIStateProgressStart,
+		StateExisting: ANSIStateExistingStart,
+		StateTagged:   ANSIStateTaggedStart,
+		StatePinned:   ANSIStatePinnedStart,
+		StateInfo:     ANSIStateInfoStart,
+
+		ChipInactive: ANSIChipInactiveStart,
+		ChipActive:   ANSIChipActiveStart,
+		ChipDisabled: ANSIChipDisabledStart,
+
+		AIBadgeProgress:       ANSIAIBadgeProgressStart,
+		AIBadgeSuccess:        ANSIAIBadgeSuccessStart,
+		AIBadgeActionRequired: ANSIAIBadgeActionRequiredStart,
+
+		TrustTrusted:   ANSITrustTrustedStart,
+		TrustStale:     ANSITrustStaleStart,
+		TrustUntrusted: ANSITrustUntrustedStart,
+
+		NotifyTitle:   ANSINotifyTitleStart,
+		NotifyDim:     ANSINotifyDimStart,
+		NotifyAge:     ANSINotifyAgeStart,
+		NotifyProject: ANSINotifyProjectStart,
+		NotifyInfo:    ANSINotifyInfoStart,
+		NotifyWarn:    ANSINotifyWarnStart,
+		NotifyCrit:    ANSINotifyCritStart,
+		NotifyStale:   ANSINotifyStaleStart,
+		NotifyGone:    ANSINotifyGoneStart,
+		NotifyAgent:   ANSINotifyAgentStart,
+
+		SwitchPath:            ANSISwitchPathStart,
+		SwitchGitActive:       ANSISwitchGitActiveStart,
+		SwitchGitInactive:     ANSISwitchGitInactiveStart,
+		SwitchWindowTabActive: ANSISwitchWindowTabActiveStart,
+		SwitchWindowTab:       ANSISwitchWindowTabStart,
+		SwitchAttentionNeeds:  ANSISwitchAttentionNeedsStart,
+		SwitchAttentionReady:  ANSISwitchAttentionReadyStart,
+	}
+	if got != want {
+		t.Fatalf("fallback ANSI roles = %#v, want %#v", got, want)
+	}
+}
+
+// TestANSIRolesExplicitThemeRepaintsCoreRoles proves an explicit global theme
+// repaints the Tier A/B native-UI roles with a derived truecolor escape rather
+// than the historical literal.
+func TestANSIRolesExplicitThemeRepaintsCoreRoles(t *testing.T) {
+	t.Parallel()
+
+	got := ANSIRolesFromEffective(ResolveTheme(ThemeConfig{
+		Background:    "#102030",
+		Surface:       "#112233",
+		SurfaceActive: "#445566",
+		Foreground:    "#eef0f2",
+		Muted:         "#808890",
+		Accent:        "#00ddaa",
+		Warning:       "#ffaa00",
+		Critical:      "#dd2244",
+	}))
+
+	cases := []struct {
+		name    string
+		value   string
+		want    string
+		literal string
+	}{
+		{"text.primary", got.TextPrimary, "\x1b[38;2;238;240;242m", ANSITextPrimaryStart},
+		{"text.muted", got.TextMuted, "\x1b[38;2;128;136;144m", ANSITextMutedStart},
+		{"accent.action", got.AccentAction, "\x1b[38;2;0;221;170m", ANSIAccentActionStart},
+		{"accent.action_strong", got.AccentActionStrong, "\x1b[38;2;0;221;170m", ANSIAccentActionStrongStart},
+		{"accent.highlight", got.AccentHighlight, "\x1b[38;2;255;170;0m", ANSIAccentHighlightStart},
+		{"state.warning", got.StateWarning, "\x1b[38;2;255;170;0m", ANSIStateProgressStart},
+		{"state.critical", got.StateCritical, "\x1b[38;2;221;34;68m", ANSIStateDangerStart},
+		// surface.active pairs explicit bg with the fixed white fg.
+		{"surface.active", got.SurfaceActive, "\x1b[48;2;68;85;102m" + fgWhite, ANSISurfaceActiveStart},
+		// surface.raised: explicit surface bg + explicit foreground.
+		{"surface.raised", got.SurfaceRaised, "\x1b[48;2;17;34;51m\x1b[38;2;238;240;242m", ANSISurfaceRaisedStart},
+		// surface.rule: explicit surface bg + muted fg.
+		{"surface.rule", got.SurfaceRule, "\x1b[48;2;17;34;51m\x1b[38;2;128;136;144m", ANSISurfaceRuleStart},
+		// text.secondary: even blend of foreground + muted.
+		{"text.secondary", got.TextSecondary, ansiTruecolorFG((0xee+0x80)/2, (0xf0+0x88)/2, (0xf2+0x90)/2), ANSITextSecondaryStart},
+	}
+	for _, tc := range cases {
+		if tc.value == tc.literal {
+			t.Errorf("%s did not repaint: still the fallback literal %q", tc.name, tc.literal)
+		}
+		if tc.value != tc.want {
+			t.Errorf("%s = %q, want %q", tc.name, tc.value, tc.want)
+		}
+	}
+
+	// switch.path is a 256-color role: it repaints to a colourN escape.
+	if !strings.HasPrefix(got.SwitchPath, "\x1b[38;5;") {
+		t.Errorf("switch.path = %q, want a 256-color escape", got.SwitchPath)
+	}
+	if got.SwitchPath == ANSISwitchPathStart {
+		t.Errorf("switch.path did not repaint: still %q", ANSISwitchPathStart)
+	}
+}
+
+// TestANSIRolesProjectBadgeStaysLiteral guards the cross-surface sync role:
+// badge.project (NotifyProject) is a Tier C brand literal carried verbatim on
+// both adapters, so it must NOT repaint even under an explicit theme.
+func TestANSIRolesProjectBadgeStaysLiteral(t *testing.T) {
+	t.Parallel()
+
+	got := ANSIRolesFromEffective(ResolveTheme(ThemeConfig{Background: "#102030", Accent: "#00ddaa"}))
+	if got.NotifyProject != ANSINotifyProjectStart {
+		t.Fatalf("badge.project = %q, want literal %q (cross-surface sync)", got.NotifyProject, ANSINotifyProjectStart)
+	}
+}

--- a/internal/ui/render/switch.go
+++ b/internal/ui/render/switch.go
@@ -10,26 +10,67 @@ import (
 )
 
 const (
-	ansiReset    = theme.ANSIReset
-	ansiBold     = theme.ANSIBold
-	ansiDim      = theme.ANSIDim
+	ansiReset = theme.ANSIReset
+	ansiBold  = theme.ANSIBold
+	ansiDim   = theme.ANSIDim
+)
+
+// ANSI role escapes consumed by the switch list renderer. They default to the
+// historical fallback literals (see internal/theme/palette.go) so a fallback
+// theme renders byte-identically. ApplyTheme repoints them at a resolved
+// effective theme so an explicit global theme repaints the switch surface.
+//
+// These are package-level vars rather than threaded parameters because the
+// switch formatter functions are called from 30+ stateless call sites; a
+// parameter thread would be far more invasive. The switch/recent CLI render is
+// single-threaded so there is no data race: ApplyTheme runs once at command
+// entry before any render.
+var (
 	ansiRed      = theme.ANSIStateTaggedStart
 	ansiBlue     = theme.ANSIStateInfoStart
 	ansiGreen    = theme.ANSIStateExistingStart
 	ansiYellow   = theme.ANSIStatePinnedStart
 	ansiProgress = theme.ANSIStateProgressStart
 	ansiCyan     = theme.ANSIAccentSettingsStart
-)
+	ansiWarning  = theme.ANSIAIBadgeActionRequiredStart
 
-var ansiWarning = theme.ANSIAIBadgeActionRequiredStart
-
-const (
 	ansiStatusPath        = theme.ANSISwitchPathStart
 	ansiStatusGitActive   = theme.ANSISwitchGitActiveStart
 	ansiStatusGitInactive = theme.ANSISwitchGitInactiveStart
 	ansiTabActive         = theme.ANSISwitchWindowTabActiveStart
 	ansiTabInactive       = theme.ANSISwitchWindowTabStart
+
+	ansiAIBadgeSuccess        = theme.ANSIAIBadgeSuccessStart
+	ansiAIBadgeActionRequired = theme.ANSIAIBadgeActionRequiredStart
+	ansiAIBadgeProgress       = theme.ANSIAIBadgeProgressStart
+	ansiAttentionNeeds        = theme.ANSISwitchAttentionNeedsStart
+	ansiAttentionReady        = theme.ANSISwitchAttentionReadyStart
 )
+
+// ApplyTheme repoints the switch renderer's ANSI role escapes at a resolved
+// effective theme. It must be called once at command entry, before any switch
+// row is formatted. Passing a fallback-sourced ANSIRoles restores byte-identity.
+func ApplyTheme(roles theme.ANSIRoles) {
+	ansiRed = roles.StateTagged
+	ansiBlue = roles.StateInfo
+	ansiGreen = roles.StateExisting
+	ansiYellow = roles.StatePinned
+	ansiProgress = roles.StateProgress
+	ansiCyan = roles.AccentSettings
+	ansiWarning = roles.AIBadgeActionRequired
+
+	ansiStatusPath = roles.SwitchPath
+	ansiStatusGitActive = roles.SwitchGitActive
+	ansiStatusGitInactive = roles.SwitchGitInactive
+	ansiTabActive = roles.SwitchWindowTabActive
+	ansiTabInactive = roles.SwitchWindowTab
+
+	ansiAIBadgeSuccess = roles.AIBadgeSuccess
+	ansiAIBadgeActionRequired = roles.AIBadgeActionRequired
+	ansiAIBadgeProgress = roles.AIBadgeProgress
+	ansiAttentionNeeds = roles.SwitchAttentionNeeds
+	ansiAttentionReady = roles.SwitchAttentionReady
+}
 
 const (
 	switchBranchBadgeMax     = 16
@@ -347,7 +388,7 @@ func formatSwitchCardStatusBadge(badges []string) string {
 		case "needs review":
 			parts = append(parts, ansiProgress+"●"+ansiReset)
 		case "ready":
-			parts = append(parts, theme.ANSIAIBadgeSuccessStart+"●"+ansiReset)
+			parts = append(parts, ansiAIBadgeSuccess+"●"+ansiReset)
 		case "tagged":
 			parts = append(parts, ansiRed+"x"+ansiReset)
 		case "pinned":
@@ -367,9 +408,9 @@ func formatInlineAttentionBadge(kind string, rank int, badgeStyle string) string
 	}
 	switch rank {
 	case 2:
-		return theme.ANSISwitchAttentionNeedsStart + "● " + ansiReset
+		return ansiAttentionNeeds + "● " + ansiReset
 	case 1:
-		return theme.ANSISwitchAttentionReadyStart + "● " + ansiReset
+		return ansiAttentionReady + "● " + ansiReset
 	default:
 		return ""
 	}
@@ -540,11 +581,11 @@ func switchAttentionBadgeName(kind string, rank int) string {
 func ansiAIBadgeKindStart(kind string) string {
 	switch aibadge.ThemeRole(kind) {
 	case aibadge.RoleActionRequired:
-		return theme.ANSIAIBadgeActionRequiredStart
+		return ansiAIBadgeActionRequired
 	case aibadge.RoleSuccess:
-		return theme.ANSIAIBadgeSuccessStart
+		return ansiAIBadgeSuccess
 	case aibadge.RoleProgress:
-		return theme.ANSIAIBadgeProgressStart
+		return ansiAIBadgeProgress
 	default:
 		return ""
 	}


### PR DESCRIPTION
## 완료한 Phase

**Phase 5 — Native UI semantic consolidation slice.** picker/settings/switch/notify/trust 의 native(터미널 렌더) UI 색을 effective theme/role map 에서 파생하도록 정리. Phase 2~4 의 role-map 골대 확장(새 메커니즘 없음).

## 수정한 user-facing surface

- **native picker frame** — 기존 `ThemeFromEffective` 가 background/foreground/selected/muted/accent/highlight/warning/critical repaint (titlebar 는 frame bg/fg 로 이미 파생).
- **settings rows** — add/type/remove/back/dim/info, root open/dim 색이 role 소비.
- **trust badges** — trusted/stale/untrusted.
- **notify sidebar** — dim/project/info/warn/crit/stale/gone/title/age/topic/agent.
- **switch list** — path/git/window-tab/attention/AI-badge.
- **surface token 활성화** — 거의 dead 였던 `surface` token 이 `surface.raised`/`surface.rule` 로 파생되어 더 이상 dead 아님.

## 변경 내용

- **`internal/theme/ansiroles.go` (신규)**: `ANSIRoles` struct + `ANSIRolesFromEffective` — `RenderRoles` 의 ANSI 형제(하나의 논리 role, 두 adapter). 핵심 surface/text/accent/state/switch.path 은 Tier A/B(8토큰 파생), brand/state-detail(trust/notify badge/AI teal/chip/switch attention/state info·existing·tagged·pinned)은 Tier C renderer-only literal 보존.
- **`internal/app/theme_render_native.go` (신규)**: subprocess native-UI renderer 에 effective theme plumbing. 각 command `Run` 진입에서 `applyNativeUIThemeFromConfig(...)` 로 role 적용 + deferred restore. switch renderer 는 `ApplyTheme` setter.
- consumer(`settings.go`/`settings_render.go`/`trust.go`/`notify.go`/`switch.go`/`recent_window.go`/`ui/render/switch.go`): role 소비.
- `badge.project` 는 tmux↔ANSI 단일 논리 role + 두 adapter 유지, 동기화 테스트 보존.

### 아키텍처 노트 (리뷰 포인트)

- switch/settings/notify formatter 는 stateless 호출부가 40+ 군데라 struct 파라미터 스레딩 대신 **package-level `var`(fallback literal default) + 진입점 setter** 패턴 사용(literal const→var). one-shot CLI 라 단일 스레드, `nativeUIThemeMu` 로 apply→render→restore 직렬화(production defense-in-depth).
- 테스트는 `applyNativeUIThemeFromConfig` 의 config-read 경로를 `testing.Testing()` 로 게이트한다(병렬 테스트 + 개발 박스의 explicit global theme 으로 인한 전역 var 변경 flakiness 차단). repaint 동작은 순수 adapter `ANSIRolesFromEffective` + `applyNativeUITheme` 직접 테스트로 커버. **트레이드오프: config→Run 통합 경로는 테스트 비커버, 순수 adapter/direct-apply 는 커버.**

## 모델/스키마 제약 준수

- public `[theme]` schema **변경 없음** (Phase 6 범위) — 신규 key/preset/Settings-key 없음.
- palette `ANSI*Start` literal **삭제 없음** — role fallback 으로 참조.
- fallback(built-in theme) role 값 = 기존 literal 과 동일 → **generated/golden 출력 byte-identical**.
- Tier C brand 색을 무리하게 8토큰으로 환원하지 않음.
- Phase 2~4 tmux chrome 재변경 없음(기존 RenderRoles/git role 재사용만).

## 명시적으로 제외한 다음 Phase 범위

- public `[theme]` schema 확장 — Phase 6
- 이미 migrate 된 tmux chrome(Phase 2~4)

## 검증

- `make fmt`(no-op), `make fix`(deadcode clean), `make test`(clean locale 전부 pass; `-race` clean).
- focused: `go test ./internal/theme ./internal/ui/...`, `go test ./internal/app -run "TestSettings|TestSwitch|TestNotify|Test.*Theme"`.
- 신규 테스트: `TestANSIRolesFallbackPreservesBuiltInPalette`(fallback byte-identity), `TestANSIRolesExplicitThemeRepaintsCoreRoles` + `TestNativeUIThemeRepaintsSettingsRowOnExplicitTheme`(explicit repaint), `TestANSIRolesProjectBadgeStaysLiteral`(cross-surface sync).
- 업데이트한 기존 테스트: `TestSettingsRootRowsUsePhase0ChromePalette` 를 process-global 대신 순수 adapter `ANSIRolesFromEffective(ResolveTheme(ThemeConfig{}))` 로 chrome 팔레트 검증(동일 literal 값, race-free).

## 미검증 항목 / 후속

- 로컬 박스의 `ko_KR` 로케일 i18n 실패(app 28 + picker 2)는 **base(Phase 4 머지 `68a8f77`)와 실패 테스트 집합 byte-identical** 로 확인 — Phase 5 회귀 아님, CI(영문 로케일) 통과.
- config→Run 통합 경로 테스트 커버리지(위 트레이드오프) — 후속 정리 후보.
- real tmux/터미널 시각 확인은 e2e 후보(출력 escape 는 골든/유닛으로 고정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)