### PR TITLE
feat(theme): active pane & popup chrome correction (Phase 5.5)

### DIFF
--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -317,7 +317,11 @@ func (c *notifyCommand) runSidebar(store notifyStore, severities, sources []stri
 		options.DeferredUpdate = nil
 	}
 	if options.Theme == nil {
-		options = fallbackRenderThemeSource().pickerOptions(options)
+		if source, err := configRenderThemeSource(c.homeDir, c.lookupEnv, ""); err == nil {
+			options = source.pickerOptions(options)
+		} else {
+			options = fallbackRenderThemeSource().pickerOptions(options)
+		}
 	}
 	result, err := c.native.Run(options)
 	if err != nil {

--- a/internal/app/recent_window.go
+++ b/internal/app/recent_window.go
@@ -413,7 +413,11 @@ func recentWindowPickerOptions(items []intpicker.Item, initialIndex int, homeDir
 		options.InitialIndex = initialIndex
 		options.InitialIndexSet = true
 	}
-	options = fallbackRenderThemeSource().pickerOptions(options)
+	if source, err := configRenderThemeSource(homeDir, lookupEnv, ""); err == nil {
+		options = source.pickerOptions(options)
+	} else {
+		options = fallbackRenderThemeSource().pickerOptions(options)
+	}
 	return options
 }
 

--- a/internal/theme/palette.go
+++ b/internal/theme/palette.go
@@ -127,6 +127,7 @@ const (
 	TmuxPaneActiveBorderFg = "colour51"
 	TmuxPaneActiveBg       = "colour45"
 	TmuxPaneActiveFg       = "colour16"
+	TmuxPaneActiveTintBg   = "colour234" // active-pane window-active-style tint; one tone darker than surface.base (colour235)
 	TmuxMessageBg          = "colour208"
 	TmuxMessageFg          = "colour16"
 

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -189,14 +189,20 @@ type RenderRoles struct {
 	StatusFg         string // status bar fg       <- foreground      (colour245 fallback)
 
 	// pane / focus chrome.
-	PaneBorder      string // pane.border          Tier A <- muted-ish (colour236)
-	FocusBorder     string // focus.border         Tier A <- accent    (colour51)
+	PaneBorder string // pane.border          Tier A <- muted-ish (colour236)
+	// focus.border — dedicated role decoupled from accent. Tier C renderer-only:
+	// carries the literal colour51, independently tunable from the topic chip /
+	// pointer / action that still share accent. Fallback colour51 (no visual
+	// change). Phase 6 public-token candidate (focus / border).
+	FocusBorder     string
 	PaneTopicChipBg string // pane.topic_chip_bg   Tier A <- accent    (colour45)
 	PaneTopicChipFg string // pane.topic_chip_fg   Tier B <- contrastFg (colour16)
 
-	// focus.pane_active_bg — Phase 2 spike-gated NEW role. Tier B:
-	// tint(surface_active) / blend(background, surface_active). Fallback is the
-	// spike-decided colour235 (window-active-style tint).
+	// focus.pane_active_bg — active-pane window-active-style tint. Decoupled from
+	// surface_active: a dedicated Tier C renderer-only DARK tint one tone darker
+	// than surface.base, carrying the literal colour234 (fallback colour234).
+	// surface_active is a LIGHT tone (colour240) and was the wrong direction.
+	// Phase 6 public-token candidate (pane_active_bg / surface_subtle).
 	FocusPaneActiveBg string
 
 	// state / severity cluster (Phase 3). Single source for the notify HUD,
@@ -256,15 +262,18 @@ func RenderRolesFromEffective(effective EffectiveTheme) RenderRoles {
 		StatusBg:         tmuxColorOrFallback(effective.Background, TmuxWindowInactiveBg),
 		StatusFg:         tmuxColorOrFallback(effective.Foreground, TmuxWindowInactiveFg),
 
-		PaneBorder:      tmuxColorOrFallback(effective.Muted, TmuxPaneBorderFg),
-		FocusBorder:     tmuxColorOrFallback(effective.Accent, TmuxPaneActiveBorderFg),
+		PaneBorder: tmuxColorOrFallback(effective.Muted, TmuxPaneBorderFg),
+		// Tier C: focus.border decoupled from accent — carries the literal so the
+		// active-pane border is tunable independently of the topic chip / pointer
+		// / action that still derive from accent. No derivation; colour51.
+		FocusBorder:     TmuxPaneActiveBorderFg,
 		PaneTopicChipBg: tmuxColorOrFallback(effective.Accent, TmuxPaneActiveBg),
 		PaneTopicChipFg: tmuxContrastFgOrFallback(effective.Accent, TmuxPaneActiveFg),
 
-		// Tier B: tint(surface_active). The spike fixed the fallback at
-		// colour235 (matching surface.base / window-inactive bg) so the
-		// generated window-active-style line is byte-stable.
-		FocusPaneActiveBg: tmuxColorOrFallback(effective.SurfaceActive, TmuxWindowInactiveBg),
+		// Tier C: dedicated dark active-pane tint, decoupled from surface_active.
+		// Carries the literal colour234 (one tone darker than surface.base) so the
+		// active pane is visibly tinted; no derivation until Phase 6.
+		FocusPaneActiveBg: TmuxPaneActiveTintBg,
 
 		// Tier A: warning/critical follow the explicit public token so an
 		// explicit theme repaints the notify/usage/statusbar severity tints.

--- a/internal/theme/resolve_test.go
+++ b/internal/theme/resolve_test.go
@@ -86,7 +86,7 @@ func TestRenderRolesFallbackPreservesBuiltInPalette(t *testing.T) {
 		FocusBorder:       TmuxPaneActiveBorderFg,
 		PaneTopicChipBg:   TmuxPaneActiveBg,
 		PaneTopicChipFg:   TmuxPaneActiveFg,
-		FocusPaneActiveBg: TmuxWindowInactiveBg, // spike-fixed colour235
+		FocusPaneActiveBg: TmuxPaneActiveTintBg, // dedicated dark tint colour234
 		StateWarning:      TmuxStateWarningFg,
 		StateCritical:     TmuxStateCriticalFg,
 		StateProgress:     TmuxStateProgressFg,
@@ -198,17 +198,13 @@ func TestRenderRolesExplicitThemeRepaintsTierABChromeRoles(t *testing.T) {
 	fallback := RenderRolesFromEffective(ResolveTheme(ThemeConfig{}))
 
 	// Tier A/B chrome roles must follow the explicit theme, not the literal.
+	// (focus.border and focus.pane_active_bg are now dedicated Tier C roles that
+	// carry their literal verbatim, so they are intentionally not asserted here.)
 	if got.PaneBorder == fallback.PaneBorder {
 		t.Fatalf("pane.border = %q, want derived from muted, not literal", got.PaneBorder)
 	}
-	if got.FocusBorder == fallback.FocusBorder {
-		t.Fatalf("focus.border = %q, want derived from accent, not literal", got.FocusBorder)
-	}
 	if got.PaneTopicChipBg == fallback.PaneTopicChipBg {
 		t.Fatalf("pane.topic_chip_bg = %q, want derived from accent", got.PaneTopicChipBg)
-	}
-	if got.FocusPaneActiveBg == fallback.FocusPaneActiveBg {
-		t.Fatalf("focus.pane_active_bg = %q, want derived from surface_active", got.FocusPaneActiveBg)
 	}
 	// contrastFg: yellow accent is light -> dark fg.
 	if got.PaneTopicChipFg != "colour16" {


### PR DESCRIPTION
## 완료한 Phase

**Phase 5.5 — Active pane & popup chrome 보정 (Phase 6 선행).** 라이브 tmux 검증으로 드러난 active-pane/popup chrome 결함 3개를 Phase 2~5 role map 위에서 수정(새 메커니즘 없음).

## 수정한 user-facing surface

### (A) active pane 배경 tint — surface_active 분리, colour234 (의도적 시각 변경)
- 기존 `FocusPaneActiveBg = tmuxColorOrFallback(effective.SurfaceActive, colour235)`: fallback colour235 = base background 와 동일해 **tint 가 안 보였고**, surface_active(밝은 톤)는 방향이 반대.
- 수정: surface_active 파생 제거 → 전용 Tier C dark role, 신규 literal **`colour234`**(base 235 보다 한 톤 어두움). `window-active-style "bg=colour234"`.
- **byte-identity 예외(유일)**: window-active-style bg colour235 → colour234. 이건 의도적 시각 변경.

### (B) active pane border — accent 분리 (전용 role, colour51 유지)
- 기존 `FocusBorder = tmuxColorOrFallback(effective.Accent, colour51)`: accent 가 border+topic chip+pointer+action 공유라 border 독립 조정 불가.
- 수정: accent 파생 제거 → 전용 Tier C role, fallback **cyan colour51 유지**. topic chip/pointer/action 은 계속 accent 파생, border 만 독립.
- **byte-identity 유지**(colour51 동일, 시각 변화 없음). explicit accent 가 더 이상 border 를 repaint 하지 않음(의도).

### (C) popup 일관성 — notify-sidebar / recent-windows 가 global theme 따르게
- 검증 결과: switch/settings 는 `configRenderThemeSource`(effective theme) 사용 → popup frame 이 theme 따름. 그러나 **notify-sidebar(`notify.go`)·recent-windows(`recent_window.go`)는 `fallbackRenderThemeSource()`** 만 써서 global theme background/surface 무시.
- 수정: switch.go 패턴(`configRenderThemeSource`, 실패 시 fallback)으로 전환 → explicit global theme 이 두 popup frame 배경/전경에 반영. severity 칩/AI badge 의미색은 state/accent role 유지.
- **byte-identity 유지**(explicit theme 미설정 시 fallback effective 로 resolve → 동일 출력).

## 모델/스키마 제약 준수

- 전용 role(`pane_active_bg`/`focus.border`)을 public `[theme]` token 으로 노출하지 않음 — **Phase 6**.
- Settings Global/Effective 뷰 병합 안 함 — **Phase 6**.
- palette literal 삭제 없음, 기존 role map 확장만.

## 검증

- `make fmt`(no-op), `make fix`(deadcode clean), `make test`.
- focused: `go test ./internal/theme`(pass), `go test ./internal/app -run "TestTmux.*Pane|TestTmux.*Theme|Test.*Theme|TestNotify|TestRecent"`.
- 역할 값 확인: `FocusPaneActiveBg=colour234`, `FocusBorder=colour51`.
- 업데이트한 테스트: `TestRenderRolesFallbackPreservesBuiltInPalette`(FocusPaneActiveBg→colour234), `TestRenderRolesExplicitThemeRepaintsTierABChromeRoles`(FocusBorder/FocusPaneActiveBg 가 Tier C 가 됐으므로 repaint 단언 제거).
- byte-identity: window-active-style colour234 만 의도적 변경, border colour51·popup fallback 경로 동일.
- 회귀 검증: 로컬 `ko_KR` 로케일 i18n 실패(focused 7건, notify 한글 문자열)는 **base(`8caf8b3`)와 실패 집합 byte-identical** 로 확인 — Phase 5.5 회귀 0건, CI 영문 로케일 통과.

## 미검증 항목

- (A)/(C) 의 실제 시각(어두운 tint 가시성, popup 배경 theme 반영)은 lead 가 머지 후 `make install` 로 live tmux 육안 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)