### PR TITLE
feat(theme): pane vs popup background separation (Phase 6b)

### DIFF
--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -1458,9 +1458,11 @@ func tmuxAppConfigWithKeymapThemeAIBadgeStyleAndDesktopNotifyMode(binaryPath, de
 		"set -g pane-border-status top",
 		// Active-pane tint (Phase 2 spike decision: window-active-style tint,
 		// not a label chip). tmux only tints the active window's panes via
-		// window-active-style; window-style restores the default bg for the
-		// rest so inactive panes are untouched.
-		"set -g window-style \"bg=default\"",
+		// window-active-style; window-style sets the inactive-pane body bg.
+		// Phase 6b: window-style now follows the `background` token via
+		// PaneInactiveBg (fallback "default" → unset stays byte-identical),
+		// separating the general pane body from the surface-driven popup chrome.
+		"set -g window-style \"bg=" + roles.PaneInactiveBg + "\"",
 		"set -g window-active-style \"bg=" + roles.FocusPaneActiveBg + "\"",
 		"set -g pane-border-format " + tmuxConfigQuote(paneBorderFormat),
 	}

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -1403,6 +1403,62 @@ func TestTmuxConfigThemeUsesGlobal256ColorBackgroundWithoutFallbackLeak(t *testi
 	}
 }
 
+// Phase 6b: an explicit `background` (surface unset) must repaint the inactive
+// pane body (window-style follows PaneInactiveBg ← background) while the
+// surface-driven popup/chrome bg (status-style ← StatusBg) stays at the
+// fallback literal — proving pane body and popup bg are separated.
+func TestTmuxConfigExplicitBackgroundRepaintsWindowStyleNotStatus(t *testing.T) {
+	t.Parallel()
+
+	effective := theme.ResolveTheme(theme.ThemeConfig{Background: "#010203"})
+	roles := theme.RenderRolesFromEffective(effective)
+	fallbackRoles := theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{}))
+
+	output := tmuxAppConfigWithKeymapTheme("/tmp/projmux", "/bin/sh", statusbarDecorationSetFromGlobal(config.StatusbarDecorationOff), defaultKeyBindingCatalog(), false, effective)
+
+	// Pane body repaints: window-style carries the background-derived color,
+	// not the historical "bg=default".
+	if roles.PaneInactiveBg == "default" {
+		t.Fatalf("PaneInactiveBg = %q, want background-derived color", roles.PaneInactiveBg)
+	}
+	if want := "set -g window-style \"bg=" + roles.PaneInactiveBg + "\""; !strings.Contains(output, want) {
+		t.Fatalf("themed app config missing %q\n%s", want, output)
+	}
+	if strings.Contains(output, "set -g window-style \"bg=default\"") {
+		t.Fatalf("window-style still bg=default with explicit background\n%s", output)
+	}
+	// Popup/chrome bg does NOT follow background: status-style keeps the surface
+	// fallback literal.
+	if want := "set -g status-style \"bg=" + fallbackRoles.StatusBg + ",fg="; !strings.Contains(output, want) {
+		t.Fatalf("status-style should keep surface fallback bg %q (popup must not follow background)\n%s", fallbackRoles.StatusBg, output)
+	}
+}
+
+// Phase 6b: an explicit `surface` (background unset) must repaint the popup/
+// chrome bg (status-style ← StatusBg ← surface) while the general pane body
+// (window-style) stays at the historical "bg=default".
+func TestTmuxConfigExplicitSurfaceRepaintsStatusNotWindowStyle(t *testing.T) {
+	t.Parallel()
+
+	effective := theme.ResolveTheme(theme.ThemeConfig{Surface: "#ff00ff"})
+	roles := theme.RenderRolesFromEffective(effective)
+	fallbackRoles := theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{}))
+
+	output := tmuxAppConfigWithKeymapTheme("/tmp/projmux", "/bin/sh", statusbarDecorationSetFromGlobal(config.StatusbarDecorationOff), defaultKeyBindingCatalog(), false, effective)
+
+	// Popup repaints: status-style follows surface, not the fallback.
+	if roles.StatusBg == fallbackRoles.StatusBg {
+		t.Fatalf("StatusBg = %q, want repainted from explicit surface", roles.StatusBg)
+	}
+	if want := "set -g status-style \"bg=" + roles.StatusBg + ",fg="; !strings.Contains(output, want) {
+		t.Fatalf("themed app config missing surface-driven status-style %q\n%s", want, output)
+	}
+	// Pane body untouched: window-style stays bg=default.
+	if want := "set -g window-style \"bg=default\""; !strings.Contains(output, want) {
+		t.Fatalf("window-style should stay bg=default with background unset\n%s", output)
+	}
+}
+
 func TestTmuxPrintConfigNilHomeDirIgnoresRelativeKeymap(t *testing.T) {
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -215,8 +215,14 @@ type RenderRoles struct {
 	WindowInactiveFg string // text on inactive    <- foreground      (colour245 fallback)
 	WindowActiveBg   string // surface.active      <- surface_active  (colour240)
 	WindowActiveFg   string // text on active      <- foreground      (colour231 fallback)
-	StatusBg         string // status bar bg       <- background      (colour235)
-	StatusFg         string // status bar fg       <- foreground      (colour245 fallback)
+	// status bar bg — popup/chrome group (Phase 6b). Follows `surface`, NOT
+	// `background`: status-style, the native popup body, and the settings/notify/
+	// recent/picker frames all route through StatusBg, so deriving it from
+	// `surface` separates popup/chrome bg from the general pane body (which now
+	// follows `background` via PaneInactiveBg). Fallback stays the colour235
+	// literal so unset surface (≈ background) is byte-identical with before.
+	StatusBg string // status bar bg       <- surface         (colour235)
+	StatusFg string // status bar fg       <- foreground      (colour245 fallback)
 
 	// pane / focus chrome.
 	PaneBorder string // pane.border          Tier A <- muted-ish (colour236)
@@ -234,6 +240,15 @@ type RenderRoles struct {
 	// falling back to the literal colour234 when unset. surface_active is a LIGHT
 	// tone (colour240) and was the wrong direction for this role.
 	FocusPaneActiveBg string
+
+	// general/pane-body inactive bg — general (pane) bg group (Phase 6b). Tier A
+	// (public token `background`): drives tmux `window-style` for inactive panes.
+	// Fallback is the terminal default literal "default" (NOT a colour literal),
+	// so an unset background stays byte-identical with the historical
+	// `window-style "bg=default"`; an explicit background repaints the pane body.
+	// Separated from StatusBg (now surface-driven) so the pane body and popup/
+	// chrome bg can be tuned independently.
+	PaneInactiveBg string
 
 	// state / severity cluster (Phase 3). Single source for the notify HUD,
 	// usage HUD, and statusbar severity tints on the tmux side.
@@ -289,8 +304,11 @@ func RenderRolesFromEffective(effective EffectiveTheme) RenderRoles {
 		WindowInactiveFg: tmuxColorOrFallback(effective.Foreground, TmuxWindowInactiveFg),
 		WindowActiveBg:   tmuxColorOrFallback(effective.SurfaceActive, TmuxWindowActiveBg),
 		WindowActiveFg:   tmuxColorOrFallback(effective.Foreground, TmuxWindowActiveFg),
-		StatusBg:         tmuxColorOrFallback(effective.Background, TmuxWindowInactiveBg),
-		StatusFg:         tmuxColorOrFallback(effective.Foreground, TmuxWindowInactiveFg),
+		// Popup/chrome group (Phase 6b): StatusBg follows `surface`, not
+		// `background`. Fallback stays the colour235 literal so unset surface is
+		// byte-identical with before (surface fallback ≈ background).
+		StatusBg: tmuxColorOrFallback(effective.Surface, TmuxWindowInactiveBg),
+		StatusFg: tmuxColorOrFallback(effective.Foreground, TmuxWindowInactiveFg),
 
 		PaneBorder: tmuxColorOrFallback(effective.Muted, TmuxPaneBorderFg),
 		// Tier A: focus.border follows the explicit `focus` public token, falling
@@ -305,6 +323,12 @@ func RenderRolesFromEffective(effective EffectiveTheme) RenderRoles {
 		// Follows the explicit `pane_active_bg` public token, falling back to the
 		// literal colour234 (one tone darker than surface.base) when unset.
 		FocusPaneActiveBg: tmuxColorOrFallback(effective.PaneActiveBg, TmuxPaneActiveTintBg),
+
+		// General/pane bg group (Phase 6b): inactive-pane window-style follows the
+		// explicit `background` public token, falling back to the terminal default
+		// literal "default" (not a colour) so unset background keeps the historical
+		// `window-style "bg=default"` byte-identical.
+		PaneInactiveBg: tmuxColorOrFallback(effective.Background, "default"),
 
 		// Tier A: warning/critical follow the explicit public token so an
 		// explicit theme repaints the notify/usage/statusbar severity tints.

--- a/internal/theme/resolve_test.go
+++ b/internal/theme/resolve_test.go
@@ -87,6 +87,7 @@ func TestRenderRolesFallbackPreservesBuiltInPalette(t *testing.T) {
 		PaneTopicChipBg:   TmuxPaneActiveBg,
 		PaneTopicChipFg:   TmuxPaneActiveFg,
 		FocusPaneActiveBg: TmuxPaneActiveTintBg, // dedicated dark tint colour234
+		PaneInactiveBg:    "default",            // Phase 6b: terminal default literal so window-style stays bg=default when unset
 		StateWarning:      TmuxStateWarningFg,
 		StateCritical:     TmuxStateCriticalFg,
 		StateProgress:     TmuxStateProgressFg,
@@ -219,6 +220,7 @@ func TestTmuxRenderTokensUseGlobalNearest256ColorsWithoutFallbackLeak(t *testing
 
 	got := TmuxRenderTokensFromEffective(ResolveTheme(ThemeConfig{
 		Background:    "#ff0000",
+		Surface:       "#ff00ff",
 		SurfaceActive: "#0000ff",
 		Foreground:    "#00ff00",
 	}))
@@ -230,8 +232,64 @@ func TestTmuxRenderTokensUseGlobalNearest256ColorsWithoutFallbackLeak(t *testing
 	if got.WindowInactiveBg == fallback.WindowInactiveBg || got.WindowInactiveFg == fallback.WindowInactiveFg || got.WindowActiveBg == fallback.WindowActiveBg || got.WindowActiveFg == fallback.WindowActiveFg {
 		t.Fatalf("global tmux render tokens = %#v, must not reuse fallback tokens %#v", got, fallback)
 	}
-	if got.StatusBg != got.WindowInactiveBg || got.StatusFg != got.WindowInactiveFg {
-		t.Fatalf("status tokens = bg %q fg %q, want inactive window bg/fg %#v", got.StatusBg, got.StatusFg, got)
+	// Phase 6b: StatusBg follows `surface` (popup/chrome group), not `background`.
+	// With both set to different colors, StatusBg must derive from the explicit
+	// surface (no fallback leak) and must NOT equal the background-driven
+	// WindowInactiveBg — proving the popup/chrome bg is separated from the pane
+	// body bg.
+	if got.StatusBg == "" {
+		t.Fatalf("status tokens = %#v, want populated StatusBg", got)
+	}
+	if got.StatusBg == fallback.StatusBg {
+		t.Fatalf("status bg = %q, want derived from explicit surface, not fallback literal %q", got.StatusBg, fallback.StatusBg)
+	}
+	if got.StatusBg == got.WindowInactiveBg {
+		t.Fatalf("status bg = %q must not equal background-driven window inactive bg %q (surface ≠ background)", got.StatusBg, got.WindowInactiveBg)
+	}
+	if got.StatusFg != got.WindowInactiveFg {
+		t.Fatalf("status fg = %q, want inactive window fg %q", got.StatusFg, got.WindowInactiveFg)
+	}
+}
+
+// Phase 6b: an explicit `background` (surface unset) repaints the general pane
+// body (PaneInactiveBg → tmux window-style) but must NOT drag the popup/chrome
+// bg with it — StatusBg follows `surface`, which stays at the fallback literal.
+func TestRenderRolesExplicitBackgroundRepaintsPaneBodyNotPopup(t *testing.T) {
+	t.Parallel()
+
+	got := RenderRolesFromEffective(ResolveTheme(ThemeConfig{Background: "#ff0000"}))
+	fallback := RenderRolesFromEffective(ResolveTheme(ThemeConfig{}))
+
+	// Pane body repaints: PaneInactiveBg follows the explicit background and is
+	// no longer the terminal default literal.
+	if got.PaneInactiveBg == "default" {
+		t.Fatalf("pane.inactive_bg = %q, want repainted from explicit background, not \"default\"", got.PaneInactiveBg)
+	}
+	if got.PaneInactiveBg != got.WindowInactiveBg {
+		t.Fatalf("pane.inactive_bg = %q, want background-derived (= WindowInactiveBg %q)", got.PaneInactiveBg, got.WindowInactiveBg)
+	}
+	// Popup does NOT follow background: StatusBg stays at the surface fallback.
+	if got.StatusBg != fallback.StatusBg {
+		t.Fatalf("status bg = %q, want surface fallback %q (popup must not follow background)", got.StatusBg, fallback.StatusBg)
+	}
+}
+
+// Phase 6b: an explicit `surface` (background unset) repaints the popup/chrome
+// bg (StatusBg) but must NOT touch the general pane body — PaneInactiveBg stays
+// at the terminal default literal so the generated window-style is "bg=default".
+func TestRenderRolesExplicitSurfaceRepaintsPopupNotPaneBody(t *testing.T) {
+	t.Parallel()
+
+	got := RenderRolesFromEffective(ResolveTheme(ThemeConfig{Surface: "#ff00ff"}))
+	fallback := RenderRolesFromEffective(ResolveTheme(ThemeConfig{}))
+
+	// Popup repaints: StatusBg follows the explicit surface, not the fallback.
+	if got.StatusBg == fallback.StatusBg {
+		t.Fatalf("status bg = %q, want repainted from explicit surface, not fallback literal %q", got.StatusBg, fallback.StatusBg)
+	}
+	// Pane body untouched: PaneInactiveBg stays "default" (unset background).
+	if got.PaneInactiveBg != "default" {
+		t.Fatalf("pane.inactive_bg = %q, want \"default\" when background unset (pane body must not follow surface)", got.PaneInactiveBg)
 	}
 }
 


### PR DESCRIPTION
## Phase 6b — Pane(일반) 배경과 popup 배경 분리

기존 role map 구조 위에서 **새 public 토큰 추가 없이** 역할 derivation만 재배치해, 일반(페인) 배경과 팝업/chrome 배경을 분리한다.

### 설계
- **일반(general) 배경 그룹 ← `background`**
  - 비활성 페인 본문: 새 `RenderRoles.PaneInactiveBg`가 tmux `window-style`을 구동. **fallback `"default"`** — background 미설정 시 `window-style "bg=default"` 그대로(byte-identical), 설정 시 페인 본문이 그 색.
  - 활성 페인: `window-active-style` = `FocusPaneActiveBg` (colour234) — 변경 없음, 그대로 background 그룹.
- **팝업(popup) 배경 그룹 ← `surface`**
  - `StatusBg` 파생을 `background` → `surface`로 이전. fallback은 colour235 리터럴 유지(surface ≈ background → 미설정 시 byte-identical). status-style·native popup body·settings/notify/recent/picker frame이 모두 `StatusBg`를 경유하므로 이 한 줄로 팝업 chrome 전체가 surface 기준이 된다.

### 변경 파일
- `internal/theme/resolve.go` — `StatusBg` ← surface, 새 `PaneInactiveBg` ← background(fallback `"default"`)
- `internal/app/tmux.go` — `window-style "bg=default"` → `roles.PaneInactiveBg`
- `internal/theme/resolve_test.go`, `internal/app/tmux_test.go` — 분리 테스트 추가/갱신

### 검증
- **byte-identity (기본 미설정)**: `window-style "bg=default"` 유지, `status-style`/popup StatusBg=colour235 유지. 기존 golden(`TestTmuxConfigWithFallbackEffectiveThemeMatchesDefaultOutput`) golden-file 수정 없이 통과.
- 명시 `background` → 페인 본문(window-style) 색 적용, 팝업은 불변 (`TestRenderRolesExplicitBackgroundRepaintsPaneBodyNotPopup`, `TestTmuxConfigExplicitBackgroundRepaintsWindowStyleNotStatus`).
- 명시 `surface` → 팝업(StatusBg)만 분리, 페인 본문은 불변 (`TestRenderRolesExplicitSurfaceRepaintsPopupNotPaneBody`, `TestTmuxConfigExplicitSurfaceRepaintsStatusNotWindowStyle`).
- `make fmt` / `make fix` clean, `go test ./internal/theme` 통과.
- `internal/app` 의 잔존 실패 26건은 `LANG=ko_KR` 로케일 i18n 실패로 main(a3e195f)과 **동일(diff IDENTICAL) — 회귀 0**. theme/tmux/StatusBg/window-style와 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)