### PR TITLE
fix(theme): apply global theme to generated tmux chrome

### DIFF
--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -562,6 +562,22 @@ func (c *tmuxCommand) runPopupSessions(args []string, stderr io.Writer) error {
 	return nil
 }
 
+// appConfigThemeSource resolves the global user theme for generated tmux
+// config (standalone snippet and app config alike) so an explicit global
+// `[theme]` actually repaints tmux chrome — status/window styles, pane and
+// active-pane borders, and the active-pane background tint. It degrades to the
+// built-in fallback when the global config cannot be read, mirroring the
+// per-popup body-style path, so config generation never fails on a missing or
+// malformed user config. Theme is a global preference, so no project path
+// participates.
+func (c *tmuxCommand) appConfigThemeSource() renderThemeSource {
+	source, err := configRenderThemeSource(c.homeDir, c.lookupEnv, "")
+	if err != nil {
+		return fallbackRenderThemeSource()
+	}
+	return source
+}
+
 func (c *tmuxCommand) runPrintConfig(args []string, stdout, stderr io.Writer) error {
 	binaryPath, err := c.parseConfigBinary(args, "tmux print-config", stderr)
 	if err != nil {
@@ -571,7 +587,7 @@ func (c *tmuxCommand) runPrintConfig(args []string, stdout, stderr io.Writer) er
 	if err != nil {
 		return err
 	}
-	_, err = io.WriteString(stdout, fallbackRenderThemeSource().tmuxStandaloneConfigWithAIBadgeStyleAndDesktopNotifyMode(binaryPath, loadStatusbarDecorationSet(c.homeDir, c.lookupEnv), loadAIBadgeStyle(c.homeDir, c.lookupEnv), loadDesktopNotifyModeForTmuxConfig(c.homeDir, c.lookupEnv), keyBindings, keymapPresent))
+	_, err = io.WriteString(stdout, c.appConfigThemeSource().tmuxStandaloneConfigWithAIBadgeStyleAndDesktopNotifyMode(binaryPath, loadStatusbarDecorationSet(c.homeDir, c.lookupEnv), loadAIBadgeStyle(c.homeDir, c.lookupEnv), loadDesktopNotifyModeForTmuxConfig(c.homeDir, c.lookupEnv), keyBindings, keymapPresent))
 	return err
 }
 
@@ -584,7 +600,7 @@ func (c *tmuxCommand) runPrintAppConfig(args []string, stdout, stderr io.Writer)
 	if err != nil {
 		return err
 	}
-	_, err = io.WriteString(stdout, fallbackRenderThemeSource().tmuxAppConfigWithAIBadgeStyleAndDesktopNotifyMode(binaryPath, c.defaultShell(), loadStatusbarDecorationSet(c.homeDir, c.lookupEnv), loadAIBadgeStyle(c.homeDir, c.lookupEnv), loadDesktopNotifyModeForTmuxConfig(c.homeDir, c.lookupEnv), keyBindings, keymapPresent))
+	_, err = io.WriteString(stdout, c.appConfigThemeSource().tmuxAppConfigWithAIBadgeStyleAndDesktopNotifyMode(binaryPath, c.defaultShell(), loadStatusbarDecorationSet(c.homeDir, c.lookupEnv), loadAIBadgeStyle(c.homeDir, c.lookupEnv), loadDesktopNotifyModeForTmuxConfig(c.homeDir, c.lookupEnv), keyBindings, keymapPresent))
 	return err
 }
 
@@ -625,7 +641,7 @@ func (c *tmuxCommand) runInstall(args []string, stdout, stderr io.Writer) error 
 	if err != nil {
 		return err
 	}
-	if err := c.writeFile(include, []byte(fallbackRenderThemeSource().tmuxStandaloneConfigWithAIBadgeStyleAndDesktopNotifyMode(binaryPath, loadStatusbarDecorationSet(c.homeDir, c.lookupEnv), loadAIBadgeStyle(c.homeDir, c.lookupEnv), loadDesktopNotifyModeForTmuxConfig(c.homeDir, c.lookupEnv), keyBindings, keymapPresent)), 0o644); err != nil {
+	if err := c.writeFile(include, []byte(c.appConfigThemeSource().tmuxStandaloneConfigWithAIBadgeStyleAndDesktopNotifyMode(binaryPath, loadStatusbarDecorationSet(c.homeDir, c.lookupEnv), loadAIBadgeStyle(c.homeDir, c.lookupEnv), loadDesktopNotifyModeForTmuxConfig(c.homeDir, c.lookupEnv), keyBindings, keymapPresent)), 0o644); err != nil {
 		return fmt.Errorf("write tmux standalone config: %w", err)
 	}
 
@@ -681,7 +697,7 @@ func (c *tmuxCommand) writeAppConfig(binaryOverride, configOverride string) (str
 	if err != nil {
 		return "", err
 	}
-	if err := c.writeFile(config, []byte(fallbackRenderThemeSource().tmuxAppConfigWithAIBadgeStyleAndDesktopNotifyMode(binaryPath, c.defaultShell(), loadStatusbarDecorationSet(c.homeDir, c.lookupEnv), loadAIBadgeStyle(c.homeDir, c.lookupEnv), loadDesktopNotifyModeForTmuxConfig(c.homeDir, c.lookupEnv), keyBindings, keymapPresent)), 0o644); err != nil {
+	if err := c.writeFile(config, []byte(c.appConfigThemeSource().tmuxAppConfigWithAIBadgeStyleAndDesktopNotifyMode(binaryPath, c.defaultShell(), loadStatusbarDecorationSet(c.homeDir, c.lookupEnv), loadAIBadgeStyle(c.homeDir, c.lookupEnv), loadDesktopNotifyModeForTmuxConfig(c.homeDir, c.lookupEnv), keyBindings, keymapPresent)), 0o644); err != nil {
 		return "", fmt.Errorf("write tmux app config: %w", err)
 	}
 	return config, nil

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -439,6 +439,73 @@ foreground = "#aabbcc"
 	}
 }
 
+func TestTmuxPrintAppConfigAppliesGlobalThemeToPaneChrome(t *testing.T) {
+	home := t.TempDir()
+	project := filepath.Join(home, "source", "repos", "app")
+	mkdirAll(t, filepath.Join(project, ".git"))
+	// Global theme drives tmux pane chrome; the project-local [theme] is
+	// global-only-ignored migration data and must not leak into the config.
+	writeFile(t, filepath.Join(home, ".config", "projmux", "config.toml"), `
+[theme]
+background = "#0000ff"
+pane_active_bg = "#41eb3a"
+focus = "#ff0000"
+`)
+	writeFile(t, filepath.Join(project, ".projmux", "config.toml"), `
+[theme]
+background = "#102030"
+pane_active_bg = "#abcdef"
+focus = "#fedcba"
+`)
+
+	cmd := &tmuxCommand{
+		executable: func() (string, error) { return "/tmp/projmux", nil },
+		homeDir:    func() (string, error) { return home, nil },
+		lookupEnv:  func(string) string { return "" },
+		readFile:   os.ReadFile,
+	}
+
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"print-app-config"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got := stdout.String()
+
+	globalRoles := theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{
+		Background: "#0000ff", PaneActiveBg: "#41eb3a", Focus: "#ff0000",
+	}))
+	fallbackRoles := theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{}))
+	projectRoles := theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{
+		Background: "#102030", PaneActiveBg: "#abcdef", Focus: "#fedcba",
+	}))
+
+	// The global theme must repaint the active-pane border, the active-pane
+	// tint, and the inactive pane body — these used to be hardcoded to the
+	// fallback because config generation ignored the global config entirely.
+	for _, want := range []string{
+		"set -g pane-active-border-style \"fg=" + globalRoles.FocusBorder + ",bold\"",
+		"set -g window-active-style \"bg=" + globalRoles.FocusPaneActiveBg + "\"",
+		"set -g window-style \"bg=" + globalRoles.PaneInactiveBg + "\"",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("print-app-config missing global-theme chrome line %q\n--- got ---\n%s", want, got)
+		}
+	}
+
+	// Guard against regression to the fallback chrome and against the ignored
+	// project theme leaking in.
+	for _, unwanted := range []string{
+		"set -g window-active-style \"bg=" + fallbackRoles.FocusPaneActiveBg + "\"",
+		"set -g pane-active-border-style \"fg=" + fallbackRoles.FocusBorder + ",bold\"",
+		"set -g window-active-style \"bg=" + projectRoles.FocusPaneActiveBg + "\"",
+		"set -g pane-active-border-style \"fg=" + projectRoles.FocusBorder + ",bold\"",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("print-app-config leaked fallback/project chrome line %q\n--- got ---\n%s", unwanted, got)
+		}
+	}
+}
+
 func TestBuildPopupToggleWithPickerBackendStylesNativeOnly(t *testing.T) {
 	t.Parallel()
 
@@ -1769,7 +1836,14 @@ func TestTmuxRenamePaneEmptyClearsManualAITopic(t *testing.T) {
 func TestTmuxPrintAppConfigUsesIsolatedAppSettings(t *testing.T) {
 	t.Parallel()
 
-	cmd := &tmuxCommand{executable: func() (string, error) { return "/tmp/projmux", nil }}
+	// Isolate HOME so generated chrome derives from the built-in fallback, not
+	// from a developer's real global ~/.config/projmux/config.toml [theme].
+	cmd := &tmuxCommand{
+		executable: func() (string, error) { return "/tmp/projmux", nil },
+		homeDir:    func() (string, error) { return t.TempDir(), nil },
+		lookupEnv:  func(string) string { return "" },
+		readFile:   os.ReadFile,
+	}
 	var stdout bytes.Buffer
 	if err := cmd.Run([]string{"print-app-config"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)


### PR DESCRIPTION
## Summary

A user's global `~/.config/projmux/config.toml` `[theme]` was **never applied to generated tmux chrome**. The config generators — `tmux print-config`, `print-app-config`, `install`, `install-app`, and the `apply` write path — all built their output from `fallbackRenderThemeSource()` (the built-in fallback with an empty `ThemeConfig`). So status/window styles, pane borders, the active-pane border (`focus`), and the active-pane background tint (`pane_active_bg`) stayed on their fallback colours no matter what the user configured.

The role-map derivation from Phases 2–6b is correct and was unit-tested by passing an effective theme straight into the config functions — but the **CLI entry points hardcoded the fallback source**, so the "explicit global theme repaints tmux chrome" contract was never wired into generated config.

### Reproduction (before)

With `pane_active_bg`/`focus`/`background` set in the global config, `tmux print-app-config` emitted the fallback unchanged:

```
set -g pane-active-border-style "fg=colour51,bold"   # focus ignored
set -g window-style "bg=default"                      # background ignored
set -g window-active-style "bg=colour234"             # pane_active_bg ignored
```

## Fix

Resolve the global theme at these entry points through a shared `appConfigThemeSource()` helper that degrades to the built-in fallback if the global config can't be read (mirroring the existing per-popup body-style path), so generation never fails on a missing/malformed config. Theme is global-only, so no project path participates.

- **Unset global theme** → byte-identical with the previous fallback output (verified).
- **Explicit global `[theme]`** → now repaints the active-pane border, active-pane tint, inactive pane body, and status/window styles.

## Tests

- New CLI-level regression test `TestTmuxPrintAppConfigAppliesGlobalThemeToPaneChrome`: asserts `print-app-config` reflects a global `[theme]` and ignores project `[theme]`. The pre-existing tests only exercised the inner functions and missed this plumbing gap.
- `TestTmuxPrintAppConfigUsesIsolatedAppSettings` made hermetic with a temp `HOME` (it previously read the developer's real config once generation became config-aware).
- Locale-independent tmux/theme test set: all green. Full-suite FAIL set is byte-identical to `main` (44 pre-existing `ko_KR`-locale failures, unrelated; pass in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)