### PR TITLE
feat(theme): close theme apply-path gaps and add terminal-default option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,7 +179,20 @@ built-in fallback preset
 
 Settings edits the global `[theme]` in `~/.config/projmux/config.toml`. The
 Effective theme view shows the final global > built-in fallback value for each
-field with source labels: `global` or `fallback`.
+field with source labels: `global` or `fallback`. Saving or resetting a theme
+value live-applies it: projmux regenerates the generated tmux config and, when
+Settings runs inside tmux, `tmux source-file`-reloads it so a running server
+repaints immediately. Outside tmux the save still succeeds and the report
+prints `Next: run \`projmux tmux apply\`` to sync a running server.
+
+The `background`, `surface`, and `surface_active` tokens additionally accept the
+value `default` ("Terminal default" in Settings) to keep that surface at the
+terminal background. Priority is **explicit `default` > preset fill > unset
+(fallback)**, so picking a preset and then setting (for example)
+`background = "default"` keeps every other token preset-filled while the pane
+body stays at the terminal default (`window-style "bg=default"`); popup/ANSI
+surfaces emit no background sequence. `default` is only valid on these three
+tokens. See `docs/theme-palette.md` for the full sentinel contract.
 
 Project `.projmux/config.toml` `[theme]` is **deprecated and ignored**: it is no
 longer an effective theme source and does not influence the native picker,

--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -114,6 +114,24 @@ Rules:
 - An invalid color invalidates only the global layer.
 - Every effective field reports `global` or `fallback` as its source label.
 
+### Terminal default sentinel
+
+The `background`, `surface`, and `surface_active` tokens accept the special value
+`default` ("Terminal default" in Settings). It pins that surface to the terminal
+background instead of a concrete color, even when a preset is selected:
+
+- Priority is **explicit `default` > preset fill > unset (fallback)**. Setting a
+  token to `default` overrides the preset's color for that token while leaving
+  every other token preset-filled.
+- On the tmux side the derived roles emit `bg=default` (for example
+  `window-style "bg=default"` from `background`, and the surface-driven
+  `StatusBg`).
+- On the ANSI side the corresponding surface emits no background sequence (no
+  `48;2;…` / `48;5;…`), so the terminal background shows through.
+- `default` is only valid on `background` / `surface` / `surface_active`. On any
+  other token it is treated as an invalid hex color and invalidates the global
+  layer (same as any other invalid color).
+
 Historical project `[theme]` values in `.projmux/config.toml` are migration
 data only. They are not a current or target source in this contract.
 

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -787,7 +787,7 @@ func (c *aiCommand) runSettings(args []string, stdout, stderr io.Writer) error {
 	if c.nativePicker == nil {
 		return errors.New("native picker is not configured")
 	}
-	result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, intpickercompat.Options{
+	result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, c.themedPickerOptions(intpickercompat.Options{
 		UI:         "ai-settings",
 		Entries:    c.settingsRows(),
 		Title:      "AI Settings - Default split mode",
@@ -795,7 +795,7 @@ func (c *aiCommand) runSettings(args []string, stdout, stderr io.Writer) error {
 		Footer:     projmuxFooter("Choose the default split mode for future AI launches."),
 		ExpectKeys: []string{"enter"},
 		Bindings:   pickerCloseBindingsForPopupToggleMode(c.homeDir, c.lookupEnv, "ai-split-settings", "esc", "ctrl-c", "ctrl-alt-s"),
-	})
+	}))
 	if err != nil {
 		if isNoSelectionExit(err) {
 			return nil
@@ -812,7 +812,7 @@ func (c *aiCommand) runAgentPicker(direction string) (intpickercompat.Result, er
 	if c.nativePicker == nil {
 		return intpickercompat.Result{}, errors.New("native picker is not configured")
 	}
-	return runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, intpickercompat.Options{
+	return runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, c.themedPickerOptions(intpickercompat.Options{
 		UI:         "ai-picker",
 		Entries:    c.agentRows(),
 		Title:      "AI Launch - Split direction: " + direction,
@@ -820,7 +820,23 @@ func (c *aiCommand) runAgentPicker(direction string) (intpickercompat.Result, er
 		Footer:     projmuxFooter("Choose an agent or shell target to launch."),
 		ExpectKeys: []string{"enter"},
 		Bindings:   pickerCloseBindingsForPopupToggleMode(c.homeDir, c.lookupEnv, aiSplitPickerPopupMode(direction), "esc", "ctrl-c", "ctrl-alt-s"),
-	})
+	}))
+}
+
+// themedPickerOptions fills options.Theme with the global theme source so AI
+// split-picker and AI settings popups paint the themed surface/background
+// instead of the runPickerOptionBackend fallback default. It degrades to the
+// built-in fallback theme on a config read error, matching the switch.go /
+// notify.go sidebar pattern. Theme is global-only, so no project path
+// participates.
+func (c *aiCommand) themedPickerOptions(options intpickercompat.Options) intpickercompat.Options {
+	if options.Theme != nil {
+		return options
+	}
+	if source, err := configRenderThemeSource(c.homeDir, c.lookupEnv, ""); err == nil {
+		return source.pickerCompatOptions(options)
+	}
+	return fallbackRenderThemeSource().pickerCompatOptions(options)
 }
 
 func aiSplitPickerPopupMode(direction string) string {

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/aiprovider"
 	intpsmux "github.com/crevissepartners/projmux/internal/integrations/psmux"
+	"github.com/crevissepartners/projmux/internal/theme"
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
 
@@ -134,6 +135,78 @@ keys = ["M-t"]
 	}
 	if containsString(runner.options.Bindings, "alt-t:abort") {
 		t.Fatalf("AI picker bindings = %#v, direct command alias must not close popup", runner.options.Bindings)
+	}
+}
+
+func TestAIPickerAppliesGlobalThemeSurface(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "projmux", "config.toml"), `
+[theme]
+background = "#0000ff"
+surface = "#112233"
+foreground = "#ffffff"
+`)
+	runner := &capturingAIRunner{}
+	cmd := testAICommand(home)
+	cmd.runner = runner
+	cmd.nativePicker = nativePickerFromCompatRunner(runner)
+
+	if _, err := cmd.runAgentPicker("right"); err != nil {
+		t.Fatalf("runAgentPicker() error = %v", err)
+	}
+	if runner.options.Theme == nil {
+		t.Fatalf("AI picker options.Theme = nil, want global theme filled")
+	}
+	if got := runner.options.Theme.Background.Source; got != theme.SourceGlobal {
+		t.Fatalf("AI picker background source = %q, want global", got)
+	}
+	if got, want := runner.options.Theme.Surface.Value.Hex, "#112233"; got != want {
+		t.Fatalf("AI picker surface hex = %q, want %q", got, want)
+	}
+}
+
+func TestAISettingsAppliesGlobalThemeSurface(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "projmux", "config.toml"), `
+[theme]
+background = "#0000ff"
+surface = "#112233"
+`)
+	runner := &capturingAIRunner{result: intpickercompat.Result{Key: "esc"}}
+	cmd := testAICommand(home)
+	cmd.runner = runner
+	cmd.nativePicker = nativePickerFromCompatRunner(runner)
+
+	if err := cmd.Run([]string{"settings"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run settings picker error = %v", err)
+	}
+	if runner.options.Theme == nil {
+		t.Fatalf("AI settings options.Theme = nil, want global theme filled")
+	}
+	if got := runner.options.Theme.Background.Source; got != theme.SourceGlobal {
+		t.Fatalf("AI settings background source = %q, want global", got)
+	}
+}
+
+func TestAIPickerUnsetThemeMatchesFallback(t *testing.T) {
+	home := t.TempDir()
+	runner := &capturingAIRunner{}
+	cmd := testAICommand(home)
+	cmd.runner = runner
+	cmd.nativePicker = nativePickerFromCompatRunner(runner)
+
+	if _, err := cmd.runAgentPicker("right"); err != nil {
+		t.Fatalf("runAgentPicker() error = %v", err)
+	}
+	if runner.options.Theme == nil {
+		t.Fatalf("AI picker options.Theme = nil, want fallback theme filled")
+	}
+	want := theme.ResolveTheme(theme.ThemeConfig{})
+	if got := runner.options.Theme.Background.Source; got != want.Background.Source {
+		t.Fatalf("AI picker unset background source = %q, want fallback %q", got, want.Background.Source)
+	}
+	if got := runner.options.Theme.Surface.Value.Hex; got != want.Surface.Value.Hex {
+		t.Fatalf("AI picker unset surface hex = %q, want fallback %q", got, want.Surface.Value.Hex)
 	}
 }
 

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -4174,31 +4174,49 @@ func (c *settingsCommand) finishKeymapApply(path string, err error, stdout io.Wr
 		_ = writeKeymapApplyReport(stdout, report)
 		return fmt.Errorf("save keybinding: %w", err)
 	}
-	configPath, err := c.writeTmuxAppConfig()
-	if err != nil {
-		report.Prepared = keymapApplyStage{Status: keymapApplyFailed, Detail: keymapApplyDiagnostic("generated tmux config", err)}
-		report.Live = keymapApplyStage{Status: keymapApplySkipped, Detail: "generated tmux config failed"}
+	prepared, live, applyErr := c.regenerateAndReloadTmuxConfig()
+	report.Prepared = prepared
+	report.Live = live
+	if applyErr != nil {
+		if prepared.Status == keymapApplyFailed {
+			_ = writeKeymapApplyReport(stdout, report)
+			return fmt.Errorf("update keybinding runtime config: %w", applyErr)
+		}
 		_ = writeKeymapApplyReport(stdout, report)
-		return fmt.Errorf("update keybinding runtime config: %w", err)
+		return fmt.Errorf("reload active tmux keybindings: %w", applyErr)
 	}
-	report.Prepared = keymapApplyStage{Status: keymapApplyOK, Detail: "generated tmux config: " + configPath}
+	return writeKeymapApplyReport(stdout, report)
+}
+
+// regenerateAndReloadTmuxConfig is the shared post-save apply core used by both
+// the keybinding and theme Settings paths: it regenerates the generated tmux app
+// config and, when running inside tmux with a configured command runner,
+// `tmux source-file`-reloads it. It returns the Prepared and Live stages plus a
+// fatal error when either stage fails. The no-server / not-inside-tmux cases are
+// graceful (Live becomes skipped, err is nil) so the durable save still
+// succeeds and callers can surface the "run `projmux tmux apply`" follow-up.
+func (c *settingsCommand) regenerateAndReloadTmuxConfig() (prepared keymapApplyStage, live keymapApplyStage, err error) {
+	configPath, genErr := c.writeTmuxAppConfig()
+	if genErr != nil {
+		prepared = keymapApplyStage{Status: keymapApplyFailed, Detail: keymapApplyDiagnostic("generated tmux config", genErr)}
+		live = keymapApplyStage{Status: keymapApplySkipped, Detail: "generated tmux config failed"}
+		return prepared, live, genErr
+	}
+	prepared = keymapApplyStage{Status: keymapApplyOK, Detail: "generated tmux config: " + configPath}
 	if c.lookupEnv == nil || strings.TrimSpace(c.lookupEnv("TMUX")) == "" {
-		report.Live = keymapApplyStage{Status: keymapApplySkipped, Detail: "Settings is not running inside tmux"}
-		return writeKeymapApplyReport(stdout, report)
+		live = keymapApplyStage{Status: keymapApplySkipped, Detail: "Settings is not running inside tmux"}
+		return prepared, live, nil
 	}
 	if c.runCommand == nil {
-		report.Live = keymapApplyStage{Status: keymapApplySkipped, Detail: "tmux command runner is not configured"}
-		return writeKeymapApplyReport(stdout, report)
+		live = keymapApplyStage{Status: keymapApplySkipped, Detail: "tmux command runner is not configured"}
+		return prepared, live, nil
 	}
-	if c.lookupEnv != nil && strings.TrimSpace(c.lookupEnv("TMUX")) != "" && c.runCommand != nil {
-		if err := c.runCommand("tmux", "source-file", configPath); err != nil {
-			report.Live = keymapApplyStage{Status: keymapApplyFailed, Detail: keymapApplyDiagnostic("live tmux reload", err)}
-			_ = writeKeymapApplyReport(stdout, report)
-			return fmt.Errorf("reload active tmux keybindings: %w", err)
-		}
+	if reloadErr := c.runCommand("tmux", "source-file", configPath); reloadErr != nil {
+		live = keymapApplyStage{Status: keymapApplyFailed, Detail: keymapApplyDiagnostic("live tmux reload", reloadErr)}
+		return prepared, live, reloadErr
 	}
-	report.Live = keymapApplyStage{Status: keymapApplyOK}
-	return writeKeymapApplyReport(stdout, report)
+	live = keymapApplyStage{Status: keymapApplyOK}
+	return prepared, live, nil
 }
 
 type keymapApplyStatus string

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -5219,6 +5219,230 @@ func TestSettingsHubKeybindingsApplyReportsLiveReloadFailure(t *testing.T) {
 	}
 }
 
+func TestSettingsThemeColorSetLiveAppliesInsideTmux(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	var tmuxCalls [][]string
+	cmd := &settingsCommand{
+		homeDir: func() (string, error) { return home, nil },
+		lookupEnv: func(name string) string {
+			if name == "TMUX" {
+				return "/tmp/tmux,1,0"
+			}
+			return ""
+		},
+		runCommand: func(name string, args ...string) error {
+			tmuxCalls = append(tmuxCalls, append([]string{name}, args...))
+			return nil
+		},
+	}
+
+	var stdout bytes.Buffer
+	if err := cmd.setThemeColor(theme.TokenBackground, "#0000ff", &stdout); err != nil {
+		t.Fatalf("setThemeColor() error = %v", err)
+	}
+
+	configToml := readFile(t, filepath.Join(home, ".config", "projmux", "config.toml"))
+	if !strings.Contains(configToml, "#0000ff") {
+		t.Fatalf("config.toml = %q, want saved background", configToml)
+	}
+	configPath := filepath.Join(home, ".config", "projmux", "tmux.conf")
+	configText := readFile(t, configPath)
+	globalRoles := theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{Background: "#0000ff"}))
+	if !strings.Contains(configText, "set -g window-style \"bg="+globalRoles.PaneInactiveBg+"\"") {
+		t.Fatalf("generated tmux config = %q, want regenerated themed window-style", configText)
+	}
+	if !reflect.DeepEqual(tmuxCalls, [][]string{{"tmux", "source-file", configPath}}) {
+		t.Fatalf("tmux calls = %#v, want source-file app config", tmuxCalls)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "theme saved and applied\n") ||
+		!strings.Contains(got, "  Saved: ok\n") ||
+		!strings.Contains(got, "  Prepared: ok\n") ||
+		!strings.Contains(got, "  Running session: ok (updated)\n") {
+		t.Fatalf("stdout = %q, want success theme apply status", got)
+	}
+}
+
+func TestSettingsThemeColorSetOutsideTmuxShowsFollowUp(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	var tmuxCalls [][]string
+	cmd := &settingsCommand{
+		homeDir:   func() (string, error) { return home, nil },
+		lookupEnv: func(string) string { return "" },
+		runCommand: func(name string, args ...string) error {
+			tmuxCalls = append(tmuxCalls, append([]string{name}, args...))
+			return nil
+		},
+	}
+
+	var stdout bytes.Buffer
+	if err := cmd.setThemeColor(theme.TokenBackground, "#0000ff", &stdout); err != nil {
+		t.Fatalf("setThemeColor() error = %v", err)
+	}
+	if len(tmuxCalls) != 0 {
+		t.Fatalf("tmux calls = %#v, want none outside tmux", tmuxCalls)
+	}
+	configToml := readFile(t, filepath.Join(home, ".config", "projmux", "config.toml"))
+	if !strings.Contains(configToml, "#0000ff") {
+		t.Fatalf("config.toml = %q, want saved background", configToml)
+	}
+	configText := readFile(t, filepath.Join(home, ".config", "projmux", "tmux.conf"))
+	if !strings.Contains(configText, "set -g @projmux_app 1") {
+		t.Fatalf("generated tmux config = %q, want regenerated app config", configText)
+	}
+	got := stdout.String()
+	for _, want := range []string{
+		"theme apply status\n",
+		"  Saved: ok (config.toml: ",
+		"  Prepared: ok (generated tmux config: ",
+		"  Running session: skipped (Settings is not running inside tmux)\n",
+		"Next: run `projmux tmux apply` to sync a running projmux tmux server.\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestSettingsThemeResetLiveAppliesInsideTmux(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "projmux", "config.toml"), `
+[theme]
+background = "#0000ff"
+`)
+	var tmuxCalls [][]string
+	cmd := &settingsCommand{
+		homeDir: func() (string, error) { return home, nil },
+		lookupEnv: func(name string) string {
+			if name == "TMUX" {
+				return "/tmp/tmux,1,0"
+			}
+			return ""
+		},
+		runCommand: func(name string, args ...string) error {
+			tmuxCalls = append(tmuxCalls, append([]string{name}, args...))
+			return nil
+		},
+	}
+
+	var stdout bytes.Buffer
+	if err := cmd.resetTheme(&stdout); err != nil {
+		t.Fatalf("resetTheme() error = %v", err)
+	}
+	configPath := filepath.Join(home, ".config", "projmux", "tmux.conf")
+	if !reflect.DeepEqual(tmuxCalls, [][]string{{"tmux", "source-file", configPath}}) {
+		t.Fatalf("tmux calls = %#v, want source-file app config after reset", tmuxCalls)
+	}
+	// After reset the generated config returns to the fallback chrome.
+	configText := readFile(t, configPath)
+	fallbackRoles := theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{}))
+	if !strings.Contains(configText, "set -g window-style \"bg="+fallbackRoles.PaneInactiveBg+"\"") {
+		t.Fatalf("generated tmux config = %q, want fallback window-style after reset", configText)
+	}
+	if !strings.Contains(stdout.String(), "theme saved and applied\n") {
+		t.Fatalf("stdout = %q, want success theme apply status", stdout.String())
+	}
+}
+
+func TestSettingsThemeColorSetReportsLiveReloadFailure(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cmd := &settingsCommand{
+		homeDir: func() (string, error) { return home, nil },
+		lookupEnv: func(name string) string {
+			if name == "TMUX" {
+				return "/tmp/tmux,1,0"
+			}
+			return ""
+		},
+		runCommand: func(string, ...string) error {
+			return errors.New("source-file failed")
+		},
+	}
+
+	var stdout bytes.Buffer
+	err := cmd.setThemeColor(theme.TokenBackground, "#0000ff", &stdout)
+	if err == nil || !strings.Contains(err.Error(), "reload active tmux theme: source-file failed") {
+		t.Fatalf("setThemeColor() error = %v, want live reload failure", err)
+	}
+	got := stdout.String()
+	for _, want := range []string{
+		"theme apply status\n",
+		"  Saved: ok (config.toml: ",
+		"  Prepared: ok (generated tmux config: ",
+		"  Running session: failed (live tmux reload: source-file failed)\n",
+		"Recovery: fix the live tmux reload issue, then run `projmux tmux apply`.\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestSettingsThemeColorSetDefaultSentinelStoresDefault(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cmd := &settingsCommand{
+		homeDir:   func() (string, error) { return home, nil },
+		lookupEnv: func(string) string { return "" },
+	}
+
+	var stdout bytes.Buffer
+	if err := cmd.setThemeColor(theme.TokenBackground, theme.ThemeDefaultSentinel, &stdout); err != nil {
+		t.Fatalf("setThemeColor(default) error = %v", err)
+	}
+	cfg, err := cmd.currentGlobalProjectConfig()
+	if err != nil {
+		t.Fatalf("currentGlobalProjectConfig() error = %v", err)
+	}
+	if cfg.Theme.Background != theme.ThemeDefaultSentinel {
+		t.Fatalf("stored background = %q, want sentinel %q", cfg.Theme.Background, theme.ThemeDefaultSentinel)
+	}
+	// The generated config must emit bg=default for the inactive pane body.
+	configText := readFile(t, filepath.Join(home, ".config", "projmux", "tmux.conf"))
+	if !strings.Contains(configText, "set -g window-style \"bg=default\"") {
+		t.Fatalf("generated tmux config = %q, want bg=default window-style", configText)
+	}
+}
+
+func TestSettingsThemeColorSetDefaultSentinelRejectedForNonSurfaceToken(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cmd := &settingsCommand{
+		homeDir:   func() (string, error) { return home, nil },
+		lookupEnv: func(string) string { return "" },
+	}
+	if err := cmd.setThemeColor(theme.TokenForeground, theme.ThemeDefaultSentinel, &bytes.Buffer{}); err == nil {
+		t.Fatalf("setThemeColor(foreground, default) error = nil, want invalid color error")
+	}
+}
+
+func TestSettingsThemeColorEntriesOfferTerminalDefaultForSurfaceTokens(t *testing.T) {
+	t.Parallel()
+
+	cmd := &settingsCommand{
+		homeDir:   func() (string, error) { return t.TempDir(), nil },
+		lookupEnv: func(string) string { return "" },
+	}
+	bgEntries := cmd.themeColorEntries(theme.TokenBackground)
+	if !hasEntryValue(bgEntries, themeAction("color-set:"+string(theme.TokenBackground)+":"+theme.ThemeDefaultSentinel)) {
+		t.Fatalf("background entries = %#v, want Terminal default choice", bgEntries)
+	}
+	fgEntries := cmd.themeColorEntries(theme.TokenForeground)
+	if hasEntryValue(fgEntries, themeAction("color-set:"+string(theme.TokenForeground)+":"+theme.ThemeDefaultSentinel)) {
+		t.Fatalf("foreground entries = %#v, must not offer Terminal default", fgEntries)
+	}
+}
+
 func TestSettingsHubKeybindingsDirectActionsHideTypedFallback(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/shell.go
+++ b/internal/app/shell.go
@@ -367,10 +367,25 @@ func (c *shellCommand) writeAppConfig(path, binaryPath string) error {
 	if err != nil {
 		return err
 	}
-	if err := c.writeFile(path, []byte(fallbackRenderThemeSource().tmuxAppConfigWithAIBadgeStyleAndDesktopNotifyMode(binaryPath, c.defaultShell(), loadStatusbarDecorationSet(c.homeDir, c.lookupEnv), loadAIBadgeStyle(c.homeDir, c.lookupEnv), loadDesktopNotifyModeForTmuxConfig(c.homeDir, c.lookupEnv), keyBindings, keymapPresent)), 0o644); err != nil {
+	if err := c.writeFile(path, []byte(c.appConfigThemeSource().tmuxAppConfigWithAIBadgeStyleAndDesktopNotifyMode(binaryPath, c.defaultShell(), loadStatusbarDecorationSet(c.homeDir, c.lookupEnv), loadAIBadgeStyle(c.homeDir, c.lookupEnv), loadDesktopNotifyModeForTmuxConfig(c.homeDir, c.lookupEnv), keyBindings, keymapPresent)), 0o644); err != nil {
 		return fmt.Errorf("write shell app config: %w", err)
 	}
 	return nil
+}
+
+// appConfigThemeSource resolves the global user theme for the shell-start writer,
+// mirroring tmuxCommand.appConfigThemeSource: an explicit global `[theme]`
+// repaints the generated tmux chrome on `projmux shell` start instead of
+// clobbering a themed config with the built-in fallback. It degrades to the
+// fallback when the global config cannot be read so shell start never fails on a
+// missing or malformed user config. Theme is global-only, so no project path
+// participates.
+func (c *shellCommand) appConfigThemeSource() renderThemeSource {
+	source, err := configRenderThemeSource(c.homeDir, c.lookupEnv, "")
+	if err != nil {
+		return fallbackRenderThemeSource()
+	}
+	return source
 }
 
 func (c *shellCommand) writePSMuxAppConfig(path, binaryPath string) error {

--- a/internal/app/shell_test.go
+++ b/internal/app/shell_test.go
@@ -17,6 +17,7 @@ import (
 
 	intpsmux "github.com/crevissepartners/projmux/internal/integrations/psmux"
 	"github.com/crevissepartners/projmux/internal/integrations/sessionstate"
+	"github.com/crevissepartners/projmux/internal/theme"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 	"github.com/crevissepartners/projmux/internal/version"
@@ -117,6 +118,95 @@ func TestShellWritesAppConfigAndRunsIsolatedTmux(t *testing.T) {
 		if strings.HasPrefix(env, "TMUX=") {
 			t.Fatalf("runner env contains TMUX: %#v", recorder.env)
 		}
+	}
+}
+
+func TestShellWriteAppConfigAppliesGlobalThemeToPaneChrome(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "projmux", "config.toml"), `
+[theme]
+background = "#0000ff"
+pane_active_bg = "#41eb3a"
+focus = "#ff0000"
+`)
+	cmd := &shellCommand{
+		lookupEnv: func(name string) string {
+			if name == "HOME" {
+				return home
+			}
+			return ""
+		},
+		homeDir:   func() (string, error) { return home, nil },
+		readFile:  os.ReadFile,
+		writeFile: os.WriteFile,
+	}
+	configPath := filepath.Join(home, ".config", "projmux", "tmux.conf")
+	if err := cmd.writeAppConfig(configPath, "/tmp/projmux"); err != nil {
+		t.Fatalf("writeAppConfig() error = %v", err)
+	}
+	got := readFile(t, configPath)
+
+	globalRoles := theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{
+		Background: "#0000ff", PaneActiveBg: "#41eb3a", Focus: "#ff0000",
+	}))
+	fallbackRoles := theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{}))
+	for _, want := range []string{
+		"set -g pane-active-border-style \"fg=" + globalRoles.FocusBorder + ",bold\"",
+		"set -g window-active-style \"bg=" + globalRoles.FocusPaneActiveBg + "\"",
+		"set -g window-style \"bg=" + globalRoles.PaneInactiveBg + "\"",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("shell app config missing global-theme chrome line %q\n--- got ---\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{
+		"set -g window-active-style \"bg=" + fallbackRoles.FocusPaneActiveBg + "\"",
+		"set -g pane-active-border-style \"fg=" + fallbackRoles.FocusBorder + ",bold\"",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("shell app config leaked fallback chrome line %q\n--- got ---\n%s", unwanted, got)
+		}
+	}
+}
+
+func TestShellWriteAppConfigUnsetThemeMatchesFallback(t *testing.T) {
+	home := t.TempDir()
+	cmd := &shellCommand{
+		lookupEnv: func(name string) string {
+			if name == "HOME" {
+				return home
+			}
+			return ""
+		},
+		homeDir:   func() (string, error) { return home, nil },
+		readFile:  os.ReadFile,
+		writeFile: os.WriteFile,
+	}
+	configPath := filepath.Join(home, ".config", "projmux", "tmux.conf")
+	if err := cmd.writeAppConfig(configPath, "/tmp/projmux"); err != nil {
+		t.Fatalf("writeAppConfig() error = %v", err)
+	}
+	got := readFile(t, configPath)
+
+	// With no global theme, the shell-start writer must be byte-identical to the
+	// built-in fallback render (the pre-change behavior).
+	catalog, present, err := loadMergedKeyBindingCatalog(keymapLoader{
+		homeDir:   cmd.homeDir,
+		lookupEnv: cmd.lookupEnv,
+		readFile:  cmd.readFile,
+	})
+	if err != nil {
+		t.Fatalf("loadMergedKeyBindingCatalog() error = %v", err)
+	}
+	want := fallbackRenderThemeSource().tmuxAppConfigWithAIBadgeStyleAndDesktopNotifyMode(
+		"/tmp/projmux", cmd.defaultShell(),
+		loadStatusbarDecorationSet(cmd.homeDir, cmd.lookupEnv),
+		loadAIBadgeStyle(cmd.homeDir, cmd.lookupEnv),
+		loadDesktopNotifyModeForTmuxConfig(cmd.homeDir, cmd.lookupEnv),
+		catalog, present,
+	)
+	if got != want {
+		t.Fatalf("shell app config unset theme is not byte-identical to fallback\n--- got ---\n%s\n--- want ---\n%s", got, want)
 	}
 }
 

--- a/internal/app/theme_settings.go
+++ b/internal/app/theme_settings.go
@@ -231,6 +231,13 @@ func (c *settingsCommand) themeColorEntries(token theme.ColorToken) []intpickerc
 		Label: c.rowLabel(settingsGlyphType, settingsColorType, "Type hex value...", "swatch + #RRGGBB input"),
 		Value: themeAction("color-type:" + string(token)),
 	})
+	if theme.TokenSupportsDefaultSentinel(token) {
+		entries = append(entries, intpickercompat.Entry{
+			Label:     c.rowLabel(settingsGlyphAdd, settingsColorAdd, "Terminal default", "keep "+themeColorLabel(token)+" at the terminal background"),
+			Value:     themeAction("color-set:" + string(token) + ":" + theme.ThemeDefaultSentinel),
+			SearchKey: "theme terminal default background " + string(token),
+		})
+	}
 	for _, preset := range theme.PresetNames() {
 		hex, ok := theme.PresetColorHex(preset, token)
 		if !ok {
@@ -280,7 +287,14 @@ func (c *settingsCommand) setThemePreset(preset string, stdout io.Writer) error 
 
 func (c *settingsCommand) setThemeColor(token theme.ColorToken, value string, stdout io.Writer) error {
 	value = strings.TrimSpace(value)
-	if value != "" {
+	switch {
+	case value == "":
+		// clear / use preset value
+	case strings.EqualFold(value, theme.ThemeDefaultSentinel) && theme.TokenSupportsDefaultSentinel(token):
+		// terminal-default sentinel: store the normalized sentinel string verbatim
+		// so the resolver can pin the pane/popup background to the terminal default.
+		value = theme.ThemeDefaultSentinel
+	default:
 		hex, ok := theme.NormalizeHexColor(value)
 		if !ok {
 			return fmt.Errorf("invalid theme color %q", value)
@@ -310,12 +324,98 @@ func (c *settingsCommand) updateTheme(stdout io.Writer, update func(*theme.Theme
 		update(&cfg.Theme)
 		return nil
 	}); err != nil {
+		return c.finishThemeApply("", err, stdout)
+	}
+	return c.finishThemeApply(path, nil, stdout)
+}
+
+// finishThemeApply mirrors finishKeymapApply for the global theme path: after the
+// durable config.toml save it regenerates the generated tmux app config and
+// `tmux source-file`-reloads it via the shared regenerateAndReloadTmuxConfig
+// core, then emits a staged Saved/Prepared/Running session report with the same
+// graceful no-server tone ("Next: run `projmux tmux apply` ...") as the keymap
+// path. This is what makes a Settings color set/reset live-apply without a
+// manual `projmux tmux apply`.
+func (c *settingsCommand) finishThemeApply(path string, saveErr error, stdout io.Writer) error {
+	report := keymapApplyReport{
+		Saved:    keymapApplyStage{Status: keymapApplyOK},
+		Prepared: keymapApplyStage{Status: keymapApplySkipped, Detail: "waiting for saved theme"},
+		Live:     keymapApplyStage{Status: keymapApplySkipped, Detail: "waiting for prepared config"},
+	}
+	if strings.TrimSpace(path) != "" {
+		report.Saved.Detail = "config.toml: " + path
+	}
+	if saveErr != nil {
+		report.Saved = keymapApplyStage{Status: keymapApplyFailed, Detail: keymapApplyDiagnostic("config.toml", saveErr)}
+		report.Prepared = keymapApplyStage{Status: keymapApplySkipped, Detail: "theme was not saved"}
+		report.Live = keymapApplyStage{Status: keymapApplySkipped, Detail: "theme was not saved"}
+		_ = writeThemeApplyReport(stdout, report)
+		return fmt.Errorf("save theme: %w", saveErr)
+	}
+	prepared, live, applyErr := c.regenerateAndReloadTmuxConfig()
+	report.Prepared = prepared
+	report.Live = live
+	if applyErr != nil {
+		_ = writeThemeApplyReport(stdout, report)
+		if prepared.Status == keymapApplyFailed {
+			return fmt.Errorf("update theme runtime config: %w", applyErr)
+		}
+		return fmt.Errorf("reload active tmux theme: %w", applyErr)
+	}
+	return writeThemeApplyReport(stdout, report)
+}
+
+// writeThemeApplyReport renders the theme apply staging report. It reuses the
+// keymap report stage/line helpers for identical formatting but with
+// theme-appropriate headline and recovery wording.
+func writeThemeApplyReport(w io.Writer, report keymapApplyReport) error {
+	if w == nil {
+		return nil
+	}
+	if report.Saved.Status == keymapApplyOK && report.Prepared.Status == keymapApplyOK && report.Live.Status == keymapApplyOK {
+		if _, err := fmt.Fprintln(w, "theme saved and applied"); err != nil {
+			return err
+		}
+		for _, line := range []string{
+			keymapApplyLine("Saved", report.Saved, false),
+			keymapApplyLine("Prepared", report.Prepared, false),
+			keymapApplyLine("Running session", report.Live, false),
+		} {
+			if _, err := fmt.Fprintln(w, line); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if _, err := fmt.Fprintln(w, "theme apply status"); err != nil {
 		return err
 	}
-	if stdout != nil {
-		_, err = fmt.Fprintf(stdout, "wrote %s\n", path)
+	for _, line := range []string{
+		keymapApplyLine("Saved", report.Saved, true),
+		keymapApplyLine("Prepared", report.Prepared, true),
+		keymapApplyLine("Running session", report.Live, true),
+	} {
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return err
+		}
 	}
-	return err
+	switch {
+	case report.Saved.Status == keymapApplyFailed:
+		_, err := fmt.Fprintln(w, "Recovery: fix the config.toml problem, then try the Settings change again.")
+		return err
+	case report.Prepared.Status == keymapApplyFailed:
+		_, err := fmt.Fprintln(w, "Recovery: resolve the generated tmux config error, then run `projmux tmux apply`.")
+		return err
+	case report.Live.Status == keymapApplyFailed:
+		_, err := fmt.Fprintln(w, "Recovery: fix the live tmux reload issue, then run `projmux tmux apply`.")
+		return err
+	case report.Live.Status == keymapApplySkipped:
+		_, err := fmt.Fprintln(w, "Next: run `projmux tmux apply` to sync a running projmux tmux server.")
+		return err
+	default:
+		return nil
+	}
 }
 
 func themeAction(action string) string {
@@ -354,6 +454,9 @@ func themeColorSummary(cfg theme.ThemeConfig, token theme.ColorToken) string {
 		}
 		return "unset"
 	}
+	if strings.EqualFold(value, theme.ThemeDefaultSentinel) {
+		return "Terminal default - overrides preset fill"
+	}
 	if cfg.Preset != "" && !strings.EqualFold(cfg.Preset, "inherit") {
 		if presetHex, ok := theme.PresetColorHex(cfg.Preset, token); ok {
 			if strings.EqualFold(value, presetHex) {
@@ -372,6 +475,9 @@ func themeColorSummary(cfg theme.ThemeConfig, token theme.ColorToken) string {
 // "fallback" source so the merged Global view surfaces the effective value inline
 // (replacing the removed Effective theme view).
 func themeColorSummaryEffective(cfg theme.ThemeConfig, effective theme.EffectiveTheme, token theme.ColorToken) string {
+	if strings.EqualFold(themeColorFieldValue(cfg, token), theme.ThemeDefaultSentinel) {
+		return "Terminal default - overrides preset fill"
+	}
 	if themeColorFieldValue(cfg, token) != "" || strings.TrimSpace(cfg.Preset) != "" {
 		return themeColorSummary(cfg, token)
 	}
@@ -424,6 +530,9 @@ func effectiveColorField(effective theme.EffectiveTheme, token theme.ColorToken)
 
 func themeColorCurrentValue(cfg theme.ThemeConfig, token theme.ColorToken) string {
 	value := themeColorFieldValue(cfg, token)
+	if strings.EqualFold(value, theme.ThemeDefaultSentinel) {
+		return "Terminal default"
+	}
 	if value != "" {
 		return value
 	}
@@ -437,6 +546,11 @@ func themeColorCurrentValue(cfg theme.ThemeConfig, token theme.ColorToken) strin
 
 func themeColorInitialQuery(cfg theme.ThemeConfig, token theme.ColorToken) string {
 	value := themeColorFieldValue(cfg, token)
+	if strings.EqualFold(value, theme.ThemeDefaultSentinel) {
+		// The sentinel is not a hex value; start the hex input empty so the user
+		// can type a color (Terminal default is set via its own row).
+		return "#"
+	}
 	if value != "" {
 		return value
 	}

--- a/internal/theme/ansiroles.go
+++ b/internal/theme/ansiroles.go
@@ -199,10 +199,15 @@ func ansi256FGOrLiteral(field ColorField, literal string) string {
 }
 
 // ansiBGFGOrLiteral pairs an explicit background field with a fixed foreground
-// escape; fallback returns the literal verbatim.
+// escape; fallback returns the literal verbatim. When the background field is the
+// terminal-default sentinel it emits the foreground escape only, so the surface
+// inherits the terminal background (no 48;2 sequence).
 func ansiBGFGOrLiteral(bg ColorField, fg, literal string) string {
 	if bg.Source == SourceFallback {
 		return literal
+	}
+	if IsThemeDefaultSpec(bg.Value) {
+		return fg
 	}
 	if b := bg.Value.TruecolorBG(); b != "" {
 		return "\x1b[" + b + "m" + fg
@@ -219,8 +224,17 @@ func ansiBGFieldFGFieldOrLiteral(bg, fg ColorField, literal string) string {
 	if bg.Source == SourceFallback && fg.Source == SourceFallback {
 		return literal
 	}
-	b := bg.Value.TruecolorBG()
 	f := fg.Value.TruecolorFG()
+	// Terminal-default sentinel background: emit the foreground escape only so the
+	// surface inherits the terminal background (no 48;2 sequence). Fall back to a
+	// foreground-token escape when the fg side is itself a fallback.
+	if IsThemeDefaultSpec(bg.Value) {
+		if f != "" {
+			return "\x1b[" + f + "m"
+		}
+		return literal
+	}
+	b := bg.Value.TruecolorBG()
 	if b == "" || f == "" {
 		return literal
 	}

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -637,6 +637,25 @@ func resolveLayer(input layerInput) (resolvedLayer, []Warning, bool) {
 		if !hasThemeValue(item.value) {
 			continue
 		}
+		// "terminal default" sentinel: only background/surface(/surface_active)
+		// support pinning the pane/popup background to the terminal default. This
+		// is treated as a real explicit value so it overrides the preset fill
+		// within the global layer (explicit default > preset). It must be
+		// intercepted BEFORE normalizeHexColor, which would reject "default" and
+		// drop the whole layer. A ColorSpec with no Hex and Tmux="default" makes
+		// the tmux roles emit `bg=default` and the ANSI surfaces fall back to the
+		// terminal background (no 48;2 / 48;5 sequence).
+		if isThemeDefaultSentinel(item.value) {
+			if tokenSupportsDefaultSentinel(item.token) {
+				colors[item.token] = ColorSpec{Tmux: ThemeDefaultSentinel}
+				continue
+			}
+			warnings = append(warnings, Warning{
+				Source: input.source, Field: string(item.token), Value: item.value,
+				Message: "terminal default is only valid for background/surface; ignored this theme layer",
+			})
+			return resolvedLayer{}, warnings, false
+		}
 		hex, ok := normalizeHexColor(item.value)
 		if !ok {
 			warnings = append(warnings, Warning{
@@ -673,6 +692,43 @@ func resolveString(layers []resolvedLayer, value func(resolvedLayer) (string, bo
 func hasThemeValue(value string) bool {
 	value = strings.TrimSpace(value)
 	return value != "" && strings.EqualFold(value, "inherit") == false
+}
+
+// ThemeDefaultSentinel is the explicit "terminal default" value a user can set
+// on the background/surface(/surface_active) tokens. It pins the pane/popup
+// background to the terminal default even when a preset is chosen
+// (explicit default > preset fill > unset/fallback). On the tmux side it surfaces
+// as `bg=default`; on the ANSI side it produces no background sequence so the
+// terminal background shows through.
+const ThemeDefaultSentinel = "default"
+
+// isThemeDefaultSentinel reports whether value is the terminal-default sentinel.
+func isThemeDefaultSentinel(value string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), ThemeDefaultSentinel)
+}
+
+// tokenSupportsDefaultSentinel restricts the "default" sentinel to the
+// background/surface family. Other tokens treat "default" as an invalid hex.
+func tokenSupportsDefaultSentinel(token ColorToken) bool {
+	switch token {
+	case TokenBackground, TokenSurface, TokenSurfaceActive:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsThemeDefaultSpec reports whether a resolved ColorSpec is the terminal-default
+// sentinel (no Hex, Tmux == "default"). Renderers use this to emit a terminal
+// reset / `bg=default` instead of a concrete color.
+func IsThemeDefaultSpec(spec ColorSpec) bool {
+	return strings.TrimSpace(spec.Hex) == "" && spec.Tmux == ThemeDefaultSentinel
+}
+
+// TokenSupportsDefaultSentinel is the exported predicate Settings uses to decide
+// whether to offer the "Terminal default" choice for a token.
+func TokenSupportsDefaultSentinel(token ColorToken) bool {
+	return tokenSupportsDefaultSentinel(token)
 }
 
 var hexColorPattern = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)

--- a/internal/theme/resolve_test.go
+++ b/internal/theme/resolve_test.go
@@ -54,6 +54,92 @@ func TestResolveThemeExplicitColorOverridesPreset(t *testing.T) {
 	}
 }
 
+func TestResolveThemeDefaultSentinelOverridesPresetForBackground(t *testing.T) {
+	t.Parallel()
+
+	got := ResolveTheme(ThemeConfig{Preset: "forest", Background: "default", Surface: "default"})
+
+	if !IsThemeDefaultSpec(got.Background.Value) || got.Background.Source != SourceGlobal {
+		t.Fatalf("background = %#v, want global terminal-default sentinel", got.Background)
+	}
+	if !IsThemeDefaultSpec(got.Surface.Value) || got.Surface.Source != SourceGlobal {
+		t.Fatalf("surface = %#v, want global terminal-default sentinel", got.Surface)
+	}
+	// SurfaceActive was not set to default, so it keeps the preset fill.
+	if got.SurfaceActive.Value.Hex == "" || got.SurfaceActive.Source != SourceGlobal {
+		t.Fatalf("surface_active = %#v, want preset-filled value, not default", got.SurfaceActive)
+	}
+}
+
+func TestResolveThemeDefaultSentinelEmitsTmuxDefaultRole(t *testing.T) {
+	t.Parallel()
+
+	roles := RenderRolesFromEffective(ResolveTheme(ThemeConfig{Preset: "forest", Background: "default", Surface: "default"}))
+	if roles.PaneInactiveBg != "default" {
+		t.Fatalf("PaneInactiveBg = %q, want default (sentinel beats preset)", roles.PaneInactiveBg)
+	}
+	if roles.StatusBg != "default" {
+		t.Fatalf("StatusBg = %q, want default (surface sentinel)", roles.StatusBg)
+	}
+}
+
+func TestResolveThemeDefaultSentinelOnlyValidForBackgroundSurface(t *testing.T) {
+	t.Parallel()
+
+	// "default" on a non-surface token (foreground) is treated as invalid hex and
+	// drops that global layer, so resolution falls back to the built-in preset.
+	got := ResolveTheme(ThemeConfig{Foreground: "default"})
+	if got.Foreground.Source != SourceFallback {
+		t.Fatalf("foreground = %#v, want fallback (default invalid for non-surface tokens)", got.Foreground)
+	}
+	if len(got.Warnings) == 0 {
+		t.Fatalf("warnings = %#v, want a warning for default on a non-surface token", got.Warnings)
+	}
+}
+
+func TestResolveThemeDefaultSentinelANSIResetsSurface(t *testing.T) {
+	t.Parallel()
+
+	ansi := ANSIRolesFromEffective(ResolveTheme(ThemeConfig{Preset: "forest", Surface: "default", Foreground: "#ffffff"}))
+	// SurfaceRaised must not contain a background sequence (48;2) when surface is
+	// the terminal-default sentinel; the foreground escape is still present.
+	if containsBGSequence(ansi.SurfaceRaised) {
+		t.Fatalf("SurfaceRaised = %q, want no background sequence for terminal-default surface", ansi.SurfaceRaised)
+	}
+}
+
+func containsBGSequence(s string) bool {
+	for _, marker := range []string{"48;2;", "48;5;"} {
+		if indexOf(s, marker) >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestResolveThemeUnsetByteIdenticalWithoutSentinel(t *testing.T) {
+	t.Parallel()
+
+	// Sentinel handling must not perturb the unset/default resolution.
+	got := ResolveTheme(ThemeConfig{})
+	want := RenderRolesFromEffective(got)
+	if want.PaneInactiveBg != "default" {
+		t.Fatalf("unset PaneInactiveBg = %q, want historical default literal", want.PaneInactiveBg)
+	}
+	if got.Background.Source != SourceFallback {
+		t.Fatalf("unset background source = %q, want fallback", got.Background.Source)
+	}
+}
+
 func TestTmuxRenderTokensFallbackPreservesBuiltInPalette(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

The previous Theme track resolves the global `[theme]` at the `tmux.go` generated-config entry points (PR #453), but three apply paths still rendered the built-in fallback theme, and a preset could not coexist with a terminal-default pane/popup background. This PR closes all four gaps. The semantic role map (`RenderRoles`/`ANSIRoles`) and the global-only source model are unchanged.

## Completed phases

- **P1 — Theme change live apply (Settings).** Extracted the post-save apply core (regenerate generated tmux config + `tmux source-file` reload + staged report) out of `finishKeymapApply` into a shared `regenerateAndReloadTmuxConfig`; `updateTheme`/`resetTheme` run it via `finishThemeApply`. A Settings color set/reset now live-reloads exactly like a keybinding save. No-server / not-in-tmux stays graceful (durable save + "run `projmux tmux apply`" follow-up). Keymap report output is byte-for-byte unchanged.
- **P2 — Generated-config theme coverage on shell start.** `shell.go` `writeAppConfig` rendered with `fallbackRenderThemeSource()`, so `projmux shell` start clobbered a themed config. It now renders via the global theme source (degrade to fallback on read error), matching `tmux.go`'s `appConfigThemeSource()`. (`writePSMuxAppConfig` has no theme tokens — no gap.)
- **P3 — AI split popups honor global theme.** `ai.go` `runAgentPicker`/`runSettings` fill `options.Theme` via `configRenderThemeSource` before `runPickerOptionBackend` (the `switch.go`/`notify.go` pattern), so the AI split picker and AI settings popups paint the themed surface/background.
- **P4 — Terminal/sh default background option.** `resolve.go` accepts a `default` sentinel on `background`/`surface`/`surface_active` only, intercepted before `normalizeHexColor` and treated as a real explicit value so **explicit default > preset fill > unset**. tmux roles emit `bg=default`; ANSI surfaces emit no background sequence. Settings offers a "Terminal default" row for those tokens.

## Modified surfaces

`internal/theme/resolve.go`, `internal/theme/ansiroles.go`, `internal/app/{settings,theme_settings,shell,ai}.go`, `docs/{configuration,theme-palette}.md` (+ focused tests).

## Excluded (out of scope)

Theme marketplace / import-export, font adapter, layout values as public tokens, role-map redesign. P4 sentinel limited to the background/surface family (no `default` on other tokens, no new color token).

## Model constraints honored

- No `RenderRoles`/`ANSIRoles` redesign — existing derivation reused.
- No project `[theme]` revival — global-only.
- Unset/default generated config + ANSI output preserved byte-identical (golden tests).
- No new color token beyond the `default` sentinel.

## Verification

- `go build ./...` clean.
- Full suite **green under `LC_ALL=C`**.
- Default **ko_KR locale failure set is identical to `main`** (46 sub-tests, pre-existing i18n env issue) — **0 regressions** introduced. Diff of failing-test names branch-vs-main is empty.
- New tests: resolver sentinel (override-preset, tmux `default`, surface-only validity, ANSI reset, unset byte-identity); Settings theme live-apply in/out of tmux + reload-failure + sentinel store/offer; shell-start writer themed + unset byte-identity; AI picker/settings themed + unset byte-identity.

### P3 audit — `runPickerOptionBackend` callers

AI picker + AI settings now themed. Already-themed: `settings.go` runPicker, `switch.go:1871`, `notify.go:320`. Intentionally left on fallback (out of this scope, candidates for a follow-up): switch settings/add-pin popups, project-startup, Projects>Sessions popups, `session_state` popup picker. `quit.go` is fallback-only by construction (`quitCommand` has no `homeDir`).

## Unverified / follow-ups

- Real `tmux source-file` live reload against a running server (P1) and on-screen rendering of themed AI popups / `bg=default` surfaces are asserted at the data/string level only — **e2e candidates**.
- Theming the remaining fallback-only popups from the P3 audit (additive, each needs its own test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)