### PR TITLE
fix(i18n): honor global config [ui] locale in picker chrome localization

### DIFF
--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -787,7 +787,7 @@ func (c *aiCommand) runSettings(args []string, stdout, stderr io.Writer) error {
 	if c.nativePicker == nil {
 		return errors.New("native picker is not configured")
 	}
-	result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, c.themedPickerOptions(intpickercompat.Options{
+	result, err := runPickerOptionBackend(c.homeDir, c.lookupEnv, c.nativePicker, c.runner, c.themedPickerOptions(intpickercompat.Options{
 		UI:         "ai-settings",
 		Entries:    c.settingsRows(),
 		Title:      "AI Settings - Default split mode",
@@ -812,7 +812,7 @@ func (c *aiCommand) runAgentPicker(direction string) (intpickercompat.Result, er
 	if c.nativePicker == nil {
 		return intpickercompat.Result{}, errors.New("native picker is not configured")
 	}
-	return runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, c.themedPickerOptions(intpickercompat.Options{
+	return runPickerOptionBackend(c.homeDir, c.lookupEnv, c.nativePicker, c.runner, c.themedPickerOptions(intpickercompat.Options{
 		UI:         "ai-picker",
 		Entries:    c.agentRows(),
 		Title:      localizeUIText(appLocale(c.homeDir, c.lookupEnv), "AI Launch - Split direction: ") + direction,

--- a/internal/app/native_picker.go
+++ b/internal/app/native_picker.go
@@ -7,12 +7,12 @@ import (
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
 
-func runPickerOptionBackend(lookupEnv func(string) string, native intpicker.Runner, compat intpickercompat.Runner, options intpickercompat.Options) (intpickercompat.Result, error) {
+func runPickerOptionBackend(homeDir func() (string, error), lookupEnv func(string) string, native intpicker.Runner, compat intpickercompat.Runner, options intpickercompat.Options) (intpickercompat.Result, error) {
 	_ = compat
 	if native == nil {
 		return intpickercompat.Result{}, fmt.Errorf("native picker is not configured")
 	}
-	options = localizePickerOptions(lookupEnv, options)
+	options = localizePickerOptions(homeDir, lookupEnv, options)
 	if options.Theme == nil {
 		options = fallbackRenderThemeSource().pickerCompatOptions(options)
 	}
@@ -26,13 +26,18 @@ func runPickerOptionBackend(lookupEnv func(string) string, native intpicker.Runn
 // (notify routes its own intpicker.Options separately).
 //
 // The active locale is taken from options.Locale when a caller already resolved
-// it (Settings sets this); otherwise it is resolved from the environment the
-// same way the rest of the app does via appLocale. Translation is idempotent,
-// so Settings localizing first and this layer re-localizing is a safe no-op.
-func localizePickerOptions(lookupEnv func(string) string, options intpickercompat.Options) intpickercompat.Options {
+// it (Settings sets this); otherwise it is resolved the same way the rest of
+// the app does via appLocale, which MUST receive the command's homeDir so the
+// global config `[ui] locale` override is honored. Passing a nil homeDir here
+// silently skips that override (appGlobalLocaleOverride returns "" for nil) and
+// falls through to the ambient LANG — which would render Korean chrome for a
+// user who pinned `[ui] locale = "en-US"` under a ko_KR terminal. Translation
+// is idempotent only when both passes resolve the SAME locale, so resolving the
+// real locale here is also what keeps Settings' own pre-localization a no-op.
+func localizePickerOptions(homeDir func() (string, error), lookupEnv func(string) string, options intpickercompat.Options) intpickercompat.Options {
 	locale := options.Locale
 	if locale == "" {
-		locale = appLocale(nil, lookupEnv)
+		locale = appLocale(homeDir, lookupEnv)
 	}
 	options.Locale = locale
 	options.Title = localizeUIText(locale, options.Title)

--- a/internal/app/native_picker_locale_test.go
+++ b/internal/app/native_picker_locale_test.go
@@ -1,0 +1,78 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
+)
+
+// localeLookupEnv builds a lookupEnv that pins the ambient locale env rungs.
+// It returns LANG=lang and empty for the higher-priority rungs so the global
+// config [ui] locale override is what must win.
+func localeLookupEnv(lang string) func(string) string {
+	return func(name string) string {
+		switch name {
+		case "LANG":
+			return lang
+		case "PROJMUX_LOCALE", "LC_ALL", "LC_MESSAGES", "XDG_CONFIG_HOME":
+			return ""
+		default:
+			return ""
+		}
+	}
+}
+
+// TestLocalizePickerOptionsHonorsConfigLocaleOverEnv reproduces the live bug a
+// user hit: global config pins `[ui] locale = "en-US"` while the terminal's
+// ambient LANG is ko_KR.UTF-8. The picker chrome (footers/titles) must render
+// English, because the config locale outranks LANG. Before the fix the shared
+// choke point resolved the locale with a nil homeDir, which skipped the config
+// override and fell through to LANG, rendering Korean chrome.
+func TestLocalizePickerOptionsHonorsConfigLocaleOverEnv(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "projmux", "config.toml"), `
+[ui]
+locale = "en-US"
+`)
+	homeDir := func() (string, error) { return home, nil }
+
+	const englishFooter = "Enter: apply  |  Back row: parent"
+	got := localizePickerOptions(homeDir, localeLookupEnv("ko_KR.UTF-8"), intpickercompat.Options{
+		Footer: englishFooter,
+	})
+	if got.Footer != englishFooter {
+		t.Fatalf("footer = %q, want English %q (config [ui] locale=en-US must outrank ambient LANG=ko_KR)", got.Footer, englishFooter)
+	}
+	if got.Locale != "en-US" {
+		t.Fatalf("resolved locale = %q, want en-US from global config override", got.Locale)
+	}
+}
+
+// TestLocalizePickerOptionsLocalizesWhenConfigKorean is the companion control:
+// with the config pinned to ko-KR the same registered footer must localize to
+// Korean, proving the choke point actually translates (so the test above is
+// guarding behavior, not a no-op path).
+func TestLocalizePickerOptionsLocalizesWhenConfigKorean(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "projmux", "config.toml"), `
+[ui]
+locale = "ko-KR"
+`)
+	homeDir := func() (string, error) { return home, nil }
+
+	const englishFooter = "Enter: apply  |  Back row: parent"
+	got := localizePickerOptions(homeDir, localeLookupEnv("en_US.UTF-8"), intpickercompat.Options{
+		Footer: englishFooter,
+	})
+	if got.Locale != "ko-KR" {
+		t.Fatalf("resolved locale = %q, want ko-KR from global config override", got.Locale)
+	}
+	if got.Footer == englishFooter {
+		t.Fatalf("footer = %q, want Korean translation (config [ui] locale=ko-KR must localize the registered footer)", got.Footer)
+	}
+}

--- a/internal/app/native_picker_test.go
+++ b/internal/app/native_picker_test.go
@@ -36,6 +36,7 @@ func TestRunPickerOptionBackendUsesNativeWhenRequested(t *testing.T) {
 	})
 
 	result, err := runPickerOptionBackend(
+		func() (string, error) { return "", nil },
 		func(name string) string {
 			if name == intpicker.BackendEnv {
 				return "native"
@@ -76,6 +77,7 @@ func TestRunPickerOptionBackendUsesSavedNativeBackend(t *testing.T) {
 	var compatCalled bool
 	nativeCalled := false
 	result, err := runPickerOptionBackend(
+		func() (string, error) { return "", nil },
 		func(name string) string {
 			switch name {
 			case intpicker.BackendEnv:
@@ -123,6 +125,7 @@ func TestRunPickerOptionBackendDefaultsToNativeBackend(t *testing.T) {
 	var compatCalled bool
 	var nativeCalled bool
 	result, err := runPickerOptionBackend(
+		func() (string, error) { return "", nil },
 		func(name string) string {
 			switch name {
 			case intpicker.BackendEnv:
@@ -164,6 +167,7 @@ func TestRunPickerOptionBackendPopulatesFallbackTheme(t *testing.T) {
 
 	var gotTheme *theme.EffectiveTheme
 	_, err := runPickerOptionBackend(
+		func() (string, error) { return "", nil },
 		func(string) string { return "" },
 		pickerRunnerFunc(func(options intpicker.Options) (intpicker.Result, error) {
 			gotTheme = options.Theme
@@ -192,6 +196,7 @@ func TestRunPickerOptionBackendPreservesSuppliedTheme(t *testing.T) {
 	})
 	var gotTheme *theme.EffectiveTheme
 	_, err := runPickerOptionBackend(
+		func() (string, error) { return "", nil },
 		func(string) string { return "" },
 		pickerRunnerFunc(func(options intpicker.Options) (intpicker.Result, error) {
 			gotTheme = options.Theme
@@ -224,6 +229,7 @@ func TestRunPickerOptionBackendIgnoresDeprecatedBackendEnvOverride(t *testing.T)
 	var nativeCalled bool
 	var compatCalled bool
 	result, err := runPickerOptionBackend(
+		func() (string, error) { return "", nil },
 		func(name string) string {
 			if name == intpicker.BackendEnv {
 				return "fzf"
@@ -259,6 +265,7 @@ func TestRunPickerOptionBackendErrorsWhenNativeMissingWithoutCallingCompatRunner
 
 	var compatCalled bool
 	_, err := runPickerOptionBackend(
+		func() (string, error) { return "", nil },
 		func(name string) string {
 			if name == intpicker.BackendEnv {
 				return "fzf"

--- a/internal/app/project_startup.go
+++ b/internal/app/project_startup.go
@@ -111,7 +111,7 @@ func (c *switchCommand) pickProjectStartupMode(sessionName, target string) proje
 	if len(candidates) == 0 {
 		return projectStartupCandidate{Kind: projectStartupKindEmpty}
 	}
-	result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, projectStartupPickerOptions(candidates))
+	result, err := runPickerOptionBackend(c.homeDir, c.lookupEnv, c.nativePicker, c.runner, projectStartupPickerOptions(candidates))
 	if err != nil {
 		return projectStartupCandidate{Kind: projectStartupKindEmpty}
 	}

--- a/internal/app/quit.go
+++ b/internal/app/quit.go
@@ -67,7 +67,7 @@ func (c *quitCommand) Run(args []string, stdout, stderr io.Writer) error {
 }
 
 func (c *quitCommand) pickAction() (string, error) {
-	result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.picker, quitActionOptions())
+	result, err := runPickerOptionBackend(os.UserHomeDir, c.lookupEnv, c.nativePicker, c.picker, quitActionOptions())
 	if err != nil {
 		if isNoSelectionExit(err) {
 			return "", nil

--- a/internal/app/session_state.go
+++ b/internal/app/session_state.go
@@ -227,7 +227,7 @@ func (c *sessionStateCommand) runPopup(args []string, stdout, stderr io.Writer) 
 }
 
 func (c *sessionStateCommand) runPopupPicker(options intpickercompat.Options) (intpickercompat.Result, error) {
-	result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, nil, options)
+	result, err := runPickerOptionBackend(c.homeDir, c.lookupEnv, c.nativePicker, nil, options)
 	if err != nil {
 		if isNoSelectionExit(err) {
 			return intpickercompat.Result{}, errSettingsClosed

--- a/internal/app/sessions.go
+++ b/internal/app/sessions.go
@@ -155,7 +155,7 @@ func (c *sessionsCommand) Run(args []string, stdout, stderr io.Writer) error {
 		if err != nil {
 			return err
 		}
-		result, err := runPickerOptionBackend(c.lookupEnv, c.native, c.runner, intpickercompat.Options{
+		result, err := runPickerOptionBackend(c.homeDir, c.lookupEnv, c.native, c.runner, intpickercompat.Options{
 			UI:      *ui,
 			Entries: rowsToEntries(rows),
 			Prompt:  "› ",
@@ -214,7 +214,7 @@ func (c *sessionsCommand) Run(args []string, stdout, stderr io.Writer) error {
 
 func (c *sessionsCommand) runSessionStateOverview(sessionName string, summaries []inttmux.RecentSessionSummary) error {
 	entries := c.sessionStateOverviewEntries(sessionName, summaries)
-	result, err := runPickerOptionBackend(c.lookupEnv, c.native, c.runner, intpickercompat.Options{
+	result, err := runPickerOptionBackend(c.homeDir, c.lookupEnv, c.native, c.runner, intpickercompat.Options{
 		UI:            "projects-sessions-state",
 		Entries:       entries,
 		Title:         "Projects > Sessions > State",

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -393,7 +393,7 @@ func (c *settingsCommand) runPicker(options intpickercompat.Options) (intpickerc
 			options = source.pickerCompatOptions(options)
 		}
 	}
-	result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, options)
+	result, err := runPickerOptionBackend(c.homeDir, c.lookupEnv, c.nativePicker, c.runner, options)
 	if err != nil {
 		if isNoSelectionExit(err) {
 			return intpickercompat.Result{}, errSettingsClosed
@@ -410,7 +410,7 @@ func (c *settingsCommand) runPicker(options intpickercompat.Options) (intpickerc
 // environment, and translation is idempotent so there is no double-translation.
 func (c *settingsCommand) localizeSettingsOptions(options intpickercompat.Options) intpickercompat.Options {
 	options.Locale = c.locale()
-	return localizePickerOptions(c.lookupEnv, options)
+	return localizePickerOptions(c.homeDir, c.lookupEnv, options)
 }
 
 func (c *settingsCommand) locale() i18n.Locale {

--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -463,7 +463,7 @@ func (c *switchCommand) runSettings(stdout, stderr io.Writer) error {
 			return err
 		}
 
-		result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, intpickercompat.Options{
+		result, err := runPickerOptionBackend(c.homeDir, c.lookupEnv, c.nativePicker, c.runner, intpickercompat.Options{
 			UI:      "settings",
 			Entries: entries,
 		})
@@ -519,7 +519,7 @@ func (c *switchCommand) runAddPinInteractive(stdout io.Writer) error {
 		return nil
 	}
 
-	result, err := runPickerOptionBackend(c.lookupEnv, c.nativePicker, c.runner, intpickercompat.Options{
+	result, err := runPickerOptionBackend(c.homeDir, c.lookupEnv, c.nativePicker, c.runner, intpickercompat.Options{
 		UI:      "pin",
 		Entries: entries,
 	})


### PR DESCRIPTION
## Bug (reported live)

A user with `[ui] locale = "en-US"` in `~/.config/projmux/config.toml`, running a **ko_KR.UTF-8** terminal, saw **Korean footers** in Settings depth-1 and the AI-split picker (e.g. `Enter 적용 …`) even though their resolved app locale is en-US.

## Root cause

The shared picker localization choke point added in #455 resolved the locale with `appLocale(**nil**, lookupEnv)`. `appLocale` only reads the global config `[ui] locale` override when it has a homeDir (`appGlobalLocaleOverride` returns `""` for nil), so the override was silently skipped and resolution fell through to ambient `LANG=ko_KR`. The footers were doubly wrong: an already-English literal is still a registered catalog key, so the ko-KR pass translated it to Korean.

Locale priority is `PROJMUX_LOCALE > [ui] locale (config) > LC_ALL > LC_MESSAGES > LANG`, so config en-US must win over ambient ko_KR — Settings itself was correct (it uses `c.locale()` = `appLocale(c.homeDir, …)`); only the non-Settings choke point dropped the homeDir.

## Fix

Thread the command's `homeDir` through `runPickerOptionBackend` → `localizePickerOptions` → `appLocale(homeDir, lookupEnv)`, so the choke point honors the config override exactly as Settings does. All call sites pass `c.homeDir`; `quitCommand` (no homeDir field) passes `os.UserHomeDir`.

## Regression test

`native_picker_locale_test.go` reproduces the exact scenario at the choke point:
- config `[ui] locale=en-US` + ambient `LANG=ko_KR` → footer stays **English** (this **fails** against the pre-fix nil-homeDir resolution — verified by reverting).
- config `locale=ko-KR` → the same registered footer localizes to **Korean** (proves the path is not a no-op).

## Why #455 missed it

The #455 `TestMain` pins ambient `LANG=en_US` for the test package, so the config-override path (config≠ambient) was never exercised. This test injects an explicit `lookupEnv` returning `LANG=ko_KR`, independent of `TestMain`.

## Verification
- `make fmt` / `make fix` clean; `make test` **fully green**.
- New tests pass with fix, fail without (revert-proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)