### PR TITLE
fix(i18n): settingsLocale honors global config [ui] locale (footers/labels)

### DIFF
--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -472,7 +472,7 @@ func (c *settingsCommand) rootOptions(tab settingsRootTab) intpickercompat.Optio
 // handling so a primary-button click on the chip resolves through the
 // same tab-resolution path as the keyboard chord.
 func settingsRootTabChips(active settingsRootTab, hasProject bool) []projmuxpicker.Chip {
-	return settingsRootTabChipsLocale(active, hasProject, settingsLocaleFromEnv())
+	return settingsRootTabChipsLocale(active, hasProject, settingsLocale())
 }
 
 func settingsRootTabChipsLocale(active settingsRootTab, hasProject bool, locale i18n.Locale) []projmuxpicker.Chip {
@@ -492,7 +492,7 @@ func settingsRootTabChipsLocale(active settingsRootTab, hasProject bool, locale 
 }
 
 func settingsPassiveRootTabChips(active settingsRootTab, hasProject bool) []projmuxpicker.Chip {
-	chips := settingsPassiveRootTabChipsLocale(active, hasProject, settingsLocaleFromEnv())
+	chips := settingsPassiveRootTabChipsLocale(active, hasProject, settingsLocale())
 	return chips
 }
 
@@ -518,7 +518,7 @@ func settingsRootContextHeader(tab settingsRootTab, ctx settingsProjectContext) 
 }
 
 func settingsRootPrompt(tab settingsRootTab) string {
-	return settingsRootPromptLocale(tab, settingsLocaleFromEnv())
+	return settingsRootPromptLocale(tab, settingsLocale())
 }
 
 func settingsRootPromptLocale(tab settingsRootTab, locale i18n.Locale) string {
@@ -568,7 +568,7 @@ func (c *settingsCommand) rootEntries() []intpickercompat.Entry {
 }
 
 func (c *settingsCommand) rootEntriesForTab(tab settingsRootTab) []intpickercompat.Entry {
-	return c.rootEntriesForTabLocale(tab, settingsLocaleFromEnv())
+	return c.rootEntriesForTabLocale(tab, settingsLocale())
 }
 
 func (c *settingsCommand) rootEntriesForTabLocale(tab settingsRootTab, locale i18n.Locale) []intpickercompat.Entry {
@@ -579,7 +579,7 @@ func (c *settingsCommand) rootEntriesForTabLocale(tab settingsRootTab, locale i1
 }
 
 func (c *settingsCommand) rootEntriesForAxis(axis SettingsAxis) []intpickercompat.Entry {
-	return c.rootEntriesForAxisLocale(axis, settingsLocaleFromEnv())
+	return c.rootEntriesForAxisLocale(axis, settingsLocale())
 }
 
 func (c *settingsCommand) rootEntriesForAxisLocale(axis SettingsAxis, locale i18n.Locale) []intpickercompat.Entry {
@@ -644,7 +644,7 @@ var (
 )
 
 func settingsRootLabel(glyph, name, description string) string {
-	return settingsRootLabelLocale(settingsLocaleFromEnv(), glyph, name, description)
+	return settingsRootLabelLocale(settingsLocale(), glyph, name, description)
 }
 
 func settingsRootLabelLocale(locale i18n.Locale, glyph, name, description string) string {
@@ -652,11 +652,11 @@ func settingsRootLabelLocale(locale i18n.Locale, glyph, name, description string
 }
 
 func settingsRootLabelDim(name, description string) string {
-	return settingsRootLabelWithColorLocale(settingsLocaleFromEnv(), settingsGlyphInfo, settingsRootColorDim, name, description)
+	return settingsRootLabelWithColorLocale(settingsLocale(), settingsGlyphInfo, settingsRootColorDim, name, description)
 }
 
 func settingsRootLabelWithColor(glyph, color, name, description string) string {
-	return settingsRootLabelWithColorLocale(settingsLocaleFromEnv(), glyph, color, name, description)
+	return settingsRootLabelWithColorLocale(settingsLocale(), glyph, color, name, description)
 }
 
 func settingsRootLabelWithColorLocale(locale i18n.Locale, glyph, color, name, description string) string {
@@ -682,7 +682,7 @@ func settingsRootLabelWithColorLocale(locale i18n.Locale, glyph, color, name, de
 }
 
 func (c *settingsCommand) sessionStateSettingsRootLabel() string {
-	return c.sessionStateSettingsRootLabelLocale(settingsLocaleFromEnv())
+	return c.sessionStateSettingsRootLabelLocale(settingsLocale())
 }
 
 func (c *settingsCommand) sessionStateSettingsRootLabelLocale(locale i18n.Locale) string {
@@ -1203,7 +1203,7 @@ func (c *settingsCommand) runAddWorkdir(stdout, stderr io.Writer) error {
 // bypasses the filesystem scan and lets the user type an absolute path
 // directly. Useful for heavy WSL mounts (/mnt/c/Users/...), large NFS, etc.
 func settingsWorkdirTypedEntry() intpickercompat.Entry {
-	return settingsWorkdirTypedEntryLocale(settingsLocaleFromEnv())
+	return settingsWorkdirTypedEntryLocale(settingsLocale())
 }
 
 func settingsWorkdirTypedEntryLocale(locale i18n.Locale) intpickercompat.Entry {
@@ -1463,7 +1463,7 @@ func (c *settingsCommand) projectRootEntryLocale(locale i18n.Locale) intpickerco
 }
 
 func (c *settingsCommand) projectRootHintEntry() intpickercompat.Entry {
-	return c.projectRootHintEntryLocale(settingsLocaleFromEnv())
+	return c.projectRootHintEntryLocale(settingsLocale())
 }
 
 func (c *settingsCommand) projectRootHintEntryLocale(locale i18n.Locale) intpickercompat.Entry {
@@ -2267,7 +2267,7 @@ func (c *settingsCommand) aiNotifyDiagnosticByID(id string) (doctorAINotifyInteg
 }
 
 func aiNotifyDiagnosticEntry(diag doctorAINotifyIntegration) intpickercompat.Entry {
-	return aiNotifyDiagnosticEntryLocale(settingsLocaleFromEnv(), diag)
+	return aiNotifyDiagnosticEntryLocale(settingsLocale(), diag)
 }
 
 func aiNotifyDiagnosticEntryLocale(locale i18n.Locale, diag doctorAINotifyIntegration) intpickercompat.Entry {
@@ -2301,7 +2301,7 @@ func aiNotifyDiagnosticTone(status doctorAINotifyStatus) (string, string) {
 }
 
 func aiNotifyDiagnosticDetailEntries(diag doctorAINotifyIntegration) []intpickercompat.Entry {
-	return aiNotifyDiagnosticDetailEntriesLocale(settingsLocaleFromEnv(), diag)
+	return aiNotifyDiagnosticDetailEntriesLocale(settingsLocale(), diag)
 }
 
 func aiNotifyDiagnosticDetailEntriesLocale(locale i18n.Locale, diag doctorAINotifyIntegration) []intpickercompat.Entry {
@@ -2331,7 +2331,7 @@ func aiNotifyDiagnosticDetailEntriesLocale(locale i18n.Locale, diag doctorAINoti
 }
 
 func aiNotifyDiagnosticCommandEntry(diag doctorAINotifyIntegration, kind, label, command string) intpickercompat.Entry {
-	return aiNotifyDiagnosticCommandEntryLocale(settingsLocaleFromEnv(), diag, kind, label, command)
+	return aiNotifyDiagnosticCommandEntryLocale(settingsLocale(), diag, kind, label, command)
 }
 
 func aiNotifyDiagnosticCommandEntryLocale(locale i18n.Locale, diag doctorAINotifyIntegration, kind, label, command string) intpickercompat.Entry {
@@ -5157,7 +5157,7 @@ func (c *settingsCommand) welcomeSettingsViewerOptions() intpickercompat.Options
 }
 
 func settingsBackEntry() intpickercompat.Entry {
-	return settingsBackEntryLocale(settingsLocaleFromEnv())
+	return settingsBackEntryLocale(settingsLocale())
 }
 
 func settingsBackEntryLocale(locale i18n.Locale) intpickercompat.Entry {

--- a/internal/app/settings_i18n.go
+++ b/internal/app/settings_i18n.go
@@ -472,8 +472,18 @@ var uiTextKeys = map[string]i18n.Key{
 // uiTextKeys / localizeUIText directly.
 var settingsTextKeys = uiTextKeys
 
-func settingsLocaleFromEnv() i18n.Locale {
-	return appLocale(nil, os.Getenv)
+// settingsLocale resolves the active UI locale for package-level eager
+// localization helpers that have no *settingsCommand (and therefore no
+// injected homeDir) — e.g. projmuxFooter, settingsLabel, and the settings root
+// chips/prompts/entries. It MUST pass os.UserHomeDir, not nil: appLocale only
+// honors the global config `[ui] locale` override when it can read the global
+// config, and a nil homeDir makes appGlobalLocaleOverride return "" so the
+// override is silently dropped and resolution falls through to the ambient
+// LANG. That nil was the bug behind footers/labels rendering Korean for a user
+// who pinned `[ui] locale = "en-US"` under a ko_KR terminal. The command-bound
+// path already does the right thing via (*settingsCommand).locale().
+func settingsLocale() i18n.Locale {
+	return appLocale(os.UserHomeDir, os.Getenv)
 }
 
 // localizeUIText is the shared UI localization entry point. Given the active
@@ -490,7 +500,7 @@ func localizeUIText(locale i18n.Locale, fallback string) string {
 }
 
 func settingsCatalogText(fallback string) string {
-	return settingsCatalogTextLocale(settingsLocaleFromEnv(), fallback)
+	return settingsCatalogTextLocale(settingsLocale(), fallback)
 }
 
 func settingsCatalogTextLocale(locale i18n.Locale, fallback string) string {

--- a/internal/app/settings_locale_test.go
+++ b/internal/app/settings_locale_test.go
@@ -1,0 +1,57 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestProjmuxFooterHonorsGlobalConfigLocale reproduces the live bug: a user
+// pinned `[ui] locale = "en-US"` in the global config while their terminal's
+// ambient LANG is ko_KR.UTF-8. Picker footers (and other package-level eager
+// localizations that route through settingsLocale) must render English,
+// because the config locale outranks LANG. Before the fix settingsLocale
+// resolved with a nil homeDir, which skipped the global config override and
+// fell through to LANG, rendering Korean footers even when the resolved app
+// locale is en-US.
+//
+// The config is injected via XDG_CONFIG_HOME so the test does not depend on the
+// developer's real ~/.config. t.Setenv forbids t.Parallel here.
+func TestProjmuxFooterHonorsGlobalConfigLocale(t *testing.T) {
+	configHome := t.TempDir()
+	writeFile(t, filepath.Join(configHome, "projmux", "config.toml"), `
+[ui]
+locale = "en-US"
+`)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("LANG", "ko_KR.UTF-8")
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LC_MESSAGES", "")
+	t.Setenv("PROJMUX_LOCALE", "")
+
+	const englishFooter = "Enter: apply  |  Back row: parent"
+	if got := projmuxFooter(englishFooter); got != englishFooter {
+		t.Fatalf("projmuxFooter = %q, want English %q (config [ui] locale=en-US must outrank ambient LANG=ko_KR)", got, englishFooter)
+	}
+}
+
+// TestProjmuxFooterLocalizesWhenConfigKorean is the companion control: with the
+// config pinned to ko-KR the same registered footer must localize to Korean,
+// proving settingsLocale actually resolves and translates (so the test above is
+// guarding behavior, not a no-op).
+func TestProjmuxFooterLocalizesWhenConfigKorean(t *testing.T) {
+	configHome := t.TempDir()
+	writeFile(t, filepath.Join(configHome, "projmux", "config.toml"), `
+[ui]
+locale = "ko-KR"
+`)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("LANG", "en_US.UTF-8")
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LC_MESSAGES", "")
+	t.Setenv("PROJMUX_LOCALE", "")
+
+	const englishFooter = "Enter: apply  |  Back row: parent"
+	if got := projmuxFooter(englishFooter); got == englishFooter {
+		t.Fatalf("projmuxFooter = %q, want Korean translation (config [ui] locale=ko-KR must localize the registered footer)", got)
+	}
+}

--- a/internal/app/settings_render.go
+++ b/internal/app/settings_render.go
@@ -54,7 +54,7 @@ const settingsLabelNameWidth = 24
 // without a glyph align with rows that use a single-cell glyph (followed by
 // the standard two-space gap before the name column).
 func settingsLabel(glyph, color, name, description string) string {
-	return settingsLabelLocale(settingsLocaleFromEnv(), glyph, color, name, description)
+	return settingsLabelLocale(settingsLocale(), glyph, color, name, description)
 }
 
 func settingsLabelLocale(locale i18n.Locale, glyph, color, name, description string) string {
@@ -91,7 +91,7 @@ func settingsLabelLocale(locale i18n.Locale, glyph, color, name, description str
 // is wrapped in the dim color so it visually recedes, and no action color
 // is applied to the name column.
 func settingsLabelDim(name, description string) string {
-	return settingsLabelDimLocale(settingsLocaleFromEnv(), name, description)
+	return settingsLabelDimLocale(settingsLocale(), name, description)
 }
 
 func settingsLabelDimLocale(locale i18n.Locale, name, description string) string {
@@ -120,7 +120,7 @@ func settingsLabelDimLocale(locale i18n.Locale, name, description string) string
 // name is a static label, the value is the resolved data, and the source
 // annotation explains where the value came from.
 func settingsLabelInfo(name, value, source string) string {
-	return settingsLabelInfoLocale(settingsLocaleFromEnv(), name, value, source)
+	return settingsLabelInfoLocale(settingsLocale(), name, value, source)
 }
 
 func settingsLabelInfoLocale(locale i18n.Locale, name, value, source string) string {


### PR DESCRIPTION
## Bug (still reproduced after #456)

A user with `[ui] locale = "en-US"` in `~/.config/projmux/config.toml`, on a **ko_KR.UTF-8** terminal, still saw **Korean footers** in Settings depth-1 and the AI-split picker after #456.

## Root cause (the second nil-homeDir)

#456 fixed the picker choke point (`localizePickerOptions`), but footers/labels are localized **eagerly at construction time** by package-level helpers — `projmuxFooter`, `settingsLabel/Dim/Info`, the settings root chips/prompts/entries — all funneling through `settingsLocaleFromEnv()` = `appLocale(**nil**, os.Getenv)`.

The nil homeDir makes `appGlobalLocaleOverride` return `""`, so the global config `[ui] locale` override is silently dropped and resolution falls through to ambient `LANG=ko_KR`. So `projmuxFooter("Choose…")` produced the **Korean** string at the call site; the choke point then received an already-Korean literal (not a registered English key) and left it as-is.

Why the picker **title** looked English but the **footer** was Korean (verified via a real PTY capture): the title is pre-localized through the homeDir-aware `appLocale` *and* then gets the dynamic direction appended (making it a non-key), so it can't reveal the locale; the footer is a registered key and exposed the wrong (ko-KR) resolution.

## Fix

`settingsLocale()` (renamed from `settingsLocaleFromEnv`, since it now consults config) resolves `appLocale(os.UserHomeDir, os.Getenv)`, honoring the config override exactly as the command-bound `(*settingsCommand).locale()` already does. One change covers every eager package-level localization (footers, labels, chips, prompts).

## Regression test

`settings_locale_test.go` injects the config via `XDG_CONFIG_HOME`:
- config `[ui] locale=en-US` + ambient `LANG=ko_KR` → `projmuxFooter` stays **English** (fails against the pre-fix nil homeDir — verified by reverting).
- config `locale=ko-KR` → the same registered footer localizes to **Korean**.

## Verification
- Confirmed via PTY capture of the real `ai picker` render that the footer was Korean pre-fix; English post-fix.
- `make fmt` / `make fix` clean; `make test` **fully green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)