### PR TITLE
feat(theme): theme remaining pickers by default at the choke point

### DIFF
--- a/internal/app/native_picker.go
+++ b/internal/app/native_picker.go
@@ -14,7 +14,18 @@ func runPickerOptionBackend(homeDir func() (string, error), lookupEnv func(strin
 	}
 	options = localizePickerOptions(homeDir, lookupEnv, options)
 	if options.Theme == nil {
-		options = fallbackRenderThemeSource().pickerCompatOptions(options)
+		// Theme-by-default: a picker that does not pre-resolve its own theme
+		// still gets the global `[theme]` so explicit background/surface reaches
+		// every popup, not just the surfaces (switch/notify/ai/settings/recent)
+		// that inject configRenderThemeSource themselves. Degrade to the built-in
+		// fallback only when the global config cannot be read, so an unset theme
+		// stays byte-identical with the historical fallback output. Theme is
+		// global-only, so no project path participates.
+		if source, err := configRenderThemeSource(homeDir, lookupEnv, ""); err == nil {
+			options = source.pickerCompatOptions(options)
+		} else {
+			options = fallbackRenderThemeSource().pickerCompatOptions(options)
+		}
 	}
 	result, err := native.Run(intpickercompat.PickerOptions(options))
 	return intpickercompat.ResultFromPicker(result), err

--- a/internal/app/native_picker_theme_test.go
+++ b/internal/app/native_picker_theme_test.go
@@ -1,0 +1,58 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/theme"
+	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
+)
+
+// TestRunPickerOptionBackendThemesFromGlobalConfigWhenUnset is the picker-
+// theming coverage guard: a picker that does NOT pre-resolve its own theme
+// (options.Theme == nil) — sessions, session_state, project_startup, quit, and
+// the switch sub-pickers — must still pick up the explicit global `[theme]` at
+// the shared choke point, instead of falling back to the built-in default. The
+// global config is injected via XDG_CONFIG_HOME so the test is hermetic.
+func TestRunPickerOptionBackendThemesFromGlobalConfigWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	configHome := t.TempDir()
+	writeFile(t, filepath.Join(configHome, "projmux", "config.toml"), `
+[theme]
+background = "#010203"
+surface = "#040506"
+foreground = "#aabbcc"
+`)
+	lookupEnv := func(name string) string {
+		if name == "XDG_CONFIG_HOME" {
+			return configHome
+		}
+		return ""
+	}
+
+	var gotTheme *theme.EffectiveTheme
+	_, err := runPickerOptionBackend(
+		func() (string, error) { return configHome, nil },
+		lookupEnv,
+		pickerRunnerFunc(func(options intpicker.Options) (intpicker.Result, error) {
+			gotTheme = options.Theme
+			return intpicker.Result{Key: "enter", Value: "x"}, nil
+		}),
+		nil,
+		intpickercompat.Options{UI: "sessions"},
+	)
+	if err != nil {
+		t.Fatalf("runPickerOptionBackend() error = %v", err)
+	}
+	if gotTheme == nil {
+		t.Fatal("native picker Theme = nil, want global-config effective theme")
+	}
+	if gotTheme.Background.Source != theme.SourceGlobal || gotTheme.Background.Value.Hex != "#010203" {
+		t.Fatalf("Background = %#v, want global #010203 (explicit global [theme] must theme an unset picker)", gotTheme.Background)
+	}
+	if gotTheme.Surface.Value.Hex != "#040506" {
+		t.Fatalf("Surface = %q, want global #040506", gotTheme.Surface.Value.Hex)
+	}
+}


### PR DESCRIPTION
## Summary

Theme apply completeness themed the core surfaces (switch/notify/ai/settings/recent) by injecting `configRenderThemeSource` per call site. But the shared picker entry point (`runPickerOptionBackend`) still fell back to the **unthemed** built-in default whenever a caller didn't pre-resolve `options.Theme`. So the standalone pickers ignored an explicit global `[theme]` and rendered their popup background/surface with the fallback palette:

- `sessions.go` (sessions / Projects > Sessions)
- `session_state.go`
- `project_startup.go`
- `quit.go`
- `switch.go` sub-pickers (add-pin, kill-confirm, settings sub)

## Fix (choke-point, mirrors #456)

`runPickerOptionBackend` already receives `homeDir`/`lookupEnv` (from the locale fix), so when `options.Theme == nil` resolve the global theme via `configRenderThemeSource(homeDir, lookupEnv, "")` and degrade to `fallbackRenderThemeSource` only on a config read error. **One change** themes every previously-unthemed picker and makes future pickers themed by default. Callers that already set `options.Theme` short-circuit — no double application.

## Constraints honored

- **Unset theme byte-identical**: `configRenderThemeSource` with no global `[theme]` resolves the fallback preset — the same source the unconditional fallback used.
- Semantic colors (severity/AI badge/git/trust) unchanged — only background/surface chrome.
- Theme is global-only; no project path participates; no new tokens; no role-map redesign.

## Tests

- New `TestRunPickerOptionBackendThemesFromGlobalConfigWhenUnset` (XDG_CONFIG_HOME-injected `[theme]`): an unset picker now reflects global `background`/`surface`; **fails** against the pre-fix unconditional fallback (verified by reverting).
- Existing `TestRunPickerOptionBackendPopulatesFallbackTheme` / `…PreservesSuppliedTheme` still hold.
- `make fmt` / `make fix` clean; `make test` fully green.

## Follow-up (not in scope)
- Real-tmux on-screen render of themed popups is an e2e visual follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)