### PR TITLE
feat(theme): preset design rubric + fix midnight state-color collision (P1)

### DIFF
--- a/internal/theme/preset_design_test.go
+++ b/internal/theme/preset_design_test.go
@@ -1,0 +1,66 @@
+package theme
+
+import "testing"
+
+// TestPresetTokensSatisfyDesignRubric enforces the Phase 1 design-quality
+// rubric hard rules on every built-in preset (and so on any preset added
+// later). WCAG contrast is a design guideline tracked separately; only the
+// three hard rules below are machine-enforced because they catch the failures
+// that make chrome unreadable or semantically ambiguous:
+//
+//	(a) the five state colors (progress/warning/critical/success/
+//	    action_required) resolve to mutually distinct tmux colourN — you must
+//	    be able to tell the states apart by color.
+//	(b) muted resolves distinct from both foreground and background — low-
+//	    signal text must still read.
+//	(c) foreground != background.
+//
+// projmux-dark is the built-in fallback baseline: its values are frozen to
+// preserve unset-theme byte-identity across the renderer goldens, and it
+// historically maps warning and progress to the same amber (they appear on
+// different surfaces). It is therefore exempt from rule (a) ONLY. Rules (b)/(c)
+// still apply to it.
+func TestPresetTokensSatisfyDesignRubric(t *testing.T) {
+	stateTokens := []ColorToken{TokenProgress, TokenWarning, TokenCritical, TokenSuccess, TokenActionRequired}
+	exemptStateDistinct := map[string]bool{"projmux-dark": true}
+
+	colourOf := func(t *testing.T, preset string, tok ColorToken) string {
+		t.Helper()
+		hex, ok := PresetColorHex(preset, tok)
+		if !ok {
+			t.Fatalf("%s: token %s unset; every preset must define all tokens", preset, tok)
+		}
+		return nearestTmuxColor(hex)
+	}
+
+	for _, preset := range PresetNames() {
+
+		// (a) state colors mutually distinct.
+		if !exemptStateDistinct[preset] {
+			seen := map[string]ColorToken{}
+			for _, tok := range stateTokens {
+				cn := colourOf(t, preset, tok)
+				if prev, dup := seen[cn]; dup {
+					t.Errorf("%s: state colors %s and %s both resolve to %s; the five state colors must be distinguishable", preset, prev, tok, cn)
+				}
+				seen[cn] = tok
+			}
+		}
+
+		// (b) muted distinct from foreground and background.
+		muted := colourOf(t, preset, TokenMuted)
+		fg := colourOf(t, preset, TokenForeground)
+		bg := colourOf(t, preset, TokenBackground)
+		if muted == fg {
+			t.Errorf("%s: muted (%s) equals foreground; low-signal text would be indistinguishable", preset, muted)
+		}
+		if muted == bg {
+			t.Errorf("%s: muted (%s) equals background; muted text would be invisible", preset, muted)
+		}
+
+		// (c) foreground != background.
+		if fg == bg {
+			t.Errorf("%s: foreground equals background (%s)", preset, fg)
+		}
+	}
+}

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -480,7 +480,7 @@ var builtinPresets = map[string]preset{
 		Colors: presetColors(map[ColorToken]string{
 			TokenBackground: "#101820", TokenSurface: "#16242d", TokenSurfaceActive: "#253844",
 			TokenForeground: "#e7eef2", TokenMuted: "#8296a1", TokenAccent: "#7bd3c6",
-			TokenCritical: "#ff6b7a", TokenWarning: "#ffd166",
+			TokenCritical: "#ff6b7a", TokenWarning: "#e6a23c",
 			TokenProgress: "#ffcc66", TokenSuccess: "#5faf87", TokenActionRequired: "#ffaf00",
 			TokenPaneActiveBg: "#1c1c1c", TokenFocus: "#00ffff",
 		}),


### PR DESCRIPTION
## Summary

First slice of the **Theme design quality** round (P1): establish a machine-enforced design rubric for built-in presets and fix the failure it surfaces.

## Rubric (`internal/theme/preset_design_test.go`)

Hard rules enforced on every preset (and any future one):
- **(a)** the five state colors (`progress`/`warning`/`critical`/`success`/`action_required`) resolve to **mutually distinct** tmux `colourN` — you must be able to tell the states apart by color.
- **(b)** `muted` resolves distinct from `foreground` and `background`.
- **(c)** `foreground` != `background`.

WCAG contrast stays a documented **guideline**, not a machine gate — 256-color quantization and user preference make strict WCAG impractical. (Rationale recorded in the roadmap + Theme token inventory note.)

## Audit finding + fix

Auditing the 5 presets found `progress == warning` (both `#ffcc66` → `colour221`) in **projmux-dark** and **midnight**.

- **projmux-dark** is the built-in **fallback baseline** — frozen to preserve unset-theme byte-identity, and warning/progress share amber historically while rendering on different surfaces. Exempt from rule (a) only; rules (b)/(c) still apply.
- **midnight** is tunable: `warning` `#ffd166` → `#e6a23c` (`colour179` gold), giving a clean 3-way amber tier (`progress` 221 / `warning` 179 / `action_required` 214).
- forest/rose/high-contrast already pass; muted/fg/bg rules pass for all 5.

## Constraints
- **No fallback byte-identity change** — projmux-dark untouched.
- Public 13-token schema unchanged; role map unchanged; no semantic recoloring beyond the one collision fix.

## Tests
- `TestPresetTokensSatisfyDesignRubric` passes; reverting the midnight fix **and** un-exempting projmux-dark makes it fail on both collisions (verified).
- `make fmt` / `make fix` clean; `make test` fully green.

## Follow-up (next PR, same round)
- P2: terminal-native preset(s) using the `default` background sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)