### PR TITLE
feat(theme): add terminal-native preset using default backgrounds (P2)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -257,10 +257,13 @@ active-pane background tint, and `focus` is the active-pane border color. Each
 of these is a public token: leave it unset to keep the historical built-in
 color, or set it to repaint the matching chrome.
 
-Supported presets are `projmux-dark`, `midnight`, `forest`, `rose`, and
-`high-contrast`. A preset fills missing color tokens, and explicit color tokens
-override preset values. Tokens the global theme leaves unset fall through to the
-built-in fallback preset.
+Supported presets are `projmux-dark`, `midnight`, `forest`, `rose`,
+`high-contrast`, and `terminal`. A preset fills missing color tokens, and
+explicit color tokens override preset values. Tokens the global theme leaves
+unset fall through to the built-in fallback preset. The `terminal` preset is
+terminal-native: its `background`/`surface` use the `default` sentinel so the
+terminal's own background shows through, with foreground/accent/state tuned for
+a dark terminal.
 
 Unknown presets and invalid color values invalidate only the global theme
 source and produce resolver warnings; the built-in fallback still resolves

--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -142,6 +142,12 @@ Built-in preset config values are:
 - `forest`
 - `rose`
 - `high-contrast`
+- `terminal` — terminal-native: `background`/`surface` ride the terminal's own
+  background via the `default` sentinel (no colour literal), so projmux only
+  paints foreground/accent/state chrome on top. Foreground does not support the
+  sentinel, so the foreground, muted, and selection-tint values are tuned for a
+  dark terminal (the common projmux host); on a light terminal, set those tokens
+  explicitly or pick another preset.
 
 ## Fallback Inventory
 

--- a/internal/theme/preset_design_test.go
+++ b/internal/theme/preset_design_test.go
@@ -24,22 +24,30 @@ func TestPresetTokensSatisfyDesignRubric(t *testing.T) {
 	stateTokens := []ColorToken{TokenProgress, TokenWarning, TokenCritical, TokenSuccess, TokenActionRequired}
 	exemptStateDistinct := map[string]bool{"projmux-dark": true}
 
-	colourOf := func(t *testing.T, preset string, tok ColorToken) string {
+	colourOf := func(t *testing.T, preset string, tok ColorToken) (string, bool) {
 		t.Helper()
 		hex, ok := PresetColorHex(preset, tok)
 		if !ok {
 			t.Fatalf("%s: token %s unset; every preset must define all tokens", preset, tok)
 		}
-		return nearestTmuxColor(hex)
+		// A terminal-default-sentinel token (background/surface family) carries no
+		// fixed hex: it rides the terminal background, so there is no colourN to
+		// compare. Report it as a sentinel so the caller skips bg-relative rules.
+		if hex == "" {
+			return "", true
+		}
+		return nearestTmuxColor(hex), false
 	}
 
 	for _, preset := range PresetNames() {
 
-		// (a) state colors mutually distinct.
+		// (a) state colors mutually distinct. State tokens never use the
+		// terminal-default sentinel (it is restricted to the background/surface
+		// family), so all five always resolve to a concrete colourN.
 		if !exemptStateDistinct[preset] {
 			seen := map[string]ColorToken{}
 			for _, tok := range stateTokens {
-				cn := colourOf(t, preset, tok)
+				cn, _ := colourOf(t, preset, tok)
 				if prev, dup := seen[cn]; dup {
 					t.Errorf("%s: state colors %s and %s both resolve to %s; the five state colors must be distinguishable", preset, prev, tok, cn)
 				}
@@ -47,19 +55,21 @@ func TestPresetTokensSatisfyDesignRubric(t *testing.T) {
 			}
 		}
 
-		// (b) muted distinct from foreground and background.
-		muted := colourOf(t, preset, TokenMuted)
-		fg := colourOf(t, preset, TokenForeground)
-		bg := colourOf(t, preset, TokenBackground)
+		muted, _ := colourOf(t, preset, TokenMuted)
+		fg, fgSentinel := colourOf(t, preset, TokenForeground)
+		bg, bgSentinel := colourOf(t, preset, TokenBackground)
+
+		// (b) muted distinct from foreground and (when fixed) background.
 		if muted == fg {
 			t.Errorf("%s: muted (%s) equals foreground; low-signal text would be indistinguishable", preset, muted)
 		}
-		if muted == bg {
+		if !bgSentinel && muted == bg {
 			t.Errorf("%s: muted (%s) equals background; muted text would be invisible", preset, muted)
 		}
 
-		// (c) foreground != background.
-		if fg == bg {
+		// (c) foreground != background. Vacuous when background rides the terminal
+		// default (no fixed background to clash with).
+		if !bgSentinel && !fgSentinel && fg == bg {
 			t.Errorf("%s: foreground equals background (%s)", preset, fg)
 		}
 	}

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -515,6 +515,23 @@ var builtinPresets = map[string]preset{
 			TokenPaneActiveBg: "#1c1c1c", TokenFocus: "#00ffff",
 		}),
 	},
+	// terminal: a terminal-native preset. background/surface ride the terminal's
+	// own background via the "default" sentinel (no colour literal); projmux only
+	// paints foreground/accent/state chrome on top. Foreground does not support
+	// the sentinel, so fg/muted/selection tints are tuned for a DARK terminal
+	// (the common projmux host) — documented in docs/theme-palette.md. State
+	// colors keep the rubric's distinct amber tier (progress 221 / warning 179 /
+	// action_required 214).
+	"terminal": {
+		Name: "terminal",
+		Colors: presetColorsWithTerminalDefault(map[ColorToken]string{
+			TokenSurfaceActive: "#303030",
+			TokenForeground:    "#d0d0d0", TokenMuted: "#8a8a8a", TokenAccent: "#5fd7af",
+			TokenCritical: "#ff5f5f", TokenWarning: "#d7af5f",
+			TokenProgress: "#ffd75f", TokenSuccess: "#5faf87", TokenActionRequired: "#ffaf00",
+			TokenPaneActiveBg: "#262626", TokenFocus: "#00ffff",
+		}, TokenBackground, TokenSurface),
+	},
 }
 
 // PresetNames returns the built-in preset config values in stable order.
@@ -760,6 +777,23 @@ func presetColors(values map[ColorToken]string) map[ColorToken]ColorSpec {
 			continue
 		}
 		out[token] = ColorSpec{Hex: normalized, Tmux: nearestTmuxColor(normalized)}
+	}
+	return out
+}
+
+// presetColorsWithTerminalDefault builds a preset color map from hex values and
+// pins each token in defaults to the terminal-default sentinel (a ColorSpec with
+// no Hex and Tmux="default"), the same shape resolveLayer produces for a user's
+// explicit "default". This lets a built-in preset ride the terminal background
+// for the background/surface family. The sentinel tokens are intentionally
+// absent from values; passing one in both places is harmless (default wins).
+func presetColorsWithTerminalDefault(values map[ColorToken]string, defaults ...ColorToken) map[ColorToken]ColorSpec {
+	out := presetColors(values)
+	for _, token := range defaults {
+		if !tokenSupportsDefaultSentinel(token) {
+			continue
+		}
+		out[token] = ColorSpec{Tmux: ThemeDefaultSentinel}
 	}
 	return out
 }

--- a/internal/theme/terminal_preset_test.go
+++ b/internal/theme/terminal_preset_test.go
@@ -1,0 +1,41 @@
+package theme
+
+import "testing"
+
+// TestTerminalPresetRidesTerminalBackground verifies the terminal-native preset
+// pins background/surface to the terminal-default sentinel (so the terminal's
+// own background shows through) while still painting foreground/accent/state
+// chrome. Selecting the preset by name must behave like the user typing
+// `background = "default"`, on both the tmux and ANSI render paths.
+func TestTerminalPresetRidesTerminalBackground(t *testing.T) {
+	t.Parallel()
+
+	effective := ResolveTheme(ThemeConfig{Preset: "terminal"})
+
+	// background/surface ride the terminal default; foreground/accent are real.
+	if !IsThemeDefaultSpec(effective.Background.Value) {
+		t.Fatalf("terminal background = %#v, want terminal-default sentinel", effective.Background)
+	}
+	if !IsThemeDefaultSpec(effective.Surface.Value) {
+		t.Fatalf("terminal surface = %#v, want terminal-default sentinel", effective.Surface)
+	}
+	if effective.Foreground.Value.Hex == "" {
+		t.Fatalf("terminal foreground = %#v, want a concrete color (fg has no sentinel)", effective.Foreground)
+	}
+
+	// tmux: pane/popup backgrounds emit bg=default.
+	roles := RenderRolesFromEffective(effective)
+	if roles.PaneInactiveBg != "default" {
+		t.Fatalf("PaneInactiveBg = %q, want default", roles.PaneInactiveBg)
+	}
+	if roles.StatusBg != "default" {
+		t.Fatalf("StatusBg = %q, want default (surface rides terminal)", roles.StatusBg)
+	}
+
+	// ANSI: the preset must still satisfy the design rubric — selecting it must
+	// not collapse state colors (guarded broadly by the rubric test; here we just
+	// confirm the preset resolves without dropping the layer).
+	if effective.Accent.Value.Hex == "" {
+		t.Fatalf("terminal accent = %#v, want a concrete accent", effective.Accent)
+	}
+}


### PR DESCRIPTION
## Summary

Second slice of the **Theme design quality** round (P2): add a `terminal` built-in preset whose `background`/`surface` use the **terminal-default sentinel**, so projmux rides the terminal's own background and only paints foreground/accent/state chrome on top. First preset to consume the `default` sentinel shipped by the terminal-default-option track.

## Changes

- **`presetColorsWithTerminalDefault` helper** — pins given tokens to `ColorSpec{Tmux: "default"}` (the same shape `resolveLayer` builds for a user's explicit `"default"`). `presetColors()` alone can't carry it because it rejects non-hex values.
- **`terminal` preset** — `background`/`surface` = `default`; `foreground`/`muted`/selection tints tuned for a **dark terminal** (foreground has no sentinel), documented as a dark-host assumption; state colors keep the rubric's distinct amber tier (progress `colour221` / warning `colour179` / action_required `colour214`).
- **Rubric test** now recognizes terminal-default-sentinel tokens and skips the background-relative rules for them (a sentinel background has no fixed `colourN` to clash with); `muted != fg` and state-distinctness still enforced.
- **Focused test** — selecting the preset emits tmux `bg=default` for pane and popup backgrounds while keeping a concrete foreground/accent (ANSI sentinel handling already shipped).
- **docs** — configuration.md / theme-palette.md preset lists + terminal-native note.

## Constraints
- No fallback byte-identity change; public 13-token schema unchanged; role map unchanged.
- ANSI side already emits no background sequence for the sentinel (terminal bg shows through) — verified via existing sentinel handling.

## Tests
- `TestTerminalPresetRidesTerminalBackground` + `TestPresetTokensSatisfyDesignRubric` (now sentinel-aware) pass.
- `make fmt` / `make fix` clean; `make test` fully green.

## Round status
Completes P1 (rubric + collision fix, #459) + P2 (this). Remaining in the track: P3 (token menu IA) and P4 (256-color picker, spike-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)