### PR TITLE
fix(theme): tune inspired preset pane colors

### DIFF
--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -166,10 +166,13 @@ Built-in preset config values are:
 - `terminal-cool` / `terminal-warm` — terminal-native variants that also use
   the `default` sentinel for `background`/`surface`, with cooler or warmer
   foreground/accent/state palettes.
-- `blue-hour` / `blue-hour-terminal` — blue-forward dark theme pair; the
-  terminal variant keeps pane and popup backgrounds at the terminal default.
+- `blue-hour` / `blue-hour-terminal` — dark theme pair tuned around a terminal
+  blue accent; `blue-hour` uses a dark blue-tinted inactive pane body, while
+  the terminal variant keeps pane and popup backgrounds at the terminal
+  default. Both keep the active pane tint black.
 - `carbon-violet` / `carbon-violet-terminal` — charcoal/violet dark theme pair;
-  the terminal variant keeps pane and popup backgrounds at the terminal default.
+  the terminal variant keeps pane and popup backgrounds at the terminal
+  default. Both keep the active pane tint black.
 
 ## Fallback Inventory
 

--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -169,7 +169,7 @@ Built-in preset config values are:
 - `blue-hour` / `blue-hour-terminal` — dark theme pair tuned around a terminal
   blue accent; `blue-hour` uses a dark blue-tinted inactive pane body, while
   the terminal variant keeps pane and popup backgrounds at the terminal
-  default. Both keep the active pane tint black.
+  default. Both keep the active pane tint at the palette black.
 - `carbon-violet` / `carbon-violet-terminal` — charcoal/violet dark theme pair;
   the terminal variant keeps pane and popup backgrounds at the terminal
   default. Both keep the active pane tint black.

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -504,21 +504,21 @@ var builtinPresets = map[string]preset{
 	"blue-hour": {
 		Name: "blue-hour",
 		Colors: presetColors(map[ColorToken]string{
-			TokenBackground: "#1e2a44", TokenSurface: "#273653", TokenSurfaceActive: "#364a6f",
-			TokenChromeForeground: "#cdd6f4", TokenTextPrimary: "#cdd6f4", TokenForeground: "#cdd6f4", TokenMuted: "#7f849c", TokenAccent: "#89b4fa",
-			TokenCritical: "#f38ba8", TokenWarning: "#f9e2af",
-			TokenProgress: "#89b4fa", TokenSuccess: "#a6e3a1", TokenActionRequired: "#fab387",
-			TokenPaneActiveBg: "#000000", TokenFocus: "#89dceb",
+			TokenBackground: "#1d2433", TokenSurface: "#2d4a6e", TokenSurfaceActive: "#4a5878",
+			TokenChromeForeground: "#acb6bf", TokenTextPrimary: "#acb6bf", TokenForeground: "#acb6bf", TokenMuted: "#4a5878", TokenAccent: "#3d8fd1",
+			TokenCritical: "#ec6a88", TokenWarning: "#efb472",
+			TokenProgress: "#5ca7e4", TokenSuccess: "#3fdaa4", TokenActionRequired: "#ffca85",
+			TokenPaneActiveBg: "#1d2433", TokenFocus: "#5ca7e4",
 		}),
 	},
 	"blue-hour-terminal": {
 		Name: "blue-hour-terminal",
 		Colors: presetColorsWithTerminalDefault(map[ColorToken]string{
-			TokenSurfaceActive:    "#364a6f",
-			TokenChromeForeground: "#cdd6f4", TokenTextPrimary: "#cdd6f4", TokenForeground: "#cdd6f4", TokenMuted: "#7f849c", TokenAccent: "#89b4fa",
-			TokenCritical: "#f38ba8", TokenWarning: "#f9e2af",
-			TokenProgress: "#89b4fa", TokenSuccess: "#a6e3a1", TokenActionRequired: "#fab387",
-			TokenPaneActiveBg: "#000000", TokenFocus: "#89dceb",
+			TokenSurfaceActive:    "#4a5878",
+			TokenChromeForeground: "#acb6bf", TokenTextPrimary: "#acb6bf", TokenForeground: "#acb6bf", TokenMuted: "#4a5878", TokenAccent: "#3d8fd1",
+			TokenCritical: "#ec6a88", TokenWarning: "#efb472",
+			TokenProgress: "#5ca7e4", TokenSuccess: "#3fdaa4", TokenActionRequired: "#ffca85",
+			TokenPaneActiveBg: "#1d2433", TokenFocus: "#5ca7e4",
 		}, TokenBackground, TokenSurface),
 	},
 	"ocean": {

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -504,21 +504,21 @@ var builtinPresets = map[string]preset{
 	"blue-hour": {
 		Name: "blue-hour",
 		Colors: presetColors(map[ColorToken]string{
-			TokenBackground: "#101923", TokenSurface: "#142434", TokenSurfaceActive: "#243b53",
-			TokenChromeForeground: "#d8e7ff", TokenTextPrimary: "#d8e7ff", TokenForeground: "#d8e7ff", TokenMuted: "#8197ad", TokenAccent: "#7aa2f7",
-			TokenCritical: "#ff5f87", TokenWarning: "#d7af5f",
-			TokenProgress: "#5fafff", TokenSuccess: "#5faf87", TokenActionRequired: "#ff8700",
-			TokenPaneActiveBg: "#0b1720", TokenFocus: "#87d7ff",
+			TokenBackground: "#1e2a44", TokenSurface: "#273653", TokenSurfaceActive: "#364a6f",
+			TokenChromeForeground: "#cdd6f4", TokenTextPrimary: "#cdd6f4", TokenForeground: "#cdd6f4", TokenMuted: "#7f849c", TokenAccent: "#89b4fa",
+			TokenCritical: "#f38ba8", TokenWarning: "#f9e2af",
+			TokenProgress: "#89b4fa", TokenSuccess: "#a6e3a1", TokenActionRequired: "#fab387",
+			TokenPaneActiveBg: "#000000", TokenFocus: "#89dceb",
 		}),
 	},
 	"blue-hour-terminal": {
 		Name: "blue-hour-terminal",
 		Colors: presetColorsWithTerminalDefault(map[ColorToken]string{
-			TokenSurfaceActive:    "#243b53",
-			TokenChromeForeground: "#d8e7ff", TokenTextPrimary: "#d8e7ff", TokenForeground: "#d8e7ff", TokenMuted: "#8197ad", TokenAccent: "#7aa2f7",
-			TokenCritical: "#ff5f87", TokenWarning: "#d7af5f",
-			TokenProgress: "#5fafff", TokenSuccess: "#5faf87", TokenActionRequired: "#ff8700",
-			TokenPaneActiveBg: "#262626", TokenFocus: "#87d7ff",
+			TokenSurfaceActive:    "#364a6f",
+			TokenChromeForeground: "#cdd6f4", TokenTextPrimary: "#cdd6f4", TokenForeground: "#cdd6f4", TokenMuted: "#7f849c", TokenAccent: "#89b4fa",
+			TokenCritical: "#f38ba8", TokenWarning: "#f9e2af",
+			TokenProgress: "#89b4fa", TokenSuccess: "#a6e3a1", TokenActionRequired: "#fab387",
+			TokenPaneActiveBg: "#000000", TokenFocus: "#89dceb",
 		}, TokenBackground, TokenSurface),
 	},
 	"ocean": {
@@ -538,7 +538,7 @@ var builtinPresets = map[string]preset{
 			TokenChromeForeground: "#d6d3df", TokenTextPrimary: "#d6d3df", TokenForeground: "#d6d3df", TokenMuted: "#8d8996", TokenAccent: "#b48ead",
 			TokenCritical: "#ff5f5f", TokenWarning: "#d7af5f",
 			TokenProgress: "#87afff", TokenSuccess: "#87af5f", TokenActionRequired: "#ff8700",
-			TokenPaneActiveBg: "#1a1b20", TokenFocus: "#b48ead",
+			TokenPaneActiveBg: "#000000", TokenFocus: "#b48ead",
 		}),
 	},
 	"carbon-violet-terminal": {
@@ -548,7 +548,7 @@ var builtinPresets = map[string]preset{
 			TokenChromeForeground: "#d6d3df", TokenTextPrimary: "#d6d3df", TokenForeground: "#d6d3df", TokenMuted: "#8d8996", TokenAccent: "#b48ead",
 			TokenCritical: "#ff5f5f", TokenWarning: "#d7af5f",
 			TokenProgress: "#87afff", TokenSuccess: "#87af5f", TokenActionRequired: "#ff8700",
-			TokenPaneActiveBg: "#262626", TokenFocus: "#b48ead",
+			TokenPaneActiveBg: "#000000", TokenFocus: "#b48ead",
 		}, TokenBackground, TokenSurface),
 	},
 	"ember": {

--- a/internal/theme/terminal_preset_test.go
+++ b/internal/theme/terminal_preset_test.go
@@ -51,21 +51,24 @@ func TestBlueHourTargetsInactivePaneBlueTint(t *testing.T) {
 	t.Parallel()
 
 	fixed := ResolveTheme(ThemeConfig{Preset: "blue-hour"})
-	if got, want := fixed.Background.Value.Hex, "#1e2a44"; got != want {
-		t.Fatalf("blue-hour background = %q, want inactive pane blue tint %q", got, want)
+	if got, want := fixed.Background.Value.Hex, "#1d2433"; got != want {
+		t.Fatalf("blue-hour background = %q, want terminal palette background %q", got, want)
 	}
-	if got, want := fixed.Accent.Value.Hex, "#89b4fa"; got != want {
+	if got, want := fixed.Surface.Value.Hex, "#2d4a6e"; got != want {
+		t.Fatalf("blue-hour surface = %q, want terminal palette selection background %q", got, want)
+	}
+	if got, want := fixed.Accent.Value.Hex, "#3d8fd1"; got != want {
 		t.Fatalf("blue-hour accent = %q, want terminal blue %q", got, want)
 	}
-	if got, want := fixed.PaneActiveBg.Value.Hex, "#000000"; got != want {
-		t.Fatalf("blue-hour pane_active_bg = %q, want black %q", got, want)
+	if got, want := fixed.PaneActiveBg.Value.Hex, "#1d2433"; got != want {
+		t.Fatalf("blue-hour pane_active_bg = %q, want terminal palette black %q", got, want)
 	}
 
 	terminal := ResolveTheme(ThemeConfig{Preset: "blue-hour-terminal"})
 	if !IsThemeDefaultSpec(terminal.Background.Value) || !IsThemeDefaultSpec(terminal.Surface.Value) {
 		t.Fatalf("blue-hour-terminal background/surface = %#v/%#v, want terminal default", terminal.Background, terminal.Surface)
 	}
-	if got, want := terminal.Accent.Value.Hex, "#89b4fa"; got != want {
+	if got, want := terminal.Accent.Value.Hex, "#3d8fd1"; got != want {
 		t.Fatalf("blue-hour-terminal accent = %q, want terminal blue %q", got, want)
 	}
 }
@@ -73,13 +76,18 @@ func TestBlueHourTargetsInactivePaneBlueTint(t *testing.T) {
 func TestInspiredPresetPairsUseBlackActivePaneTint(t *testing.T) {
 	t.Parallel()
 
-	for _, preset := range []string{"blue-hour", "blue-hour-terminal", "carbon-violet", "carbon-violet-terminal"} {
+	for preset, want := range map[string]string{
+		"blue-hour":              "#1d2433",
+		"blue-hour-terminal":     "#1d2433",
+		"carbon-violet":          "#000000",
+		"carbon-violet-terminal": "#000000",
+	} {
 		t.Run(preset, func(t *testing.T) {
 			t.Parallel()
 
 			effective := ResolveTheme(ThemeConfig{Preset: preset})
-			if got, want := effective.PaneActiveBg.Value.Hex, "#000000"; got != want {
-				t.Fatalf("%s pane_active_bg = %q, want black %q", preset, got, want)
+			if got := effective.PaneActiveBg.Value.Hex; got != want {
+				t.Fatalf("%s pane_active_bg = %q, want palette black %q", preset, got, want)
 			}
 		})
 	}

--- a/internal/theme/terminal_preset_test.go
+++ b/internal/theme/terminal_preset_test.go
@@ -46,3 +46,41 @@ func TestTerminalPresetRidesTerminalBackground(t *testing.T) {
 		})
 	}
 }
+
+func TestBlueHourTargetsInactivePaneBlueTint(t *testing.T) {
+	t.Parallel()
+
+	fixed := ResolveTheme(ThemeConfig{Preset: "blue-hour"})
+	if got, want := fixed.Background.Value.Hex, "#1e2a44"; got != want {
+		t.Fatalf("blue-hour background = %q, want inactive pane blue tint %q", got, want)
+	}
+	if got, want := fixed.Accent.Value.Hex, "#89b4fa"; got != want {
+		t.Fatalf("blue-hour accent = %q, want terminal blue %q", got, want)
+	}
+	if got, want := fixed.PaneActiveBg.Value.Hex, "#000000"; got != want {
+		t.Fatalf("blue-hour pane_active_bg = %q, want black %q", got, want)
+	}
+
+	terminal := ResolveTheme(ThemeConfig{Preset: "blue-hour-terminal"})
+	if !IsThemeDefaultSpec(terminal.Background.Value) || !IsThemeDefaultSpec(terminal.Surface.Value) {
+		t.Fatalf("blue-hour-terminal background/surface = %#v/%#v, want terminal default", terminal.Background, terminal.Surface)
+	}
+	if got, want := terminal.Accent.Value.Hex, "#89b4fa"; got != want {
+		t.Fatalf("blue-hour-terminal accent = %q, want terminal blue %q", got, want)
+	}
+}
+
+func TestInspiredPresetPairsUseBlackActivePaneTint(t *testing.T) {
+	t.Parallel()
+
+	for _, preset := range []string{"blue-hour", "blue-hour-terminal", "carbon-violet", "carbon-violet-terminal"} {
+		t.Run(preset, func(t *testing.T) {
+			t.Parallel()
+
+			effective := ResolveTheme(ThemeConfig{Preset: preset})
+			if got, want := effective.PaneActiveBg.Value.Hex, "#000000"; got != want {
+				t.Fatalf("%s pane_active_bg = %q, want black %q", preset, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- align blue-hour with the provided terminal-blue palette ( background/black,  blue,  selection surface)
- keep blue-hour active pane tint at palette black and carbon-violet active pane tint at black across fixed and terminal variants
- document the pane color intent and add regression coverage for the preset pair colors

## Validation
- GOCACHE=/tmp/projmux-gocache go test ./internal/theme
- make fmt
- make fix
- make test
- git diff --check

## Not run
- make test-integration: Docker is not installed/enabled in this WSL distro
- make test-e2e: Docker is not installed/enabled in this WSL distro
