### PR TITLE
fix(theme): clarify preset contrast intent

### DIFF
--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -169,10 +169,12 @@ Built-in preset config values are:
 - `blue-hour` / `blue-hour-terminal` — dark theme pair tuned around a terminal
   blue accent; `blue-hour` uses a dark blue-tinted inactive pane body, while
   the terminal variant keeps pane and popup backgrounds at the terminal
-  default. Both keep the active pane tint at the palette black.
+  default. Both keep the active pane tint true black.
 - `carbon-violet` / `carbon-violet-terminal` — charcoal/violet dark theme pair;
   the terminal variant keeps pane and popup backgrounds at the terminal
   default. Both keep the active pane tint black.
+- `high-contrast` — black surfaces, white text, a vivid blue active surface,
+  and bright cyan/yellow/red/green state colors.
 
 ## Fallback Inventory
 

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -508,7 +508,7 @@ var builtinPresets = map[string]preset{
 			TokenChromeForeground: "#acb6bf", TokenTextPrimary: "#acb6bf", TokenForeground: "#acb6bf", TokenMuted: "#4a5878", TokenAccent: "#3d8fd1",
 			TokenCritical: "#ec6a88", TokenWarning: "#efb472",
 			TokenProgress: "#5ca7e4", TokenSuccess: "#3fdaa4", TokenActionRequired: "#ffca85",
-			TokenPaneActiveBg: "#1d2433", TokenFocus: "#5ca7e4",
+			TokenPaneActiveBg: "#000000", TokenFocus: "#5ca7e4",
 		}),
 	},
 	"blue-hour-terminal": {
@@ -518,7 +518,7 @@ var builtinPresets = map[string]preset{
 			TokenChromeForeground: "#acb6bf", TokenTextPrimary: "#acb6bf", TokenForeground: "#acb6bf", TokenMuted: "#4a5878", TokenAccent: "#3d8fd1",
 			TokenCritical: "#ec6a88", TokenWarning: "#efb472",
 			TokenProgress: "#5ca7e4", TokenSuccess: "#3fdaa4", TokenActionRequired: "#ffca85",
-			TokenPaneActiveBg: "#1d2433", TokenFocus: "#5ca7e4",
+			TokenPaneActiveBg: "#000000", TokenFocus: "#5ca7e4",
 		}, TokenBackground, TokenSurface),
 	},
 	"ocean": {
@@ -584,11 +584,11 @@ var builtinPresets = map[string]preset{
 	"high-contrast": {
 		Name: "high-contrast",
 		Colors: presetColors(map[ColorToken]string{
-			TokenBackground: "#000000", TokenSurface: "#101010", TokenSurfaceActive: "#303030",
-			TokenChromeForeground: "#ffffff", TokenTextPrimary: "#ffffff", TokenForeground: "#ffffff", TokenMuted: "#b8b8b8", TokenAccent: "#00ffd0",
-			TokenCritical: "#ff4040", TokenWarning: "#ffd700",
-			TokenProgress: "#ffcc66", TokenSuccess: "#5faf87", TokenActionRequired: "#ffaf00",
-			TokenPaneActiveBg: "#1c1c1c", TokenFocus: "#00ffff",
+			TokenBackground: "#000000", TokenSurface: "#000000", TokenSurfaceActive: "#005fff",
+			TokenChromeForeground: "#ffffff", TokenTextPrimary: "#ffffff", TokenForeground: "#ffffff", TokenMuted: "#bfbfbf", TokenAccent: "#00ffff",
+			TokenCritical: "#ff0000", TokenWarning: "#ffff00",
+			TokenProgress: "#00bfff", TokenSuccess: "#00ff66", TokenActionRequired: "#ffaf00",
+			TokenPaneActiveBg: "#000000", TokenFocus: "#ffffff",
 		}),
 	},
 	// terminal: a terminal-native preset. background/surface ride the terminal's

--- a/internal/theme/terminal_preset_test.go
+++ b/internal/theme/terminal_preset_test.go
@@ -60,8 +60,8 @@ func TestBlueHourTargetsInactivePaneBlueTint(t *testing.T) {
 	if got, want := fixed.Accent.Value.Hex, "#3d8fd1"; got != want {
 		t.Fatalf("blue-hour accent = %q, want terminal blue %q", got, want)
 	}
-	if got, want := fixed.PaneActiveBg.Value.Hex, "#1d2433"; got != want {
-		t.Fatalf("blue-hour pane_active_bg = %q, want terminal palette black %q", got, want)
+	if got, want := fixed.PaneActiveBg.Value.Hex, "#000000"; got != want {
+		t.Fatalf("blue-hour pane_active_bg = %q, want true black %q", got, want)
 	}
 
 	terminal := ResolveTheme(ThemeConfig{Preset: "blue-hour-terminal"})
@@ -77,8 +77,8 @@ func TestInspiredPresetPairsUseBlackActivePaneTint(t *testing.T) {
 	t.Parallel()
 
 	for preset, want := range map[string]string{
-		"blue-hour":              "#1d2433",
-		"blue-hour-terminal":     "#1d2433",
+		"blue-hour":              "#000000",
+		"blue-hour-terminal":     "#000000",
 		"carbon-violet":          "#000000",
 		"carbon-violet-terminal": "#000000",
 	} {
@@ -90,5 +90,33 @@ func TestInspiredPresetPairsUseBlackActivePaneTint(t *testing.T) {
 				t.Fatalf("%s pane_active_bg = %q, want palette black %q", preset, got, want)
 			}
 		})
+	}
+}
+
+func TestHighContrastPresetUsesStrongContrastPalette(t *testing.T) {
+	t.Parallel()
+
+	effective := ResolveTheme(ThemeConfig{Preset: "high-contrast"})
+	for name, field := range map[string]ColorField{
+		"background":        effective.Background,
+		"surface":           effective.Surface,
+		"pane_active_bg":    effective.PaneActiveBg,
+		"foreground":        effective.Foreground,
+		"chrome_foreground": effective.ChromeForeground,
+		"text_primary":      effective.TextPrimary,
+	} {
+		want := "#000000"
+		if name == "foreground" || name == "chrome_foreground" || name == "text_primary" {
+			want = "#ffffff"
+		}
+		if got := field.Value.Hex; got != want {
+			t.Fatalf("high-contrast %s = %q, want %q", name, got, want)
+		}
+	}
+	if got, want := effective.SurfaceActive.Value.Hex, "#005fff"; got != want {
+		t.Fatalf("high-contrast surface_active = %q, want vivid active surface %q", got, want)
+	}
+	if got, want := effective.Focus.Value.Hex, "#ffffff"; got != want {
+		t.Fatalf("high-contrast focus = %q, want white focus %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- make blue-hour and blue-hour-terminal active pane tint true black while keeping the blue palette on inactive/background roles
- keep carbon-violet active pane tint black through regression coverage
- strengthen high-contrast with black surfaces, white text, vivid active surface, and bright state colors

## Validation
- make fmt
- make fix
- GOCACHE=/tmp/projmux-gocache go test ./internal/theme
- make test
- git diff --check

## Not run
- make test-integration: Docker is not installed/enabled in this WSL distro
- make test-e2e: Docker is not installed/enabled in this WSL distro
