### PR TITLE
fix(theme): darken readable preset surfaces

### DIFF
--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -163,8 +163,10 @@ Built-in preset config values are:
 - `forest`
 - `rose`
 - `blue-hour` — dark theme tuned around a terminal blue accent; it uses a dark
-  blue-tinted inactive pane body and a true black active pane tint.
-- `carbon-violet` — charcoal/violet dark theme with a black active pane tint.
+  blue-tinted inactive pane body, darker popup/status surfaces, and a true black
+  active pane tint.
+- `carbon-violet` — charcoal/violet dark theme with darker popup/status
+  surfaces and a black active pane tint.
 - `high-contrast` — black surfaces, white text, a vivid blue active surface,
   near-black active pane tint, vivid cyan focus, and bright
   cyan/yellow/red/green state colors.

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -510,7 +510,7 @@ var builtinPresets = map[string]preset{
 	"blue-hour": {
 		Name: "blue-hour",
 		Colors: presetColors(map[ColorToken]string{
-			TokenBackground: "#1e1e2e", TokenSurface: "#2d4a6e", TokenSurfaceActive: "#4a5878",
+			TokenBackground: "#1e1e2e", TokenSurface: "#16242d", TokenStatusBackground: "#132b38", TokenSurfaceActive: "#4a5878",
 			TokenChromeForeground: "#acb6bf", TokenTextPrimary: "#acb6bf", TokenForeground: "#acb6bf", TokenMuted: "#4a5878", TokenAccent: "#3d8fd1",
 			TokenCritical: "#ec6a88", TokenWarning: "#efb472",
 			TokenProgress: "#5ca7e4", TokenSuccess: "#3fdaa4", TokenActionRequired: "#ffca85",
@@ -520,7 +520,7 @@ var builtinPresets = map[string]preset{
 	"carbon-violet": {
 		Name: "carbon-violet",
 		Colors: presetColors(map[ColorToken]string{
-			TokenBackground: "#1f2026", TokenSurface: "#292a30", TokenSurfaceActive: "#3a3b44",
+			TokenBackground: "#1f2026", TokenSurface: "#23212b", TokenStatusBackground: "#1a1822", TokenSurfaceActive: "#3a3b44",
 			TokenChromeForeground: "#d6d3df", TokenTextPrimary: "#d6d3df", TokenForeground: "#d6d3df", TokenMuted: "#8d8996", TokenAccent: "#b48ead",
 			TokenCritical: "#ff5f5f", TokenWarning: "#d7af5f",
 			TokenProgress: "#87afff", TokenSuccess: "#87af5f", TokenActionRequired: "#ff8700",

--- a/internal/theme/terminal_preset_test.go
+++ b/internal/theme/terminal_preset_test.go
@@ -9,8 +9,11 @@ func TestBlueHourTargetsInactivePaneBlueTint(t *testing.T) {
 	if got, want := fixed.Background.Value.Hex, "#1e1e2e"; got != want {
 		t.Fatalf("blue-hour background = %q, want terminal palette background %q", got, want)
 	}
-	if got, want := fixed.Surface.Value.Hex, "#2d4a6e"; got != want {
-		t.Fatalf("blue-hour surface = %q, want terminal palette selection background %q", got, want)
+	if got, want := fixed.Surface.Value.Hex, "#16242d"; got != want {
+		t.Fatalf("blue-hour surface = %q, want midnight popup surface %q", got, want)
+	}
+	if got, want := fixed.StatusBackground.Value.Hex, "#132b38"; got != want {
+		t.Fatalf("blue-hour status_background = %q, want ocean status surface %q", got, want)
 	}
 	if got, want := fixed.Accent.Value.Hex, "#3d8fd1"; got != want {
 		t.Fatalf("blue-hour accent = %q, want terminal blue %q", got, want)
@@ -19,6 +22,21 @@ func TestBlueHourTargetsInactivePaneBlueTint(t *testing.T) {
 		t.Fatalf("blue-hour pane_active_bg = %q, want true black %q", got, want)
 	}
 
+}
+
+func TestCarbonVioletUsesReadablePopupAndStatusSurfaces(t *testing.T) {
+	t.Parallel()
+
+	effective := ResolveTheme(ThemeConfig{Preset: "carbon-violet"})
+	if got, want := effective.Surface.Value.Hex, "#23212b"; got != want {
+		t.Fatalf("carbon-violet surface = %q, want darker readable popup surface %q", got, want)
+	}
+	if got, want := effective.StatusBackground.Value.Hex, "#1a1822"; got != want {
+		t.Fatalf("carbon-violet status_background = %q, want darker status surface %q", got, want)
+	}
+	if got, want := effective.PaneActiveBg.Value.Hex, "#000000"; got != want {
+		t.Fatalf("carbon-violet pane_active_bg = %q, want true black %q", got, want)
+	}
 }
 
 func TestInspiredPresetPairsUseBlackActivePaneTint(t *testing.T) {


### PR DESCRIPTION
## Summary
- darken `blue-hour` popup/native surface using the removed midnight surface token
- split `blue-hour` status background to the removed ocean surface token
- darken `carbon-violet` popup and status surfaces for better readability
- lock the preset intent with resolver tests and update theme docs

## Validation
- `make fmt`
- `make fix`
- `go test ./internal/theme -run 'TestBlueHourTargetsInactivePaneBlueTint|TestCarbonVioletUsesReadablePopupAndStatusSurfaces|TestInspiredPresetPairsUseBlackActivePaneTint|TestPresetTokensSatisfyDesignRubric'`
- `HOME=/tmp/projmux-test-home XDG_CONFIG_HOME=/tmp/projmux-test-home/.config make test` (outside sandbox because tests bind local sockets)
- `git diff --check`

## Not Run
- `make test-integration` / `make test-e2e`: Docker is not available in this WSL distro (`docker` command not found).