### PR TITLE
fix(theme): retune blue hour pane contrast

### DIFF
--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -163,8 +163,8 @@ Built-in preset config values are:
 - `forest`
 - `rose`
 - `blue-hour` — dark theme tuned around a terminal blue accent; it uses a dark
-  blue-tinted inactive pane body, darker popup/status surfaces, and a true black
-  active pane tint.
+  blue-tinted inactive pane body, black popup surface, deep navy status bar,
+  and a deep indigo active pane tint.
 - `carbon-violet` — charcoal/violet dark theme with darker popup/status
   surfaces and a black active pane tint.
 - `high-contrast` — black surfaces, white text, a vivid blue active surface,

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -510,11 +510,11 @@ var builtinPresets = map[string]preset{
 	"blue-hour": {
 		Name: "blue-hour",
 		Colors: presetColors(map[ColorToken]string{
-			TokenBackground: "#1e1e2e", TokenSurface: "#16242d", TokenStatusBackground: "#132b38", TokenSurfaceActive: "#4a5878",
+			TokenBackground: "#1e1e2e", TokenSurface: "#000000", TokenStatusBackground: "#07111f", TokenSurfaceActive: "#4a5878",
 			TokenChromeForeground: "#acb6bf", TokenTextPrimary: "#acb6bf", TokenForeground: "#acb6bf", TokenMuted: "#4a5878", TokenAccent: "#3d8fd1",
 			TokenCritical: "#ec6a88", TokenWarning: "#efb472",
 			TokenProgress: "#5ca7e4", TokenSuccess: "#3fdaa4", TokenActionRequired: "#ffca85",
-			TokenPaneActiveBg: "#000000", TokenFocus: "#5ca7e4",
+			TokenPaneActiveBg: "#161a3a", TokenFocus: "#5ca7e4",
 		}),
 	},
 	"carbon-violet": {

--- a/internal/theme/terminal_preset_test.go
+++ b/internal/theme/terminal_preset_test.go
@@ -9,17 +9,17 @@ func TestBlueHourTargetsInactivePaneBlueTint(t *testing.T) {
 	if got, want := fixed.Background.Value.Hex, "#1e1e2e"; got != want {
 		t.Fatalf("blue-hour background = %q, want terminal palette background %q", got, want)
 	}
-	if got, want := fixed.Surface.Value.Hex, "#16242d"; got != want {
-		t.Fatalf("blue-hour surface = %q, want midnight popup surface %q", got, want)
+	if got, want := fixed.Surface.Value.Hex, "#000000"; got != want {
+		t.Fatalf("blue-hour surface = %q, want black popup surface %q", got, want)
 	}
-	if got, want := fixed.StatusBackground.Value.Hex, "#132b38"; got != want {
-		t.Fatalf("blue-hour status_background = %q, want ocean status surface %q", got, want)
+	if got, want := fixed.StatusBackground.Value.Hex, "#07111f"; got != want {
+		t.Fatalf("blue-hour status_background = %q, want deep navy status surface %q", got, want)
 	}
 	if got, want := fixed.Accent.Value.Hex, "#3d8fd1"; got != want {
 		t.Fatalf("blue-hour accent = %q, want terminal blue %q", got, want)
 	}
-	if got, want := fixed.PaneActiveBg.Value.Hex, "#000000"; got != want {
-		t.Fatalf("blue-hour pane_active_bg = %q, want true black %q", got, want)
+	if got, want := fixed.PaneActiveBg.Value.Hex, "#161a3a"; got != want {
+		t.Fatalf("blue-hour pane_active_bg = %q, want deep indigo active-pane tint %q", got, want)
 	}
 
 }
@@ -39,11 +39,11 @@ func TestCarbonVioletUsesReadablePopupAndStatusSurfaces(t *testing.T) {
 	}
 }
 
-func TestInspiredPresetPairsUseBlackActivePaneTint(t *testing.T) {
+func TestInspiredPresetPairsUseConfiguredActivePaneTint(t *testing.T) {
 	t.Parallel()
 
 	for preset, want := range map[string]string{
-		"blue-hour":     "#000000",
+		"blue-hour":     "#161a3a",
 		"carbon-violet": "#000000",
 	} {
 		t.Run(preset, func(t *testing.T) {
@@ -51,7 +51,7 @@ func TestInspiredPresetPairsUseBlackActivePaneTint(t *testing.T) {
 
 			effective := ResolveTheme(ThemeConfig{Preset: preset})
 			if got := effective.PaneActiveBg.Value.Hex; got != want {
-				t.Fatalf("%s pane_active_bg = %q, want palette black %q", preset, got, want)
+				t.Fatalf("%s pane_active_bg = %q, want configured active-pane tint %q", preset, got, want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- set `blue-hour` popup/native `surface` to black
- darken `blue-hour` `status_background` to deep navy so status blue text reads better
- retune `blue-hour` active pane tint to deep indigo instead of black
- update preset tests and docs for the new intent

## Validation
- `make fmt`
- `make fix`
- `go test ./internal/theme -run 'TestBlueHourTargetsInactivePaneBlueTint|TestInspiredPresetPairsUseConfiguredActivePaneTint|TestPresetTokensSatisfyDesignRubric'`
- `HOME=/tmp/projmux-test-home XDG_CONFIG_HOME=/tmp/projmux-test-home/.config make test` (outside sandbox because tests bind local sockets)
- `git diff --check`

## Not Run
- `make test-integration` / `make test-e2e`: Docker is not available in this WSL distro (`docker` command not found).