### PR TITLE
fix(theme): darken active surfaces

### DIFF
--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -167,7 +167,7 @@ Built-in preset config values are:
   and a deep indigo active pane tint.
 - `carbon-violet` — charcoal/violet dark theme with darker popup/status
   surfaces and a black active pane tint.
-- `high-contrast` — black surfaces, white text, a vivid blue active surface,
+- `high-contrast` — black surfaces, white text, a dark blue active surface,
   near-black active pane tint, vivid cyan focus, and bright
   cyan/yellow/red/green state colors.
 

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -510,7 +510,7 @@ var builtinPresets = map[string]preset{
 	"blue-hour": {
 		Name: "blue-hour",
 		Colors: presetColors(map[ColorToken]string{
-			TokenBackground: "#1e1e2e", TokenSurface: "#000000", TokenStatusBackground: "#07111f", TokenSurfaceActive: "#4a5878",
+			TokenBackground: "#1e1e2e", TokenSurface: "#000000", TokenStatusBackground: "#07111f", TokenSurfaceActive: "#252f55",
 			TokenChromeForeground: "#acb6bf", TokenTextPrimary: "#acb6bf", TokenForeground: "#acb6bf", TokenMuted: "#4a5878", TokenAccent: "#3d8fd1",
 			TokenCritical: "#ec6a88", TokenWarning: "#efb472",
 			TokenProgress: "#5ca7e4", TokenSuccess: "#3fdaa4", TokenActionRequired: "#ffca85",
@@ -560,7 +560,7 @@ var builtinPresets = map[string]preset{
 	"high-contrast": {
 		Name: "high-contrast",
 		Colors: presetColors(map[ColorToken]string{
-			TokenBackground: "#000000", TokenSurface: "#000000", TokenSurfaceActive: "#005fff",
+			TokenBackground: "#000000", TokenSurface: "#000000", TokenSurfaceActive: "#00306f",
 			TokenChromeForeground: "#ffffff", TokenTextPrimary: "#ffffff", TokenForeground: "#ffffff", TokenMuted: "#bfbfbf", TokenAccent: "#00ffff",
 			TokenCritical: "#ff0000", TokenWarning: "#ffff00",
 			TokenProgress: "#00bfff", TokenSuccess: "#00ff66", TokenActionRequired: "#ffaf00",

--- a/internal/theme/terminal_preset_test.go
+++ b/internal/theme/terminal_preset_test.go
@@ -15,6 +15,9 @@ func TestBlueHourTargetsInactivePaneBlueTint(t *testing.T) {
 	if got, want := fixed.StatusBackground.Value.Hex, "#07111f"; got != want {
 		t.Fatalf("blue-hour status_background = %q, want deep navy status surface %q", got, want)
 	}
+	if got, want := fixed.SurfaceActive.Value.Hex, "#252f55"; got != want {
+		t.Fatalf("blue-hour surface_active = %q, want readable active surface %q", got, want)
+	}
 	if got, want := fixed.Accent.Value.Hex, "#3d8fd1"; got != want {
 		t.Fatalf("blue-hour accent = %q, want terminal blue %q", got, want)
 	}
@@ -76,8 +79,8 @@ func TestHighContrastPresetUsesStrongContrastPalette(t *testing.T) {
 			t.Fatalf("high-contrast %s = %q, want %q", name, got, want)
 		}
 	}
-	if got, want := effective.SurfaceActive.Value.Hex, "#005fff"; got != want {
-		t.Fatalf("high-contrast surface_active = %q, want vivid active surface %q", got, want)
+	if got, want := effective.SurfaceActive.Value.Hex, "#00306f"; got != want {
+		t.Fatalf("high-contrast surface_active = %q, want readable dark blue active surface %q", got, want)
 	}
 	if got, want := effective.PaneActiveBg.Value.Hex, "#080808"; got != want {
 		t.Fatalf("high-contrast pane_active_bg = %q, want near-black active pane tint %q", got, want)


### PR DESCRIPTION
## Summary
- darken `blue-hour` `surface_active` so muted/description text stays readable on selected rows
- darken `high-contrast` `surface_active` while keeping the active surface blue
- update preset tests and docs for the new contrast intent

## Validation
- `make fmt`
- `make fix`
- `go test ./internal/theme -run 'TestBlueHourTargetsInactivePaneBlueTint|TestHighContrastPresetUsesStrongContrastPalette|TestPresetTokensSatisfyDesignRubric'`
- `HOME=/tmp/projmux-test-home XDG_CONFIG_HOME=/tmp/projmux-test-home/.config make test` (outside sandbox because tests bind local sockets)
- `git diff --check`

## Not Run
- `make test-integration` / `make test-e2e`: Docker is not available in this WSL distro (`docker` command not found).