### PR TITLE
fix: keep notify sidebar open after child enter

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -75,7 +75,7 @@
   three-line grouped card rendering with child-count/fold semantics plus focus/ack/non-critical-clear/clear-all
   actions, notify/statusbar/sidebar attention-vs-AI palette assertions including muted inactive/gone rows,
   native picker-session-local `a` ack that refreshes the sidebar without
-  focusing or restarting the picker, non-critical `x` bulk clear that preserves critical rows, empty
+  focusing or restarting the picker, native child-row Enter focus/ack handling that refreshes and keeps the sidebar open across success, target-gone cleanup, and transient focus failure, non-critical `x` bulk clear that preserves critical rows, empty
   state rendering after all visible non-critical rows are cleared, and notify queue-write refresh events
   that update an open native sidebar best-effort without failing queue pushes, and `focus` dispatch diagnostics for session fallback, unresolved
   targets, window fallback, pane fallback, explicit id failures as unresolved exits, and

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -486,7 +486,28 @@ func (c *notifyCommand) notifySidebarPickerOptions(store notifyStore, entries []
 			delete(expanded, groupKey)
 			return refresh()
 		}
-		return intpicker.DeferredUpdate{Result: &intpicker.Result{Key: ctx.Key, Value: ctx.Value, Query: ctx.Query}}, nil
+		id := strings.TrimSpace(ctx.Value)
+		if id == "" || id == notifySidebarEmptyValue {
+			return refresh()
+		}
+		entry, ok := findNotificationByID(current, id)
+		if !ok {
+			return refresh()
+		}
+		if err := c.focusNotification(entry, "notify-sidebar", "row-select", clientTTY); err != nil {
+			if isFocusTargetUnresolved(err) {
+				if ackErr := store.Ack(id); ackErr != nil {
+					return intpicker.DeferredUpdate{}, fmt.Errorf("ack target-gone notification: %w", ackErr)
+				}
+				return refresh()
+			}
+			c.displayNotifySidebarMessage(fmt.Sprintf("notify focus failed: %s; not acked", focusFailureSummary(err)))
+			return refresh()
+		}
+		if err := ackFocusedNotification(store, entry, current); err != nil {
+			return intpicker.DeferredUpdate{}, fmt.Errorf("ack focused notification: %w", err)
+		}
+		return refresh()
 	}
 	actions := append(
 		pickerCloseActionsForPopupToggleMode(c.homeDir, c.lookupEnv, "notify-sidebar", "esc"),

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -1246,6 +1246,146 @@ func TestNotifyListSidebarAAcksSelectedRowAndRefreshes(t *testing.T) {
 	}
 }
 
+func TestNotifyListSidebarEnterOnChildFocusesAcksAndRefreshes(t *testing.T) {
+	t.Parallel()
+
+	groupValue := notifySidebarGroupValue("pane\x00sock\x00main\x00%2")
+	store := &stubNotifyStore{
+		listEntries: []notify.Notification{
+			{ID: "new", Text: "reply ready", Severity: notify.SeverityInfo, Source: notify.SourceAI, Socket: "sock", Session: "main", Window: "@1", Pane: "%2", CreatedAt: time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)},
+			{ID: "old", Text: "deploy ok", Severity: notify.SeverityInfo, Source: notify.SourceAI, Socket: "sock", Session: "main", Window: "@1", Pane: "%2", CreatedAt: time.Date(2026, time.May, 6, 11, 59, 0, 0, time.UTC)},
+		},
+	}
+	picker := &recordingNotifyNativePicker{
+		steps: []notifyNativeActionStep{
+			{key: "right", value: groupValue, selectedIndex: 0},
+			{key: "enter", value: "old", selectedIndex: 2},
+		},
+	}
+	runner := &focusFakeRunner{}
+	cmd := newCmd(store)
+	cmd.native = picker
+	cmd.runner = runner
+	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
+
+	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if got, want := store.ackedIDs, []string{"old"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ackedIDs = %#v, want focused child ack %#v", got, want)
+	}
+	focusCalls := filterFocusCalls(runner.calls)
+	if len(focusCalls) != 1 {
+		t.Fatalf("focus calls = %#v, want one child focus call", focusCalls)
+	}
+	if !sliceContainsPair(focusCalls[0].args, "--target", "main:@1.%2") {
+		t.Fatalf("focus args = %#v, want child target", focusCalls[0].args)
+	}
+	if !sliceContainsPair(focusCalls[0].args, "--kind", "row-select") {
+		t.Fatalf("focus args = %#v, want row-select kind", focusCalls[0].args)
+	}
+	if len(picker.updates) != 2 {
+		t.Fatalf("updates = %#v, want right unfold update and child enter refresh", picker.updates)
+	}
+	if len(picker.updates[0]) != 3 || picker.updates[0][0].Value != groupValue || picker.updates[0][2].Value != "old" {
+		t.Fatalf("first update = %#v, want expanded group with selected child", picker.updates[0])
+	}
+	if len(picker.updates[1]) != 1 || picker.updates[1][0].Value != groupValue {
+		t.Fatalf("second update = %#v, want sidebar to stay open with remaining row", picker.updates[1])
+	}
+}
+
+func TestNotifyListSidebarEnterOnChildTargetGoneAcksAndRefreshes(t *testing.T) {
+	t.Parallel()
+
+	groupValue := notifySidebarGroupValue("pane\x00\x00main\x00%2")
+	store := &stubNotifyStore{
+		listEntries: []notify.Notification{
+			{ID: "new", Text: "reply ready", Severity: notify.SeverityInfo, Source: notify.SourceExternal, Session: "main", Window: "@1", Pane: "%2", CreatedAt: time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)},
+			{ID: "gone", Text: "stale", Severity: notify.SeverityInfo, Source: notify.SourceExternal, Session: "main", Window: "@1", Pane: "%2", CreatedAt: time.Date(2026, time.May, 6, 11, 59, 0, 0, time.UTC)},
+		},
+	}
+	picker := &recordingNotifyNativePicker{
+		steps: []notifyNativeActionStep{
+			{key: "right", value: groupValue, selectedIndex: 0},
+			{key: "enter", value: "gone", selectedIndex: 2},
+		},
+	}
+	runner := &focusFakeRunner{respond: func(args []string) ([]byte, error) {
+		if containsArg(args, "focus") {
+			return nil, &fakeExitError{code: focusExitNotResolved, msg: "target unresolved"}
+		}
+		return nil, nil
+	}}
+	cmd := newCmd(store)
+	cmd.native = picker
+	cmd.runner = runner
+	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
+
+	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if got, want := store.ackedIDs, []string{"gone"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ackedIDs = %#v, want target-gone child ack %#v", got, want)
+	}
+	if focusCalls := filterFocusCalls(runner.calls); len(focusCalls) != 1 {
+		t.Fatalf("focus calls = %#v, want one failed focus call before cleanup", focusCalls)
+	}
+	if len(picker.updates) != 2 {
+		t.Fatalf("updates = %#v, want right unfold update and target-gone refresh", picker.updates)
+	}
+	if len(picker.updates[1]) != 1 || picker.updates[1][0].Value != groupValue {
+		t.Fatalf("second update = %#v, want sidebar to stay open with remaining row", picker.updates[1])
+	}
+}
+
+func TestNotifyListSidebarEnterOnChildFocusFailureDoesNotAckAndRefreshes(t *testing.T) {
+	t.Parallel()
+
+	groupValue := notifySidebarGroupValue("pane\x00\x00main\x00%2")
+	store := &stubNotifyStore{
+		listEntries: []notify.Notification{
+			{ID: "new", Text: "reply ready", Severity: notify.SeverityInfo, Source: notify.SourceExternal, Session: "main", Window: "@1", Pane: "%2", CreatedAt: time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)},
+			{ID: "retry", Text: "retry me", Severity: notify.SeverityInfo, Source: notify.SourceExternal, Session: "main", Window: "@1", Pane: "%2", CreatedAt: time.Date(2026, time.May, 6, 11, 59, 0, 0, time.UTC)},
+		},
+	}
+	picker := &recordingNotifyNativePicker{
+		steps: []notifyNativeActionStep{
+			{key: "right", value: groupValue, selectedIndex: 0},
+			{key: "enter", value: "retry", selectedIndex: 2},
+		},
+	}
+	runner := &focusFakeRunner{respond: func(args []string) ([]byte, error) {
+		if containsArg(args, "focus") {
+			return nil, errors.New("focus failed")
+		}
+		return nil, nil
+	}}
+	cmd := newCmd(store)
+	cmd.native = picker
+	cmd.runner = runner
+	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
+
+	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(store.ackedIDs) != 0 {
+		t.Fatalf("ackedIDs = %#v, want none when child focus fails", store.ackedIDs)
+	}
+	if focusCalls := filterFocusCalls(runner.calls); len(focusCalls) != 1 {
+		t.Fatalf("focus calls = %#v, want one failed focus call", focusCalls)
+	}
+	if !hasFocusFakeCall(runner.calls, "tmux", []string{"display-message", "notify focus failed: focus failed; not acked"}) {
+		t.Fatalf("runner calls = %#v, want clear focus-failed display message", runner.calls)
+	}
+	if len(picker.updates) != 2 {
+		t.Fatalf("updates = %#v, want right unfold update and unchanged refresh", picker.updates)
+	}
+	if len(picker.updates[1]) != 3 || picker.updates[1][0].Value != groupValue || picker.updates[1][2].Value != "retry" {
+		t.Fatalf("second update = %#v, want sidebar to stay open with child still retryable", picker.updates[1])
+	}
+}
+
 func TestNotifyListSidebarRightLeftFoldNavigation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Completed Phase: Phase 0 — Child row Enter stay-open slice
- Updated Notify sidebar child row Enter (`NotifySidebar:FocusAndAck`) to run as a mutable refresh action, matching the group row stay-open path.
- Child Enter now keeps the sidebar open after focus/ack success, target-gone cleanup, and transient focus failure refreshes.
- Updated the maintained notify sidebar test list in `docs/agent-workflow.md`.

## User-facing surface
- Notify sidebar child row Enter focus/ack.

## Explicitly excluded scope
- Popup overlay background pane interaction.
- Notify queue schema changes.
- Focus dispatcher redesign.
- Native picker engine rewrite.
- Popup-toggle close policy.
- OS notification click-to-focus policy.
- Sidebar grouping/card layout redesign.
- Raw `send-keys` pass-through or popup-behind pane manipulation.

## Constraints kept
- No notify queue schema change.
- No focus dispatcher redesign.
- No native picker engine rewrite.
- No popup-toggle close-key or same-key-close policy change.
- No OS notification click-to-focus policy change.

## Verification
- `go test ./internal/app -run 'TestNotifySidebar|TestNotify.*Focus|Test.*Notify.*Sidebar'`
- `make fmt`
- `make fix`
- `make test`
- `git diff --check`

## Unverified / follow-up
- `make test-integration` was not run in this Phase 0 slice.
- `make test-e2e` was not run in this Phase 0 slice.
- Follow-up Phase: none for this active detail after Phase 0 is merged; explicitly excluded popup overlay/background interaction remains out of scope in its separate backlog item.
