### PR TITLE
perf(ai): speed up resume session discovery

### DIFF
--- a/internal/integrations/agents/aisessions/sessions.go
+++ b/internal/integrations/agents/aisessions/sessions.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -23,6 +24,9 @@ const (
 
 	SourceClaudeTranscript = "claude-transcript"
 	SourceCodexRollout     = "codex-rollout"
+
+	sessionScanLineLimit  = 100
+	sessionTitleLineLimit = 100
 )
 
 // SessionContext captures project metadata associated with a resume session.
@@ -127,7 +131,9 @@ func discoverClaude(cwd, projectsDir string) []SessionMeta {
 		if err != nil {
 			continue
 		}
-		details, ok := scanSessionJSONL(path)
+		details, ok := scanSessionJSONL(path, sessionScanOptions{
+			targetCWD: cwd,
+		})
 		if !ok {
 			continue
 		}
@@ -178,7 +184,10 @@ func discoverCodex(cwd, sessionsDir string) []SessionMeta {
 		if err != nil {
 			return nil
 		}
-		details, ok := scanSessionJSONL(path)
+		details, ok := scanSessionJSONL(path, sessionScanOptions{
+			targetCWD:  cwd,
+			requireCWD: true,
+		})
 		if !ok || details.id == "" || cleanCWD(details.cwd) != cwd {
 			return nil
 		}
@@ -239,23 +248,41 @@ type sessionDetails struct {
 	branch string
 }
 
-func scanSessionJSONL(path string) (sessionDetails, bool) {
+type sessionScanOptions struct {
+	targetCWD  string
+	requireCWD bool
+}
+
+func scanSessionJSONL(path string, opts sessionScanOptions) (sessionDetails, bool) {
 	f, err := os.Open(path)
 	if err != nil {
 		return sessionDetails{}, false
 	}
 	defer f.Close()
 
+	return scanSessionJSONLReader(f, opts)
+}
+
+func scanSessionJSONLReader(r io.Reader, opts sessionScanOptions) (sessionDetails, bool) {
 	var details sessionDetails
-	scanner := bufio.NewScanner(f)
+	targetCWD := cleanCWD(opts.targetCWD)
+	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
+	lineNo := 0
 	for scanner.Scan() {
+		lineNo++
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
+			if lineNo >= sessionScanLineLimit {
+				break
+			}
 			continue
 		}
 		var fields map[string]any
 		if err := json.Unmarshal([]byte(line), &fields); err != nil {
+			if lineNo >= sessionScanLineLimit {
+				break
+			}
 			continue
 		}
 		if details.id == "" {
@@ -263,15 +290,37 @@ func scanSessionJSONL(path string) (sessionDetails, bool) {
 		}
 		if details.cwd == "" {
 			details.cwd = firstNestedString(fields, "cwd", "current_dir", "currentDir", "project_dir", "projectDir", "project_path", "projectPath", "working_directory", "workingDirectory")
+			if targetCWD != "" && details.cwd != "" && cleanCWD(details.cwd) != targetCWD {
+				return sessionDetails{}, false
+			}
 		}
 		if details.branch == "" {
 			details.branch = firstNestedString(fields, "gitBranch", "git_branch", "branch")
 		}
-		if details.title == "" {
+		if details.title == "" && lineNo <= sessionTitleLineLimit {
 			details.title = titleFromRecord(fields)
 		}
+		if details.ready(opts.requireCWD, targetCWD) {
+			return details, true
+		}
+		if lineNo >= sessionScanLineLimit {
+			break
+		}
+	}
+	if opts.requireCWD && details.cwd == "" {
+		return sessionDetails{}, false
 	}
 	return details, details.id != "" || details.cwd != "" || details.title != ""
+}
+
+func (details sessionDetails) ready(requireCWD bool, targetCWD string) bool {
+	if details.id == "" || details.title == "" || details.branch == "" {
+		return false
+	}
+	if targetCWD != "" && details.cwd == "" {
+		return false
+	}
+	return !requireCWD || details.cwd != ""
 }
 
 func titleFromRecord(fields map[string]any) string {

--- a/internal/integrations/agents/aisessions/sessions_test.go
+++ b/internal/integrations/agents/aisessions/sessions_test.go
@@ -1,8 +1,11 @@
 package aisessions
 
 import (
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -132,6 +135,83 @@ func TestDiscoverSkipsNoisyTitleCandidates(t *testing.T) {
 	}
 }
 
+func TestScanSessionJSONLStopsAfterCwdMismatch(t *testing.T) {
+	t.Parallel()
+
+	firstLine := `{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000077","cwd":"/workspace/other","git_branch":"feat/other"}}` + "\n"
+	reader := newFailAfterReader(firstLine+`{"type":"event_msg","payload":{"message":"must not be read"}}`+"\n", len(firstLine))
+
+	details, ok := scanSessionJSONLReader(reader, sessionScanOptions{
+		targetCWD:  "/workspace/app",
+		requireCWD: true,
+	})
+
+	if ok {
+		t.Fatalf("scanSessionJSONLReader() ok = true, details = %#v", details)
+	}
+	if reader.failed {
+		t.Fatal("scanSessionJSONLReader() read past mismatched cwd metadata")
+	}
+}
+
+func TestScanSessionJSONLEarlyExitsAfterOutputFields(t *testing.T) {
+	t.Parallel()
+
+	prefix := `{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000066","cwd":"/workspace/app","git_branch":"feat/perf"}}` + "\n" +
+		`{"type":"event_msg","payload":{"message":"Speed up resume picker"}}` + "\n"
+	reader := newFailAfterReader(prefix+`{"type":"event_msg","payload":{"message":"must not be read"}}`+"\n", len(prefix))
+
+	details, ok := scanSessionJSONLReader(reader, sessionScanOptions{
+		targetCWD:  "/workspace/app",
+		requireCWD: true,
+	})
+
+	if !ok {
+		t.Fatal("scanSessionJSONLReader() ok = false")
+	}
+	if reader.failed {
+		t.Fatal("scanSessionJSONLReader() read after id/cwd/title/branch were available")
+	}
+	if details.id != "019f0000-0000-7000-8000-000000000066" ||
+		details.cwd != "/workspace/app" ||
+		details.branch != "feat/perf" ||
+		details.title != "Speed up resume picker" {
+		t.Fatalf("details = %#v", details)
+	}
+}
+
+func TestDiscoverUsesShortIDWhenTitleIsOutsideBoundedPrefix(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "codex", "sessions", "2026", "06", "25")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	id := "019f0000-0000-7000-8000-000000000055"
+	var lines strings.Builder
+	lines.WriteString(`{"type":"session_meta","payload":{"id":"` + id + `","cwd":"/workspace/app","git_branch":"feat/title-bound"}}` + "\n")
+	for i := 1; i < sessionTitleLineLimit; i++ {
+		lines.WriteString(`{"type":"event_msg","payload":{"message":"# AGENTS.md instructions for /workspace/app"}}` + "\n")
+	}
+	lines.WriteString(`{"type":"event_msg","payload":{"message":"Title after bounded prefix"}}` + "\n")
+	path := filepath.Join(sessionsDir, "rollout-late-title.jsonl")
+	writeFile(t, path, lines.String())
+
+	got, err := Discover("/workspace/app", DiscoverOptions{
+		CodexSessionsDir: filepath.Join(root, "codex", "sessions"),
+	})
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Discover() len = %d, want 1: %#v", len(got), got)
+	}
+	if got[0].Title != shortResumeID(id) {
+		t.Fatalf("Title = %q, want short id fallback %q", got[0].Title, shortResumeID(id))
+	}
+}
+
 func TestEncodeClaudeProjectPath(t *testing.T) {
 	t.Parallel()
 
@@ -179,4 +259,31 @@ func assertSession(t *testing.T, got, want SessionMeta) {
 		!got.LastModified.Equal(want.LastModified) {
 		t.Fatalf("session = %#v, want %#v", got, want)
 	}
+}
+
+type failAfterReader struct {
+	data   string
+	limit  int
+	offset int
+	failed bool
+}
+
+func newFailAfterReader(data string, limit int) *failAfterReader {
+	return &failAfterReader{data: data, limit: limit}
+}
+
+func (r *failAfterReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if r.offset >= len(r.data) {
+		return 0, io.EOF
+	}
+	if r.offset >= r.limit {
+		r.failed = true
+		return 0, errors.New("read past limit")
+	}
+	p[0] = r.data[r.offset]
+	r.offset++
+	return 1, nil
 }


### PR DESCRIPTION
## Summary
- stop scanning JSONL files as soon as a mismatched cwd is discovered
- bound resume-session scans to the first 100 lines and only derive titles from that prefix
- exit early once id/cwd/title/branch output fields are available

## Root Cause
The resume picker's Codex discovery path walked every rollout file under `~/.codex/sessions` and scanned each JSONL file to the end before applying the cwd filter. On the measured local rollout set, that meant opening 637 files and reading roughly 445 MB for each picker load.

## Tests
- `go test ./internal/integrations/agents/aisessions`
- `GOCACHE=/tmp/projmux-go-cache go build ./...`
- `GOCACHE=/tmp/projmux-go-cache go test ./internal/...`
- `make fmt`
- `GOCACHE=/tmp/projmux-go-cache make fix` (passed; unrelated `go fix` rewrite was not kept in the PR)
- `GOCACHE=/tmp/projmux-go-cache make test`
- `GOCACHE=/tmp/projmux-go-cache make test-integration`
- `GOCACHE=/tmp/projmux-go-cache make test-e2e`
