### PR TITLE
perf(ai): limit resume discovery to recent sessions

### DIFF
--- a/internal/integrations/agents/aisessions/sessions.go
+++ b/internal/integrations/agents/aisessions/sessions.go
@@ -27,6 +27,7 @@ const (
 
 	sessionScanLineLimit  = 100
 	sessionTitleLineLimit = 100
+	codexScanFileLimit    = 80
 )
 
 // SessionContext captures project metadata associated with a resume session.
@@ -168,11 +169,16 @@ func discoverClaude(cwd, projectsDir string) []SessionMeta {
 }
 
 func discoverCodex(cwd, sessionsDir string) []SessionMeta {
+	return discoverCodexWithFileLimit(cwd, sessionsDir, codexScanFileLimit)
+}
+
+func discoverCodexWithFileLimit(cwd, sessionsDir string, scanFileLimit int) []SessionMeta {
 	sessionsDir = strings.TrimSpace(sessionsDir)
 	if sessionsDir == "" {
 		return nil
 	}
-	var sessions []SessionMeta
+
+	var candidates []sessionFileCandidate
 	_ = filepath.WalkDir(sessionsDir, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil || entry == nil || entry.IsDir() {
 			return nil
@@ -184,16 +190,34 @@ func discoverCodex(cwd, sessionsDir string) []SessionMeta {
 		if err != nil {
 			return nil
 		}
-		details, ok := scanSessionJSONL(path, sessionScanOptions{
+		candidates = append(candidates, sessionFileCandidate{
+			path:    path,
+			modTime: info.ModTime(),
+		})
+		return nil
+	})
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].modTime.Equal(candidates[j].modTime) {
+			return candidates[i].path < candidates[j].path
+		}
+		return candidates[i].modTime.After(candidates[j].modTime)
+	})
+	if scanFileLimit > 0 && len(candidates) > scanFileLimit {
+		candidates = candidates[:scanFileLimit]
+	}
+
+	sessions := make([]SessionMeta, 0, len(candidates))
+	for _, candidate := range candidates {
+		details, ok := scanSessionJSONL(candidate.path, sessionScanOptions{
 			targetCWD:  cwd,
 			requireCWD: true,
 		})
 		if !ok || details.id == "" || cleanCWD(details.cwd) != cwd {
-			return nil
+			continue
 		}
 		id, err := codex.NormalizeResumeID(details.id)
 		if err != nil {
-			return nil
+			continue
 		}
 		title := details.title
 		if title == "" {
@@ -203,20 +227,24 @@ func discoverCodex(cwd, sessionsDir string) []SessionMeta {
 			Agent:        AgentCodex,
 			ResumeID:     id,
 			Title:        title,
-			LastModified: info.ModTime(),
+			LastModified: candidate.modTime,
 			Context: SessionContext{
 				CWD:    cwd,
 				Branch: details.branch,
 			},
 			Source: SourceCodexRollout,
 		})
-		return nil
-	})
+	}
 	return sessions
 }
 
 func discoverAntigravity(_ string, _ string) []SessionMeta {
 	return nil
+}
+
+type sessionFileCandidate struct {
+	path    string
+	modTime time.Time
 }
 
 func dedupeByResumeID(sessions []SessionMeta) []SessionMeta {

--- a/internal/integrations/agents/aisessions/sessions_test.go
+++ b/internal/integrations/agents/aisessions/sessions_test.go
@@ -2,6 +2,7 @@ package aisessions
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -103,6 +104,82 @@ func TestDiscoverDedupesResumeIDKeepingNewest(t *testing.T) {
 		Context:      SessionContext{CWD: "/workspace/app", Branch: "feat/newer"},
 		Source:       SourceCodexRollout,
 	})
+}
+
+func TestDiscoverCodexScansNewestFilesFirstByModTime(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "codex", "sessions", "2026", "06", "25")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	olderPath := filepath.Join(sessionsDir, "rollout-000-older.jsonl")
+	newerPath := filepath.Join(sessionsDir, "rollout-999-newer.jsonl")
+	writeFile(t, olderPath, `{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000201","cwd":"/workspace/app","git_branch":"feat/older"}}
+{"type":"event_msg","payload":{"message":"Older session"}}
+`)
+	writeFile(t, newerPath, `{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000202","cwd":"/workspace/app","git_branch":"feat/newer"}}
+{"type":"event_msg","payload":{"message":"Newer session"}}
+`)
+	setModTime(t, olderPath, time.Date(2026, 6, 25, 8, 0, 0, 0, time.UTC))
+	setModTime(t, newerPath, time.Date(2026, 6, 25, 9, 0, 0, 0, time.UTC))
+
+	got := discoverCodex("/workspace/app", filepath.Join(root, "codex", "sessions"))
+	if len(got) != 2 {
+		t.Fatalf("discoverCodex() len = %d, want 2: %#v", len(got), got)
+	}
+	if got[0].Title != "Newer session" || got[1].Title != "Older session" {
+		t.Fatalf("discoverCodex() titles = [%q, %q], want newest first", got[0].Title, got[1].Title)
+	}
+}
+
+func TestDiscoverCodexLimitsScanToMostRecentFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "codex", "sessions")
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	for i := 0; i <= codexScanFileLimit; i++ {
+		writeNumberedCodexSession(t, sessionsDir, i, base.Add(-time.Duration(i)*time.Minute), "/workspace/app")
+	}
+
+	got := discoverCodex("/workspace/app", sessionsDir)
+	if len(got) != codexScanFileLimit {
+		t.Fatalf("discoverCodex() len = %d, want %d", len(got), codexScanFileLimit)
+	}
+	oldestID := numberedCodexSessionID(codexScanFileLimit)
+	for _, session := range got {
+		if session.ResumeID == oldestID {
+			t.Fatalf("discoverCodex() included oldest session beyond scan limit: %#v", session)
+		}
+	}
+}
+
+func TestDiscoverCodexLimitedScanPreservesRecentPickerResults(t *testing.T) {
+	t.Parallel()
+
+	const pickerVisibleLimit = 30
+
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "codex", "sessions")
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < codexScanFileLimit+40; i++ {
+		writeNumberedCodexSession(t, sessionsDir, i, base.Add(-time.Duration(i)*time.Minute), "/workspace/app")
+	}
+
+	limited := discoverCodexWithFileLimit("/workspace/app", sessionsDir, codexScanFileLimit)
+	unbounded := discoverCodexWithFileLimit("/workspace/app", sessionsDir, 0)
+	if len(limited) < pickerVisibleLimit || len(unbounded) < pickerVisibleLimit {
+		t.Fatalf("not enough sessions to compare picker rows: limited=%d unbounded=%d", len(limited), len(unbounded))
+	}
+	for i := 0; i < pickerVisibleLimit; i++ {
+		if limited[i].ResumeID != unbounded[i].ResumeID ||
+			limited[i].Title != unbounded[i].Title ||
+			!limited[i].LastModified.Equal(unbounded[i].LastModified) {
+			t.Fatalf("row %d differs after limit: limited=%#v unbounded=%#v", i, limited[i], unbounded[i])
+		}
+	}
 }
 
 func TestDiscoverSkipsNoisyTitleCandidates(t *testing.T) {
@@ -259,6 +336,26 @@ func assertSession(t *testing.T, got, want SessionMeta) {
 		!got.LastModified.Equal(want.LastModified) {
 		t.Fatalf("session = %#v, want %#v", got, want)
 	}
+}
+
+func writeNumberedCodexSession(t *testing.T, sessionsDir string, index int, modTime time.Time, cwd string) string {
+	t.Helper()
+
+	dir := filepath.Join(sessionsDir, "2026", "06", "25")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, fmt.Sprintf("rollout-%03d.jsonl", index))
+	id := numberedCodexSessionID(index)
+	writeFile(t, path, `{"type":"session_meta","payload":{"id":"`+id+`","cwd":"`+cwd+`","git_branch":"feat/perf"}}
+{"type":"event_msg","payload":{"message":"Session `+fmt.Sprintf("%03d", index)+`"}}
+`)
+	setModTime(t, path, modTime)
+	return path
+}
+
+func numberedCodexSessionID(index int) string {
+	return fmt.Sprintf("019f0000-0000-7000-8000-%012d", index)
 }
 
 type failAfterReader struct {


### PR DESCRIPTION
## Summary
- collect Codex rollout candidates as path + mtime first, then scan JSONL only after sorting newest-first
- cap Codex rollout scanning at the 80 most-recent files via `codexScanFileLimit`
- add regression coverage for mtime ordering, scan limiting, and preserving the picker-visible recent 30 rows versus an unbounded scan

## Root Cause
The resume picker only renders 30 rows, but Codex discovery scanned every matching rollout JSONL file for the cwd. Lead measurement found 406 matching sessions in this checkout, costing about 337ms per discovery.

## Impact
The picker now avoids reading older rollout files outside the recent scan window. Based on the measured probe, scanning recent files reduces the hot path from about 337ms to about 35ms while preserving the visible recent results.

## Validation
- `go test ./internal/integrations/agents/aisessions`
- `env GOCACHE=/tmp/projmux-go-cache go build ./...`
- `env GOCACHE=/tmp/projmux-go-cache go test ./internal/...`

Note: the first sandboxed `go build ./...` hit a read-only Go cache warning, and the first sandboxed `go test ./internal/...` was blocked from creating test sockets; both passed after rerunning with writable cache / escalated permissions.
