### PR TITLE
feat(ai): fixed-column resume picker row view (Phase 0)

### DIFF
--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -884,8 +884,12 @@ func (c *aiCommand) runResumeSessionPicker(direction string, sessions []aisessio
 	if c.nativePicker == nil {
 		return intpickercompat.Result{}, errors.New("native picker is not configured")
 	}
-	entries, visible, total := aiResumeSessionRows(sessions)
 	locale := appLocale(c.homeDir, c.lookupEnv)
+	var now time.Time
+	if c.now != nil {
+		now = c.now()
+	}
+	entries, visible, total := aiResumeSessionRows(sessions, now, locale)
 	footer := fmt.Sprintf(localizeUIText(locale, "Showing latest %d resume sessions."), visible)
 	if total > visible {
 		footer = fmt.Sprintf(localizeUIText(locale, "Showing latest %d of %d resume sessions."), visible, total)
@@ -908,7 +912,38 @@ type aiResumeSelection struct {
 	updatedAt time.Time
 }
 
-func aiResumeSessionRows(sessions []aisessions.SessionMeta) ([]intpickercompat.Entry, int, int) {
+// Resume picker row column schema (Phase 0 — row view slice).
+//
+// Every row lays out the same fixed-width columns so they align in the popup
+// regardless of locale or CJK content, with the title as the trailing
+// variable-width column:
+//
+//	[agent ] MM-DD HH:MM <rel>  <branch>            <shortid> [<extra>] <title…>
+//	  6        11          6      18                  8         (0)       rest
+//
+// Column order / cell width (visible cells, fixed columns left-aligned):
+//   - agent badge: aiResumeAgentCellWidth (inside cyan [ ])
+//   - absolute time: aiResumeTimeWidth ("MM-DD HH:MM", dim)
+//   - relative age: aiResumeRelCellWidth (compact, locale-aware, dim)
+//   - branch: aiResumeBranchCellWidth (dim, cut)
+//   - short resume id: aiResumeShortIDWidth (dim, leading runes)
+//   - extra-meta slot: reserved for the Phase 2 cwd column; empty today so the
+//     layout matches the current view (source is intentionally not surfaced —
+//     it duplicates the agent badge).
+//   - title: trailing variable width, cut with an ellipsis past
+//     aiResumeTitleMaxCells.
+const (
+	aiResumeAgentCellWidth  = 6
+	aiResumeTimeWidth       = 11
+	aiResumeRelCellWidth    = 6
+	aiResumeBranchCellWidth = 18
+	aiResumeShortIDWidth    = 8
+	aiResumeTitleMaxCells   = 72
+	aiResumeTimeLayout      = "01-02 15:04"
+	aiResumeEmptyCell       = "-"
+)
+
+func aiResumeSessionRows(sessions []aisessions.SessionMeta, now time.Time, locale i18n.Locale) ([]intpickercompat.Entry, int, int) {
 	total := len(sessions)
 	if len(sessions) > aiResumePickerLimit {
 		sessions = sessions[:aiResumePickerLimit]
@@ -920,25 +955,38 @@ func aiResumeSessionRows(sessions []aisessions.SessionMeta) ([]intpickercompat.E
 		SearchKey: "new session fresh agent picker",
 	})
 	for _, session := range sessions {
-		rows = append(rows, aiResumeSessionRow(session))
+		rows = append(rows, aiResumeSessionRow(session, now, locale))
 	}
 	return rows, len(sessions), total
 }
 
-func aiResumeSessionRow(session aisessions.SessionMeta) intpickercompat.Entry {
+func aiResumeSessionRow(session aisessions.SessionMeta, now time.Time, locale i18n.Locale) intpickercompat.Entry {
 	agent := strings.TrimSpace(session.Agent)
 	resumeID := strings.TrimSpace(session.ResumeID)
 	branch := strings.TrimSpace(session.Context.Branch)
 	if branch == "" {
-		branch = "-"
+		branch = aiResumeEmptyCell
 	}
 	title := cleanAIResumeTitle(session.Title, resumeID)
-	label := fmt.Sprintf("\x1b[36m[%-6s]\x1b[0m %s  \x1b[90m%-18s\x1b[0m %s",
-		agent,
-		session.LastModified.Local().Format("2006-01-02 15:04"),
-		truncateAIResumeRunes(branch, 18),
-		title,
-	)
+
+	// Fixed columns: pad/truncate each to a stable cell width, then colorize.
+	badge := "\x1b[36m[" + aiResumeFitCell(agent, aiResumeAgentCellWidth) + "]\x1b[0m"
+	absTime := ansiDim(aiResumeAbsoluteTime(session.LastModified))
+	relTime := ansiDim(aiResumeFitCell(aiResumeRelativeAge(now, session.LastModified, locale), aiResumeRelCellWidth))
+	branchCell := ansiDim(aiResumeFitCell(branch, aiResumeBranchCellWidth))
+	shortID := ansiDim(aiResumeFitCell(aiResumeShortID(resumeID), aiResumeShortIDWidth))
+
+	// Reserved extra-meta slot (Phase 2 cwd column). Empty today, so the column
+	// contributes nothing and the layout is identical to the current view; a
+	// non-empty value carries its own trailing gap before the title.
+	extra := aiResumeExtraMetaCell(session)
+	if extra != "" {
+		extra += " "
+	}
+
+	label := fmt.Sprintf("%s %s %s %s %s %s%s",
+		badge, absTime, relTime, branchCell, shortID, extra, title)
+
 	return intpickercompat.Entry{
 		Label:     label,
 		Value:     aiResumePickerValue(agent, resumeID),
@@ -946,23 +994,79 @@ func aiResumeSessionRow(session aisessions.SessionMeta) intpickercompat.Entry {
 	}
 }
 
+// aiResumeAbsoluteTime renders the fixed-width "MM-DD HH:MM" column, padding to
+// a stable width when the timestamp is missing so columns stay aligned.
+func aiResumeAbsoluteTime(t time.Time) string {
+	if t.IsZero() {
+		return strings.Repeat(" ", aiResumeTimeWidth)
+	}
+	return t.Local().Format(aiResumeTimeLayout)
+}
+
+// aiResumeRelativeAge renders a compact, locale-aware relative age ("2h", "3d",
+// "2시간"). It returns empty when either timestamp is unknown so the column pads
+// to a blank cell instead of a bogus age.
+func aiResumeRelativeAge(now, modified time.Time, locale i18n.Locale) string {
+	if now.IsZero() || modified.IsZero() {
+		return ""
+	}
+	age := now.Sub(modified)
+	if age < 0 {
+		age = 0
+	}
+	return i18n.FormatDuration(age, locale, i18n.FormatCompact)
+}
+
+// aiResumeShortID returns the leading runes of the resume id for a compact
+// fixed-width identifier column.
+func aiResumeShortID(resumeID string) string {
+	runes := []rune(strings.TrimSpace(resumeID))
+	if len(runes) > aiResumeShortIDWidth {
+		return string(runes[:aiResumeShortIDWidth])
+	}
+	return string(runes)
+}
+
+// aiResumeExtraMetaCell is the reserved extra-meta column. Phase 0 keeps it
+// empty (source duplicates the agent badge); Phase 2 returns the cwd relative
+// path here. Keeping a single seam documents where the next column slots in.
+func aiResumeExtraMetaCell(_ aisessions.SessionMeta) string {
+	return ""
+}
+
 func cleanAIResumeTitle(title, resumeID string) string {
 	title = strings.Join(strings.Fields(title), " ")
 	if title == "" {
-		title = resumeID
+		title = strings.TrimSpace(resumeID)
 	}
 	if title == "" {
 		return "(untitled)"
 	}
-	return truncateAIResumeRunes(title, 72)
+	return truncateAIResumeCells(title, aiResumeTitleMaxCells)
 }
 
-func truncateAIResumeRunes(value string, limit int) string {
-	runes := []rune(strings.TrimSpace(value))
-	if limit <= 0 || len(runes) <= limit {
-		return string(runes)
+// aiResumeFitCell truncates value to width terminal cells and right-pads with
+// spaces, so fixed columns align even with CJK or empty content.
+func aiResumeFitCell(value string, width int) string {
+	fitted := i18n.TruncateTerminalCells(strings.TrimSpace(value), width)
+	if pad := width - i18n.TerminalCellWidth(fitted); pad > 0 {
+		fitted += strings.Repeat(" ", pad)
 	}
-	return string(runes[:limit])
+	return fitted
+}
+
+// truncateAIResumeCells clips value to limit terminal cells, appending an
+// ellipsis when it overflows. Width-based (not rune-count) so CJK titles stay
+// inside narrow popups.
+func truncateAIResumeCells(value string, limit int) string {
+	value = strings.TrimSpace(value)
+	if limit <= 0 {
+		return ""
+	}
+	if i18n.TerminalCellWidth(value) <= limit {
+		return value
+	}
+	return i18n.TruncateTerminalCells(value, limit-1) + "…"
 }
 
 func aiResumePickerValue(agent, resumeID string) string {

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/aiprovider"
+	"github.com/crevissepartners/projmux/internal/i18n"
 	"github.com/crevissepartners/projmux/internal/integrations/agents/aisessions"
 	intpsmux "github.com/crevissepartners/projmux/internal/integrations/psmux"
 	"github.com/crevissepartners/projmux/internal/theme"
@@ -280,7 +281,7 @@ func TestAIResumePickerRowsCapAndMetadata(t *testing.T) {
 		})
 	}
 
-	rows, visible, total := aiResumeSessionRows(sessions)
+	rows, visible, total := aiResumeSessionRows(sessions, time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC), i18n.FallbackLocale)
 
 	if visible != aiResumePickerLimit || total != aiResumePickerLimit+2 {
 		t.Fatalf("visible,total = %d,%d, want %d,%d", visible, total, aiResumePickerLimit, aiResumePickerLimit+2)
@@ -296,6 +297,138 @@ func TestAIResumePickerRowsCapAndMetadata(t *testing.T) {
 	}
 	if !strings.Contains(rows[1].SearchKey, sessions[0].ResumeID) {
 		t.Fatalf("session row search key = %q, want resume id", rows[1].SearchKey)
+	}
+}
+
+// aiResumeRowPrefixWidth is the fixed-column prefix width that every session
+// row shares before the trailing title: badge[8] + " " + time[11] + " " +
+// rel[6] + " " + branch[18] + " " + shortid[8] + " " (separator before title).
+const aiResumeRowPrefixWidth = (aiResumeAgentCellWidth + 2) + 1 + aiResumeTimeWidth + 1 +
+	aiResumeRelCellWidth + 1 + aiResumeBranchCellWidth + 1 + aiResumeShortIDWidth + 1
+
+func TestAIResumeSessionRowColumnsAlign(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	sessions := []aisessions.SessionMeta{
+		{
+			Agent:        aiModeClaude,
+			ResumeID:     "019f0000-0000-7000-8000-000000000001",
+			Title:        "short title",
+			LastModified: now.Add(-2 * time.Hour),
+			Context:      aisessions.SessionContext{Branch: "main"},
+		},
+		{
+			Agent:        aiModeAntigravity, // longer than the badge cell
+			ResumeID:     "abc",             // shorter than the short-id cell
+			Title:        strings.Repeat("very-long-title ", 12),
+			LastModified: now.Add(-72 * time.Hour),
+			Context:      aisessions.SessionContext{Branch: "feature/extremely-long-branch-name-overflow"},
+		},
+		{
+			Agent:        aiModeCodex,
+			ResumeID:     "019f0000-0000-7000-8000-000000000003",
+			Title:        "한글 제목 정렬 확인", // wide runes in the title
+			LastModified: now.Add(-30 * time.Minute),
+			Context:      aisessions.SessionContext{Branch: ""}, // empty -> placeholder
+		},
+	}
+
+	rows, visible, total := aiResumeSessionRows(sessions, now, i18n.FallbackLocale)
+	if visible != len(sessions) || total != len(sessions) {
+		t.Fatalf("visible,total = %d,%d, want %d,%d", visible, total, len(sessions), len(sessions))
+	}
+
+	for i, session := range sessions {
+		row := rows[i+1] // row 0 is the New Session entry
+		title := cleanAIResumeTitle(session.Title, session.ResumeID)
+		// The fixed-column prefix width is label width minus the rendered title.
+		prefix := i18n.TerminalCellWidth(row.Label) - i18n.TerminalCellWidth(title)
+		if prefix != aiResumeRowPrefixWidth {
+			t.Fatalf("row %d prefix width = %d, want %d (label %q)", i, prefix, aiResumeRowPrefixWidth, row.Label)
+		}
+	}
+
+	// Empty branch renders the placeholder, not a collapsed column.
+	if !strings.Contains(rows[3].Label, aiResumeEmptyCell) {
+		t.Fatalf("empty-branch row = %q, want %q placeholder", rows[3].Label, aiResumeEmptyCell)
+	}
+}
+
+func TestAIResumeSessionRowTitleEllipsis(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	long := strings.Repeat("x", aiResumeTitleMaxCells+25)
+	row := aiResumeSessionRow(aisessions.SessionMeta{
+		Agent:        aiModeClaude,
+		ResumeID:     "019f0000-0000-7000-8000-000000000009",
+		Title:        long,
+		LastModified: now.Add(-time.Hour),
+	}, now, i18n.FallbackLocale)
+
+	if !strings.Contains(row.Label, "…") {
+		t.Fatalf("row label = %q, want ellipsis on overflow", row.Label)
+	}
+	title := cleanAIResumeTitle(long, "")
+	if w := i18n.TerminalCellWidth(title); w > aiResumeTitleMaxCells {
+		t.Fatalf("clipped title width = %d, want <= %d", w, aiResumeTitleMaxCells)
+	}
+	// Short ids surface in the short-id column.
+	if !strings.Contains(row.Label, "019f0000") {
+		t.Fatalf("row label = %q, want short resume id", row.Label)
+	}
+}
+
+func TestAIResumeFitCell(t *testing.T) {
+	if got := aiResumeFitCell("ab", 6); got != "ab    " {
+		t.Fatalf("pad short = %q, want %q", got, "ab    ")
+	}
+	if got := aiResumeFitCell("abcdefgh", 6); got != "abcdef" {
+		t.Fatalf("truncate long = %q, want %q", got, "abcdef")
+	}
+	// Wide runes must be measured in cells, not bytes/runes.
+	if got := i18n.TerminalCellWidth(aiResumeFitCell("한글", 6)); got != 6 {
+		t.Fatalf("CJK cell width = %d, want 6", got)
+	}
+}
+
+func TestTruncateAIResumeCells(t *testing.T) {
+	if got := truncateAIResumeCells("hello", 10); got != "hello" {
+		t.Fatalf("under limit = %q, want unchanged", got)
+	}
+	got := truncateAIResumeCells("abcdefghij", 5)
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("over limit = %q, want ellipsis suffix", got)
+	}
+	if w := i18n.TerminalCellWidth(got); w > 5 {
+		t.Fatalf("clipped width = %d, want <= 5", w)
+	}
+}
+
+func TestAIResumeRelativeAge(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	if got := aiResumeRelativeAge(now, now.Add(-2*time.Hour), i18n.FallbackLocale); got != "2h" {
+		t.Fatalf("relative hours = %q, want %q", got, "2h")
+	}
+	if got := aiResumeRelativeAge(now, now.Add(-72*time.Hour), i18n.FallbackLocale); got != "3d" {
+		t.Fatalf("relative days = %q, want %q", got, "3d")
+	}
+	// Unknown timestamps yield an empty (padded) cell rather than a bogus age.
+	if got := aiResumeRelativeAge(time.Time{}, now, i18n.FallbackLocale); got != "" {
+		t.Fatalf("zero now = %q, want empty", got)
+	}
+	if got := aiResumeRelativeAge(now, time.Time{}, i18n.FallbackLocale); got != "" {
+		t.Fatalf("zero modified = %q, want empty", got)
+	}
+	// Future timestamps clamp to zero instead of going negative.
+	if got := aiResumeRelativeAge(now, now.Add(time.Hour), i18n.FallbackLocale); got != "0s" {
+		t.Fatalf("future = %q, want %q", got, "0s")
+	}
+}
+
+func TestAIResumeShortID(t *testing.T) {
+	if got := aiResumeShortID("019f0000-0000-7000"); got != "019f0000" {
+		t.Fatalf("short id = %q, want %q", got, "019f0000")
+	}
+	if got := aiResumeShortID("abc"); got != "abc" {
+		t.Fatalf("short id (short) = %q, want %q", got, "abc")
 	}
 }
 


### PR DESCRIPTION
## 완료한 Phase
- **Phase 0 — Row view slice** (AI resume picker). Presentation-only 재설계.

## 무엇이 바뀌나 (user-facing surface)
`projmux ai picker --resume` (resume session picker) 의 각 row 를 일관된 고정폭 컬럼 리스트로 재설계했습니다.

```
[agent ] MM-DD HH:MM <rel>  <branch>            <shortid> <title…>
  6        11          6      18                  8         rest
```

- **컬럼(순서/폭)**: agent badge `[6]` · 절대시간 `MM-DD HH:MM` `[11]` · **상대시간 `[6]`** (compact, locale-aware) · branch `[18]` · short resume id `[8]` · title(가변폭, 말줄임 cut).
- **절대+상대 시간 병기** (Lead 결정). 상대시간은 `i18n.FormatDuration(..., FormatCompact)` 로 `2h`/`3d` (en) / `2시간`/`3일` (ko).
- **추가-메타 슬롯 예약**: short id 와 title 사이에 Phase 2 cwd 컬럼이 들어올 자리를 `aiResumeExtraMetaCell` 한 곳으로 예약(지금은 빈 문자열 → 레이아웃 현행 동일). source 는 강제 노출하지 않음(agent 와 중복).
- **폭 기준 truncation/padding** (`i18n.TerminalCellWidth` / `TruncateTerminalCells`): CJK 제목·좁은 popup 에서도 정렬 유지. title 초과 시 `…` cut.
- branch 비어도 `-` placeholder 로 컬럼 유지 → 레이아웃 안 깨짐.
- `[+ New Session]` 상단 고정 유지. 선택값/라우팅(`aiResumePickerValue`/`parseAIResumePickerValue`) 무변경.

## 명시적으로 제외한 다음 Phase 범위
- **Phase 1 (설정)**: `aiResumePickerLimit=30` 변경/설정화, `[ai]` config 섹션, `Settings > AI > Resume picker` 서브메뉴 — 손대지 않음.
- **Phase 2 (depth)**: `aisessions` 디스커버리/cwd-tree 필터/`DiscoverOptions.Depth`/cwd 컬럼 노출 — 자리만 예약, 구현 없음.

## 모델/스키마/제약 준수
- `aisessions.SessionMeta` 신규 필드 **추가 없음** — 기존 `Agent / ResumeID / Title / LastModified / Context{CWD,Branch} / Source` 만 사용.
- config / Settings / i18n 신규 설정 row 추가 없음. 기존 theme ANSI 색·i18n 헤더 관습 유지.

## 검증
- `go build ./...` 통과.
- `go test ./internal/...` 전체 통과.
- 추가 단위 테스트 (`internal/app/ai_test.go`):
  - `TestAIResumeSessionRowColumnsAlign` — 가변 agent/branch/id/CJK 에서 고정 컬럼 prefix 폭 동일, 빈 branch placeholder.
  - `TestAIResumeSessionRowTitleEllipsis` — title 초과 시 `…` cut + 폭 ≤ 한계, short id 노출.
  - `TestAIResumeFitCell` / `TestTruncateAIResumeCells` — 폭 기준 pad/truncate, CJK cell 폭.
  - `TestAIResumeRelativeAge` — `2h`/`3d`, zero→빈칸, 미래→`0s` clamp.
  - `TestAIResumeShortID` — 앞 8 runes.
  - 기존 `TestAIResumePickerRowsCapAndMetadata` 신규 시그니처로 갱신.

## 미검증 / 후속
- 실제 tmux popup 렌더 스냅샷은 e2e 후보(단위 테스트로 컬럼 정렬·폭은 고정). 로컬 scratch 렌더로 ASCII/CJK/빈 branch/en·ko 정렬 육안 확인함.
- Phase 1(limit 설정), Phase 2(cwd-depth + cwd 컬럼)는 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)