### PR TITLE
feat(ai): symlink loop guard + session uniqueness for resume discovery (Phase 4)

### DIFF
--- a/internal/integrations/agents/aisessions/sessions.go
+++ b/internal/integrations/agents/aisessions/sessions.go
@@ -1,4 +1,14 @@
 // Package aisessions discovers resume-capable AI agent sessions on disk.
+//
+// Symlink policy: directory traversal (the depth>0 Claude project-dir
+// enumeration and the codex sessions walk) follows symlinked directories so
+// sessions stored behind a symlink stay discoverable, but every directory is
+// recorded in a pathGuard keyed by its resolved real path. Re-entering an
+// already-visited real directory is refused, so a symlink cycle (a directory
+// linking to one of its ancestors) or two symlink paths aliasing the same real
+// directory can never cause an unbounded walk or scan the same file twice.
+// Results are additionally deduped by ResumeID (the session identity), so a
+// session reached through two paths still appears in the picker exactly once.
 package aisessions
 
 import (
@@ -141,16 +151,24 @@ func discoverClaude(cwd, projectsDir string, depth int) []SessionMeta {
 		return nil
 	}
 	encoded := EncodeClaudeProjectPath(cwd)
+	guard := newPathGuard()
 	var sessions []SessionMeta
 	for _, entry := range entries {
-		if entry == nil || !entry.IsDir() {
+		// entryIsDir follows symlinks so a symlinked project dir still counts.
+		if entry == nil || !entryIsDir(projectsDir, entry) {
 			continue
 		}
 		name := entry.Name()
 		if name != encoded && !strings.HasPrefix(name, encoded+"-") {
 			continue
 		}
-		sessions = append(sessions, discoverClaudeDir(filepath.Join(projectsDir, name), cwd, depth)...)
+		dir := filepath.Join(projectsDir, name)
+		// Two project-dir names can symlink to the same real directory; scan the
+		// underlying sessions only once so a session is not discovered twice.
+		if !guard.visit(dir) {
+			continue
+		}
+		sessions = append(sessions, discoverClaudeDir(dir, cwd, depth)...)
 	}
 	return sessions
 }
@@ -249,22 +267,11 @@ func discoverCodexWithFileLimit(cwd, sessionsDir string, scanFileLimit, depth in
 	treeFilter := depth > 0
 
 	var candidates []sessionFileCandidate
-	_ = filepath.WalkDir(sessionsDir, func(path string, entry fs.DirEntry, err error) error {
-		if err != nil || entry == nil || entry.IsDir() {
-			return nil
-		}
-		if matched, matchErr := filepath.Match("rollout-*.jsonl", entry.Name()); matchErr != nil || !matched {
-			return nil
-		}
-		info, err := entry.Info()
-		if err != nil {
-			return nil
-		}
+	walkCodexSessionFiles(sessionsDir, newPathGuard(), func(path string, modTime time.Time) {
 		candidates = append(candidates, sessionFileCandidate{
 			path:    path,
-			modTime: info.ModTime(),
+			modTime: modTime,
 		})
-		return nil
 	})
 	sort.SliceStable(candidates, func(i, j int) bool {
 		if candidates[i].modTime.Equal(candidates[j].modTime) {
@@ -312,6 +319,100 @@ func discoverCodexWithFileLimit(cwd, sessionsDir string, scanFileLimit, depth in
 		})
 	}
 	return sessions
+}
+
+// walkCodexSessionFiles walks root for codex rollout files, descending into
+// subdirectories and following symlinked directories. guard makes following
+// safe: it records the resolved real path of every directory entered, so a
+// symlink cycle (a directory linking to an ancestor) or two symlink paths
+// aliasing the same real directory resolve to an already-visited location and
+// are skipped. The walk is therefore always bounded regardless of symlinks.
+func walkCodexSessionFiles(dir string, guard *pathGuard, visit func(path string, modTime time.Time)) {
+	// A directory whose real path was already walked is a cycle or alias; stop.
+	if !guard.visit(dir) {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		full := filepath.Join(dir, entry.Name())
+		if entryIsDir(dir, entry) {
+			walkCodexSessionFiles(full, guard, visit)
+			continue
+		}
+		if matched, matchErr := filepath.Match("rollout-*.jsonl", entry.Name()); matchErr != nil || !matched {
+			continue
+		}
+		if entry.Type()&fs.ModeSymlink != 0 {
+			// Follow the link to the real file for its mtime, and skip it if the
+			// same real file was already collected through another path.
+			info, statErr := os.Stat(full)
+			if statErr != nil || info.IsDir() || !guard.visit(full) {
+				continue
+			}
+			visit(full, info.ModTime())
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		visit(full, info.ModTime())
+	}
+}
+
+// pathGuard bounds a symlink-following directory walk. It records the resolved
+// real path of every directory (and symlinked file) already visited so a
+// symlink cycle or alias resolves to an already-seen real location and is
+// refused, making an unbounded walk or a double scan impossible independent of
+// the depth cap.
+type pathGuard struct {
+	visited map[string]struct{}
+}
+
+func newPathGuard() *pathGuard {
+	return &pathGuard{visited: make(map[string]struct{})}
+}
+
+// visit reports whether path's resolved real location is newly seen. A false
+// return means path aliases an already-visited real location and must be
+// skipped to avoid re-walking it.
+func (g *pathGuard) visit(path string) bool {
+	real := resolveRealPath(path)
+	if _, ok := g.visited[real]; ok {
+		return false
+	}
+	g.visited[real] = struct{}{}
+	return true
+}
+
+// resolveRealPath returns path with all symlinks resolved. A broken or cyclic
+// symlink cannot be resolved; the cleaned literal path is used instead, which
+// still dedupes exact repeats without following a dangling link.
+func resolveRealPath(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return filepath.Clean(path)
+}
+
+// entryIsDir reports whether entry under parent is a directory, following one
+// level of symlink so a symlinked directory counts as a directory. Broken
+// symlinks report false.
+func entryIsDir(parent string, entry fs.DirEntry) bool {
+	if entry.IsDir() {
+		return true
+	}
+	if entry.Type()&fs.ModeSymlink == 0 {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(parent, entry.Name()))
+	return err == nil && info.IsDir()
 }
 
 // withinTree reports whether recordedCWD is cwd itself or a descendant up to

--- a/internal/integrations/agents/aisessions/symlink_test.go
+++ b/internal/integrations/agents/aisessions/symlink_test.go
@@ -1,0 +1,161 @@
+package aisessions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// mustSymlink creates oldname<-newname, skipping the test when the platform or
+// filesystem does not support symlinks rather than failing spuriously.
+func mustSymlink(t *testing.T, oldname, newname string) {
+	t.Helper()
+	if err := os.Symlink(oldname, newname); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+}
+
+// discoverWithin runs Discover in a goroutine and fails if it does not return
+// within the deadline, turning an unbounded symlink walk into a test failure
+// instead of a hang until the go-test timeout.
+func discoverWithin(t *testing.T, cwd string, opts DiscoverOptions, deadline time.Duration) []SessionMeta {
+	t.Helper()
+	type result struct {
+		sessions []SessionMeta
+		err      error
+	}
+	done := make(chan result, 1)
+	go func() {
+		got, err := Discover(cwd, opts)
+		done <- result{got, err}
+	}()
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("Discover() error = %v", r.err)
+		}
+		return r.sessions
+	case <-time.After(deadline):
+		t.Fatal("Discover() did not terminate: symlink cycle guard failed")
+		return nil
+	}
+}
+
+// A directory that symlinks back to one of its ancestors is a cycle. A walk
+// that follows symlinks without a guard would recurse forever; the pathGuard
+// must terminate it and still return the real session once.
+func TestDiscoverCodexSymlinkCycleTerminatesBounded(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "codex", "sessions")
+	claudeDir := filepath.Join(root, "claude", "projects") // isolate from real home
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+
+	writeNumberedCodexSession(t, sessionsDir, 1, base, "/workspace/app")
+	writeNumberedCodexSession(t, sessionsDir, 2, base.Add(-time.Minute), "/workspace/app/web")
+
+	// .../2026/loop -> sessionsDir (its grandparent): a self-referential cycle.
+	mustSymlink(t, sessionsDir, filepath.Join(sessionsDir, "2026", "loop"))
+
+	got := discoverWithin(t, "/workspace/app", DiscoverOptions{
+		ClaudeProjectsDir: claudeDir,
+		CodexSessionsDir:  sessionsDir,
+		Depth:             2,
+	}, 10*time.Second)
+
+	if len(got) != 2 {
+		t.Fatalf("Discover() len = %d, want 2 (exact + child, no cycle duplication): %#v", len(got), got)
+	}
+}
+
+// Two symlink paths that alias the same real session directory must yield the
+// session once, not once per path.
+func TestDiscoverCodexSymlinkAliasDedupes(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "codex", "sessions")
+	claudeDir := filepath.Join(root, "claude", "projects")
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+
+	writeNumberedCodexSession(t, sessionsDir, 1, base, "/workspace/app")
+
+	// A sibling directory that symlinks to the whole real sessions tree, so the
+	// single rollout file is reachable through two distinct paths.
+	aliasParent := filepath.Join(root, "codex")
+	mustSymlink(t, sessionsDir, filepath.Join(aliasParent, "sessions-alias"))
+	// Walk from the parent so both "sessions" and "sessions-alias" are seen.
+	got := discoverWithin(t, "/workspace/app", DiscoverOptions{
+		ClaudeProjectsDir: claudeDir,
+		CodexSessionsDir:  aliasParent,
+		Depth:             0,
+	}, 10*time.Second)
+
+	if len(got) != 1 {
+		t.Fatalf("Discover() len = %d, want 1 (aliased session deduped): %#v", len(got), got)
+	}
+	if got[0].Context.CWD != "/workspace/app" {
+		t.Fatalf("Context.CWD = %q, want /workspace/app", got[0].Context.CWD)
+	}
+}
+
+// A symlinked codex sessions directory (the whole store behind a link) must
+// still be discoverable — the follow-symlinks policy in effect.
+func TestDiscoverCodexFollowsSymlinkedStore(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	realStore := filepath.Join(root, "real", "sessions")
+	claudeDir := filepath.Join(root, "claude", "projects")
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	writeNumberedCodexSession(t, realStore, 1, base, "/workspace/app")
+
+	linkedStore := filepath.Join(root, "linked-sessions")
+	mustSymlink(t, realStore, linkedStore)
+
+	got := discoverWithin(t, "/workspace/app", DiscoverOptions{
+		ClaudeProjectsDir: claudeDir,
+		CodexSessionsDir:  linkedStore,
+		Depth:             0,
+	}, 10*time.Second)
+
+	if len(got) != 1 {
+		t.Fatalf("Discover() len = %d, want 1 (session behind symlinked store): %#v", len(got), got)
+	}
+}
+
+// Two Claude project-dir names that alias the same real directory (one a
+// symlink whose name shares the encoded-cwd prefix) must not surface the
+// session twice at depth>0.
+func TestDiscoverClaudeSymlinkAliasDedupes(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	projectsDir := filepath.Join(root, "claude", "projects")
+	codexDir := filepath.Join(root, "codex", "sessions")
+
+	realPath := writeClaudeSession(t, projectsDir, "-workspace-app", "root.jsonl",
+		"11111111-2222-4333-8444-555555550001", "/workspace/app", "feat/root", "Root session")
+	setModTime(t, realPath, time.Date(2026, 6, 25, 9, 0, 0, 0, time.UTC))
+
+	// A second project-dir name that resolves to the same real directory. Its
+	// name shares the "-workspace-app-" prefix, so the pre-filter accepts it and
+	// only the real-path guard prevents a duplicate scan.
+	mustSymlink(t, filepath.Join(projectsDir, "-workspace-app"),
+		filepath.Join(projectsDir, "-workspace-app-dup"))
+
+	got := discoverWithin(t, "/workspace/app", DiscoverOptions{
+		ClaudeProjectsDir: projectsDir,
+		CodexSessionsDir:  codexDir,
+		Depth:             1,
+	}, 10*time.Second)
+
+	if len(got) != 1 {
+		t.Fatalf("Discover() len = %d, want 1 (aliased Claude project deduped): %#v", len(got), got)
+	}
+	if got[0].Title != "Root session" {
+		t.Fatalf("Title = %q, want Root session", got[0].Title)
+	}
+}


### PR DESCRIPTION
## 완료한 Phase

**Phase 4 — Symlink loop guard + session uniqueness** (로드맵 "AI resume picker view and scope settings" 의 마지막 슬라이스). Phase 0~3 은 기 머지됨.

## 배경

Phase 2 의 `resume_scan_depth > 0` 은 cwd 하위 트리를 순회한다. 심링크 cycle(자기 조상을 가리키는 디렉터리)이나 같은 실디렉터리를 가리키는 교차 링크가 있으면 **무한 순회/행(hang)** 또는 **같은 세션 중복 방문**이 가능하다. 기존 dedup 은 ResumeID 기준이라 순회 루프 자체는 별도 가드가 필요했다.

## 확정한 symlink 정책

**심링크 디렉터리를 따라가되(follow), 순회 중 방문한 모든 디렉터리를 resolved real-path 로 기록하는 `pathGuard` 로 가드한다.**

- 심링크 뒤에 저장된 세션도 발견 가능(유용성).
- 이미 방문한 real-path 로의 재진입은 거부 → cycle/alias 여도 depth 상한과 **무관하게** 무한 루프 불가.
- (참고: Go `filepath.WalkDir` 는 심링크 미추적이었음 → codex 순회를 가드된 재귀 walker 로 교체하면서 정책을 "따라가되 가드" 로 명시 확정.)

**가드 키 / dedup 키 구분**
- **visited 키 = resolved real path** (`filepath.EvalSymlinks`, broken/cyclic 링크는 `filepath.Clean` 폴백) — 순회 레벨. 같은 실디렉터리/실파일 재방문 차단.
- **결과 dedup 키 = ResumeID** (세션 정체성) — 유지. real-path 를 dedup 키에 넣으면 두 경로로 닿은 **같은 세션이 분리**되므로, real-path 는 순회 가드에만 쓰고 결과 dedup 은 ResumeID 로 collapse.

## 수정한 surface

- `internal/integrations/agents/aisessions/sessions.go`
  - 패키지 doc 에 symlink 정책 명시.
  - codex: `filepath.WalkDir` → 가드된 재귀 walker `walkCodexSessionFiles` (심링크 추적 + cycle/alias 가드 + 심링크 파일 dedup).
  - claude depth>0 project-dir 열거: `entry.IsDir()` → `entryIsDir`(심링크 추적) + `pathGuard` 로 같은 실디렉터리 중복 스캔 차단.
  - 헬퍼 추가: `pathGuard`/`newPathGuard`/`visit`, `resolveRealPath`, `entryIsDir`.

user-facing config/CLI/UI 변경 없음 (내부 디스커버리 robustness 만).

## 명시적으로 제외한 범위 (회귀 금지 준수)

- depth 의미/필터 로직(Phase 2 `withinTree`/`codexScanBudget`) — 무변경.
- Settings/UI drill-in(Phase 3) — 무변경.
- `[ai]` config 스키마/clamp/env — 무변경.
- **depth 0 및 심링크 없는 일반 케이스** 동작·성능 — 무변경(테스트로 회귀 없음 확인).

## 검증

- `go build ./...` ✅
- `go test ./internal/...` ✅ (전 패키지 pass)
- `make fmt` / `make fix`(go fix + deadcode allowlist clean) ✅
- 신규 `internal/integrations/agents/aisessions/symlink_test.go` (모두 `t.TempDir()` + `os.Symlink`, 실 홈 디렉터리 미의존):
  - `TestDiscoverCodexSymlinkCycleTerminatesBounded`: 조상으로의 심링크 cycle + depth 2 → 10s 데드라인 내 종료(무한 루프 없음), 결과 정상(exact+child 2건, 중복 없음).
  - `TestDiscoverCodexSymlinkAliasDedupes`: 두 경로로 aliasing 되는 세션 → 단일 결과.
  - `TestDiscoverCodexFollowsSymlinkedStore`: 통째로 심링크된 sessions 스토어도 발견(정책 확인).
  - `TestDiscoverClaudeSymlinkAliasDedupes`: 같은 실 project-dir 를 가리키는 두 이름(prefix 충돌) → depth 1 에서 단일 결과.

## 미검증 / 후속

- tmux 실동작(실제 심링크된 홈 세션 스토어에서 picker 렌더)은 fixture 단위 테스트로 대체 — lead 수동 확인 후보.
- 이 로드맵의 남은 Phase 없음(Phase 4 가 마지막 슬라이스). 머지/설치본 반영 + 기능 Done 처리는 lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
