### PR TITLE
fix(sidebar): follow active session cursor after Ctrl-X kill

### DIFF
--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -1980,11 +1980,25 @@ func (c *switchCommand) switchSidebarRefreshUpdate(ctx context.Context) (intpick
 	if err != nil {
 		return intpicker.DeferredUpdate{}, fmt.Errorf("discover switch candidates: %w", err)
 	}
-	_, items, _, err := c.renderFullRows(ctx, switchUISidebar, paths)
+	_, items, sessionNames, err := c.renderFullRows(ctx, switchUISidebar, paths)
 	if err != nil {
 		return intpicker.DeferredUpdate{}, err
 	}
 	update := intpicker.DeferredUpdate{Items: items}
+	// After a kill, tmux switches to c.focusSession; move the sidebar cursor
+	// to match by reverse-mapping the active session name back to its row
+	// value. sessionNames is keyed by cleaned candidate path, so match items
+	// through the same cleaning to keep FocusValue byte-identical to the row
+	// Value the picker compares against. Empty focusSession or an absent row
+	// leaves FocusValue empty, preserving the prior cursor-follow behaviour.
+	if focus := strings.TrimSpace(c.focusSession); focus != "" {
+		for _, item := range items {
+			if strings.TrimSpace(sessionNames[cleanOptionalPath(item.Value)]) == focus {
+				update.FocusValue = item.Value
+				break
+			}
+		}
+	}
 	surface, err := c.switchPickerSurface(switchPlan{UI: switchUISidebar}, true)
 	if err != nil {
 		return intpicker.DeferredUpdate{}, err

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -2834,6 +2834,81 @@ func TestSwitchCommandPickerSidebarKillMutatesNativePickerAndRefreshesRows(t *te
 	}
 }
 
+func TestSwitchCommandPickerSidebarKillRefreshFocusesActiveSession(t *testing.T) {
+	t.Parallel()
+
+	executor := &capturingSwitchSessionExecutor{
+		exists: map[string]bool{
+			"tmp-app":      true,
+			"tmp-previous": true,
+			"tmp-worker":   true,
+		},
+		recentSessions: []string{"tmp-app", "tmp-previous", "tmp-worker"},
+	}
+	executor.killHook = func(sessionName string) {
+		executor.exists[sessionName] = false
+	}
+
+	var focusValue string
+	cmd := &switchCommand{
+		discover: func(candidates.Inputs) ([]string, error) {
+			return []string{"/tmp/app", "/tmp/previous", "/tmp/worker"}, nil
+		},
+		pinStore: func() (switchPinStore, error) { return &stubSwitchPinStore{}, nil },
+		nativePicker: pickerRunnerFunc(func(options intpicker.Options) (intpicker.Result, error) {
+			var killAction intpicker.Action
+			for _, action := range options.Actions {
+				if action.Key == switchKillExpectKey {
+					killAction = action
+					break
+				}
+			}
+			if killAction.Mutate == nil {
+				t.Fatalf("kill action = %#v, want mutable native action", killAction)
+			}
+			update, err := killAction.Mutate(intpicker.ActionContext{
+				Key:           switchKillExpectKey,
+				Value:         "/tmp/app",
+				SelectedIndex: 0,
+			})
+			if err != nil {
+				t.Fatalf("kill mutate error = %v", err)
+			}
+			focusValue = update.FocusValue
+			return intpicker.Result{Closed: true}, nil
+		}),
+		sessions:   executor,
+		executable: func() (string, error) { return "/tmp/projmux", nil },
+		identity: switchIdentityResolverFunc(func(path string) (string, error) {
+			switch path {
+			case "/tmp/app":
+				return "tmp-app", nil
+			case "/tmp/previous":
+				return "tmp-previous", nil
+			case "/tmp/worker":
+				return "tmp-worker", nil
+			default:
+				return "", errors.New("unexpected path")
+			}
+		}),
+		validate:   func(string) error { return nil },
+		homeDir:    func() (string, error) { return "/home/tester", nil },
+		workingDir: func() (string, error) { return "/tmp", nil },
+	}
+
+	if err := cmd.Run([]string{"--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	// After the kill tmux switches to tmp-previous; the refresh must point
+	// FocusValue at that session's row path so the sidebar cursor follows.
+	if got, want := cmd.focusSession, "tmp-previous"; got != want {
+		t.Fatalf("focus session = %q, want %q", got, want)
+	}
+	if got, want := focusValue, "/tmp/previous"; got != want {
+		t.Fatalf("refresh FocusValue = %q, want active session path %q", got, want)
+	}
+}
+
 func TestSwitchCommandPickerSidebarKillMutateBlocksWithoutPreviousLiveSession(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/picker/backend.go
+++ b/internal/ui/picker/backend.go
@@ -64,6 +64,14 @@ type DeferredUpdate struct {
 	Items   []Item
 	Preview Preview
 	Result  *Result
+	// FocusValue, when non-empty, moves the selection cursor to the item
+	// whose Value matches it after the update is applied. It overrides the
+	// default behaviour of preserving the previously selected value, which
+	// breaks when that value was removed from the list (e.g. the sidebar
+	// row for a just-killed session). When empty, the previous value is
+	// preserved as before. Falls back safely (0/clamp) if the value is not
+	// present in the new item list.
+	FocusValue string
 }
 
 type Options struct {
@@ -517,7 +525,7 @@ func runNativeInteractive(in io.Reader, out io.Writer, options Options) (Result,
 		key, err := nextNativeInteractiveKey(in, keyCh, &deferredCh, func(update DeferredUpdate) {
 			options = applyNativeDeferredUpdate(options, update)
 			nextItems := nativeFilteredItems(options, query)
-			selected = nativeSelectedIndexForValue(nextItems, focusValue, selected)
+			selected = nativeSelectedIndexForValue(nextItems, nativeDeferredFocusValue(update, focusValue), selected)
 			previewOffset = 0
 		}, options.UI)
 		if key.Name == "" && key.Text == "" && err == nil {
@@ -590,7 +598,7 @@ func runNativeInteractive(in io.Reader, out io.Writer, options Options) (Result,
 			if refresh {
 				options = applyNativeDeferredUpdate(options, update)
 				nextItems := nativeFilteredItems(options, query)
-				selected = nativeSelectedIndexForValue(nextItems, selectedNativeValue(items, selected), selected)
+				selected = nativeSelectedIndexForValue(nextItems, nativeDeferredFocusValue(update, selectedNativeValue(items, selected)), selected)
 				previewOffset = 0
 			}
 			nativeDebugLogf("interactive ui=%q action key=%q intent=%q refresh=%t result_key=%q closed=%t value=%q query=%q", options.UI, action.Key, action.Intent, refresh, result.Key, result.Closed, result.Value, result.Query)
@@ -608,7 +616,7 @@ func runNativeInteractive(in io.Reader, out io.Writer, options Options) (Result,
 				if refresh {
 					options = applyNativeDeferredUpdate(options, update)
 					nextItems := nativeFilteredItems(options, query)
-					selected = nativeSelectedIndexForValue(nextItems, selectedNativeValue(items, selected), selected)
+					selected = nativeSelectedIndexForValue(nextItems, nativeDeferredFocusValue(update, selectedNativeValue(items, selected)), selected)
 					previewOffset = 0
 				}
 				nativeDebugLogf("interactive ui=%q text_action key=%q intent=%q refresh=%t result_key=%q closed=%t value=%q query=%q", options.UI, action.Key, action.Intent, refresh, result.Key, result.Closed, result.Value, result.Query)
@@ -826,6 +834,17 @@ func applyNativeDeferredUpdate(options Options, update DeferredUpdate) Options {
 		options.Preview = update.Preview
 	}
 	return options
+}
+
+// nativeDeferredFocusValue resolves which item value the cursor should track
+// after a deferred update. An explicit DeferredUpdate.FocusValue wins so a
+// refresh can move the cursor to a specific row (e.g. the newly active session
+// after a sidebar kill); otherwise the previously focused value is preserved.
+func nativeDeferredFocusValue(update DeferredUpdate, fallbackValue string) string {
+	if value := strings.TrimSpace(update.FocusValue); value != "" {
+		return value
+	}
+	return fallbackValue
 }
 
 func nativeSelectedIndexForValue(items []Item, value string, fallback int) int {

--- a/internal/ui/picker/backend_test.go
+++ b/internal/ui/picker/backend_test.go
@@ -2790,6 +2790,130 @@ func TestNativeInteractiveCustomActionRefreshPreservesSelectedValue(t *testing.T
 	}
 }
 
+func TestNativeDeferredFocusValue(t *testing.T) {
+	t.Parallel()
+
+	if got := nativeDeferredFocusValue(DeferredUpdate{FocusValue: "  /repo/worker  "}, "/repo/api"); got != "/repo/worker" {
+		t.Fatalf("explicit FocusValue = %q, want trimmed /repo/worker", got)
+	}
+	if got := nativeDeferredFocusValue(DeferredUpdate{}, "/repo/api"); got != "/repo/api" {
+		t.Fatalf("unset FocusValue = %q, want fallback /repo/api", got)
+	}
+	if got := nativeDeferredFocusValue(DeferredUpdate{FocusValue: "   "}, "/repo/api"); got != "/repo/api" {
+		t.Fatalf("blank FocusValue = %q, want fallback /repo/api", got)
+	}
+}
+
+func TestNativeInteractiveDeferredFocusValueMovesCursor(t *testing.T) {
+	t.Parallel()
+
+	// Simulate a sidebar kill: the originally selected row (/repo/api) is
+	// gone from the refreshed list and FocusValue points at the newly
+	// active session, so the cursor must jump there instead of clamping.
+	result, err := runNativeInteractive(strings.NewReader("x\r"), io.Discard, Options{
+		UI:              "sidebar",
+		DisableSearch:   true,
+		InitialIndex:    0,
+		InitialIndexSet: true,
+		Items: []Item{
+			{Title: "api", Value: "/repo/api"},
+			{Title: "web", Value: "/repo/web"},
+			{Title: "worker", Value: "/repo/worker"},
+		},
+		Actions: []Action{{
+			Key:    "x",
+			Intent: ActionCustom,
+			Mutate: func(ctx ActionContext) (DeferredUpdate, error) {
+				return DeferredUpdate{
+					Items: []Item{
+						{Title: "web", Value: "/repo/web"},
+						{Title: "worker", Value: "/repo/worker"},
+					},
+					FocusValue: "/repo/worker",
+				}, nil
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("runNativeInteractive() error = %v", err)
+	}
+	if result.Value != "/repo/worker" {
+		t.Fatalf("result = %#v, want cursor moved to FocusValue /repo/worker", result)
+	}
+}
+
+func TestNativeInteractiveDeferredFocusValueUnsetPreservesLegacyFallback(t *testing.T) {
+	t.Parallel()
+
+	// Without FocusValue the removed previous value (/repo/api) is not
+	// found, so selection clamps to index 0 (/repo/web) — the pre-existing
+	// behaviour other pickers rely on must not regress.
+	result, err := runNativeInteractive(strings.NewReader("x\r"), io.Discard, Options{
+		UI:              "sidebar",
+		DisableSearch:   true,
+		InitialIndex:    0,
+		InitialIndexSet: true,
+		Items: []Item{
+			{Title: "api", Value: "/repo/api"},
+			{Title: "web", Value: "/repo/web"},
+			{Title: "worker", Value: "/repo/worker"},
+		},
+		Actions: []Action{{
+			Key:    "x",
+			Intent: ActionCustom,
+			Mutate: func(ctx ActionContext) (DeferredUpdate, error) {
+				return DeferredUpdate{Items: []Item{
+					{Title: "web", Value: "/repo/web"},
+					{Title: "worker", Value: "/repo/worker"},
+				}}, nil
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("runNativeInteractive() error = %v", err)
+	}
+	if result.Value != "/repo/web" {
+		t.Fatalf("result = %#v, want legacy fallback /repo/web", result)
+	}
+}
+
+func TestNativeInteractiveDeferredFocusValueMissingFallsBackSafely(t *testing.T) {
+	t.Parallel()
+
+	// FocusValue absent from the refreshed list must not panic or escape
+	// range; it clamps to the prior selected index (1 -> /repo/worker).
+	result, err := runNativeInteractive(strings.NewReader("x\r"), io.Discard, Options{
+		UI:              "sidebar",
+		DisableSearch:   true,
+		InitialIndex:    1,
+		InitialIndexSet: true,
+		Items: []Item{
+			{Title: "api", Value: "/repo/api"},
+			{Title: "web", Value: "/repo/web"},
+			{Title: "worker", Value: "/repo/worker"},
+		},
+		Actions: []Action{{
+			Key:    "x",
+			Intent: ActionCustom,
+			Mutate: func(ctx ActionContext) (DeferredUpdate, error) {
+				return DeferredUpdate{
+					Items: []Item{
+						{Title: "web", Value: "/repo/web"},
+						{Title: "worker", Value: "/repo/worker"},
+					},
+					FocusValue: "/repo/ghost",
+				}, nil
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("runNativeInteractive() error = %v", err)
+	}
+	if result.Value != "/repo/worker" {
+		t.Fatalf("result = %#v, want safe fallback /repo/worker", result)
+	}
+}
+
 func TestNativeInteractiveRunsFocusActionOnSelectionChange(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 요지
Alt-1 프로젝트 사이드바(`sessionizer-sidebar`)에서 **Ctrl-X**(`Sidebar:KillSession`)로 세션 kill 시, tmux 는 직전 활성 세션으로 스위치되는데 **사이드바 커서(하이라이트)가 죽은 행 자리에 남는** 버그를 고친다.

## 원인
- `switchSidebarRefreshUpdate` 가 목록만 재빌드해 `DeferredUpdate{Items}` 만 반환 — 커서 위치 정보를 안 넘김.
- picker deferred apply 는 *직전 선택값*(=죽은 세션 path)을 새 목록에서 찾으려다 실패 → 옛 index 폴백 → 엉뚱한 행.
- `DeferredUpdate` 에 커서 지정 필드가 없었음.

## 변경
- **`internal/ui/picker/backend.go`**: `DeferredUpdate` 에 `FocusValue string` 추가. deferred/refresh apply 경로(background goroutine + action/text-action refresh)에서 `FocusValue` 가 채워지면 그 `Item.Value` 로 커서 이동, 목록에 없으면 안전 폴백(0/clamp). 비어있으면 기존 "직전 값 유지" 동작 그대로. 공용 헬퍼 `nativeDeferredFocusValue` 로 3개 경로 통일.
- **`internal/app/switch.go`**: `switchSidebarRefreshUpdate` 가 재빌드한 rows 의 `sessionName→path` 역매핑으로 `c.focusSession`(kill 후 현재 활성 세션)의 path 를 `update.FocusValue` 에 설정. `item.Value` 를 직접 써서 picker 비교값과 byte-identical 보장.

## 비목표 (회귀 없음)
- 사이드바 rows/정렬/kill 로직·다른 popup 커서 동작 변경 없음. `FocusValue` 는 공용 필드지만 이번엔 사이드바 kill refresh 만 채움.

## 검증
- 신규 테스트:
  - `backend_test.go`: `nativeDeferredFocusValue`(지정/부재/blank), action refresh 시 FocusValue 로 커서 이동 / 미설정 시 legacy 폴백 / 목록에 없는 값이면 안전 폴백.
  - `switch_test.go`: kill refresh 가 `DeferredUpdate.FocusValue` 를 활성 세션 path 로 채움.
- `go build ./...`, `go test ./internal/...` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)