### PR TITLE
feat(ai): recency-anchored resume row with per-agent badge + turn count (Phase 0)

### DIFF
--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -913,35 +914,37 @@ type aiResumeSelection struct {
 	updatedAt time.Time
 }
 
-// Resume picker row column schema (Phase 0 — row view slice).
+// Resume picker row column schema (Phase 0 — row enrichment slice).
 //
 // Every row lays out the same fixed-width columns so they align in the popup
 // regardless of locale or CJK content, with the title as the trailing
-// variable-width column:
+// variable-width column. The recency anchor leads (it matches the newest-first
+// sort axis), followed by a per-agent colour badge:
 //
-//	[agent ] MM-DD HH:MM <rel>  <branch>            <shortid> [<extra>] <title…>
-//	  6        11          6      18                  8         (0)       rest
+//	<rel>  [agent]   <branch>            [<cwd>] <turns> <title…>
+//	 6      (tight)+pad→8   18                  (14)     5       rest
 //
 // Column order / cell width (visible cells, fixed columns left-aligned):
-//   - agent badge: aiResumeAgentCellWidth (inside cyan [ ])
-//   - absolute time: aiResumeTimeWidth ("MM-DD HH:MM", dim)
-//   - relative age: aiResumeRelCellWidth (compact, locale-aware, dim)
-//   - branch: aiResumeBranchCellWidth (dim, cut)
-//   - short resume id: aiResumeShortIDWidth (dim, leading runes)
-//   - extra-meta slot: reserved for the Phase 2 cwd column; empty today so the
-//     layout matches the current view (source is intentionally not surfaced —
-//     it duplicates the agent badge).
+//   - relative age: aiResumeRelCellWidth (compact, locale-aware, dim) — leads.
+//   - agent badge: tight per-agent-coloured "[name]" padded to
+//     aiResumeBadgeCellWidth; padding sits outside the brackets/colour.
+//   - branch: aiResumeBranchCellWidth (dim, cut).
+//   - extra-meta slot: the depth>0 relative-cwd column (aiResumeCWDCellWidth,
+//     dim); empty at depth 0 so the layout collapses to the base view.
+//   - turns: aiResumeTurnsCellWidth ("8t"/"31t", dim), blank when unknown.
 //   - title: trailing variable width, cut with an ellipsis past
 //     aiResumeTitleMaxCells.
+//
+// The absolute time and short resume id are intentionally dropped from the
+// visible columns; the resume id stays in SearchKey so id search still works.
 const (
 	aiResumeAgentCellWidth  = 6
-	aiResumeTimeWidth       = 11
+	aiResumeBadgeCellWidth  = aiResumeAgentCellWidth + 2 // tight "[name]" + brackets
 	aiResumeRelCellWidth    = 6
 	aiResumeBranchCellWidth = 18
-	aiResumeShortIDWidth    = 8
 	aiResumeCWDCellWidth    = 14
-	aiResumeTitleMaxCells   = 72
-	aiResumeTimeLayout      = "01-02 15:04"
+	aiResumeTurnsCellWidth  = 5
+	aiResumeTitleMaxCells   = 90
 	aiResumeEmptyCell       = "-"
 )
 
@@ -972,25 +975,26 @@ func aiResumeSessionRow(session aisessions.SessionMeta, now time.Time, locale i1
 	}
 	title := cleanAIResumeTitle(session.Title, resumeID)
 
-	// Fixed columns: pad/truncate each to a stable cell width, then colorize.
-	badge := "\x1b[36m[" + aiResumeFitCell(agent, aiResumeAgentCellWidth) + "]\x1b[0m"
-	absTime := ansiDim(aiResumeAbsoluteTime(session.LastModified))
+	// Recency anchor leads (matches the newest-first sort axis), then the
+	// per-agent colour badge, branch (+cwd at depth>0), turn count, and the
+	// flexible title. Fixed columns pad/truncate to a stable cell width.
 	relTime := ansiDim(aiResumeFitCell(aiResumeRelativeAge(now, session.LastModified, locale), aiResumeRelCellWidth))
+	badge := aiResumeAgentBadge(agent)
 	branchCell := ansiDim(aiResumeFitCell(branch, aiResumeBranchCellWidth))
-	shortID := ansiDim(aiResumeFitCell(aiResumeShortID(resumeID), aiResumeShortIDWidth))
 
-	// Extra-meta slot (Phase 2 cwd column). Empty at depth 0, so the column
-	// contributes nothing and the layout is identical to the historical view. At
-	// depth>0 every row carries a fixed-width relative-cwd cell (exact matches
-	// render "./") so the title column stays aligned, plus a trailing gap.
+	// Extra-meta slot (depth>0 cwd column). Empty at depth 0, so the column
+	// contributes nothing and the layout collapses to the base view. At depth>0
+	// every row carries a fixed-width relative-cwd cell (exact matches render
+	// "./") so the title column stays aligned, plus a trailing gap.
 	relCWD := aiResumeExtraMetaCell(session, baseCWD, depth)
 	extra := ""
 	if relCWD != "" {
 		extra = ansiDim(aiResumeFitCell(relCWD, aiResumeCWDCellWidth)) + " "
 	}
+	turnsCell := ansiDim(aiResumeTurnsCell(session.Turns))
 
-	label := fmt.Sprintf("%s %s %s %s %s %s%s",
-		badge, absTime, relTime, branchCell, shortID, extra, title)
+	label := fmt.Sprintf("%s %s %s %s%s %s",
+		relTime, badge, branchCell, extra, turnsCell, title)
 
 	return intpickercompat.Entry{
 		Label:     label,
@@ -999,13 +1003,45 @@ func aiResumeSessionRow(session aisessions.SessionMeta, now time.Time, locale i1
 	}
 }
 
-// aiResumeAbsoluteTime renders the fixed-width "MM-DD HH:MM" column, padding to
-// a stable width when the timestamp is missing so columns stay aligned.
-func aiResumeAbsoluteTime(t time.Time) string {
-	if t.IsZero() {
-		return strings.Repeat(" ", aiResumeTimeWidth)
+// aiResumeAgentBadge renders the agent tag as a tight, per-agent-coloured
+// "[name]" token padded to a fixed column width. The brackets hug the name
+// ("[codex]", never "[codex ]") and only the tight token is coloured; the
+// alignment padding after "]" stays uncoloured so columns line up in the popup.
+func aiResumeAgentBadge(agent string) string {
+	inner := i18n.TruncateTerminalCells(strings.TrimSpace(agent), aiResumeAgentCellWidth)
+	tight := "[" + inner + "]"
+	badge := aiResumeAgentColor(agent) + tight + "\x1b[0m"
+	if pad := aiResumeBadgeCellWidth - i18n.TerminalCellWidth(tight); pad > 0 {
+		badge += strings.Repeat(" ", pad)
 	}
-	return t.Local().Format(aiResumeTimeLayout)
+	return badge
+}
+
+// aiResumeAgentColor maps an agent to a distinct ANSI colour so the badge tells
+// at a glance which resume CLI a row uses. The theme palette carries no
+// per-agent accent token, so these are the roadmap's fixed-hue fallback; codex
+// keeps the historical cyan. Unknown agents fall back to default foreground.
+func aiResumeAgentColor(agent string) string {
+	switch strings.ToLower(strings.TrimSpace(agent)) {
+	case aiModeClaude:
+		return "\x1b[35m" // magenta
+	case aiModeCodex:
+		return "\x1b[36m" // cyan (historical badge colour)
+	case aiModeAntigravity:
+		return "\x1b[34m" // blue
+	default:
+		return "\x1b[37m"
+	}
+}
+
+// aiResumeTurnsCell renders the user-turn count ("8t", "31t") in a fixed-width
+// dim column, or a blank (padded) cell when the count is unknown (zero).
+func aiResumeTurnsCell(turns int) string {
+	label := ""
+	if turns > 0 {
+		label = strconv.Itoa(turns) + "t"
+	}
+	return aiResumeFitCell(label, aiResumeTurnsCellWidth)
 }
 
 // aiResumeRelativeAge renders a compact, locale-aware relative age ("2h", "3d",
@@ -1017,16 +1053,6 @@ func aiResumeRelativeAge(now, modified time.Time, locale i18n.Locale) string {
 	}
 	age := max(now.Sub(modified), 0)
 	return i18n.FormatDuration(age, locale, i18n.FormatCompact)
-}
-
-// aiResumeShortID returns the leading runes of the resume id for a compact
-// fixed-width identifier column.
-func aiResumeShortID(resumeID string) string {
-	runes := []rune(strings.TrimSpace(resumeID))
-	if len(runes) > aiResumeShortIDWidth {
-		return string(runes[:aiResumeShortIDWidth])
-	}
-	return string(runes)
 }
 
 // aiResumeExtraMetaCell fills the reserved extra-meta column. At depth 0 it

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -301,10 +301,10 @@ func TestAIResumePickerRowsCapAndMetadata(t *testing.T) {
 }
 
 // aiResumeRowPrefixWidth is the fixed-column prefix width that every session
-// row shares before the trailing title: badge[8] + " " + time[11] + " " +
-// rel[6] + " " + branch[18] + " " + shortid[8] + " " (separator before title).
-const aiResumeRowPrefixWidth = (aiResumeAgentCellWidth + 2) + 1 + aiResumeTimeWidth + 1 +
-	aiResumeRelCellWidth + 1 + aiResumeBranchCellWidth + 1 + aiResumeShortIDWidth + 1
+// row shares before the trailing title: rel[6] + " " + badge[8] + " " +
+// branch[18] + " " + turns[5] + " " (separator before title).
+const aiResumeRowPrefixWidth = aiResumeRelCellWidth + 1 + aiResumeBadgeCellWidth + 1 +
+	aiResumeBranchCellWidth + 1 + aiResumeTurnsCellWidth + 1
 
 func TestAIResumeSessionRowColumnsAlign(t *testing.T) {
 	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
@@ -393,9 +393,10 @@ func TestAIResumeSessionRowsLimitBoundaries(t *testing.T) {
 func TestAIResumeSessionRowTitleEllipsis(t *testing.T) {
 	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
 	long := strings.Repeat("x", aiResumeTitleMaxCells+25)
+	const resumeID = "019f0000-0000-7000-8000-000000000009"
 	row := aiResumeSessionRow(aisessions.SessionMeta{
 		Agent:        aiModeClaude,
-		ResumeID:     "019f0000-0000-7000-8000-000000000009",
+		ResumeID:     resumeID,
 		Title:        long,
 		LastModified: now.Add(-time.Hour),
 	}, now, i18n.FallbackLocale, "", 0)
@@ -407,9 +408,12 @@ func TestAIResumeSessionRowTitleEllipsis(t *testing.T) {
 	if w := i18n.TerminalCellWidth(title); w > aiResumeTitleMaxCells {
 		t.Fatalf("clipped title width = %d, want <= %d", w, aiResumeTitleMaxCells)
 	}
-	// Short ids surface in the short-id column.
-	if !strings.Contains(row.Label, "019f0000") {
-		t.Fatalf("row label = %q, want short resume id", row.Label)
+	// The resume id is dropped from the visible columns but stays searchable.
+	if strings.Contains(row.Label, "019f0000") {
+		t.Fatalf("row label = %q, should not surface the resume id column", row.Label)
+	}
+	if !strings.Contains(row.SearchKey, resumeID) {
+		t.Fatalf("row search key = %q, want resume id preserved for search", row.SearchKey)
 	}
 }
 
@@ -528,12 +532,62 @@ func TestAIResumeRelativeAge(t *testing.T) {
 	}
 }
 
-func TestAIResumeShortID(t *testing.T) {
-	if got := aiResumeShortID("019f0000-0000-7000"); got != "019f0000" {
-		t.Fatalf("short id = %q, want %q", got, "019f0000")
+func TestAIResumeTurnsCell(t *testing.T) {
+	// Known counts render as "<n>t" left-aligned in a fixed-width cell.
+	if got := aiResumeTurnsCell(8); strings.TrimRight(got, " ") != "8t" {
+		t.Fatalf("turns cell = %q, want %q", got, "8t")
 	}
-	if got := aiResumeShortID("abc"); got != "abc" {
-		t.Fatalf("short id (short) = %q, want %q", got, "abc")
+	if got := aiResumeTurnsCell(120); strings.TrimRight(got, " ") != "120t" {
+		t.Fatalf("turns cell = %q, want %q", got, "120t")
+	}
+	if w := i18n.TerminalCellWidth(aiResumeTurnsCell(31)); w != aiResumeTurnsCellWidth {
+		t.Fatalf("turns cell width = %d, want %d", w, aiResumeTurnsCellWidth)
+	}
+	// Unknown (zero) turns render as a blank padded cell, not "0t".
+	blank := aiResumeTurnsCell(0)
+	if strings.TrimSpace(blank) != "" {
+		t.Fatalf("zero turns cell = %q, want blank", blank)
+	}
+	if w := i18n.TerminalCellWidth(blank); w != aiResumeTurnsCellWidth {
+		t.Fatalf("blank turns cell width = %d, want %d", w, aiResumeTurnsCellWidth)
+	}
+}
+
+func TestAIResumeAgentBadgeTightBracketsAndColor(t *testing.T) {
+	// Padding sits outside the brackets: "[codex]", never "[codex ]".
+	badge := aiResumeAgentBadge(aiModeCodex)
+	if !strings.Contains(badge, "[codex]") {
+		t.Fatalf("codex badge = %q, want tight [codex]", badge)
+	}
+	if strings.Contains(badge, "[codex ") {
+		t.Fatalf("codex badge = %q, want no padding inside brackets", badge)
+	}
+	// Every agent badge occupies the same visible cell width regardless of name.
+	for _, agent := range []string{aiModeClaude, aiModeCodex, aiModeAntigravity} {
+		if w := i18n.TerminalCellWidth(aiResumeAgentBadge(agent)); w != aiResumeBadgeCellWidth {
+			t.Fatalf("%s badge width = %d, want %d", agent, w, aiResumeBadgeCellWidth)
+		}
+	}
+	// Distinct agents get distinct colours (per-agent disambiguation).
+	claudeColor := aiResumeAgentColor(aiModeClaude)
+	codexColor := aiResumeAgentColor(aiModeCodex)
+	agyColor := aiResumeAgentColor(aiModeAntigravity)
+	if claudeColor == codexColor || codexColor == agyColor || claudeColor == agyColor {
+		t.Fatalf("agent colours not distinct: claude=%q codex=%q agy=%q", claudeColor, codexColor, agyColor)
+	}
+}
+
+func TestAIResumeSessionRowShowsTurns(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	row := aiResumeSessionRow(aisessions.SessionMeta{
+		Agent:        aiModeCodex,
+		ResumeID:     "019f0000-0000-7000-8000-000000000042",
+		Title:        "Optimize picker",
+		LastModified: now.Add(-time.Hour),
+		Turns:        31,
+	}, now, i18n.FallbackLocale, "", 0)
+	if !strings.Contains(row.Label, "31t") {
+		t.Fatalf("row label = %q, want turn count 31t", row.Label)
 	}
 }
 

--- a/internal/integrations/agents/aisessions/sessions.go
+++ b/internal/integrations/agents/aisessions/sessions.go
@@ -58,6 +58,12 @@ type SessionMeta struct {
 	LastModified time.Time
 	Context      SessionContext
 	Source       string
+
+	// Turns is the count of user turns observed while scanning the session log.
+	// It is a low-cost signal counted in the same bounded pass that extracts the
+	// title (no extra file pass), so it saturates for very long sessions at the
+	// scan-line limit. Zero means "unknown" and renders as a blank cell.
+	Turns int
 }
 
 // DiscoverOptions controls where session logs are read from. Empty roots use
@@ -235,6 +241,7 @@ func discoverClaudeDir(dir, cwd string, depth int) []SessionMeta {
 				Branch: details.branch,
 			},
 			Source: SourceClaudeTranscript,
+			Turns:  details.turns,
 		})
 	}
 	return sessions
@@ -316,6 +323,7 @@ func discoverCodexWithFileLimit(cwd, sessionsDir string, scanFileLimit, depth in
 				Branch: details.branch,
 			},
 			Source: SourceCodexRollout,
+			Turns:  details.turns,
 		})
 	}
 	return sessions
@@ -485,6 +493,7 @@ type sessionDetails struct {
 	title  string
 	cwd    string
 	branch string
+	turns  int
 }
 
 type sessionScanOptions struct {
@@ -539,8 +548,14 @@ func scanSessionJSONLReader(r io.Reader, opts sessionScanOptions) (sessionDetail
 		if details.title == "" && lineNo <= sessionTitleLineLimit {
 			details.title = titleFromRecord(fields)
 		}
-		if details.ready(opts.requireCWD, targetCWD) {
-			return details, true
+		// Count user turns in the same bounded pass that extracts the title. We
+		// deliberately do not early-exit once id/title/branch/cwd are known: a
+		// turn count is only meaningful if the scan sees the whole bounded window,
+		// so it keeps reading up to sessionScanLineLimit. The cwd-mismatch abort
+		// above still short-circuits non-matching sessions on their first cwd
+		// record, so the extra reads are paid only for sessions we will display.
+		if isUserTurnRecord(fields) {
+			details.turns++
 		}
 		if lineNo >= sessionScanLineLimit {
 			break
@@ -552,14 +567,69 @@ func scanSessionJSONLReader(r io.Reader, opts sessionScanOptions) (sessionDetail
 	return details, details.id != "" || details.cwd != "" || details.title != ""
 }
 
-func (details sessionDetails) ready(requireCWD bool, targetCWD string) bool {
-	if details.id == "" || details.title == "" || details.branch == "" {
+// isUserTurnRecord reports whether a session-log record is a user turn (a human
+// prompt), counting toward SessionMeta.Turns. It matches codex user_message /
+// user-role response items and Claude user records, but excludes tool-result
+// carrier records (Claude replays tool output as role "user"), so the count
+// tracks conversational turns rather than raw record lines.
+func isUserTurnRecord(fields map[string]any) bool {
+	switch strings.ToLower(stringJSONField(fields, "type")) {
+	case "event_msg":
+		// codex: payload.type == "user_message" is the human prompt event.
+		if payload, ok := fields["payload"].(map[string]any); ok {
+			return strings.EqualFold(stringJSONField(payload, "type"), "user_message")
+		}
+		return false
+	case "response_item":
+		// codex: a response item with role "user" carrying real text.
+		if payload, ok := fields["payload"].(map[string]any); ok && strings.EqualFold(stringJSONField(payload, "role"), "user") {
+			return hasUserText(payload["content"])
+		}
+		return false
+	case "user":
+		// claude: a user record whose message content is real user text.
+		if message, ok := fields["message"].(map[string]any); ok {
+			return hasUserText(message["content"])
+		}
+		return hasUserText(fields["content"])
+	default:
+		if strings.EqualFold(stringJSONField(fields, "role"), "user") {
+			return hasUserText(fields["content"])
+		}
 		return false
 	}
-	if targetCWD != "" && details.cwd == "" {
-		return false
+}
+
+// hasUserText reports whether content holds real user-authored text rather than
+// a tool-result / tool-use carrier. A bare string counts; an array counts only
+// if it holds a string or a non-tool block with text, so Claude's tool-result
+// user records (content is an array of tool_result blocks) are not miscounted.
+func hasUserText(value any) bool {
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v) != ""
+	case []any:
+		for _, item := range v {
+			switch item := item.(type) {
+			case string:
+				if strings.TrimSpace(item) != "" {
+					return true
+				}
+			case map[string]any:
+				switch strings.ToLower(stringJSONField(item, "type")) {
+				case "tool_result", "tool_use":
+					continue
+				case "text":
+					return true
+				default:
+					if stringJSONField(item, "text") != "" {
+						return true
+					}
+				}
+			}
+		}
 	}
-	return !requireCWD || details.cwd != ""
+	return false
 }
 
 func titleFromRecord(fields map[string]any) string {

--- a/internal/integrations/agents/aisessions/sessions_test.go
+++ b/internal/integrations/agents/aisessions/sessions_test.go
@@ -231,14 +231,19 @@ func TestScanSessionJSONLStopsAfterCwdMismatch(t *testing.T) {
 	}
 }
 
-func TestScanSessionJSONLEarlyExitsAfterOutputFields(t *testing.T) {
+func TestScanSessionJSONLCountsTurnsPastMetadata(t *testing.T) {
 	t.Parallel()
 
-	prefix := `{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000066","cwd":"/workspace/app","git_branch":"feat/perf"}}` + "\n" +
-		`{"type":"event_msg","payload":{"message":"Speed up resume picker"}}` + "\n"
-	reader := newFailAfterReader(prefix+`{"type":"event_msg","payload":{"message":"must not be read"}}`+"\n", len(prefix))
+	// The scan does not early-exit once id/cwd/title/branch are known: it keeps
+	// reading (bounded by sessionScanLineLimit) so it can count user turns. The
+	// title still comes from the first user prompt; later user prompts only add
+	// to the turn count.
+	log := `{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000066","cwd":"/workspace/app","git_branch":"feat/perf"}}` + "\n" +
+		`{"type":"event_msg","payload":{"type":"user_message","message":"Speed up resume picker"}}` + "\n" +
+		`{"type":"event_msg","payload":{"type":"agent_message","message":"On it"}}` + "\n" +
+		`{"type":"event_msg","payload":{"type":"user_message","message":"Also add turn counts"}}` + "\n"
 
-	details, ok := scanSessionJSONLReader(reader, sessionScanOptions{
+	details, ok := scanSessionJSONLReader(strings.NewReader(log), sessionScanOptions{
 		targetCWD:  "/workspace/app",
 		requireCWD: true,
 	})
@@ -246,14 +251,65 @@ func TestScanSessionJSONLEarlyExitsAfterOutputFields(t *testing.T) {
 	if !ok {
 		t.Fatal("scanSessionJSONLReader() ok = false")
 	}
-	if reader.failed {
-		t.Fatal("scanSessionJSONLReader() read after id/cwd/title/branch were available")
-	}
 	if details.id != "019f0000-0000-7000-8000-000000000066" ||
 		details.cwd != "/workspace/app" ||
 		details.branch != "feat/perf" ||
 		details.title != "Speed up resume picker" {
 		t.Fatalf("details = %#v", details)
+	}
+	if details.turns != 2 {
+		t.Fatalf("turns = %d, want 2 (two user_message records, agent_message excluded)", details.turns)
+	}
+}
+
+func TestScanSessionJSONLCountsClaudeUserTurnsExcludingToolResults(t *testing.T) {
+	t.Parallel()
+
+	// Claude replays tool output as role "user"; those carrier records must not
+	// inflate the turn count. Only real user prompts (string / text content)
+	// count.
+	log := `{"type":"user","message":{"role":"user","content":"first prompt"},"cwd":"/workspace/app","sessionId":"11111111-2222-4333-8444-555555555555","gitBranch":"main"}` + "\n" +
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash"}]}}` + "\n" +
+		`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"output"}]}}` + "\n" +
+		`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"second prompt"}]}}` + "\n"
+
+	details, ok := scanSessionJSONLReader(strings.NewReader(log), sessionScanOptions{targetCWD: "/workspace/app"})
+	if !ok {
+		t.Fatalf("scanSessionJSONLReader() ok = false, details = %#v", details)
+	}
+	if details.turns != 2 {
+		t.Fatalf("turns = %d, want 2 (tool_result carrier excluded)", details.turns)
+	}
+}
+
+func TestDiscoverPopulatesTurnCount(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "codex", "sessions", "2026", "06", "25")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sessionsDir, "rollout-turns.jsonl")
+	writeFile(t, path, `{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000099","cwd":"/workspace/app","git_branch":"feat/turns"}}
+{"type":"event_msg","payload":{"type":"user_message","message":"First"}}
+{"type":"event_msg","payload":{"type":"agent_message","message":"Reply"}}
+{"type":"event_msg","payload":{"type":"user_message","message":"Second"}}
+{"type":"event_msg","payload":{"type":"user_message","message":"Third"}}
+`)
+	setModTime(t, path, time.Date(2026, 6, 25, 9, 0, 0, 0, time.UTC))
+
+	got, err := Discover("/workspace/app", DiscoverOptions{
+		CodexSessionsDir: filepath.Join(root, "codex", "sessions"),
+	})
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Discover() len = %d, want 1: %#v", len(got), got)
+	}
+	if got[0].Turns != 3 {
+		t.Fatalf("Turns = %d, want 3", got[0].Turns)
 	}
 }
 


### PR DESCRIPTION
## 완료한 Phase

**Phase 0 — Row enrichment slice** (로드맵 디테일: *AI resume list enrichment and antigravity*). 확정 설계(2026-07-01, 한 줄 밀도 재배치)를 그대로 구현.

## 수정한 user-facing surface

AI Resume 피커의 세션 row 레이아웃을 가치순으로 재배치:

```
<rel>   [agent]   <branch>[ <cwd> ]  <turns>  <title…>
```

| 순서 | 컬럼 | 변경 |
|---|---|---|
| 1 | 상대시각(recency) | **맨 앞으로** — 최신순 정렬축과 일치하는 스캔 앵커 |
| 2 | agent 배지 | **agent별 구분색**(claude=magenta, codex=cyan(기존 유지), agy=blue). 괄호 tight `[codex]`, 패딩은 `]` 바깥·색 밖 |
| 3 | branch (+depth>0 cwd) | 유지 |
| 4 | **turn 수** (신규) | `8t`/`31t`/`120t`, 미상 시 빈칸 |
| 5 | title | flex, 폭 순증(절대시각·id 회수분 + turns 반영, max 72→90) |

렌더 예 (ANSI 제거):
```
2s     [claude] feat/x             8t    로드맵 구성하려 한다 이거 저거
6d     [codex]  main               31t   리스트 피커 성능 최적화
6d     [antigr] main               120t  /goal something
1h     [codex]  -                        no branch no turns
1h     [claude] feat/web           ./web          5t    child dir session   (depth1)
```

- **보이는 컬럼에서 제거**: 절대시각, short id. `resumeID` 는 `SearchKey` 에 유지 → **id 검색은 그대로 동작**.
- `aisessions.SessionMeta` 에 `Turns int` 추가. `scanSessionJSONL` 이 title 스캔과 **같은 bounded pass** 에서 user turn 레코드를 카운트(추가 파일 패스 없음). 레코드 타입 기준(codex `user_message`/user-role `response_item`, claude `user`), claude 의 `tool_result` carrier user 레코드는 제외해 실제 대화 turn 만 카운트.

## 모델/스키마/엔진 제약 준수

- 세션 정렬/dedup/cap/depth·New Session·선택 라우팅 로직 **무변경**. depth cwd 컬럼 위치 유지.
- discovery 파이프라인·symlink guard·resume argv 무변경. 설정/theme 로직 변경 없음(theme 팔레트에 per-agent 토큰이 없어 설계의 "고정 ANSI fallback" 경로 채택).

## 명시적으로 제외한 다음 Phase 범위 (비목표)

- 고비용 필드(claude 모델·git dirty·token), 마지막 메시지 프리뷰.
- **Antigravity 편입 (Phase 1 spike / Phase 2 inclusion)** — `discoverAntigravity` 는 여전히 nil.
- `StartedAt`/`SizeBytes` 등 선택 저비용 필드 — 이번엔 파싱도 미포함(turn 수만 필수).

## 설계 판단 노트 (lead 검토 요망)

turn 카운트와 기존 스캔 조기종료(metadata 완성 시 early-exit, 전용 테스트 존재)는 상충한다 — 조기종료를 두면 title 이 첫 user 메시지에서 잡히며 카운트가 ~1 로 고정되어 기능이 무의미해진다. 그래서:
- **metadata 완성 조기종료를 완화**(카운트가 bounded window 전체를 보게). 스캔 상한 `sessionScanLineLimit`(100줄)은 그대로 → worst-case 는 기존과 동일.
- **cwd 불일치 조기중단은 유지** → 비매칭 세션(대부분)은 여전히 첫 cwd 레코드에서 abort. 추가 읽기는 **실제 표시될 매칭 세션에만** 발생.
- 결과 turn 수는 스캔 window(100줄) 내 lower-bound. 매우 긴 세션은 saturate(정밀도보다 상대적 규모 신호 목적).

## 검증

- `go build ./...` ✅
- `go test ./internal/...` ✅ (aisessions turn 카운트 fixture 테스트, ai_test.go 신규 컬럼 순서·id 검색 유지·배지 tight/색·turns 셀 테스트 추가)
- `make fmt` / `make fix`(deadcode clean) / `make test` ✅

## 미검증 항목 / 후속

- tmux 실제 popup 안에서의 시각 확인은 e2e 후보(단위 테스트로 폭 정렬·truncation·좁은 폭 안전은 커버). 로컬 렌더 프리뷰로 레이아웃은 확인.
- 후속: Phase 1(antigravity discovery spike) → Phase 2(inclusion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
