### PR TITLE
feat(ai): antigravity usage parity — context-window HUD/status exposure (Phase 0)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -259,10 +259,12 @@ Codex shares the global `30s`). `--json` emits the snapshot array; when
 backoff is active the wrapper `{snapshots, backoff}` object is emitted
 instead.
 
-Antigravity has no supported 5-hour/weekly quota adapter. `--model
-antigravity` renders an explicit unsupported note: the stable Antigravity
-signal is `context-window-only` statusline data, which is not mixed into the
-Claude/Codex quota HUD.
+Antigravity has no 5-hour/weekly quota contract, so it is surfaced
+`context-window-only`: the adapter emits a single `context` window row
+(context-window fullness, no `RESETS_AT`) sourced from the latest
+statusline `context_window` seen via hook ingest. `--model antigravity`
+renders that row; in the HUD it shows as `Antigravity ctx [bar] N%`
+alongside the Claude/Codex quota bars.
 
 ## status
 
@@ -473,9 +475,10 @@ Antigravity notify metadata uses `agent=antigravity`. Phase 3 session-state
 restore is included: Antigravity ingest stores `conversationId` as pane thread
 metadata for matching and as session-state resume metadata. Restore uses
 `agy --conversation <uuid>` when that id is present and UUID-shaped; otherwise
-session-state preview/doctor render `resume unavailable`. Usage quota HUD
-support remains unsupported because the only stable usage signal is
-`context-window-only` statusline data. Transcript contents are not read.
+session-state preview/doctor render `resume unavailable`. The statusline
+`context_window` value is persisted on ingest and surfaced by the usage HUD
+as a `context-window-only` row (Antigravity has no 5h/weekly quota contract).
+Transcript contents are not read.
 
 `ingest bell --pane <pane_id>` is the narrow tmux-bell fallback ingest path.
 It does not require the pane to be AI-managed. Projmux resolves session,

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -634,10 +634,11 @@ include `conversationId`/`conversation_id`, `cwd`, `workspace.path`,
 Antigravity ingest uses `conversationId` as pane thread metadata for matching
 and as session-state resume metadata. Session restore uses
 `agy --conversation <uuid>` only when that id is present and UUID-shaped;
-otherwise preview and doctor render `resume unavailable`. Antigravity usage
-quota HUD support remains unsupported because the stable usage signal is
-`context-window-only` statusline data, not 5-hour/weekly quota data. Raw
-payloads or transcript contents are not stored.
+otherwise preview and doctor render `resume unavailable`. The statusline
+`context_window` percentage is persisted to the usage state dir on ingest so
+the usage HUD can surface it as a `context-window-only` row — Antigravity has
+no 5-hour/weekly quota contract, so no quota bars are emitted. Raw payloads or
+transcript contents are not stored.
 
 ## Ingest Debug Log
 

--- a/docs/usage-tracking.md
+++ b/docs/usage-tracking.md
@@ -122,11 +122,12 @@ claude is in backoff, try again in 30m (use --force to bypass)
 
 When no AI agents are enabled, all-model table output contains no
 provider rows and prints a short Settings hint. `--json` returns an
-empty array. Explicit `--model claude` and `--model codex` bypass the
-enabled-agent filter for read-only inspection and collect/render only
-the requested adapter. Explicit `--model antigravity` renders the same
-unsupported/context-window-only note even when Antigravity is disabled, because
-there is no supported Antigravity quota adapter to collect.
+empty array. Explicit `--model claude`, `--model codex` and
+`--model antigravity` bypass the enabled-agent filter for read-only
+inspection and collect/render only the requested adapter. Antigravity
+exposes no 5h/weekly quota, so its adapter reports a single `context`
+window row (context-window fullness, no `RESETS_AT`) sourced from the
+latest statusline `context_window` observed via hook ingest.
 
 ### `projmux status usage`
 

--- a/internal/app/ai_ingest.go
+++ b/internal/app/ai_ingest.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/notify"
+	antigravityadapter "github.com/crevissepartners/projmux/internal/core/usage/adapters/antigravity"
 	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
 )
 
@@ -783,6 +784,7 @@ func (c *aiCommand) ingestAntigravityHook(data []byte) error {
 	}
 
 	c.markAIHookPane(paneID, aiModeAntigravity, payload.CWD, payload.ConversationID, payload.ConversationID, payload.TranscriptPath)
+	c.persistAntigravityContextUsage(payload)
 	metadata := payload.antigravityMetadata()
 	action := c.aiHookEffectiveAction(aiHookProviderAntigravity, payload.EventName)
 
@@ -866,6 +868,51 @@ func (c *aiCommand) ingestAntigravityHook(data []byte) error {
 		c.quietAntigravityHook(paneID, payload, aiHookNoHandlerReason(action))
 		return nil
 	}
+}
+
+// persistAntigravityContextUsage records the latest context-window
+// percentage carried by an antigravity hook into the usage state
+// directory so the usage adapter (and thus the HUD/status bar) can surface
+// it. Best-effort: antigravity exposes no 5h/weekly quota, so this
+// context-window gauge is the only usage-shaped signal available. A
+// missing or unparseable value, or a write failure, is silently ignored —
+// usage is a non-critical side channel of hook ingest.
+func (c *aiCommand) persistAntigravityContextUsage(payload antigravityHookPayload) {
+	pct, ok := antigravityadapter.ParsePercent(payload.ContextWindow)
+	if !ok {
+		return
+	}
+	baseDir, err := c.usageStateDir()
+	if err != nil {
+		return
+	}
+	_ = antigravityadapter.WriteContext(baseDir, antigravityadapter.ContextRecord{
+		Pct:       pct,
+		UpdatedAt: c.now().UTC(),
+	})
+}
+
+// usageStateDir resolves the directory the usage snapshot cache and the
+// antigravity context sidecar live in. It mirrors usageCommand.resolveStateDir
+// so the ingest writer and the adapter reader agree even when
+// PROJMUX_USAGE_STATE_DIR redirects the cache to a synced location.
+func (c *aiCommand) usageStateDir() (string, error) {
+	if override := strings.TrimSpace(c.env(stateDirEnvVar)); override != "" {
+		return override, nil
+	}
+	homeDir, err := c.homeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	paths, err := config.Homes{
+		HomeDir:    homeDir,
+		ConfigHome: c.env("XDG_CONFIG_HOME"),
+		StateHome:  c.env("XDG_STATE_HOME"),
+	}.Paths()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(paths.StateDir, "usage"), nil
 }
 
 func (c *aiCommand) quietCodexHook(paneID string, payload codexHookPayload, reason string) {

--- a/internal/app/ai_ingest_test.go
+++ b/internal/app/ai_ingest_test.go
@@ -14,8 +14,40 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/notify"
+	antigravityadapter "github.com/crevissepartners/projmux/internal/core/usage/adapters/antigravity"
 	"github.com/crevissepartners/projmux/internal/i18n"
 )
+
+func TestPersistAntigravityContextUsage(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	now := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	cmd.now = func() time.Time { return now }
+
+	// Numeric context_window is persisted so the adapter surfaces it.
+	cmd.persistAntigravityContextUsage(antigravityHookPayload{ContextWindow: "42%"})
+
+	baseDir, err := cmd.usageStateDir()
+	if err != nil {
+		t.Fatalf("usageStateDir: %v", err)
+	}
+	snaps, err := antigravityadapter.New(baseDir).Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(snaps) != 1 || snaps[0].Pct != 42 || snaps[0].Model != "antigravity" {
+		t.Fatalf("snapshots = %#v, want single antigravity 42%% context row", snaps)
+	}
+
+	// Non-numeric / empty values are ignored (clean degrade, no garbage file
+	// churn) — the previously persisted value stays intact.
+	cmd.persistAntigravityContextUsage(antigravityHookPayload{ContextWindow: ""})
+	cmd.persistAntigravityContextUsage(antigravityHookPayload{ContextWindow: "n/a"})
+	snaps, err = antigravityadapter.New(baseDir).Collect(context.Background())
+	if err != nil || len(snaps) != 1 || snaps[0].Pct != 42 {
+		t.Fatalf("after non-numeric writes snapshots = %#v err = %v, want unchanged 42%%", snaps, err)
+	}
+}
 
 func TestParseCodexHookPayload(t *testing.T) {
 	t.Parallel()

--- a/internal/app/statusbar_test.go
+++ b/internal/app/statusbar_test.go
@@ -736,7 +736,7 @@ func TestStatusbarDefaultUsageStateFiltersDisabledProviders(t *testing.T) {
 	}
 }
 
-func TestStatusbarDefaultUsageStateShowsAntigravityUnsupported(t *testing.T) {
+func TestStatusbarDefaultUsageStateShowsAntigravityContext(t *testing.T) {
 	home := t.TempDir()
 	configHome := filepath.Join(home, "xdg-config")
 	stateHome := filepath.Join(home, "xdg-state")
@@ -749,30 +749,34 @@ func TestStatusbarDefaultUsageStateShowsAntigravityUnsupported(t *testing.T) {
 	if err := config.SaveAIEnabledAgentsFile(paths.AIEnabledAgentsFile(), []config.AIAgentProvider{config.AIAgentAntigravity}); err != nil {
 		t.Fatalf("SaveAIEnabledAgentsFile: %v", err)
 	}
-	if err := coreusage.NewStore(filepath.Join(paths.StateDir, "usage")).SaveState(coreusage.State{}); err != nil {
+	now := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
+	if err := coreusage.NewStore(filepath.Join(paths.StateDir, "usage")).SaveState(coreusage.State{
+		Snapshots: []coreusage.Snapshot{
+			{Model: "antigravity", Window: coreusage.WindowContext, Pct: 42, UpdatedAt: now},
+		},
+	}); err != nil {
 		t.Fatalf("seed usage state: %v", err)
 	}
 
-	now := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
 	cmd := newStatusbarCommand()
 	cmd.now = func() time.Time { return now }
 	state, err := cmd.defaultUsageState(context.Background())
 	if err != nil {
 		t.Fatalf("defaultUsageState: %v", err)
 	}
-	if len(state.Snapshots) != 0 {
-		t.Fatalf("Snapshots = %#v, want no quota rows", state.Snapshots)
+	if len(state.Unsupported) != 0 {
+		t.Fatalf("Unsupported = %#v, want none now that Antigravity usage is supported", state.Unsupported)
 	}
-	if len(state.Unsupported) != 1 || state.Unsupported[0].Model != "antigravity" {
-		t.Fatalf("Unsupported = %#v, want Antigravity unsupported row", state.Unsupported)
+	if len(state.Snapshots) != 1 || state.Snapshots[0].Model != "antigravity" || state.Snapshots[0].Window != coreusage.WindowContext {
+		t.Fatalf("Snapshots = %#v, want single Antigravity context row", state.Snapshots)
 	}
 
 	popup := statusbarUsagePopup(state, now, "/usr/local/bin/projmux")
-	if !strings.Contains(popup.Command, "Antigravity") || !strings.Contains(popup.Command, "unsupported") {
-		t.Fatalf("popup command = %q, want Antigravity unsupported row", popup.Command)
+	if !strings.Contains(popup.Command, "Antigravity") || !strings.Contains(popup.Command, "42%") {
+		t.Fatalf("popup command = %q, want Antigravity context row", popup.Command)
 	}
-	if toast := statusbarUsageToast(state); toast != "usage: antigravity unsupported" {
-		t.Fatalf("toast = %q, want Antigravity unsupported", toast)
+	if toast := statusbarUsageToast(state); !strings.Contains(toast, "Antigravity") || !strings.Contains(toast, "42%") {
+		t.Fatalf("toast = %q, want Antigravity context usage", toast)
 	}
 }
 

--- a/internal/app/usage.go
+++ b/internal/app/usage.go
@@ -17,6 +17,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/aiprovider"
 	"github.com/crevissepartners/projmux/internal/core/usage"
+	antigravityadapter "github.com/crevissepartners/projmux/internal/core/usage/adapters/antigravity"
 	claudeadapter "github.com/crevissepartners/projmux/internal/core/usage/adapters/claude"
 	codexadapter "github.com/crevissepartners/projmux/internal/core/usage/adapters/codex"
 	"github.com/crevissepartners/projmux/internal/theme"
@@ -61,7 +62,7 @@ func (c *usageCommand) Run(args []string, stdout, stderr io.Writer) error {
 	fs := flag.NewFlagSet("usage", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	model := fs.String("model", "all", "filter by model: codex | claude | antigravity | all")
-	window := fs.String("window", "all", "filter by window: 5h | weekly | all")
+	window := fs.String("window", "all", "filter by window: 5h | weekly | context | all")
 	asJSON := fs.Bool("json", false, "emit a JSON array instead of the tab-aligned table")
 	// --force / -f bypasses the per-adapter throttle floor AND clears
 	// any active backoff before invoking adapters. Useful when bound
@@ -242,6 +243,13 @@ func (c *usageCommand) managerForScope(modelScope []string) (*usage.Manager, err
 }
 
 func (c *usageCommand) defaultManager(modelScope []string) (*usage.Manager, error) {
+	// Resolve the state dir up front: the Antigravity adapter reads its
+	// context sidecar from the same directory the snapshot cache lives in,
+	// so it needs the resolved path at construction time.
+	stateDir, err := c.resolveStateDir()
+	if err != nil {
+		return nil, err
+	}
 	registry := usage.NewRegistry()
 	for _, model := range normalizeUsageModelScope(modelScope) {
 		provider, ok := aiprovider.Lookup(model)
@@ -257,11 +265,11 @@ func (c *usageCommand) defaultManager(modelScope []string) (*usage.Manager, erro
 			if err := registry.Register(codexadapter.New()); err != nil {
 				return nil, fmt.Errorf("usage: register codex adapter: %w", err)
 			}
+		case aiprovider.Antigravity:
+			if err := registry.Register(antigravityadapter.New(stateDir)); err != nil {
+				return nil, fmt.Errorf("usage: register antigravity adapter: %w", err)
+			}
 		}
-	}
-	stateDir, err := c.resolveStateDir()
-	if err != nil {
-		return nil, err
 	}
 	// PROJMUX_USAGE_LIMITS_PATH is deprecated in schema v2 — observe it
 	// here purely so users who set it don't see a "permission denied" or
@@ -377,14 +385,10 @@ func (c *usageCommand) unsupportedUsageProviders(model string, explicitModel boo
 }
 
 func unsupportedUsageProviderFor(provider aiprovider.Metadata) usageUnsupportedProvider {
-	reason := "no supported 5h/weekly quota usage adapter"
-	if provider.ID == aiprovider.Antigravity {
-		reason = "context-window-only statusline data; no supported 5h/weekly quota or reset contract"
-	}
 	return usageUnsupportedProvider{
 		Model:  string(provider.ID),
 		Label:  provider.DisplayName,
-		Reason: reason,
+		Reason: "no supported usage adapter",
 	}
 }
 
@@ -636,6 +640,12 @@ type modelDisplay struct {
 	hasWeek    bool
 	weekPct    float64
 	weekStale  int
+	// context-window fullness (usage.WindowContext). Used by adapters
+	// without a 5h/weekly quota contract (Antigravity). Rendered as a
+	// `ctx` pair alongside — or in place of — the time-windowed bars.
+	hasContext bool
+	contextPct float64
+	ctxStale   int
 	// lastSync is max(fiveUpdatedAt, weekUpdatedAt). Used together
 	// with `now` to compute the age indicator. Zero when no row
 	// supplied an UpdatedAt timestamp.
@@ -711,7 +721,7 @@ func renderTierLongHUD(models []modelDisplay, now time.Time) string {
 func renderLongHUDInternal(models []modelDisplay, now time.Time, withAge bool) string {
 	blocks := make([]string, 0, len(models))
 	for _, m := range models {
-		if !m.hasFive && !m.hasWeek {
+		if !m.hasFive && !m.hasWeek && !m.hasContext {
 			continue
 		}
 		var b strings.Builder
@@ -725,18 +735,23 @@ func renderLongHUDInternal(models []modelDisplay, now time.Time, withAge bool) s
 			}
 		}
 		first := true
-		if m.hasFive {
-			b.WriteByte(' ')
-			b.WriteString(renderHUDPair("5h", m.fivePct))
-			first = false
-		}
-		if m.hasWeek {
+		writePair := func(window string, pct float64) {
 			if first {
 				b.WriteByte(' ')
+				first = false
 			} else {
 				b.WriteString(statusInnerSeparator)
 			}
-			b.WriteString(renderHUDPair("weekly", m.weekPct))
+			b.WriteString(renderHUDPair(window, pct))
+		}
+		if m.hasFive {
+			writePair("5h", m.fivePct)
+		}
+		if m.hasWeek {
+			writePair("weekly", m.weekPct)
+		}
+		if m.hasContext {
+			writePair("ctx", m.contextPct)
 		}
 		b.WriteString(statusDefaultReset)
 		blocks = append(blocks, b.String())
@@ -747,12 +762,21 @@ func renderLongHUDInternal(models []modelDisplay, now time.Time, withAge bool) s
 	return strings.Join(blocks, statusModelSeparator) + statusDefaultReset
 }
 
-// renderTierFiveHOnlyHUD drops the weekly bar but keeps the 5h bar.
+// renderTierFiveHOnlyHUD drops the weekly bar but keeps a single primary
+// bar per model: 5h when present, else the context bar (so context-only
+// models like Antigravity stay visible at this narrower tier).
 func renderTierFiveHOnlyHUD(models []modelDisplay, now time.Time) string {
 	_ = now
 	blocks := make([]string, 0, len(models))
 	for _, m := range models {
-		if !m.hasFive {
+		window := ""
+		var pct float64
+		switch {
+		case m.hasFive:
+			window, pct = "5h", m.fivePct
+		case m.hasContext:
+			window, pct = "ctx", m.contextPct
+		default:
 			continue
 		}
 		var b strings.Builder
@@ -760,7 +784,7 @@ func renderTierFiveHOnlyHUD(models []modelDisplay, now time.Time) string {
 		b.WriteString(m.label)
 		b.WriteString(statusDefaultReset)
 		b.WriteByte(' ')
-		b.WriteString(renderHUDPair("5h", m.fivePct))
+		b.WriteString(renderHUDPair(window, pct))
 		b.WriteString(statusDefaultReset)
 		blocks = append(blocks, b.String())
 	}
@@ -808,12 +832,15 @@ func renderTierTextShort(models []modelDisplay, now time.Time) string {
 // tier carries staleness via the age indicator. The non-JSON `usage`
 // table CLI still surfaces a STALE column for verbose inspection.
 func renderTextPair(m modelDisplay, label string) string {
-	parts := make([]string, 0, 2)
+	parts := make([]string, 0, 3)
 	if m.hasFive {
 		parts = append(parts, fmt.Sprintf("5h:%s", percentText(m.fivePct)))
 	}
 	if m.hasWeek {
 		parts = append(parts, fmt.Sprintf("weekly:%s", percentText(m.weekPct)))
+	}
+	if m.hasContext {
+		parts = append(parts, fmt.Sprintf("ctx:%s", percentText(m.contextPct)))
 	}
 	if len(parts) == 0 {
 		return ""
@@ -926,6 +953,10 @@ func buildModelDisplays(snaps []usage.Snapshot, now time.Time) []modelDisplay {
 			row.hasWeek = true
 			row.weekPct = s.Pct
 			row.weekStale = level
+		case usage.WindowContext:
+			row.hasContext = true
+			row.contextPct = s.Pct
+			row.ctxStale = level
 		}
 		// lastSync tracks the most recent successful refresh
 		// across the model's rows; the long HUD tier renders its
@@ -935,11 +966,15 @@ func buildModelDisplays(snaps []usage.Snapshot, now time.Time) []modelDisplay {
 		if !s.UpdatedAt.IsZero() && s.UpdatedAt.After(row.lastSync) {
 			row.lastSync = s.UpdatedAt
 		}
-		if strings.EqualFold(s.Model, "claude") {
+		// Claude data is throttled/backoff-gated and Antigravity data is
+		// hook-driven (only refreshed when agy emits a statusline), so both
+		// can go stale — surface the age indicator. Codex reads the latest
+		// rollout every call so its age is always ~now (showAge stays false).
+		if strings.EqualFold(s.Model, "claude") || strings.EqualFold(s.Model, "antigravity") {
 			row.showAge = true
 		}
 	}
-	canonical := []string{"claude", "codex"}
+	canonical := []string{"claude", "codex", "antigravity"}
 	listed := make(map[string]bool, len(canonical))
 	out := make([]modelDisplay, 0, len(byModel))
 	for _, m := range canonical {
@@ -964,6 +999,8 @@ func modelDisplayLabel(model string) string {
 		return "Claude"
 	case "codex":
 		return "Codex"
+	case "antigravity":
+		return "Antigravity"
 	default:
 		if model == "" {
 			return "?"
@@ -984,6 +1021,8 @@ func modelShortLabel(model string) string {
 		return "C"
 	case "codex":
 		return "X"
+	case "antigravity":
+		return "A"
 	default:
 		if model == "" {
 			return "?"
@@ -1049,7 +1088,7 @@ func runeLen(s string) int {
 
 func printUsageHelp(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  projmux usage [--model codex|claude|antigravity|all] [--window 5h|weekly|all] [--json] [--force|-f]")
+	fmt.Fprintln(w, "  projmux usage [--model codex|claude|antigravity|all] [--window 5h|weekly|context|all] [--json] [--force|-f]")
 	fmt.Fprintln(w, "  projmux status usage [--max-width N] [--force|-f]")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Flags:")

--- a/internal/app/usage_test.go
+++ b/internal/app/usage_test.go
@@ -46,6 +46,57 @@ func TestFormatStatusUsageRendersBothModelsHUD(t *testing.T) {
 	}
 }
 
+func TestFormatStatusUsageRendersAntigravityContext(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	// Antigravity exposes only a context-window gauge — no 5h/weekly quota.
+	// It must still render a `ctx` bar in the HUD.
+	snaps := []usage.Snapshot{
+		{Model: "antigravity", Window: usage.WindowContext, Pct: 42, UpdatedAt: now},
+	}
+	got := formatStatusUsage(snaps, 0, now)
+
+	if !strings.Contains(got, "Antigravity") {
+		t.Fatalf("missing Antigravity label: %q", got)
+	}
+	if !strings.Contains(got, "ctx ") {
+		t.Fatalf("missing ctx window label: %q", got)
+	}
+	if !strings.Contains(got, "42%") {
+		t.Fatalf("missing context percentage: %q", got)
+	}
+	if !strings.Contains(got, "█") || !strings.Contains(got, "░") {
+		t.Fatalf("missing bar runes: %q", got)
+	}
+}
+
+// TestFormatStatusUsageCanonicalOrder locks the HUD ordering: Claude,
+// Codex, then Antigravity, regardless of snapshot input order. This also
+// guards claude/codex against regression when a context-only model is
+// present.
+func TestFormatStatusUsageCanonicalOrder(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	snaps := []usage.Snapshot{
+		{Model: "antigravity", Window: usage.WindowContext, Pct: 42, UpdatedAt: now},
+		{Model: "codex", Window: usage.Window5h, Pct: 71, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
+		{Model: "claude", Window: usage.Window5h, Pct: 12, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
+	}
+	got := formatStatusUsage(snaps, 0, now)
+
+	iClaude := strings.Index(got, "Claude")
+	iCodex := strings.Index(got, "Codex")
+	iAgy := strings.Index(got, "Antigravity")
+	if iClaude < 0 || iCodex < 0 || iAgy < 0 {
+		t.Fatalf("missing a model label: %q", got)
+	}
+	if !(iClaude < iCodex && iCodex < iAgy) {
+		t.Fatalf("canonical order Claude<Codex<Antigravity not held: claude=%d codex=%d agy=%d in %q", iClaude, iCodex, iAgy, got)
+	}
+}
+
 func TestFormatStatusUsageOmitsPlaceholderRows(t *testing.T) {
 	t.Parallel()
 
@@ -340,13 +391,14 @@ func TestUsageStatusScopesToEnabledCodexOnly(t *testing.T) {
 	}
 }
 
-func TestUsageStatusIgnoresEnabledAntigravityUntilAdapterExists(t *testing.T) {
+func TestUsageStatusShowsAntigravityContext(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
 	store := usage.NewStore(t.TempDir())
-	claudeAd := &stubAdapter{name: "claude"}
-	codexAd := &stubAdapter{name: "codex"}
+	agyAd := &stubAdapter{name: "antigravity", snaps: []usage.Snapshot{
+		{Model: "antigravity", Window: usage.WindowContext, Pct: 63, UpdatedAt: now},
+	}}
 
 	c := newUsageCommand()
 	c.now = func() time.Time { return now }
@@ -354,8 +406,7 @@ func TestUsageStatusIgnoresEnabledAntigravityUntilAdapterExists(t *testing.T) {
 		return []config.AIAgentProvider{config.AIAgentAntigravity}, nil
 	}
 	c.managerFn = scopedUsageManagerFactory(t, store, now, map[string]*stubAdapter{
-		"claude": claudeAd,
-		"codex":  codexAd,
+		"antigravity": agyAd,
 	})
 
 	stdout := &bytes.Buffer{}
@@ -363,61 +414,80 @@ func TestUsageStatusIgnoresEnabledAntigravityUntilAdapterExists(t *testing.T) {
 	if err := c.runStatus(nil, stdout, stderr); err != nil {
 		t.Fatalf("runStatus: %v", err)
 	}
-	if got := stdout.String(); got != "" {
-		t.Fatalf("status usage output = %q, want empty without Antigravity usage adapter", got)
+	out := stdout.String()
+	if !strings.Contains(out, "Antigravity") || !strings.Contains(out, "63%") {
+		t.Fatalf("expected Antigravity context HUD: %q", out)
 	}
-	if claudeAd.collectCalls != 0 || codexAd.collectCalls != 0 {
-		t.Fatalf("collect calls with only Antigravity enabled = claude:%d codex:%d, want 0/0", claudeAd.collectCalls, codexAd.collectCalls)
+	if agyAd.collectCalls != 1 {
+		t.Fatalf("antigravity collect calls = %d, want 1", agyAd.collectCalls)
 	}
 }
 
-func TestUsageRunShowsAntigravityUnsupportedState(t *testing.T) {
+func TestUsageRunShowsAntigravityContextUsage(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
 	store := usage.NewStore(t.TempDir())
+	agyAd := &stubAdapter{name: "antigravity", snaps: []usage.Snapshot{
+		{Model: "antigravity", Window: usage.WindowContext, Pct: 55, UpdatedAt: now},
+	}}
 	c := newUsageCommand()
 	c.now = func() time.Time { return now }
 	c.enabledAgentsFn = func() ([]config.AIAgentProvider, error) {
 		return []config.AIAgentProvider{config.AIAgentAntigravity}, nil
 	}
-	c.managerFn = scopedUsageManagerFactory(t, store, now, map[string]*stubAdapter{})
+	c.managerFn = scopedUsageManagerFactory(t, store, now, map[string]*stubAdapter{
+		"antigravity": agyAd,
+	})
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	if err := c.Run([]string{"--model", "all"}, stdout, stderr); err != nil {
-		t.Fatalf("Run: %v", err)
+		t.Fatalf("Run: %v stderr=%s", err, stderr.String())
 	}
 	output := stdout.String()
-	if !strings.Contains(output, "Antigravity usage unsupported") ||
-		!strings.Contains(output, "context-window-only") ||
-		!strings.Contains(output, "no supported 5h/weekly quota or reset contract") {
-		t.Fatalf("output = %q, want Antigravity unsupported context-window-only state", output)
+	if !strings.Contains(output, "antigravity") || !strings.Contains(output, "context") || !strings.Contains(output, "55%") {
+		t.Fatalf("output = %q, want antigravity context row", output)
+	}
+	if strings.Contains(output, "unsupported") {
+		t.Fatalf("output = %q, Antigravity usage should no longer be unsupported", output)
 	}
 	if strings.Contains(output, "enable Claude or Codex") {
 		t.Fatalf("output = %q, should not imply Antigravity is not an enabled agent", output)
 	}
+	if agyAd.collectCalls != 1 {
+		t.Fatalf("antigravity collect calls = %d, want 1", agyAd.collectCalls)
+	}
 }
 
-func TestUsageRunExplicitAntigravityShowsUnsupportedState(t *testing.T) {
+func TestUsageRunExplicitAntigravityWorksWhenDisabled(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
 	store := usage.NewStore(t.TempDir())
+	agyAd := &stubAdapter{name: "antigravity", snaps: []usage.Snapshot{
+		{Model: "antigravity", Window: usage.WindowContext, Pct: 77, UpdatedAt: now},
+	}}
 	c := newUsageCommand()
 	c.now = func() time.Time { return now }
 	c.enabledAgentsFn = func() ([]config.AIAgentProvider, error) {
 		return []config.AIAgentProvider{config.AIAgentClaude}, nil
 	}
-	c.managerFn = scopedUsageManagerFactory(t, store, now, map[string]*stubAdapter{})
+	c.managerFn = scopedUsageManagerFactory(t, store, now, map[string]*stubAdapter{
+		"antigravity": agyAd,
+	})
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	if err := c.Run([]string{"--model", "antigravity"}, stdout, stderr); err != nil {
-		t.Fatalf("Run: %v", err)
+		t.Fatalf("Run: %v stderr=%s", err, stderr.String())
 	}
-	if output := stdout.String(); !strings.Contains(output, "Antigravity usage unsupported") {
-		t.Fatalf("output = %q, want explicit Antigravity unsupported state", output)
+	output := stdout.String()
+	if !strings.Contains(output, "antigravity") || !strings.Contains(output, "77%") {
+		t.Fatalf("output = %q, want explicit antigravity context row", output)
+	}
+	if agyAd.collectCalls != 1 {
+		t.Fatalf("antigravity collect calls = %d, want 1 for explicit model", agyAd.collectCalls)
 	}
 }
 

--- a/internal/core/aiprovider/registry.go
+++ b/internal/core/aiprovider/registry.go
@@ -91,9 +91,11 @@ var registry = []Metadata{
 		DisplayName:     "Antigravity",
 		ShortName:       "Antigravity",
 		BinaryName:      "agy",
+		UsageModel:      string(Antigravity),
 		HookProvider:    string(Antigravity),
 		SettingsVisible: true,
 		PickerEligible:  true,
+		UsageSupported:  true,
 		HookDiagnostics: SupportMetadata{
 			Supported: true,
 			ID:        "antigravity-hooks",

--- a/internal/core/aiprovider/registry_test.go
+++ b/internal/core/aiprovider/registry_test.go
@@ -14,7 +14,7 @@ func TestProviderRegistryOrdersSurfaces(t *testing.T) {
 	if got, want := providerIDs(PickerEligible()), []ID{Codex, Claude, Antigravity}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("PickerEligible() = %#v, want %#v", got, want)
 	}
-	if got, want := providerIDs(UsageSupported()), []ID{Claude, Codex}; !reflect.DeepEqual(got, want) {
+	if got, want := providerIDs(UsageSupported()), []ID{Claude, Codex, Antigravity}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("UsageSupported() = %#v, want %#v", got, want)
 	}
 	if got, want := providerIDs(HookDiagnosticSupported()), []ID{Claude, Codex, Antigravity}; !reflect.DeepEqual(got, want) {
@@ -61,8 +61,14 @@ func TestProviderRegistryMetadataForCurrentAgents(t *testing.T) {
 	if !ok {
 		t.Fatalf("Lookup(antigravity) missing")
 	}
-	if antigravity.UsageSupported || antigravity.UsageModel != "" || antigravity.Integrate.Supported || !antigravity.SessionState.Supported {
-		t.Fatalf("Antigravity metadata = %#v, want session-state support without quota usage/integrate support", antigravity)
+	// Phase 0 (usage parity) wires antigravity into the usage infra:
+	// UsageSupported + UsageModel are set. Integrate remains unsupported
+	// (that is a later phase); session-state stays supported.
+	if !antigravity.UsageSupported || antigravity.UsageModel != string(Antigravity) {
+		t.Fatalf("Antigravity metadata = %#v, want usage support with UsageModel set", antigravity)
+	}
+	if antigravity.Integrate.Supported || !antigravity.SessionState.Supported {
+		t.Fatalf("Antigravity metadata = %#v, want session-state support without integrate support", antigravity)
 	}
 	if !antigravity.HookDiagnostics.Supported || antigravity.HookDiagnostics.ID != "antigravity-hooks" || antigravity.HookProvider != "antigravity" {
 		t.Fatalf("Antigravity hook metadata = %#v, want manual hook diagnostics support", antigravity)

--- a/internal/core/usage/adapters/antigravity/antigravity.go
+++ b/internal/core/usage/adapters/antigravity/antigravity.go
@@ -1,0 +1,171 @@
+// Package antigravity implements a best-effort usage Adapter for the
+// Antigravity CLI (`agy`).
+//
+// Unlike Claude (OAuth usage API) and Codex (rate_limits in the rollout
+// JSONL), Antigravity exposes NO server-side 5h/weekly quota contract. The
+// only usage-shaped signal it emits is the statusline `context_window`
+// percentage — how full the active conversation's context window is. This
+// adapter is therefore context-window-only: it surfaces a single
+// usage.Snapshot on the usage.WindowContext window and never fabricates
+// 5h/weekly rows.
+//
+// Source of truth: a small sidecar file written by the antigravity hook
+// ingest path (`projmux ai ingest antigravity-hook`) whenever a hook
+// payload carries a context_window value. The ingest path and this adapter
+// agree on the file name (ContextFileName) and schema (ContextRecord); the
+// file lives in the same directory as the usage snapshot cache so a single
+// PROJMUX_USAGE_STATE_DIR override keeps both in sync.
+//
+// The value reflects the most recently observed context window across all
+// antigravity panes — it is a live gauge, not an account-wide quota, so it
+// carries no ResetsAt. Best-effort throughout: a missing or malformed
+// sidecar reads as zero snapshots so the status segment degrades cleanly.
+package antigravity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/usage"
+)
+
+// Name is the adapter's registered identifier. It matches the aiprovider
+// registry ID and the usage model key so scope filtering lines up.
+const Name = "antigravity"
+
+// ContextFileName is the sidecar JSON the ingest path writes and this
+// adapter reads. It sits alongside the usage snapshot cache
+// (snapshots.json) in the resolved usage state directory.
+const ContextFileName = "antigravity-context.json"
+
+// ContextRecord is the on-disk schema shared between the hook ingest path
+// (writer) and this adapter (reader). Pct is the context-window fullness
+// percentage (0-100); UpdatedAt is when the value was last observed.
+type ContextRecord struct {
+	Pct       float64   `json:"pct"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Adapter is the Antigravity implementation of usage.Adapter.
+type Adapter struct {
+	baseDir string
+}
+
+// New returns an Adapter that reads ContextFileName from baseDir (the
+// resolved usage state directory).
+func New(baseDir string) *Adapter {
+	return &Adapter{baseDir: baseDir}
+}
+
+// Name implements usage.Adapter.
+func (a *Adapter) Name() string { return Name }
+
+// Collect reads the context sidecar and returns a single context-window
+// Snapshot. Best-effort: a missing base dir, missing file, malformed JSON
+// or an out-of-range percentage all read as zero snapshots (no error) so
+// the status segment stays silent rather than breaking.
+func (a *Adapter) Collect(_ context.Context) ([]usage.Snapshot, error) {
+	if strings.TrimSpace(a.baseDir) == "" {
+		return nil, nil
+	}
+	rec, ok, err := readContext(filepath.Join(a.baseDir, ContextFileName))
+	if err != nil {
+		// Surface for diagnostics under PROJMUX_USAGE_DEBUG; the hot path
+		// swallows it. Return no snapshots so rendering degrades cleanly.
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	pct := rec.Pct
+	if pct < 0 {
+		pct = 0
+	}
+	return []usage.Snapshot{{
+		Model:     Name,
+		Window:    usage.WindowContext,
+		Pct:       pct,
+		UpdatedAt: rec.UpdatedAt.UTC(),
+	}}, nil
+}
+
+func readContext(path string) (ContextRecord, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ContextRecord{}, false, nil
+		}
+		return ContextRecord{}, false, err
+	}
+	if len(data) == 0 {
+		return ContextRecord{}, false, nil
+	}
+	var rec ContextRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return ContextRecord{}, false, err
+	}
+	return rec, true, nil
+}
+
+// WriteContext atomically persists rec to <baseDir>/ContextFileName,
+// creating baseDir if needed. Used by the antigravity hook ingest path.
+func WriteContext(baseDir string, rec ContextRecord) error {
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		return err
+	}
+	rec.UpdatedAt = rec.UpdatedAt.UTC()
+	data, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(baseDir, ContextFileName)
+	tmp, err := os.CreateTemp(baseDir, "."+ContextFileName+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+// ParsePercent parses an antigravity context_window string (e.g. "42%",
+// "42", "42.5 %") into a percentage float. The bool is false when the
+// input is empty or not a number, so callers can skip persisting garbage.
+func ParsePercent(raw string) (float64, bool) {
+	s := strings.TrimSpace(raw)
+	s = strings.TrimSuffix(s, "%")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	pct, err := strconv.ParseFloat(s, 64)
+	if err != nil || pct < 0 {
+		return 0, false
+	}
+	return pct, true
+}

--- a/internal/core/usage/adapters/antigravity/antigravity_test.go
+++ b/internal/core/usage/adapters/antigravity/antigravity_test.go
@@ -1,0 +1,114 @@
+package antigravity
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/usage"
+)
+
+func TestParsePercent(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in     string
+		want   float64
+		wantOK bool
+	}{
+		{"42%", 42, true},
+		{"42", 42, true},
+		{"42.5 %", 42.5, true},
+		{"  0% ", 0, true},
+		{"", 0, false},
+		{"n/a", 0, false},
+		{"%", 0, false},
+		{"-3%", 0, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParsePercent(tc.in)
+		if ok != tc.wantOK || (ok && got != tc.want) {
+			t.Errorf("ParsePercent(%q) = (%v, %v), want (%v, %v)", tc.in, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+func TestCollectMissingFile(t *testing.T) {
+	t.Parallel()
+	a := New(t.TempDir())
+	snaps, err := a.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(snaps) != 0 {
+		t.Fatalf("Collect with no sidecar = %v, want empty", snaps)
+	}
+}
+
+func TestCollectEmptyBaseDir(t *testing.T) {
+	t.Parallel()
+	a := New("")
+	snaps, err := a.Collect(context.Background())
+	if err != nil || len(snaps) != 0 {
+		t.Fatalf("Collect with empty baseDir = (%v, %v), want (nil, nil)", snaps, err)
+	}
+}
+
+func TestWriteThenCollect(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	updated := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	if err := WriteContext(dir, ContextRecord{Pct: 42, UpdatedAt: updated}); err != nil {
+		t.Fatalf("WriteContext: %v", err)
+	}
+	a := New(dir)
+	snaps, err := a.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("Collect = %d snapshots, want 1", len(snaps))
+	}
+	s := snaps[0]
+	if s.Model != Name || s.Window != usage.WindowContext || s.Pct != 42 {
+		t.Fatalf("snapshot = %+v, want model=%s window=context pct=42", s, Name)
+	}
+	if !s.UpdatedAt.Equal(updated) {
+		t.Fatalf("UpdatedAt = %v, want %v", s.UpdatedAt, updated)
+	}
+	if !s.ResetsAt.IsZero() {
+		t.Fatalf("ResetsAt = %v, want zero (context window has no reset)", s.ResetsAt)
+	}
+}
+
+func TestCollectMalformedFileDegrades(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ContextFileName), []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	a := New(dir)
+	snaps, err := a.Collect(context.Background())
+	if err == nil {
+		t.Fatalf("Collect on malformed file: want diagnostic error, got nil")
+	}
+	if len(snaps) != 0 {
+		t.Fatalf("Collect on malformed file = %v, want no snapshots", snaps)
+	}
+}
+
+func TestCollectClampsNegativePct(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := WriteContext(dir, ContextRecord{Pct: -5, UpdatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("WriteContext: %v", err)
+	}
+	snaps, err := New(dir).Collect(context.Background())
+	if err != nil || len(snaps) != 1 {
+		t.Fatalf("Collect = (%v, %v), want 1 snapshot", snaps, err)
+	}
+	if snaps[0].Pct != 0 {
+		t.Fatalf("Pct = %v, want clamped to 0", snaps[0].Pct)
+	}
+}

--- a/internal/core/usage/store.go
+++ b/internal/core/usage/store.go
@@ -180,7 +180,7 @@ func (s *Store) SaveState(state State) error {
 	// Stable ordering: model asc, window asc within model.
 	sorted := make([]Snapshot, len(state.Snapshots))
 	copy(sorted, state.Snapshots)
-	windowOrder := map[Window]int{Window5h: 0, WindowWeekly: 1}
+	windowOrder := map[Window]int{Window5h: 0, WindowWeekly: 1, WindowContext: 2}
 	sort.SliceStable(sorted, func(i, j int) bool {
 		if sorted[i].Model != sorted[j].Model {
 			return sorted[i].Model < sorted[j].Model
@@ -260,7 +260,7 @@ func (s *Store) CleanupLegacyArtifacts() {
 func SortedSnapshots(snaps []Snapshot) []Snapshot {
 	out := make([]Snapshot, len(snaps))
 	copy(out, snaps)
-	windowOrder := map[Window]int{Window5h: 0, WindowWeekly: 1}
+	windowOrder := map[Window]int{Window5h: 0, WindowWeekly: 1, WindowContext: 2}
 	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Model != out[j].Model {
 			return out[i].Model < out[j].Model

--- a/internal/core/usage/usage.go
+++ b/internal/core/usage/usage.go
@@ -31,13 +31,20 @@ type Window string
 const (
 	Window5h     Window = "5h"
 	WindowWeekly Window = "weekly"
+	// WindowContext is a non-time-bounded window describing how full the
+	// active context window is (0-100%). Unlike 5h/weekly it has no reset
+	// cadence — it rises and falls with the conversation — so Duration()
+	// returns 0 and adapters leave ResetsAt zero. Used by adapters (e.g.
+	// Antigravity) that expose a context-fullness metric but no
+	// server-side quota contract.
+	WindowContext Window = "context"
 )
 
 // Duration is the rolling window length used when describing windows. The
 // weekly window's duration is approximate — actual rollover follows the
 // vendor's published reset cadence (Anthropic returns an explicit
 // resets_at; Codex's rate_limits payload includes resets_at as a unix
-// timestamp).
+// timestamp). WindowContext has no reset cadence and returns 0.
 func (w Window) Duration() time.Duration {
 	switch w {
 	case Window5h:


### PR DESCRIPTION
## 완료한 Phase

**Antigravity gap closure — Phase 0: Usage parity slice** (로드맵 디테일 - Antigravity gap closure).

antigravity(`agy`)를 usage 인프라에 편입해 상태바/HUD에 노출한다. antigravity는 5h/weekly quota 계약이 없어 **context-window-only**로 명시하되 상태바엔 표시되게 했다.

## 수정한 user-facing surface

- **`projmux status usage` HUD**: `Antigravity ctx [██████░░░░] 63%` 형태로 노출. context-only 모델이라 5h/weekly 바 대신 `ctx` 바 하나. 좁은 너비 tier(5h-only)에서도 context 바로 살아남고, text tier에서는 `ctx:63%`.
- **`projmux usage` 테이블 / `--json`**: `antigravity | context | 63% | -` 행. `--model antigravity` 명시 조회 지원. RESETS_AT은 reset 계약이 없어 `-`로 깨끗하게 degrade.
- **`--window context`** 필터 값 추가, help/flag 텍스트 갱신.
- **상태바 팝업**: 기존 generic window 렌더가 `context` window를 그대로 처리 → Antigravity 행 노출(코드 변경 불필요).
- **HUD age indicator**: antigravity는 hook 구동이라 stale 가능 → `(3h)` 같은 muted age 표기로 degrade(패닉 없음).

## 구현 요약

- `internal/core/usage/adapters/antigravity/` 신설: context 사이드카(`antigravity-context.json`) 읽어 `WindowContext` Snapshot 1개 emit. 파일 없음/파손 시 no-snapshot으로 clean degrade.
- `usage.WindowContext` window 추가, store `windowOrder`에 편입.
- `aiprovider/registry.go`: antigravity `UsageModel` + `UsageSupported=true`.
- `internal/app/usage.go`: 등록 스위치에 antigravity case, canonical 순서 `[claude, codex, antigravity]`, HUD 렌더러 3개 tier에 context 처리.
- `ai_ingest.go`: antigravity hook 수신 시 statusline `context_window`(예: `"42%"`)를 usage state dir에 best-effort 영속화. `PROJMUX_USAGE_STATE_DIR`를 usage 커맨드와 동일하게 존중하는 공유 resolver 사용.
- docs(cli/usage-tracking/hooks) 갱신.

## 명시적으로 제외한 다음 Phase 범위 (회귀 금지 대상)

- Phase 1: hook 이벤트 커버리지 확장, notify 포맷터.
- Phase 2: `projmux ai integrate antigravity`, Settings primary 승격.
- Phase 3: resume confidence 상향, resume discovery.
- **claude/codex usage 동작은 일절 변경하지 않음.**

## 모델/스키마/엔진 제약 준수

- usage `Snapshot` 스키마는 필드 추가 없이 재사용(기존 `Window` enum에 `context` 값만 추가). snapshots.json v2 스키마 유지.
- claude/codex adapter·렌더 경로 미변경 — canonical에 antigravity를 뒤에 append하고, context 렌더 분기는 `hasContext`로만 진입하므로 claude/codex 출력 바이트 동일.

## 검증

- `go build ./...` ✓
- `go test ./internal/...` ✓ (전 패키지 pass)
- `go vet` / `gofmt` / `make fmt` / `make fix`(deadcode clean) ✓
- adapter fixture 테스트(파싱/write→collect/malformed degrade/negative clamp), usage 등록·필터·canonical·context 렌더 테스트, ingest 영속화 테스트, aiprovider registry 테스트 갱신.
- 실 바이너리 e2e 스모크: 사이드카 seed 후 `usage --model antigravity`(테이블/JSON), `status usage`(HUD, fresh & 3h-stale) 확인 — 위 surface 예시가 실제 출력.

## 미검증 항목 / 후속

- **실 tmux 파이프라인 e2e**: hook ingest→pane match(`matchAIPane`, TMUX_PANE 필요)→collect→HUD 전 구간은 live tmux 세션이 있어야 검증 가능 → e2e 후보. 단위 테스트로 각 단계(persist / adapter Collect / HUD 렌더)는 커버됨.
- 다중 antigravity pane 동시 사용 시 사이드카는 "가장 최근 관측된 context-window"를 보유(계정 전역 quota가 아닌 라이브 게이지). Phase 0 범위 내 알려진 한계로, adapter doc comment에 명시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
