### PR TITLE
feat(ai): antigravity session inclusion in resume picker — disk discovery (Phase 2)

### DIFF
--- a/internal/integrations/agents/aisessions/antigravity_test.go
+++ b/internal/integrations/agents/aisessions/antigravity_test.go
@@ -1,0 +1,164 @@
+package aisessions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// antigravityHistoryFixture is a history.jsonl with a mix of valid records, a
+// malformed line, a blank line, a record for a different cwd, a record whose
+// conversationId is not a valid UUID, and two valid records for the target cwd
+// (one older, one newer). Only the two target-cwd valid records should surface.
+const antigravityHistoryFixture = `{"conversationId":"aaaaaaaa-bbbb-4ccc-8ddd-000000000001","workspace":"/workspace/app","timestamp":1779433568000,"display":"First antigravity session"}
+{"conversationId":"aaaaaaaa-bbbb-4ccc-8ddd-000000000002","workspace":"/workspace/app","timestamp":1779433570000,"display":"Second antigravity session"}
+{"conversationId":"aaaaaaaa-bbbb-4ccc-8ddd-000000000003","workspace":"/workspace/other","timestamp":1779433571000,"display":"Different cwd session"}
+{"conversationId":"not-a-uuid","workspace":"/workspace/app","timestamp":1779433572000,"display":"Invalid id session"}
+{"conversationId":"aaaaaaaa-bbbb-4ccc-8ddd-000000000004","workspace":"/workspace/app"  BROKEN JSON
+{"conversationId":"aaaaaaaa-bbbb-4ccc-8ddd-000000000005","workspace":"/workspace/app","timestamp":1779433569000,"display":"<command-name>/goal"}
+`
+
+func writeAntigravityHistory(t *testing.T, content string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "history.jsonl")
+	writeFile(t, path, content)
+	return path
+}
+
+func TestDiscoverAntigravityFiltersSortsAndSkips(t *testing.T) {
+	t.Parallel()
+
+	path := writeAntigravityHistory(t, antigravityHistoryFixture)
+
+	got, err := Discover("/workspace/app", DiscoverOptions{
+		AntigravityHistoryPath: path,
+	})
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+
+	// Three valid target-cwd records survive: id 0002 (newest), 0005 (noisy
+	// title falls back to short id), 0001 (oldest). The other-cwd record, the
+	// invalid-id record, and the malformed line are all skipped.
+	if len(got) != 3 {
+		t.Fatalf("Discover() len = %d, want 3: %#v", len(got), got)
+	}
+
+	assertSession(t, got[0], SessionMeta{
+		Agent:        AgentAntigravity,
+		ResumeID:     "aaaaaaaa-bbbb-4ccc-8ddd-000000000002",
+		Title:        "Second antigravity session",
+		LastModified: time.UnixMilli(1779433570000),
+		Context:      SessionContext{CWD: "/workspace/app"},
+		Source:       SourceAntigravityHistory,
+	})
+	// The noisy "<command-name>/goal" display is rejected by the shared title
+	// cleaner, so this row falls back to the short resume id.
+	assertSession(t, got[1], SessionMeta{
+		Agent:        AgentAntigravity,
+		ResumeID:     "aaaaaaaa-bbbb-4ccc-8ddd-000000000005",
+		Title:        shortResumeID("aaaaaaaa-bbbb-4ccc-8ddd-000000000005"),
+		LastModified: time.UnixMilli(1779433569000),
+		Context:      SessionContext{CWD: "/workspace/app"},
+		Source:       SourceAntigravityHistory,
+	})
+	assertSession(t, got[2], SessionMeta{
+		Agent:        AgentAntigravity,
+		ResumeID:     "aaaaaaaa-bbbb-4ccc-8ddd-000000000001",
+		Title:        "First antigravity session",
+		LastModified: time.UnixMilli(1779433568000),
+		Context:      SessionContext{CWD: "/workspace/app"},
+		Source:       SourceAntigravityHistory,
+	})
+	for _, session := range got {
+		if session.Turns != 0 {
+			t.Fatalf("Turns = %d, want 0 (history.jsonl has no per-turn data)", session.Turns)
+		}
+	}
+}
+
+func TestDiscoverAntigravityMissingFileYieldsNoRows(t *testing.T) {
+	t.Parallel()
+
+	got, err := Discover("/workspace/app", DiscoverOptions{
+		AntigravityHistoryPath: filepath.Join(t.TempDir(), "missing", "history.jsonl"),
+	})
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("Discover() len = %d, want 0: %#v", len(got), got)
+	}
+}
+
+func TestDiscoverAntigravityDepthWidensToChildWorkspace(t *testing.T) {
+	t.Parallel()
+
+	content := `{"conversationId":"aaaaaaaa-bbbb-4ccc-8ddd-000000000010","workspace":"/workspace/app/child","timestamp":1779433580000,"display":"Child workspace session"}
+{"conversationId":"aaaaaaaa-bbbb-4ccc-8ddd-000000000011","workspace":"/workspace/app/child/grandchild","timestamp":1779433581000,"display":"Too deep session"}
+`
+	path := writeAntigravityHistory(t, content)
+
+	// depth 0: the exact-cwd filter rejects the child workspace.
+	exact, err := Discover("/workspace/app", DiscoverOptions{AntigravityHistoryPath: path})
+	if err != nil {
+		t.Fatalf("Discover(depth=0) error = %v", err)
+	}
+	if len(exact) != 0 {
+		t.Fatalf("Discover(depth=0) len = %d, want 0: %#v", len(exact), exact)
+	}
+
+	// depth 1: the direct child matches and records its own workspace; the
+	// grandchild is one level too deep and is excluded.
+	widened, err := Discover("/workspace/app", DiscoverOptions{AntigravityHistoryPath: path, Depth: 1})
+	if err != nil {
+		t.Fatalf("Discover(depth=1) error = %v", err)
+	}
+	if len(widened) != 1 {
+		t.Fatalf("Discover(depth=1) len = %d, want 1: %#v", len(widened), widened)
+	}
+	assertSession(t, widened[0], SessionMeta{
+		Agent:        AgentAntigravity,
+		ResumeID:     "aaaaaaaa-bbbb-4ccc-8ddd-000000000010",
+		Title:        "Child workspace session",
+		LastModified: time.UnixMilli(1779433580000),
+		Context:      SessionContext{CWD: "/workspace/app/child"},
+		Source:       SourceAntigravityHistory,
+	})
+}
+
+func TestDiscoverMergesAntigravityWithOtherAgents(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "codex", "sessions", "2026", "06", "25")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codexPath := filepath.Join(codexDir, "rollout-codex.jsonl")
+	writeFile(t, codexPath, `{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000301","cwd":"/workspace/app","git_branch":"feat/codex"}}
+{"type":"event_msg","payload":{"type":"user_message","message":"Codex session"}}
+`)
+	setModTime(t, codexPath, time.UnixMilli(1779433569000))
+
+	agyPath := writeAntigravityHistory(t, `{"conversationId":"aaaaaaaa-bbbb-4ccc-8ddd-000000000020","workspace":"/workspace/app","timestamp":1779433570000,"display":"Newest antigravity session"}
+`)
+
+	got, err := Discover("/workspace/app", DiscoverOptions{
+		CodexSessionsDir:       filepath.Join(root, "codex", "sessions"),
+		AntigravityHistoryPath: agyPath,
+	})
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("Discover() len = %d, want 2: %#v", len(got), got)
+	}
+	// The antigravity record is newer, so it sorts first ahead of the codex row.
+	if got[0].Agent != AgentAntigravity || got[1].Agent != AgentCodex {
+		t.Fatalf("agents = [%q, %q], want [antigravity, codex] newest first", got[0].Agent, got[1].Agent)
+	}
+}

--- a/internal/integrations/agents/aisessions/sessions.go
+++ b/internal/integrations/agents/aisessions/sessions.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crevissepartners/projmux/internal/integrations/agents/antigravity"
 	"github.com/crevissepartners/projmux/internal/integrations/agents/claude"
 	"github.com/crevissepartners/projmux/internal/integrations/agents/codex"
 )
@@ -32,8 +33,9 @@ const (
 	AgentCodex       = codex.AgentName
 	AgentAntigravity = "antigravity"
 
-	SourceClaudeTranscript = "claude-transcript"
-	SourceCodexRollout     = "codex-rollout"
+	SourceClaudeTranscript   = "claude-transcript"
+	SourceCodexRollout       = "codex-rollout"
+	SourceAntigravityHistory = "antigravity-history"
 
 	sessionScanLineLimit  = 100
 	sessionTitleLineLimit = 100
@@ -80,10 +82,12 @@ type DiscoverOptions struct {
 	ClaudeProjectsDir string
 	CodexSessionsDir  string
 
-	// AntigravitySessionsDir is reserved for a future supported on-disk format.
-	// Phase 0 intentionally returns no Antigravity rows because no stable local
-	// session store layout has been confirmed.
-	AntigravitySessionsDir string
+	// AntigravityHistoryPath is the Antigravity CLI session index (JSONL). Each
+	// line records one conversation's id, workspace cwd, timestamp, and first
+	// message; Discover parses it through the same cwd/depth/dedup/sort pipeline
+	// as the other agents. Empty resolves to ~/.gemini/antigravity-cli/history.jsonl
+	// under HomeDir; a missing or malformed file yields no Antigravity rows.
+	AntigravityHistoryPath string
 }
 
 // Discover returns resume sessions for cwd across supported agents, newest
@@ -99,7 +103,7 @@ func Discover(cwd string, opts DiscoverOptions) ([]SessionMeta, error) {
 	var sessions []SessionMeta
 	sessions = append(sessions, discoverClaude(cwd, opts.ClaudeProjectsDir, depth)...)
 	sessions = append(sessions, discoverCodex(cwd, opts.CodexSessionsDir, depth)...)
-	sessions = append(sessions, discoverAntigravity(cwd, opts.AntigravitySessionsDir)...)
+	sessions = append(sessions, discoverAntigravity(cwd, opts.AntigravityHistoryPath, depth)...)
 	sessions = dedupeByResumeID(sessions)
 
 	sort.SliceStable(sessions, func(i, j int) bool {
@@ -133,6 +137,9 @@ func (opts DiscoverOptions) withDefaults() DiscoverOptions {
 	}
 	if strings.TrimSpace(opts.CodexSessionsDir) == "" && home != "" {
 		opts.CodexSessionsDir = filepath.Join(home, ".codex", "sessions")
+	}
+	if strings.TrimSpace(opts.AntigravityHistoryPath) == "" && home != "" {
+		opts.AntigravityHistoryPath = filepath.Join(home, ".gemini", "antigravity-cli", "history.jsonl")
 	}
 	return opts
 }
@@ -457,8 +464,78 @@ func withinTree(recordedCWD, cwd string, depth int) bool {
 	return len(strings.Split(rel, "/")) <= depth
 }
 
-func discoverAntigravity(_ string, _ string) []SessionMeta {
-	return nil
+// antigravityHistoryRecord is one line of the Antigravity CLI session index
+// (~/.gemini/antigravity-cli/history.jsonl). Only the fields Discover surfaces
+// are decoded; unknown fields are ignored.
+type antigravityHistoryRecord struct {
+	ConversationID string `json:"conversationId"`
+	Workspace      string `json:"workspace"`
+	Timestamp      int64  `json:"timestamp"`
+	Display        string `json:"display"`
+}
+
+// discoverAntigravity reads the Antigravity history index and returns the
+// sessions whose recorded workspace is within depth levels of cwd. It runs
+// through the same cwd/depth filter the other agents use (the shared Discover
+// caller then dedupes, sorts, and caps). A missing file, malformed lines, and
+// records whose conversationId is not a valid resume id are skipped silently so
+// a broken index degrades to no Antigravity rows rather than an error.
+func discoverAntigravity(cwd, historyPath string, depth int) []SessionMeta {
+	historyPath = strings.TrimSpace(historyPath)
+	if historyPath == "" {
+		return nil
+	}
+	f, err := os.Open(historyPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var sessions []SessionMeta
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var record antigravityHistoryRecord
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			continue
+		}
+		id, err := antigravity.NormalizeResumeID(record.ConversationID)
+		if err != nil {
+			continue
+		}
+		if !withinTree(record.Workspace, cwd, depth) {
+			continue
+		}
+		// Mirror the other agents: at exact-cwd depth the recorded cwd is the
+		// search target; depth>0 records the session's own workspace so the picker
+		// can render the relative column.
+		recordedCWD := cwd
+		if depth > 0 {
+			recordedCWD = cleanCWD(record.Workspace)
+		}
+		title := cleanTitleCandidate(record.Display)
+		if title == "" {
+			title = shortResumeID(id)
+		}
+		sessions = append(sessions, SessionMeta{
+			Agent:        AgentAntigravity,
+			ResumeID:     id,
+			Title:        title,
+			LastModified: time.UnixMilli(record.Timestamp),
+			Context: SessionContext{
+				CWD: recordedCWD,
+			},
+			Source: SourceAntigravityHistory,
+			// history.jsonl carries no per-turn data; Antigravity turn count is
+			// unknown (0) and renders as a blank cell.
+			Turns: 0,
+		})
+	}
+	return sessions
 }
 
 type sessionFileCandidate struct {


### PR DESCRIPTION
## 완료한 Phase

**Phase 2 — Antigravity session inclusion** (로드맵 디테일: *AI resume list enrichment and antigravity*, 확정안 **(A) disk-discovery**).

`discoverAntigravity` stub 을 실제 disk-discovery 로 교체. `~/.gemini/antigravity-cli/history.jsonl` (JSONL) 각 줄을 파싱:

- `conversationId` → `ResumeID` (`antigravity.NormalizeResumeID` 로 UUID 검증, 실패 줄 skip)
- `workspace` → `Context.CWD`
- `timestamp`(ms epoch) → `LastModified` (`time.UnixMilli`)
- `display` → `Title` (기존 공용 title 정리 규칙 재사용; noisy 후보는 short-id fallback)
- `Agent="antigravity"`, `Source="antigravity-history"`, `Branch` 빈값, `Turns=0`

cwd 필터·depth(`withinTree`)·dedup·정렬·cap 은 **기존 Discover 파이프라인 그대로** 태움 (workspace 를 recorded cwd 로 사용). 파일 없음/손상 줄/비-UUID id 는 조용히 skip → 빈 결과.

`DiscoverOptions` 에 `AntigravityHistoryPath` 추가 (`withDefaults` 에서 HomeDir 기준 `~/.gemini/antigravity-cli/history.jsonl` 로 채움). 미사용이던 예약 필드 `AntigravitySessionsDir` 를 이 필드로 교체.

## 수정한 user-facing surface

- resume picker: 현재 cwd(및 depth 범위)의 antigravity 세션이 agent 배지와 함께 표시됨. 선택 시 기존 wiring(`agy --conversation <uuid>`)으로 resume.
- antigravity 세션 0개(파일 없음)면 기존과 동일 — claude/codex 회귀 없음.

## 명시적으로 제외한 범위

- resume 실행 wiring (`antigravity.ResumeArgs`) — 이미 존재, 무변경.
- claude/codex discovery·row·설정·usage — 무변경.
- per-conversation transcript/SQLite 파싱으로 turn 수 채우기 — 비용↑, 이번 제외 (antigravity `Turns=0` 빈칸 유지).
- Phase 0 row enrichment (이미 머지됨), Antigravity gap closure 로드맵.

## 모델/스키마/엔진 제약 준수

- `SessionMeta` 스키마 무변경(기존 필드만 채움).
- Discover 파이프라인(dedup/sort/depth/cap) 로직 무변경 — antigravity 를 태우기만 함.
- 대상 파일은 `internal/integrations/agents/aisessions/sessions.go` (+ 신규 테스트) 로 한정.

## 검증 명령

- `go build ./...` ✅
- `go test ./internal/...` ✅ (전체 green)
- `make fmt` / `make fix` ✅ (gofmt clean, deadcode clean, go vet clean)
- fixture 테스트 신규 (`antigravity_test.go`):
  - 정상/손상 줄/blank/다른 cwd/비-UUID id 혼합 → target cwd 3건만, 최신순 정렬, skip 검증
  - noisy display(`<command-name>`) → short-id fallback
  - 파일 없음 → 빈 결과 (패닉 없음)
  - depth 0 는 exact-cwd, depth 1 은 직속 child workspace 편입 / grandchild 제외
  - claude/codex 와 병합 시 정렬 통합

## 미검증 항목 / 후속

- tmux 실제 동작(선택 → 새 split 에서 `agy --conversation <uuid>` 실제 resume, pane resume option 기록)은 **e2e 후보**. resume argv 자체는 기존 `antigravity` 패키지 테스트가 커버.
- antigravity turn 수 표시(transcript 파싱)는 후속 Phase 후보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
