### PR TITLE
feat(ai): session-anchored cwd for AI split/resume (Phase 1)

### DIFF
--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -29,6 +29,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/integrations/agents/codex"
 	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
 	intpsmux "github.com/crevissepartners/projmux/internal/integrations/psmux"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
@@ -1690,7 +1691,7 @@ func (c *aiCommand) resolveContextDir() string {
 	}
 	if c.env("TMUX") != "" {
 		if path := c.readMuxTrimmed("display-message", "-p", "-F", "#{pane_current_path}"); isDir(path) {
-			return path
+			return c.anchorPaneContextDir(path)
 		}
 	}
 	if target := c.resolveRecentTmuxTarget(); target != "" {
@@ -1699,6 +1700,58 @@ func (c *aiCommand) resolveContextDir() string {
 		}
 	}
 	return c.resolveIDEContextDir()
+}
+
+// anchorPaneContextDir reconciles the live pane cwd against the current
+// session's project anchor (@projmux_project_path, set at creation). When the
+// pane sits inside the project tree (the anchor itself or a descendant) the
+// intentional subdir is respected and the pane cwd wins; when it has drifted
+// outside (another repo, $HOME, …) the anchor wins so discovery and launch stay
+// project-relative. Sessions without an anchor (pre-anchor or externally
+// created) fall back to the pane cwd unchanged — no regression.
+func (c *aiCommand) anchorPaneContextDir(paneCWD string) string {
+	session := c.readMuxTrimmed("display-message", "-p", "-F", "#{session_name}")
+	anchor := c.resolveSessionProjectPath(session)
+	if anchor == "" {
+		return paneCWD
+	}
+	if pathWithinTree(anchor, paneCWD) {
+		return paneCWD
+	}
+	return anchor
+}
+
+// resolveSessionProjectPath reads the project cwd anchor stored on the named
+// session at creation time (@projmux_project_path). It returns the anchor only
+// when it still resolves to a directory; otherwise "" so callers fall back to
+// the live pane cwd.
+func (c *aiCommand) resolveSessionProjectPath(sessionName string) string {
+	if strings.TrimSpace(sessionName) == "" {
+		return ""
+	}
+	anchor := c.readMuxTrimmed("show-options", "-t", sessionName, "-v", inttmux.ProjectPathSessionOption)
+	if isDir(anchor) {
+		return anchor
+	}
+	return ""
+}
+
+// pathWithinTree reports whether path is anchor itself or a descendant of it.
+// It uses a pure path comparison (filepath.Rel with no leading ".."), matching
+// the roadmap's "path descendant" rule; both inputs are assumed to be existing
+// directories so no symlink resolution is attempted.
+func pathWithinTree(anchor, path string) bool {
+	anchor = strings.TrimSpace(anchor)
+	path = strings.TrimSpace(path)
+	if anchor == "" || path == "" {
+		return false
+	}
+	rel, err := filepath.Rel(anchor, path)
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, "../"))
 }
 
 func (c *aiCommand) resolveAgentContextDir(mode string) string {

--- a/internal/app/ai_context_dir_test.go
+++ b/internal/app/ai_context_dir_test.go
@@ -1,0 +1,146 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+)
+
+// stubbedContextDirCommand builds an aiCommand whose tmux reads are answered
+// from the supplied pane cwd / session name / anchor, so resolveContextDir can
+// be exercised without a live tmux. env holds extra environment overrides
+// (e.g. TMUX_SPLIT_CONTEXT_DIR); TMUX is always set so the in-tmux branch runs.
+func stubbedContextDirCommand(paneCWD, sessionName, anchor string, env map[string]string) *aiCommand {
+	return &aiCommand{
+		lookupEnv: func(name string) string {
+			if name == "TMUX" {
+				return "/tmp/tmux-1234/default,1,0"
+			}
+			if v, ok := env[name]; ok {
+				return v
+			}
+			return ""
+		},
+		readCommand: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if name != "tmux" {
+				return nil, nil
+			}
+			joined := strings.Join(args, " ")
+			switch {
+			case strings.HasPrefix(joined, "display-message") && strings.Contains(joined, "#{pane_current_path}"):
+				return []byte(paneCWD + "\n"), nil
+			case strings.HasPrefix(joined, "display-message") && strings.Contains(joined, "#{session_name}"):
+				return []byte(sessionName + "\n"), nil
+			case strings.HasPrefix(joined, "show-options") && strings.Contains(joined, inttmux.ProjectPathSessionOption):
+				if anchor == "" {
+					return nil, nil
+				}
+				return []byte(anchor + "\n"), nil
+			default:
+				return nil, nil
+			}
+		},
+	}
+}
+
+func TestResolveContextDirEnvOverrideWins(t *testing.T) {
+	t.Parallel()
+	anchor := t.TempDir()
+	override := t.TempDir()
+	cmd := stubbedContextDirCommand(anchor, "proj", anchor, map[string]string{"TMUX_SPLIT_CONTEXT_DIR": override})
+	if got := cmd.resolveContextDir(); got != override {
+		t.Fatalf("resolveContextDir() = %q, want env override %q", got, override)
+	}
+}
+
+func TestResolveContextDirPaneEqualsAnchor(t *testing.T) {
+	t.Parallel()
+	anchor := t.TempDir()
+	cmd := stubbedContextDirCommand(anchor, "proj", anchor, nil)
+	if got := cmd.resolveContextDir(); got != anchor {
+		t.Fatalf("resolveContextDir() = %q, want pane cwd %q", got, anchor)
+	}
+}
+
+func TestResolveContextDirPaneDescendantKept(t *testing.T) {
+	t.Parallel()
+	anchor := t.TempDir()
+	sub := filepath.Join(anchor, "web", "api")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	cmd := stubbedContextDirCommand(sub, "proj", anchor, nil)
+	if got := cmd.resolveContextDir(); got != sub {
+		t.Fatalf("resolveContextDir() = %q, want descendant pane cwd %q", got, sub)
+	}
+}
+
+func TestResolveContextDirPaneOutsideDriftsToAnchor(t *testing.T) {
+	t.Parallel()
+	anchor := t.TempDir()
+	outside := t.TempDir()
+	cmd := stubbedContextDirCommand(outside, "proj", anchor, nil)
+	if got := cmd.resolveContextDir(); got != anchor {
+		t.Fatalf("resolveContextDir() = %q, want anchor %q for out-of-tree pane", got, anchor)
+	}
+}
+
+func TestResolveContextDirNoAnchorFallsBackToPane(t *testing.T) {
+	t.Parallel()
+	// No anchor option (pre-anchor / external session): keep current behaviour.
+	pane := t.TempDir()
+	cmd := stubbedContextDirCommand(pane, "proj", "", nil)
+	if got := cmd.resolveContextDir(); got != pane {
+		t.Fatalf("resolveContextDir() = %q, want live pane cwd %q", got, pane)
+	}
+}
+
+func TestResolveSessionProjectPath(t *testing.T) {
+	t.Parallel()
+	anchor := t.TempDir()
+
+	cmd := stubbedContextDirCommand(anchor, "proj", anchor, nil)
+	if got := cmd.resolveSessionProjectPath("proj"); got != anchor {
+		t.Fatalf("resolveSessionProjectPath() = %q, want %q", got, anchor)
+	}
+	if got := cmd.resolveSessionProjectPath(""); got != "" {
+		t.Fatalf("resolveSessionProjectPath(\"\") = %q, want empty", got)
+	}
+
+	// Anchor points at a path that no longer exists → treated as absent.
+	stale := stubbedContextDirCommand(anchor, "proj", filepath.Join(anchor, "gone"), nil)
+	if got := stale.resolveSessionProjectPath("proj"); got != "" {
+		t.Fatalf("resolveSessionProjectPath() with stale anchor = %q, want empty", got)
+	}
+}
+
+func TestPathWithinTree(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		anchor string
+		path   string
+		want   bool
+	}{
+		{"exact", "/proj", "/proj", true},
+		{"descendant", "/proj", "/proj/web", true},
+		{"deep descendant", "/proj", "/proj/web/api", true},
+		{"sibling", "/proj", "/other", false},
+		{"parent", "/proj/web", "/proj", false},
+		{"prefix not boundary", "/proj", "/project", false},
+		{"empty anchor", "", "/proj", false},
+		{"empty path", "/proj", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := pathWithinTree(tc.anchor, tc.path); got != tc.want {
+				t.Fatalf("pathWithinTree(%q, %q) = %v, want %v", tc.anchor, tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/integrations/tmux/client.go
+++ b/internal/integrations/tmux/client.go
@@ -40,6 +40,12 @@ const (
 	tmuxEscapedFieldSep = "\\037"
 )
 
+// ProjectPathSessionOption stores the project cwd a session was created with.
+// It is written once at session creation and never drifts, so AI split/resume
+// can anchor to the project root even after a pane wanders via `cd`. Read back
+// by the app layer's resolveSessionProjectPath.
+const ProjectPathSessionOption = "@projmux_project_path"
+
 type commandRunner interface {
 	Run(ctx context.Context, name string, args ...string) ([]byte, error)
 }
@@ -470,6 +476,7 @@ func (c *Client) EnsureSession(ctx context.Context, sessionName, cwd string) err
 	}
 
 	c.applyProjectSessionEnv(ctx, sessionName, sessionEnv)
+	c.setProjectPathAnchor(ctx, sessionName, cwd)
 	c.runPostCreate(ctx, sessionName, cwd, "persistent")
 	c.runStartupCommand(ctx, sessionName, cwd, "persistent", paneID)
 	return nil
@@ -495,6 +502,7 @@ func (c *Client) CreateEphemeralSession(ctx context.Context, sessionName, cwd st
 		return fmt.Errorf("create tmux ephemeral session %q: %w", sessionName, err)
 	}
 	c.applyProjectSessionEnv(ctx, sessionName, sessionEnv)
+	c.setProjectPathAnchor(ctx, sessionName, cwd)
 	if _, err := c.runner.Run(ctx, "tmux", "set-option", "-t", sessionName, "-q", "@projmux_ephemeral", "1"); err != nil {
 		// set-option failure is intentionally swallowed; the session is still
 		// usable. The post-create hook still runs so the session gets the same
@@ -531,6 +539,18 @@ func (c *Client) applyProjectSessionEnv(ctx context.Context, sessionName string,
 	for _, key := range sortedMapKeys(env) {
 		_, _ = c.runner.Run(ctx, "tmux", "set-environment", "-t", sessionName, key, env[key])
 	}
+}
+
+// setProjectPathAnchor records the project cwd on the freshly created session
+// so AI split/resume can anchor to the project root even after a pane drifts
+// via `cd`. Failures are swallowed (matching the ephemeral marker): the session
+// is still usable and simply falls back to the live pane cwd when the anchor is
+// missing.
+func (c *Client) setProjectPathAnchor(ctx context.Context, sessionName, cwd string) {
+	if strings.TrimSpace(cwd) == "" {
+		return
+	}
+	_, _ = c.runner.Run(ctx, "tmux", "set-option", "-t", sessionName, "-q", ProjectPathSessionOption, cwd)
 }
 
 func (c *Client) runPreCreate(ctx context.Context, sessionName, cwd, kind string) error {

--- a/internal/integrations/tmux/client_test.go
+++ b/internal/integrations/tmux/client_test.go
@@ -868,6 +868,7 @@ func TestClientEnsureSessionCreatesMissingSession(t *testing.T) {
 		steps: []scriptedStep{
 			{err: exitError(t, 1)},
 			{},
+			{},
 		},
 	}
 	client := NewClient(runner)
@@ -879,10 +880,43 @@ func TestClientEnsureSessionCreatesMissingSession(t *testing.T) {
 	want := []commandCall{
 		{name: "tmux", args: []string{"has-session", "-t", "=workspace"}},
 		{name: "tmux", args: []string{"new-session", "-d", "-s", "workspace", "-c", "/tmp/projmux"}},
+		{name: "tmux", args: []string{"set-option", "-t", "workspace", "-q", "@projmux_project_path", "/tmp/projmux"}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("unexpected calls %#v", runner.calls)
 	}
+}
+
+func TestClientEnsureSessionStoresProjectPathAnchor(t *testing.T) {
+	t.Parallel()
+
+	runner := &scriptedRunner{
+		t: t,
+		steps: []scriptedStep{
+			{err: exitError(t, 1)},
+			{},
+			{},
+		},
+	}
+	client := NewClient(runner)
+
+	if err := client.EnsureSession(context.Background(), "workspace", "/tmp/projmux"); err != nil {
+		t.Fatalf("EnsureSession returned error: %v", err)
+	}
+
+	want := commandCall{name: "tmux", args: []string{"set-option", "-t", "workspace", "-q", ProjectPathSessionOption, "/tmp/projmux"}}
+	if !containsCommandCall(runner.calls, want) {
+		t.Fatalf("EnsureSession did not store the project path anchor; calls = %#v", runner.calls)
+	}
+}
+
+func containsCommandCall(calls []commandCall, want commandCall) bool {
+	for _, call := range calls {
+		if reflect.DeepEqual(call, want) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestClientEnsureSessionSkipsCreateWhenSessionExists(t *testing.T) {
@@ -914,6 +948,7 @@ func TestClientCreateEphemeralSessionCreatesAndMarksSession(t *testing.T) {
 		steps: []scriptedStep{
 			{},
 			{},
+			{},
 		},
 	}
 	client := NewClient(runner)
@@ -924,6 +959,7 @@ func TestClientCreateEphemeralSessionCreatesAndMarksSession(t *testing.T) {
 
 	wantCalls := []commandCall{
 		{name: "tmux", args: []string{"new-session", "-d", "-s", "scratch-20260423-123456", "-c", "/tmp/projmux"}},
+		{name: "tmux", args: []string{"set-option", "-t", "scratch-20260423-123456", "-q", "@projmux_project_path", "/tmp/projmux"}},
 		{name: "tmux", args: []string{"set-option", "-t", "scratch-20260423-123456", "-q", "@projmux_ephemeral", "1"}},
 	}
 	if !reflect.DeepEqual(runner.calls, wantCalls) {
@@ -937,6 +973,7 @@ func TestClientCreateEphemeralSessionIgnoresMarkerFailure(t *testing.T) {
 	runner := &scriptedRunner{
 		t: t,
 		steps: []scriptedStep{
+			{},
 			{},
 			{err: errors.New("set-option failed")},
 		},
@@ -1760,6 +1797,7 @@ func TestClientEnsureSessionInvokesPostCreateRunnerOnNewSession(t *testing.T) {
 		steps: []scriptedStep{
 			{err: exitError(t, 1)},
 			{},
+			{},
 		},
 	}
 	hook := &fakePostCreateRunner{}
@@ -1791,6 +1829,7 @@ func TestClientEnsureSessionRunsLifecycleHooksForNewSession(t *testing.T) {
 		steps: []scriptedStep{
 			{err: exitError(t, 1)},
 			{output: []byte("%7\n")},
+			{},
 			{output: []byte("zsh\n")},
 			{},
 			{},
@@ -1810,6 +1849,7 @@ func TestClientEnsureSessionRunsLifecycleHooksForNewSession(t *testing.T) {
 	wantCalls := []commandCall{
 		{name: "tmux", args: []string{"has-session", "-t", "=workspace"}},
 		{name: "tmux", args: []string{"new-session", "-d", "-s", "workspace", "-c", "/tmp/projmux", "-P", "-F", "#{pane_id}"}},
+		{name: "tmux", args: []string{"set-option", "-t", "workspace", "-q", "@projmux_project_path", "/tmp/projmux"}},
 		{name: "tmux", args: []string{"display-message", "-p", "-t", "%7", "-F", "#{pane_current_command}"}},
 		{name: "tmux", args: []string{"send-keys", "-t", "%7", "echo ready", "Enter"}},
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", "@projmux_recipe_kind", "startup"}},
@@ -1834,6 +1874,7 @@ func TestClientEnsureSessionSkipsStartupMarkersWhenNoStartupHook(t *testing.T) {
 		steps: []scriptedStep{
 			{err: exitError(t, 1)},
 			{output: []byte("%7\n")},
+			{},
 		},
 	}
 	hook := &fakeLifecycleInspectorRunner{hasHooks: false}
@@ -1846,6 +1887,7 @@ func TestClientEnsureSessionSkipsStartupMarkersWhenNoStartupHook(t *testing.T) {
 	wantCalls := []commandCall{
 		{name: "tmux", args: []string{"has-session", "-t", "=workspace"}},
 		{name: "tmux", args: []string{"new-session", "-d", "-s", "workspace", "-c", "/tmp/projmux", "-P", "-F", "#{pane_id}"}},
+		{name: "tmux", args: []string{"set-option", "-t", "workspace", "-q", "@projmux_project_path", "/tmp/projmux"}},
 	}
 	if !reflect.DeepEqual(runner.calls, wantCalls) {
 		t.Fatalf("unexpected tmux calls %#v", runner.calls)
@@ -1868,6 +1910,7 @@ func TestClientEnsureSessionSkipsStartupMarkersWhenNoCommand(t *testing.T) {
 				steps: []scriptedStep{
 					{err: exitError(t, 1)},
 					{output: []byte("%7\n")},
+					{},
 				},
 			}
 			hook := &fakeLifecycleRunner{startupOK: tc == "empty command"}
@@ -1880,6 +1923,7 @@ func TestClientEnsureSessionSkipsStartupMarkersWhenNoCommand(t *testing.T) {
 			wantCalls := []commandCall{
 				{name: "tmux", args: []string{"has-session", "-t", "=workspace"}},
 				{name: "tmux", args: []string{"new-session", "-d", "-s", "workspace", "-c", "/tmp/projmux", "-P", "-F", "#{pane_id}"}},
+				{name: "tmux", args: []string{"set-option", "-t", "workspace", "-q", "@projmux_project_path", "/tmp/projmux"}},
 			}
 			if !reflect.DeepEqual(runner.calls, wantCalls) {
 				t.Fatalf("unexpected tmux calls %#v", runner.calls)
@@ -1896,6 +1940,7 @@ func TestClientEnsureSessionSkipsStartupMarkersWhenSendKeysFails(t *testing.T) {
 		steps: []scriptedStep{
 			{err: exitError(t, 1)},
 			{output: []byte("%7\n")},
+			{},
 			{output: []byte("zsh\n")},
 			{err: errors.New("send failed")},
 		},
@@ -1913,6 +1958,7 @@ func TestClientEnsureSessionSkipsStartupMarkersWhenSendKeysFails(t *testing.T) {
 	wantCalls := []commandCall{
 		{name: "tmux", args: []string{"has-session", "-t", "=workspace"}},
 		{name: "tmux", args: []string{"new-session", "-d", "-s", "workspace", "-c", "/tmp/projmux", "-P", "-F", "#{pane_id}"}},
+		{name: "tmux", args: []string{"set-option", "-t", "workspace", "-q", "@projmux_project_path", "/tmp/projmux"}},
 		{name: "tmux", args: []string{"display-message", "-p", "-t", "%7", "-F", "#{pane_current_command}"}},
 		{name: "tmux", args: []string{"send-keys", "-t", "%7", "echo ready", "Enter"}},
 	}
@@ -1962,6 +2008,7 @@ func TestClientEnsureSessionAppliesProjectSessionEnvOnCreateAndAfterCreate(t *te
 			{},
 			{},
 			{},
+			{},
 		},
 	}
 	hook := &fakeLifecycleRunner{
@@ -1981,6 +2028,7 @@ func TestClientEnsureSessionAppliesProjectSessionEnvOnCreateAndAfterCreate(t *te
 		{name: "tmux", args: []string{"new-session", "-d", "-s", "workspace", "-c", "/tmp/projmux", "-e", "FOO=bar", "-e", "ZED=last", "-P", "-F", "#{pane_id}"}},
 		{name: "tmux", args: []string{"set-environment", "-t", "workspace", "FOO", "bar"}},
 		{name: "tmux", args: []string{"set-environment", "-t", "workspace", "ZED", "last"}},
+		{name: "tmux", args: []string{"set-option", "-t", "workspace", "-q", "@projmux_project_path", "/tmp/projmux"}},
 	}
 	if !reflect.DeepEqual(runner.calls, wantCalls) {
 		t.Fatalf("unexpected tmux calls %#v", runner.calls)
@@ -1994,6 +2042,7 @@ func TestClientEnsureSessionAppliesProjectKubeSessionEnvOnCreate(t *testing.T) {
 		t: t,
 		steps: []scriptedStep{
 			{err: exitError(t, 1)},
+			{},
 			{},
 			{},
 			{},
@@ -2073,7 +2122,7 @@ func TestClientCreateEphemeralSessionInvokesPostCreateRunner(t *testing.T) {
 
 	runner := &scriptedRunner{
 		t:     t,
-		steps: []scriptedStep{{}, {}},
+		steps: []scriptedStep{{}, {}, {}},
 	}
 	hook := &fakePostCreateRunner{}
 	client := NewClient(runner, withPostCreateRunnerInterface(hook), WithSocketName("projmux"))
@@ -2102,6 +2151,7 @@ func TestClientCreateEphemeralSessionRunsHookEvenWhenMarkerFails(t *testing.T) {
 	runner := &scriptedRunner{
 		t: t,
 		steps: []scriptedStep{
+			{},
 			{},
 			{err: errors.New("set-option failed")},
 		},


### PR DESCRIPTION
## 완료한 Phase

**Phase 1 — Smart context resolver** (로드맵: *AI split session-anchored cwd*). Phase 0(anchor source spike)는 선행 완료됨.

## 문제

`internal/app/ai.go` `resolveContextDir()` 가 라이브 pane cwd(`#{pane_current_path}`)를 그대로 썼다. agent/사용자가 pane 안에서 `cd` 로 프로젝트 밖으로 드리프트하면:
- **discovery cwd**: Ctrl-R resume picker 후보가 틀어지고
- **launch cwd**: 새/resume AI split 이 엉뚱한 데서 열렸다.

## 구현

- **앵커 쓰기**: `internal/integrations/tmux/client.go` `EnsureSession`/`CreateEphemeralSession` 가 세션 생성 직후 `set-option -t <session> -q @projmux_project_path <cwd>` 로 프로젝트 cwd 를 세션옵션에 저장한다 (`applyProjectSessionEnv` 직후, 신규 `setProjectPathAnchor` 헬퍼). 옵션 이름은 `inttmux.ProjectPathSessionOption` 상수로 writer/reader 가 공유.
- **앵커 읽기**: `resolveSessionProjectPath(sessionName)` — `show-options -t <session> -v @projmux_project_path` → `isDir` 이면 반환, 아니면 "".
- **스마트 resolver**: `resolveContextDir()` 가 pane cwd 와 앵커를 비교한다 (`anchorPaneContextDir`):
  - pane cwd 가 앵커거나 그 자손(`pathWithinTree`, `filepath.Rel` 이 `..` 없음) → **pane cwd** (의도적 subdir 존중)
  - 밖으로 드리프트 → **앵커** (프로젝트 루트 복귀)
  - 앵커 미확보(옵션 없는 기존/외부 세션) → **pane cwd** (현행 fallback, 회귀 없음)
  - `TMUX_SPLIT_CONTEXT_DIR` env override 는 최우선 유지.

## 수정한 user-facing surface

- 모든 AI split 경로(claude/codex/shell/selective/resume)의 discovery·launch cwd. 두 축 모두 `resolveContextDir` 를 타므로 한 곳 수정으로 반영.

## 명시적으로 제외한 범위 (비목표)

- resume 리스트 row/depth 등 다른 로드맵.
- 세션 앵커를 바꾸는 UI (읽기 전용).
- "트리 안" 판정은 순수 경로 자손 기준. git-root 보정은 후속(오픈 질문).

## 모델/스키마/엔진 제약

- 세션옵션 추가만 했고 기존 스키마/lifecycle 흐름은 변경 없음. 앵커 저장 실패는 ephemeral 마커와 동일하게 swallow → 세션은 여전히 사용 가능하고 현행 fallback 으로 동작.

## 검증

- `go build ./...`, `make fmt`, `make fix`(deadcode clean), `make test` (= `go test ./...`) 통과.
- 신규 단위 테스트:
  - `internal/app/ai_context_dir_test.go`: `resolveContextDir` (env override / pane==anchor / 자손 / 밖 드리프트 / 앵커 미확보), `resolveSessionProjectPath` (정상·빈 세션명·stale 경로), `pathWithinTree` 표.
  - `internal/integrations/tmux/client_test.go`: `EnsureSession`/`CreateEphemeralSession` 가 `@projmux_project_path` 를 저장하는지 (기존 exact-call 테스트 갱신 + 전용 `TestClientEnsureSessionStoresProjectPathAnchor`).

## 미검증 항목 / 후속

- **e2e 수동 스모크(미검증)**: 실제 tmux 에서 프로젝트 밖 `cd` 후 Ctrl-R/AI split → 루트 기준 discovery·launch, subdir `cd` 후엔 subdir 유지. 단위 테스트로 로직은 고정했으나 라이브 tmux 동작은 lead 확인 필요.
- 후속: 모노레포에서 subdir 가 별 repo 일 때 git-root 기준 "트리 안" 보정 (오픈 질문).

🤖 Generated with [Claude Code](https://claude.com/claude-code)