### PR TITLE
fix(recent-windows): project badge = session-anchor basename

### DIFF
--- a/internal/app/recent_window.go
+++ b/internal/app/recent_window.go
@@ -270,12 +270,13 @@ func (c *recentWindowCommand) currentSnapshot(ctx context.Context) (recentwindow
 		"#{@projmux_ai_topic}",
 		"#{pane_current_command}",
 		"#{pane_current_path}",
+		"#{@projmux_project_path}",
 	}, recentWindowFieldSep))
 	if err != nil {
 		return recentwindows.Snapshot{}, fmt.Errorf("snapshot current tmux window: %w", err)
 	}
-	fields := parseRecentWindowFields(output, 9)
-	if len(fields) != 9 || fields[1] == "" || fields[2] == "" {
+	fields := parseRecentWindowFields(output, 10)
+	if len(fields) != 10 || fields[1] == "" || fields[2] == "" {
 		return recentwindows.Snapshot{}, fmt.Errorf("snapshot current tmux window: tmux returned incomplete metadata")
 	}
 	titles, badgeKinds, topics, commands := c.windowPaneMetadata(ctx, fields[2])
@@ -284,7 +285,7 @@ func (c *recentWindowCommand) currentSnapshot(ctx context.Context) (recentwindow
 		Session:        fields[1],
 		WindowID:       fields[2],
 		WindowName:     fields[3],
-		Project:        recentWindowProjectName(fields[8]),
+		Project:        recentWindowSnapshotProject(fields[9], fields[8], fields[1]),
 		LastPaneID:     fields[4],
 		LastPaneTitle:  fields[5],
 		PaneTitles:     titles,
@@ -822,6 +823,37 @@ func joinRecentWindowParts(values ...string) string {
 		parts = append(parts, value)
 	}
 	return strings.Join(parts, " · ")
+}
+
+// recentWindowSnapshotProject resolves the project badge source for a recorded
+// snapshot. It prefers the session anchor (@projmux_project_path) basename so
+// the badge stays the project name even after the pane cwd drifts into a subdir
+// (the anchor is fixed at session creation, roadmap #488). It falls back to the
+// nearest project-marker basename of the live pane cwd, then the session name,
+// so anchor-less sessions keep their prior behavior with no regression.
+func recentWindowSnapshotProject(anchorPath, panePath, session string) string {
+	if name := recentWindowAnchorProjectName(anchorPath); name != "" {
+		return name
+	}
+	if name := recentWindowProjectName(panePath); name != "" {
+		return name
+	}
+	return strings.TrimSpace(session)
+}
+
+// recentWindowAnchorProjectName returns the basename of the session anchor path.
+// The anchor is already the project root, so (unlike recentWindowProjectName) it
+// does not walk for a project marker — its last segment is the project basename.
+func recentWindowAnchorProjectName(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	name := filepath.Base(filepath.Clean(path))
+	if name == "." || name == string(filepath.Separator) {
+		return ""
+	}
+	return name
 }
 
 func recentWindowProjectName(path string) string {

--- a/internal/app/recent_window_test.go
+++ b/internal/app/recent_window_test.go
@@ -1076,6 +1076,7 @@ func TestRecentWindowRecordSnapshotsCurrentTmuxWindow(t *testing.T) {
 			"Phase 4 recorder",
 			"codex",
 			filepath.Join(project, "internal", "app"),
+			"",
 		}, recentWindowFieldSep) + "\n",
 		listPanesOutput: strings.Join([]string{"codex-review", "in_progress", "Phase 9 picker", "codex"}, recentWindowFieldSep) + "\n" +
 			strings.Join([]string{"Claude Code", "response_complete", "Recent windows queue", "claude"}, recentWindowFieldSep) + "\n" +
@@ -1136,6 +1137,106 @@ func TestRecentWindowRecordSnapshotsCurrentTmuxWindow(t *testing.T) {
 	}
 }
 
+func TestRecentWindowSnapshotProjectPriority(t *testing.T) {
+	tests := []struct {
+		name    string
+		anchor  string
+		pane    string
+		session string
+		want    string
+	}{
+		{
+			name:    "anchor basename wins over live cwd",
+			anchor:  "/home/es5h/source/repos/projmux",
+			pane:    "/home/es5h/source/repos/projmux/internal/app",
+			session: "repos-projmux",
+			want:    "projmux",
+		},
+		{
+			name:    "anchor stable when cwd drifts into subdir",
+			anchor:  "/home/es5h/source/repos/projmux",
+			pane:    "/home/es5h/source/repos/projmux/internal/core/recentwindows",
+			session: "repos-projmux",
+			want:    "projmux",
+		},
+		{
+			name:    "no anchor falls back to marker basename",
+			anchor:  "",
+			pane:    projectMarkerDir(t),
+			session: "repos-projmux",
+			want:    "projmux-fixture",
+		},
+		{
+			name:    "no anchor and no marker falls back to session",
+			anchor:  "",
+			pane:    "",
+			session: "repos-projmux",
+			want:    "repos-projmux",
+		},
+		{
+			name:    "anchor trailing slash still yields basename",
+			anchor:  "/home/es5h/source/repos/projmux/",
+			pane:    "/tmp/elsewhere",
+			session: "repos-projmux",
+			want:    "projmux",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := recentWindowSnapshotProject(tt.anchor, tt.pane, tt.session); got != tt.want {
+				t.Fatalf("recentWindowSnapshotProject(%q, %q, %q) = %q, want %q", tt.anchor, tt.pane, tt.session, got, tt.want)
+			}
+		})
+	}
+}
+
+// projectMarkerDir creates a temp project directory named "projmux-fixture"
+// with a .git marker so recentWindowProjectName resolves it as the nearest
+// project root basename.
+func projectMarkerDir(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "projmux-fixture")
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatalf("create marker: %v", err)
+	}
+	return filepath.Join(root, "internal", "app")
+}
+
+func TestRecentWindowRecordUsesSessionAnchorProject(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux,1,0")
+
+	now := time.Date(2026, 7, 1, 1, 2, 3, 0, time.UTC)
+	runner := &recentWindowFakeRunner{
+		recordOutput: strings.Join([]string{
+			"/tmp/tmux",
+			"repos-projmux",
+			"@6",
+			"agent",
+			"%54",
+			"shell",
+			"topic",
+			"zsh",
+			// Live pane cwd drifted deep into a subdir with no project marker.
+			"/home/es5h/source/repos/projmux/internal/core/recentwindows",
+			// Session anchor pins the project root.
+			"/home/es5h/source/repos/projmux",
+		}, recentWindowFieldSep) + "\n",
+	}
+	store := &recentWindowStubStore{}
+	cmd := &recentWindowCommand{
+		runner:       runner,
+		storeFactory: func(string) (recentWindowStore, error) { return store, nil },
+		now:          func() time.Time { return now },
+	}
+
+	if err := cmd.RunRecord(nil, nil, nil); err != nil {
+		t.Fatalf("RunRecord() error = %v", err)
+	}
+	if got := store.records[0].Project; got != "projmux" {
+		t.Fatalf("snapshot project = %q, want %q (session anchor basename, cwd-drift independent)", got, "projmux")
+	}
+}
+
 func TestRecentWindowRecordParsesEscapedSnapshotSeparators(t *testing.T) {
 	t.Setenv("TMUX", "/tmp/tmux,1,0")
 
@@ -1150,6 +1251,7 @@ func TestRecentWindowRecordParsesEscapedSnapshotSeparators(t *testing.T) {
 			"topic",
 			"zsh",
 			"/repo/projmux",
+			"",
 		}, recentWindowEscapedFieldSep) + "\n",
 	}
 	store := &recentWindowStubStore{}
@@ -1184,6 +1286,7 @@ func TestRecentWindowRecordRepeatedSameWindowDoesNotGrowQueue(t *testing.T) {
 			"",
 			"zsh",
 			"/repo/projmux",
+			"",
 		}, recentWindowFieldSep) + "\n",
 	}
 	cmd := &recentWindowCommand{
@@ -1366,7 +1469,7 @@ func (r *recentWindowFakeRunner) Run(_ context.Context, name string, args ...str
 	if name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-F", strings.Join([]string{"#{socket_path}", "#{session_name}", "#{window_id}"}, recentWindowFieldSep)}) {
 		return []byte(r.currentOutput), nil
 	}
-	if name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-F", strings.Join([]string{"#{socket_path}", "#{session_name}", "#{window_id}", "#{window_name}", "#{pane_id}", "#{pane_title}", "#{@projmux_ai_topic}", "#{pane_current_command}", "#{pane_current_path}"}, recentWindowFieldSep)}) {
+	if name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-F", strings.Join([]string{"#{socket_path}", "#{session_name}", "#{window_id}", "#{window_name}", "#{pane_id}", "#{pane_title}", "#{@projmux_ai_topic}", "#{pane_current_command}", "#{pane_current_path}", "#{@projmux_project_path}"}, recentWindowFieldSep)}) {
 		return []byte(r.recordOutput), nil
 	}
 	if name == "tmux" && len(args) == 5 && args[0] == "list-panes" && args[1] == "-t" && args[3] == "-F" && args[4] == strings.Join([]string{"#{pane_title}", "#{@projmux_ai_badge_kind}", "#{@projmux_ai_topic}", "#{pane_current_command}"}, recentWindowFieldSep) {


### PR DESCRIPTION
## 완료한 작업

recent windows(Alt-3/Ctrl-E) picker 의 보라 project 뱃지가 **프로젝트명이 아니라 라이브 pane cwd 마지막 세그먼트**로 뜨던 버그 픽스. 단일 PR.

### 원인
`internal/app/recent_window.go` `currentSnapshot` 이 `Project = recentWindowProjectName(#{pane_current_path})` 로 채움. subdir 로 `cd` 하거나 project marker 가 없으면 cwd 마지막 세그먼트로 붕괴. 뱃지(`recentWindowBadgeText`)는 `Project` 우선이라 그 값이 그대로 노출됨.

### 수정 (확정 결정 그대로)
- `currentSnapshot` tmux 쿼리에 `#{@projmux_project_path}` 세션 앵커 필드 추가 (AI split anchored cwd #488 에서 도입).
- `Project` 채우기 우선순위:
  1. `@projmux_project_path` 있으면 → **그 basename** (예 `/home/es5h/source/repos/projmux` → `projmux`)
  2. 없으면 → 기존 `recentWindowProjectName(#{pane_current_path})` (nearest-project-marker basename) fallback
  3. 그것도 비면 → 세션명 fallback
- 결과: cwd 를 subdir 로 `cd` 해도 뱃지가 **프로젝트 basename** 로 안정.

## 수정한 user-facing surface
- recent windows picker 각 행의 line-1 보라 project 뱃지 텍스트 (이제 프로젝트 basename).

## 명시적으로 지킨 제약 (회귀 금지)
- 뱃지 **색/레이아웃/트렁케이션** 무변경 (`recentWindowBadgeText` 로직 그대로 — 이제 `Project` 가 올바른 값).
- recent windows 정렬/기록의 다른 필드 무변경.
- 앵커 없는 세션은 기존 fallback 동작 유지 (회귀 없음).
- Snapshot schema / recentwindows engine 재설계 없음.

## 검증
- `go build ./...` 통과.
- `go test ./internal/...` 전체 통과.
- 신규 테스트:
  - `TestRecentWindowSnapshotProjectPriority`: 앵커 basename 우선 / cwd drift 안정 / 앵커+marker 없음 시 marker basename fallback / 둘 다 없으면 세션명 fallback / 앵커 trailing slash basename.
  - `TestRecentWindowRecordUsesSessionAnchorProject`: 라이브 cwd 가 marker 없는 subdir 로 드리프트해도 앵커 basename(`projmux`) 로 기록.
- 기존 record 테스트 fixture 3건에 앵커 필드 추가, 앵커 없는 케이스는 기존 marker-fallback 동작 그대로 검증 유지.

## 미검증 / 후속
- 실제 tmux 세션에서 picker 렌더 육안 확인은 e2e 후보 (lead QA). 앵커 세션옵션은 #488 에서 세션 생성 시 set.

머지/로컬 바이너리 교체는 lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)