### PR TITLE
perf(ai): defer resume turn count so discovery renders fast again

### DIFF
--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -853,7 +853,14 @@ func (c *aiCommand) runResumePicker(direction string) error {
 	contextDir := c.resolveContextDir()
 	homeDir, _ := c.home()
 	depth := resolveAIResumeScanDepth(c.homeDir, c.lookupEnv, contextDir).Depth
-	sessions, err := aisessions.Discover(contextDir, aisessions.DiscoverOptions{HomeDir: homeDir, Depth: depth})
+	// Defer the turn count: discovery returns candidates fast (early-exit, no
+	// per-turn scan) so the picker renders immediately, and the turn column is
+	// filled for the displayed rows by a background pass (see runResumeSessionPicker).
+	sessions, err := aisessions.Discover(contextDir, aisessions.DiscoverOptions{
+		HomeDir:    homeDir,
+		Depth:      depth,
+		DeferTurns: true,
+	})
 	if err != nil {
 		return err
 	}
@@ -897,14 +904,29 @@ func (c *aiCommand) runResumeSessionPicker(direction string, sessions []aisessio
 	if total > visible {
 		footer = fmt.Sprintf(localizeUIText(locale, "Showing latest %d of %d resume sessions."), visible, total)
 	}
+	// The rows above render immediately with a blank turn column (discovery
+	// deferred the expensive per-turn scan). Fill it in a background pass over
+	// just the displayed sessions and hand the picker rebuilt rows; the turn
+	// count pops in without blocking the initial list. Values/search keys are
+	// unchanged by the turn count, so focus and filtering are preserved.
+	displayed := sessions
+	if n := normalizeResumePickerLimit(limit); len(displayed) > n {
+		displayed = displayed[:n]
+	}
+	deferredUpdate := func() (intpicker.DeferredUpdate, error) {
+		aisessions.EnrichTurns(displayed)
+		enriched, _, _ := aiResumeSessionRows(sessions, limit, now, locale, baseCWD, depth)
+		return intpicker.DeferredUpdate{Items: intpickercompat.PickerItemsFromEntries(enriched)}, nil
+	}
 	return runPickerOptionBackend(c.homeDir, c.lookupEnv, c.nativePicker, c.runner, c.themedPickerOptions(intpickercompat.Options{
-		UI:         "ai-resume-picker",
-		Entries:    entries,
-		Title:      localizeUIText(locale, "AI Resume - Split direction: ") + direction,
-		Prompt:     "AI Resume > ",
-		Footer:     projmuxFooter(footer),
-		ExpectKeys: []string{"enter"},
-		Bindings:   pickerCloseBindingsForPopupToggleMode(c.homeDir, c.lookupEnv, aiResumePickerPopupMode(direction), "esc", "ctrl-c", "ctrl-alt-s"),
+		UI:             "ai-resume-picker",
+		Entries:        entries,
+		Title:          localizeUIText(locale, "AI Resume - Split direction: ") + direction,
+		Prompt:         "AI Resume > ",
+		Footer:         projmuxFooter(footer),
+		ExpectKeys:     []string{"enter"},
+		Bindings:       pickerCloseBindingsForPopupToggleMode(c.homeDir, c.lookupEnv, aiResumePickerPopupMode(direction), "esc", "ctrl-c", "ctrl-alt-s"),
+		DeferredUpdate: deferredUpdate,
 	}))
 }
 

--- a/internal/integrations/agents/aisessions/sessions.go
+++ b/internal/integrations/agents/aisessions/sessions.go
@@ -62,10 +62,19 @@ type SessionMeta struct {
 	Source       string
 
 	// Turns is the count of user turns observed while scanning the session log.
-	// It is a low-cost signal counted in the same bounded pass that extracts the
-	// title (no extra file pass), so it saturates for very long sessions at the
-	// scan-line limit. Zero means "unknown" and renders as a blank cell.
+	// Counting turns needs the whole bounded scan window (it defeats the cheap
+	// id/cwd/title/branch early-exit), so it is not paid during candidate
+	// discovery; Discover fills it only for the top TurnEnrichLimit sessions in
+	// a bounded second pass (see enrichTurns), which are the only rows the picker
+	// displays. It saturates for very long sessions at the scan-line limit. Zero
+	// means "unknown" (not yet enriched, or no per-turn data) and renders as a
+	// blank cell.
 	Turns int
+
+	// sourcePath is the on-disk session log the turn-count enrich pass re-scans.
+	// It is internal to discovery (unexported, invisible to the picker contract)
+	// and empty for agents with no per-turn log, such as Antigravity.
+	sourcePath string
 }
 
 // DiscoverOptions controls where session logs are read from. Empty roots use
@@ -88,6 +97,15 @@ type DiscoverOptions struct {
 	// as the other agents. Empty resolves to ~/.gemini/antigravity-cli/history.jsonl
 	// under HomeDir; a missing or malformed file yields no Antigravity rows.
 	AntigravityHistoryPath string
+
+	// DeferTurns returns candidates without their user-turn count. Turn counting
+	// is the one expensive field (it reads the whole bounded scan window instead
+	// of early-exiting the cheap id/cwd/title/branch pass), so a picker that
+	// wants to render immediately sets this to get a fast candidate list and then
+	// fills the turn column for the rows it displays with a background EnrichTurns
+	// pass. The default (false) counts turns inline for every session, preserving
+	// the historical fully-counted result for callers that block on Discover.
+	DeferTurns bool
 }
 
 // Discover returns resume sessions for cwd across supported agents, newest
@@ -115,7 +133,42 @@ func Discover(cwd string, opts DiscoverOptions) ([]SessionMeta, error) {
 		}
 		return sessions[i].LastModified.After(sessions[j].LastModified)
 	})
+	// Candidate discovery above early-exits without counting turns (the cheap
+	// pass). Unless the caller defers it, fill the turn count inline now.
+	if !opts.DeferTurns {
+		enrichTurns(sessions)
+	}
 	return sessions, nil
+}
+
+// EnrichTurns fills SessionMeta.Turns for the given sessions by scanning each
+// session's log for user turns, returning the same slice for convenience. A
+// picker that discovered candidates with DiscoverOptions.DeferTurns calls this
+// on just the rows it displays (a bounded set) from a background goroutine, so
+// the expensive turn-count scan never blocks the initial render. It is a no-op
+// on sessions with no per-turn log (empty sourcePath, e.g. Antigravity).
+func EnrichTurns(sessions []SessionMeta) []SessionMeta {
+	enrichTurns(sessions)
+	return sessions
+}
+
+// enrichTurns re-scans each session's log for user turns and records the count.
+// Turn counting is the one field that defeats the candidate early-exit (it must
+// read the whole bounded window), so paying it only for displayed rows — inline
+// for blocking callers, or in the background via EnrichTurns — is what keeps
+// discovery fast. Sessions with no per-turn log (empty sourcePath) and
+// unreadable logs are left at Turns 0 (rendered blank).
+func enrichTurns(sessions []SessionMeta) {
+	for i := range sessions {
+		if sessions[i].sourcePath == "" {
+			continue
+		}
+		details, ok := scanSessionJSONL(sessions[i].sourcePath, sessionScanOptions{countTurns: true})
+		if !ok {
+			continue
+		}
+		sessions[i].Turns = details.turns
+	}
 }
 
 // EncodeClaudeProjectPath returns Claude Code's project directory name for cwd:
@@ -248,7 +301,9 @@ func discoverClaudeDir(dir, cwd string, depth int) []SessionMeta {
 				Branch: details.branch,
 			},
 			Source: SourceClaudeTranscript,
-			Turns:  details.turns,
+			// Turns is left at 0 here; the candidate scan does not count turns.
+			// enrichTurns re-scans sourcePath to fill it for displayed rows.
+			sourcePath: path,
 		})
 	}
 	return sessions
@@ -330,7 +385,8 @@ func discoverCodexWithFileLimit(cwd, sessionsDir string, scanFileLimit, depth in
 				Branch: details.branch,
 			},
 			Source: SourceCodexRollout,
-			Turns:  details.turns,
+			// Turns is left at 0 here; enrichTurns fills it from sourcePath.
+			sourcePath: candidate.path,
 		})
 	}
 	return sessions
@@ -576,6 +632,26 @@ type sessionDetails struct {
 type sessionScanOptions struct {
 	targetCWD  string
 	requireCWD bool
+
+	// countTurns keeps the scan reading the whole bounded window to count user
+	// turns. When false (candidate discovery), the scan early-exits the moment
+	// id/cwd/title/branch are known, which is the cheap pass that keeps discovery
+	// fast; the turn count is then filled for displayed rows in a separate pass.
+	countTurns bool
+}
+
+// ready reports whether the cheap candidate fields (id, title, branch, and a
+// cwd consistent with the scan's constraints) are all captured, so a non
+// turn-counting scan can stop before the line limit. This is the early-exit
+// that keeps candidate discovery fast.
+func (details sessionDetails) ready(requireCWD bool, targetCWD string) bool {
+	if details.id == "" || details.title == "" || details.branch == "" {
+		return false
+	}
+	if targetCWD != "" && details.cwd == "" {
+		return false
+	}
+	return !requireCWD || details.cwd != ""
 }
 
 func scanSessionJSONL(path string, opts sessionScanOptions) (sessionDetails, bool) {
@@ -625,14 +701,18 @@ func scanSessionJSONLReader(r io.Reader, opts sessionScanOptions) (sessionDetail
 		if details.title == "" && lineNo <= sessionTitleLineLimit {
 			details.title = titleFromRecord(fields)
 		}
-		// Count user turns in the same bounded pass that extracts the title. We
-		// deliberately do not early-exit once id/title/branch/cwd are known: a
-		// turn count is only meaningful if the scan sees the whole bounded window,
-		// so it keeps reading up to sessionScanLineLimit. The cwd-mismatch abort
-		// above still short-circuits non-matching sessions on their first cwd
-		// record, so the extra reads are paid only for sessions we will display.
-		if isUserTurnRecord(fields) {
-			details.turns++
+		if opts.countTurns {
+			// Turn counting only means something if the scan sees the whole
+			// bounded window, so this pass keeps reading up to the line limit
+			// (no early-exit). It is paid only for the displayed rows enrichTurns
+			// re-scans, not during candidate discovery.
+			if isUserTurnRecord(fields) {
+				details.turns++
+			}
+		} else if details.ready(opts.requireCWD, targetCWD) {
+			// Candidate discovery: stop as soon as the cheap fields are known.
+			// This is the #477 early-exit the turn count had defeated.
+			return details, true
 		}
 		if lineNo >= sessionScanLineLimit {
 			break

--- a/internal/integrations/agents/aisessions/sessions_test.go
+++ b/internal/integrations/agents/aisessions/sessions_test.go
@@ -234,10 +234,10 @@ func TestScanSessionJSONLStopsAfterCwdMismatch(t *testing.T) {
 func TestScanSessionJSONLCountsTurnsPastMetadata(t *testing.T) {
 	t.Parallel()
 
-	// The scan does not early-exit once id/cwd/title/branch are known: it keeps
-	// reading (bounded by sessionScanLineLimit) so it can count user turns. The
-	// title still comes from the first user prompt; later user prompts only add
-	// to the turn count.
+	// The turn-counting pass (countTurns) does not early-exit once
+	// id/cwd/title/branch are known: it keeps reading (bounded by
+	// sessionScanLineLimit) so it can count user turns. The title still comes
+	// from the first user prompt; later user prompts only add to the turn count.
 	log := `{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000066","cwd":"/workspace/app","git_branch":"feat/perf"}}` + "\n" +
 		`{"type":"event_msg","payload":{"type":"user_message","message":"Speed up resume picker"}}` + "\n" +
 		`{"type":"event_msg","payload":{"type":"agent_message","message":"On it"}}` + "\n" +
@@ -246,6 +246,7 @@ func TestScanSessionJSONLCountsTurnsPastMetadata(t *testing.T) {
 	details, ok := scanSessionJSONLReader(strings.NewReader(log), sessionScanOptions{
 		targetCWD:  "/workspace/app",
 		requireCWD: true,
+		countTurns: true,
 	})
 
 	if !ok {
@@ -262,6 +263,37 @@ func TestScanSessionJSONLCountsTurnsPastMetadata(t *testing.T) {
 	}
 }
 
+func TestScanSessionJSONLCandidatePassEarlyExitsBeforeCountingTurns(t *testing.T) {
+	t.Parallel()
+
+	// Candidate discovery (countTurns=false) must stop the moment the cheap
+	// id/cwd/title/branch fields are captured and must not read the rest of the
+	// window, so the turn count stays 0 and the tail is never touched. This is
+	// the #477 early-exit the always-on turn count had defeated.
+	metaAndFirstTurn := `{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000066","cwd":"/workspace/app","git_branch":"feat/perf"}}` + "\n" +
+		`{"type":"event_msg","payload":{"type":"user_message","message":"Speed up resume picker"}}` + "\n"
+	tail := `{"type":"event_msg","payload":{"type":"user_message","message":"must not be read"}}` + "\n"
+	reader := newFailAfterReader(metaAndFirstTurn+tail, len(metaAndFirstTurn))
+
+	details, ok := scanSessionJSONLReader(reader, sessionScanOptions{
+		targetCWD:  "/workspace/app",
+		requireCWD: true,
+	})
+
+	if !ok {
+		t.Fatal("scanSessionJSONLReader() ok = false")
+	}
+	if reader.failed {
+		t.Fatal("scanSessionJSONLReader() read past the ready candidate fields")
+	}
+	if details.title != "Speed up resume picker" {
+		t.Fatalf("title = %q, want first user prompt", details.title)
+	}
+	if details.turns != 0 {
+		t.Fatalf("turns = %d, want 0 (candidate pass does not count turns)", details.turns)
+	}
+}
+
 func TestScanSessionJSONLCountsClaudeUserTurnsExcludingToolResults(t *testing.T) {
 	t.Parallel()
 
@@ -273,7 +305,7 @@ func TestScanSessionJSONLCountsClaudeUserTurnsExcludingToolResults(t *testing.T)
 		`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"output"}]}}` + "\n" +
 		`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"second prompt"}]}}` + "\n"
 
-	details, ok := scanSessionJSONLReader(strings.NewReader(log), sessionScanOptions{targetCWD: "/workspace/app"})
+	details, ok := scanSessionJSONLReader(strings.NewReader(log), sessionScanOptions{targetCWD: "/workspace/app", countTurns: true})
 	if !ok {
 		t.Fatalf("scanSessionJSONLReader() ok = false, details = %#v", details)
 	}
@@ -310,6 +342,64 @@ func TestDiscoverPopulatesTurnCount(t *testing.T) {
 	}
 	if got[0].Turns != 3 {
 		t.Fatalf("Turns = %d, want 3", got[0].Turns)
+	}
+}
+
+func TestDiscoverDeferTurnsLeavesCountZeroUntilEnriched(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "codex", "sessions", "2026", "06", "25")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sessionsDir, "rollout-defer.jsonl")
+	writeFile(t, path, `{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000099","cwd":"/workspace/app","git_branch":"feat/turns"}}
+{"type":"event_msg","payload":{"type":"user_message","message":"First"}}
+{"type":"event_msg","payload":{"type":"agent_message","message":"Reply"}}
+{"type":"event_msg","payload":{"type":"user_message","message":"Second"}}
+{"type":"event_msg","payload":{"type":"user_message","message":"Third"}}
+`)
+	setModTime(t, path, time.Date(2026, 6, 25, 9, 0, 0, 0, time.UTC))
+
+	opts := DiscoverOptions{
+		CodexSessionsDir: filepath.Join(root, "codex", "sessions"),
+		DeferTurns:       true,
+	}
+	got, err := Discover("/workspace/app", opts)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Discover() len = %d, want 1: %#v", len(got), got)
+	}
+	// Deferred: the identity fields are present but the turn count is not paid.
+	if got[0].ResumeID == "" || got[0].Title == "" {
+		t.Fatalf("deferred candidate missing identity fields: %#v", got[0])
+	}
+	if got[0].Turns != 0 {
+		t.Fatalf("Turns = %d, want 0 before enrichment (DeferTurns)", got[0].Turns)
+	}
+
+	// The background enrich pass fills the same count the blocking path produces.
+	enriched := EnrichTurns(got)
+	if enriched[0].Turns != 3 {
+		t.Fatalf("Turns after EnrichTurns = %d, want 3", enriched[0].Turns)
+	}
+	if got[0].Turns != 3 {
+		t.Fatalf("EnrichTurns did not fill the passed slice: Turns = %d, want 3", got[0].Turns)
+	}
+}
+
+func TestEnrichTurnsIgnoresSessionsWithoutLog(t *testing.T) {
+	t.Parallel()
+
+	// Antigravity rows carry no per-turn log (empty sourcePath); enrichment must
+	// leave them at 0 rather than panic or read a bogus path.
+	sessions := []SessionMeta{{Agent: AgentAntigravity, ResumeID: "abc", Turns: 0}}
+	got := EnrichTurns(sessions)
+	if got[0].Turns != 0 {
+		t.Fatalf("Turns = %d, want 0 (no per-turn log)", got[0].Turns)
 	}
 }
 

--- a/internal/ui/pickercompat/picker.go
+++ b/internal/ui/pickercompat/picker.go
@@ -73,25 +73,35 @@ func ResultToPicker(result Result) picker.Result {
 func PickerOptions(options Options) picker.Options {
 	initialIndex, initialIndexSet := pickerInitialIndex(options)
 	return picker.Options{
-		UI:              options.UI,
-		Items:           pickerItems(options),
-		Title:           options.Title,
-		TitleChips:      options.TitleChips,
-		Prompt:          options.Prompt,
-		Header:          options.Header,
-		Footer:          options.Footer,
-		Locale:          options.Locale,
-		Actions:         pickerActions(options),
-		Preview:         picker.Preview{Command: options.PreviewCommand, Window: options.PreviewWindow},
-		Theme:           options.Theme,
-		InitialQuery:    options.InitialQuery,
-		InitialIndex:    initialIndex,
-		InitialIndexSet: initialIndexSet,
-		DisableSearch:   options.DisableSearch,
-		AcceptQuery:     options.AcceptQuery,
-		ColorGrid:       options.ColorGrid,
-		MultiLine:       options.Read0,
+		UI:                    options.UI,
+		Items:                 pickerItems(options),
+		Title:                 options.Title,
+		TitleChips:            options.TitleChips,
+		Prompt:                options.Prompt,
+		Header:                options.Header,
+		Footer:                options.Footer,
+		Locale:                options.Locale,
+		Actions:               pickerActions(options),
+		Preview:               picker.Preview{Command: options.PreviewCommand, Window: options.PreviewWindow},
+		Theme:                 options.Theme,
+		InitialQuery:          options.InitialQuery,
+		InitialIndex:          initialIndex,
+		InitialIndexSet:       initialIndexSet,
+		DisableSearch:         options.DisableSearch,
+		AcceptQuery:           options.AcceptQuery,
+		ColorGrid:             options.ColorGrid,
+		MultiLine:             options.Read0,
+		DeferredUpdate:        options.DeferredUpdate,
+		DeferredUpdateTrigger: options.DeferredUpdateTrigger,
 	}
+}
+
+// PickerItemsFromEntries converts compat entries to native picker items. It lets
+// a caller build a picker.DeferredUpdate (whose Items are native) from the same
+// Entry rows it renders initially, without duplicating the label/value/search
+// mapping.
+func PickerItemsFromEntries(entries []Entry) []picker.Item {
+	return pickerItemsFromEntries(entries)
 }
 
 func ResultFromPicker(result picker.Result) Result {

--- a/internal/ui/pickercompat/types.go
+++ b/internal/ui/pickercompat/types.go
@@ -3,6 +3,7 @@ package pickercompat
 import (
 	"github.com/crevissepartners/projmux/internal/i18n"
 	"github.com/crevissepartners/projmux/internal/theme"
+	"github.com/crevissepartners/projmux/internal/ui/picker"
 	"github.com/crevissepartners/projmux/internal/ui/projmuxpicker"
 )
 
@@ -30,6 +31,13 @@ type Options struct {
 	// ColorGrid renders the native picker as an xterm-256 swatch grid with a
 	// live preview instead of a filtered list.
 	ColorGrid bool
+	// DeferredUpdate, when set, is run by the native picker after the first
+	// render to fill in expensive fields (e.g. a background pass that computes
+	// per-row data) without blocking the initial list. DeferredUpdateTrigger, if
+	// non-nil, re-runs it on every signal; nil runs it once. Both pass straight
+	// through to the native picker Options.
+	DeferredUpdate        func() (picker.DeferredUpdate, error)
+	DeferredUpdateTrigger <-chan struct{}
 }
 
 type Entry struct {


### PR DESCRIPTION
## Problem

Resume picker discovery regressed from **~50ms → ~158ms (warm) / ~180ms (cold)** on a 74-session cwd. The turn-count field added in #485 made `scanSessionJSONLReader` read the full 100-line window for **every** matching session, defeating the #477 `id/cwd/title/branch` early-exit — each matched file got re-full-scanned.

Root cause: turn counting is the only field that needs the whole bounded window. `recency/agent/branch/cwd/title` all come out cheaply via early-exit.

## Fix — progressive (turns deferred, identity immediate)

- **Candidate discovery restores the #477 early-exit.** New `sessionScanOptions.countTurns` gates turn counting; the cheap pass stops the moment the identity fields are known. `DiscoverOptions.DeferTurns` returns candidates without turns.
- **The AI resume picker discovers with `DeferTurns`** (list renders immediately with a blank turn column), then fills turns for just the displayed rows via a background `EnrichTurns` pass surfaced through the picker's existing `DeferredUpdate` mechanism. Row `Value`/`SearchKey` are unchanged by the count, so **focus and filtering are preserved**; the turn column pops in a moment later.
- `pickercompat.Options` now passes `DeferredUpdate`/`DeferredUpdateTrigger` through to the native picker (+ exported `PickerItemsFromEntries` helper).

## Timing (real 74-session cwd, warm)

| Path | Before | After |
|---|---|---|
| Discover (picker-blocking) | ~158ms | **~40ms** |
| Background `EnrichTurns` (top-30, off render path) | — | ~69ms |
| Old inline "count all turns" | ~183ms | ~183ms (still available to blocking callers) |

Discover now beats the ~50ms pre-regression baseline and is well under the sub-80ms goal.

## Invariants (no display regression)

- Sort, title, **turn values**, cwd, branch, id, and dedup are unchanged for the rows the picker shows (list is capped to the display limit; enrichment covers exactly those rows).
- cwd filter / depth (`withinTree`) / codex mtime budget / antigravity discovery / corrupt-file skip all unchanged.
- Blocking `Discover` callers (default `DeferTurns=false`) still get every turn counted inline — back-compat preserved.

## User-facing surface

- `projmux ai` resume split picker: identical rows, faster to appear; turn count fills in shortly after the list shows.

## Validation

- `go build ./...`, `go test ./internal/...` pass (incl. `-race` on aisessions/picker).
- New tests: candidate pass early-exits before counting turns; `DeferTurns` leaves count 0 until `EnrichTurns`; `EnrichTurns` no-ops on logless (antigravity) rows. Existing turn-count unit tests updated to the `countTurns` path.

## Not verified (needs live tmux)

- The background turn-column pop-in was verified via the unit/timing path, not a live TUI session; the `DeferredUpdate` goroutine path only runs in interactive mode. Suggest a quick manual check of the resume picker in a real pane before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)