### PR TITLE
fix(recent-windows): worktree cwd resolves to main repo project badge (#489 follow-up)

### DIFF
--- a/internal/app/recent_window.go
+++ b/internal/app/recent_window.go
@@ -865,7 +865,58 @@ func recentWindowProjectName(path string) string {
 	if root == "" {
 		root = path
 	}
+	// A git worktree carries its own `.git` marker, so nearestProjectMarker stops
+	// at the worktree dir whose basename is the branch/worktree name, not the
+	// project. When <root>/.git is a FILE (the worktree case) resolve the main
+	// repo root by parsing it — a pure file read, no git subprocess, since the
+	// recent list can hold many entries — and use the main project basename. A
+	// regular repo (.git dir), a missing .git, or a corrupt/unexpected .git file
+	// falls through to the existing marker-basename behavior and never panics.
+	if main := recentWindowWorktreeMainProjectName(root); main != "" {
+		return main
+	}
 	name := filepath.Base(filepath.Clean(root))
+	if name == "." || name == string(filepath.Separator) {
+		return ""
+	}
+	return name
+}
+
+// recentWindowWorktreeMainProjectName returns the main repository's project
+// basename when root is a git worktree, else "". A worktree's <root>/.git is a
+// file whose content is `gitdir: <main>/.git/worktrees/<name>`; the main repo
+// root is the path segment before `/.git/worktrees/`. Anything else — a `.git`
+// directory (regular repo), a missing/unreadable file, or content without the
+// expected `gitdir:` worktree pointer — yields "" so the caller keeps its prior
+// behavior. No git subprocess is spawned; only the marker file is read.
+func recentWindowWorktreeMainProjectName(root string) string {
+	gitPath := filepath.Join(root, ".git")
+	info, err := osStat(gitPath)
+	if err != nil || info.IsDir() {
+		return ""
+	}
+	data, err := os.ReadFile(gitPath)
+	if err != nil {
+		return ""
+	}
+	gitdir := ""
+	for line := range strings.SplitSeq(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(line, "gitdir:"); ok {
+			gitdir = strings.TrimSpace(rest)
+			break
+		}
+	}
+	if gitdir == "" {
+		return ""
+	}
+	gitdir = filepath.ToSlash(gitdir)
+	idx := strings.Index(gitdir, "/.git/worktrees/")
+	if idx <= 0 {
+		return ""
+	}
+	mainRoot := filepath.Clean(filepath.FromSlash(gitdir[:idx]))
+	name := filepath.Base(mainRoot)
 	if name == "." || name == string(filepath.Separator) {
 		return ""
 	}

--- a/internal/app/recent_window_worktree_test.go
+++ b/internal/app/recent_window_worktree_test.go
@@ -1,0 +1,102 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRecentWindowProjectNameResolvesWorktreeToMainRepo covers the #489
+// follow-up: an anchor-less session whose pane cwd sits inside a git worktree
+// must resolve the recent-window project badge to the MAIN repo basename
+// (projmux), not the worktree/branch directory name. A regular repo and a
+// corrupt/unexpected .git file keep the prior nearest-marker-basename behavior.
+func TestRecentWindowProjectNameResolvesWorktreeToMainRepo(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) string
+		want  string
+	}{
+		{
+			name: "worktree .git file resolves to main repo basename",
+			setup: func(t *testing.T) string {
+				main := filepath.Join(t.TempDir(), "projmux")
+				worktree := filepath.Join(main, ".wt", "fix", "recent-window-worktree-project")
+				if err := os.MkdirAll(worktree, 0o755); err != nil {
+					t.Fatalf("create worktree dir: %v", err)
+				}
+				gitdir := filepath.Join(main, ".git", "worktrees", "recent-window-worktree-project")
+				writeWorktreeGitFile(t, worktree, "gitdir: "+gitdir+"\n")
+				return worktree
+			},
+			want: "projmux",
+		},
+		{
+			name: "worktree cwd drifted into a subdir still resolves to main repo",
+			setup: func(t *testing.T) string {
+				main := filepath.Join(t.TempDir(), "projmux")
+				worktree := filepath.Join(main, ".wt", "feature", "some-branch")
+				sub := filepath.Join(worktree, "internal", "app")
+				if err := os.MkdirAll(sub, 0o755); err != nil {
+					t.Fatalf("create worktree subdir: %v", err)
+				}
+				gitdir := filepath.Join(main, ".git", "worktrees", "some-branch")
+				writeWorktreeGitFile(t, worktree, "gitdir: "+gitdir+"\n")
+				return sub
+			},
+			want: "projmux",
+		},
+		{
+			name: "regular repo .git dir keeps marker basename",
+			setup: func(t *testing.T) string {
+				root := filepath.Join(t.TempDir(), "projmux-fixture")
+				if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+					t.Fatalf("create marker: %v", err)
+				}
+				return filepath.Join(root, "internal", "app")
+			},
+			want: "projmux-fixture",
+		},
+		{
+			name: "corrupt .git file falls back to worktree basename",
+			setup: func(t *testing.T) string {
+				worktree := filepath.Join(t.TempDir(), "branch-dir")
+				if err := os.MkdirAll(worktree, 0o755); err != nil {
+					t.Fatalf("create worktree dir: %v", err)
+				}
+				writeWorktreeGitFile(t, worktree, "this is not a gitdir pointer\n")
+				return worktree
+			},
+			want: "branch-dir",
+		},
+		{
+			name: "gitdir without worktrees segment falls back to worktree basename",
+			setup: func(t *testing.T) string {
+				worktree := filepath.Join(t.TempDir(), "linked-dir")
+				if err := os.MkdirAll(worktree, 0o755); err != nil {
+					t.Fatalf("create worktree dir: %v", err)
+				}
+				writeWorktreeGitFile(t, worktree, "gitdir: /some/other/place/.git\n")
+				return worktree
+			},
+			want: "linked-dir",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := tt.setup(t)
+			if got := recentWindowProjectName(path); got != tt.want {
+				t.Fatalf("recentWindowProjectName(%q) = %q, want %q", path, got, tt.want)
+			}
+		})
+	}
+}
+
+// writeWorktreeGitFile writes a `.git` FILE (not directory) inside root with the
+// given content, mirroring how git materializes a worktree's gitlink.
+func writeWorktreeGitFile(t *testing.T, root, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, ".git"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write worktree .git file: %v", err)
+	}
+}


### PR DESCRIPTION
## 요약

recent windows(Alt-3) 보라 프로젝트 뱃지가 **worktree 창**에서 프로젝트명(`projmux`)이 아니라 **worktree 브랜치 디렉터리명**으로 뜨던 버그(#489 follow-up)를 fallback 경로에서 수정.

## 완료한 작업 (단일 phase)

- `internal/app/recent_window.go` `recentWindowProjectName`: root 확정 후 `<root>/.git` 가 **파일**(=worktree)이면 그 `gitdir: <main>/.git/worktrees/<name>` 포인터를 **순수 파일 파싱**해 메인 repo root basename(`projmux`) 반환. `.git` 이 디렉터리(일반 repo)/없음/손상이면 기존 marker-basename 동작 유지.
- 신규 헬퍼 `recentWindowWorktreeMainProjectName` 추가 — git 서브프로세스 없이 `.git` 파일 read + 문자열 파싱만.

## 원인

#489 로 `Project` 는 세션 앵커 `@projmux_project_path` basename 우선이나, **앵커 없는 옛(#488 이전) 세션**은 `recentWindowProjectName(pane_current_path)` = `nearestProjectMarker(cwd)` basename 으로 fallback. worktree 는 자체 `.git`(파일)이 있어 marker 워크가 worktree 디렉터리에서 멈춰 브랜치명을 반환.

## 수정한 user-facing surface

- recent windows picker 라인1 프로젝트 뱃지 텍스트(앵커 없는 worktree 세션에 한함). 색/레이아웃/뱃지 팔레트 무변경.

## 모델/스키마/제약 준수

- **앵커 우선순위(#489) 무변경** — worktree 해석은 fallback 안에서만.
- 일반 repo/dir 동작, 앵커 있는 세션 동작 무변경.
- **git 서브프로세스 미사용**(recent list 항목 다수) — `.git` 파일 read + 파싱만.
- 손상/예상밖 `.git` → 안전 fallback(기존 basename), 패닉 없음.

## 명시적으로 제외한 범위

- 앵커 우선순위 재설계, snapshot schema/engine 변경, 뱃지 색·레이아웃 변경.

## 검증

- `internal/app/recent_window_worktree_test.go` (신규): worktree `.git`-파일 fixture → 메인 basename(`projmux`), subdir 드리프트 → `projmux`, 일반 `.git` dir → marker basename, 손상 `.git` → worktree basename fallback, worktrees 세그먼트 없는 gitdir → fallback.
- `go build ./...` ✅
- `go test ./internal/...` ✅ (전체 통과)
- `make fmt`, `make fix`(deadcode clean) ✅

## 미검증 / 후속

- 실제 tmux 에서 앵커 없는 worktree 세션의 recent 뱃지 육안 확인은 e2e 후보(단위 테스트로 로직 고정). 앵커 있는 신 세션은 이미 #489 로 정상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
