### PR TITLE
fix(ai): accurate resume turn count via full-file deferred scan (#490 follow-up)

### DIFF
--- a/internal/integrations/agents/aisessions/sessions.go
+++ b/internal/integrations/agents/aisessions/sessions.go
@@ -40,6 +40,13 @@ const (
 	sessionScanLineLimit  = 100
 	sessionTitleLineLimit = 100
 	codexScanFileLimit    = 80
+	// turnCountLineLimit bounds the deferred full-file turn count so a
+	// pathological multi-hundred-MB log cannot stall the background enrich pass.
+	// It sits far above the candidate scan window (sessionScanLineLimit): turn
+	// counting runs in the background for displayed rows only, so it can read the
+	// whole log for an accurate total while the initial render stays fast. Real
+	// sessions of hundreds of turns finish well within it.
+	turnCountLineLimit = 200000
 	// codexScanBudgetMax caps the depth-widened codex scan budget. depth>0
 	// widens the per-discovery file budget (more child cwds match), but an
 	// unbounded walk would defeat the perf limit, so the budget tops out here.
@@ -61,14 +68,13 @@ type SessionMeta struct {
 	Context      SessionContext
 	Source       string
 
-	// Turns is the count of user turns observed while scanning the session log.
-	// Counting turns needs the whole bounded scan window (it defeats the cheap
-	// id/cwd/title/branch early-exit), so it is not paid during candidate
-	// discovery; Discover fills it only for the top TurnEnrichLimit sessions in
-	// a bounded second pass (see enrichTurns), which are the only rows the picker
-	// displays. It saturates for very long sessions at the scan-line limit. Zero
-	// means "unknown" (not yet enriched, or no per-turn data) and renders as a
-	// blank cell.
+	// Turns is the count of user turns in the session log. Counting turns means
+	// scanning the whole log (it defeats the cheap id/cwd/title/branch early-exit
+	// of candidate discovery), so it is not paid during discovery; Discover fills
+	// it only for the rows the picker displays, in a background second pass (see
+	// enrichTurns) that reads the full file for an accurate total regardless of
+	// session length. Zero means "unknown" (not yet enriched, or no per-turn
+	// data) and renders as a blank cell.
 	Turns int
 
 	// sourcePath is the on-disk session log the turn-count enrich pass re-scans.
@@ -152,23 +158,61 @@ func EnrichTurns(sessions []SessionMeta) []SessionMeta {
 	return sessions
 }
 
-// enrichTurns re-scans each session's log for user turns and records the count.
-// Turn counting is the one field that defeats the candidate early-exit (it must
-// read the whole bounded window), so paying it only for displayed rows — inline
-// for blocking callers, or in the background via EnrichTurns — is what keeps
-// discovery fast. Sessions with no per-turn log (empty sourcePath) and
-// unreadable logs are left at Turns 0 (rendered blank).
+// enrichTurns re-scans each session's whole log for user turns and records the
+// count. Turn counting is the one field that defeats the candidate early-exit
+// (it must read the whole file, not just the fast candidate window), so paying
+// it only for displayed rows — inline for blocking callers, or in the background
+// via EnrichTurns — is what keeps discovery fast. Sessions with no per-turn log
+// (empty sourcePath) and unreadable logs are left at Turns 0 (rendered blank).
 func enrichTurns(sessions []SessionMeta) {
 	for i := range sessions {
 		if sessions[i].sourcePath == "" {
 			continue
 		}
-		details, ok := scanSessionJSONL(sessions[i].sourcePath, sessionScanOptions{countTurns: true})
+		turns, ok := countUserTurns(sessions[i].sourcePath)
 		if !ok {
 			continue
 		}
-		sessions[i].Turns = details.turns
+		sessions[i].Turns = turns
 	}
+}
+
+// countUserTurns returns the number of user-turn records in the whole session
+// log at path (bounded only by turnCountLineLimit). Unlike the candidate scan it
+// extracts nothing else — each line is tested only by isUserTurnRecord — so
+// reading the full file stays cheap, and it runs only in the deferred enrich
+// pass for displayed rows, never during discovery. ok is false only when the
+// file cannot be opened; an empty or all-malformed log yields (0, true).
+func countUserTurns(path string) (int, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, false
+	}
+	defer f.Close()
+	return countUserTurnsReader(f)
+}
+
+func countUserTurnsReader(r io.Reader) (int, bool) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
+	turns := 0
+	for lineNo := 0; scanner.Scan(); lineNo++ {
+		if lineNo >= turnCountLineLimit {
+			break
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var fields map[string]any
+		if err := json.Unmarshal([]byte(line), &fields); err != nil {
+			continue
+		}
+		if isUserTurnRecord(fields) {
+			turns++
+		}
+	}
+	return turns, true
 }
 
 // EncodeClaudeProjectPath returns Claude Code's project directory name for cwd:
@@ -626,18 +670,11 @@ type sessionDetails struct {
 	title  string
 	cwd    string
 	branch string
-	turns  int
 }
 
 type sessionScanOptions struct {
 	targetCWD  string
 	requireCWD bool
-
-	// countTurns keeps the scan reading the whole bounded window to count user
-	// turns. When false (candidate discovery), the scan early-exits the moment
-	// id/cwd/title/branch are known, which is the cheap pass that keeps discovery
-	// fast; the turn count is then filled for displayed rows in a separate pass.
-	countTurns bool
 }
 
 // ready reports whether the cheap candidate fields (id, title, branch, and a
@@ -701,17 +738,10 @@ func scanSessionJSONLReader(r io.Reader, opts sessionScanOptions) (sessionDetail
 		if details.title == "" && lineNo <= sessionTitleLineLimit {
 			details.title = titleFromRecord(fields)
 		}
-		if opts.countTurns {
-			// Turn counting only means something if the scan sees the whole
-			// bounded window, so this pass keeps reading up to the line limit
-			// (no early-exit). It is paid only for the displayed rows enrichTurns
-			// re-scans, not during candidate discovery.
-			if isUserTurnRecord(fields) {
-				details.turns++
-			}
-		} else if details.ready(opts.requireCWD, targetCWD) {
+		if details.ready(opts.requireCWD, targetCWD) {
 			// Candidate discovery: stop as soon as the cheap fields are known.
-			// This is the #477 early-exit the turn count had defeated.
+			// This is the #477 early-exit; the turn count is a separate deferred
+			// full-file pass (see countUserTurns), so nothing defeats it here.
 			return details, true
 		}
 		if lineNo >= sessionScanLineLimit {

--- a/internal/integrations/agents/aisessions/sessions_test.go
+++ b/internal/integrations/agents/aisessions/sessions_test.go
@@ -231,45 +231,32 @@ func TestScanSessionJSONLStopsAfterCwdMismatch(t *testing.T) {
 	}
 }
 
-func TestScanSessionJSONLCountsTurnsPastMetadata(t *testing.T) {
+func TestCountUserTurnsExcludesAgentMessages(t *testing.T) {
 	t.Parallel()
 
-	// The turn-counting pass (countTurns) does not early-exit once
-	// id/cwd/title/branch are known: it keeps reading (bounded by
-	// sessionScanLineLimit) so it can count user turns. The title still comes
-	// from the first user prompt; later user prompts only add to the turn count.
+	// The deferred turn count reads the whole log counting only user turns; the
+	// session_meta and agent_message records are not user turns.
 	log := `{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000066","cwd":"/workspace/app","git_branch":"feat/perf"}}` + "\n" +
 		`{"type":"event_msg","payload":{"type":"user_message","message":"Speed up resume picker"}}` + "\n" +
 		`{"type":"event_msg","payload":{"type":"agent_message","message":"On it"}}` + "\n" +
 		`{"type":"event_msg","payload":{"type":"user_message","message":"Also add turn counts"}}` + "\n"
 
-	details, ok := scanSessionJSONLReader(strings.NewReader(log), sessionScanOptions{
-		targetCWD:  "/workspace/app",
-		requireCWD: true,
-		countTurns: true,
-	})
-
+	turns, ok := countUserTurnsReader(strings.NewReader(log))
 	if !ok {
-		t.Fatal("scanSessionJSONLReader() ok = false")
+		t.Fatal("countUserTurnsReader() ok = false")
 	}
-	if details.id != "019f0000-0000-7000-8000-000000000066" ||
-		details.cwd != "/workspace/app" ||
-		details.branch != "feat/perf" ||
-		details.title != "Speed up resume picker" {
-		t.Fatalf("details = %#v", details)
-	}
-	if details.turns != 2 {
-		t.Fatalf("turns = %d, want 2 (two user_message records, agent_message excluded)", details.turns)
+	if turns != 2 {
+		t.Fatalf("turns = %d, want 2 (two user_message records, agent_message excluded)", turns)
 	}
 }
 
 func TestScanSessionJSONLCandidatePassEarlyExitsBeforeCountingTurns(t *testing.T) {
 	t.Parallel()
 
-	// Candidate discovery (countTurns=false) must stop the moment the cheap
-	// id/cwd/title/branch fields are captured and must not read the rest of the
-	// window, so the turn count stays 0 and the tail is never touched. This is
-	// the #477 early-exit the always-on turn count had defeated.
+	// Candidate discovery must stop the moment the cheap id/cwd/title/branch
+	// fields are captured and must not read the rest of the window; the tail is
+	// never touched. This is the #477 early-exit. The turn count is a separate
+	// deferred full-file pass (countUserTurns), so it never runs here.
 	metaAndFirstTurn := `{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000066","cwd":"/workspace/app","git_branch":"feat/perf"}}` + "\n" +
 		`{"type":"event_msg","payload":{"type":"user_message","message":"Speed up resume picker"}}` + "\n"
 	tail := `{"type":"event_msg","payload":{"type":"user_message","message":"must not be read"}}` + "\n"
@@ -289,9 +276,6 @@ func TestScanSessionJSONLCandidatePassEarlyExitsBeforeCountingTurns(t *testing.T
 	if details.title != "Speed up resume picker" {
 		t.Fatalf("title = %q, want first user prompt", details.title)
 	}
-	if details.turns != 0 {
-		t.Fatalf("turns = %d, want 0 (candidate pass does not count turns)", details.turns)
-	}
 }
 
 func TestScanSessionJSONLCountsClaudeUserTurnsExcludingToolResults(t *testing.T) {
@@ -305,12 +289,12 @@ func TestScanSessionJSONLCountsClaudeUserTurnsExcludingToolResults(t *testing.T)
 		`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"output"}]}}` + "\n" +
 		`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"second prompt"}]}}` + "\n"
 
-	details, ok := scanSessionJSONLReader(strings.NewReader(log), sessionScanOptions{targetCWD: "/workspace/app", countTurns: true})
+	turns, ok := countUserTurnsReader(strings.NewReader(log))
 	if !ok {
-		t.Fatalf("scanSessionJSONLReader() ok = false, details = %#v", details)
+		t.Fatal("countUserTurnsReader() ok = false")
 	}
-	if details.turns != 2 {
-		t.Fatalf("turns = %d, want 2 (tool_result carrier excluded)", details.turns)
+	if turns != 2 {
+		t.Fatalf("turns = %d, want 2 (tool_result carrier excluded)", turns)
 	}
 }
 
@@ -342,6 +326,67 @@ func TestDiscoverPopulatesTurnCount(t *testing.T) {
 	}
 	if got[0].Turns != 3 {
 		t.Fatalf("Turns = %d, want 3", got[0].Turns)
+	}
+}
+
+func TestCountUserTurnsCountsBeyondCandidateScanLimit(t *testing.T) {
+	t.Parallel()
+
+	// The candidate scan stops at sessionScanLineLimit (100). The deferred turn
+	// count must not: a long session with user turns well past line 100 must
+	// count all of them, otherwise long sessions are badly under-reported — the
+	// #490 follow-up bug (real ~505 user turns rendered as ~17).
+	var b strings.Builder
+	b.WriteString(`{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-0000000000aa","cwd":"/workspace/app","git_branch":"feat/long"}}` + "\n")
+	const userTurns = 505
+	for i := 0; i < userTurns; i++ {
+		b.WriteString(`{"type":"event_msg","payload":{"type":"user_message","message":"prompt"}}` + "\n")
+		b.WriteString(`{"type":"event_msg","payload":{"type":"agent_message","message":"reply"}}` + "\n")
+	}
+
+	turns, ok := countUserTurnsReader(strings.NewReader(b.String()))
+	if !ok {
+		t.Fatal("countUserTurnsReader() ok = false")
+	}
+	if turns != userTurns {
+		t.Fatalf("turns = %d, want %d (must count past the %d-line candidate limit)", turns, userTurns, sessionScanLineLimit)
+	}
+}
+
+func TestEnrichTurnsCountsBeyondCandidateScanLimit(t *testing.T) {
+	t.Parallel()
+
+	// End-to-end: Discover + enrich on a >100-line log must report the full user
+	// turn count, proving enrichTurns wires through the full-file countUserTurns
+	// path rather than the bounded candidate window.
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "codex", "sessions", "2026", "06", "25")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sessionsDir, "rollout-long.jsonl")
+
+	var b strings.Builder
+	b.WriteString(`{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-0000000000ab","cwd":"/workspace/app","git_branch":"feat/long"}}` + "\n")
+	const userTurns = 250
+	for i := 0; i < userTurns; i++ {
+		b.WriteString(`{"type":"event_msg","payload":{"type":"user_message","message":"prompt"}}` + "\n")
+		b.WriteString(`{"type":"event_msg","payload":{"type":"agent_message","message":"reply"}}` + "\n")
+	}
+	writeFile(t, path, b.String())
+	setModTime(t, path, time.Date(2026, 6, 25, 9, 0, 0, 0, time.UTC))
+
+	got, err := Discover("/workspace/app", DiscoverOptions{
+		CodexSessionsDir: filepath.Join(root, "codex", "sessions"),
+	})
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Discover() len = %d, want 1: %#v", len(got), got)
+	}
+	if got[0].Turns != userTurns {
+		t.Fatalf("Turns = %d, want %d (full-file enrich must count past the %d-line candidate limit)", got[0].Turns, userTurns, sessionScanLineLimit)
 	}
 }
 


### PR DESCRIPTION
## Problem

The resume picker under-counts user turns for long sessions. Observed: a session with **~505** real user turns rendered as **~17**. On a real 6413-line session log the difference is **4 → 269**.

**Cause:** turn counting rode the shared candidate scan, which caps at `sessionScanLineLimit = 100`. Only user turns within the first 100 log lines were counted. That cap originally protected the *synchronous* discovery scan — but #490 moved the turn count into a **deferred background enrich pass**, so the cap no longer buys any initial-render speed for turns.

## Fix

- Add `countUserTurns` / `countUserTurnsReader`: a dedicated **full-file** scan (bounded only by `turnCountLineLimit = 200000` as a pathological-size guard) that tests each line with `isUserTurnRecord` and extracts nothing else, so the full pass stays cheap.
- `enrichTurns` now calls `countUserTurns` instead of the 100-line-capped `scanSessionJSONL(countTurns: true)`.
- Drop the now-unused `countTurns` scan option and `sessionDetails.turns` field.

## User-facing surface

- `projmux ai` resume picker turn column: long sessions now show accurate totals (hundreds) instead of a value clamped at ≤100 lines' worth of turns.

## No regression (non-goals held)

- **Initial render speed unchanged**: discovery still defers turns (`DeferTurns`), the picker still fills the turn column in a background pass over **displayed rows only** (`internal/app/ai.go` `runResumeSessionPicker` untouched), turns still pop in without blocking.
- title/cwd initial scan stays **bounded** (fast path) — only the deferred turn scan goes full-file.
- sort / dedup / cap / #490 progressive structure untouched.
- No schema/engine changes.

## Verification

- `go build ./...` ✓
- `go test ./internal/...` ✓
- `go vet ./internal/integrations/agents/aisessions/...` ✓
- New tests:
  - `TestCountUserTurnsExcludesAgentMessages` — agent_message excluded
  - `TestScanSessionJSONLCountsClaudeUserTurnsExcludingToolResults` — Claude tool_result carriers excluded
  - `TestCountUserTurnsCountsBeyondCandidateScanLimit` — >100-line fixture (505 user turns) counts all
  - `TestEnrichTurnsCountsBeyondCandidateScanLimit` — end-to-end Discover+enrich on 250-turn fixture reports full count
- Real-session before/after (6413 lines): old 100-line cap = **4**, full scan = **269**.

## Not in scope (follow-up)

- Antigravity turn count still unknown (history index carries no per-turn data) — unchanged, renders blank.
- Live tmux picker behavior is unit-covered here; interactive `projmux ai` render is an e2e candidate (not exercised in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)