### PR TITLE
fix(recent-windows): session over drifted cwd for anchor-less badge

### DIFF
--- a/internal/app/recent_window.go
+++ b/internal/app/recent_window.go
@@ -826,19 +826,53 @@ func joinRecentWindowParts(values ...string) string {
 }
 
 // recentWindowSnapshotProject resolves the project badge source for a recorded
-// snapshot. It prefers the session anchor (@projmux_project_path) basename so
-// the badge stays the project name even after the pane cwd drifts into a subdir
-// (the anchor is fixed at session creation, roadmap #488). It falls back to the
-// nearest project-marker basename of the live pane cwd, then the session name,
-// so anchor-less sessions keep their prior behavior with no regression.
+// snapshot, in session-first priority so a drifted pane cwd can never mislabel
+// the window with a foreign project:
+//
+//  1. Session anchor (@projmux_project_path) basename — fixed at session
+//     creation (roadmap #488) so it survives any pane cwd drift (#489).
+//  2. Worktree main-repo resolution — when the pane cwd sits inside a git
+//     worktree, its MAIN repo is unambiguously the session's project (a worktree
+//     of X always belongs to X), so keep resolving it even without an anchor
+//     (#491). This is a resolved project identity, not the cwd's own basename.
+//  3. Session identity — an anchor-less (pre-#488) session's pane cwd may have
+//     drifted into an entirely different sibling repo, so a plain regular-repo
+//     cwd basename is NOT trusted; the session name always reflects the window's
+//     real session (roadmap: recent-windows badge session over drifted cwd).
+//  4. cwd project-marker basename — true last resort, reached only when there is
+//     no session name at all (currentSnapshot guarantees one, so this is purely
+//     defensive and never fires in practice).
 func recentWindowSnapshotProject(anchorPath, panePath, session string) string {
 	if name := recentWindowAnchorProjectName(anchorPath); name != "" {
 		return name
 	}
-	if name := recentWindowProjectName(panePath); name != "" {
+	if name := recentWindowWorktreeProjectName(panePath); name != "" {
 		return name
 	}
-	return strings.TrimSpace(session)
+	if s := strings.TrimSpace(session); s != "" {
+		return s
+	}
+	return recentWindowProjectName(panePath)
+}
+
+// recentWindowWorktreeProjectName resolves the MAIN repo project basename when
+// the pane cwd sits inside (or under) a git worktree, else "". It mirrors
+// recentWindowProjectName's marker walk to find the enclosing project root, then
+// reuses recentWindowWorktreeMainProjectName's pure `.git`-file parse (no git
+// subprocess) to turn a worktree gitlink into its main-repo basename. A regular
+// repo (.git dir), a missing marker, or a non-worktree `.git` file yields "" so
+// the caller prefers the session identity over an untrusted regular-repo cwd
+// basename.
+func recentWindowWorktreeProjectName(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	root := nearestProjectMarker(path, os.TempDir())
+	if root == "" {
+		root = path
+	}
+	return recentWindowWorktreeMainProjectName(root)
 }
 
 // recentWindowAnchorProjectName returns the basename of the session anchor path.

--- a/internal/app/recent_window_test.go
+++ b/internal/app/recent_window_test.go
@@ -1119,8 +1119,11 @@ func TestRecentWindowRecordSnapshotsCurrentTmuxWindow(t *testing.T) {
 	if !reflect.DeepEqual(got.PaneCommands, []string{"codex", "claude", "zsh"}) {
 		t.Fatalf("snapshot pane commands = %+v, want per-pane commands aligned with titles", got.PaneCommands)
 	}
-	if got.Project != filepath.Base(project) {
-		t.Fatalf("snapshot project = %q, want %q", got.Project, filepath.Base(project))
+	// Anchor-less snapshot (empty @projmux_project_path): the regular-repo pane
+	// cwd basename is untrusted (it may be a drifted foreign repo), so the badge
+	// source is the session identity, not the cwd basename.
+	if got.Project != "repos-projmux" {
+		t.Fatalf("snapshot project = %q, want %q (session identity for anchor-less cwd)", got.Project, "repos-projmux")
 	}
 	if got.LastFocusedAt != now {
 		t.Fatalf("snapshot time = %s, want %s", got.LastFocusedAt, now)
@@ -1160,11 +1163,24 @@ func TestRecentWindowSnapshotProjectPriority(t *testing.T) {
 			want:    "projmux",
 		},
 		{
-			name:    "no anchor falls back to marker basename",
+			// Anchor-less session whose pane cwd drifted into a *different*
+			// sibling repo (its own .git dir). The regular-repo basename is NOT
+			// trusted — the session identity must win, else the badge shows the
+			// foreign project (roadmap: badge session over drifted cwd).
+			name:    "no anchor + regular-repo cwd falls back to session identity",
 			anchor:  "",
 			pane:    projectMarkerDir(t),
 			session: "repos-projmux",
-			want:    "projmux-fixture",
+			want:    "repos-projmux",
+		},
+		{
+			// #491 preserved even without an anchor: a worktree's main-repo
+			// resolution is unambiguous, so it beats the session identity.
+			name:    "no anchor + worktree cwd resolves to main repo (#491)",
+			anchor:  "",
+			pane:    worktreeMarkerDir(t),
+			session: "fix-recent-window-session-badge",
+			want:    "projmux",
 		},
 		{
 			name:    "no anchor and no marker falls back to session",
@@ -1200,6 +1216,23 @@ func projectMarkerDir(t *testing.T) string {
 		t.Fatalf("create marker: %v", err)
 	}
 	return filepath.Join(root, "internal", "app")
+}
+
+// worktreeMarkerDir creates a git worktree layout (main repo "projmux" with a
+// worktree whose `.git` is a gitlink file) and returns a subdir inside the
+// worktree, so recentWindowWorktreeProjectName resolves it to the main repo
+// basename "projmux" (#491), independent of any session anchor.
+func worktreeMarkerDir(t *testing.T) string {
+	t.Helper()
+	main := filepath.Join(t.TempDir(), "projmux")
+	worktree := filepath.Join(main, ".wt", "fix", "recent-window-session-badge")
+	sub := filepath.Join(worktree, "internal", "app")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("create worktree subdir: %v", err)
+	}
+	gitdir := filepath.Join(main, ".git", "worktrees", "recent-window-session-badge")
+	writeWorktreeGitFile(t, worktree, "gitdir: "+gitdir+"\n")
+	return sub
 }
 
 func TestRecentWindowRecordUsesSessionAnchorProject(t *testing.T) {


### PR DESCRIPTION
## 문제

recent windows(Alt-3) 뱃지가 **세션과 다른 repo 이름**으로 떴다. 실측:

- `session='repos-donus-db' project='donus-partition-split-lab'` ← **틀림** (세션 프로젝트는 `donus-db`)
- `session='repos-donus' project='donus'` ← 정상

## 원인

`donus-partition-split-lab` 은 별도 형제 repo(worktree 아님, 자체 `.git` dir). 그 창은 `repos-donus-db` 세션인데 pane cwd 가 그 다른 repo 로 드리프트한 채 기록됐다. `repos-donus-db` 는 앵커(`@projmux_project_path`)가 없는 옛 세션(#488 이전)이라, `recentWindowSnapshotProject` 의 fallback 이 **드리프트한 cwd 의 regular-repo basename** 을 세션보다 신뢰했다. #489(앵커 우선)/#491(worktree→main)는 "앵커 없음 + cwd 가 아예 다른 regular repo" 조합을 못 잡았다.

## 수정

`recentWindowSnapshotProject` 를 **세션 우선** 우선순위로 재정렬:

1. **앵커 basename** — 세션 생성 시 고정, cwd 드리프트 무관 (#489)
2. **worktree main-repo 해석** — pane cwd 가 worktree 안이면 main repo 가 곧 세션 프로젝트(모호성 없음)라 앵커 없어도 유지 (#491). cwd 의 basename 이 아니라 *해석된 프로젝트 정체성*.
3. **세션 정체성** — 앵커 없는 세션의 regular-repo cwd basename 은 드리프트한 형제 repo 일 수 있으므로 **신뢰하지 않음**. 세션명이 창의 실제 세션을 항상 반영.
4. cwd project-marker basename — 세션명이 아예 없을 때만 닿는 방어적 최후 수단(`currentSnapshot` 이 세션명을 보장하므로 실사용에선 안 탐).

세션명 de-slug 는 lossy 라 하지 않고 세션명 그대로 노출(드리프트 repo 보다 안전).

## user-facing surface

- recent windows(Alt-3) picker 의 line-1 project 뱃지 텍스트. 색/레이아웃 무변경.

## 회귀 방지 (비목표 준수)

- **#489**(앵커 우선): 무변경 — 앵커 있으면 그대로 앵커 basename.
- **#491**(worktree→main): 유지 — worktree 해석이 세션 정체성보다 우선. `recentWindowProjectName` 함수 및 그 worktree 테스트 그대로.
- 뱃지 색/레이아웃: 무변경.

## 검증

- `go build ./...` ✅
- `go test ./internal/...` ✅ (전체 green)
- `make fmt` / `make deadcode` ✅ (deadcode clean, allowlisted)
- 신규/갱신 테스트 (`internal/app/recent_window_test.go`):
  - 앵커 없음 + regular-repo(다른 repo) cwd → 세션 정체성
  - 앵커 없음 + worktree cwd → main repo (#491, 앵커 무관)
  - 앵커 있음 → 앵커 (#489, 유지)
  - `TestRecentWindowRecordSnapshotsCurrentTmuxWindow`: 앵커 없는 기록 → 세션 정체성으로 갱신

## 미검증 / 후속

- tmux 실제 동작(실 store 재기록으로 기존 드리프트 항목 교정)은 e2e 후보 — 단위 레벨에서만 검증. 재기록 시 앵커 없는 창은 세션명으로 교정된다.
- 옛 세션 앵커 backfill 은 별개 트랙(비범위).

🤖 Generated with [Claude Code](https://claude.com/claude-code)