### PR TITLE
fix(update): npm install -g @latest + installer autodetect + surfaced feedback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GO_FILES := $(shell find . -type f -name '*.go' \
 
 DEADCODE_ALLOWLIST ?= .deadcode-allowlist.txt
 
-.PHONY: fmt fmt-check fix build install npm-pack test test-integration test-install-smoke test-e2e e2e verify deadcode
+.PHONY: fmt fmt-check fix build install npm-pack test test-integration test-install-smoke test-e2e test-e2e-update e2e verify deadcode
 
 build:
 	@mkdir -p $(BUILD_DIR)
@@ -100,6 +100,11 @@ test-install-smoke:
 
 test-e2e:
 	scripts/test-e2e-docker.sh
+
+# Opt-in / local: depends on the public npm registry and published projmux
+# package, so it is not part of `verify`.
+test-e2e-update:
+	scripts/test-e2e-update-docker.sh
 
 e2e: test-e2e
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -705,18 +705,25 @@ fresh cached update is available, the shell welcome uses Enter=Continue,
 `${XDG_CACHE_HOME:-~/.cache}/projmux/update-skip.json` and suppresses that tag
 until a newer latest release appears.
 
-Installer detection honors
-`PROJMUX_INSTALLER=npm|go|github-release|source`. When unset or invalid,
-the source is reported as `unknown` with guidance to set the variable.
+Installer detection honors an explicit
+`PROJMUX_INSTALLER=npm|go|github-release|source` first. When it is unset,
+detection falls back to inspecting the running binary: an npm install tree
+(`node_modules/@projmux/...`) is reported as `npm`, a `go install …@latest`
+binary in `$GOBIN`/`$GOPATH/bin`/`~/go/bin` as `go`, and a local `go build`
+(`make install`) — which reports a `(devel)` main-module version — as `source`.
+`github-release` installs are indistinguishable from a hand-placed binary and
+still require an explicit `PROJMUX_INSTALLER=github-release`. Anything else is
+reported as `unknown` with guidance.
 `apply` is installer-aware and only runs after explicit user selection.
-For npm installs, it runs `npm update -g projmux` and then
-`projmux tmux apply` unless `--no-apply` is set. For Go installs, it
-delegates to the existing atomic `projmux upgrade` flow. For
-`github-release` installs, it downloads the latest matching
-`projmux_<version>_<goos>_<goarch>.tar.gz` release asset, extracts the
+For npm installs, it runs `npm install -g projmux@latest` (which reliably
+crosses minor/major versions where `npm update -g` does not, and re-resolves
+the per-platform optional dependency) and then `projmux tmux apply` unless
+`--no-apply` is set. For Go installs, it delegates to the existing atomic
+`projmux upgrade` flow. For `github-release` installs, it downloads the latest
+matching `projmux_<version>_<goos>_<goarch>.tar.gz` release asset, extracts the
 binary, atomically replaces the current executable, then applies tmux
 configuration unless `--no-apply` is set. `source` installs report an
-actionable error because they must be updated from the source checkout.
+actionable error to update the checkout with `git pull --ff-only && make install`.
 
 ## upgrade
 
@@ -729,7 +736,7 @@ projmux upgrade [--ref @latest|@<tag>|@<branch>]
 runs `projmux tmux apply` (skipped with `--no-apply`). Reads
 `PROJMUX_PROJDIR` from the calling shell and memoizes the primary entry
 to `~/.config/projmux/projdir`. npm-installed binaries reject this
-command; use `projmux update apply` or `npm update -g projmux` for npm
+command; use `projmux update apply` or `npm install -g projmux@latest` for npm
 installs.
 
 ## welcome

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -25,10 +25,18 @@ projmux update apply
 Use `--dry-run` to see the planned action and `--no-apply` to skip reloading
 the live tmux config after the binary changes.
 
-Shell Upgrade invokes only `projmux update apply`. Shell Skip until next stores
-the current latest release tag in `update-skip.json`; the prompt appears again
-when the cached latest tag changes. For `source` and unknown installer sources,
-Upgrade prints guidance and continues shell entry without applying anything.
+Shell Upgrade invokes only `projmux update apply`, then reports success or the
+specific failure inline and continues into the shell either way (a failed
+upgrade is never fatal to shell entry). Shell Skip until next stores the current
+latest release tag in `update-skip.json`; the prompt appears again when the
+cached latest tag changes. For `source` and unknown installer sources, Upgrade
+prints guidance and continues shell entry without applying anything.
+
+The installer is detected from an explicit `PROJMUX_INSTALLER` first, then
+inferred from the running binary when unset (npm install tree → `npm`,
+`go install …@latest` binary in `$GOBIN`/`$GOPATH/bin`/`~/go/bin` → `go`, a
+local `go build`/`make install` `(devel)` binary → `source`). `github-release`
+still requires an explicit `PROJMUX_INSTALLER=github-release`.
 
 ## Behavior Changes
 
@@ -118,12 +126,20 @@ npm install -g projmux
 For npm-managed installs, `projmux update apply` runs:
 
 ```sh
-npm update -g projmux
+npm install -g projmux@latest
 projmux tmux apply
 ```
 
+`npm install -g projmux@latest` is used instead of `npm update -g projmux`
+because `npm update -g` honors the installed semver range and frequently
+refuses to move a global install across a newer minor/major release, leaving it
+stuck on an old version. `install -g …@latest` always fetches the newest
+published release and re-resolves the per-platform optional dependency.
+
 The npm shim sets `PROJMUX_INSTALLER=npm` so projmux can detect this path
-automatically. You can also update manually with `npm update -g projmux`.
+automatically. Even when the shim is bypassed, projmux infers the npm install
+from the binary path (`node_modules/@projmux/...`). You can also update manually
+with `npm install -g projmux@latest`.
 
 ## Go Installs
 

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -5383,9 +5383,22 @@ func (c *settingsCommand) execute(value string, stdout, stderr io.Writer) error 
 		action := strings.TrimPrefix(value, settingsActionPrefixUpdate)
 		switch action {
 		case "apply":
-			return c.update.Run([]string{"apply"}, stdout, stderr)
+			// Surface success/failure inline and keep Settings open rather
+			// than closing the whole UI on a handled update error (e.g. a
+			// source/unknown install that cannot auto-update). The Installer
+			// row already carries the manual guidance.
+			if err := c.update.Run([]string{"apply"}, stdout, stderr); err != nil {
+				_, _ = fmt.Fprintf(stdout, "Update failed: %v\n", err)
+				return nil
+			}
+			_, _ = fmt.Fprintln(stdout, "Update complete. Restart projmux to run the new version.")
+			return nil
 		case "check":
-			return c.update.Run([]string{"check"}, stdout, stderr)
+			if err := c.update.Run([]string{"check"}, stdout, stderr); err != nil {
+				_, _ = fmt.Fprintf(stdout, "Update check failed: %v\n", err)
+				return nil
+			}
+			return nil
 		default:
 			return fmt.Errorf("unknown update settings action: %s", action)
 		}

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -6202,7 +6202,7 @@ func TestSettingsHubRunsUpdateApplyAction(t *testing.T) {
 	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	want := []string{"npm update -g projmux", "projmux tmux apply"}
+	want := []string{"npm install -g projmux@latest", "projmux tmux apply"}
 	if !equalStrings(ran, want) {
 		t.Fatalf("ran = %#v, want %#v", ran, want)
 	}

--- a/internal/app/shell_test.go
+++ b/internal/app/shell_test.go
@@ -946,7 +946,7 @@ func TestShellWelcomeAppliesInlineUpdate(t *testing.T) {
 	if err := cmd.Run([]string{"--no-install"}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	wantCommands := []string{"npm update -g projmux", "projmux tmux apply"}
+	wantCommands := []string{"npm install -g projmux@latest", "projmux tmux apply"}
 	if !reflect.DeepEqual(updateCommands, wantCommands) {
 		t.Fatalf("update commands = %#v, want %#v", updateCommands, wantCommands)
 	}
@@ -1187,10 +1187,58 @@ func TestShellWelcomeUnsupportedInstallerShowsGuidanceAndContinues(t *testing.T)
 	if recorder.name != "tmux" {
 		t.Fatalf("shell did not continue into tmux, command = %q", recorder.name)
 	}
-	for _, want := range []string{"Upgrade guidance", "source", "update from the source checkout"} {
+	for _, want := range []string{"Upgrade guidance", "source", "make install"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 		}
+	}
+}
+
+func TestShellWelcomeSurfacesUpdateFailureAndContinues(t *testing.T) {
+	now := time.Date(2026, 5, 10, 12, 34, 56, 0, time.UTC)
+	update, cacheDir := testUpdateCommand(t, now)
+	update.getenv = func(name string) string {
+		if name == "PROJMUX_INSTALLER" {
+			return "npm"
+		}
+		return ""
+	}
+	update.runExternal = func(name string, args []string, stdout, stderr io.Writer) error {
+		return fmt.Errorf("npm registry unreachable")
+	}
+	writeUpdateCacheFixture(t, cacheDir, updateCache{
+		Version:     1,
+		CheckedAt:   now,
+		TagName:     testVersionTag(t, 1),
+		PublishedAt: now,
+	})
+
+	home := t.TempDir()
+	recorder := &recordingShellRunner{}
+	cmd := &shellCommand{
+		executable:   func() (string, error) { return "/tmp/projmux", nil },
+		lookupEnv:    func(string) string { return "" },
+		homeDir:      func() (string, error) { return home, nil },
+		welcomeInput: strings.NewReader("u\n"),
+		writeFile:    os.WriteFile,
+		runCommand:   recorder.run,
+		update:       update,
+		nativePicker: nativePickerFromCompatRunner(shellUpdateRunnerFunc(func(options intpickercompat.Options) (intpickercompat.Result, error) {
+			t.Fatalf("unexpected separate update prompt: %#v", options)
+			return intpickercompat.Result{}, nil
+		})),
+	}
+	markShellWelcomed(t, cmd)
+
+	var stdout bytes.Buffer
+	if err := cmd.Run(nil, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v, update failure must not block shell entry", err)
+	}
+	if recorder.name != "tmux" {
+		t.Fatalf("shell did not continue into tmux after failed update, command = %q", recorder.name)
+	}
+	if !strings.Contains(stdout.String(), "Update failed") {
+		t.Fatalf("stdout = %q, want failure surfaced", stdout.String())
 	}
 }
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -49,6 +50,8 @@ type updateCommand struct {
 	chmod       func(name string, mode os.FileMode) error
 	remove      func(name string) error
 	copyFile    func(src, dst string) error
+	buildInfo   func() (*debug.BuildInfo, bool)
+	userHomeDir func() (string, error)
 }
 
 type updateCache struct {
@@ -106,6 +109,8 @@ func newUpdateCommand() *updateCommand {
 		chmod:       os.Chmod,
 		remove:      os.Remove,
 		copyFile:    copyRegularFile,
+		buildInfo:   debug.ReadBuildInfo,
+		userHomeDir: os.UserHomeDir,
 	}
 }
 
@@ -185,7 +190,12 @@ func (c updateApplyCommand) String() string {
 func (c *updateCommand) applyCommands(source string, noApply bool) ([]updateApplyCommand, error) {
 	switch source {
 	case "npm":
-		commands := []updateApplyCommand{{Name: "npm", Args: []string{"update", "-g", "projmux"}}}
+		// `npm update -g` honors the installed semver range and frequently
+		// refuses to cross into a newer minor/major, so global installs get
+		// stuck on an old version. `npm install -g projmux@latest` always
+		// pulls the newest published release and re-resolves the per-platform
+		// optionalDependency, which is what "update" must actually do.
+		commands := []updateApplyCommand{{Name: "npm", Args: []string{"install", "-g", "projmux@latest"}}}
 		if !noApply {
 			commands = append(commands, updateApplyCommand{Name: "projmux", Args: []string{"tmux", "apply"}})
 		}
@@ -203,9 +213,9 @@ func (c *updateCommand) applyCommands(source string, noApply bool) ([]updateAppl
 	case "github-release":
 		return nil, errors.New("update apply for github-release installs is handled by direct release binary replacement")
 	case "source":
-		return nil, errors.New("update apply for source installs is not supported; update the source checkout and rebuild")
+		return nil, errors.New("update apply is not available for source installs; update the checkout with `git pull --ff-only && make install`")
 	default:
-		return nil, errors.New("update apply requires PROJMUX_INSTALLER=npm, PROJMUX_INSTALLER=go, or PROJMUX_INSTALLER=github-release")
+		return nil, errors.New("update apply could not detect a supported installer; run from an npm/go/github-release install or set PROJMUX_INSTALLER=npm|go|github-release (source installs update with `git pull --ff-only && make install`)")
 	}
 }
 
@@ -659,20 +669,134 @@ func (c *updateCommand) detectInstaller() updateInstaller {
 	if c.getenv != nil {
 		source = strings.TrimSpace(c.getenv("PROJMUX_INSTALLER"))
 	}
+	// An explicit PROJMUX_INSTALLER always wins. Only fall back to
+	// autodetection when it is unset so that update apply works even when the
+	// binary was not launched through the npm shim (which is the only path
+	// that exports the variable today).
+	autodetected := false
+	if source == "" {
+		source = c.autodetectInstaller()
+		autodetected = source != ""
+	}
 	switch source {
 	case "npm":
-		return updateInstaller{Source: source, Note: "Installed by npm shim; update with projmux update apply or npm update -g projmux."}
+		note := "Installed by npm; update apply runs `npm install -g projmux@latest`."
+		if autodetected {
+			note = "Detected npm install; update apply runs `npm install -g projmux@latest`."
+		}
+		return updateInstaller{Source: source, Note: note}
 	case "go":
-		return updateInstaller{Source: source, Note: "Installed with Go tooling; update apply delegates to projmux upgrade."}
+		note := "Installed with Go tooling; update apply delegates to projmux upgrade."
+		if autodetected {
+			note = "Detected `go install` binary; update apply delegates to projmux upgrade."
+		}
+		return updateInstaller{Source: source, Note: note}
 	case "github-release":
 		return updateInstaller{Source: source, Note: "Installed from a GitHub release binary; update apply replaces the current binary atomically."}
 	case "source":
-		return updateInstaller{Source: source, Note: "Installed from source; update from the source checkout until update apply exists."}
+		note := "Installed from source; update with `git pull --ff-only && make install`."
+		if autodetected {
+			note = "Detected source build; update with `git pull --ff-only && make install` (not auto-updated)."
+		}
+		return updateInstaller{Source: source, Note: note}
 	case "":
-		return updateInstaller{Source: "unknown", Note: "Set PROJMUX_INSTALLER=npm|go|github-release|source to make update guidance installer-aware."}
+		return updateInstaller{Source: "unknown", Note: "Could not detect the installer. Set PROJMUX_INSTALLER=npm|go|github-release, or update source builds with `git pull --ff-only && make install`."}
 	default:
 		return updateInstaller{Source: "unknown", Note: "Unrecognized PROJMUX_INSTALLER=" + source + "; expected npm|go|github-release|source."}
 	}
+}
+
+// autodetectInstaller infers the installer source from the running binary when
+// PROJMUX_INSTALLER is unset. It only recognizes the distribution channels that
+// can be updated in place (npm and go install) plus source builds, which it
+// reports so callers can print manual guidance instead of failing silently.
+// github-release installs are indistinguishable from a hand-placed binary
+// without a marker, so they continue to require an explicit PROJMUX_INSTALLER.
+func (c *updateCommand) autodetectInstaller() string {
+	exe := ""
+	if c.executable != nil {
+		if resolved, err := c.executable(); err == nil {
+			exe = strings.TrimSpace(resolved)
+		}
+	}
+	if exe != "" && isNpmExecutablePath(exe) {
+		return "npm"
+	}
+	// A binary produced by `go build`/`make install` from a local checkout
+	// reports a "(devel)" main module version, while `go install …@latest`
+	// stamps the resolved tag. This is the only reliable way to tell a source
+	// build apart from a go-install binary when both live in GOBIN/~/go/bin.
+	if c.isSourceBuild() {
+		return "source"
+	}
+	if exe != "" && c.isGoInstallPath(exe) {
+		return "go"
+	}
+	return ""
+}
+
+// isNpmExecutablePath reports whether the resolved binary lives inside an npm
+// install tree. The npm platform packages install the real binary at
+// node_modules/@projmux/<platform>/bin/projmux.
+func isNpmExecutablePath(exe string) bool {
+	normalized := filepath.ToSlash(exe)
+	if !strings.Contains(normalized, "node_modules/") {
+		return false
+	}
+	return strings.Contains(normalized, "/@projmux/") || strings.Contains(normalized, "node_modules/projmux/")
+}
+
+func (c *updateCommand) isSourceBuild() bool {
+	if c.buildInfo == nil {
+		return false
+	}
+	info, ok := c.buildInfo()
+	if !ok || info == nil {
+		return false
+	}
+	v := strings.TrimSpace(info.Main.Version)
+	return v == "" || v == "(devel)"
+}
+
+// isGoInstallPath reports whether exe sits in the directory `go install` writes
+// to: $GOBIN, else $GOPATH/bin, else ~/go/bin.
+func (c *updateCommand) isGoInstallPath(exe string) bool {
+	dir := filepath.Dir(exe)
+	for _, candidate := range c.goInstallDirs() {
+		if candidate == "" {
+			continue
+		}
+		if filepath.Clean(candidate) == filepath.Clean(dir) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *updateCommand) goInstallDirs() []string {
+	getenv := c.getenv
+	if getenv == nil {
+		getenv = func(string) string { return "" }
+	}
+	var dirs []string
+	if gobin := strings.TrimSpace(getenv("GOBIN")); gobin != "" {
+		dirs = append(dirs, gobin)
+	}
+	if gopath := strings.TrimSpace(getenv("GOPATH")); gopath != "" {
+		for _, p := range filepath.SplitList(gopath) {
+			if p = strings.TrimSpace(p); p != "" {
+				dirs = append(dirs, filepath.Join(p, "bin"))
+			}
+		}
+	}
+	if c.userHomeDir != nil {
+		if home, err := c.userHomeDir(); err == nil {
+			if home = strings.TrimSpace(home); home != "" {
+				dirs = append(dirs, filepath.Join(home, "go", "bin"))
+			}
+		}
+	}
+	return dirs
 }
 
 func (c *updateCommand) currentExecutable() (string, error) {

--- a/internal/app/update_test.go
+++ b/internal/app/update_test.go
@@ -10,12 +10,125 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/crevissepartners/projmux/internal/version"
 )
+
+func buildInfoWithVersion(v string) func() (*debug.BuildInfo, bool) {
+	return func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Main: debug.Module{Version: v}}, true
+	}
+}
+
+func TestDetectInstallerAutodetection(t *testing.T) {
+	t.Parallel()
+
+	const homeDir = "/home/tester"
+	goBin := filepath.Join(homeDir, "go", "bin", "projmux")
+	npmBin := "/usr/lib/node_modules/@projmux/linux-x64/bin/projmux"
+
+	tests := []struct {
+		name       string
+		env        map[string]string
+		exe        string
+		buildInfo  func() (*debug.BuildInfo, bool)
+		wantSource string
+		wantNote   string
+	}{
+		{
+			name:       "explicit env wins over path",
+			env:        map[string]string{"PROJMUX_INSTALLER": "npm"},
+			exe:        goBin,
+			buildInfo:  buildInfoWithVersion("v0.7.2"),
+			wantSource: "npm",
+			wantNote:   "Installed by npm",
+		},
+		{
+			name:       "npm path detected without env",
+			exe:        npmBin,
+			buildInfo:  buildInfoWithVersion("v0.7.2"),
+			wantSource: "npm",
+			wantNote:   "Detected npm install",
+		},
+		{
+			name:       "devel build detected as source",
+			exe:        goBin,
+			buildInfo:  buildInfoWithVersion("(devel)"),
+			wantSource: "source",
+			wantNote:   "make install",
+		},
+		{
+			name:       "go install in home go bin",
+			exe:        goBin,
+			buildInfo:  buildInfoWithVersion("v0.7.2"),
+			wantSource: "go",
+			wantNote:   "Detected `go install`",
+		},
+		{
+			name:       "go install honors GOBIN",
+			env:        map[string]string{"GOBIN": "/opt/gobin"},
+			exe:        "/opt/gobin/projmux",
+			buildInfo:  buildInfoWithVersion("v0.7.2"),
+			wantSource: "go",
+			wantNote:   "Detected `go install`",
+		},
+		{
+			name:       "unrecognized path stays unknown",
+			exe:        "/usr/local/bin/projmux",
+			buildInfo:  buildInfoWithVersion("v0.7.2"),
+			wantSource: "unknown",
+			wantNote:   "Could not detect the installer",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd, _ := testUpdateCommand(t, time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC))
+			env := tc.env
+			cmd.getenv = func(name string) string { return env[name] }
+			cmd.executable = func() (string, error) { return tc.exe, nil }
+			cmd.buildInfo = tc.buildInfo
+			cmd.userHomeDir = func() (string, error) { return homeDir, nil }
+
+			got := cmd.detectInstaller()
+			if got.Source != tc.wantSource {
+				t.Fatalf("detectInstaller() source = %q, want %q", got.Source, tc.wantSource)
+			}
+			if !strings.Contains(got.Note, tc.wantNote) {
+				t.Fatalf("detectInstaller() note = %q, want substring %q", got.Note, tc.wantNote)
+			}
+		})
+	}
+}
+
+func TestUpdateApplyNpmUsesInstallLatest(t *testing.T) {
+	t.Parallel()
+
+	cmd, _ := testUpdateCommand(t, time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC))
+	cmd.getenv = func(name string) string {
+		if name == "PROJMUX_INSTALLER" {
+			return "npm"
+		}
+		return ""
+	}
+	var ran []string
+	cmd.runExternal = func(name string, args []string, stdout, stderr io.Writer) error {
+		ran = append(ran, updateApplyCommand{Name: name, Args: args}.String())
+		return nil
+	}
+	if err := cmd.Run([]string{"apply", "--no-apply"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	want := []string{"npm install -g projmux@latest"}
+	if len(ran) != 1 || ran[0] != want[0] {
+		t.Fatalf("ran = %#v, want %#v", ran, want)
+	}
+}
 
 type updateRoundTripFunc func(*http.Request) (*http.Response, error)
 
@@ -61,7 +174,7 @@ func TestUpdateStatusUnknownWithoutCache(t *testing.T) {
 		"current:   " + version.String(),
 		"latest:    unknown (unknown)",
 		"state:     unknown",
-		"installer: unknown - Set PROJMUX_INSTALLER=npm|go|github-release|source",
+		"installer: unknown - Could not detect the installer. Set PROJMUX_INSTALLER=npm|go|github-release",
 		filepath.Join(cacheDir, updateCacheFileName),
 	} {
 		if !strings.Contains(out, want) {
@@ -195,7 +308,7 @@ func TestUpdateApplyDryRunForNPM(t *testing.T) {
 	}
 	out := stdout.String()
 	for _, want := range []string{
-		"would run: npm update -g projmux",
+		"would run: npm install -g projmux@latest",
 		"would run: projmux tmux apply",
 	} {
 		if !strings.Contains(out, want) {
@@ -223,7 +336,7 @@ func TestUpdateApplyRunsNPMCommands(t *testing.T) {
 	if err := cmd.Run([]string{"apply"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	want := []string{"npm update -g projmux", "projmux tmux apply"}
+	want := []string{"npm install -g projmux@latest", "projmux tmux apply"}
 	if !equalStrings(ran, want) {
 		t.Fatalf("ran = %#v, want %#v", ran, want)
 	}
@@ -389,8 +502,8 @@ func TestUpdateApplyRejectsUnsupportedInstallers(t *testing.T) {
 		installer string
 		want      string
 	}{
-		{name: "unknown", installer: "", want: "PROJMUX_INSTALLER=github-release"},
-		{name: "source", installer: "source", want: "not supported"},
+		{name: "unknown", installer: "", want: "could not detect a supported installer"},
+		{name: "source", installer: "source", want: "not available for source installs"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/app/upgrade.go
+++ b/internal/app/upgrade.go
@@ -80,7 +80,7 @@ func (c *upgradeCommand) Run(args []string, stdout, stderr io.Writer) error {
 	}
 
 	if source := c.installerSource(); source == "npm" {
-		return errors.New("projmux upgrade is for Go/source installs; npm installs should run 'projmux update apply' or 'npm update -g projmux'")
+		return errors.New("projmux upgrade is for Go/source installs; npm installs should run 'projmux update apply' or 'npm install -g projmux@latest'")
 	}
 
 	opts := upgradeOptions{

--- a/internal/app/upgrade_test.go
+++ b/internal/app/upgrade_test.go
@@ -227,7 +227,7 @@ func TestUpgradeRunRejectsNPMInstaller(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Run() error = nil, want npm installer rejection")
 	}
-	for _, want := range []string{"npm installs", "projmux update apply", "npm update -g projmux"} {
+	for _, want := range []string{"npm installs", "projmux update apply", "npm install -g projmux@latest"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("Run() error = %v, want %q", err, want)
 		}

--- a/internal/app/welcome.go
+++ b/internal/app/welcome.go
@@ -62,8 +62,15 @@ func (c *shellCommand) promptWelcome(stdout, stderr io.Writer) (bool, error) {
 			return true, nil
 		}
 		if err := c.update.Run([]string{"apply"}, stdout, stderr); err != nil {
-			return true, fmt.Errorf("run shell welcome update: %w", err)
+			// Surface the failure but never block shell entry on it: the user
+			// asked to enter the shell, and a failed upgrade should be visible,
+			// not fatal.
+			_, _ = fmt.Fprintf(stdout, "Update failed: %v\n", err)
+			_, _ = fmt.Fprintln(stdout, "Continuing shell entry; retry later with `projmux update apply`.")
+			return true, nil
 		}
+		_, _ = fmt.Fprintf(stdout, "Updated projmux from %s to %s. Restart projmux shell to run the new version.\n",
+			strings.TrimSpace(status.CurrentVersion), strings.TrimSpace(status.LatestVersion))
 	default:
 	}
 	return true, nil

--- a/scripts/test-docker-run.sh
+++ b/scripts/test-docker-run.sh
@@ -13,6 +13,9 @@ shift
 image="${PROJMUX_TEST_IMAGE:-projmux:test-linux}"
 dockerfile="${PROJMUX_TEST_DOCKERFILE:-$root/test/docker/Dockerfile}"
 docker_context="${PROJMUX_TEST_DOCKER_CONTEXT:-$root/test/docker}"
+# Suites are network-isolated by default. Suites that must reach a real
+# registry (e.g. the npm update-flow e2e) override this to "bridge".
+docker_network="${PROJMUX_TEST_DOCKER_NETWORK:-none}"
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker is required for this test target" >&2
@@ -26,7 +29,7 @@ docker build \
   "$docker_context"
 
 docker run --rm \
-  --network none \
+  --network "$docker_network" \
   --user "$(id -u):$(id -g)" \
   -e HOME=/tmp/projmux-home \
   -e XDG_CACHE_HOME=/tmp/projmux-cache \

--- a/scripts/test-e2e-update-docker.sh
+++ b/scripts/test-e2e-update-docker.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# npm update-flow e2e. Unlike the network-isolated smoke suite this one must
+# reach the public npm registry, so it uses a Node.js-capable image and a
+# bridged network. It depends on the published `projmux` npm package, so it is
+# opt-in / local rather than a required CI gate.
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+export PROJMUX_TEST_IMAGE="${PROJMUX_TEST_IMAGE:-projmux:test-node}"
+export PROJMUX_TEST_DOCKERFILE="${PROJMUX_TEST_DOCKERFILE:-$root/test/docker/Dockerfile.node}"
+export PROJMUX_TEST_DOCKER_NETWORK="${PROJMUX_TEST_DOCKER_NETWORK:-bridge}"
+
+exec "$root/scripts/test-docker-run.sh" test/e2e/update-flow.sh "$@"

--- a/test/docker/Dockerfile.node
+++ b/test/docker/Dockerfile.node
@@ -1,0 +1,21 @@
+# Image for the npm update-flow e2e: Go (to build the binary under test) plus
+# Node.js and npm (to exercise the real `npm install -g projmux@latest` path
+# against the public registry).
+FROM golang:1.25-trixie
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV GOTOOLCHAIN=local
+ENV PATH=/go/bin:$PATH
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    coreutils \
+    git \
+    make \
+    nodejs \
+    npm \
+    tmux \
+  && rm -rf /var/lib/apt/lists/*
+WORKDIR /workspace

--- a/test/e2e/update-flow.sh
+++ b/test/e2e/update-flow.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# npm update-flow e2e.
+#
+# Proves the npm update fix end to end against the real registry:
+#   1. install an older published projmux globally via npm
+#   2. run the freshly-built (fixed) binary's `update apply`, which must run
+#      `npm install -g projmux@latest` (not the old `npm update -g`, which
+#      frequently refuses to cross a newer minor/major and leaves the install
+#      stuck on the old version)
+#   3. assert the global `projmux` is now the latest published version
+#   4. (bonus) assert installer autodetection reports `npm` from an npm-shaped
+#      binary path even when PROJMUX_INSTALLER is unset
+#
+# This depends on the public npm registry and the published `projmux` package,
+# so it is opt-in / local rather than a required CI gate. It skips cleanly when
+# the registry is unreachable or too few versions are published.
+
+fail() { echo "update-flow e2e: $*" >&2; exit 1; }
+skip() { echo "update-flow e2e SKIP: $*" >&2; exit 0; }
+
+# Non-root container user cannot write the default global prefix; point npm at
+# writable dirs under HOME.
+export HOME="${HOME:-/tmp/projmux-home}"
+mkdir -p "$HOME"
+export NPM_CONFIG_PREFIX="$HOME/.npm-global"
+export NPM_CONFIG_CACHE="$HOME/.npm-cache"
+export NPM_CONFIG_UPDATE_NOTIFIER=false
+export NPM_CONFIG_FUND=false
+export NPM_CONFIG_AUDIT=false
+mkdir -p "$NPM_CONFIG_PREFIX/bin" "$NPM_CONFIG_CACHE"
+export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
+
+command -v node >/dev/null 2>&1 || fail "node is required"
+command -v npm >/dev/null 2>&1 || fail "npm is required"
+command -v go >/dev/null 2>&1 || fail "go is required to build the binary under test"
+
+echo ">> npm $(npm --version), node $(node --version)"
+
+if ! npm ping >/dev/null 2>&1; then
+  skip "npm registry unreachable (this suite needs network; run with a bridged network)"
+fi
+
+versions_json="$(npm view projmux versions --json 2>/dev/null)" || skip "cannot query published projmux versions"
+latest="$(npm view projmux version 2>/dev/null || true)"
+[ -n "$latest" ] || skip "no published projmux latest dist-tag"
+
+# Pick the newest published version that is not the current latest.
+older="$(node -e '
+  const versions = JSON.parse(process.argv[1]);
+  const arr = Array.isArray(versions) ? versions : [versions];
+  const latest = process.argv[2];
+  const older = arr.filter((v) => v !== latest);
+  console.log(older.length ? older[older.length - 1] : "");
+' "$versions_json" "$latest")"
+[ -n "$older" ] || skip "need at least two published versions to test an upgrade (latest=$latest)"
+
+echo ">> published older=$older latest=$latest"
+
+# Step 1: install the older version globally and confirm it is active.
+npm install -g "projmux@$older" >/dev/null 2>&1 || fail "npm install -g projmux@$older failed"
+got_old="$(projmux version 2>/dev/null || true)"
+echo ">> before update: $got_old"
+echo "$got_old" | grep -Fq "$older" || fail "expected installed version $older, got: $got_old"
+
+# Step 2: build the fixed binary under test from the mounted source tree.
+build="$(mktemp -d)"
+( cd /workspace && go build -o "$build/projmux" ./cmd/projmux ) || fail "go build ./cmd/projmux failed"
+
+# Guard: the fixed apply must plan `npm install -g projmux@latest`.
+fixed_plan="$(PROJMUX_INSTALLER=npm "$build/projmux" update apply --dry-run --no-apply 2>&1)" || fail "fixed apply --dry-run failed: $fixed_plan"
+echo "$fixed_plan" | grep -Fq "npm install -g projmux@latest" \
+  || fail "fixed apply plan missing 'npm install -g projmux@latest': $fixed_plan"
+
+# Step 3: run the fixed apply for real (skip tmux reload; not the focus here).
+PROJMUX_INSTALLER=npm "$build/projmux" update apply --no-apply || fail "update apply failed"
+
+# Step 4: the global projmux must now be the latest published version.
+got_new="$(projmux version 2>/dev/null || true)"
+echo ">> after update: $got_new"
+echo "$got_new" | grep -Fq "$latest" || fail "after update expected $latest, got: $got_new"
+[ "$older" != "$latest" ] && echo "$got_new" | grep -Fq "$older" \
+  && fail "still reporting old version $older after update: $got_new"
+echo ">> PASS: upgraded $older -> $latest via fixed 'update apply'"
+
+# Step 5 (bonus): installer autodetection from an npm-shaped path with the env
+# hint removed. Copy the fixed binary into a node_modules/@projmux layout and
+# confirm `update status` self-reports source=npm without PROJMUX_INSTALLER.
+npmshape="$build/node_modules/@projmux/linux-x64/bin"
+mkdir -p "$npmshape"
+cp "$build/projmux" "$npmshape/projmux"
+detected="$(env -u PROJMUX_INSTALLER "$npmshape/projmux" update status --json 2>/dev/null || true)"
+echo "$detected" | grep -Fq '"source": "npm"' \
+  || fail "autodetection did not report npm from npm-shaped path: $detected"
+echo ">> PASS: installer autodetection reports npm without PROJMUX_INSTALLER"
+
+echo ">> update-flow e2e complete"


### PR DESCRIPTION
## Problem

welcome gate `u` (Upgrade) and Settings > About > Update did **nothing for npm users**, and failures were silent.

Two root causes:
- **npm command**: `update apply`'s npm branch ran `npm update -g projmux`. `npm update -g` honors the installed semver range and frequently refuses to cross into a newer minor/major, so global installs stay stuck on an old version.
- **installer detection**: the source was read **only** from `PROJMUX_INSTALLER`, which is exported by the npm shim alone. A binary run directly (not via the shim) fell through to a silent apply error.

## Completed

**npm command fix (core)**
- npm apply now runs `npm install -g projmux@latest` — reliably fetches the newest published release and re-resolves the per-platform `optionalDependency`.

**Installer autodetection (env-unset fallback, distribution channels only)**
- `detectInstaller()` infers the source when `PROJMUX_INSTALLER` is unset:
  - npm install tree (`node_modules/@projmux/...`) → `npm`
  - `go install …@latest` binary in `$GOBIN` / `$GOPATH/bin` / `~/go/bin` → `go`
  - local `go build` / `make install` binary (reports `(devel)` main-module version via `debug.ReadBuildInfo`) → `source`
- Explicit `PROJMUX_INSTALLER` **still wins**. `github-release` is indistinguishable from a hand-placed binary without a marker, so it **still requires an explicit hint** (unchanged, documented).
- The `(devel)` check is what cleanly separates a source `make install` from a `go install @latest` binary when both live in `~/go/bin` — this **protects dev builds** from being clobbered by a remote `@latest`.

**Feedback surfacing (silent no-op removed)**
- welcome `u`: prints success (`Updated projmux from X to Y…`) or the specific failure inline; a failed upgrade **no longer aborts shell entry**.
- Settings > About > Update Now / Check Updates: surface success/failure inline and keep Settings open instead of closing the whole UI on a handled error.
- source/unknown installers show short `git pull --ff-only && make install` guidance.

## User-facing surfaces touched
- `internal/app/update.go` — npm command, autodetection, installer notes/errors
- `internal/app/welcome.go` — shell welcome `u` success/failure surfacing
- `internal/app/settings.go` — About Update Now/Check inline outcome
- `internal/app/upgrade.go` — npm guidance string
- `docs/upgrading.md`, `docs/cli.md`

## Explicitly out of scope (no regression)
- **source-build auto-update is not implemented** — source is guidance-only.
- github-release apply path and explicit-env precedence are unchanged.

## Docker e2e (new)
`test/e2e/update-flow.sh` + `scripts/test-e2e-update-docker.sh` + `make test-e2e-update` (node+go image, bridged network):
1. `npm install -g projmux@<older>` → assert `projmux version` == older
2. build the fixed binary from source, run `PROJMUX_INSTALLER=npm <fixed> update apply` (the `npm install -g projmux@latest` path)
3. assert the global `projmux version` == latest published
4. bonus: assert npm autodetection from an npm-shaped path with `PROJMUX_INSTALLER` unset

Opt-in/local (depends on the public npm registry); **not** wired into `make verify`.

## Verification (all passing locally)
- `go build ./...`, `go vet ./internal/app`
- `go test ./...` (incl. new `TestDetectInstallerAutodetection`, `TestUpdateApplyNpmUsesInstallLatest`, `TestShellWelcomeSurfacesUpdateFailureAndContinues`)
- `make fmt-check`
- `make test-e2e-update` → PASS (upgraded `0.7.1 → 0.7.2` via fixed apply; autodetect reported npm)
- `make test-e2e` (existing smoke) → PASS (confirms the network-param change to the shared runner defaults to `--network none`)

## Unverified / follow-ups
- The e2e proves the positive path with the two currently-published versions (`0.7.1`/`0.7.2`, a patch bump). A deterministic contrast against `npm update -g` failing needs a minor/major gap in published versions; the buggy-command behavior is documented and unit-covered by the exact-command assertions.
- github-release autodetection (marker) remains a future item — still explicit-env only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
