### PR TITLE
fix(recent-windows): de-slug project badge via shared display-name wrapper

### DIFF
--- a/internal/app/recent_window.go
+++ b/internal/app/recent_window.go
@@ -285,11 +285,11 @@ func (c *recentWindowCommand) currentSnapshot(ctx context.Context) (recentwindow
 		Session:    fields[1],
 		WindowID:   fields[2],
 		WindowName: fields[3],
-		Project: projectidentity.Resolve(projectidentity.Inputs{
+		Project: resolveProjectDisplayName(projectidentity.Inputs{
 			AnchorPath:  fields[9],
 			PaneCWD:     fields[8],
 			SessionName: fields[1],
-		}, projectidentity.OSFS).Name,
+		}, projectidentity.OSFS),
 		LastPaneID:     fields[4],
 		LastPaneTitle:  fields[5],
 		PaneTitles:     titles,

--- a/internal/app/recent_window_test.go
+++ b/internal/app/recent_window_test.go
@@ -1121,9 +1121,11 @@ func TestRecentWindowRecordSnapshotsCurrentTmuxWindow(t *testing.T) {
 	}
 	// Anchor-less snapshot (empty @projmux_project_path): the regular-repo pane
 	// cwd basename is untrusted (it may be a drifted foreign repo), so the badge
-	// source is the session identity, not the cwd basename.
-	if got.Project != "repos-projmux" {
-		t.Fatalf("snapshot project = %q, want %q (session identity for anchor-less cwd)", got.Project, "repos-projmux")
+	// source stays the session identity, not the cwd basename (#493 drift
+	// guarantee). The display label is de-slugged the same way statusbar/switch
+	// are, so "repos-projmux" surfaces as "projmux" rather than the raw slug.
+	if got.Project != "projmux" {
+		t.Fatalf("snapshot project = %q, want %q (de-slugged session identity for anchor-less cwd)", got.Project, "projmux")
 	}
 	if got.LastFocusedAt != now {
 		t.Fatalf("snapshot time = %s, want %s", got.LastFocusedAt, now)
@@ -1172,6 +1174,87 @@ func TestRecentWindowRecordUsesSessionAnchorProject(t *testing.T) {
 	}
 	if got := store.records[0].Project; got != "projmux" {
 		t.Fatalf("snapshot project = %q, want %q (session anchor basename, cwd-drift independent)", got, "projmux")
+	}
+}
+
+// TestRecentWindowRecordDeSlugsAnchorlessSessionBadge pins the recent-windows
+// badge to the SAME de-slug rule the statusbar and switch sidebar apply: an
+// anchor-less session named "repos-donus-db" must surface as "donus-db", not
+// the raw "repos-donus-db" slug. The badge routes through
+// resolveProjectDisplayName, so the reduction only fires when the resolver falls
+// through to the session name.
+func TestRecentWindowRecordDeSlugsAnchorlessSessionBadge(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux,1,0")
+
+	now := time.Date(2026, 7, 7, 1, 2, 3, 0, time.UTC)
+	runner := &recentWindowFakeRunner{
+		recordOutput: strings.Join([]string{
+			"/tmp/tmux",
+			"repos-donus-db",
+			"@6",
+			"agent",
+			"%54",
+			"shell",
+			"topic",
+			"zsh",
+			// No project marker on the pane cwd path.
+			"/home/es5h/nowhere",
+			// No session anchor (@projmux_project_path empty): older/foreign session.
+			"",
+		}, recentWindowFieldSep) + "\n",
+	}
+	store := &recentWindowStubStore{}
+	cmd := &recentWindowCommand{
+		runner:       runner,
+		storeFactory: func(string) (recentWindowStore, error) { return store, nil },
+		now:          func() time.Time { return now },
+	}
+
+	if err := cmd.RunRecord(nil, nil, nil); err != nil {
+		t.Fatalf("RunRecord() error = %v", err)
+	}
+	if got := store.records[0].Project; got != "donus-db" {
+		t.Fatalf("snapshot project = %q, want %q (de-slugged session badge matching statusbar/switch)", got, "donus-db")
+	}
+}
+
+// TestRecentWindowRecordDoesNotOverCutHyphenatedAnchorName guards the over-cut
+// regression: the de-slug is a lossy cut-at-first-dash meant only for session
+// slugs. A real hyphenated project name coming from the session ANCHOR must NOT
+// be reduced, so "my-app" stays "my-app" instead of collapsing to "app". This
+// is exactly why the badge routes through resolveProjectDisplayName (de-slug
+// only when Source==SessionName) rather than DeSlug(Resolve(...).Name).
+func TestRecentWindowRecordDoesNotOverCutHyphenatedAnchorName(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux,1,0")
+
+	now := time.Date(2026, 7, 7, 1, 2, 3, 0, time.UTC)
+	runner := &recentWindowFakeRunner{
+		recordOutput: strings.Join([]string{
+			"/tmp/tmux",
+			"repos-my-app",
+			"@6",
+			"agent",
+			"%54",
+			"shell",
+			"topic",
+			"zsh",
+			"/home/es5h/source/repos/my-app",
+			// Session anchor pins a real hyphenated project root.
+			"/home/es5h/source/repos/my-app",
+		}, recentWindowFieldSep) + "\n",
+	}
+	store := &recentWindowStubStore{}
+	cmd := &recentWindowCommand{
+		runner:       runner,
+		storeFactory: func(string) (recentWindowStore, error) { return store, nil },
+		now:          func() time.Time { return now },
+	}
+
+	if err := cmd.RunRecord(nil, nil, nil); err != nil {
+		t.Fatalf("RunRecord() error = %v", err)
+	}
+	if got := store.records[0].Project; got != "my-app" {
+		t.Fatalf("snapshot project = %q, want %q (anchor basename must not be de-slug over-cut)", got, "my-app")
 	}
 }
 


### PR DESCRIPTION
## 완료한 작업 (naming v2 마무리 픽스)

recent windows(Alt-3) 보라 뱃지가 **raw 슬러그**(`repos-projmux`/`repos-donus-db`)로 뜨던 문제 수정. statusbar·switch sidebar 는 de-slug 돼서 `projmux`/`donus-db` 로 나오는데 recent windows 만 달라 일관성이 깨져 있었음.

### 원인
`recent_window.go:288` 의 `currentSnapshot` 이 `projectidentity.Resolve(...).Name` 를 **직접** 호출 → SessionName 을 verbatim 반환(de-slug 누락). de-slug 은 공유 wrapper `resolveProjectDisplayName`(status.go:1003) 에 있고 statusbar/switch 만 경유하고 있었음.

### 수정
`currentSnapshot` 의 프로젝트명 계산을 `resolveProjectDisplayName(inputs, projectidentity.OSFS)` 경유로 변경 (statusbar/switch 와 동일 경로). de-slug 은 resolver 가 `Source==SessionName` 로 fallback 할 때만 적용되므로:
- 앵커 없는 세션 뱃지: `repos-projmux`→`projmux`, `repos-donus-db`→`donus-db` ✅
- 앵커/worktree-main/cwd 이름: 그대로 (하이픈 포함 실제 이름 `my-app` over-cut 방지) ✅
- **#493 드리프트 보증 유지**: 드리프트된 cwd basename 이 아니라 세션 정체성이 소스 — 표시 라벨만 de-slug.

## 수정한 user-facing surface
- recent windows 프로젝트 뱃지 (de-slug 일관성). statusbar/switch/notify 는 **무변경**.

## 모델/제약 준수
- resolver 로직·`resolveProjectDisplayName` 자체 **변경 없음** (재사용만).
- de-slug 은 `Source==SessionName` 일 때만 (wrapper 가 이미 그렇게 함) — anchor/worktree-main/cwd basename 은 de-slug 안 됨.
- 앵커 backfill·slug 정책(Phase 2/3)은 이번 범위 밖 — 손대지 않음.

## 검증
- `go build ./...` ✅
- `go test ./internal/...` ✅ (전 패키지 green)
- 추가 테스트:
  - `TestRecentWindowRecordSnapshotsCurrentTmuxWindow` — 앵커 없는 `repos-projmux` → `projmux` (기존 raw-slug 단언 갱신)
  - `TestRecentWindowRecordDeSlugsAnchorlessSessionBadge` — `repos-donus-db` → `donus-db`
  - `TestRecentWindowRecordDoesNotOverCutHyphenatedAnchorName` — 앵커 `my-app` 은 `my-app` 유지 (over-cut 회귀 가드)

## 미검증 / 후속
- tmux 실제 렌더 스크린샷 확인은 lead e2e 후보 (설치본에서 Alt-3 뱃지 육안 확인).
- Phase 2(앵커 backfill)/Phase 3(slug 정책)은 별도 위임.

🤖 Generated with [Claude Code](https://claude.com/claude-code)