### PR TITLE
feat(notify): clear gone notifications via G key

### DIFF
--- a/internal/app/keybinding_catalog.go
+++ b/internal/app/keybinding_catalog.go
@@ -645,6 +645,15 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			PlainChord:  "C-x",
 		},
 		{
+			ID:          "NotifySidebar:ClearGone",
+			Description: "Clear gone notifications",
+			DisplayName: "Notify Sidebar: Clear Gone",
+			Kind:        keyBindingActionPickerInternal,
+			Tier:        keyBindingTierNativePickerInternal,
+			Surface:     "NotifySidebar",
+			PlainChord:  "G",
+		},
+		{
 			ID:          "Settings:SwitchTabPrev",
 			Description: "Switch Settings tab left",
 			DisplayName: "Previous Settings Tab",

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -362,6 +362,15 @@ func (c *notifyCommand) runSidebar(store notifyStore, severities, sources []stri
 			return err
 		}
 		return nil
+	case pickerKeyMatchesAction(c.homeDir, c.lookupEnv, result.Key, "NotifySidebar:ClearGone", "G"):
+		removed, err := c.clearGoneNotifications(store, entries)
+		if err != nil {
+			return err
+		}
+		if removed == 0 {
+			c.displayNotifySidebarMessage("no gone notifications")
+		}
+		return nil
 	default:
 		if groupKey := notifySidebarGroupKeyFromValue(id); groupKey != "" {
 			return c.focusAndAckNotifySidebarGroup(store, entries, groupKey, clientTTY, locale)
@@ -449,6 +458,20 @@ func (c *notifyCommand) notifySidebarPickerOptions(store notifyStore, entries []
 		}
 		return refresh()
 	}
+	clearGone := func(ctx intpicker.ActionContext) (intpicker.DeferredUpdate, error) {
+		current, err := c.notifySidebarFilteredEntries(store, severities, sources, limit)
+		if err != nil {
+			return intpicker.DeferredUpdate{}, err
+		}
+		removed, err := c.clearGoneNotifications(store, current)
+		if err != nil {
+			return intpicker.DeferredUpdate{}, err
+		}
+		if removed == 0 {
+			c.displayNotifySidebarMessage("no gone notifications")
+		}
+		return refresh()
+	}
 	unfold := func(ctx intpicker.ActionContext) (intpicker.DeferredUpdate, error) {
 		current, err := c.notifySidebarFilteredEntries(store, severities, sources, limit)
 		if err != nil {
@@ -501,6 +524,9 @@ func (c *notifyCommand) notifySidebarPickerOptions(store notifyStore, entries []
 	actions = append(actions,
 		notifySidebarMutableActions(effectivePickerKeysForActions(c.homeDir, c.lookupEnv, []string{"NotifySidebar:ClearNonCritical"}, []string{"x"}), clearNonCritical)...,
 	)
+	actions = append(actions,
+		notifySidebarMutableActions(effectivePickerKeysForActions(c.homeDir, c.lookupEnv, []string{"NotifySidebar:ClearGone"}, []string{"G"}), clearGone)...,
+	)
 	actions = append(actions, notifySidebarMutableActions([]string{"right"}, unfold)...)
 	actions = append(actions, notifySidebarMutableActions([]string{"left"}, fold)...)
 	for _, key := range effectivePickerKeysForActions(c.homeDir, c.lookupEnv, []string{"NotifySidebar:ClearAll"}, []string{"ctrl-x"}) {
@@ -542,6 +568,7 @@ func notifySidebarFooter(homeDir func() (string, error), lookupEnv func(string) 
 		{ActionID: "NotifySidebar:Ack", Label: "ack child"},
 		{ActionID: "NotifySidebar:AckGroup", Label: "ack group"},
 		{ActionID: "NotifySidebar:ClearNonCritical", Label: "clear non-critical"},
+		{ActionID: "NotifySidebar:ClearGone", Label: "clear gone"},
 		{ActionID: "NotifySidebar:ClearAll", Label: "clear all"},
 	})
 	local := keybindingReadableChord("Right") + ": " + localizeUIText(locale, "show child rows") + "  |  " + keybindingReadableChord("Left") + ": " + localizeUIText(locale, "hide child rows")
@@ -600,6 +627,33 @@ func ackNonCriticalNotifications(store notifyStore, entries []notify.Notificatio
 		}
 	}
 	return nil
+}
+
+// ackGoneNotifications dismisses every entry whose display classification is
+// notifyDisplayGone, leaving live/inactive/critical rows untouched. It returns
+// the number of entries acked so callers can no-op with a hint when the queue
+// has nothing gone. GONE classification is reused from classifyNotifyRowState;
+// this helper never changes that policy.
+func ackGoneNotifications(store notifyStore, entries []notify.Notification, liveByID map[string]notifyLivePane, paneSet notifyLivePaneSet) (int, error) {
+	removed := 0
+	for _, entry := range entries {
+		if classifyNotifyRowState(entry, liveByID, paneSet) != notifyDisplayGone {
+			continue
+		}
+		if err := store.Ack(entry.ID); err != nil {
+			return removed, fmt.Errorf("clear gone notification: %w", err)
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+// clearGoneNotifications resolves best-effort live state and dismisses gone
+// entries. It shares the runSidebar dispatch path and the in-picker clearGone
+// handler so both surfaces classify identically.
+func (c *notifyCommand) clearGoneNotifications(store notifyStore, entries []notify.Notification) (int, error) {
+	liveByID, paneSet := c.notifyLiveStateBestEffort()
+	return ackGoneNotifications(store, entries, liveByID, paneSet)
 }
 
 const notifySidebarEmptyValue = "__projmux_notify_empty__"

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -437,10 +437,10 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if got, want := picker.options.Header, "Newest first"; got != want {
 		t.Fatalf("picker header = %q, want %q", got, want)
 	}
-	if got, want := picker.options.Footer, "Right: show child rows  |  Left: hide child rows  |  Enter: focus live/inactive / clean gone  |  a: ack child  |  A: ack group  |  x: clear non-critical  |  Ctrl-X: clear all"; got != want {
+	if got, want := picker.options.Footer, "Right: show child rows  |  Left: hide child rows  |  Enter: focus live/inactive / clean gone  |  a: ack child  |  A: ack group  |  x: clear non-critical  |  G: clear gone  |  Ctrl-X: clear all"; got != want {
 		t.Fatalf("picker footer = %q, want %q", got, want)
 	}
-	if got, want := picker.options.ExpectKeys, []string{"enter", "a", "A", "x", "right", "left", "ctrl-x"}; !reflect.DeepEqual(got, want) {
+	if got, want := picker.options.ExpectKeys, []string{"enter", "a", "A", "x", "G", "right", "left", "ctrl-x"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("expect keys = %#v, want %#v", got, want)
 	}
 	groupValue := notifySidebarGroupValue("pane\x00projmux\x00main\x000")
@@ -519,7 +519,7 @@ keys = ["C-y"]
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run error = %v", err)
 	}
-	want := "Right: show child rows  |  Left: hide child rows  |  Enter: focus live/inactive / clean gone  |  a: ack child  |  A: ack group  |  c: clear non-critical  |  Ctrl-Y: clear all"
+	want := "Right: show child rows  |  Left: hide child rows  |  Enter: focus live/inactive / clean gone  |  a: ack child  |  A: ack group  |  c: clear non-critical  |  G: clear gone  |  Ctrl-Y: clear all"
 	if got := picker.options.Footer; got != want {
 		t.Fatalf("picker footer = %q, want %q", got, want)
 	}
@@ -1227,7 +1227,7 @@ func TestNotifyListSidebarAAcksSelectedRowAndRefreshes(t *testing.T) {
 	if got, want := compatOptions.Bindings, []string{"esc:abort", "alt-2:abort"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("picker bindings = %#v, want %#v", got, want)
 	}
-	if got, want := compatOptions.ExpectKeys, []string{"enter", "a", "A", "x", "right", "left", "ctrl-x"}; !reflect.DeepEqual(got, want) {
+	if got, want := compatOptions.ExpectKeys, []string{"enter", "a", "A", "x", "G", "right", "left", "ctrl-x"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("expect keys = %#v, want %#v", got, want)
 	}
 	second := picker.updates[0]
@@ -1736,6 +1736,120 @@ func TestNotifyListSidebarXClearNonCriticalRendersEmptyState(t *testing.T) {
 	if stdout.String() != "" {
 		t.Fatalf("stdout = %q, want no sidebar clear output", stdout.String())
 	}
+}
+
+func TestNotifyListSidebarGClearsGoneOnly(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{
+		listEntries: []notify.Notification{
+			{ID: "live", Text: "reply ready", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+			{ID: "gone", Text: "orphan", Severity: notify.SeverityWarn, Source: notify.SourceAI, Session: ""},
+			{ID: "crit", Text: "prod down", Severity: notify.SeverityCritical, Source: notify.SourceAI, Session: "main"},
+		},
+	}
+	picker := &recordingNotifyNativePicker{
+		steps: []notifyNativeActionStep{{key: "G", value: "live", selectedIndex: 0}},
+	}
+	cmd := newCmd(store)
+	cmd.native = picker
+
+	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if got, want := store.ackedIDs, []string{"gone"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ackedIDs = %#v, want %#v (gone-only)", got, want)
+	}
+	remaining := map[string]bool{}
+	for _, e := range store.listEntries {
+		remaining[e.ID] = true
+	}
+	if !remaining["live"] || !remaining["crit"] {
+		t.Fatalf("live/critical entries were removed: remaining = %#v", store.listEntries)
+	}
+}
+
+func TestNotifyListSidebarGNoGoneNotificationsIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotifyStore{
+		listEntries: []notify.Notification{
+			{ID: "live", Text: "reply ready", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"},
+			{ID: "crit", Text: "prod down", Severity: notify.SeverityCritical, Source: notify.SourceAI, Session: "main"},
+		},
+	}
+	picker := &recordingNotifyNativePicker{
+		steps: []notifyNativeActionStep{{key: "G", value: "live", selectedIndex: 0}},
+	}
+	runner := &focusFakeRunner{}
+	cmd := newCmd(store)
+	cmd.native = picker
+	cmd.runner = runner
+
+	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(store.ackedIDs) != 0 {
+		t.Fatalf("ackedIDs = %#v, want none (no gone notifications)", store.ackedIDs)
+	}
+	if !sawFocusRunnerDisplayMessage(runner.calls, "no gone notifications") {
+		t.Fatalf("expected 'no gone notifications' hint, calls = %#v", runner.calls)
+	}
+}
+
+func TestNotifyListSidebarClearGoneRebindsFromKeymap(t *testing.T) {
+	t.Parallel()
+
+	action, ok := keyBindingActionByID(defaultKeyBindingCatalog(), "NotifySidebar:ClearGone")
+	if !ok {
+		t.Fatal("NotifySidebar:ClearGone missing from default catalog")
+	}
+	if got := firstNonEmptyString(keyBindingEffectivePlainChords(action)); got != "G" {
+		t.Fatalf("default ClearGone chord = %q, want G", got)
+	}
+
+	home := t.TempDir()
+	keymapPath := filepath.Join(home, ".config", "projmux", "keymap.toml")
+	if err := os.MkdirAll(filepath.Dir(keymapPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(keymapPath, []byte(`[bindings."NotifySidebar:ClearGone"]
+keys = ["d"]
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	store := &stubNotifyStore{
+		listEntries: []notify.Notification{{ID: "abc", Text: "deploy ok", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "main"}},
+	}
+	picker := &stubNotifyPicker{result: intpickercompat.Result{}}
+	cmd := newCmd(store)
+	cmd.homeDir = func() (string, error) { return home, nil }
+	cmd.lookupEnv = func(string) string { return "" }
+	cmd.picker = picker
+	cmd.native = nativePickerFromCompatRunner(picker)
+
+	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(picker.options.Footer, "d: clear gone") {
+		t.Fatalf("footer missing rebound clear-gone chord: %q", picker.options.Footer)
+	}
+	if strings.Contains(picker.options.Footer, "G: clear gone") {
+		t.Fatalf("footer still shows default clear-gone chord after rebind: %q", picker.options.Footer)
+	}
+}
+
+func sawFocusRunnerDisplayMessage(calls []focusFakeCall, want string) bool {
+	for _, c := range calls {
+		if c.name != "tmux" || len(c.args) < 2 || c.args[0] != "display-message" {
+			continue
+		}
+		if c.args[1] == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestNotifyListSidebarSubscribesToQueueRefreshEvents(t *testing.T) {


### PR DESCRIPTION
## 목표

notify sidebar(pending notifications)에서 **`G`(기본 키)로 GONE 항목만 일괄 제거**. 라이브/inactive/critical 알림은 무변경.

새 ActionID `NotifySidebar:ClearGone` 를 keybinding catalog 에 등록 → **rebindable**(Settings > Keybindings), default 만 `G`. 키바인딩 워크플로우는 기존 a/x/Ctrl-X 와 완전 동일.

> 상세 문서: `~/obsidian/main/30.Projects.Design/Projmux/10.Roadmap/Backlog/로드맵 디테일 - Notify sidebar clear gone action.md`

## 변경 (4점)

1. **catalog 등록** (`keybinding_catalog.go`): 기존 NotifySidebar 항목 옆에 `NotifySidebar:ClearGone` (default `G`, Surface `NotifySidebar`, rebindable).
2. **핸들러** (`notify.go`): `clearGone` 추가 + 공유 헬퍼 `clearGoneNotifications`/`ackGoneNotifications`. `classifyNotifyRowState == notifyDisplayGone` 인 항목만 dismiss. GONE 판정 로직(`notify_classify.go`) 재사용만, 무변경.
3. **배선** (`notify.go`): mutable action 등록(`effectivePickerKeysForActions([...ClearGone], ["G"])`) + `runSidebar` result-key 디스패치 fallback + footer/도움말 목록에 `G clear gone` 추가.
4. **no-op**: GONE 0개면 `"no gone notifications"` 안내 후 무변경.

## 비목표 (회귀 없음 확인)

- a/x/Ctrl-X/enter/A 동작·키 무변경.
- GONE 판정 로직 무변경(재사용만).
- 라이브/inactive/critical 은 `G` 로 절대 안 지워짐(오직 GONE).
- 키는 catalog 경유 rebindable — 하드코딩 없음(default 만 `G`).

## 완료 기준

- [x] notify sidebar 에서 `G` → GONE 항목만 전부 제거, 라이브/inactive/critical 유지.
- [x] Settings > Keybindings 에서 `NotifySidebar:ClearGone` 리바인드 가능(다른 액션과 동일 워크플로우).
- [x] GONE 0개면 no-op + footer 힌트 노출.
- [x] `go build ./...`, `go test ./internal/...` 통과 + 신규 테스트:
  - `TestNotifyListSidebarGClearsGoneOnly` — gone-only 제거(라이브/critical 유지)
  - `TestNotifyListSidebarGNoGoneNotificationsIsNoOp` — GONE 0 no-op + 안내 메시지
  - `TestNotifyListSidebarClearGoneRebindsFromKeymap` — catalog default `G` + keymap rebind 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)