### PR TITLE
fix(notify): rebind clear-gone to lowercase g

### DIFF
--- a/internal/app/keybinding_catalog.go
+++ b/internal/app/keybinding_catalog.go
@@ -651,7 +651,7 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			Kind:        keyBindingActionPickerInternal,
 			Tier:        keyBindingTierNativePickerInternal,
 			Surface:     "NotifySidebar",
-			PlainChord:  "G",
+			PlainChord:  "g",
 		},
 		{
 			ID:          "Settings:SwitchTabPrev",

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -362,7 +362,7 @@ func (c *notifyCommand) runSidebar(store notifyStore, severities, sources []stri
 			return err
 		}
 		return nil
-	case pickerKeyMatchesAction(c.homeDir, c.lookupEnv, result.Key, "NotifySidebar:ClearGone", "G"):
+	case pickerKeyMatchesAction(c.homeDir, c.lookupEnv, result.Key, "NotifySidebar:ClearGone", "g"):
 		removed, err := c.clearGoneNotifications(store, entries)
 		if err != nil {
 			return err
@@ -525,7 +525,7 @@ func (c *notifyCommand) notifySidebarPickerOptions(store notifyStore, entries []
 		notifySidebarMutableActions(effectivePickerKeysForActions(c.homeDir, c.lookupEnv, []string{"NotifySidebar:ClearNonCritical"}, []string{"x"}), clearNonCritical)...,
 	)
 	actions = append(actions,
-		notifySidebarMutableActions(effectivePickerKeysForActions(c.homeDir, c.lookupEnv, []string{"NotifySidebar:ClearGone"}, []string{"G"}), clearGone)...,
+		notifySidebarMutableActions(effectivePickerKeysForActions(c.homeDir, c.lookupEnv, []string{"NotifySidebar:ClearGone"}, []string{"g"}), clearGone)...,
 	)
 	actions = append(actions, notifySidebarMutableActions([]string{"right"}, unfold)...)
 	actions = append(actions, notifySidebarMutableActions([]string{"left"}, fold)...)

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -437,10 +437,10 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	if got, want := picker.options.Header, "Newest first"; got != want {
 		t.Fatalf("picker header = %q, want %q", got, want)
 	}
-	if got, want := picker.options.Footer, "Right: show child rows  |  Left: hide child rows  |  Enter: focus live/inactive / clean gone  |  a: ack child  |  A: ack group  |  x: clear non-critical  |  G: clear gone  |  Ctrl-X: clear all"; got != want {
+	if got, want := picker.options.Footer, "Right: show child rows  |  Left: hide child rows  |  Enter: focus live/inactive / clean gone  |  a: ack child  |  A: ack group  |  x: clear non-critical  |  g: clear gone  |  Ctrl-X: clear all"; got != want {
 		t.Fatalf("picker footer = %q, want %q", got, want)
 	}
-	if got, want := picker.options.ExpectKeys, []string{"enter", "a", "A", "x", "G", "right", "left", "ctrl-x"}; !reflect.DeepEqual(got, want) {
+	if got, want := picker.options.ExpectKeys, []string{"enter", "a", "A", "x", "g", "right", "left", "ctrl-x"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("expect keys = %#v, want %#v", got, want)
 	}
 	groupValue := notifySidebarGroupValue("pane\x00projmux\x00main\x000")
@@ -519,7 +519,7 @@ keys = ["C-y"]
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run error = %v", err)
 	}
-	want := "Right: show child rows  |  Left: hide child rows  |  Enter: focus live/inactive / clean gone  |  a: ack child  |  A: ack group  |  c: clear non-critical  |  G: clear gone  |  Ctrl-Y: clear all"
+	want := "Right: show child rows  |  Left: hide child rows  |  Enter: focus live/inactive / clean gone  |  a: ack child  |  A: ack group  |  c: clear non-critical  |  g: clear gone  |  Ctrl-Y: clear all"
 	if got := picker.options.Footer; got != want {
 		t.Fatalf("picker footer = %q, want %q", got, want)
 	}
@@ -1227,7 +1227,7 @@ func TestNotifyListSidebarAAcksSelectedRowAndRefreshes(t *testing.T) {
 	if got, want := compatOptions.Bindings, []string{"esc:abort", "alt-2:abort"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("picker bindings = %#v, want %#v", got, want)
 	}
-	if got, want := compatOptions.ExpectKeys, []string{"enter", "a", "A", "x", "G", "right", "left", "ctrl-x"}; !reflect.DeepEqual(got, want) {
+	if got, want := compatOptions.ExpectKeys, []string{"enter", "a", "A", "x", "g", "right", "left", "ctrl-x"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("expect keys = %#v, want %#v", got, want)
 	}
 	second := picker.updates[0]
@@ -1749,7 +1749,7 @@ func TestNotifyListSidebarGClearsGoneOnly(t *testing.T) {
 		},
 	}
 	picker := &recordingNotifyNativePicker{
-		steps: []notifyNativeActionStep{{key: "G", value: "live", selectedIndex: 0}},
+		steps: []notifyNativeActionStep{{key: "g", value: "live", selectedIndex: 0}},
 	}
 	cmd := newCmd(store)
 	cmd.native = picker
@@ -1779,7 +1779,7 @@ func TestNotifyListSidebarGNoGoneNotificationsIsNoOp(t *testing.T) {
 		},
 	}
 	picker := &recordingNotifyNativePicker{
-		steps: []notifyNativeActionStep{{key: "G", value: "live", selectedIndex: 0}},
+		steps: []notifyNativeActionStep{{key: "g", value: "live", selectedIndex: 0}},
 	}
 	runner := &focusFakeRunner{}
 	cmd := newCmd(store)
@@ -1804,8 +1804,8 @@ func TestNotifyListSidebarClearGoneRebindsFromKeymap(t *testing.T) {
 	if !ok {
 		t.Fatal("NotifySidebar:ClearGone missing from default catalog")
 	}
-	if got := firstNonEmptyString(keyBindingEffectivePlainChords(action)); got != "G" {
-		t.Fatalf("default ClearGone chord = %q, want G", got)
+	if got := firstNonEmptyString(keyBindingEffectivePlainChords(action)); got != "g" {
+		t.Fatalf("default ClearGone chord = %q, want g", got)
 	}
 
 	home := t.TempDir()
@@ -1835,7 +1835,7 @@ keys = ["d"]
 	if !strings.Contains(picker.options.Footer, "d: clear gone") {
 		t.Fatalf("footer missing rebound clear-gone chord: %q", picker.options.Footer)
 	}
-	if strings.Contains(picker.options.Footer, "G: clear gone") {
+	if strings.Contains(picker.options.Footer, "g: clear gone") {
 		t.Fatalf("footer still shows default clear-gone chord after rebind: %q", picker.options.Footer)
 	}
 }


### PR DESCRIPTION
## 요약
notify sidebar clear-gone 기본 키 `Shift+G` → 소문자 `g`.

## 근거
- notify sidebar 는 `DisableSearch: true` (notify.go:548) — 검색 없음 → 소문자 letter 쿼리 충돌 없음.
- `Shift+G` 오타 나기 쉽고 소문자 `g` 는 무반응이라 혼란. 소문자 `g` = 단일 키 bulk clear, `x` 와 일관. rebindable 유지.

## 변경
- keybinding_catalog.go: ClearGone PlainChord G→g / notify.go dispatch·wiring fallback / notify_test.go 기대값.

## 검증
build·vet·`go test ./internal/...` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)