### PR TITLE
fix(switch): dedup symlinked projects via canonical real-path identity

### DIFF
--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -1358,21 +1358,35 @@ func cleanOptionalPath(path string) string {
 	return filepath.Clean(path)
 }
 
+// bestSwitchCandidateMatch finds the candidate whose directory contains (or
+// equals) path, comparing on canonical real paths so a session cwd spelled via
+// a symlink matches its real-path candidate row (and vice versa). The returned
+// value is the candidate's original display spelling, never the resolved real
+// path, so callers keep the user's form for display and cd.
 func bestSwitchCandidateMatch(path string, candidatePaths []string) string {
-	cleanPath := filepath.Clean(path)
+	canonicalPath := candidates.CanonicalPath(path)
+	if canonicalPath == "" {
+		return ""
+	}
+
 	best := ""
+	bestLen := -1
 
 	for _, candidatePath := range candidatePaths {
-		candidatePath = filepath.Clean(candidatePath)
-		if candidatePath == cleanPath {
+		canonicalCandidate := candidates.CanonicalPath(candidatePath)
+		if canonicalCandidate == "" {
+			continue
+		}
+		if canonicalCandidate == canonicalPath {
 			return candidatePath
 		}
 
-		prefix := candidatePath + string(filepath.Separator)
-		if !strings.HasPrefix(cleanPath, prefix) {
+		prefix := canonicalCandidate + string(filepath.Separator)
+		if !strings.HasPrefix(canonicalPath, prefix) {
 			continue
 		}
-		if len(candidatePath) > len(best) {
+		if len(canonicalCandidate) > bestLen {
+			bestLen = len(canonicalCandidate)
 			best = candidatePath
 		}
 	}

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -3699,3 +3699,78 @@ func (f switchFixtureFS) path(rel string) string {
 
 	return filepath.Join(f.root, filepath.FromSlash(rel))
 }
+
+func TestBestSwitchCandidateMatchCrossesSymlinkForms(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	realProj := filepath.Join(tmp, "real", "proj")
+	if err := os.MkdirAll(filepath.Join(realProj, "sub"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+	linkRoot := filepath.Join(tmp, "link")
+	if err := os.Symlink(filepath.Join(tmp, "real"), linkRoot); err != nil {
+		t.Fatalf("Symlink(): %v", err)
+	}
+	symlinkProj := filepath.Join(linkRoot, "proj")
+
+	tests := []struct {
+		name       string
+		path       string
+		candidates []string
+		want       string
+	}{
+		{
+			name:       "session cwd via real path matches symlink candidate row",
+			path:       realProj,
+			candidates: []string{symlinkProj},
+			want:       symlinkProj,
+		},
+		{
+			name:       "session cwd via symlink matches real-path candidate row",
+			path:       symlinkProj,
+			candidates: []string{realProj},
+			want:       realProj,
+		},
+		{
+			name:       "nested real cwd prefix-matches symlink candidate, returns display form",
+			path:       filepath.Join(realProj, "sub"),
+			candidates: []string{symlinkProj},
+			want:       symlinkProj,
+		},
+		{
+			name:       "no match returns empty",
+			path:       filepath.Join(tmp, "elsewhere"),
+			candidates: []string{symlinkProj},
+			want:       "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bestSwitchCandidateMatch(tc.path, tc.candidates); got != tc.want {
+				t.Fatalf("bestSwitchCandidateMatch(%q, %q) = %q, want %q", tc.path, tc.candidates, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBestSwitchCandidateMatchBrokenLinkFallsBackToLexical(t *testing.T) {
+	t.Parallel()
+
+	// Neither path exists on disk, so EvalSymlinks fails and CanonicalPath must
+	// fall back to lexical Clean without panicking, still matching by prefix.
+	base := filepath.Join(string(filepath.Separator), "no", "such", "root")
+	candidate := filepath.Join(base, "proj")
+	nested := filepath.Join(candidate, "deep")
+
+	if got := bestSwitchCandidateMatch(nested, []string{candidate}); got != candidate {
+		t.Fatalf("bestSwitchCandidateMatch(%q, %q) = %q, want %q", nested, candidate, got, candidate)
+	}
+	if got := bestSwitchCandidateMatch(candidate, []string{candidate}); got != candidate {
+		t.Fatalf("bestSwitchCandidateMatch(exact) = %q, want %q", got, candidate)
+	}
+	if got := bestSwitchCandidateMatch("", []string{candidate}); got != "" {
+		t.Fatalf("bestSwitchCandidateMatch(blank) = %q, want empty", got)
+	}
+}

--- a/internal/core/candidates/discovery.go
+++ b/internal/core/candidates/discovery.go
@@ -120,16 +120,23 @@ func (s *orderedSet) appendRootChildren(root string) error {
 	return nil
 }
 
+// append records path in insertion order, deduplicating by its canonical
+// (symlink-resolved) real path. The retained value in values is the caller's
+// original display form: identity collapses symlink and real-path spellings of
+// the same directory into one candidate, while the shown/cd path stays as the
+// user spelled it. First encounter wins, so config-derived forms (home dir,
+// pins) that are appended first take precedence over discovered children.
 func (s *orderedSet) append(path string) {
 	if s.seen == nil {
 		s.seen = make(map[string]struct{})
 	}
 
-	if _, ok := s.seen[path]; ok {
+	key := CanonicalPath(path)
+	if _, ok := s.seen[key]; ok {
 		return
 	}
 
-	s.seen[path] = struct{}{}
+	s.seen[key] = struct{}{}
 	s.values = append(s.values, path)
 }
 
@@ -145,6 +152,27 @@ func dirExists(path string) bool {
 func cleanPath(path string) string {
 	if path == "" {
 		return ""
+	}
+
+	return filepath.Clean(path)
+}
+
+// CanonicalPath resolves path to its real, symlink-free location for use as an
+// identity/dedup/match key only. It is never a display or cd target: callers
+// keep the user's original (symlink) spelling for those.
+//
+// Symlinks are resolved via filepath.EvalSymlinks. When resolution fails
+// (missing path, broken/dangling link, permission error) it falls back to
+// filepath.Clean so callers get a stable lexical key instead of an error, and
+// never panic or abort. For a path with no symlink components the result
+// equals filepath.Clean(path), so symlink-free behaviour is unchanged.
+func CanonicalPath(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
 	}
 
 	return filepath.Clean(path)

--- a/internal/core/candidates/discovery_test.go
+++ b/internal/core/candidates/discovery_test.go
@@ -156,3 +156,104 @@ func (f fixtureFS) path(rel string) string {
 
 	return filepath.Join(f.root, filepath.FromSlash(rel))
 }
+
+func TestDiscoverDedupesSymlinkAndRealPathKeepingDisplayForm(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	fixture.mkdir("real/proj")
+
+	linkRoot := fixture.path("link")
+	if err := os.Symlink(fixture.path("real"), linkRoot); err != nil {
+		t.Fatalf("Symlink(): %v", err)
+	}
+
+	symlinkProj := filepath.Join(linkRoot, "proj")
+	realProj := fixture.path("real/proj")
+
+	got, err := Discover(Inputs{
+		// Symlink spelling is encountered first, so it wins as the display form.
+		Pins: []string{symlinkProj, realProj},
+	})
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+
+	want := []string{symlinkProj}
+	if !slices.Equal(got, want) {
+		t.Fatalf("Discover() = %q, want %q (symlink and real path must collapse to one, keeping symlink spelling)", got, want)
+	}
+}
+
+func TestDiscoverDedupePrefersFirstEncounteredDisplayForm(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	fixture.mkdir("real/proj")
+
+	linkRoot := fixture.path("link")
+	if err := os.Symlink(fixture.path("real"), linkRoot); err != nil {
+		t.Fatalf("Symlink(): %v", err)
+	}
+
+	symlinkProj := filepath.Join(linkRoot, "proj")
+	realProj := fixture.path("real/proj")
+
+	got, err := Discover(Inputs{
+		// Real path is encountered first here, so it wins.
+		Pins: []string{realProj, symlinkProj},
+	})
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+
+	want := []string{realProj}
+	if !slices.Equal(got, want) {
+		t.Fatalf("Discover() = %q, want %q", got, want)
+	}
+}
+
+func TestCanonicalPathResolvesSymlinkAndFallsBack(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	fixture.mkdir("real/proj")
+
+	linkRoot := fixture.path("link")
+	if err := os.Symlink(fixture.path("real"), linkRoot); err != nil {
+		t.Fatalf("Symlink(): %v", err)
+	}
+
+	symlinkProj := filepath.Join(linkRoot, "proj")
+	realProj := fixture.path("real/proj")
+
+	wantResolved, err := filepath.EvalSymlinks(realProj)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(): %v", err)
+	}
+	if got := CanonicalPath(symlinkProj); got != wantResolved {
+		t.Fatalf("CanonicalPath(symlink) = %q, want %q", got, wantResolved)
+	}
+	if got := CanonicalPath(realProj); got != wantResolved {
+		t.Fatalf("CanonicalPath(real) = %q, want %q", got, wantResolved)
+	}
+
+	// Broken/dangling symlink and missing paths must fall back to Clean without
+	// erroring or panicking.
+	brokenLink := fixture.path("broken")
+	if err := os.Symlink(fixture.path("does-not-exist"), brokenLink); err != nil {
+		t.Fatalf("Symlink(broken): %v", err)
+	}
+	if got := CanonicalPath(brokenLink); got != filepath.Clean(brokenLink) {
+		t.Fatalf("CanonicalPath(broken) = %q, want %q", got, filepath.Clean(brokenLink))
+	}
+
+	missing := fixture.path("missing/./child")
+	if got := CanonicalPath(missing); got != filepath.Clean(missing) {
+		t.Fatalf("CanonicalPath(missing) = %q, want %q", got, filepath.Clean(missing))
+	}
+
+	if got := CanonicalPath("   "); got != "" {
+		t.Fatalf("CanonicalPath(blank) = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## 완료한 작업

로드맵 디테일 `Sidebar symlinked project dedup` — **Phase 0 (유일 phase)** 완료.

Alt-1 프로젝트 사이드바에서 심링크 경유 프로젝트(`~/obsidian` → `/mnt/c/...` 심링크)가 **심링크 형태 + 실경로 형태 두 줄**로 중복되고, 두 줄 다 세션 배지가 붙던 버그. 경로 identity(dedup + 세션↔후보 매칭)가 어휘적 `filepath.Clean` 만 써서 두 spelling 이 다른 키가 됐던 게 원인.

## 원칙: "실경로로 비교(collapse), 심링크 경로로 표시·동작"

- 신설 `candidates.CanonicalPath`: `filepath.EvalSymlinks` 로 실경로 해석, **미존재/끊긴 링크/권한 오류 시 `filepath.Clean` fallback** (에러/패닉 없음). 심링크 없는 경로는 `Clean` 과 동일 결과.
- `orderedSet` dedup **키 = canonical 실경로**, 단 `values`(표시/반환 경로)는 **입력(심링크) 형태 유지**. 첫 등장 우선 → config/pin 형태가 discovered children 보다 우선.
- `bestSwitchCandidateMatch` 동등/prefix 비교를 **canonical 기준**으로. 반환값은 후보의 **표시 형태**(실경로 아님).

## 수정한 user-facing surface

- Alt-1 `switch` 사이드바: 심링크+실경로 동일 프로젝트 → **한 줄**, 세션 배지 그 한 줄에 정상 부착.
- 표시·cd 대상 경로는 사용자(심링크) 형태 그대로. `/mnt/c/...` 재작성 안 함.

## Lead 결정 준수

- identity/dedup/매칭 키 = resolved 실경로 (내부 전용, 표시·cd 대상 아님).
- 표시 + 세션 cwd = 심링크(사용자) 경로 그대로.

## 명시적으로 제외한 범위 (비목표)

- Naming model v2 identity 통합·세션명 deslug — 별개 로드맵.
- 심링크를 따라가는 디렉터리 순회 추가 — 여긴 경로 "비교" canonical 화만.
- 심링크 없는 목록·정렬·현재선택·세션 매칭 동작 무변경.

## 검증

- `go build ./...` ✅
- `go test ./internal/...` ✅ (전 패키지 통과)
- 신규 테스트:
  - `TestDiscoverDedupesSymlinkAndRealPathKeepingDisplayForm` — `os.Symlink` dir, 심링크+실경로 둘 다 입력 → 후보 1개, 심링크 표시 형태 유지.
  - `TestDiscoverDedupePrefersFirstEncounteredDisplayForm` — 첫 등장 형태 우선.
  - `TestCanonicalPathResolvesSymlinkAndFallsBack` — 심링크 해석 + 끊긴 링크/미존재 `Clean` fallback.
  - `TestBestSwitchCandidateMatchCrossesSymlinkForms` — 심링크/실경로 교차 매칭, 표시 형태 반환.
  - `TestBestSwitchCandidateMatchBrokenLinkFallsBackToLexical` — 끊긴 링크 lexical fallback, 패닉 없음.

## 미검증 항목 / 후속

- 실제 tmux 에서 Alt-1 사이드바를 열어 `~/obsidian` 경유 프로젝트가 한 줄로 뜨는지는 **e2e 미검증** (단위 테스트로만 고정). Lead 로컬 e2e 후보.
- canonicalize 헬퍼가 향후 Naming model v2 identity resolver 의 path 조각으로 흡수될지는 오픈 질문.

🤖 Generated with [Claude Code](https://claude.com/claude-code)