### PR TITLE
fix(switch): rebuild symlinked current-path candidate in alias form

### DIFF
--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -3774,3 +3774,41 @@ func TestBestSwitchCandidateMatchBrokenLinkFallsBackToLexical(t *testing.T) {
 		t.Fatalf("bestSwitchCandidateMatch(blank) = %q, want empty", got)
 	}
 }
+
+func TestSwitchCurrentSelectionMatchesSnappedSymlinkCandidate(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "real", "proj"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+	linkRoot := filepath.Join(tmp, "link")
+	if err := os.Symlink(filepath.Join(tmp, "real"), linkRoot); err != nil {
+		t.Fatalf("Symlink(): %v", err)
+	}
+
+	// tmux reports the resolved real path as the active session cwd.
+	realCurrent := filepath.Join(tmp, "real", "proj")
+
+	got, err := candidates.Discover(candidates.Inputs{
+		ManagedRoots: []string{linkRoot},
+		CurrentPath:  realCurrent,
+	})
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+
+	symlinkProj := filepath.Join(linkRoot, "proj")
+	if !slices.Contains(got, symlinkProj) {
+		t.Fatalf("Discover() = %q, want symlink-form candidate %q", got, symlinkProj)
+	}
+	if slices.Contains(got, realCurrent) {
+		t.Fatalf("Discover() = %q leaked real-path candidate %q", got, realCurrent)
+	}
+
+	// The current-session highlight resolves the real-path cwd onto the single
+	// symlink-form candidate row produced by discovery.
+	if match := bestSwitchCandidateMatch(realCurrent, got); match != symlinkProj {
+		t.Fatalf("bestSwitchCandidateMatch(%q, %q) = %q, want %q", realCurrent, got, match, symlinkProj)
+	}
+}

--- a/internal/core/candidates/discovery.go
+++ b/internal/core/candidates/discovery.go
@@ -55,33 +55,62 @@ func (i Inputs) snapRoots() []string {
 	return roots
 }
 
+// snappedCurrentPath collapses the active session cwd to the managed-root child
+// that contains it, returned in that root's own (symlink) spelling.
+//
+// tmux reports pane_current_path as a kernel-resolved real path, so a cwd under
+// a symlinked managed root (e.g. ~/obsidian -> /mnt/c/...) arrives spelled as
+// the real path. Matching each root both lexically and on its canonical
+// (symlink-resolved) form lets a real-path cwd map back onto the symlink-form
+// root, and the returned path is rebuilt from the root's original spelling so
+// the current-path candidate dedups against, and displays identically to, the
+// root-children candidates instead of leaking the /mnt/c real path. Roots that
+// are not symlinks (or whose links are broken) fall back to the lexical match,
+// preserving the pre-existing Clean behaviour.
 func snappedCurrentPath(path string, managedRoots []string) string {
 	if !dirExists(path) {
 		return ""
 	}
 
 	current := cleanPath(path)
+	canonicalCurrent := CanonicalPath(path)
 	for _, root := range managedRoots {
 		if !dirExists(root) {
 			continue
 		}
 
 		cleanRoot := cleanPath(root)
-		prefix := cleanRoot + string(filepath.Separator)
-		if !strings.HasPrefix(current, prefix) {
-			continue
+
+		// Lexical match: cwd already spelled under this root's form.
+		if project := childSegment(current, cleanRoot); project != "" {
+			return filepath.Join(cleanRoot, project)
 		}
 
-		rel := strings.TrimPrefix(current, prefix)
-		project := strings.SplitN(rel, string(filepath.Separator), 2)[0]
-		if project == "" {
-			continue
+		// Canonical match: cwd is the real path of a child under this root's
+		// symlink spelling. Rebuild from cleanRoot (symlink form) so display
+		// and dedup stay in the user's spelling, not the resolved real path.
+		if project := childSegment(canonicalCurrent, CanonicalPath(root)); project != "" {
+			return filepath.Join(cleanRoot, project)
 		}
-
-		return filepath.Join(cleanRoot, project)
 	}
 
 	return current
+}
+
+// childSegment returns the first path segment of path relative to root, or ""
+// when path is not strictly under root.
+func childSegment(path, root string) string {
+	if path == "" || root == "" {
+		return ""
+	}
+
+	prefix := root + string(filepath.Separator)
+	if !strings.HasPrefix(path, prefix) {
+		return ""
+	}
+
+	rel := strings.TrimPrefix(path, prefix)
+	return strings.SplitN(rel, string(filepath.Separator), 2)[0]
 }
 
 type orderedSet struct {

--- a/internal/core/candidates/discovery_test.go
+++ b/internal/core/candidates/discovery_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -255,5 +256,83 @@ func TestCanonicalPathResolvesSymlinkAndFallsBack(t *testing.T) {
 
 	if got := CanonicalPath("   "); got != "" {
 		t.Fatalf("CanonicalPath(blank) = %q, want empty", got)
+	}
+}
+
+func TestDiscoverSnapsRealPathCurrentBackToSymlinkRoot(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	fixture.mkdir("home")
+	fixture.mkdir("real/proj")
+
+	// linkRoot is the managed root spelled via a symlink (~/obsidian style);
+	// its real location is fixture/real.
+	linkRoot := fixture.path("link")
+	if err := os.Symlink(fixture.path("real"), linkRoot); err != nil {
+		t.Fatalf("Symlink(): %v", err)
+	}
+
+	// tmux reports the kernel-resolved real path as the active session cwd.
+	realCurrent := fixture.path("real/proj")
+
+	got, err := Discover(Inputs{
+		HomeDir:      fixture.path("home"),
+		ManagedRoots: []string{linkRoot},
+		CurrentPath:  realCurrent,
+	})
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+
+	symlinkProj := filepath.Join(linkRoot, "proj")
+	want := []string{
+		fixture.path("home"),
+		symlinkProj,
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("Discover() = %q, want %q (real-path current must snap back to the symlink-form root and dedup with root children)", got, want)
+	}
+
+	realPrefix := fixture.path("real") + string(filepath.Separator)
+	for _, c := range got {
+		if c == realCurrent || strings.HasPrefix(c, realPrefix) {
+			t.Fatalf("Discover() leaked real path %q; candidates = %q", c, got)
+		}
+	}
+}
+
+func TestSnappedCurrentPathRebuildsSymlinkFormAndFallsBack(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	fixture.mkdir("real/proj/deeper")
+
+	linkRoot := fixture.path("link")
+	if err := os.Symlink(fixture.path("real"), linkRoot); err != nil {
+		t.Fatalf("Symlink(): %v", err)
+	}
+
+	// A real-path cwd nested under a symlink-form managed root snaps back to the
+	// symlink spelling, one segment below the root.
+	realCurrent := fixture.path("real/proj/deeper")
+	if got, want := snappedCurrentPath(realCurrent, []string{linkRoot}), filepath.Join(linkRoot, "proj"); got != want {
+		t.Fatalf("snappedCurrentPath(real current) = %q, want %q", got, want)
+	}
+
+	// Broken root symlink: no reconstruction, current returned as-is (Clean),
+	// no panic.
+	brokenRoot := fixture.path("broken")
+	if err := os.Symlink(fixture.path("does-not-exist"), brokenRoot); err != nil {
+		t.Fatalf("Symlink(broken): %v", err)
+	}
+	if got, want := snappedCurrentPath(realCurrent, []string{brokenRoot}), filepath.Clean(realCurrent); got != want {
+		t.Fatalf("snappedCurrentPath(broken root) = %q, want %q", got, want)
+	}
+
+	// Current outside every managed root is returned unchanged.
+	outside := fixture.path("real/proj")
+	if got, want := snappedCurrentPath(outside, []string{fixture.path("nope")}), filepath.Clean(outside); got != want {
+		t.Fatalf("snappedCurrentPath(outside root) = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## 완료한 Phase
- **Phase 0 — current-path alias 재구성** (유일 phase). #501 후속 표시 버그.

## 문제
#501 로 심링크 프로젝트 중복은 1줄로 합쳐졌으나, **세션 활성화 후** 그 행의 표시 경로가 `~/obsidian/…` (심링크 형태) → `/mnt/c/Users/lspkl/Obsidian/…` (realpath) 로 뒤집혔다. 활성/비활성이 다른 형태로 표시되는 비일관성.

## 원인
- 활성 세션 cwd 를 tmux `#{pane_current_path}` 로 읽는데 커널이 **resolve 된 realpath** 를 돌려준다(심링크 형태 불가).
- 그 realpath 가 discovery 의 current-path 후보로 **먼저** 추가되고(home→pins→current→root-children), dedup(`orderedSet`)이 first-seen 형태를 표시로 유지 → realpath 승리.
- `snappedCurrentPath` 의 root-prefix 비교가 `filepath.Clean`(어휘적)이라 current(real `/mnt/c`)가 managed root(심링크 `~/obsidian…`) 하위임을 못 알아채 snap 되지 않고 realpath 가 그대로 후보화.

## 구현 — "실경로로 식별, config alias 형태로 재구성해 표시"
`internal/core/candidates/discovery.go` `snappedCurrentPath`:
- root 매칭을 **어휘(lexical) + canonical(`candidates.CanonicalPath`=EvalSymlinks 양쪽)** 두 단계로. 공용 `childSegment` 헬퍼로 정리.
- canonical 매칭 시 project 세그먼트를 canonical rel 에서 뽑되, 반환 경로는 **심링크 형태 root(`cleanRoot`)로 재구성**(`filepath.Join(cleanRoot, project)`) → current-path 후보가 심링크 형태가 되어 dedup·표시·현재선택 하이라이트가 전부 심링크 형태로 일관.
- 심링크 아님 / 해석 실패 / 끊긴 링크 / root 밖 → 기존 Clean 동작으로 fallback(에러·panic 없음).

## 수정한 user-facing surface
- 사이드바/switch 후보 목록에서 **활성화된 심링크 프로젝트 행의 표시 경로**. 활성화 전·후 모두 `~/obsidian/…` 심링크 형태로 일관 표시. 현재-세션 하이라이트도 심링크 형태 후보 행에 정상 매칭.

## 모델/제약 준수 (비목표 회귀 금지)
- #501 의 실경로 dedup identity(`candidates.CanonicalPath` 키) **변경 없음** — 그 위에 표시 재구성만 추가.
- 세션 cwd 를 realpath 로 강제하거나 `pane_current_path` 소스 교체 **안 함**(커널 동작, 불가/불필요) — 표시 재구성으로만 해결.
- 세션명 deslug / Naming model v2 통합 **안 함**.
- root/pin 밖 심링크 current 로만 닿는 프로젝트는 복원할 alias 가 없어 realpath 표시 유지(수용된 한계).

## 명시적으로 제외한 다음 범위
- (선택 safety net) `orderedSet` dedup 충돌 시 config-source 표시 우선 교체 — primary 재구성만으로 완료 기준 충족하여 미포함.
- Naming model v2 identity 통합.

## 검증
- `go build ./...` ✅
- `go test ./internal/...` ✅ (전체 통과)
- `go vet ./internal/core/candidates/... ./internal/app/...` ✅
- `make fmt` / `make fix` (deadcode clean)
- 신규 테스트:
  - `TestDiscoverSnapsRealPathCurrentBackToSymlinkRoot` — `t.TempDir()`+`os.Symlink` managed root, current 를 **realpath 형태**로 입력 → Discover 결과가 **심링크 형태 root** 로 재구성·dedup, realpath 누출 없음.
  - `TestSnappedCurrentPathRebuildsSymlinkFormAndFallsBack` — nested realpath current 재구성 + 끊긴 root 심링크/root 밖 fallback.
  - `TestSwitchCurrentSelectionMatchesSnappedSymlinkCandidate` — discovery+`bestSwitchCandidateMatch` 통합: realpath cwd 가 단일 심링크 형태 후보 행에 하이라이트 매칭.

## 미검증 항목 / 후속
- 실제 tmux 세션에서 `pane_current_path` 로 활성화 후 사이드바 육안 확인은 **e2e 후보**(로컬 tmux 필요). 단위 테스트로 realpath→심링크 재구성 경로는 고정함.

머지/설치는 lead. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
