### PR TITLE
feat(insert): generic InsertFileText pane insert (Phase 0+1)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -67,6 +67,7 @@ type App struct {
 	focus        *focusCommand
 	hook         *hookCommand
 	initCmd      *initCommand
+	insertText   *insertFileTextCommand
 	kill         *killCommand
 	notify       *notifyCommand
 	pin          *pinCommand
@@ -107,6 +108,7 @@ func New() *App {
 		focus:        newFocusCommand(),
 		hook:         newHookCommand(),
 		initCmd:      newInitCommand(),
+		insertText:   newInsertFileTextCommand(),
 		kill:         newKillCommand(),
 		notify:       newNotifyCommand(),
 		pin:          newPinCommand(),
@@ -158,6 +160,8 @@ func (a *App) Run(args []string, stdout, stderr io.Writer) error {
 		return a.hook.Run(args[1:], stdout, stderr)
 	case "init":
 		return a.initCmd.Run(args[1:], stdout, stderr)
+	case "insert-file-text":
+		return a.insertText.Run(args[1:], stdout, stderr)
 	case "kill":
 		return a.kill.Run(args[1:], stdout, stderr)
 	case "notify":
@@ -231,6 +235,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  focus     Switch the active client to a session/window/pane target")
 	fmt.Fprintln(w, "  hook      List, edit, validate, and trust lifecycle hook config")
 	fmt.Fprintln(w, "  init      Preview/apply supported terminal key delivery mappings")
+	fmt.Fprintln(w, "  insert-file-text  Insert a configured text file's contents into the active pane")
 	fmt.Fprintln(w, "  kill      Terminate tagged tmux sessions")
 	fmt.Fprintln(w, "  notify    Manage the pending AI notify queue (push/list/ack/reconcile)")
 	fmt.Fprintln(w, "  pin       Manage pinned project directories")

--- a/internal/app/insert_file_text.go
+++ b/internal/app/insert_file_text.go
@@ -1,0 +1,311 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/crevissepartners/projmux/internal/i18n"
+	"github.com/crevissepartners/projmux/internal/integrations/hooks"
+	"github.com/crevissepartners/projmux/internal/integrations/mux"
+	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
+)
+
+// User-facing status messages. They are registered in uiTextKeys +
+// default_catalog.go so localizeUIText resolves them for en-US and ko-KR. The
+// error variants are prefixes; the offending source name is appended at
+// runtime.
+const (
+	insertMessageNotFound       = "insert source not found:"
+	insertMessageUnreadable     = "insert source unreadable:"
+	insertMessageEmpty          = "insert source empty:"
+	insertMessageNoneConfigured = "no insert-file-text source configured"
+)
+
+// insertMuxRunner is the mux boundary the command needs: the literal pane-insert
+// primitive, a status-line message, popup hosting for the N-source picker, and
+// active-pane resolution. mux.Runner satisfies it; tests inject a mux.Runner
+// built over a recording backend so clipboard non-use is directly asserted.
+type insertMuxRunner interface {
+	SendKeysLiteral(ctx context.Context, paneTarget, text string) error
+	ShowStatusMessage(ctx context.Context, target, message string) error
+	DisplayPopup(ctx context.Context, command string, options mux.PopupOptions) error
+	DisplayMessageTrimmed(ctx context.Context, opts mux.DisplayMessageOptions) (string, error)
+}
+
+type insertFileTextCommand struct {
+	runner       insertMuxRunner
+	nativePicker intpicker.Runner
+	loadSources  func() (map[string]hooks.InsertFileTextSource, error)
+	readFile     func(string) ([]byte, error)
+	homeDir      func() (string, error)
+	lookupEnv    func(string) string
+	executable   func() (string, error)
+}
+
+func newInsertFileTextCommand() *insertFileTextCommand {
+	return &insertFileTextCommand{
+		runner:       mux.DefaultRunner(),
+		nativePicker: intpicker.NativeRunner{In: os.Stdin, Out: os.Stdout},
+		loadSources:  loadInsertFileTextSources,
+		readFile:     os.ReadFile,
+		homeDir:      os.UserHomeDir,
+		lookupEnv:    os.Getenv,
+		executable:   os.Executable,
+	}
+}
+
+// loadInsertFileTextSources reads the configured sources from the global
+// projmux config. Insert-file-text is global-only for the MVP.
+func loadInsertFileTextSources() (map[string]hooks.InsertFileTextSource, error) {
+	path, err := hooks.GlobalConfigPath(os.Getenv, os.UserHomeDir)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := hooks.LoadGlobalConfig(path)
+	if err != nil {
+		return nil, err
+	}
+	return cfg.InsertFileText, nil
+}
+
+// Run inserts a configured text source into a tmux pane.
+//
+//	insert-file-text <name> [--pane <id>]   direct insert of a named source
+//	insert-file-text [--pane <id>]          resolve at runtime: 0 sources -> a
+//	                                        status message, 1 -> direct insert,
+//	                                        N -> a popup source picker
+//	insert-file-text --pick [--pane <id>]   render the picker inside an open
+//	                                        popup (has a TTY) and insert
+func (c *insertFileTextCommand) Run(args []string, _ io.Writer, stderr io.Writer) error {
+	fs := flag.NewFlagSet("insert-file-text", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	pane := fs.String("pane", "", "target tmux pane id (defaults to the active pane)")
+	pick := fs.Bool("pick", false, "render the source picker inside an open popup")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	// Accept the optional source name before or after flags: flag.Parse stops at
+	// the first non-flag token, so a leading name (`insert-file-text NAME
+	// --pane X`) leaves the flags unparsed. Peel the name and re-parse the rest.
+	name := ""
+	rest := fs.Args()
+	if len(rest) > 0 {
+		name = strings.TrimSpace(rest[0])
+		if err := fs.Parse(rest[1:]); err != nil {
+			return err
+		}
+	}
+	if fs.NArg() != 0 {
+		return usageError("insert-file-text accepts at most one source name")
+	}
+
+	ctx := context.Background()
+	target := strings.TrimSpace(*pane)
+
+	if *pick {
+		return c.runPick(ctx, target)
+	}
+	if name != "" {
+		return c.insertNamed(ctx, target, name)
+	}
+	return c.resolveAndInsert(ctx, target)
+}
+
+// insertNamed inserts an explicitly named source (the CLI contract).
+func (c *insertFileTextCommand) insertNamed(ctx context.Context, target, name string) error {
+	sources, err := c.loadSources()
+	if err != nil {
+		return fmt.Errorf("load insert-file-text sources: %w", err)
+	}
+	source, ok := sources[name]
+	if !ok {
+		return c.notify(ctx, target, insertMessageNotFound, name)
+	}
+	return c.insertSource(ctx, target, name, source)
+}
+
+// resolveAndInsert enumerates configured sources and branches 0/1/N. This is the
+// keybinding path: it runs in a run-shell (no TTY), so the N branch delegates to
+// a popup that can host the interactive picker.
+func (c *insertFileTextCommand) resolveAndInsert(ctx context.Context, target string) error {
+	sources, err := c.loadSources()
+	if err != nil {
+		return fmt.Errorf("load insert-file-text sources: %w", err)
+	}
+	names := sortedInsertSourceNames(sources)
+	switch len(names) {
+	case 0:
+		return c.notify(ctx, target, insertMessageNoneConfigured, "")
+	case 1:
+		return c.insertSource(ctx, target, names[0], sources[names[0]])
+	default:
+		return c.openPicker(ctx, target, names)
+	}
+}
+
+// runPick renders the picker inside an already-open popup and inserts the chosen
+// source into the originating pane.
+func (c *insertFileTextCommand) runPick(ctx context.Context, target string) error {
+	if target == "" {
+		target = strings.TrimSpace(c.lookupEnv("TMUX_SPLIT_TARGET_PANE"))
+	}
+	sources, err := c.loadSources()
+	if err != nil {
+		return fmt.Errorf("load insert-file-text sources: %w", err)
+	}
+	names := sortedInsertSourceNames(sources)
+	switch len(names) {
+	case 0:
+		return c.notify(ctx, target, insertMessageNoneConfigured, "")
+	case 1:
+		return c.insertSource(ctx, target, names[0], sources[names[0]])
+	}
+	name, err := c.pickSource(names)
+	if err != nil {
+		if isNoSelectionExit(err) {
+			return nil
+		}
+		return err
+	}
+	if name == "" {
+		return nil
+	}
+	source, ok := sources[name]
+	if !ok {
+		return c.notify(ctx, target, insertMessageNotFound, name)
+	}
+	return c.insertSource(ctx, target, name, source)
+}
+
+// insertSource resolves a source to text and injects it as literal pane input.
+// Any failure to produce non-empty text surfaces a short status message; the
+// clipboard is never touched.
+func (c *insertFileTextCommand) insertSource(ctx context.Context, target, name string, source hooks.InsertFileTextSource) error {
+	path := expandInsertHomePath(c.homeDir, source.Path)
+	if strings.TrimSpace(path) == "" {
+		return c.notify(ctx, target, insertMessageUnreadable, name)
+	}
+	data, err := c.readFile(path)
+	if err != nil {
+		return c.notify(ctx, target, insertMessageUnreadable, name)
+	}
+	text := string(data)
+	if source.Trim {
+		text = strings.TrimSpace(text)
+	}
+	if text == "" {
+		return c.notify(ctx, target, insertMessageEmpty, name)
+	}
+	return c.runner.SendKeysLiteral(ctx, target, text)
+}
+
+// openPicker resolves the active pane (so the popup does not target itself) and
+// opens a tmux popup that re-invokes this command with --pick.
+func (c *insertFileTextCommand) openPicker(ctx context.Context, target string, _ []string) error {
+	binaryPath, err := c.executable()
+	if err != nil {
+		return err
+	}
+	if target == "" {
+		if resolved, rerr := c.runner.DisplayMessageTrimmed(ctx, mux.DisplayMessageOptions{Format: mux.TmuxFormat("pane_id")}); rerr == nil {
+			target = strings.TrimSpace(resolved)
+		}
+	}
+	command := shellQuote(binaryPath) + " insert-file-text --pick"
+	if target != "" {
+		command += " --pane " + shellQuote(target)
+	}
+	err = c.runner.DisplayPopup(ctx, command, mux.PopupOptions{
+		Target:        target,
+		Width:         "60%",
+		Height:        "50%",
+		CloseBehavior: mux.PopupCloseOnExit,
+	})
+	if isNoSelectionExit(err) {
+		return nil
+	}
+	return err
+}
+
+// pickSource shows the source-name picker and returns the accepted source name
+// (empty when the user cancelled).
+func (c *insertFileTextCommand) pickSource(names []string) (string, error) {
+	if c.nativePicker == nil {
+		return "", errors.New("native picker is not configured")
+	}
+	entries := make([]intpickercompat.Entry, 0, len(names))
+	for _, name := range names {
+		entries = append(entries, intpickercompat.Entry{Label: name, Value: name, SearchKey: name})
+	}
+	result, err := runPickerOptionBackend(c.homeDir, c.lookupEnv, c.nativePicker, nil, intpickercompat.Options{
+		UI:         "insert-file-text",
+		Entries:    entries,
+		Title:      "Insert File Text - Choose a source",
+		Prompt:     "Insert > ",
+		Footer:     projmuxFooter("Choose a text source to insert into the active pane."),
+		ExpectKeys: []string{"enter"},
+	})
+	if err != nil {
+		return "", err
+	}
+	if result.Key != "enter" || result.Value == "" {
+		return "", nil
+	}
+	return result.Value, nil
+}
+
+// notify shows a short, localized status-line message. The error-variant
+// prefixes append the source name. It always returns nil so a keybinding's
+// run-shell does not surface a shell error for an expected, user-visible
+// condition.
+func (c *insertFileTextCommand) notify(ctx context.Context, target, fallback, name string) error {
+	message := localizeUIText(c.locale(), fallback)
+	if name != "" {
+		message = message + " " + name
+	}
+	_ = c.runner.ShowStatusMessage(ctx, target, message)
+	return nil
+}
+
+func (c *insertFileTextCommand) locale() i18n.Locale {
+	return appLocale(c.homeDir, c.lookupEnv)
+}
+
+func sortedInsertSourceNames(sources map[string]hooks.InsertFileTextSource) []string {
+	names := make([]string, 0, len(sources))
+	for name := range sources {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// expandInsertHomePath expands a leading `~` (MVP: home only, no env vars).
+func expandInsertHomePath(homeDir func() (string, error), path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path
+	}
+	if homeDir == nil {
+		return path
+	}
+	home, err := homeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return path
+	}
+	if path == "~" {
+		return home
+	}
+	return filepath.Join(home, strings.TrimPrefix(path, "~/"))
+}

--- a/internal/app/insert_file_text_test.go
+++ b/internal/app/insert_file_text_test.go
@@ -1,0 +1,322 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/integrations/hooks"
+	"github.com/crevissepartners/projmux/internal/integrations/mux"
+)
+
+type insertRecordedCall struct {
+	name string
+	args []string
+}
+
+// insertMuxBackend records every tmux subprocess call so tests can assert the
+// exact commands the insert-file-text command issues (and, critically, that no
+// clipboard command is ever emitted).
+type insertMuxBackend struct {
+	calls []insertRecordedCall
+	out   []byte
+	err   error
+}
+
+func (b *insertMuxBackend) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	b.calls = append(b.calls, insertRecordedCall{name: name, args: append([]string(nil), args...)})
+	return append([]byte(nil), b.out...), b.err
+}
+
+func (b *insertMuxBackend) call(sub string) ([]string, bool) {
+	for _, c := range b.calls {
+		if len(c.args) > 0 && c.args[0] == sub {
+			return c.args, true
+		}
+	}
+	return nil, false
+}
+
+// touchedClipboard reports whether any recorded call could reach the OS
+// clipboard: a send-keys `-w` (OSC52) or a buffer/clipboard command. Note `-w`
+// on display-popup is the width flag, not clipboard, so the check is scoped by
+// subcommand.
+func (b *insertMuxBackend) touchedClipboard() bool {
+	for _, c := range b.calls {
+		if len(c.args) == 0 {
+			continue
+		}
+		switch c.args[0] {
+		case "send-keys":
+			if slices.Contains(c.args, "-w") {
+				return true
+			}
+		case "set-buffer", "set-clipboard", "save-buffer", "load-buffer":
+			return true
+		}
+	}
+	return false
+}
+
+func newInsertTestCommand(t *testing.T, backend mux.Backend, sources map[string]hooks.InsertFileTextSource, files map[string]string) *insertFileTextCommand {
+	t.Helper()
+	home := t.TempDir()
+	return &insertFileTextCommand{
+		runner:      mux.NewRunner(backend),
+		loadSources: func() (map[string]hooks.InsertFileTextSource, error) { return sources, nil },
+		readFile: func(p string) ([]byte, error) {
+			if content, ok := files[p]; ok {
+				return []byte(content), nil
+			}
+			return nil, os.ErrNotExist
+		},
+		homeDir:    func() (string, error) { return home, nil },
+		lookupEnv:  func(string) string { return "" },
+		executable: func() (string, error) { return "/usr/bin/projmux", nil },
+	}
+}
+
+func TestInsertFileTextNamedInsertsTrimmedLiteral(t *testing.T) {
+	backend := &insertMuxBackend{}
+	sources := map[string]hooks.InsertFileTextSource{
+		"screenshot": {Path: "/tmp/latest.path", Trim: true},
+	}
+	files := map[string]string{"/tmp/latest.path": "  /home/es5h/shot.png  \n"}
+	cmd := newInsertTestCommand(t, backend, sources, files)
+
+	if err := cmd.Run([]string{"screenshot", "--pane", "%3"}, os.Stdout, os.Stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	args, ok := backend.call("send-keys")
+	if !ok {
+		t.Fatalf("no send-keys call; calls=%#v", backend.calls)
+	}
+	want := []string{"send-keys", "-t", "%3", "-l", "--", "/home/es5h/shot.png"}
+	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("send-keys args = %#v, want %#v", args, want)
+	}
+	if backend.touchedClipboard() {
+		t.Fatalf("clipboard command emitted: %#v", backend.calls)
+	}
+}
+
+func TestInsertFileTextExpandsHome(t *testing.T) {
+	backend := &insertMuxBackend{}
+	home := t.TempDir()
+	expanded := filepath.Join(home, ".screenshots", "latest.path")
+	sources := map[string]hooks.InsertFileTextSource{"s": {Path: "~/.screenshots/latest.path", Trim: true}}
+	cmd := &insertFileTextCommand{
+		runner:      mux.NewRunner(backend),
+		loadSources: func() (map[string]hooks.InsertFileTextSource, error) { return sources, nil },
+		readFile: func(p string) ([]byte, error) {
+			if p == expanded {
+				return []byte("/home/es5h/shot.png"), nil
+			}
+			return nil, os.ErrNotExist
+		},
+		homeDir:    func() (string, error) { return home, nil },
+		lookupEnv:  func(string) string { return "" },
+		executable: func() (string, error) { return "/usr/bin/projmux", nil },
+	}
+
+	if err := cmd.Run([]string{"s", "--pane", "%1"}, os.Stdout, os.Stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	args, ok := backend.call("send-keys")
+	if !ok {
+		t.Fatalf("no send-keys call; calls=%#v", backend.calls)
+	}
+	if args[len(args)-1] != "/home/es5h/shot.png" {
+		t.Fatalf("inserted text = %q, want the file body (proves ~ was expanded)", args[len(args)-1])
+	}
+}
+
+func TestInsertFileTextTrimOptOutKeepsWhitespace(t *testing.T) {
+	backend := &insertMuxBackend{}
+	sources := map[string]hooks.InsertFileTextSource{"raw": {Path: "/tmp/raw.txt", Trim: false}}
+	files := map[string]string{"/tmp/raw.txt": "  keep  "}
+	cmd := newInsertTestCommand(t, backend, sources, files)
+
+	if err := cmd.Run([]string{"raw", "--pane", "%1"}, os.Stdout, os.Stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	args, _ := backend.call("send-keys")
+	if got := args[len(args)-1]; got != "  keep  " {
+		t.Fatalf("inserted text = %q, want untrimmed %q", got, "  keep  ")
+	}
+}
+
+func TestInsertFileTextMissingSourceShowsMessageAndNeverInserts(t *testing.T) {
+	backend := &insertMuxBackend{}
+	cmd := newInsertTestCommand(t, backend, map[string]hooks.InsertFileTextSource{}, nil)
+
+	if err := cmd.Run([]string{"nope", "--pane", "%1"}, os.Stdout, os.Stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if _, ok := backend.call("send-keys"); ok {
+		t.Fatalf("send-keys should not be called for a missing source")
+	}
+	args, ok := backend.call("display-message")
+	if !ok {
+		t.Fatalf("expected a display-message; calls=%#v", backend.calls)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "not found") || !strings.Contains(joined, "nope") {
+		t.Fatalf("display-message = %q, want not-found + source name", joined)
+	}
+	if backend.touchedClipboard() {
+		t.Fatalf("clipboard command emitted: %#v", backend.calls)
+	}
+}
+
+func TestInsertFileTextUnreadableShowsMessage(t *testing.T) {
+	backend := &insertMuxBackend{}
+	sources := map[string]hooks.InsertFileTextSource{"x": {Path: "/tmp/missing.txt", Trim: true}}
+	cmd := newInsertTestCommand(t, backend, sources, nil)
+
+	if err := cmd.Run([]string{"x", "--pane", "%1"}, os.Stdout, os.Stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if _, ok := backend.call("send-keys"); ok {
+		t.Fatalf("send-keys should not run for an unreadable source")
+	}
+	args, ok := backend.call("display-message")
+	if !ok || !strings.Contains(strings.Join(args, " "), "unreadable") {
+		t.Fatalf("expected an unreadable display-message; calls=%#v", backend.calls)
+	}
+}
+
+func TestInsertFileTextEmptyAfterTrimShowsMessage(t *testing.T) {
+	backend := &insertMuxBackend{}
+	sources := map[string]hooks.InsertFileTextSource{"x": {Path: "/tmp/empty.txt", Trim: true}}
+	files := map[string]string{"/tmp/empty.txt": "   \n\t"}
+	cmd := newInsertTestCommand(t, backend, sources, files)
+
+	if err := cmd.Run([]string{"x", "--pane", "%1"}, os.Stdout, os.Stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if _, ok := backend.call("send-keys"); ok {
+		t.Fatalf("send-keys should not run for an empty source")
+	}
+	args, ok := backend.call("display-message")
+	if !ok || !strings.Contains(strings.Join(args, " "), "empty") {
+		t.Fatalf("expected an empty display-message; calls=%#v", backend.calls)
+	}
+}
+
+func TestInsertFileTextZeroSourcesShowsMessage(t *testing.T) {
+	backend := &insertMuxBackend{}
+	cmd := newInsertTestCommand(t, backend, map[string]hooks.InsertFileTextSource{}, nil)
+
+	// No positional name -> runtime resolution over 0 configured sources.
+	if err := cmd.Run([]string{"--pane", "%1"}, os.Stdout, os.Stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if _, ok := backend.call("send-keys"); ok {
+		t.Fatalf("send-keys should not run with zero sources")
+	}
+	if _, ok := backend.call("display-popup"); ok {
+		t.Fatalf("no popup should open with zero sources")
+	}
+	args, ok := backend.call("display-message")
+	if !ok || !strings.Contains(strings.Join(args, " "), "no insert-file-text source configured") {
+		t.Fatalf("expected a none-configured display-message; calls=%#v", backend.calls)
+	}
+}
+
+func TestInsertFileTextSingleSourceInsertsDirectly(t *testing.T) {
+	backend := &insertMuxBackend{}
+	sources := map[string]hooks.InsertFileTextSource{"only": {Path: "/tmp/only.txt", Trim: true}}
+	files := map[string]string{"/tmp/only.txt": "value"}
+	cmd := newInsertTestCommand(t, backend, sources, files)
+
+	if err := cmd.Run([]string{"--pane", "%5"}, os.Stdout, os.Stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if _, ok := backend.call("display-popup"); ok {
+		t.Fatalf("a single source must insert directly, not open a picker popup")
+	}
+	args, ok := backend.call("send-keys")
+	if !ok || args[len(args)-1] != "value" {
+		t.Fatalf("expected a direct send-keys of the single source; calls=%#v", backend.calls)
+	}
+}
+
+func TestInsertFileTextMultipleSourcesOpenPicker(t *testing.T) {
+	backend := &insertMuxBackend{}
+	sources := map[string]hooks.InsertFileTextSource{
+		"a": {Path: "/tmp/a.txt", Trim: true},
+		"b": {Path: "/tmp/b.txt", Trim: true},
+	}
+	cmd := newInsertTestCommand(t, backend, sources, nil)
+
+	// A concrete --pane avoids the active-pane resolution lookup.
+	if err := cmd.Run([]string{"--pane", "%9"}, os.Stdout, os.Stderr); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if _, ok := backend.call("send-keys"); ok {
+		t.Fatalf("N sources must defer to a picker popup, not insert directly")
+	}
+	args, ok := backend.call("display-popup")
+	if !ok {
+		t.Fatalf("expected a display-popup for N sources; calls=%#v", backend.calls)
+	}
+	command := args[len(args)-1]
+	if !strings.Contains(command, "insert-file-text --pick") {
+		t.Fatalf("popup command = %q, want the --pick re-invocation", command)
+	}
+	if !strings.Contains(command, "--pane") || !strings.Contains(command, "%9") {
+		t.Fatalf("popup command = %q, want the origin pane threaded through", command)
+	}
+	if backend.touchedClipboard() {
+		t.Fatalf("clipboard command emitted: %#v", backend.calls)
+	}
+}
+
+func TestInsertFileTextCatalogEntryIsOptInAndRebindable(t *testing.T) {
+	action, ok := keyBindingActionByID(defaultKeyBindingCatalog(), "InsertFileText")
+	if !ok {
+		t.Fatal("catalog is missing the InsertFileText action")
+	}
+	if chords := keyBindingEffectivePlainChords(action); len(chords) != 0 {
+		t.Fatalf("default chords = %#v, want empty (opt-in, no default binding)", chords)
+	}
+	if !keyBindingEditable(action) {
+		t.Fatal("InsertFileText must be editable so Settings can rebind it")
+	}
+	body := renderTmuxBindingBody("/usr/bin/projmux", action)
+	if !strings.Contains(body, "insert-file-text --pane #{pane_id}") {
+		t.Fatalf("tmux body = %q, want the run-shell insert-file-text binding", body)
+	}
+	if strings.Contains(body, "-w") {
+		t.Fatalf("tmux body = %q, must not carry a clipboard flag", body)
+	}
+}
+
+func TestInsertFileTextKeymapRoundTrip(t *testing.T) {
+	parsed, err := parseKeymapFile("/tmp/keymap.toml", `[bindings.InsertFileText]
+keys = ["M-i"]
+`)
+	if err != nil {
+		t.Fatalf("parseKeymapFile error: %v", err)
+	}
+	merged, err := mergeKeymapOverrides(defaultKeyBindingCatalog(), parsed)
+	if err != nil {
+		t.Fatalf("mergeKeymapOverrides error: %v", err)
+	}
+	action, ok := keyBindingActionByID(merged, "InsertFileText")
+	if !ok {
+		t.Fatal("merged catalog dropped InsertFileText")
+	}
+	if got := keyBindingEffectivePlainChords(action); len(got) != 1 || got[0] != "M-i" {
+		t.Fatalf("effective chords = %#v, want [M-i]", got)
+	}
+	lines := strings.Join(tmuxBindLines("/bin/projmux", keyBindingCatalogForScopeFrom(merged, keyBindingScopeStandalone)), "\n")
+	if !strings.Contains(lines, "bind-key -n M-i run-shell") || !strings.Contains(lines, "insert-file-text --pane #{pane_id}") {
+		t.Fatalf("tmux bind lines =\n%s\nwant an M-i run-shell insert-file-text binding", lines)
+	}
+}

--- a/internal/app/keybinding_catalog.go
+++ b/internal/app/keybinding_catalog.go
@@ -398,6 +398,22 @@ func defaultKeyBindingCatalog() []keyBindingAction {
 			TmuxBody:    "current",
 		},
 		{
+			// Opt-in only: the default chord is intentionally empty so an
+			// unconfigured user (Linux/Ghostty included) sees no behavior
+			// change. The binding carries no source argument; the CLI resolves
+			// configured [insert_file_text.*] sources at runtime (0 -> message,
+			// 1 -> direct insert, N -> picker).
+			ID:          "InsertFileText",
+			Description: "Insert a configured text file's contents into the active pane",
+			DisplayName: "Insert File Text",
+			Kind:        keyBindingActionCommand,
+			Tier:        keyBindingTierUserConfigurableDirect,
+			Scope:       keyBindingScopeStandalone,
+			PlainChord:  "",
+			TmuxKind:    tmuxBindingRunProjmux,
+			TmuxBody:    "insert-file-text --pane #{pane_id}",
+		},
+		{
 			ID:             "new-window",
 			Description:    "New tmux window in the current pane directory",
 			Kind:           keyBindingActionCommand,

--- a/internal/app/settings_i18n.go
+++ b/internal/app/settings_i18n.go
@@ -504,6 +504,14 @@ var uiTextKeys = map[string]i18n.Key{
 	"Sessions":                                 "picker.crumb.sessions",
 	"State":                                    "picker.crumb.state",
 	"Session state opens read-only; destructive actions keep the current confirmation policy.": "picker.sessions.state_readonly_note",
+
+	"Insert File Text - Choose a source": "picker.insert_file_text.title",
+	"Insert > ":                          "picker.insert_file_text.prompt",
+	"Choose a text source to insert into the active pane.": "picker.insert_file_text.footer",
+	"insert source not found:":                             "insert_file_text.message.not_found",
+	"insert source unreadable:":                            "insert_file_text.message.unreadable",
+	"insert source empty:":                                 "insert_file_text.message.empty",
+	"no insert-file-text source configured":                "insert_file_text.message.none",
 }
 
 // settingsTextKeys preserves the historical name for the shared registry so

--- a/internal/i18n/default_catalog.go
+++ b/internal/i18n/default_catalog.go
@@ -530,6 +530,13 @@ var defaultCatalogData = map[Locale]map[Key]Entry{
 		Key("picker.crumb.sessions"):                                         textEntry("Sessions"),
 		Key("picker.crumb.state"):                                            textEntry("State"),
 		Key("picker.sessions.state_readonly_note"):                           textEntry("Session state opens read-only; destructive actions keep the current confirmation policy."),
+		Key("picker.insert_file_text.title"):                                 textEntry("Insert File Text - Choose a source"),
+		Key("picker.insert_file_text.prompt"):                                textEntry("Insert > "),
+		Key("picker.insert_file_text.footer"):                                textEntry("Choose a text source to insert into the active pane."),
+		Key("insert_file_text.message.not_found"):                            textEntry("insert source not found:"),
+		Key("insert_file_text.message.unreadable"):                           textEntry("insert source unreadable:"),
+		Key("insert_file_text.message.empty"):                                textEntry("insert source empty:"),
+		Key("insert_file_text.message.none"):                                 textEntry("no insert-file-text source configured"),
 	},
 	Locale("ko-KR"): {
 		KeyNotifyAIResponseComplete:                                          textEntry("응답 완료"),
@@ -1056,6 +1063,13 @@ var defaultCatalogData = map[Locale]map[Key]Entry{
 		Key("picker.crumb.sessions"):                                         textEntry("세션"),
 		Key("picker.crumb.state"):                                            textEntry("상태"),
 		Key("picker.sessions.state_readonly_note"):                           textEntry("세션 상태는 읽기 전용으로 열리며, 파괴적 동작은 현재 확인 정책을 따릅니다."),
+		Key("picker.insert_file_text.title"):                                 textEntry("파일 텍스트 삽입 - 소스 선택"),
+		Key("picker.insert_file_text.prompt"):                                textEntry("삽입 > "),
+		Key("picker.insert_file_text.footer"):                                textEntry("활성 페인에 삽입할 텍스트 소스를 선택하세요."),
+		Key("insert_file_text.message.not_found"):                            textEntry("삽입 소스를 찾을 수 없음:"),
+		Key("insert_file_text.message.unreadable"):                           textEntry("삽입 소스를 읽을 수 없음:"),
+		Key("insert_file_text.message.empty"):                                textEntry("삽입 소스가 비어 있음:"),
+		Key("insert_file_text.message.none"):                                 textEntry("설정된 insert-file-text 소스가 없습니다"),
 	},
 }
 

--- a/internal/integrations/hooks/insert_file_text_test.go
+++ b/internal/integrations/hooks/insert_file_text_test.go
@@ -1,0 +1,128 @@
+package hooks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseInsertFileTextSourceDefaultsTrimTrue(t *testing.T) {
+	cfg, err := ParseProjectConfig(`[insert_file_text.latest_screenshot]
+path = "~/.screenshots/latest.path"
+`)
+	if err != nil {
+		t.Fatalf("ParseProjectConfig returned error: %v", err)
+	}
+	source, ok := cfg.InsertFileText["latest_screenshot"]
+	if !ok {
+		t.Fatalf("insert_file_text source not parsed: %#v", cfg.InsertFileText)
+	}
+	if source.Path != "~/.screenshots/latest.path" {
+		t.Fatalf("source path = %q, want the raw ~ path (expansion happens at read time)", source.Path)
+	}
+	if !source.Trim {
+		t.Fatalf("trim = %v, want default true", source.Trim)
+	}
+}
+
+func TestParseInsertFileTextTrimOptOut(t *testing.T) {
+	cfg, err := ParseProjectConfig(`[insert_file_text.raw]
+path = "/tmp/raw.txt"
+trim = false
+`)
+	if err != nil {
+		t.Fatalf("ParseProjectConfig returned error: %v", err)
+	}
+	if cfg.InsertFileText["raw"].Trim {
+		t.Fatalf("trim = true, want false after opt-out")
+	}
+}
+
+func TestParseInsertFileTextRejectsInvalidName(t *testing.T) {
+	_, err := ParseProjectConfig(`[insert_file_text.bad name]
+path = "/tmp/x"
+`)
+	if err == nil {
+		t.Fatalf("expected an error for an invalid source name")
+	}
+	if !strings.Contains(err.Error(), "unsupported section") {
+		t.Fatalf("error = %v, want unsupported section", err)
+	}
+}
+
+func TestParseInsertFileTextRejectsUnknownKey(t *testing.T) {
+	_, err := ParseProjectConfig(`[insert_file_text.x]
+path = "/tmp/x"
+mode = "append"
+`)
+	if err == nil || !strings.Contains(err.Error(), "unsupported insert_file_text key") {
+		t.Fatalf("error = %v, want unsupported insert_file_text key", err)
+	}
+}
+
+func TestParseInsertFileTextRejectsNonBoolTrim(t *testing.T) {
+	_, err := ParseProjectConfig(`[insert_file_text.x]
+path = "/tmp/x"
+trim = "yes"
+`)
+	if err == nil || !strings.Contains(err.Error(), "boolean") {
+		t.Fatalf("error = %v, want a boolean parse error", err)
+	}
+}
+
+func TestValidateProjectConfigRequiresInsertFileTextPath(t *testing.T) {
+	cfg, err := ParseProjectConfig(`[insert_file_text.x]
+path = ""
+`)
+	if err != nil {
+		t.Fatalf("ParseProjectConfig returned error: %v", err)
+	}
+	if err := validateProjectConfig(cfg); err == nil {
+		t.Fatalf("expected a validation error for an empty path")
+	}
+}
+
+func TestRenderInsertFileTextRoundTrips(t *testing.T) {
+	original := `[insert_file_text.raw]
+path = "/tmp/raw.txt"
+trim = false
+
+[insert_file_text.screenshot]
+path = "~/.screenshots/latest.path"
+`
+	cfg, err := ParseProjectConfig(original)
+	if err != nil {
+		t.Fatalf("ParseProjectConfig returned error: %v", err)
+	}
+	rendered := renderProjectConfig(cfg)
+
+	reparsed, err := ParseProjectConfig(rendered)
+	if err != nil {
+		t.Fatalf("re-parse of rendered config failed: %v\nrendered:\n%s", err, rendered)
+	}
+	if len(reparsed.InsertFileText) != 2 {
+		t.Fatalf("round-trip lost sources: %#v", reparsed.InsertFileText)
+	}
+	if reparsed.InsertFileText["raw"].Trim {
+		t.Fatalf("round-trip lost trim=false opt-out")
+	}
+	if !reparsed.InsertFileText["screenshot"].Trim {
+		t.Fatalf("round-trip lost trim default true")
+	}
+	// The trim-on default is not persisted; only the opt-out is written.
+	if strings.Contains(rendered, "trim = true") {
+		t.Fatalf("render wrote the default trim = true:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "trim = false") {
+		t.Fatalf("render dropped the trim = false opt-out:\n%s", rendered)
+	}
+}
+
+func TestUnconfiguredInsertFileTextIsNil(t *testing.T) {
+	cfg, err := ParseProjectConfig("[startup]\nrun = \"echo hi\"\n")
+	if err != nil {
+		t.Fatalf("ParseProjectConfig returned error: %v", err)
+	}
+	if cfg.InsertFileText != nil {
+		t.Fatalf("InsertFileText = %#v, want nil when unconfigured", cfg.InsertFileText)
+	}
+}

--- a/internal/integrations/hooks/project_config.go
+++ b/internal/integrations/hooks/project_config.go
@@ -17,14 +17,45 @@ const projectConfigRelativePath = ".projmux/config.toml"
 
 var envKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
+// insertFileTextNamePattern bounds `[insert_file_text.<name>]` source names to a
+// filename-safe, binding-safe identifier set.
+var insertFileTextNamePattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_-]*$`)
+
+const insertFileTextSectionPrefix = "insert_file_text."
+
 type ProjectConfig struct {
-	StartupRun string
-	Hooks      map[Event]string
-	Env        map[string]string
-	Kube       KubeConfig
-	Theme      theme.ThemeConfig
-	UI         UIConfig
-	AI         AIConfig
+	StartupRun     string
+	Hooks          map[Event]string
+	Env            map[string]string
+	Kube           KubeConfig
+	Theme          theme.ThemeConfig
+	UI             UIConfig
+	AI             AIConfig
+	InsertFileText map[string]InsertFileTextSource
+}
+
+// InsertFileTextSource describes one `[insert_file_text.<name>]` source: a text
+// file whose (optionally trimmed) contents are inserted into the active pane.
+type InsertFileTextSource struct {
+	// Path is the source file. A leading `~` is expanded at read time, not here.
+	Path string
+	// Trim reports whether surrounding whitespace is stripped before insert.
+	// Defaults to true; the parser seeds new sources with Trim=true so an
+	// unspecified `trim` behaves as trim-on.
+	Trim bool
+}
+
+// ValidateInsertFileTextName reports whether name is a supported
+// `[insert_file_text.<name>]` source identifier.
+func ValidateInsertFileTextName(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("insert_file_text source name is required")
+	}
+	if !insertFileTextNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid insert_file_text source name %q", name)
+	}
+	return nil
 }
 
 type KubeConfig struct {
@@ -177,6 +208,9 @@ func ParseProjectConfig(content string) (ProjectConfig, error) {
 	if len(cfg.Env) == 0 {
 		cfg.Env = nil
 	}
+	if len(cfg.InsertFileText) == 0 {
+		cfg.InsertFileText = nil
+	}
 	return cfg, nil
 }
 
@@ -244,6 +278,9 @@ func isSupportedProjectConfigSection(section string) bool {
 	if eventName, ok := strings.CutPrefix(section, "hooks."); ok {
 		return normalizeEvent(Event(eventName)) != ""
 	}
+	if name, ok := strings.CutPrefix(section, insertFileTextSectionPrefix); ok {
+		return ValidateInsertFileTextName(name) == nil
+	}
 	return false
 }
 
@@ -297,6 +334,9 @@ func applyProjectConfigValue(cfg *ProjectConfig, section, key, value string, lin
 			return fmt.Errorf("line %d: unsupported ai key %q", lineNo, key)
 		}
 	default:
+		if name, ok := strings.CutPrefix(section, insertFileTextSectionPrefix); ok {
+			return applyInsertFileTextConfigValue(cfg, name, key, value, lineNo)
+		}
 		eventName, ok := strings.CutPrefix(section, "hooks.")
 		if !ok || key != "run" {
 			return fmt.Errorf("line %d: unsupported key %q in section %q", lineNo, key, section)
@@ -307,6 +347,35 @@ func applyProjectConfigValue(cfg *ProjectConfig, section, key, value string, lin
 		}
 		cfg.Hooks[event] = value
 	}
+	return nil
+}
+
+func applyInsertFileTextConfigValue(cfg *ProjectConfig, name, key, value string, lineNo int) error {
+	if err := ValidateInsertFileTextName(name); err != nil {
+		return fmt.Errorf("line %d: %w", lineNo, err)
+	}
+	if cfg.InsertFileText == nil {
+		cfg.InsertFileText = map[string]InsertFileTextSource{}
+	}
+	// Seed new sources with the trim-on default so an unspecified `trim` key
+	// resolves to true rather than the bool zero value.
+	source, ok := cfg.InsertFileText[name]
+	if !ok {
+		source = InsertFileTextSource{Trim: true}
+	}
+	switch key {
+	case "path":
+		source.Path = value
+	case "trim":
+		trim, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("line %d: invalid insert_file_text trim %q: %w", lineNo, value, err)
+		}
+		source.Trim = trim
+	default:
+		return fmt.Errorf("line %d: unsupported insert_file_text key %q", lineNo, key)
+	}
+	cfg.InsertFileText[name] = source
 	return nil
 }
 
@@ -357,6 +426,19 @@ func applyProjectThemeConfigValue(cfg *theme.ThemeConfig, key, value string, lin
 }
 
 func parseProjectConfigValue(section, key, value string) (string, error) {
+	if strings.HasPrefix(section, insertFileTextSectionPrefix) && key == "trim" {
+		// trim is a bare boolean (no quotes), e.g.
+		//   [insert_file_text.latest_screenshot]
+		//   trim = true
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return "", fmt.Errorf("value must be a boolean")
+		}
+		if _, err := strconv.ParseBool(value); err != nil {
+			return "", fmt.Errorf("invalid boolean value: %w", err)
+		}
+		return value, nil
+	}
 	if section == "ai" && (key == "resume_picker_limit" || key == "resume_scan_depth") {
 		// resume_picker_limit and resume_scan_depth are bare integers (no
 		// quotes), e.g.
@@ -455,6 +537,13 @@ func normalizeProjectConfig(cfg *ProjectConfig) {
 	cfg.UI.Locale = strings.TrimSpace(cfg.UI.Locale)
 	cfg.AI.ResumePickerLimit = ClampAIResumePickerLimit(cfg.AI.ResumePickerLimit)
 	cfg.AI.ResumeScanDepth = ClampAIResumeScanDepth(cfg.AI.ResumeScanDepth)
+	for name, source := range cfg.InsertFileText {
+		source.Path = strings.TrimSpace(source.Path)
+		cfg.InsertFileText[name] = source
+	}
+	if len(cfg.InsertFileText) == 0 {
+		cfg.InsertFileText = nil
+	}
 }
 
 func validateProjectConfig(cfg ProjectConfig) error {
@@ -466,6 +555,14 @@ func validateProjectConfig(cfg ProjectConfig) error {
 	for event := range cfg.Hooks {
 		if normalizeEvent(event) == "" {
 			return fmt.Errorf("unsupported hook event %q", event)
+		}
+	}
+	for name, source := range cfg.InsertFileText {
+		if err := ValidateInsertFileTextName(name); err != nil {
+			return err
+		}
+		if strings.TrimSpace(source.Path) == "" {
+			return fmt.Errorf("insert_file_text source %q requires a path", name)
 		}
 	}
 	return nil
@@ -556,10 +653,33 @@ func renderProjectConfig(cfg ProjectConfig) string {
 		}
 		sections = append(sections, b.String())
 	}
+	for _, name := range sortedInsertFileTextNames(cfg.InsertFileText) {
+		source := cfg.InsertFileText[name]
+		var b strings.Builder
+		fmt.Fprintf(&b, "[%s%s]\n", insertFileTextSectionPrefix, name)
+		b.WriteString("path = ")
+		b.WriteString(strconv.Quote(strings.TrimSpace(source.Path)))
+		b.WriteString("\n")
+		// trim defaults to true, so only the opt-out is persisted; a rendered
+		// config round-trips back to the same source.
+		if !source.Trim {
+			b.WriteString("trim = false\n")
+		}
+		sections = append(sections, b.String())
+	}
 	if len(sections) == 0 {
 		return ""
 	}
 	return strings.Join(sections, "\n")
+}
+
+func sortedInsertFileTextNames(sources map[string]InsertFileTextSource) []string {
+	names := make([]string, 0, len(sources))
+	for name := range sources {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func renderThemeConfigSection(cfg theme.ThemeConfig) string {

--- a/internal/integrations/mux/insert.go
+++ b/internal/integrations/mux/insert.go
@@ -1,0 +1,37 @@
+package mux
+
+import (
+	"context"
+	"strings"
+)
+
+// SendKeysLiteral injects literal text into a pane's input using tmux
+// `send-keys -l`. It is the thin, reusable primitive for "put literal text into
+// a pane" that higher layers (e.g. insert-file-text) build on.
+//
+// Contract, by design:
+//   - Literal only: `-l` sends the bytes verbatim; tmux does not interpret them
+//     as key names. `--` terminates option parsing so text starting with `-` is
+//     still delivered literally.
+//   - No Enter: the primitive never appends a submit key. Callers that want a
+//     newline include it in text (the MVP consumer intentionally does not).
+//   - No clipboard: this never passes `-w` (OSC52) or any set-buffer/clipboard
+//     command, so the OS clipboard is never touched.
+//
+// An empty paneTarget sends to the active pane.
+func (r Runner) SendKeysLiteral(ctx context.Context, paneTarget, text string) error {
+	args := []string{"send-keys"}
+	args = appendPaneTargetArgs(args, paneTarget)
+	args = append(args, "-l", "--", text)
+	return r.Run(ctx, args...)
+}
+
+// ShowStatusMessage displays a transient message in the tmux status line via
+// `display-message` (no `-p`, so it renders instead of printing). An empty
+// target scopes the message to the current client.
+func (r Runner) ShowStatusMessage(ctx context.Context, target, message string) error {
+	args := []string{"display-message"}
+	args = appendPaneTargetArgs(args, target)
+	args = append(args, "--", strings.TrimRight(message, "\r\n"))
+	return r.Run(ctx, args...)
+}

--- a/internal/integrations/mux/insert_test.go
+++ b/internal/integrations/mux/insert_test.go
@@ -1,0 +1,72 @@
+package mux
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSendKeysLiteralTargetsPaneWithLiteralFlag(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	if err := runner.SendKeysLiteral(context.Background(), "%7", "/home/es5h/shot.png"); err != nil {
+		t.Fatalf("SendKeysLiteral returned error: %v", err)
+	}
+
+	if backend.name != "tmux" {
+		t.Fatalf("backend name = %q, want tmux", backend.name)
+	}
+	want := []string{"send-keys", "-t", "%7", "-l", "--", "/home/es5h/shot.png"}
+	if !reflect.DeepEqual(backend.args, want) {
+		t.Fatalf("SendKeysLiteral args = %#v, want %#v", backend.args, want)
+	}
+}
+
+func TestSendKeysLiteralEmptyTargetOmitsPaneArgs(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	if err := runner.SendKeysLiteral(context.Background(), "", "value"); err != nil {
+		t.Fatalf("SendKeysLiteral returned error: %v", err)
+	}
+	want := []string{"send-keys", "-l", "--", "value"}
+	if !reflect.DeepEqual(backend.args, want) {
+		t.Fatalf("SendKeysLiteral args = %#v, want %#v", backend.args, want)
+	}
+}
+
+// TestSendKeysLiteralNeverTouchesClipboard is the guardrail behind the whole
+// feature: the literal insert primitive must never emit the OSC52 (`-w`) flag or
+// any clipboard/buffer command.
+func TestSendKeysLiteralNeverTouchesClipboard(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	if err := runner.SendKeysLiteral(context.Background(), "%1", "-flag-looking-text"); err != nil {
+		t.Fatalf("SendKeysLiteral returned error: %v", err)
+	}
+	for _, arg := range backend.args {
+		if arg == "-w" {
+			t.Fatalf("SendKeysLiteral emitted clipboard flag -w: %#v", backend.args)
+		}
+	}
+	joined := strings.Join(backend.args, " ")
+	if strings.Contains(joined, "set-buffer") || strings.Contains(joined, "copy") {
+		t.Fatalf("SendKeysLiteral emitted a clipboard/buffer command: %#v", backend.args)
+	}
+}
+
+func TestShowStatusMessageRendersMessage(t *testing.T) {
+	backend := &recordingBackend{}
+	runner := NewRunner(backend)
+
+	if err := runner.ShowStatusMessage(context.Background(), "%2", "insert source empty: shot\n"); err != nil {
+		t.Fatalf("ShowStatusMessage returned error: %v", err)
+	}
+	want := []string{"display-message", "-t", "%2", "--", "insert source empty: shot"}
+	if !reflect.DeepEqual(backend.args, want) {
+		t.Fatalf("ShowStatusMessage args = %#v, want %#v", backend.args, want)
+	}
+}


### PR DESCRIPTION
## 요약
설정된 텍스트 파일 내용을 현재 active tmux pane 에 **mux literal 로 삽입**하는 generic consumer. 첫 use case = WSL 에서 Windows 스크린샷 경로(`~/.screenshots/latest.path`) 삽입이지만 특정 앱 비의존 generic (screenshot-watcher 는 optional producer).

## Phase 0 — CLI + config + insert primitive
- config `[insert_file_text.<name>]` (`path` ~ 확장, `trim` default true), global
- CLI `projmux insert-file-text <name> [--pane]`
- mux runner 재사용 primitive 로 literal 삽입 (`send-keys -l`, Enter 없음, **OS 클립보드 무변경** — `-w` 미사용)
- 없음/읽기실패/빈값 → `tmux display-message`, 성공 무음

## Phase 1 — Keybinding (단일 정적 액션 + 런타임 소스해결)
- `keybinding_catalog` 에 `InsertFileText` 1개, **기본 chord 없음(opt-in)**
- 런타임: 소스 0개 → message / 1개 → 직행 / N개 → picker
- Settings>Keybindings 노출, i18n en/ko
- 동적 per-source 바인딩 없음, 기본 바인딩 없음 → 미설정 시 Linux/Ghostty 무영향

## 검증
- config/`~`확장/trim/없음/빈값/정상 mux literal / **클립보드 command 미호출** / 0·1·N 분기 (mux mock)
- `go build ./...` / `go test ./internal/...` 통과

Phase 2(docs/recipe)는 후속.
설계: `30.Projects.Design/Projmux/10.Roadmap/Backlog/로드맵 디테일 - InsertFileText generic pane insert`

🤖 Generated with [Claude Code](https://claude.com/claude-code)