### PR TITLE
refactor(agents): unify resume adapters behind shared implementation

### DIFF
--- a/internal/integrations/agents/aisessions/sessions_test.go
+++ b/internal/integrations/agents/aisessions/sessions_test.go
@@ -339,7 +339,7 @@ func TestCountUserTurnsCountsBeyondCandidateScanLimit(t *testing.T) {
 	var b strings.Builder
 	b.WriteString(`{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-0000000000aa","cwd":"/workspace/app","git_branch":"feat/long"}}` + "\n")
 	const userTurns = 505
-	for i := 0; i < userTurns; i++ {
+	for range userTurns {
 		b.WriteString(`{"type":"event_msg","payload":{"type":"user_message","message":"prompt"}}` + "\n")
 		b.WriteString(`{"type":"event_msg","payload":{"type":"agent_message","message":"reply"}}` + "\n")
 	}
@@ -369,7 +369,7 @@ func TestEnrichTurnsCountsBeyondCandidateScanLimit(t *testing.T) {
 	var b strings.Builder
 	b.WriteString(`{"type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-0000000000ab","cwd":"/workspace/app","git_branch":"feat/long"}}` + "\n")
 	const userTurns = 250
-	for i := 0; i < userTurns; i++ {
+	for range userTurns {
 		b.WriteString(`{"type":"event_msg","payload":{"type":"user_message","message":"prompt"}}` + "\n")
 		b.WriteString(`{"type":"event_msg","payload":{"type":"agent_message","message":"reply"}}` + "\n")
 	}

--- a/internal/integrations/agents/antigravity/resume.go
+++ b/internal/integrations/agents/antigravity/resume.go
@@ -4,7 +4,8 @@ package antigravity
 import (
 	"errors"
 	"fmt"
-	"strings"
+
+	"github.com/crevissepartners/projmux/internal/integrations/agents"
 )
 
 const (
@@ -13,38 +14,36 @@ const (
 
 var ErrInvalidResumeID = errors.New("invalid antigravity resume id")
 
+var adapter = agents.ResumeAdapter{
+	ErrInvalidResumeID: ErrInvalidResumeID,
+	BuildArgv: func(id string) []string {
+		return []string{"agy", "--conversation", id}
+	},
+	ValidateID: func(id string) error {
+		if !isUUIDLike(id) {
+			return fmt.Errorf("%w: expected conversation uuid", ErrInvalidResumeID)
+		}
+		return nil
+	},
+}
+
 // ResumeArgs returns the structured Antigravity CLI argv for resuming a saved
 // conversation. Antigravity's stable external id is the conversation UUID
 // surfaced as statusline `conversation_id` or hook `conversationId`.
 func ResumeArgs(resumeID string) ([]string, error) {
-	id, err := NormalizeResumeID(resumeID)
-	if err != nil {
-		return nil, err
-	}
-	return []string{"agy", "--conversation", id}, nil
+	return adapter.ResumeArgs(resumeID)
 }
 
 // ResumeCommand renders ResumeArgs as a shell command suitable for tmux
 // send-keys. Arguments are shell-quoted because the typed command is still
 // interpreted by the pane's shell.
 func ResumeCommand(resumeID string) (string, error) {
-	args, err := ResumeArgs(resumeID)
-	if err != nil {
-		return "", err
-	}
-	return shellJoin(args), nil
+	return adapter.ResumeCommand(resumeID)
 }
 
 // NormalizeResumeID trims and validates an Antigravity conversation id.
 func NormalizeResumeID(resumeID string) (string, error) {
-	id := strings.TrimSpace(resumeID)
-	if id == "" {
-		return "", fmt.Errorf("%w: empty", ErrInvalidResumeID)
-	}
-	if !isUUIDLike(id) {
-		return "", fmt.Errorf("%w: expected conversation uuid", ErrInvalidResumeID)
-	}
-	return id, nil
+	return adapter.NormalizeResumeID(resumeID)
 }
 
 func isUUIDLike(id string) bool {
@@ -64,32 +63,4 @@ func isUUIDLike(id string) bool {
 		}
 	}
 	return true
-}
-
-func shellJoin(args []string) string {
-	quoted := make([]string, 0, len(args))
-	for _, arg := range args {
-		quoted = append(quoted, shellQuote(arg))
-	}
-	return strings.Join(quoted, " ")
-}
-
-func shellQuote(s string) string {
-	if s == "" {
-		return "''"
-	}
-	if strings.IndexFunc(s, func(r rune) bool {
-		return !(r >= 'a' && r <= 'z' ||
-			r >= 'A' && r <= 'Z' ||
-			r >= '0' && r <= '9' ||
-			r == '-' ||
-			r == '_' ||
-			r == '.' ||
-			r == '/' ||
-			r == ':' ||
-			r == '=')
-	}) == -1 {
-		return s
-	}
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/integrations/agents/claude/resume.go
+++ b/internal/integrations/agents/claude/resume.go
@@ -3,9 +3,8 @@ package claude
 
 import (
 	"errors"
-	"fmt"
-	"strings"
-	"unicode"
+
+	"github.com/crevissepartners/projmux/internal/integrations/agents"
 )
 
 const (
@@ -14,65 +13,28 @@ const (
 
 var ErrInvalidResumeID = errors.New("invalid claude resume id")
 
+var adapter = agents.ResumeAdapter{
+	ErrInvalidResumeID: ErrInvalidResumeID,
+	BuildArgv: func(id string) []string {
+		return []string{"claude", "--resume", id}
+	},
+	ValidateID: agents.RejectControlCharacters(ErrInvalidResumeID),
+}
+
 // ResumeArgs returns the structured Claude CLI argv for resuming a saved
 // interactive session.
 func ResumeArgs(resumeID string) ([]string, error) {
-	id, err := NormalizeResumeID(resumeID)
-	if err != nil {
-		return nil, err
-	}
-	return []string{"claude", "--resume", id}, nil
+	return adapter.ResumeArgs(resumeID)
 }
 
 // ResumeCommand renders ResumeArgs as a shell command suitable for tmux
 // send-keys. Arguments are shell-quoted because the typed command is still
 // interpreted by the pane's shell.
 func ResumeCommand(resumeID string) (string, error) {
-	args, err := ResumeArgs(resumeID)
-	if err != nil {
-		return "", err
-	}
-	return shellJoin(args), nil
+	return adapter.ResumeCommand(resumeID)
 }
 
 // NormalizeResumeID trims and validates a Claude session resume id.
 func NormalizeResumeID(resumeID string) (string, error) {
-	id := strings.TrimSpace(resumeID)
-	if id == "" {
-		return "", fmt.Errorf("%w: empty", ErrInvalidResumeID)
-	}
-	for _, r := range id {
-		if unicode.IsControl(r) {
-			return "", fmt.Errorf("%w: contains control character", ErrInvalidResumeID)
-		}
-	}
-	return id, nil
-}
-
-func shellJoin(args []string) string {
-	quoted := make([]string, 0, len(args))
-	for _, arg := range args {
-		quoted = append(quoted, shellQuote(arg))
-	}
-	return strings.Join(quoted, " ")
-}
-
-func shellQuote(s string) string {
-	if s == "" {
-		return "''"
-	}
-	if strings.IndexFunc(s, func(r rune) bool {
-		return !(r >= 'a' && r <= 'z' ||
-			r >= 'A' && r <= 'Z' ||
-			r >= '0' && r <= '9' ||
-			r == '-' ||
-			r == '_' ||
-			r == '.' ||
-			r == '/' ||
-			r == ':' ||
-			r == '=')
-	}) == -1 {
-		return s
-	}
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+	return adapter.NormalizeResumeID(resumeID)
 }

--- a/internal/integrations/agents/codex/resume.go
+++ b/internal/integrations/agents/codex/resume.go
@@ -3,9 +3,8 @@ package codex
 
 import (
 	"errors"
-	"fmt"
-	"strings"
-	"unicode"
+
+	"github.com/crevissepartners/projmux/internal/integrations/agents"
 )
 
 const (
@@ -14,65 +13,28 @@ const (
 
 var ErrInvalidResumeID = errors.New("invalid codex resume id")
 
+var adapter = agents.ResumeAdapter{
+	ErrInvalidResumeID: ErrInvalidResumeID,
+	BuildArgv: func(id string) []string {
+		return []string{"codex", "resume", id}
+	},
+	ValidateID: agents.RejectControlCharacters(ErrInvalidResumeID),
+}
+
 // ResumeArgs returns the structured Codex CLI argv for resuming a saved
 // interactive session.
 func ResumeArgs(resumeID string) ([]string, error) {
-	id, err := NormalizeResumeID(resumeID)
-	if err != nil {
-		return nil, err
-	}
-	return []string{"codex", "resume", id}, nil
+	return adapter.ResumeArgs(resumeID)
 }
 
 // ResumeCommand renders ResumeArgs as a shell command suitable for tmux
 // send-keys. Arguments are shell-quoted because the typed command is still
 // interpreted by the pane's shell.
 func ResumeCommand(resumeID string) (string, error) {
-	args, err := ResumeArgs(resumeID)
-	if err != nil {
-		return "", err
-	}
-	return shellJoin(args), nil
+	return adapter.ResumeCommand(resumeID)
 }
 
 // NormalizeResumeID trims and validates a Codex session resume id.
 func NormalizeResumeID(resumeID string) (string, error) {
-	id := strings.TrimSpace(resumeID)
-	if id == "" {
-		return "", fmt.Errorf("%w: empty", ErrInvalidResumeID)
-	}
-	for _, r := range id {
-		if unicode.IsControl(r) {
-			return "", fmt.Errorf("%w: contains control character", ErrInvalidResumeID)
-		}
-	}
-	return id, nil
-}
-
-func shellJoin(args []string) string {
-	quoted := make([]string, 0, len(args))
-	for _, arg := range args {
-		quoted = append(quoted, shellQuote(arg))
-	}
-	return strings.Join(quoted, " ")
-}
-
-func shellQuote(s string) string {
-	if s == "" {
-		return "''"
-	}
-	if strings.IndexFunc(s, func(r rune) bool {
-		return !(r >= 'a' && r <= 'z' ||
-			r >= 'A' && r <= 'Z' ||
-			r >= '0' && r <= '9' ||
-			r == '-' ||
-			r == '_' ||
-			r == '.' ||
-			r == '/' ||
-			r == ':' ||
-			r == '=')
-	}) == -1 {
-		return s
-	}
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+	return adapter.NormalizeResumeID(resumeID)
 }

--- a/internal/integrations/agents/resume.go
+++ b/internal/integrations/agents/resume.go
@@ -1,0 +1,96 @@
+// Package agents contains shared session restore plumbing for the per-agent
+// CLI adapter packages (claude, codex, antigravity).
+package agents
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// ResumeAdapter parameterizes an agent CLI's session resume behavior. Each
+// agent package declares one adapter and delegates its exported helpers to it.
+type ResumeAdapter struct {
+	// ErrInvalidResumeID is the agent's sentinel error wrapped by
+	// NormalizeResumeID failures.
+	ErrInvalidResumeID error
+	// BuildArgv renders the agent CLI argv for a normalized resume id.
+	BuildArgv func(id string) []string
+	// ValidateID checks a trimmed, non-empty resume id and returns an error
+	// wrapping ErrInvalidResumeID when the id is malformed.
+	ValidateID func(id string) error
+}
+
+// ResumeArgs returns the structured agent CLI argv for resuming a saved
+// interactive session.
+func (a ResumeAdapter) ResumeArgs(resumeID string) ([]string, error) {
+	id, err := a.NormalizeResumeID(resumeID)
+	if err != nil {
+		return nil, err
+	}
+	return a.BuildArgv(id), nil
+}
+
+// ResumeCommand renders ResumeArgs as a shell command suitable for tmux
+// send-keys. Arguments are shell-quoted because the typed command is still
+// interpreted by the pane's shell.
+func (a ResumeAdapter) ResumeCommand(resumeID string) (string, error) {
+	args, err := a.ResumeArgs(resumeID)
+	if err != nil {
+		return "", err
+	}
+	return shellJoin(args), nil
+}
+
+// NormalizeResumeID trims and validates an agent session resume id.
+func (a ResumeAdapter) NormalizeResumeID(resumeID string) (string, error) {
+	id := strings.TrimSpace(resumeID)
+	if id == "" {
+		return "", fmt.Errorf("%w: empty", a.ErrInvalidResumeID)
+	}
+	if err := a.ValidateID(id); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// RejectControlCharacters returns a resume-id validator that rejects ids
+// containing control characters, wrapping sentinel in the returned error.
+func RejectControlCharacters(sentinel error) func(string) error {
+	return func(id string) error {
+		for _, r := range id {
+			if unicode.IsControl(r) {
+				return fmt.Errorf("%w: contains control character", sentinel)
+			}
+		}
+		return nil
+	}
+}
+
+func shellJoin(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuote(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if strings.IndexFunc(s, func(r rune) bool {
+		return !(r >= 'a' && r <= 'z' ||
+			r >= 'A' && r <= 'Z' ||
+			r >= '0' && r <= '9' ||
+			r == '-' ||
+			r == '_' ||
+			r == '.' ||
+			r == '/' ||
+			r == ':' ||
+			r == '=')
+	}) == -1 {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}


### PR DESCRIPTION
## Summary
- `integrations/agents/{claude,codex,antigravity}/resume.go` were ~95% copy-paste (identical normalize/quote logic, only argv line and sentinel error differ); collapse into one parameterized `agents.ResumeAdapter` in the parent package.
- Each agent package keeps its exact exported API (`AgentName`, `ErrInvalidResumeID`, `ResumeArgs`, `ResumeCommand`, `NormalizeResumeID`) as thin wrappers — all callers untouched, error strings and argv shapes preserved verbatim.
- Triplicated `shellJoin`/`shellQuote` reduced to a single copy; adding a 4th agent becomes a ~20-line adapter declaration. Net -9 lines, duplication 3→1.

## Test plan
- [x] make fmt
- [x] make fix (deadcode gate clean)
- [x] make test

## Globalization
- [x] No user-facing string changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)