### PR TITLE
refactor(notify): centralize notification metadata keys in core/notify

### DIFF
--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -22,6 +22,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/aibadge"
 	"github.com/crevissepartners/projmux/internal/core/aiprovider"
+	"github.com/crevissepartners/projmux/internal/core/notify"
 	"github.com/crevissepartners/projmux/internal/i18n"
 	"github.com/crevissepartners/projmux/internal/integrations/agents/aisessions"
 	"github.com/crevissepartners/projmux/internal/integrations/agents/antigravity"
@@ -2973,7 +2974,7 @@ func aiNotificationTextAgentWithMetadata(text string, metadata map[string]string
 }
 
 func aiNotificationMetadataAgent(metadata map[string]string) string {
-	switch strings.ToLower(strings.TrimSpace(metadata["agent"])) {
+	switch strings.ToLower(strings.TrimSpace(metadata[notify.MetaAgent])) {
 	case "codex":
 		return "Codex"
 	case "claude":
@@ -2984,7 +2985,7 @@ func aiNotificationMetadataAgent(metadata map[string]string) string {
 }
 
 func aiNotificationMetadataCategoryID(metadata map[string]string) string {
-	category := strings.TrimSpace(metadata["category"])
+	category := strings.TrimSpace(metadata[notify.MetaCategory])
 	if category == "" {
 		return ""
 	}

--- a/internal/app/ai_ingest.go
+++ b/internal/app/ai_ingest.go
@@ -247,9 +247,9 @@ func (c *aiCommand) ingestBell(paneID string) error {
 	}
 	text := composeBellNotifyText(info)
 	metadata := map[string]string{
-		"agent": "bell",
-		"event": "bell",
-		"pane":  info.Pane,
+		notify.MetaAgent: "bell",
+		notify.MetaEvent: "bell",
+		"pane":           info.Pane,
 	}
 	if info.Session != "" {
 		metadata["session"] = info.Session

--- a/internal/app/ai_ingest_antigravity.go
+++ b/internal/app/ai_ingest_antigravity.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/core/notify"
 	antigravityadapter "github.com/crevissepartners/projmux/internal/core/usage/adapters/antigravity"
 )
 
@@ -252,8 +253,8 @@ func normalizeAntigravityEventName(name string) string {
 
 func (p antigravityHookPayload) antigravityMetadata() map[string]string {
 	metadata := map[string]string{
-		"agent":              aiModeAntigravity,
-		"event":              p.EventName,
+		notify.MetaAgent:     aiModeAntigravity,
+		notify.MetaEvent:     p.EventName,
 		"conversation_id":    p.ConversationID,
 		"cwd":                p.CWD,
 		"transcript_path":    p.TranscriptPath,

--- a/internal/app/ai_ingest_claude.go
+++ b/internal/app/ai_ingest_claude.go
@@ -310,8 +310,8 @@ func parseClaudeHookPayload(data []byte) (claudeHookPayload, error) {
 
 func (p claudeHookPayload) claudeMetadata() map[string]string {
 	metadata := map[string]string{
-		"agent":             aiModeClaude,
-		"event":             p.EventName,
+		notify.MetaAgent:    aiModeClaude,
+		notify.MetaEvent:    p.EventName,
 		"session_id":        p.SessionID,
 		"cwd":               p.CWD,
 		"transcript_path":   p.TranscriptPath,

--- a/internal/app/ai_ingest_codex.go
+++ b/internal/app/ai_ingest_codex.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/crevissepartners/projmux/internal/core/notify"
 )
 
 type codexHookPayload struct {
@@ -197,8 +199,8 @@ func parseCodexHookPayload(data []byte) (codexHookPayload, error) {
 
 func (p codexHookPayload) codexHookMetadata() map[string]string {
 	metadata := map[string]string{
-		"agent":           aiModeCodex,
-		"event":           p.EventName,
+		notify.MetaAgent:  aiModeCodex,
+		notify.MetaEvent:  p.EventName,
 		"session_id":      p.SessionID,
 		"thread_id":       p.matchThreadID(),
 		"turn_id":         p.TurnID,
@@ -223,16 +225,16 @@ func (p codexHookPayload) codexHookMetadata() map[string]string {
 
 func (p codexHookPayload) codexGenericHookMetadata() map[string]string {
 	metadata := map[string]string{
-		"provider":   aiHookProviderCodex,
-		"agent":      aiModeCodex,
-		"event":      p.EventName,
-		"tool":       p.ToolName,
-		"tool_name":  p.ToolName,
-		"cwd":        p.CWD,
-		"thread_id":  p.matchThreadID(),
-		"session_id": p.SessionID,
-		"turn_id":    p.TurnID,
-		"model":      p.Model,
+		"provider":       aiHookProviderCodex,
+		notify.MetaAgent: aiModeCodex,
+		notify.MetaEvent: p.EventName,
+		"tool":           p.ToolName,
+		"tool_name":      p.ToolName,
+		"cwd":            p.CWD,
+		"thread_id":      p.matchThreadID(),
+		"session_id":     p.SessionID,
+		"turn_id":        p.TurnID,
+		"model":          p.Model,
 	}
 	out := make(map[string]string, len(metadata))
 	for k, v := range metadata {

--- a/internal/app/ai_notify_body.go
+++ b/internal/app/ai_notify_body.go
@@ -184,10 +184,10 @@ func mergeAINotifyBodyMetadata(metadata map[string]string, body aiNotifyBody) ma
 	merged := make(map[string]string, len(metadata)+2)
 	maps.Copy(merged, metadata)
 	if body.Agent != "" {
-		merged["agent"] = body.Agent
+		merged[notify.MetaAgent] = body.Agent
 	}
 	if body.Category != "" {
-		merged["category"] = body.Category
+		merged[notify.MetaCategory] = body.Category
 	}
 	return merged
 }

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -1102,7 +1102,7 @@ func notifySidebarGroupPreview(entry notify.Notification, locale i18n.Locale) st
 		if text == "" {
 			text = entry.Text
 		}
-		if notifySidebarLabelCell(entry.Metadata["topic"]) == notifySidebarLabelCell(entry.Text) {
+		if notifySidebarLabelCell(entry.Metadata[notify.MetaTopic]) == notifySidebarLabelCell(entry.Text) {
 			text = "Ready"
 		}
 		return notifySidebarLabelCell(text)
@@ -1138,7 +1138,7 @@ func notifySidebarGroupContextLabel(group notifySidebarGroup, liveByID map[strin
 func notifySidebarGroupExplicitAgent(rows []notifySidebarRow, liveByID map[string]notifyLivePane) string {
 	for _, row := range rows {
 		live := liveByID[row.Notify.ID]
-		if agent := firstNonEmptyNotifySidebarString(live.Agent, row.Notify.Metadata["agent"], row.Notify.Metadata["provider"]); agent != "" {
+		if agent := firstNonEmptyNotifySidebarString(live.Agent, row.Notify.Metadata[notify.MetaAgent], row.Notify.Metadata["provider"]); agent != "" {
 			return notifySidebarAgentDisplayName(agent)
 		}
 	}
@@ -1150,7 +1150,7 @@ func notifySidebarGroupContext(rows []notifySidebarRow, liveByID map[string]noti
 		live := liveByID[row.Notify.ID]
 		if context := firstNonEmptyNotifySidebarString(
 			live.Topic,
-			row.Notify.Metadata["topic"],
+			row.Notify.Metadata[notify.MetaTopic],
 			live.Title,
 			row.Notify.Metadata["pane_title"],
 			row.Notify.Metadata["title"],
@@ -1235,7 +1235,7 @@ func notifySidebarLabelForLocale(e notify.Notification, now time.Time, display n
 		text = notifySidebarDimText(text)
 	}
 	if e.Source == notify.SourceAI {
-		if notifySidebarLabelCell(e.Metadata["topic"]) == notifySidebarLabelCell(e.Text) {
+		if notifySidebarLabelCell(e.Metadata[notify.MetaTopic]) == notifySidebarLabelCell(e.Text) {
 			text = "Ready"
 			if display != notifyDisplayLive {
 				text = notifySidebarDimText(text)
@@ -1388,7 +1388,7 @@ func notifySidebarTopicBadge(e notify.Notification) string {
 	if e.Source != notify.SourceAI {
 		return ""
 	}
-	topic := notifySidebarLabelCell(e.Metadata["topic"])
+	topic := notifySidebarLabelCell(e.Metadata[notify.MetaTopic])
 	if topic == "" {
 		return ""
 	}

--- a/internal/app/notify_consume.go
+++ b/internal/app/notify_consume.go
@@ -76,7 +76,7 @@ func sameNotifyTargetPane(a, b notify.Notification) bool {
 }
 
 func protectedAINotifyEvent(n notify.Notification) bool {
-	event := strings.ToLower(strings.TrimSpace(n.Metadata["event"]))
+	event := strings.ToLower(strings.TrimSpace(n.Metadata[notify.MetaEvent]))
 	id := strings.ToLower(strings.TrimSpace(n.ID))
 	return strings.Contains(event, "permission") ||
 		strings.Contains(event, "stopfailure") ||

--- a/internal/app/notify_producer.go
+++ b/internal/app/notify_producer.go
@@ -199,21 +199,21 @@ func composeAttentionReplyText(agent, topic string) string {
 func mergeAttentionNotifyMetadata(metadata map[string]string, agent, topic, severity string) map[string]string {
 	merged := make(map[string]string, len(metadata)+3)
 	maps.Copy(merged, metadata)
-	if strings.TrimSpace(merged["agent"]) == "" {
-		merged["agent"] = strings.ToLower(strings.TrimSpace(agent))
+	if strings.TrimSpace(merged[notify.MetaAgent]) == "" {
+		merged[notify.MetaAgent] = strings.ToLower(strings.TrimSpace(agent))
 	}
-	if strings.TrimSpace(merged["topic"]) == "" {
-		merged["topic"] = strings.TrimSpace(topic)
+	if strings.TrimSpace(merged[notify.MetaTopic]) == "" {
+		merged[notify.MetaTopic] = strings.TrimSpace(topic)
 	}
-	if strings.TrimSpace(merged["category"]) == "" {
+	if strings.TrimSpace(merged[notify.MetaCategory]) == "" {
 		if severity == notify.SeverityCritical {
-			merged["category"] = "approval_required"
+			merged[notify.MetaCategory] = "approval_required"
 		} else {
-			merged["category"] = "response_complete"
+			merged[notify.MetaCategory] = "response_complete"
 		}
 	}
-	if strings.TrimSpace(merged["state"]) == "" {
-		merged["state"] = "need"
+	if strings.TrimSpace(merged[notify.MetaState]) == "" {
+		merged[notify.MetaState] = "need"
 	}
 	return merged
 }

--- a/internal/app/notify_reconcile.go
+++ b/internal/app/notify_reconcile.go
@@ -188,7 +188,7 @@ func (c *notifyCommand) runReconcile(args []string, stdout, stderr io.Writer) er
 }
 
 func attentionNotifyMetadataMatches(got, want map[string]string) bool {
-	for _, key := range []string{"agent", "category", "state", "topic"} {
+	for _, key := range []string{notify.MetaAgent, notify.MetaCategory, notify.MetaState, notify.MetaTopic} {
 		if strings.TrimSpace(got[key]) != strings.TrimSpace(want[key]) {
 			return false
 		}

--- a/internal/core/notify/notification.go
+++ b/internal/core/notify/notification.go
@@ -28,6 +28,15 @@ const (
 	SourceExternal = "external"
 )
 
+// Metadata keys shared by the notify produce/consume/reconcile sites.
+const (
+	MetaAgent    = "agent"
+	MetaTopic    = "topic"
+	MetaEvent    = "event"
+	MetaCategory = "category"
+	MetaState    = "state"
+)
+
 // DefaultTTL is the default freshness window applied when the caller does not
 // supply --ttl. Expiration is metadata only; it does not remove entries from
 // the pending queue.


### PR DESCRIPTION
## Summary
- The notify and AI clusters share a notification-metadata vocabulary (`agent`/`topic`/`event`/`category`/`state`) only as bare string literals scattered across produce/consume/reconcile/ingest sites — the one piece of the shared model that wasn't centralized in `internal/core/notify`.
- Add exported `Meta*` key constants next to the existing `Severity*`/`Source*` consts and replace the literals at 10 app-side sites (producer, consume, reconcile, ai ingest per-agent files, notify sidebar reads).
- Test-file literals are deliberately left as-is — they prove the wire format is unchanged. `MetaBadge` from the design brief was dropped: "badge" is never used as a metadata key in the repo.
- First of two steps toward promoting the notify cluster out of `internal/app` (step 2: `LivePaneLister` seam to sever the notify→attention reach-in).

## Test plan
- [x] make fmt
- [x] make fix (deadcode gate clean)
- [x] make test

## Globalization
- [x] No user-facing string changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
