### PR TITLE
refactor(usage): promote usage command into its own package

### DIFF
--- a/internal/app/ai_ingest_antigravity.go
+++ b/internal/app/ai_ingest_antigravity.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/crevissepartners/projmux/internal/app/usagecmd"
 	"github.com/crevissepartners/projmux/internal/config"
 	antigravityadapter "github.com/crevissepartners/projmux/internal/core/usage/adapters/antigravity"
 )
@@ -151,11 +152,11 @@ func (c *aiCommand) persistAntigravityContextUsage(payload antigravityHookPayloa
 }
 
 // usageStateDir resolves the directory the usage snapshot cache and the
-// antigravity context sidecar live in. It mirrors usageCommand.resolveStateDir
+// antigravity context sidecar live in. It mirrors usagecmd.Command.resolveStateDir
 // so the ingest writer and the adapter reader agree even when
 // PROJMUX_USAGE_STATE_DIR redirects the cache to a synced location.
 func (c *aiCommand) usageStateDir() (string, error) {
-	if override := strings.TrimSpace(c.env(stateDirEnvVar)); override != "" {
+	if override := strings.TrimSpace(c.env(usagecmd.StateDirEnvVar)); override != "" {
 		return override, nil
 	}
 	homeDir, err := c.homeDir()

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/crevissepartners/projmux/internal/app/usagecmd"
 	"github.com/crevissepartners/projmux/internal/integrations/hooks"
 	"github.com/crevissepartners/projmux/internal/version"
 )
@@ -88,7 +89,7 @@ type App struct {
 	tmux         *tmuxCommand
 	update       *updateCommand
 	upgrade      *upgradeCommand
-	usage        *usageCommand
+	usage        *usagecmd.Command
 	welcome      *welcomeCommand
 	window       *windowCommand
 }
@@ -129,7 +130,7 @@ func New() *App {
 		tmux:         newTmuxCommand(),
 		update:       update,
 		upgrade:      newUpgradeCommand(),
-		usage:        newUsageCommand(),
+		usage:        usagecmd.New(nil),
 		welcome:      newWelcomeCommand(update),
 		window:       newWindowCommand(),
 	}

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -12,11 +12,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crevissepartners/projmux/internal/app/usagecmd"
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/notify"
 	"github.com/crevissepartners/projmux/internal/core/projectidentity"
 	"github.com/crevissepartners/projmux/internal/i18n"
 	"github.com/crevissepartners/projmux/internal/theme"
+	intrender "github.com/crevissepartners/projmux/internal/ui/render"
 )
 
 const (
@@ -45,7 +47,7 @@ type statusCommand struct {
 	homeDir       func() (string, error)
 	readCommand   func(ctx context.Context, name string, args ...string) ([]byte, error)
 	now           func() time.Time
-	usage         *usageCommand
+	usage         *usagecmd.Command
 	notifyStoreFn func() (notifyStore, error)
 }
 
@@ -55,7 +57,7 @@ func newStatusCommand() *statusCommand {
 		homeDir:       os.UserHomeDir,
 		readCommand:   readExternalCommand,
 		now:           time.Now,
-		usage:         newUsageCommand(),
+		usage:         usagecmd.New(nil),
 		notifyStoreFn: defaultStatusNotifyStore,
 	}
 }
@@ -86,9 +88,9 @@ func (c *statusCommand) Run(args []string, stdout, stderr io.Writer) error {
 		return c.runKube(args[1:], stdout, stderr)
 	case "usage":
 		if c.usage == nil {
-			c.usage = newUsageCommand()
+			c.usage = usagecmd.New(nil)
 		}
-		return c.usage.runStatus(args[1:], stdout, stderr)
+		return c.usage.RunStatus(args[1:], stdout, stderr)
 	case "notify":
 		return c.runNotify(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
@@ -913,7 +915,7 @@ func truncateNotifyWithEllipsis(s string, maxWidth int) string {
 	if maxWidth <= 0 {
 		return ""
 	}
-	plain := stripTmuxEscapes(s)
+	plain := intrender.StripTmuxEscapes(s)
 	if notifyVisualLen(plain) <= maxWidth {
 		return plain
 	}

--- a/internal/app/status_notify_test.go
+++ b/internal/app/status_notify_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/core/notify"
 	"github.com/crevissepartners/projmux/internal/i18n"
 	"github.com/crevissepartners/projmux/internal/theme"
+	intrender "github.com/crevissepartners/projmux/internal/ui/render"
 )
 
 func newStatusNotifyCommand(store notifyStore) *statusCommand {
@@ -353,8 +354,8 @@ func TestStatusNotifyLongBodyClipsBeforeDroppingAge(t *testing.T) {
 		{ID: "c", Text: "oldest", Severity: notify.SeverityInfo, Source: notify.SourceAI, Session: "project"},
 	}
 	out := formatStatusNotify(entries, 80, now)
-	if visualLen(out) > 80 {
-		t.Fatalf("visualLen=%d > 80: %q", visualLen(out), out)
+	if intrender.VisualLen(out) > 80 {
+		t.Fatalf("visualLen=%d > 80: %q", intrender.VisualLen(out), out)
 	}
 	for _, want := range []string{
 		notifyLineOpen + renderNotifyProjectBadge("project"),
@@ -374,8 +375,8 @@ func TestStatusNotifyWidthTier1Long(t *testing.T) {
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	out := formatStatusNotify(fixtureAIEntry(now), 96, now)
-	if visualLen(out) > 96 {
-		t.Fatalf("tier1 visualLen=%d > 96: %q", visualLen(out), out)
+	if intrender.VisualLen(out) > 96 {
+		t.Fatalf("tier1 visualLen=%d > 96: %q", intrender.VisualLen(out), out)
 	}
 	for _, want := range []string{
 		notifyLineOpen + renderNotifyProjectBadge("s"),
@@ -437,8 +438,8 @@ func TestStatusNotifyWidthTier2ClipsTextBeforeAge(t *testing.T) {
 	// clip body text while retaining contextual badges and age.
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	out := formatStatusNotify(fixtureAIEntry(now), 45, now)
-	if visualLen(out) > 45 {
-		t.Fatalf("tier2 visualLen=%d > 45: %q", visualLen(out), out)
+	if intrender.VisualLen(out) > 45 {
+		t.Fatalf("tier2 visualLen=%d > 45: %q", intrender.VisualLen(out), out)
 	}
 	for _, want := range []string{
 		notifyLineOpen + renderNotifyProjectBadge("s"),
@@ -459,8 +460,8 @@ func TestStatusNotifyWidthTier3DropsAgeAfterClippingText(t *testing.T) {
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	out := formatStatusNotify(fixtureAIEntry(now), 24, now)
-	if visualLen(out) > 24 {
-		t.Fatalf("tier3 visualLen=%d > 24: %q", visualLen(out), out)
+	if intrender.VisualLen(out) > 24 {
+		t.Fatalf("tier3 visualLen=%d > 24: %q", intrender.VisualLen(out), out)
 	}
 	for _, want := range []string{
 		notifyLineOpen + renderNotifyProjectBadge("s"),
@@ -485,8 +486,8 @@ func TestStatusNotifyWidthTier4TruncatesText(t *testing.T) {
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	out := formatStatusNotify(fixtureAIEntry(now), 24, now)
-	if visualLen(out) > 24 {
-		t.Fatalf("tier4 visualLen=%d > 24: %q", visualLen(out), out)
+	if intrender.VisualLen(out) > 24 {
+		t.Fatalf("tier4 visualLen=%d > 24: %q", intrender.VisualLen(out), out)
 	}
 	if strings.Contains(out, " NEED ") || strings.Contains(out, " claude ") {
 		t.Fatalf("tier4 should drop badges before icon fallback at this width: %q", out)
@@ -506,8 +507,8 @@ func TestStatusNotifyWidthTier5DropsBadgeAndDot(t *testing.T) {
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	out := formatStatusNotify(fixtureAIEntry(now), 14, now)
-	if visualLen(out) > 14 {
-		t.Fatalf("tier5 visualLen=%d > 14: %q", visualLen(out), out)
+	if intrender.VisualLen(out) > 14 {
+		t.Fatalf("tier5 visualLen=%d > 14: %q", intrender.VisualLen(out), out)
 	}
 	if strings.Contains(out, " NEED ") || strings.Contains(out, " claude ") {
 		t.Fatalf("tier5 must drop the block badges: %q", out)
@@ -531,8 +532,8 @@ func TestStatusNotifyWidthTier6HardTruncate(t *testing.T) {
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	out := formatStatusNotify(fixtureAIEntry(now), 8, now)
-	if visualLen(out) > 8 {
-		t.Fatalf("tier6 visualLen=%d > 8: %q", visualLen(out), out)
+	if intrender.VisualLen(out) > 8 {
+		t.Fatalf("tier6 visualLen=%d > 8: %q", intrender.VisualLen(out), out)
 	}
 	if !strings.HasSuffix(out, "#[default]") {
 		t.Fatalf("tier6 must end with #[default]: %q", out)
@@ -551,8 +552,8 @@ func TestStatusNotifyCriticalVeryNarrowFallbackHasNoStandaloneDot(t *testing.T) 
 		Session:   "prod",
 		CreatedAt: now,
 	}}, 6, now)
-	if visualLen(out) > 6 {
-		t.Fatalf("critical narrow visualLen=%d > 6: %q", visualLen(out), out)
+	if intrender.VisualLen(out) > 6 {
+		t.Fatalf("critical narrow visualLen=%d > 6: %q", intrender.VisualLen(out), out)
 	}
 	if strings.Contains(out, notifyIcon) {
 		t.Fatalf("critical narrow fallback must not render standalone dot: %q", out)

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crevissepartners/projmux/internal/app/usagecmd"
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/notify"
 	"github.com/crevissepartners/projmux/internal/core/projectidentity"
@@ -488,25 +489,9 @@ func (c *statusbarCommand) loadUsageState(ctx context.Context) (statusbarUsageSt
 }
 
 func (c *statusbarCommand) defaultUsageState(_ context.Context) (statusbarUsageState, error) {
-	cmd := newUsageCommand()
-	cmd.now = c.nowTime
-	modelScope := cmd.ambientModelScope()
-	mgr, err := cmd.managerForScope(modelScope)
+	state, unsupported, cacheMTime, err := usagecmd.New(c.nowTime).CachedState()
 	if err != nil {
 		return statusbarUsageState{}, err
-	}
-	state, err := mgr.LoadState()
-	if err != nil {
-		return statusbarUsageState{}, err
-	}
-	state = filterUsageStateByModels(state, modelScope)
-	unsupported := cmd.unsupportedUsageProviders("all", false)
-	var cacheMTime time.Time
-	stateDir, err := cmd.resolveStateDir()
-	if err == nil {
-		if info, statErr := os.Stat(coreusage.NewStore(stateDir).FilePath()); statErr == nil {
-			cacheMTime = info.ModTime()
-		}
 	}
 	out := statusbarUsageStateFromCache(state, cacheMTime)
 	out.Unsupported = unsupported
@@ -731,7 +716,7 @@ type statusbarUsageState struct {
 	LastSyncSource string
 	CacheMTime     time.Time
 	LoadError      error
-	Unsupported    []usageUnsupportedProvider
+	Unsupported    []usagecmd.UnsupportedProvider
 }
 
 type statusbarUsagePopupView struct {
@@ -831,7 +816,7 @@ func statusbarUsageToast(state statusbarUsageState) string {
 	return "usage: " + strings.Join(parts, " · ")
 }
 
-func statusbarUnsupportedUsageLine(provider usageUnsupportedProvider) string {
+func statusbarUnsupportedUsageLine(provider usagecmd.UnsupportedProvider) string {
 	label := strings.TrimSpace(provider.Label)
 	if label == "" {
 		label = provider.Model
@@ -847,7 +832,7 @@ func statusbarUsageSyncLine(state statusbarUsageState, now time.Time) string {
 	local := state.LastSync.Local()
 	value := local.Format("2006-01-02 15:04:05")
 	if age := usageSyncAge(state.LastSync, now); age >= time.Second {
-		value += " (" + formatBackoffDuration(age.Round(time.Second)) + " ago)"
+		value += " (" + usagecmd.FormatBackoffDuration(age.Round(time.Second)) + " ago)"
 	}
 	if state.LastSyncSource == "cache mtime" {
 		value += " cache"
@@ -891,11 +876,11 @@ func statusbarUsageRows(snaps []coreusage.Snapshot) []statusbarUsageRow {
 			continue
 		}
 		row := statusbarUsageRow{
-			model:    modelDisplayLabel(s.Model),
+			model:    usagecmd.ModelDisplayLabel(s.Model),
 			window:   string(s.Window),
 			used:     usageCountText(s.Tokens),
 			limit:    usageLimitText(s.Limit),
-			pct:      percentText(s.Pct),
+			pct:      usagecmd.PercentText(s.Pct),
 			pctValue: s.Pct,
 			reset:    usageResetText(s.ResetsAt),
 		}

--- a/internal/app/statusbar_sessionstate.go
+++ b/internal/app/statusbar_sessionstate.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crevissepartners/projmux/internal/app/usagecmd"
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/integrations/sessionstate"
 	"github.com/crevissepartners/projmux/internal/ui/projmuxpicker"
@@ -50,7 +51,7 @@ func statusbarSessionStateSavedText(savedAt, now time.Time) string {
 	text := savedAt.Local().Format("2006-01-02 15:04:05 MST")
 	age := statusbarSessionStateAge(savedAt, now)
 	if age >= time.Second {
-		text += " (" + formatBackoffDuration(age.Round(time.Second)) + " ago)"
+		text += " (" + usagecmd.FormatBackoffDuration(age.Round(time.Second)) + " ago)"
 	}
 	return text
 }

--- a/internal/app/usagecmd/usage.go
+++ b/internal/app/usagecmd/usage.go
@@ -1,4 +1,7 @@
-package app
+// Package usagecmd implements the `projmux usage` and `projmux status usage`
+// command surfaces on top of internal/core/usage. It owns the CLI flag
+// parsing, adapter registry wiring, and the HUD/table/JSON rendering tiers.
+package usagecmd
 
 import (
 	"context"
@@ -24,19 +27,24 @@ import (
 	intrender "github.com/crevissepartners/projmux/internal/ui/render"
 )
 
-// usageCommand exposes the `projmux usage` and `projmux status usage`
+// Command exposes the `projmux usage` and `projmux status usage`
 // surfaces. Both share a single Manager so collect-once-render-twice stays
 // cheap.
-type usageCommand struct {
+type Command struct {
 	managerFn       func([]string) (*usage.Manager, error)
 	enabledAgentsFn func() ([]config.AIAgentProvider, error)
 	now             func() time.Time
 	lookupEnv       func(string) string
 }
 
-func newUsageCommand() *usageCommand {
-	return &usageCommand{
-		now:       time.Now,
+// New builds the usage command. now is the wall clock injected into the
+// Manager and staleness rendering; nil falls back to time.Now.
+func New(now func() time.Time) *Command {
+	if now == nil {
+		now = time.Now
+	}
+	return &Command{
+		now:       now,
 		lookupEnv: os.Getenv,
 	}
 }
@@ -59,7 +67,7 @@ const staleAfter = 10 * time.Minute
 const veryStaleAfter = 1 * time.Hour
 
 // Run implements `projmux usage [...]`.
-func (c *usageCommand) Run(args []string, stdout, stderr io.Writer) error {
+func (c *Command) Run(args []string, stdout, stderr io.Writer) error {
 	fs := flag.NewFlagSet("usage", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	model := fs.String("model", "all", "filter by model: codex | claude | antigravity | all")
@@ -154,12 +162,12 @@ const statusRefreshThrottle = 30 * time.Second
 // a healthy install.
 const usageDebugEnvVar = "PROJMUX_USAGE_DEBUG"
 
-// runStatus implements the `projmux status usage` subcommand. It triggers
+// RunStatus implements the `projmux status usage` subcommand. It triggers
 // an opportunistic, throttled cache refresh (so a fresh install or a stale
 // cache self-heals on the next tmux redraw) and then reads the persisted
 // cache to render the HUD segment. Adapter failures during this hot path
 // are swallowed unless PROJMUX_USAGE_DEBUG is set.
-func (c *usageCommand) runStatus(args []string, stdout, stderr io.Writer) error {
+func (c *Command) RunStatus(args []string, stdout, stderr io.Writer) error {
 	fs := flag.NewFlagSet("status usage", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	maxWidth := fs.Int("max-width", 0, "truncate output to N runes (0 = no truncation)")
@@ -225,10 +233,10 @@ func (c *usageCommand) runStatus(args []string, stdout, stderr io.Writer) error 
 	return err
 }
 
-// stateDirEnvVar lets multi-machine users redirect the snapshot cache to
+// StateDirEnvVar lets multi-machine users redirect the snapshot cache to
 // a synced location (Dropbox, iCloud Drive, etc) so the HUD on every box
 // reflects whichever machine collected most recently.
-const stateDirEnvVar = "PROJMUX_USAGE_STATE_DIR"
+const StateDirEnvVar = "PROJMUX_USAGE_STATE_DIR"
 
 // limitsEnvVar is documented as deprecated in v2: authoritative limits
 // come from the upstream APIs themselves, so the override file has no
@@ -236,14 +244,14 @@ const stateDirEnvVar = "PROJMUX_USAGE_STATE_DIR"
 // existing user configs keep working.
 const limitsEnvVar = "PROJMUX_USAGE_LIMITS_PATH"
 
-func (c *usageCommand) managerForScope(modelScope []string) (*usage.Manager, error) {
+func (c *Command) managerForScope(modelScope []string) (*usage.Manager, error) {
 	if c.managerFn != nil {
 		return c.managerFn(modelScope)
 	}
 	return c.defaultManager(modelScope)
 }
 
-func (c *usageCommand) defaultManager(modelScope []string) (*usage.Manager, error) {
+func (c *Command) defaultManager(modelScope []string) (*usage.Manager, error) {
 	// Resolve the state dir up front: the Antigravity adapter reads its
 	// context sidecar from the same directory the snapshot cache lives in,
 	// so it needs the resolved path at construction time.
@@ -284,8 +292,8 @@ func (c *usageCommand) defaultManager(modelScope []string) (*usage.Manager, erro
 // to <StateDir>/usage. The env-var path is used verbatim so users can
 // point it at e.g. ~/Dropbox/projmux/usage to share the cache across
 // machines.
-func (c *usageCommand) resolveStateDir() (string, error) {
-	if override := strings.TrimSpace(c.env(stateDirEnvVar)); override != "" {
+func (c *Command) resolveStateDir() (string, error) {
+	if override := strings.TrimSpace(c.env(StateDirEnvVar)); override != "" {
 		return override, nil
 	}
 	paths, err := config.DefaultPathsFromEnv()
@@ -295,7 +303,33 @@ func (c *usageCommand) resolveStateDir() (string, error) {
 	return filepath.Join(paths.StateDir, "usage"), nil
 }
 
-func (c *usageCommand) modelScope(model string) ([]string, bool) {
+// CachedState loads the persisted usage state scoped to the ambient
+// enabled agents without triggering any adapter collection. It returns the
+// filtered state, the enabled providers whose usage is unsupported, and the
+// mtime of the on-disk snapshot cache (zero when the cache is missing).
+// Used by the statusbar usage popup, which renders from cache only.
+func (c *Command) CachedState() (usage.State, []UnsupportedProvider, time.Time, error) {
+	modelScope := c.ambientModelScope()
+	mgr, err := c.managerForScope(modelScope)
+	if err != nil {
+		return usage.State{}, nil, time.Time{}, err
+	}
+	state, err := mgr.LoadState()
+	if err != nil {
+		return usage.State{}, nil, time.Time{}, err
+	}
+	state = filterUsageStateByModels(state, modelScope)
+	unsupported := c.unsupportedUsageProviders("all", false)
+	var cacheMTime time.Time
+	if stateDir, err := c.resolveStateDir(); err == nil {
+		if info, statErr := os.Stat(usage.NewStore(stateDir).FilePath()); statErr == nil {
+			cacheMTime = info.ModTime()
+		}
+	}
+	return state, unsupported, cacheMTime, nil
+}
+
+func (c *Command) modelScope(model string) ([]string, bool) {
 	model = strings.ToLower(strings.TrimSpace(model))
 	if model == "" {
 		model = "all"
@@ -311,11 +345,11 @@ func (c *usageCommand) modelScope(model string) ([]string, bool) {
 	}
 }
 
-func (c *usageCommand) ambientModelScope() []string {
+func (c *Command) ambientModelScope() []string {
 	return aiAgentProvidersToUsageModels(c.currentUsageEnabledAgents())
 }
 
-func (c *usageCommand) currentUsageEnabledAgents() []config.AIAgentProvider {
+func (c *Command) currentUsageEnabledAgents() []config.AIAgentProvider {
 	if c.enabledAgentsFn != nil {
 		agents, err := c.enabledAgentsFn()
 		if err == nil {
@@ -356,13 +390,16 @@ func aiAgentProvidersToUsageModels(agents []config.AIAgentProvider) []string {
 	return out
 }
 
-type usageUnsupportedProvider struct {
+// UnsupportedProvider describes an enabled AI agent whose usage cannot be
+// reported (no supported adapter). Rendered as a one-line note by the table
+// form and the statusbar usage popup.
+type UnsupportedProvider struct {
 	Model  string
 	Label  string
 	Reason string
 }
 
-func (c *usageCommand) unsupportedUsageProviders(model string, explicitModel bool) []usageUnsupportedProvider {
+func (c *Command) unsupportedUsageProviders(model string, explicitModel bool) []UnsupportedProvider {
 	model = strings.ToLower(strings.TrimSpace(model))
 	if model == "" {
 		model = "all"
@@ -372,9 +409,9 @@ func (c *usageCommand) unsupportedUsageProviders(model string, explicitModel boo
 		if !ok || provider.UsageSupported {
 			return nil
 		}
-		return []usageUnsupportedProvider{unsupportedUsageProviderFor(provider)}
+		return []UnsupportedProvider{unsupportedUsageProviderFor(provider)}
 	}
-	out := make([]usageUnsupportedProvider, 0)
+	out := make([]UnsupportedProvider, 0)
 	for _, agent := range c.currentUsageEnabledAgents() {
 		provider, ok := aiprovider.Lookup(string(agent))
 		if !ok || provider.UsageSupported {
@@ -385,15 +422,15 @@ func (c *usageCommand) unsupportedUsageProviders(model string, explicitModel boo
 	return out
 }
 
-func unsupportedUsageProviderFor(provider aiprovider.Metadata) usageUnsupportedProvider {
-	return usageUnsupportedProvider{
+func unsupportedUsageProviderFor(provider aiprovider.Metadata) UnsupportedProvider {
+	return UnsupportedProvider{
 		Model:  string(provider.ID),
 		Label:  provider.DisplayName,
 		Reason: "no supported usage adapter",
 	}
 }
 
-func writeUsageUnsupportedNotes(w io.Writer, providers []usageUnsupportedProvider) {
+func writeUsageUnsupportedNotes(w io.Writer, providers []UnsupportedProvider) {
 	for _, provider := range providers {
 		label := strings.TrimSpace(provider.Label)
 		if label == "" {
@@ -403,7 +440,7 @@ func writeUsageUnsupportedNotes(w io.Writer, providers []usageUnsupportedProvide
 	}
 }
 
-func (c *usageCommand) env(name string) string {
+func (c *Command) env(name string) string {
 	if c.lookupEnv == nil {
 		return ""
 	}
@@ -602,8 +639,8 @@ func staleLevel(s usage.Snapshot, now time.Time) int {
 	}
 }
 
-// HUD layout constants. Separators are constant runes so visualLen can
-// reliably count cells without ever falling back to the tmux-escape
+// HUD layout constants. Separators are constant runes so render.VisualLen
+// can reliably count cells without ever falling back to the tmux-escape
 // stripper.
 const (
 	statusInnerSeparator = " · " // between 5h and weekly inside a model.
@@ -691,7 +728,7 @@ func formatStatusUsage(snaps []usage.Snapshot, maxWidth int, now time.Time) stri
 		if out == "" {
 			continue
 		}
-		if maxWidth <= 0 || visualLen(out) <= maxWidth {
+		if maxWidth <= 0 || intrender.VisualLen(out) <= maxWidth {
 			return out
 		}
 	}
@@ -726,7 +763,7 @@ func renderLongHUDInternal(models []modelDisplay, now time.Time, withAge bool) s
 			continue
 		}
 		var b strings.Builder
-		b.WriteString("#[fg=" + tmuxAccentAIFg + ",bold]")
+		b.WriteString("#[fg=" + theme.TmuxAccentAIFg + ",bold]")
 		b.WriteString(m.label)
 		b.WriteString(statusDefaultReset)
 		if withAge {
@@ -781,7 +818,7 @@ func renderTierFiveHOnlyHUD(models []modelDisplay, now time.Time) string {
 			continue
 		}
 		var b strings.Builder
-		b.WriteString("#[fg=" + tmuxAccentAIFg + ",bold]")
+		b.WriteString("#[fg=" + theme.TmuxAccentAIFg + ",bold]")
 		b.WriteString(m.label)
 		b.WriteString(statusDefaultReset)
 		b.WriteByte(' ')
@@ -835,13 +872,13 @@ func renderTierTextShort(models []modelDisplay, now time.Time) string {
 func renderTextPair(m modelDisplay, label string) string {
 	parts := make([]string, 0, 3)
 	if m.hasFive {
-		parts = append(parts, fmt.Sprintf("5h:%s", percentText(m.fivePct)))
+		parts = append(parts, fmt.Sprintf("5h:%s", PercentText(m.fivePct)))
 	}
 	if m.hasWeek {
-		parts = append(parts, fmt.Sprintf("weekly:%s", percentText(m.weekPct)))
+		parts = append(parts, fmt.Sprintf("weekly:%s", PercentText(m.weekPct)))
 	}
 	if m.hasContext {
-		parts = append(parts, fmt.Sprintf("ctx:%s", percentText(m.contextPct)))
+		parts = append(parts, fmt.Sprintf("ctx:%s", PercentText(m.contextPct)))
 	}
 	if len(parts) == 0 {
 		return ""
@@ -863,7 +900,7 @@ func renderHUDPair(window string, pct float64) string {
 	// percent number then re-applies the same color as the bar fill so the
 	// numeric matches visually (a red bar's 90% reads red too).
 	return fmt.Sprintf("%s%s #[fg=%s]%s%s",
-		window+" ", bar, color, percentText(pct), statusDefaultReset)
+		window+" ", bar, color, PercentText(pct), statusDefaultReset)
 }
 
 // formatLastSyncAge formats the age payload used by the HUD's
@@ -909,10 +946,10 @@ func renderAgeIndicator(m modelDisplay, now time.Time) string {
 	return fmt.Sprintf("#[fg=%s](%s)%s", color, text, statusDefaultReset)
 }
 
-// percentText formats a percentage. Negative values are clamped to 0.
+// PercentText formats a percentage. Negative values are clamped to 0.
 // Above 100 we still print the actual number (the bar saturates, the
 // numeric does not — the user must see how far over they are).
-func percentText(pct float64) string {
+func PercentText(pct float64) string {
 	if pct < 0 {
 		pct = 0
 	}
@@ -938,7 +975,7 @@ func buildModelDisplays(snaps []usage.Snapshot, now time.Time) []modelDisplay {
 		if !ok {
 			row = &modelDisplay{
 				model:      s.Model,
-				label:      modelDisplayLabel(s.Model),
+				label:      ModelDisplayLabel(s.Model),
 				shortLabel: modelShortLabel(s.Model),
 			}
 			byModel[s.Model] = row
@@ -993,8 +1030,8 @@ func buildModelDisplays(snaps []usage.Snapshot, now time.Time) []modelDisplay {
 	return out
 }
 
-// modelDisplayLabel maps a model name to its capitalized HUD label.
-func modelDisplayLabel(model string) string {
+// ModelDisplayLabel maps a model name to its capitalized HUD label.
+func ModelDisplayLabel(model string) string {
 	switch strings.ToLower(model) {
 	case "claude":
 		return "Claude"
@@ -1039,8 +1076,8 @@ func truncateWithEllipsis(s string, maxWidth int) string {
 	if maxWidth <= 0 {
 		return ""
 	}
-	plain := stripTmuxEscapes(s)
-	if visualLen(plain) <= maxWidth {
+	plain := intrender.StripTmuxEscapes(s)
+	if intrender.VisualLen(plain) <= maxWidth {
 		return plain
 	}
 	rs := []rune(plain)
@@ -1048,39 +1085,6 @@ func truncateWithEllipsis(s string, maxWidth int) string {
 		return string(rs[:1])
 	}
 	return string(rs[:maxWidth-1]) + "…"
-}
-
-// visualLen returns the rune count of s after stripping tmux `#[...]`
-// escape sequences. The HUD format strings only contain single-cell runes
-// (ASCII + `█` + `░` + `·`), so rune count matches display width 1:1.
-func visualLen(s string) int {
-	return len([]rune(stripTmuxEscapes(s)))
-}
-
-// stripTmuxEscapes removes `#[...]` escape sequences from s. A literal `#`
-// followed by a non-`[` is preserved untouched so user content with `#` is
-// not mangled.
-func stripTmuxEscapes(s string) string {
-	if !strings.Contains(s, "#[") {
-		return s
-	}
-	var b strings.Builder
-	b.Grow(len(s))
-	for i := 0; i < len(s); {
-		if s[i] == '#' && i+1 < len(s) && s[i+1] == '[' {
-			end := strings.IndexByte(s[i+2:], ']')
-			if end < 0 {
-				// Unterminated escape — emit verbatim and stop scanning.
-				b.WriteString(s[i:])
-				break
-			}
-			i += 2 + end + 1
-			continue
-		}
-		b.WriteByte(s[i])
-		i++
-	}
-	return b.String()
 }
 
 func runeLen(s string) int {
@@ -1120,14 +1124,14 @@ func writeBackoffNote(w io.Writer, state usage.State, now time.Time) {
 		if remaining <= 0 {
 			remaining = bs.Until.Sub(now).Round(time.Second)
 		}
-		fmt.Fprintf(w, "%s is in backoff, try again in %s (use --force to bypass)\n", name, formatBackoffDuration(remaining))
+		fmt.Fprintf(w, "%s is in backoff, try again in %s (use --force to bypass)\n", name, FormatBackoffDuration(remaining))
 	}
 }
 
-// formatBackoffDuration renders a duration in compact form (e.g. "12m",
+// FormatBackoffDuration renders a duration in compact form (e.g. "12m",
 // "1h3m", "45s"). Designed to round-trip through both the table note
 // and the HUD without ever emitting the noisy default Go form.
-func formatBackoffDuration(d time.Duration) string {
+func FormatBackoffDuration(d time.Duration) string {
 	if d < 0 {
 		d = 0
 	}

--- a/internal/app/usagecmd/usage_test.go
+++ b/internal/app/usagecmd/usage_test.go
@@ -1,4 +1,4 @@
-package app
+package usagecmd
 
 import (
 	"bytes"
@@ -10,6 +10,8 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/config"
 	"github.com/crevissepartners/projmux/internal/core/usage"
+	"github.com/crevissepartners/projmux/internal/theme"
+	intrender "github.com/crevissepartners/projmux/internal/ui/render"
 )
 
 func TestFormatStatusUsageRendersBothModelsHUD(t *testing.T) {
@@ -38,7 +40,7 @@ func TestFormatStatusUsageRendersBothModelsHUD(t *testing.T) {
 			t.Fatalf("missing %q in %q", want, got)
 		}
 	}
-	if !strings.Contains(got, "#[fg="+tmuxAccentAIFg+",bold]") {
+	if !strings.Contains(got, "#[fg="+theme.TmuxAccentAIFg+",bold]") {
 		t.Fatalf("missing AI label color: %q", got)
 	}
 	if !strings.HasSuffix(got, "#[default]") {
@@ -170,14 +172,14 @@ func TestFormatStatusUsageWidthTiers(t *testing.T) {
 	if !strings.Contains(long, "Claude") || !strings.Contains(long, "weekly ") {
 		t.Fatalf("tier1 long HUD missing weekly bar: %q", long)
 	}
-	if visualLen(long) > 200 {
-		t.Fatalf("tier1 visualLen=%d > 200", visualLen(long))
+	if intrender.VisualLen(long) > 200 {
+		t.Fatalf("tier1 visualLen=%d > 200", intrender.VisualLen(long))
 	}
 
 	// Tier 2: drop weekly bars (label + 5h only).
 	tier2 := formatStatusUsage(snaps, 60, now)
-	if visualLen(tier2) > 60 {
-		t.Fatalf("tier2 visualLen=%d > 60: %q", visualLen(tier2), tier2)
+	if intrender.VisualLen(tier2) > 60 {
+		t.Fatalf("tier2 visualLen=%d > 60: %q", intrender.VisualLen(tier2), tier2)
 	}
 	if !strings.Contains(tier2, "Claude") || !strings.Contains(tier2, "Codex") {
 		t.Fatalf("tier2 missing labels: %q", tier2)
@@ -191,8 +193,8 @@ func TestFormatStatusUsageWidthTiers(t *testing.T) {
 
 	// Tier 3: drop bars, keep long labels.
 	tier3 := formatStatusUsage(snaps, 50, now)
-	if visualLen(tier3) > 50 {
-		t.Fatalf("tier3 visualLen=%d > 50: %q", visualLen(tier3), tier3)
+	if intrender.VisualLen(tier3) > 50 {
+		t.Fatalf("tier3 visualLen=%d > 50: %q", intrender.VisualLen(tier3), tier3)
 	}
 	if !strings.Contains(tier3, "Claude 5h:42% weekly:18%") {
 		t.Fatalf("tier3 long-label form missing: %q", tier3)
@@ -203,8 +205,8 @@ func TestFormatStatusUsageWidthTiers(t *testing.T) {
 
 	// Tier 4: single-letter labels.
 	tier4 := formatStatusUsage(snaps, 45, now)
-	if visualLen(tier4) > 45 {
-		t.Fatalf("tier4 visualLen=%d > 45: %q", visualLen(tier4), tier4)
+	if intrender.VisualLen(tier4) > 45 {
+		t.Fatalf("tier4 visualLen=%d > 45: %q", intrender.VisualLen(tier4), tier4)
 	}
 	if !strings.Contains(tier4, "C 5h:42%") || !strings.Contains(tier4, "X 5h:71%") {
 		t.Fatalf("tier4 short-label form missing: %q", tier4)
@@ -215,8 +217,8 @@ func TestFormatStatusUsageWidthTiers(t *testing.T) {
 
 	// Tier 5: hard truncate with ellipsis.
 	tier5 := formatStatusUsage(snaps, 15, now)
-	if visualLen(tier5) > 15 {
-		t.Fatalf("tier5 visualLen=%d > 15: %q", visualLen(tier5), tier5)
+	if intrender.VisualLen(tier5) > 15 {
+		t.Fatalf("tier5 visualLen=%d > 15: %q", intrender.VisualLen(tier5), tier5)
 	}
 	if !strings.HasSuffix(tier5, "…") {
 		t.Fatalf("tier5 must end with ellipsis: %q", tier5)
@@ -235,30 +237,8 @@ func TestFormatStatusUsageOverLimitShowsActualPercent(t *testing.T) {
 	if !strings.Contains(got, "319%") {
 		t.Fatalf("missing actual over-limit percent: %q", got)
 	}
-	if !strings.Contains(got, tmuxStateCriticalFg+",bold") {
+	if !strings.Contains(got, theme.TmuxStateCriticalFg+",bold") {
 		t.Fatalf("over-limit must use critical color: %q", got)
-	}
-}
-
-func TestVisualLenIgnoresTmuxEscapes(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		in   string
-		want int
-	}{
-		{"", 0},
-		{"abc", 3},
-		{"#[fg=red]abc#[default]", 3},
-		{"#[fg=" + tmuxAccentAIFg + ",bold]Claude#[default] 5h", 9},
-		{"a#[fg=red]b#[default]c", 3},
-		{"abc#[broken", 11},
-		{"hash#tag", 8},
-	}
-	for _, tc := range cases {
-		if got := visualLen(tc.in); got != tc.want {
-			t.Fatalf("visualLen(%q) = %d, want %d", tc.in, got, tc.want)
-		}
 	}
 }
 
@@ -308,8 +288,7 @@ func TestUsageRunAllScopesToEnabledClaudeOnly(t *testing.T) {
 		{Model: "codex", Window: usage.Window5h, Pct: 89, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
 	}}
 
-	c := newUsageCommand()
-	c.now = func() time.Time { return now }
+	c := New(func() time.Time { return now })
 	c.enabledAgentsFn = func() ([]config.AIAgentProvider, error) {
 		return []config.AIAgentProvider{config.AIAgentClaude}, nil
 	}
@@ -361,8 +340,7 @@ func TestUsageStatusScopesToEnabledCodexOnly(t *testing.T) {
 		{Model: "codex", Window: usage.Window5h, Pct: 23, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
 	}}
 
-	c := newUsageCommand()
-	c.now = func() time.Time { return now }
+	c := New(func() time.Time { return now })
 	c.enabledAgentsFn = func() ([]config.AIAgentProvider, error) {
 		return []config.AIAgentProvider{config.AIAgentCodex}, nil
 	}
@@ -373,8 +351,8 @@ func TestUsageStatusScopesToEnabledCodexOnly(t *testing.T) {
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	if err := c.runStatus(nil, stdout, stderr); err != nil {
-		t.Fatalf("runStatus: %v", err)
+	if err := c.RunStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("RunStatus: %v", err)
 	}
 	out := stdout.String()
 	if !strings.Contains(out, "Codex") || !strings.Contains(out, "23%") {
@@ -400,8 +378,7 @@ func TestUsageStatusShowsAntigravityContext(t *testing.T) {
 		{Model: "antigravity", Window: usage.WindowContext, Pct: 63, UpdatedAt: now},
 	}}
 
-	c := newUsageCommand()
-	c.now = func() time.Time { return now }
+	c := New(func() time.Time { return now })
 	c.enabledAgentsFn = func() ([]config.AIAgentProvider, error) {
 		return []config.AIAgentProvider{config.AIAgentAntigravity}, nil
 	}
@@ -411,8 +388,8 @@ func TestUsageStatusShowsAntigravityContext(t *testing.T) {
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	if err := c.runStatus(nil, stdout, stderr); err != nil {
-		t.Fatalf("runStatus: %v", err)
+	if err := c.RunStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("RunStatus: %v", err)
 	}
 	out := stdout.String()
 	if !strings.Contains(out, "Antigravity") || !strings.Contains(out, "63%") {
@@ -431,8 +408,7 @@ func TestUsageRunShowsAntigravityContextUsage(t *testing.T) {
 	agyAd := &stubAdapter{name: "antigravity", snaps: []usage.Snapshot{
 		{Model: "antigravity", Window: usage.WindowContext, Pct: 55, UpdatedAt: now},
 	}}
-	c := newUsageCommand()
-	c.now = func() time.Time { return now }
+	c := New(func() time.Time { return now })
 	c.enabledAgentsFn = func() ([]config.AIAgentProvider, error) {
 		return []config.AIAgentProvider{config.AIAgentAntigravity}, nil
 	}
@@ -468,8 +444,7 @@ func TestUsageRunExplicitAntigravityWorksWhenDisabled(t *testing.T) {
 	agyAd := &stubAdapter{name: "antigravity", snaps: []usage.Snapshot{
 		{Model: "antigravity", Window: usage.WindowContext, Pct: 77, UpdatedAt: now},
 	}}
-	c := newUsageCommand()
-	c.now = func() time.Time { return now }
+	c := New(func() time.Time { return now })
 	c.enabledAgentsFn = func() ([]config.AIAgentProvider, error) {
 		return []config.AIAgentProvider{config.AIAgentClaude}, nil
 	}
@@ -507,8 +482,7 @@ func TestUsageAllWithNoEnabledAgentsSkipsCollectAndShowsFallback(t *testing.T) {
 	claudeAd := &stubAdapter{name: "claude"}
 	codexAd := &stubAdapter{name: "codex"}
 
-	c := newUsageCommand()
-	c.now = func() time.Time { return now }
+	c := New(func() time.Time { return now })
 	c.enabledAgentsFn = func() ([]config.AIAgentProvider, error) {
 		return nil, nil
 	}
@@ -534,8 +508,8 @@ func TestUsageAllWithNoEnabledAgentsSkipsCollectAndShowsFallback(t *testing.T) {
 	}
 
 	stdout.Reset()
-	if err := c.runStatus(nil, stdout, stderr); err != nil {
-		t.Fatalf("runStatus: %v", err)
+	if err := c.RunStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("RunStatus: %v", err)
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("status output with no enabled agents = %q, want empty", stdout.String())
@@ -554,8 +528,7 @@ func TestUsageExplicitClaudeWorksWhenDisabled(t *testing.T) {
 		{Model: "codex", Window: usage.Window5h, Pct: 91, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
 	}}
 
-	c := newUsageCommand()
-	c.now = func() time.Time { return now }
+	c := New(func() time.Time { return now })
 	c.enabledAgentsFn = func() ([]config.AIAgentProvider, error) {
 		return []config.AIAgentProvider{config.AIAgentCodex}, nil
 	}
@@ -596,8 +569,7 @@ func TestUsageExplicitCodexWorksWhenDisabled(t *testing.T) {
 		{Model: "codex", Window: usage.Window5h, Pct: 91, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
 	}}
 
-	c := newUsageCommand()
-	c.now = func() time.Time { return now }
+	c := New(func() time.Time { return now })
 	c.enabledAgentsFn = func() ([]config.AIAgentProvider, error) {
 		return []config.AIAgentProvider{config.AIAgentClaude}, nil
 	}
@@ -672,7 +644,7 @@ func scopedUsageManagerFactory(t *testing.T, store *usage.Store, now time.Time, 
 func TestUsageRunJSONEmptyCacheReturnsArray(t *testing.T) {
 	t.Parallel()
 
-	c := newUsageCommand()
+	c := New(nil)
 	c.managerFn = func([]string) (*usage.Manager, error) {
 		dir := t.TempDir()
 		registry := usage.NewRegistry()
@@ -697,7 +669,7 @@ func TestUsageStatusEmitsFormattedSegment(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
-	c := newUsageCommand()
+	c := New(nil)
 	mgr := newStubManager(t, []*stubAdapter{
 		{name: "claude", snaps: []usage.Snapshot{
 			{Model: "claude", Window: usage.Window5h, Pct: 30, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
@@ -713,8 +685,8 @@ func TestUsageStatusEmitsFormattedSegment(t *testing.T) {
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	if err := c.runStatus(nil, stdout, stderr); err != nil {
-		t.Fatalf("runStatus: %v", err)
+	if err := c.RunStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("RunStatus: %v", err)
 	}
 	out := stdout.String()
 	if !strings.Contains(out, "Claude") || !strings.Contains(out, "Codex") {
@@ -725,14 +697,14 @@ func TestUsageStatusEmitsFormattedSegment(t *testing.T) {
 func TestUsageStatusManagerErrorIsSilent(t *testing.T) {
 	t.Parallel()
 
-	c := newUsageCommand()
+	c := New(nil)
 	c.managerFn = func([]string) (*usage.Manager, error) {
 		return nil, errors.New("boom")
 	}
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	if err := c.runStatus(nil, stdout, stderr); err != nil {
-		t.Fatalf("runStatus must swallow error, got %v", err)
+	if err := c.RunStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("RunStatus must swallow error, got %v", err)
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout = %q, want empty", stdout.String())
@@ -743,7 +715,7 @@ func TestUsageStatusMaybeCollectThrottledOnSecondCall(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
-	c := newUsageCommand()
+	c := New(nil)
 	mgr := newStubManager(t, []*stubAdapter{
 		{name: "claude", snaps: []usage.Snapshot{
 			{Model: "claude", Window: usage.Window5h, Pct: 5, ResetsAt: now.Add(time.Hour), UpdatedAt: now},
@@ -756,13 +728,13 @@ func TestUsageStatusMaybeCollectThrottledOnSecondCall(t *testing.T) {
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	if err := c.runStatus(nil, stdout, stderr); err != nil {
-		t.Fatalf("first runStatus: %v", err)
+	if err := c.RunStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("first RunStatus: %v", err)
 	}
 	first := stdout.String()
 	stdout.Reset()
-	if err := c.runStatus(nil, stdout, stderr); err != nil {
-		t.Fatalf("second runStatus: %v", err)
+	if err := c.RunStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("second RunStatus: %v", err)
 	}
 	second := stdout.String()
 	if first == "" || second == "" {
@@ -773,7 +745,7 @@ func TestUsageStatusMaybeCollectThrottledOnSecondCall(t *testing.T) {
 func TestUsageStatusSwallowsAdapterErrorByDefault(t *testing.T) {
 	t.Parallel()
 
-	c := newUsageCommand()
+	c := New(nil)
 	dir := t.TempDir()
 	registry := usage.NewRegistry()
 	_ = registry.Replace(&stubAdapter{
@@ -788,8 +760,8 @@ func TestUsageStatusSwallowsAdapterErrorByDefault(t *testing.T) {
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	if err := c.runStatus(nil, stdout, stderr); err != nil {
-		t.Fatalf("runStatus: %v", err)
+	if err := c.RunStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("RunStatus: %v", err)
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty (adapter failures must be silent)", stderr.String())
@@ -799,7 +771,7 @@ func TestUsageStatusSwallowsAdapterErrorByDefault(t *testing.T) {
 func TestUsageStatusEchoesAdapterErrorWithDebugEnv(t *testing.T) {
 	t.Parallel()
 
-	c := newUsageCommand()
+	c := New(nil)
 	c.lookupEnv = func(name string) string {
 		if name == usageDebugEnvVar {
 			return "1"
@@ -820,8 +792,8 @@ func TestUsageStatusEchoesAdapterErrorWithDebugEnv(t *testing.T) {
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	if err := c.runStatus(nil, stdout, stderr); err != nil {
-		t.Fatalf("runStatus: %v", err)
+	if err := c.RunStatus(nil, stdout, stderr); err != nil {
+		t.Fatalf("RunStatus: %v", err)
 	}
 	if !strings.Contains(stderr.String(), "network down") {
 		t.Fatalf("stderr = %q, want adapter error surfaced under PROJMUX_USAGE_DEBUG", stderr.String())
@@ -1019,7 +991,7 @@ func TestUsageRunForceBypassesBackoffAndThrottle(t *testing.T) {
 	}
 	mgr := usage.NewManager(registry, store, func() time.Time { return now })
 
-	c := newUsageCommand()
+	c := New(nil)
 	c.managerFn = func([]string) (*usage.Manager, error) { return mgr, nil }
 	c.now = func() time.Time { return now }
 
@@ -1068,7 +1040,7 @@ func TestUsageRunDefaultRespectsBackoff(t *testing.T) {
 	}
 	mgr := usage.NewManager(registry, store, func() time.Time { return now })
 
-	c := newUsageCommand()
+	c := New(nil)
 	c.managerFn = func([]string) (*usage.Manager, error) { return mgr, nil }
 	c.now = func() time.Time { return now }
 
@@ -1154,8 +1126,8 @@ func TestFormatBackoffDurationShapes(t *testing.T) {
 		{75 * time.Minute, "1h15m"},
 	}
 	for _, tc := range cases {
-		if got := formatBackoffDuration(tc.in); got != tc.want {
-			t.Fatalf("formatBackoffDuration(%v) = %q, want %q", tc.in, got, tc.want)
+		if got := FormatBackoffDuration(tc.in); got != tc.want {
+			t.Fatalf("FormatBackoffDuration(%v) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }
@@ -1270,7 +1242,7 @@ func TestFormatStatusUsageAgeDropsOnTier2(t *testing.T) {
 	if !strings.Contains(tier1, "(3m)") {
 		t.Fatalf("tier1 missing age indicator at unconstrained width: %q", tier1)
 	}
-	tier1Width := visualLen(tier1)
+	tier1Width := intrender.VisualLen(tier1)
 	// Pick a budget that fits tier 2 but not tier 1.
 	budget := tier1Width - 1
 	tier2 := formatStatusUsage(snaps, budget, now)
@@ -1280,8 +1252,8 @@ func TestFormatStatusUsageAgeDropsOnTier2(t *testing.T) {
 	if !strings.Contains(tier2, "weekly ") {
 		t.Fatalf("tier2 must keep the weekly bar: %q", tier2)
 	}
-	if visualLen(tier2) > budget {
-		t.Fatalf("tier2 visualLen=%d > budget=%d: %q", visualLen(tier2), budget, tier2)
+	if intrender.VisualLen(tier2) > budget {
+		t.Fatalf("tier2 visualLen=%d > budget=%d: %q", intrender.VisualLen(tier2), budget, tier2)
 	}
 }
 
@@ -1353,10 +1325,10 @@ func TestUsageHelpDocumentsForceFlag(t *testing.T) {
 func TestResolveStateDirHonoursEnvOverride(t *testing.T) {
 	t.Parallel()
 
-	c := newUsageCommand()
+	c := New(nil)
 	want := "/tmp/projmux-shared-usage"
 	c.lookupEnv = func(name string) string {
-		if name == stateDirEnvVar {
+		if name == StateDirEnvVar {
 			return want
 		}
 		return ""

--- a/internal/ui/render/tmuxtext.go
+++ b/internal/ui/render/tmuxtext.go
@@ -1,0 +1,41 @@
+package render
+
+// Tmux status-line text measurement helpers shared by the usage HUD and the
+// notify segment. Both render `#[...]`-styled segments into a fixed cell
+// budget, so the escape stripper and the visual-length counter live here as
+// the neutral home for every command-layer consumer.
+
+import "strings"
+
+// VisualLen returns the rune count of s after stripping tmux `#[...]`
+// escape sequences. The HUD format strings only contain single-cell runes
+// (ASCII + `█` + `░` + `·`), so rune count matches display width 1:1.
+func VisualLen(s string) int {
+	return len([]rune(StripTmuxEscapes(s)))
+}
+
+// StripTmuxEscapes removes `#[...]` escape sequences from s. A literal `#`
+// followed by a non-`[` is preserved untouched so user content with `#` is
+// not mangled.
+func StripTmuxEscapes(s string) string {
+	if !strings.Contains(s, "#[") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if s[i] == '#' && i+1 < len(s) && s[i+1] == '[' {
+			end := strings.IndexByte(s[i+2:], ']')
+			if end < 0 {
+				// Unterminated escape — emit verbatim and stop scanning.
+				b.WriteString(s[i:])
+				break
+			}
+			i += 2 + end + 1
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}

--- a/internal/ui/render/tmuxtext_test.go
+++ b/internal/ui/render/tmuxtext_test.go
@@ -1,0 +1,29 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/theme"
+)
+
+func TestVisualLenIgnoresTmuxEscapes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"abc", 3},
+		{"#[fg=red]abc#[default]", 3},
+		{"#[fg=" + theme.TmuxAccentAIFg + ",bold]Claude#[default] 5h", 9},
+		{"a#[fg=red]b#[default]c", 3},
+		{"abc#[broken", 11},
+		{"hash#tag", 8},
+	}
+	for _, tc := range cases {
+		if got := VisualLen(tc.in); got != tc.want {
+			t.Fatalf("VisualLen(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- First cluster promotion out of the `internal/app` god-package (46k LOC) from the roadmap "app 패키지 다이어트" track: the usage command moves to `internal/app/usagecmd` with a minimal exported surface (`Command`, `New`, `Run`, `RunStatus`, `CachedState`, display helpers, `StateDirEnvVar`).
- The statusbar previously reached into five unexported usage internals to load cached state; that block moves verbatim behind one `Command.CachedState()` call instead of exporting five members. Clock is constructor-injected (`New(now)`), matching the package DI idiom.
- `StripTmuxEscapes`/`VisualLen` relocate to `internal/ui/render/tmuxtext.go` as the import-neutral home (used by usagecmd and the app notify segment). No app→usagecmd→app cycle: usagecmd imports only config/core/theme/ui/render.
- Runtime smoke on the real binary: `projmux usage`, `usage --help`, `status usage --max-width 60` render byte-shape identical output.

## Test plan
- [x] make fmt
- [x] make fix (deadcode gate clean)
- [x] make test (37 packages ok, incl. new usagecmd/render suites)
- [x] manual: `projmux usage` / `projmux status usage` output unchanged

## Globalization
- [x] No user-facing string changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
