### PR TITLE
refactor(settings): depend on role interfaces instead of concrete commands

### DIFF
--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -107,6 +107,13 @@ func newAICommand() *aiCommand {
 	}
 }
 
+// newSettingsAIFallback builds the minimally wired aiCommand Settings falls
+// back to when no ai dependency was injected. It lives next to aiCommand so
+// the settings files never construct the struct directly.
+func newSettingsAIFallback(homeDir func() (string, error), lookupEnv func(string) string) *aiCommand {
+	return &aiCommand{homeDir: homeDir, lookupEnv: lookupEnv}
+}
+
 // notifyProducer returns the wired-up producer or a noop when the command
 // was constructed without one (the test fixtures build aiCommand structs
 // directly).

--- a/internal/app/settings.go
+++ b/internal/app/settings.go
@@ -16,10 +16,11 @@ import (
 )
 
 type settingsCommand struct {
-	ai                  *aiCommand
-	switcher            *switchCommand
-	update              *updateCommand
-	quit                *quitCommand
+	ai                  settingsAI
+	switcher            settingsSwitcher
+	update              updateRunner
+	quit                quitRunner
+	newAI               func() aiHookSettingsReader
 	runner              intpickercompat.Runner
 	nativePicker        intpicker.Runner
 	homeDir             func() (string, error)
@@ -35,11 +36,7 @@ type settingsCommand struct {
 var errSettingsClosed = errors.New("settings closed")
 
 func newSettingsCommand(ai *aiCommand, switcher *switchCommand, update *updateCommand, quit *quitCommand) *settingsCommand {
-	return &settingsCommand{
-		ai:           ai,
-		switcher:     switcher,
-		update:       update,
-		quit:         quit,
+	c := &settingsCommand{
 		nativePicker: intpicker.NativeRunner{In: os.Stdin, Out: os.Stdout},
 		homeDir:      os.UserHomeDir,
 		lookupEnv:    os.Getenv,
@@ -52,6 +49,25 @@ func newSettingsCommand(ai *aiCommand, switcher *switchCommand, update *updateCo
 		},
 		tmuxRunner: inttmux.ExecRunner{},
 	}
+	// The concrete commands satisfy the settings role interfaces structurally.
+	// Guard the nil pointers so the `c.<dep> == nil` checks keep their
+	// pre-interface semantics (a nil *T stored in an interface is non-nil).
+	if ai != nil {
+		c.ai = ai
+	}
+	if switcher != nil {
+		c.switcher = switcher
+	}
+	if update != nil {
+		c.update = update
+	}
+	if quit != nil {
+		c.quit = quit
+	}
+	c.newAI = func() aiHookSettingsReader {
+		return newSettingsAIFallback(c.homeDir, c.lookupEnv)
+	}
+	return c
 }
 
 // statFile checks paths via the injected osStat seam, falling back to os.Stat
@@ -349,7 +365,7 @@ func (c *settingsCommand) runWelcomeSettingsViewer() error {
 }
 
 func (c *settingsCommand) welcomeSettingsViewerOptions() intpickercompat.Options {
-	status, hasStatus := resolveWelcomeUpdateStatus(c.update)
+	status, hasStatus := resolveWelcomeUpdateStatusFrom(c.update)
 	var body strings.Builder
 	locale := appLocale(c.homeDir, c.lookupEnv)
 	_ = writeShellWelcome(&body, welcomeCurrentVersion(), status, hasStatus, false, false, false, welcomeWidthFromEnv(c.lookupEnv), locale)

--- a/internal/app/settings_ai.go
+++ b/internal/app/settings_ai.go
@@ -613,9 +613,15 @@ func aiEnabledAgentDisplayName(provider config.AIAgentProvider) string {
 	return string(provider)
 }
 
-func (c *settingsCommand) aiForSettings() *aiCommand {
+func (c *settingsCommand) aiForSettings() aiHookSettingsReader {
 	if c.ai != nil {
 		return c.ai
 	}
-	return &aiCommand{homeDir: c.homeDir, lookupEnv: c.lookupEnv}
+	if c.newAI != nil {
+		return c.newAI()
+	}
+	// Struct-literal constructions leave the factory nil; keep the previous
+	// nil-ai fallback of a minimally wired aiCommand without naming the
+	// struct here.
+	return newSettingsAIFallback(c.homeDir, c.lookupEnv)
 }

--- a/internal/app/settings_deps.go
+++ b/internal/app/settings_deps.go
@@ -1,0 +1,98 @@
+package app
+
+import (
+	"io"
+
+	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
+)
+
+// This file defines the role interfaces settingsCommand depends on instead of
+// the concrete command structs. The dependency direction stays strictly
+// settings -> {switch, ai, update, quit}; app.go keeps passing the concrete
+// commands, which satisfy these interfaces structurally.
+
+// projectContextResolver resolves the project/workdir context Settings renders
+// (implemented by *switchCommand; consumed by settings_projects.go).
+type projectContextResolver interface {
+	resolveWorkingDir() (string, error)
+	resolveHomeDir() (string, error)
+	resolveSwitchTarget(args []string, command string) (string, error)
+	resolveSwitchTargetNoMemoize(args []string, command string) (string, error)
+	switchRepoRoot(homeDir string) string
+	currentProjdirInfo() (string, string, error)
+	projdirSettingsInfo() (projdirSettingsInfo, error)
+}
+
+// projectDirStore reads and writes pinned projects and saved workdirs
+// (implemented by *switchCommand; consumed by settings_projects.go).
+type projectDirStore interface {
+	loadPins() ([]string, error)
+	loadSavedWorkdirs() ([]string, error)
+	envWorkdirSources() []envWorkdirSource
+	filesystemPinEntries() ([]intpickercompat.Entry, error)
+	filesystemWorkdirEntries() ([]intpickercompat.Entry, error)
+	saveSavedProjdir(target string, stdout io.Writer) error
+	addWorkdir(target string, stdout io.Writer) error
+}
+
+// switchSettingsActions executes the switch-owned settings actions
+// (implemented by *switchCommand; consumed by settings.go).
+type switchSettingsActions interface {
+	executeSettingsAction(action string, stdout, stderr io.Writer) error
+	executeProjdirSettingsAction(action string, stdout, stderr io.Writer) error
+	executeWorkdirSettingsAction(action string, stdout, stderr io.Writer) error
+}
+
+// settingsSwitcher is the composite contract behind settingsCommand.switcher.
+// A single field keeps the existing struct-literal constructions (tests and
+// the ctor) unchanged while the three embedded roles document which slice of
+// the switch command each settings file consumes.
+type settingsSwitcher interface {
+	projectContextResolver
+	projectDirStore
+	switchSettingsActions
+}
+
+// aiModeController toggles the default AI agent mode (implemented by
+// *aiCommand; consumed by settings.go and settings_ai.go).
+type aiModeController interface {
+	getMode() string
+	setMode(mode string) error
+}
+
+// aiHookSettingsReader reads AI hook catalogs and effective runtime actions
+// for the notifications settings pages (implemented by *aiCommand; consumed by
+// settings_notifications.go via aiForSettings).
+type aiHookSettingsReader interface {
+	loadAIHookCatalog(provider string) (aiHookCatalog, error)
+	aiHookEffectiveAction(provider, event string) aiHookActionResolution
+}
+
+// settingsAI is the composite contract behind settingsCommand.ai.
+type settingsAI interface {
+	aiModeController
+	aiHookSettingsReader
+}
+
+// updateRunner runs update actions and reports cached release status
+// (implemented by *updateCommand; consumed by settings.go and
+// settings_about.go).
+type updateRunner interface {
+	Run(args []string, stdout, stderr io.Writer) error
+	status() (updateStatus, error)
+}
+
+// quitRunner opens the quit actions picker (implemented by *quitCommand;
+// consumed by settings.go).
+type quitRunner interface {
+	Run(args []string, stdout, stderr io.Writer) error
+}
+
+// Compile-time checks that the concrete commands keep satisfying the settings
+// role interfaces.
+var (
+	_ settingsSwitcher = (*switchCommand)(nil)
+	_ settingsAI       = (*aiCommand)(nil)
+	_ updateRunner     = (*updateCommand)(nil)
+	_ quitRunner       = (*quitCommand)(nil)
+)

--- a/internal/app/settings_notifications.go
+++ b/internal/app/settings_notifications.go
@@ -413,7 +413,12 @@ func (c *settingsCommand) currentAINotifyDiagnostics() []doctorAINotifyIntegrati
 	if c.aiNotifyDiagnostics != nil {
 		diagnostics = c.aiNotifyDiagnostics()
 	} else {
-		diagnostics = doctorAINotifyDiagnostics(c.ai)
+		// The doctor diagnostics need the full *aiCommand. Recover it when
+		// the injected dependency is the concrete command (production
+		// wiring); otherwise pass nil so doctorAINotifyDiagnostics builds
+		// its own default, matching the previous nil-ai handling.
+		ai, _ := c.ai.(*aiCommand)
+		diagnostics = doctorAINotifyDiagnostics(ai)
 	}
 	return diagnostics
 }

--- a/internal/app/welcome.go
+++ b/internal/app/welcome.go
@@ -145,6 +145,18 @@ func welcomeWidthFromEnv(lookupEnv func(string) string) int {
 }
 
 func resolveWelcomeUpdateStatus(update *updateCommand) (updateStatus, bool) {
+	// Concrete-typed wrapper: keep the nil *updateCommand check here so the
+	// shell/welcome callers never wrap a typed nil pointer in the interface.
+	if update == nil {
+		return updateStatus{}, false
+	}
+	return resolveWelcomeUpdateStatusFrom(update)
+}
+
+// resolveWelcomeUpdateStatusFrom is the interface-typed variant used by the
+// Settings About > Welcome viewer, which holds its update dependency behind
+// the updateRunner seam.
+func resolveWelcomeUpdateStatusFrom(update updateRunner) (updateStatus, bool) {
 	if update == nil {
 		return updateStatus{}, false
 	}


### PR DESCRIPTION
## Summary
- Last planned step of the "app 패키지 다이어트" roadmap track: `settingsCommand` stored concrete `*switchCommand`/`*aiCommand`/`*updateCommand`/`*quitCommand` and called 20+ unexported methods on them — the coupling that has blocked any future separation of these clusters.
- Introduce small role interfaces in `settings_deps.go` (`projectContextResolver`, `projectDirStore`, `switchSettingsActions` — composed as `settingsSwitcher`; `aiModeController` + `aiHookSettingsReader` — composed as `settingsAI`; `updateRunner`; `quitRunner`) with compile-time satisfaction assertions. Field types swap to the interfaces; `newSettingsCommand`'s signature and app wiring are unchanged, and zero test files needed edits.
- Settings no longer constructs `aiCommand` literally: `aiForSettings()` resolves through an injected `newAI` factory (`newSettingsAIFallback` lives next to `newAICommand` in ai.go), preserving nil-fallback semantics exactly.
- Per the design brief, this seam is the deliberate stopping point: a physical package split is gated on relocating `projdirSettingsInfo`/`envWorkdirSource`/`updateStatus` to a neutral home and severing the `tmux.go` settings reach-in, and is intentionally NOT attempted here.

## Test plan
- [x] make fmt
- [x] make fix (deadcode gate clean)
- [x] make test (all packages ok)

## Globalization
- [x] No user-facing string changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
