### PR TITLE
refactor(notify): decouple live-pane checks from attention internals

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -111,7 +111,7 @@ func New() *App {
 		initCmd:      newInitCommand(),
 		insertText:   newInsertFileTextCommand(),
 		kill:         newKillCommand(),
-		notify:       newNotifyCommand(),
+		notify:       newNotifyCommand(newDefaultLivePaneLister()),
 		pin:          newPinCommand(),
 		popupWaitKey: newPopupWaitKeyCommand(),
 		preview:      newPreviewCommand(),

--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -487,6 +487,48 @@ func (c *attentionCommand) listAttentionPanes() ([]attentionPaneRow, error) {
 	return out, nil
 }
 
+// attentionLivePaneLister implements the notify cluster's livePaneLister
+// seam on top of [attentionCommand.listAttentionPanes], translating
+// attentionPaneRow into the neutral livePaneRow DTO so the notify side does
+// not depend on attention internals (state consts, title-prefix helpers).
+type attentionLivePaneLister struct {
+	runner tmuxRunner
+}
+
+func newAttentionLivePaneLister(runner tmuxRunner) livePaneLister {
+	return attentionLivePaneLister{runner: runner}
+}
+
+// newDefaultLivePaneLister builds the production live-pane lister used by
+// the app constructor wiring in [New].
+func newDefaultLivePaneLister() livePaneLister {
+	return newAttentionLivePaneLister(inttmux.ExecRunner{})
+}
+
+func (l attentionLivePaneLister) ListLivePanes() ([]livePaneRow, error) {
+	rows, err := (&attentionCommand{runner: l.runner}).listAttentionPanes()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]livePaneRow, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, livePaneRow{
+			Session:        row.Session,
+			Window:         row.Window,
+			Pane:           row.Pane,
+			Socket:         row.Socket,
+			Title:          row.Title,
+			AttentionState: row.AttentionState,
+			AIState:        row.AIState,
+			Agent:          row.Agent,
+			Topic:          row.Topic,
+			ReplyState:     row.AttentionState == attentionStateReply,
+			TitleBadge:     hasAttentionPrefix(row.Title) || hasBraillePrefix(row.Title),
+		})
+	}
+	return out, nil
+}
+
 func filterAttentionRows(rows []attentionPaneRow) []attentionPaneRow {
 	out := make([]attentionPaneRow, 0, len(rows))
 	for _, row := range rows {

--- a/internal/app/native_picker_test.go
+++ b/internal/app/native_picker_test.go
@@ -305,7 +305,7 @@ func TestProductionPickerConstructorsDoNotCreateCompatRunner(t *testing.T) {
 	if cmd := newSessionsCommand(); cmd.runner != nil {
 		t.Fatal("newSessionsCommand() created compat runner")
 	}
-	if cmd := newNotifyCommand(); cmd.picker != nil {
+	if cmd := newNotifyCommand(newDefaultLivePaneLister()); cmd.picker != nil {
 		t.Fatal("newNotifyCommand() created compat runner")
 	}
 }

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -35,6 +35,7 @@ type notifyCommand struct {
 	storeErr   error
 	now        func() time.Time
 	runner     tmuxRunner
+	livePanes  livePaneLister
 	hooks      *sendNotiHookDispatcher
 	events     notifyQueueRefreshEvents
 	picker     intpickercompat.Runner
@@ -44,10 +45,11 @@ type notifyCommand struct {
 	homeDir    func() (string, error)
 }
 
-func newNotifyCommand() *notifyCommand {
+func newNotifyCommand(livePanes livePaneLister) *notifyCommand {
 	cmd := &notifyCommand{
 		now:        time.Now,
 		runner:     reconcileDefaultRunner(),
+		livePanes:  livePanes,
 		hooks:      newSendNotiHookDispatcher(),
 		native:     intpicker.NativeRunner{In: os.Stdin, Out: os.Stdout},
 		executable: os.Executable,
@@ -1682,6 +1684,10 @@ type notifyLivePane struct {
 	Topic          string `json:"topic,omitempty"`
 	Target         string `json:"target"`
 	ShouldQueue    bool   `json:"should_queue"`
+	// replyState mirrors livePaneRow.ReplyState (pane is in attention "reply"
+	// state) for the manual-reply vs title-attention distinction. Unexported so
+	// the `--live` JSON shape stays unchanged.
+	replyState bool
 }
 
 type notifyLiveRow struct {
@@ -1732,7 +1738,7 @@ func (c *notifyCommand) buildNotifyLiveReportLocale(entries []notify.Notificatio
 		liveCopy := live
 		if !live.ShouldQueue {
 			state := "live-title-attention"
-			if live.AttentionState == attentionStateReply {
+			if live.replyState {
 				state = "live-manual-reply"
 			}
 			report.Rows = append(report.Rows, notifyLiveRow{
@@ -1814,7 +1820,7 @@ func notifyLiveExplanationKey(state string) (i18n.Key, string) {
 // a missing tmux server only suppresses the stale/gone classification —
 // listing entries themselves continues to work.
 func (c *notifyCommand) notifyLiveByIDBestEffort() map[string]notifyLivePane {
-	if c == nil || c.runner == nil {
+	if c == nil || c.livePanes == nil {
 		return nil
 	}
 	panes, err := c.listNotifyLivePanes()
@@ -1824,12 +1830,12 @@ func (c *notifyCommand) notifyLiveByIDBestEffort() map[string]notifyLivePane {
 	return notifyLiveShouldQueueByID(panes)
 }
 
-// notifyLiveStateBestEffort reads the attention pane rows once and returns
-// both the reply+agent index (for stale detection) and the full pane inventory
+// notifyLiveStateBestEffort reads the live pane rows once and returns both
+// the reply+agent index (for stale detection) and the full pane inventory
 // (for gone detection), swallowing any tmux error into nil/nil. Sidebar
 // renders use this so a single `list-panes` subprocess feeds both classifiers.
 func (c *notifyCommand) notifyLiveStateBestEffort() (map[string]notifyLivePane, notifyLivePaneSet) {
-	if c == nil || c.runner == nil {
+	if c == nil || c.livePanes == nil {
 		return nil, nil
 	}
 	panes, paneSet, err := c.listNotifyLivePanesAndSet()
@@ -1881,9 +1887,9 @@ func notifyLivePaneSetKey(session, pane string) string {
 }
 
 // newNotifyLivePaneSet builds a pane-inventory set from the full (unfiltered)
-// attention pane rows. It returns nil when no rows have a usable pane target,
+// live pane rows. It returns nil when no rows have a usable pane target,
 // so callers uniformly read nil as "inventory unavailable".
-func newNotifyLivePaneSet(rows []attentionPaneRow) notifyLivePaneSet {
+func newNotifyLivePaneSet(rows []livePaneRow) notifyLivePaneSet {
 	set := make(notifyLivePaneSet, len(rows))
 	for _, row := range rows {
 		if strings.TrimSpace(row.Pane) == "" {
@@ -1908,12 +1914,22 @@ func (s notifyLivePaneSet) Has(entry notify.Notification) bool {
 	return ok
 }
 
-// listNotifyLivePanesAndSet reads the attention pane rows once and returns both
+// listLivePaneRows reads the full (unfiltered) live pane inventory through
+// the livePaneLister seam. Every notify-side live read funnels through here
+// so the attention dependency stays behind the injected lister.
+func (c *notifyCommand) listLivePaneRows() ([]livePaneRow, error) {
+	if c == nil || c.livePanes == nil {
+		return nil, errors.New("live pane lister is not configured")
+	}
+	return c.livePanes.ListLivePanes()
+}
+
+// listNotifyLivePanesAndSet reads the live pane rows once and returns both
 // the attention/reply-filtered notifyLivePane slice (for stale detection) and
 // the full pane-inventory set (for GONE detection), avoiding a second tmux
 // subprocess.
 func (c *notifyCommand) listNotifyLivePanesAndSet() ([]notifyLivePane, notifyLivePaneSet, error) {
-	rows, err := (&attentionCommand{runner: c.runner}).listAttentionPanes()
+	rows, err := c.listLivePaneRows()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1921,14 +1937,14 @@ func (c *notifyCommand) listNotifyLivePanesAndSet() ([]notifyLivePane, notifyLiv
 }
 
 func (c *notifyCommand) listNotifyLivePanes() ([]notifyLivePane, error) {
-	rows, err := (&attentionCommand{runner: c.runner}).listAttentionPanes()
+	rows, err := c.listLivePaneRows()
 	if err != nil {
 		return nil, err
 	}
 	return notifyLivePanesFromRows(rows), nil
 }
 
-func notifyLivePanesFromRows(rows []attentionPaneRow) []notifyLivePane {
+func notifyLivePanesFromRows(rows []livePaneRow) []notifyLivePane {
 	out := make([]notifyLivePane, 0, len(rows))
 	for _, row := range rows {
 		live := notifyLivePane{
@@ -1947,9 +1963,10 @@ func notifyLivePanesFromRows(rows []attentionPaneRow) []notifyLivePane {
 				Window:  row.Window,
 				Pane:    row.Pane,
 			}),
-			ShouldQueue: row.AttentionState == attentionStateReply && strings.TrimSpace(row.Agent) != "",
+			ShouldQueue: row.ReplyState && strings.TrimSpace(row.Agent) != "",
+			replyState:  row.ReplyState,
 		}
-		if live.AttentionState == attentionStateReply || hasAttentionPrefix(live.Title) || hasBraillePrefix(live.Title) {
+		if row.ReplyState || row.TitleBadge {
 			out = append(out, live)
 		}
 	}

--- a/internal/app/notify_classify_test.go
+++ b/internal/app/notify_classify_test.go
@@ -71,7 +71,7 @@ func TestClassifyNotifyRowStateMatchesLiveReport(t *testing.T) {
 		},
 	}
 	cmd := newCmd(store)
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 
 	report, err := cmd.buildNotifyLiveReport(entries)
 	if err != nil {
@@ -153,7 +153,7 @@ func TestClassifyNotifyRowStatePaneInventoryGone(t *testing.T) {
 
 	now := time.Date(2026, time.June, 19, 12, 0, 0, 0, time.UTC)
 	// Live inventory has only %84 and %85 in repos-test-sample:@13.
-	paneSet := newNotifyLivePaneSet([]attentionPaneRow{
+	paneSet := newNotifyLivePaneSet([]livePaneRow{
 		{Session: "repos-test-sample", Window: "@13", Pane: "%84"},
 		{Session: "repos-test-sample", Window: "@13", Pane: "%85"},
 	})

--- a/internal/app/notify_livepane.go
+++ b/internal/app/notify_livepane.go
@@ -1,0 +1,35 @@
+package app
+
+// livePaneRow is the neutral projection of one live tmux pane that the
+// notify cluster consumes. Producers (today: the attention-side lister in
+// attention.go) compute the badge/state semantics up front — ReplyState and
+// TitleBadge — so notify code never reaches into attention internals to
+// interpret raw pane options or title glyphs.
+type livePaneRow struct {
+	Session string
+	Window  string
+	Pane    string
+	Socket  string
+	Title   string
+	// AttentionState is the raw attention state string, carried only so the
+	// `notify list --live` JSON keeps surfacing it verbatim.
+	AttentionState string
+	AIState        string
+	Agent          string
+	Topic          string
+	// ReplyState reports that the pane's attention state machine is in the
+	// "reply ready" state (the producer's push condition, together with a
+	// non-empty Agent).
+	ReplyState bool
+	// TitleBadge reports that the pane title carries an attention/braille
+	// badge prefix (title-only attention, no queue entry).
+	TitleBadge bool
+}
+
+// livePaneLister lists every pane on the tmux server as neutral live-pane
+// rows. It is the seam between the notify cluster (consumer) and the
+// attention cluster (producer); notifyCommand receives an implementation via
+// constructor wiring in [New].
+type livePaneLister interface {
+	ListLivePanes() ([]livePaneRow, error)
+}

--- a/internal/app/notify_reconcile.go
+++ b/internal/app/notify_reconcile.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -9,26 +8,8 @@ import (
 	"strings"
 
 	"github.com/crevissepartners/projmux/internal/core/notify"
-	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
-
-// reconcileListPanesFormats are the fields used by the reconcile pass. The
-// producer key set (session, pane id, agent, topic, socket) drives id
-// construction and queue text composition; the
-// attention/ai state fields decide whether the pane should be in the queue.
-var reconcileListPanesFormats = []string{
-	intmux.TmuxFormat("session_name"),
-	intmux.TmuxFormat("window_id"),
-	intmux.TmuxFormat("pane_id"),
-	intmux.PaneOptionFormat(attentionStateOption),
-	intmux.PaneOptionFormat(aiPaneStateOption),
-	intmux.PaneOptionFormat(aiPaneAgentOption),
-	intmux.PaneOptionFormat(aiPaneTopicOption),
-	intmux.TmuxFormat("socket_path"),
-}
-
-var reconcileListPanesFormat = intmux.JoinFormats("|", reconcileListPanesFormats...)
 
 // reconcileResult is the summary returned by the reconcile pass.
 type reconcileResult struct {
@@ -39,29 +20,16 @@ type reconcileResult struct {
 	Errors []string `json:"errors"`
 }
 
-// reconcilePane is the projection of one row from
-// `tmux list-panes -a -F <reconcileListPanesFormat>` after parsing.
-type reconcilePane struct {
-	Session        string
-	Window         string
-	Pane           string
-	AttentionState string
-	AIState        string
-	Agent          string
-	Topic          string
-	Socket         string
-}
-
-// shouldHaveQueueEntry reports whether the pane's live state means it must
-// be present in the notify queue. The producer pushes when the attention
-// state machine reports `reply` AND there is an AI agent associated with
-// the pane (manual `attention toggle` on a shell pane is intentionally
-// skipped). The reconcile pass mirrors that contract.
-func (p reconcilePane) shouldHaveQueueEntry() bool {
+// reconcileShouldHaveQueueEntry reports whether the pane's live state means
+// it must be present in the notify queue. The producer pushes when the
+// attention state machine reports `reply` AND there is an AI agent
+// associated with the pane (manual `attention toggle` on a shell pane is
+// intentionally skipped). The reconcile pass mirrors that contract.
+func reconcileShouldHaveQueueEntry(p livePaneRow) bool {
 	if strings.TrimSpace(p.Agent) == "" {
 		return false
 	}
-	if p.AttentionState == attentionStateReply {
+	if p.ReplyState {
 		return true
 	}
 	// The AI flow flips attention to reply on `status set waiting` but the
@@ -71,16 +39,17 @@ func (p reconcilePane) shouldHaveQueueEntry() bool {
 	return false
 }
 
-// id returns the canonical queue id used by the producer. Reusing the
-// shared helper guarantees push/ack/reconcile all agree on the key.
-func (p reconcilePane) id() string {
+// reconcileEntryID returns the canonical queue id used by the producer.
+// Reusing the shared helper guarantees push/ack/reconcile all agree on the
+// key.
+func reconcileEntryID(p livePaneRow) string {
 	return buildAttentionNotifyID(p.Session, p.Pane)
 }
 
-// text returns the canonical queue text used by the producer. Reusing the
-// shared helper guarantees the agent/topic rendering stays in lockstep
-// with the event-driven path.
-func (p reconcilePane) text() string {
+// reconcileEntryText returns the canonical queue text used by the producer.
+// Reusing the shared helper guarantees the agent/topic rendering stays in
+// lockstep with the event-driven path.
+func reconcileEntryText(p livePaneRow) string {
 	return composeAttentionReplyText(p.Agent, p.Topic)
 }
 
@@ -115,7 +84,7 @@ func (c *notifyCommand) runReconcile(args []string, stdout, stderr io.Writer) er
 
 	result := reconcileResult{Errors: []string{}}
 
-	panes, listErr := c.listReconcilePanes()
+	panes, listErr := c.listLivePaneRows()
 	if listErr != nil {
 		// Common case: tmux is not running. Treat as soft failure so the
 		// post-install hook does not break.
@@ -123,12 +92,12 @@ func (c *notifyCommand) runReconcile(args []string, stdout, stderr io.Writer) er
 		return writeReconcileSummary(stdout, result, *asJSON)
 	}
 
-	wantByID := make(map[string]reconcilePane, len(panes))
+	wantByID := make(map[string]livePaneRow, len(panes))
 	for _, p := range panes {
-		if !p.shouldHaveQueueEntry() {
+		if !reconcileShouldHaveQueueEntry(p) {
 			continue
 		}
-		wantByID[p.id()] = p
+		wantByID[reconcileEntryID(p)] = p
 	}
 
 	existing, listQueueErr := store.List()
@@ -143,7 +112,7 @@ func (c *notifyCommand) runReconcile(args []string, stdout, stderr io.Writer) er
 
 	// Push pass: for every pane that should be in the queue, add or refresh.
 	for id, pane := range wantByID {
-		want := pane.text()
+		want := reconcileEntryText(pane)
 		metadata := mergeAttentionNotifyMetadata(nil, pane.Agent, pane.Topic, notify.SeverityInfo)
 		if cur, ok := existingByID[id]; ok && cur.Text == want && attentionNotifyMetadataMatches(cur.Metadata, metadata) {
 			result.Kept++
@@ -194,43 +163,6 @@ func attentionNotifyMetadataMatches(got, want map[string]string) bool {
 		}
 	}
 	return true
-}
-
-// listReconcilePanes shells out to `tmux list-panes -a -F ...` and parses
-// every live pane row. Empty/blank rows are skipped. A nil runner short-
-// circuits to an empty slice so unit tests that exercise unrelated paths
-// do not need to wire a fake.
-func (c *notifyCommand) listReconcilePanes() ([]reconcilePane, error) {
-	if c == nil || c.runner == nil {
-		return nil, errors.New("tmux runner is not configured")
-	}
-	rows, err := intmux.NewRunner(c.runner).ListPanes(context.Background(), intmux.ListPanesOptions{
-		All:              true,
-		Formats:          reconcileListPanesFormats,
-		Delimiter:        "|",
-		AllowExtraFields: true,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("tmux list-panes: %w", err)
-	}
-	out := make([]reconcilePane, 0, len(rows))
-	for _, fields := range rows {
-		p := reconcilePane{
-			Session:        fields[0],
-			Window:         fields[1],
-			Pane:           fields[2],
-			AttentionState: fields[3],
-			AIState:        fields[4],
-			Agent:          fields[5],
-			Topic:          fields[6],
-			Socket:         fields[7],
-		}
-		if p.Session == "" || p.Pane == "" {
-			continue
-		}
-		out = append(out, p)
-	}
-	return out, nil
 }
 
 // writeReconcileSummary renders the result as either JSON or a single

--- a/internal/app/notify_reconcile_test.go
+++ b/internal/app/notify_reconcile_test.go
@@ -23,6 +23,13 @@ type reconcileTmuxRunner struct {
 	calls  int
 }
 
+// reconcilePaneRow renders one live pane row in the attention list-panes
+// format the livePaneLister seam parses: session, window, pane, active,
+// title, attention state, ai state, agent, topic, socket.
+func reconcilePaneRow(session, window, pane, attention, ai, agent, topic, socket string) []byte {
+	return notifyLivePaneRows([]string{session, window, pane, "0", "", attention, ai, agent, topic, socket})
+}
+
 func (r *reconcileTmuxRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
 	if name == "tmux" && len(args) >= 2 && args[0] == "list-panes" && args[1] == "-a" {
 		r.calls++
@@ -92,9 +99,10 @@ func (s *memNotifyStore) AckAll() (int, error) {
 
 func newReconcileCmd(store notifyStore, runner tmuxRunner) *notifyCommand {
 	return &notifyCommand{
-		store:  store,
-		now:    func() time.Time { return time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC) },
-		runner: runner,
+		store:     store,
+		now:       func() time.Time { return time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC) },
+		runner:    runner,
+		livePanes: newAttentionLivePaneLister(runner),
 	}
 }
 
@@ -102,7 +110,7 @@ func TestNotifyReconcilePushesMissingEntryForReplyPane(t *testing.T) {
 	t.Parallel()
 
 	runner := &reconcileTmuxRunner{
-		output: []byte("main|@4|%16|reply|waiting|claude|notify wiring|/tmp/tmux-1000/projmux\n"),
+		output: reconcilePaneRow("main", "@4", "%16", "reply", "waiting", "claude", "notify wiring", "/tmp/tmux-1000/projmux"),
 	}
 	store := &memNotifyStore{}
 	cmd := newReconcileCmd(store, runner)
@@ -146,7 +154,7 @@ func TestNotifyReconcilePublishesQueueRefreshBestEffort(t *testing.T) {
 	t.Parallel()
 
 	runner := &reconcileTmuxRunner{
-		output: []byte("main|@4|%16|reply|waiting|claude|notify wiring|/tmp/tmux-1000/projmux\n"),
+		output: reconcilePaneRow("main", "@4", "%16", "reply", "waiting", "claude", "notify wiring", "/tmp/tmux-1000/projmux"),
 	}
 	store := &memNotifyStore{}
 	events := &stubNotifyQueueEvents{publishErr: errors.New("listener unavailable")}
@@ -193,7 +201,7 @@ func TestNotifyReconcileReportsStaleEntryWhenPaneNoLongerReply(t *testing.T) {
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	runner := &reconcileTmuxRunner{
 		// Pane %16 is still alive but no longer in reply state.
-		output: []byte("main|@4|%16||idle|claude||/tmp/tmux/default\n"),
+		output: reconcilePaneRow("main", "@4", "%16", "", "idle", "claude", "", "/tmp/tmux/default"),
 	}
 	store := &memNotifyStore{
 		entries: []notify.Notification{
@@ -265,7 +273,7 @@ func TestNotifyReconcileKeepsMatchingEntryWithoutDuplicatePush(t *testing.T) {
 
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	runner := &reconcileTmuxRunner{
-		output: []byte("main|@4|%16|reply|waiting|claude|notify wiring|/tmp/tmux/default\n"),
+		output: reconcilePaneRow("main", "@4", "%16", "reply", "waiting", "claude", "notify wiring", "/tmp/tmux/default"),
 	}
 	store := &memNotifyStore{
 		entries: []notify.Notification{
@@ -305,7 +313,7 @@ func TestNotifyReconcileRefreshesEntryWithStaleText(t *testing.T) {
 	now := time.Date(2026, time.May, 6, 12, 0, 0, 0, time.UTC)
 	runner := &reconcileTmuxRunner{
 		// Topic on pane is "new topic" but queued entry still has old text.
-		output: []byte("main|@4|%16|reply||claude|new topic|\n"),
+		output: reconcilePaneRow("main", "@4", "%16", "reply", "", "claude", "new topic", ""),
 	}
 	store := &memNotifyStore{
 		entries: []notify.Notification{
@@ -347,7 +355,7 @@ func TestNotifyReconcileSkipsPaneWithoutAgent(t *testing.T) {
 	runner := &reconcileTmuxRunner{
 		// Pane is in reply state but has no AI agent (manual attention toggle
 		// on a shell pane). Producer skips it; reconcile mirrors that.
-		output: []byte("main|@4|%5|reply|||shell topic|\n"),
+		output: reconcilePaneRow("main", "@4", "%5", "reply", "", "", "shell topic", ""),
 	}
 	store := &memNotifyStore{}
 	cmd := newReconcileCmd(store, runner)
@@ -400,7 +408,7 @@ func TestNotifyReconcileIdempotent(t *testing.T) {
 	t.Parallel()
 
 	runner := &reconcileTmuxRunner{
-		output: []byte("main|@4|%16|reply|waiting|claude|notify wiring|/tmp/tmux/default\n"),
+		output: reconcilePaneRow("main", "@4", "%16", "reply", "waiting", "claude", "notify wiring", "/tmp/tmux/default"),
 	}
 	store := &memNotifyStore{}
 	cmd := newReconcileCmd(store, runner)
@@ -429,7 +437,7 @@ func TestNotifyReconcileJSONOutput(t *testing.T) {
 	t.Parallel()
 
 	runner := &reconcileTmuxRunner{
-		output: []byte("main|@4|%16|reply|waiting|claude||\n"),
+		output: reconcilePaneRow("main", "@4", "%16", "reply", "waiting", "claude", "", ""),
 	}
 	store := &memNotifyStore{}
 	cmd := newReconcileCmd(store, runner)

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -198,6 +198,15 @@ func newCmd(store notifyStore) *notifyCommand {
 	}
 }
 
+// setNotifyLiveRunner wires both the focus/tmux runner and the live-pane
+// lister from the same fake, mirroring the production wiring in app.New so
+// tests keep exercising the attention row parsing behind the livePaneLister
+// seam.
+func setNotifyLiveRunner(cmd *notifyCommand, runner tmuxRunner) {
+	cmd.runner = runner
+	cmd.livePanes = newAttentionLivePaneLister(runner)
+}
+
 func TestNotifyPushHappyPath(t *testing.T) {
 	t.Parallel()
 
@@ -413,7 +422,7 @@ func TestNotifyListSidebarFocusesAndAcksSelectedRow(t *testing.T) {
 	cmd := newCmd(store)
 	cmd.picker = picker
 	cmd.native = nativePickerFromCompatRunner(picker)
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
 
 	if err := cmd.Run([]string{"list", "--ui=sidebar", "--client", "/dev/pts/7"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
@@ -575,7 +584,7 @@ func TestNotifyListSidebarTitleDecoration(t *testing.T) {
 			}
 			cmd.picker = picker
 			cmd.native = nativePickerFromCompatRunner(picker)
-			cmd.runner = runner
+			setNotifyLiveRunner(cmd, runner)
 
 			if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 				t.Fatalf("Run error = %v", err)
@@ -974,7 +983,7 @@ func TestNotifySidebarReadModelPaneInventoryGoneVsStale(t *testing.T) {
 		// %83 is absent from tmux → GONE.
 		{ID: "ai:repos-test-sample:%83", Text: "Ready", Severity: notify.SeverityInfo, Source: notify.SourceAI, Metadata: map[string]string{"agent": "codex", "category": "response_complete"}, Session: "repos-test-sample", Window: "@13", Pane: "%83", CreatedAt: now.Add(-1 * time.Minute)},
 	}
-	paneSet := newNotifyLivePaneSet([]attentionPaneRow{
+	paneSet := newNotifyLivePaneSet([]livePaneRow{
 		{Session: "repos-test-sample", Window: "@13", Pane: "%84"},
 		{Session: "repos-test-sample", Window: "@13", Pane: "%85"},
 	})
@@ -1065,7 +1074,7 @@ func TestNotifySidebarNativeBackendDoesNotCallCompatRunner(t *testing.T) {
 		compatCalled = true
 		return intpickercompat.Result{}, nil
 	})
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
 	cmd.lookupEnv = func(name string) string {
 		if name == "PROJMUX_NOTIFY_ORIGIN_CLIENT" {
@@ -1126,7 +1135,7 @@ func TestNotifyListSidebarDoesNotAckWhenFocusFails(t *testing.T) {
 	cmd := newCmd(store)
 	cmd.picker = picker
 	cmd.native = nativePickerFromCompatRunner(picker)
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
 
 	err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{})
@@ -1165,7 +1174,7 @@ func TestNotifyListSidebarTargetGoneAcksSelectedRow(t *testing.T) {
 	cmd.now = func() time.Time { return now }
 	cmd.picker = picker
 	cmd.native = nativePickerFromCompatRunner(picker)
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
 
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
@@ -1195,7 +1204,7 @@ func TestNotifyListSidebarAAcksSelectedRowAndRefreshes(t *testing.T) {
 	runner := &focusFakeRunner{}
 	cmd := newCmd(store)
 	cmd.native = picker
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 
 	var stdout bytes.Buffer
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &stdout, &bytes.Buffer{}); err != nil {
@@ -1346,7 +1355,7 @@ func TestNotifyListSidebarEnterOnFoldedGroupFocusesRepresentativeAndAcksVisibleG
 	runner := &focusFakeRunner{}
 	cmd := newCmd(store)
 	cmd.native = picker
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
 
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
@@ -1390,7 +1399,7 @@ func TestNotifyListSidebarEnterOnExpandedGroupFocusesAndAcksWithoutFolding(t *te
 	runner := &focusFakeRunner{}
 	cmd := newCmd(store)
 	cmd.native = picker
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
 
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
@@ -1430,7 +1439,7 @@ func TestNotifyListSidebarEnterOnGroupTargetGoneCleansVisibleGroupWithoutFocus(t
 	runner := &focusFakeRunner{}
 	cmd := newCmd(store)
 	cmd.native = picker
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
 
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
@@ -1471,7 +1480,7 @@ func TestNotifyListSidebarEnterOnGroupStaleRoutableFocusesAndAcks(t *testing.T) 
 	}}
 	cmd := newCmd(store)
 	cmd.native = picker
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
 
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
@@ -1516,7 +1525,7 @@ func TestNotifyListSidebarEnterOnGroupPrefersLiveRepresentativeOverNewerStaleRow
 	}}
 	cmd := newCmd(store)
 	cmd.native = picker
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
 
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
@@ -1561,7 +1570,7 @@ func TestNotifyListSidebarEnterOnGroupTargetGoneRaceCleansVisibleGroup(t *testin
 	}}
 	cmd := newCmd(store)
 	cmd.native = picker
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
 
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
@@ -1602,7 +1611,7 @@ func TestNotifyListSidebarEnterOnGroupFocusFailureDoesNotAckAndRefreshes(t *test
 	}}
 	cmd := newCmd(store)
 	cmd.native = picker
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 	cmd.executable = func() (string, error) { return "/usr/local/bin/projmux", nil }
 
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
@@ -1667,7 +1676,7 @@ func TestNotifyListSidebarXClearsNonCriticalAndPreservesCritical(t *testing.T) {
 	}
 	cmd := newCmd(store)
 	cmd.native = picker
-	cmd.runner = &focusFakeRunner{}
+	setNotifyLiveRunner(cmd, &focusFakeRunner{})
 
 	var stdout bytes.Buffer
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &stdout, &bytes.Buffer{}); err != nil {
@@ -1784,7 +1793,7 @@ func TestNotifyListSidebarGNoGoneNotificationsIsNoOp(t *testing.T) {
 	runner := &focusFakeRunner{}
 	cmd := newCmd(store)
 	cmd.native = picker
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run error = %v", err)
@@ -2008,7 +2017,7 @@ func TestNotifyListSidebarAAckRefreshesLiveStateEachLoop(t *testing.T) {
 	cmd := newCmd(store)
 	cmd.now = func() time.Time { return now }
 	cmd.native = picker
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 
 	if err := cmd.Run([]string{"list", "--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("Run error = %v", err)
@@ -2086,7 +2095,7 @@ func TestNotifyListLiveHumanExplainsManualReplyWithoutQueue(t *testing.T) {
 		},
 	}
 	cmd := newCmd(store)
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 
 	var stdout bytes.Buffer
 	if err := cmd.Run([]string{"list", "--live"}, &stdout, &bytes.Buffer{}); err != nil {
@@ -2119,7 +2128,7 @@ func TestNotifyListLiveHumanExplainsTitlePrefixWithoutQueue(t *testing.T) {
 		},
 	}
 	cmd := newCmd(store)
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 
 	var stdout bytes.Buffer
 	if err := cmd.Run([]string{"list", "--live"}, &stdout, &bytes.Buffer{}); err != nil {
@@ -2182,7 +2191,7 @@ func TestNotifyListLiveJSONExplainsQueueAndLiveStates(t *testing.T) {
 		},
 	}
 	cmd := newCmd(store)
-	cmd.runner = runner
+	setNotifyLiveRunner(cmd, runner)
 
 	var stdout bytes.Buffer
 	if err := cmd.Run([]string{"list", "--live", "--json"}, &stdout, &bytes.Buffer{}); err != nil {

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -470,7 +470,7 @@ func (c *statusCommand) notifyLiveByIDBestEffort() map[string]notifyLivePane {
 		return nil
 	}
 	runner := statusCommandRunnerAdapter{read: c.readCommand}
-	panes, err := (&notifyCommand{runner: runner}).listNotifyLivePanes()
+	panes, err := (&notifyCommand{livePanes: newAttentionLivePaneLister(runner)}).listNotifyLivePanes()
 	if err != nil {
 		return nil
 	}
@@ -486,12 +486,12 @@ func (c *statusCommand) notifyLiveStateBestEffort() (map[string]notifyLivePane, 
 		return nil, nil
 	}
 	runner := statusCommandRunnerAdapter{read: c.readCommand}
-	return (&notifyCommand{runner: runner}).notifyLiveStateBestEffort()
+	return (&notifyCommand{livePanes: newAttentionLivePaneLister(runner)}).notifyLiveStateBestEffort()
 }
 
-// statusCommandRunnerAdapter wraps statusCommand.readCommand so the existing
-// notifyCommand.listNotifyLivePanes helper can be reused without exporting
-// the underlying runner.
+// statusCommandRunnerAdapter wraps statusCommand.readCommand so the
+// attention-backed live-pane lister can be reused without exporting the
+// underlying runner.
 type statusCommandRunnerAdapter struct {
 	read func(ctx context.Context, name string, args ...string) ([]byte, error)
 }

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -634,7 +634,7 @@ func (c *statusbarCommand) classifyHeadDisplayBestEffort(head notify.Notificatio
 	if c == nil || c.runner == nil {
 		return classifyNotifyRowState(head, nil, nil)
 	}
-	panes, paneSet, err := (&notifyCommand{runner: c.runner}).listNotifyLivePanesAndSet()
+	panes, paneSet, err := (&notifyCommand{livePanes: newAttentionLivePaneLister(c.runner)}).listNotifyLivePanesAndSet()
 	if err != nil {
 		return classifyNotifyRowState(head, nil, nil)
 	}


### PR DESCRIPTION
## Summary
- Step 2 of decoupling the notify cluster from the AI/attention cluster (step 1: #509 metadata consts): notify's live/sidebar stale-detection and reconcile paths constructed `attentionCommand` directly and consumed `attentionPaneRow`/attention consts — the last un-interfaced reach-in blocking a future notify package promotion.
- Introduce a `livePaneLister` seam with a neutral live-pane DTO (`notify_livepane.go`); the attention side implements the lister via an adapter (`attention.go`). `notify list --live`, sidebar live-state, and `notify reconcile` consume the seam through constructor wiring instead of attention internals.
- Behavior is unchanged — the existing notify/reconcile/status tests are adapted to build the DTO where they previously built attention rows, and remain the guard on the logic-dense live-explanation paths. The only internal delta: `notify reconcile` now reads panes through the same attention row format (a superset of the old reconcile-only field list), so there is one pane-listing format instead of two; push/kept/stale semantics and error text are identical.

## Test plan
- [x] make fmt
- [x] make fix (deadcode gate clean)
- [x] make test

## Globalization
- [x] No user-facing string changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
