### PR TITLE
refactor(init): promote terminal-init cluster into internal/app/initcmd

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/crevissepartners/projmux/internal/app/initcmd"
 	"github.com/crevissepartners/projmux/internal/app/usagecmd"
 	"github.com/crevissepartners/projmux/internal/integrations/hooks"
 	"github.com/crevissepartners/projmux/internal/version"
@@ -67,7 +68,7 @@ type App struct {
 	doctor       *doctorCommand
 	focus        *focusCommand
 	hook         *hookCommand
-	initCmd      *initCommand
+	initCmd      *initcmd.Command
 	insertText   *insertFileTextCommand
 	kill         *killCommand
 	notify       *notifyCommand

--- a/internal/app/initcmd/init.go
+++ b/internal/app/initcmd/init.go
@@ -1,4 +1,9 @@
-package app
+// Package initcmd implements the `projmux init` command: it auto-merges
+// projmux keybindings into a terminal emulator's config file via per-terminal
+// TerminalAdapter implementations. The desired bindings are injected by the
+// caller (the app package derives them from its keybinding catalog), so this
+// package has no dependency on the rest of the app.
+package initcmd
 
 import (
 	"errors"
@@ -10,10 +15,10 @@ import (
 	"strings"
 )
 
-// initCommand auto-merges projmux keybindings into a terminal emulator's
+// Command auto-merges projmux keybindings into a terminal emulator's
 // config file. The framework dispatches by terminal name and delegates the
 // actual merge to a TerminalAdapter implementation.
-type initCommand struct {
+type Command struct {
 	registry *terminalRegistry
 	getenv   func(string) string
 	readFile func(string) ([]byte, error)
@@ -39,9 +44,15 @@ type initResult struct {
 	Applied  bool
 }
 
-func newInitCommand() *initCommand {
-	return &initCommand{
-		registry: defaultTerminalRegistry,
+// New builds the init command with the supplied terminal adapters registered.
+// Registration panics on duplicate names so wiring bugs surface immediately.
+func New(adapters ...TerminalAdapter) *Command {
+	registry := newTerminalRegistry()
+	for _, a := range adapters {
+		registry.register(a)
+	}
+	return &Command{
+		registry: registry,
 		getenv:   os.Getenv,
 		readFile: os.ReadFile,
 		stat:     os.Stat,
@@ -54,7 +65,7 @@ func newInitCommand() *initCommand {
 // dry-run that prints the planned changes; --apply commits them with a
 // timestamped backup. The terminal name may appear before or after flags,
 // e.g. `projmux init ghostty --apply` or `projmux init --apply ghostty`.
-func (c *initCommand) Run(args []string, stdout, stderr io.Writer) error {
+func (c *Command) Run(args []string, stdout, stderr io.Writer) error {
 	terminalName, flagArgs := splitInitArgs(args)
 
 	fs := flag.NewFlagSet("init", flag.ContinueOnError)
@@ -89,14 +100,14 @@ func (c *initCommand) Run(args []string, stdout, stderr io.Writer) error {
 	return c.printPlan(result.Terminal, result.Plan, stdout)
 }
 
-func (c *initCommand) run(opts initOptions) (initResult, error) {
+func (c *Command) run(opts initOptions) (initResult, error) {
 	if opts.Apply && opts.DryRun {
 		return initResult{}, errors.New("init: --apply and --dry-run are mutually exclusive")
 	}
 
 	registry := c.registry
 	if registry == nil {
-		registry = defaultTerminalRegistry
+		registry = newTerminalRegistry()
 	}
 
 	var (
@@ -147,7 +158,7 @@ func (c *initCommand) run(opts initOptions) (initResult, error) {
 	return initResult{Terminal: adapter.Name(), Plan: plan, Applied: true}, nil
 }
 
-func (c *initCommand) env() func(string) string {
+func (c *Command) env() func(string) string {
 	if c.getenv != nil {
 		return c.getenv
 	}
@@ -167,7 +178,7 @@ func (c *initCommand) env() func(string) string {
 //
 // Adapters that only register a single ConfigPath fall through to the same
 // logic with a one-element candidate list.
-func (c *initCommand) resolveConfigPath(adapter TerminalAdapter, override string) (string, error) {
+func (c *Command) resolveConfigPath(adapter TerminalAdapter, override string) (string, error) {
 	if override != "" {
 		return c.absConfigPath(override)
 	}
@@ -205,7 +216,7 @@ func (c *initCommand) resolveConfigPath(adapter TerminalAdapter, override string
 // candidatesFor returns the adapter's well-known config path candidates,
 // falling back to a single-element list for adapters that have not opted
 // into ConfigPathCandidatesResolver.
-func (c *initCommand) candidatesFor(adapter TerminalAdapter) ([]string, error) {
+func (c *Command) candidatesFor(adapter TerminalAdapter) ([]string, error) {
 	if multi, ok := adapter.(ConfigPathCandidatesResolver); ok {
 		return multi.ConfigPathCandidates(c.env())
 	}
@@ -218,7 +229,7 @@ func (c *initCommand) candidatesFor(adapter TerminalAdapter) ([]string, error) {
 
 // absConfigPath turns a (possibly relative) --config override into an
 // absolute path so downstream stat/symlink checks behave consistently.
-func (c *initCommand) absConfigPath(p string) (string, error) {
+func (c *Command) absConfigPath(p string) (string, error) {
 	if filepath.IsAbs(p) {
 		return p, nil
 	}
@@ -238,7 +249,7 @@ func (c *initCommand) absConfigPath(p string) (string, error) {
 // dotfiles users commonly symlink terminal configs into a tracked repo, and
 // silently editing through the symlink would mutate that repo without their
 // knowledge.
-func (c *initCommand) guardSymlink(path string, allow bool) error {
+func (c *Command) guardSymlink(path string, allow bool) error {
 	lstatFn := c.lstat
 	if lstatFn == nil {
 		lstatFn = os.Lstat
@@ -261,7 +272,7 @@ func (c *initCommand) guardSymlink(path string, allow bool) error {
 
 // loadConfig reads the terminal config and reports whether it already exists.
 // A missing file is not an error; the merge will create it.
-func (c *initCommand) loadConfig(path string) (string, bool, error) {
+func (c *Command) loadConfig(path string) (string, bool, error) {
 	statFn := c.stat
 	if statFn == nil {
 		statFn = os.Stat
@@ -283,7 +294,7 @@ func (c *initCommand) loadConfig(path string) (string, bool, error) {
 	return string(data), true, nil
 }
 
-func (c *initCommand) printPlan(terminal string, plan MergePlan, stdout io.Writer) error {
+func (c *Command) printPlan(terminal string, plan MergePlan, stdout io.Writer) error {
 	if _, err := fmt.Fprintf(stdout, "projmux init %s (dry-run)\n", terminal); err != nil {
 		return err
 	}
@@ -322,7 +333,7 @@ func (c *initCommand) printPlan(terminal string, plan MergePlan, stdout io.Write
 	return err
 }
 
-func (c *initCommand) printApplyResult(terminal string, plan MergePlan, stdout io.Writer) error {
+func (c *Command) printApplyResult(terminal string, plan MergePlan, stdout io.Writer) error {
 	if _, err := fmt.Fprintf(stdout, "projmux init %s --apply\n", terminal); err != nil {
 		return err
 	}
@@ -379,12 +390,4 @@ func splitInitArgs(args []string) (terminal string, flagArgs []string) {
 		flagArgs = append(flagArgs, a)
 	}
 	return terminal, flagArgs
-}
-
-// init registers the bundled terminal adapters with the package-level
-// registry. Future terminals add a sibling file with their own init() block,
-// or extend this list when registration order matters.
-func init() {
-	RegisterTerminalAdapter(NewGhosttyAdapter())
-	RegisterTerminalAdapter(NewWindowsTerminalAdapter())
 }

--- a/internal/app/initcmd/init_ghostty.go
+++ b/internal/app/initcmd/init_ghostty.go
@@ -1,4 +1,4 @@
-package app
+package initcmd
 
 import (
 	"fmt"
@@ -8,17 +8,14 @@ import (
 	"time"
 )
 
-// ghosttyBinding is one keybind = trigger=action pair the projmux init
-// command guarantees in the user's Ghostty config. Entries are derived from
-// the built-in keybinding catalog; docs/keybindings.md mirrors it for users.
-type ghosttyBinding struct {
+// GhosttyBinding is one keybind = trigger=action pair the projmux init
+// command guarantees in the user's Ghostty config. The caller derives the
+// desired entries from its keybinding catalog; docs/keybindings.md mirrors
+// them for users.
+type GhosttyBinding struct {
 	Trigger string
 	Action  string
 }
-
-// ghosttyDesiredBindings mirrors the "Ghostty" section of docs/keybindings.md.
-// Update the built-in keybinding catalog and docs when adjusting terminal routing.
-var ghosttyDesiredBindings = ghosttyBindingsFromCatalog()
 
 // ghosttyManagedHeader marks the projmux-managed block in the Ghostty config.
 const (
@@ -28,6 +25,8 @@ const (
 
 // GhosttyAdapter implements TerminalAdapter for the Ghostty terminal.
 type GhosttyAdapter struct {
+	// desired is the list of bindings the merge guarantees in the config.
+	desired []GhosttyBinding
 	// now allows tests to pin the timestamp used for backup file names.
 	now func() time.Time
 	// userHomeDir defaults to os.UserHomeDir for path resolution.
@@ -39,9 +38,11 @@ type GhosttyAdapter struct {
 }
 
 // NewGhosttyAdapter constructs a Ghostty adapter wired to real filesystem
-// helpers. Tests can override the internal hooks afterwards.
-func NewGhosttyAdapter() *GhosttyAdapter {
+// helpers that guarantees the supplied bindings. Tests can override the
+// internal hooks afterwards.
+func NewGhosttyAdapter(desired []GhosttyBinding) *GhosttyAdapter {
 	return &GhosttyAdapter{
+		desired:     desired,
 		now:         time.Now,
 		userHomeDir: os.UserHomeDir,
 		writeFile:   os.WriteFile,
@@ -135,10 +136,10 @@ func (g *GhosttyAdapter) PlanMerge(currentConfig string, fileExists bool) (Merge
 	stripped, userBindings := splitGhosttyConfig(currentConfig)
 
 	var (
-		toAppend []ghosttyBinding
+		toAppend []GhosttyBinding
 		changes  []MergeChange
 	)
-	for _, want := range ghosttyDesiredBindings {
+	for _, want := range g.desired {
 		existing, ok := userBindings[want.Trigger]
 		switch {
 		case !ok:
@@ -316,7 +317,7 @@ func parseGhosttyKeybind(line string) (string, string, bool) {
 // renderGhosttyConfig appends a managed projmux block containing the supplied
 // bindings to stripped. It guarantees a single blank line separator between
 // existing user content and the managed block, and a trailing newline.
-func renderGhosttyConfig(stripped string, additions []ghosttyBinding) string {
+func renderGhosttyConfig(stripped string, additions []GhosttyBinding) string {
 	var b strings.Builder
 	if stripped != "" {
 		b.WriteString(strings.TrimRight(stripped, "\n"))

--- a/internal/app/initcmd/init_ghostty_test.go
+++ b/internal/app/initcmd/init_ghostty_test.go
@@ -1,4 +1,4 @@
-package app
+package initcmd
 
 import (
 	"bytes"
@@ -9,9 +9,20 @@ import (
 	"time"
 )
 
+// testGhosttyBindings is a catalog-shaped fixture. The real desired bindings
+// are derived from the app keybinding catalog and injected by the caller;
+// merge behavior only depends on the (trigger, action) shape.
+var testGhosttyBindings = []GhosttyBinding{
+	{Trigger: "alt+1", Action: `text:\x1b1`},
+	{Trigger: "alt+2", Action: `text:\x1b2`},
+	{Trigger: "alt+3", Action: `text:\x1b3`},
+	{Trigger: "alt+4", Action: `text:\x1b4`},
+	{Trigger: "alt+5", Action: `text:\x1b5`},
+}
+
 func newGhosttyTestAdapter(t *testing.T) *GhosttyAdapter {
 	t.Helper()
-	a := NewGhosttyAdapter()
+	a := NewGhosttyAdapter(testGhosttyBindings)
 	a.now = func() time.Time { return time.Date(2026, 4, 30, 1, 32, 15, 0, time.UTC) }
 	return a
 }
@@ -19,7 +30,7 @@ func newGhosttyTestAdapter(t *testing.T) *GhosttyAdapter {
 func TestGhosttyAdapterDetect(t *testing.T) {
 	t.Parallel()
 
-	a := NewGhosttyAdapter()
+	a := NewGhosttyAdapter(testGhosttyBindings)
 
 	cases := []struct {
 		name string
@@ -46,7 +57,7 @@ func TestGhosttyAdapterDetect(t *testing.T) {
 
 func TestGhosttyAdapterDetectNilEnv(t *testing.T) {
 	t.Parallel()
-	a := NewGhosttyAdapter()
+	a := NewGhosttyAdapter(testGhosttyBindings)
 	if a.Detect(nil) {
 		t.Fatalf("Detect(nil) = true, want false")
 	}
@@ -55,7 +66,7 @@ func TestGhosttyAdapterDetectNilEnv(t *testing.T) {
 func TestGhosttyAdapterConfigPathPrefersXDG(t *testing.T) {
 	t.Parallel()
 
-	a := NewGhosttyAdapter()
+	a := NewGhosttyAdapter(testGhosttyBindings)
 	env := func(k string) string {
 		if k == "XDG_CONFIG_HOME" {
 			return "/xdg"
@@ -74,7 +85,7 @@ func TestGhosttyAdapterConfigPathPrefersXDG(t *testing.T) {
 func TestGhosttyAdapterConfigPathFallsBackToHome(t *testing.T) {
 	t.Parallel()
 
-	a := NewGhosttyAdapter()
+	a := NewGhosttyAdapter(testGhosttyBindings)
 	a.userHomeDir = func() (string, error) { return "/home/u", nil }
 	got, err := a.ConfigPath(func(string) string { return "" })
 	if err != nil {
@@ -105,10 +116,10 @@ func TestGhosttyPlanMergeEmptyConfigAddsAllBindings(t *testing.T) {
 			addCount++
 		}
 	}
-	if addCount != len(ghosttyDesiredBindings) {
-		t.Fatalf("add count = %d, want %d", addCount, len(ghosttyDesiredBindings))
+	if addCount != len(testGhosttyBindings) {
+		t.Fatalf("add count = %d, want %d", addCount, len(testGhosttyBindings))
 	}
-	for _, kb := range ghosttyDesiredBindings {
+	for _, kb := range testGhosttyBindings {
 		needle := "keybind = " + kb.Trigger + "=" + kb.Action
 		if !strings.Contains(plan.Updated, needle) {
 			t.Fatalf("Updated missing %q\n--\n%s", needle, plan.Updated)
@@ -119,22 +130,6 @@ func TestGhosttyPlanMergeEmptyConfigAddsAllBindings(t *testing.T) {
 	}
 	if strings.Contains(plan.Updated, "c"+"si:") {
 		t.Fatalf("Updated contains retired CSI action:\n%s", plan.Updated)
-	}
-}
-
-func TestGhosttyDesiredBindingsUsePlainMeta(t *testing.T) {
-	t.Parallel()
-
-	if len(ghosttyDesiredBindings) == 0 {
-		t.Fatal("ghosttyDesiredBindings is empty, want Alt-1..5 plain Meta mappings")
-	}
-	for _, binding := range ghosttyDesiredBindings {
-		if strings.Contains(binding.Action, "c"+"si:") {
-			t.Fatalf("ghostty binding uses retired CSI action: %#v", binding)
-		}
-		if !strings.HasPrefix(binding.Action, `text:\x1b`) {
-			t.Fatalf("ghostty binding action = %q, want plain Meta text action", binding.Action)
-		}
 	}
 }
 
@@ -176,7 +171,7 @@ func TestGhosttyPlanMergePartialAddsMissingBindings(t *testing.T) {
 		t.Fatalf("expected effect when bindings missing")
 	}
 
-	expectAdd := len(ghosttyDesiredBindings) - 2
+	expectAdd := len(testGhosttyBindings) - 2
 	addCount := 0
 	noopCount := 0
 	for _, ch := range plan.Changes {
@@ -425,7 +420,7 @@ func TestSplitGhosttyConfigUserOverrideTrumpsManagedBlock(t *testing.T) {
 func TestGhosttyAdapterConfigPathCandidatesXDG(t *testing.T) {
 	t.Parallel()
 
-	a := NewGhosttyAdapter()
+	a := NewGhosttyAdapter(testGhosttyBindings)
 	env := func(k string) string {
 		if k == "XDG_CONFIG_HOME" {
 			return "/xdg"
@@ -453,7 +448,7 @@ func TestGhosttyAdapterConfigPathCandidatesXDG(t *testing.T) {
 func TestGhosttyAdapterConfigPathCandidatesHomeFallback(t *testing.T) {
 	t.Parallel()
 
-	a := NewGhosttyAdapter()
+	a := NewGhosttyAdapter(testGhosttyBindings)
 	a.userHomeDir = func() (string, error) { return "/home/u", nil }
 	got, err := a.ConfigPathCandidates(func(string) string { return "" })
 	if err != nil {
@@ -474,11 +469,11 @@ func TestGhosttyAdapterConfigPathCandidatesHomeFallback(t *testing.T) {
 // per-test temp dir as if it were $XDG_CONFIG_HOME. The Ghostty adapter is
 // the sole registered terminal so the test exercises the production code
 // path including ConfigPathCandidates.
-func newGhosttyTestInitCommand(t *testing.T, xdg string) *initCommand {
+func newGhosttyTestInitCommand(t *testing.T, xdg string) *Command {
 	t.Helper()
 	reg := newTestRegistry()
-	reg.register(NewGhosttyAdapter())
-	return &initCommand{
+	reg.register(NewGhosttyAdapter(testGhosttyBindings))
+	return &Command{
 		registry: reg,
 		getenv: func(k string) string {
 			if k == "XDG_CONFIG_HOME" {

--- a/internal/app/initcmd/init_terminal.go
+++ b/internal/app/initcmd/init_terminal.go
@@ -1,4 +1,4 @@
-package app
+package initcmd
 
 import (
 	"fmt"
@@ -44,9 +44,8 @@ func (p MergePlan) HasEffect() bool {
 
 // TerminalAdapter is the per-terminal contract for `projmux init`.
 //
-// Implementations register themselves in the package-level registry via
-// RegisterTerminalAdapter so the init command can dispatch by name and
-// auto-detect the active terminal.
+// Implementations are registered by the caller via New so the init command
+// can dispatch by name and auto-detect the active terminal.
 type TerminalAdapter interface {
 	// Name returns the terminal's canonical CLI name, e.g. "ghostty".
 	Name() string
@@ -79,32 +78,32 @@ type ConfigPathCandidatesResolver interface {
 	ConfigPathCandidates(env func(string) string) ([]string, error)
 }
 
-// terminalRegistry is the global registry of TerminalAdapter implementations.
+// terminalRegistry indexes TerminalAdapter implementations by name for the
+// init command's dispatch and auto-detection.
 type terminalRegistry struct {
 	mu       sync.RWMutex
 	adapters map[string]TerminalAdapter
 }
 
-var defaultTerminalRegistry = &terminalRegistry{adapters: map[string]TerminalAdapter{}}
-
-// RegisterTerminalAdapter adds a TerminalAdapter to the default registry.
-// It panics on duplicate names so registration bugs surface at init time.
-func RegisterTerminalAdapter(a TerminalAdapter) {
-	defaultTerminalRegistry.register(a)
+// newTerminalRegistry returns an empty registry.
+func newTerminalRegistry() *terminalRegistry {
+	return &terminalRegistry{adapters: map[string]TerminalAdapter{}}
 }
 
+// register adds an adapter to the registry. It panics on nil adapters, empty
+// names, and duplicate names so wiring bugs surface immediately.
 func (r *terminalRegistry) register(a TerminalAdapter) {
 	if a == nil {
-		panic("RegisterTerminalAdapter: nil adapter")
+		panic("terminalRegistry.register: nil adapter")
 	}
 	name := a.Name()
 	if name == "" {
-		panic("RegisterTerminalAdapter: empty Name()")
+		panic("terminalRegistry.register: empty Name()")
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, exists := r.adapters[name]; exists {
-		panic(fmt.Sprintf("RegisterTerminalAdapter: %q already registered", name))
+		panic(fmt.Sprintf("terminalRegistry.register: %q already registered", name))
 	}
 	r.adapters[name] = a
 }
@@ -142,11 +141,4 @@ func (r *terminalRegistry) detect(env func(string) string) (TerminalAdapter, boo
 		}
 	}
 	return nil, false
-}
-
-// reset clears the registry. Test helper.
-func (r *terminalRegistry) reset() {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.adapters = map[string]TerminalAdapter{}
 }

--- a/internal/app/initcmd/init_test.go
+++ b/internal/app/initcmd/init_test.go
@@ -1,4 +1,4 @@
-package app
+package initcmd
 
 import (
 	"bytes"
@@ -123,15 +123,21 @@ func TestTerminalRegistryDetectNoMatch(t *testing.T) {
 	}
 }
 
-func TestRegisterTerminalAdapterRegistersGhosttyByDefault(t *testing.T) {
+func TestNewRegistersSuppliedAdapters(t *testing.T) {
 	t.Parallel()
 
-	got, ok := defaultTerminalRegistry.lookup("ghostty")
-	if !ok {
-		t.Fatalf("default registry missing ghostty adapter")
+	cmd := New(NewGhosttyAdapter(nil), NewWindowsTerminalAdapter(nil))
+	for _, name := range []string{"ghostty", "windows-terminal"} {
+		got, ok := cmd.registry.lookup(name)
+		if !ok {
+			t.Fatalf("New() registry missing %s adapter", name)
+		}
+		if got.Name() != name {
+			t.Fatalf("adapter name = %q, want %q", got.Name(), name)
+		}
 	}
-	if got.Name() != "ghostty" {
-		t.Fatalf("default ghostty adapter name = %q, want ghostty", got.Name())
+	if names := cmd.registry.names(); len(names) != 2 {
+		t.Fatalf("names() = %v, want exactly the two supplied adapters", names)
 	}
 }
 
@@ -141,7 +147,7 @@ func TestInitCommandUnknownTerminalReturnsError(t *testing.T) {
 	reg := newTestRegistry()
 	reg.register(&fakeAdapter{name: "alpha"})
 
-	cmd := &initCommand{registry: reg, getenv: func(string) string { return "" }}
+	cmd := &Command{registry: reg, getenv: func(string) string { return "" }}
 	var stdout, stderr bytes.Buffer
 	err := cmd.Run([]string{"unknown"}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "unknown terminal") {
@@ -155,7 +161,7 @@ func TestInitCommandAutoDetectFailsWithoutMatch(t *testing.T) {
 	reg := newTestRegistry()
 	reg.register(&fakeAdapter{name: "alpha"})
 
-	cmd := &initCommand{registry: reg, getenv: func(string) string { return "" }}
+	cmd := &Command{registry: reg, getenv: func(string) string { return "" }}
 	var stdout, stderr bytes.Buffer
 	err := cmd.Run(nil, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "auto-detect") {
@@ -180,7 +186,7 @@ func TestInitCommandDryRunPrintsPlanAndDoesNotApply(t *testing.T) {
 	reg := newTestRegistry()
 	reg.register(adapter)
 
-	cmd := &initCommand{
+	cmd := &Command{
 		registry: reg,
 		getenv:   func(string) string { return "" },
 		readFile: os.ReadFile,
@@ -215,7 +221,7 @@ func TestInitCommandApplyInvokesAdapter(t *testing.T) {
 	reg := newTestRegistry()
 	reg.register(adapter)
 
-	cmd := &initCommand{
+	cmd := &Command{
 		registry: reg,
 		getenv:   func(string) string { return "" },
 		readFile: os.ReadFile,
@@ -243,7 +249,7 @@ func TestInitCommandRunSurfacePlansAndApplies(t *testing.T) {
 	adapter := &fakeAdapter{name: "alpha", configPath: cfg}
 	reg := newTestRegistry()
 	reg.register(adapter)
-	cmd := &initCommand{
+	cmd := &Command{
 		registry: reg,
 		getenv:   func(string) string { return "" },
 		readFile: os.ReadFile,
@@ -276,7 +282,7 @@ func TestInitCommandRunSurfacePlansAndApplies(t *testing.T) {
 func TestInitCommandRejectsApplyAndDryRunTogether(t *testing.T) {
 	t.Parallel()
 
-	cmd := &initCommand{
+	cmd := &Command{
 		registry: newTestRegistry(),
 		getenv:   func(string) string { return "" },
 	}
@@ -290,7 +296,7 @@ func TestInitCommandRejectsApplyAndDryRunTogether(t *testing.T) {
 func TestInitCommandLoadConfigMissingFile(t *testing.T) {
 	t.Parallel()
 
-	cmd := &initCommand{
+	cmd := &Command{
 		readFile: os.ReadFile,
 		stat: func(name string) (os.FileInfo, error) {
 			return nil, os.ErrNotExist
@@ -312,7 +318,7 @@ func TestInitCommandLoadConfigPropagatesUnexpectedStatError(t *testing.T) {
 	t.Parallel()
 
 	sentinel := errors.New("boom")
-	cmd := &initCommand{
+	cmd := &Command{
 		stat: func(name string) (os.FileInfo, error) { return nil, sentinel },
 	}
 	if _, _, err := cmd.loadConfig("/whatever"); !errors.Is(err, sentinel) {

--- a/internal/app/initcmd/init_windows_terminal.go
+++ b/internal/app/initcmd/init_windows_terminal.go
@@ -1,4 +1,4 @@
-package app
+package initcmd
 
 import (
 	"bytes"
@@ -14,11 +14,11 @@ import (
 	"unicode"
 )
 
-// wtBinding mirrors one Windows Terminal action+keybinding pair the projmux
-// init command guarantees in the user's settings.json. Entries are derived
-// from the built-in keybinding catalog; docs/keybindings.md mirrors it for
-// users.
-type wtBinding struct {
+// WTBinding mirrors one Windows Terminal action+keybinding pair the projmux
+// init command guarantees in the user's settings.json. The caller derives the
+// desired entries from its keybinding catalog; docs/keybindings.md mirrors
+// them for users.
+type WTBinding struct {
 	// ID is the stable settings.json identifier (prefixed with User.projmux).
 	// Same value is used in both the actions[] entry and the keybindings[]
 	// entry so the two halves stay in sync across re-runs.
@@ -35,14 +35,11 @@ type wtBinding struct {
 // with this string in `id` is owned by the merge; anything else is the user's.
 const wtIDPrefix = "User.projmux"
 
-// wtDesiredBindings mirrors the "Windows Terminal" section of
-// docs/keybindings.md. Update the built-in keybinding catalog and docs when
-// adjusting terminal routing.
-var wtDesiredBindings = windowsTerminalBindingsFromCatalog()
-
 // WindowsTerminalAdapter implements TerminalAdapter for Windows Terminal,
 // covering both native Windows installs and WSL where the host shell is WT.
 type WindowsTerminalAdapter struct {
+	// desired is the list of bindings the merge guarantees in settings.json.
+	desired []WTBinding
 	// now allows tests to pin the timestamp used for backup file names.
 	now func() time.Time
 	// userHomeDir defaults to os.UserHomeDir for the WSL fallback path.
@@ -60,10 +57,12 @@ type WindowsTerminalAdapter struct {
 	runCmdExe func(args []string) (string, error)
 }
 
-// NewWindowsTerminalAdapter constructs a WT adapter wired to real OS helpers.
-// Tests can override the internal hooks afterwards.
-func NewWindowsTerminalAdapter() *WindowsTerminalAdapter {
+// NewWindowsTerminalAdapter constructs a WT adapter wired to real OS helpers
+// that guarantees the supplied bindings. Tests can override the internal
+// hooks afterwards.
+func NewWindowsTerminalAdapter(desired []WTBinding) *WindowsTerminalAdapter {
 	return &WindowsTerminalAdapter{
+		desired:     desired,
 		now:         time.Now,
 		userHomeDir: os.UserHomeDir,
 		stat:        os.Stat,
@@ -282,7 +281,7 @@ func (w *WindowsTerminalAdapter) PlanMerge(currentConfig string, fileExists bool
 	var changes []MergeChange
 	dirty := false
 
-	for _, want := range wtDesiredBindings {
+	for _, want := range w.desired {
 		// 1) Conflict check: a non-projmux binding already owns these keys.
 		if existingKB, ok := keybindingByKeys[strings.ToLower(want.Keys)]; ok {
 			existingID, _ := existingKB["id"].(string)
@@ -385,7 +384,7 @@ func (w *WindowsTerminalAdapter) PlanMerge(currentConfig string, fileExists bool
 }
 
 // newProjmuxAction builds the canonical actions[] entry for a binding.
-func newProjmuxAction(b wtBinding) map[string]any {
+func newProjmuxAction(b WTBinding) map[string]any {
 	return map[string]any{
 		"command": map[string]any{
 			"action": "sendInput",
@@ -396,7 +395,7 @@ func newProjmuxAction(b wtBinding) map[string]any {
 }
 
 // newProjmuxKeybinding builds the canonical keybindings[] entry for a binding.
-func newProjmuxKeybinding(b wtBinding) map[string]any {
+func newProjmuxKeybinding(b WTBinding) map[string]any {
 	return map[string]any{
 		"id":   b.ID,
 		"keys": b.Keys,

--- a/internal/app/initcmd/init_windows_terminal_test.go
+++ b/internal/app/initcmd/init_windows_terminal_test.go
@@ -1,4 +1,4 @@
-package app
+package initcmd
 
 import (
 	"encoding/json"
@@ -10,11 +10,20 @@ import (
 	"time"
 )
 
+// testWTBindings is a catalog-shaped fixture. The real desired bindings are
+// derived from the app keybinding catalog and injected by the caller; merge
+// behavior only depends on the (id, keys, input) shape.
+var testWTBindings = []WTBinding{
+	{ID: "User.projmuxSidebar", Keys: "alt+1", Input: "\x1b1"},
+	{ID: "User.projmuxSessions", Keys: "alt+2", Input: "\x1b2"},
+	{ID: "User.projmuxAgent", Keys: "alt+3", Input: "\x1b3"},
+}
+
 // newWTTestAdapter returns a WindowsTerminalAdapter with deterministic
 // timestamps and no implicit cmd.exe interop, suitable for unit tests.
 func newWTTestAdapter(t *testing.T) *WindowsTerminalAdapter {
 	t.Helper()
-	a := NewWindowsTerminalAdapter()
+	a := NewWindowsTerminalAdapter(testWTBindings)
 	a.now = func() time.Time { return time.Date(2026, 4, 30, 1, 32, 15, 0, time.UTC) }
 	a.runCmdExe = func([]string) (string, error) { return "", errors.New("interop disabled in test") }
 	return a
@@ -45,25 +54,10 @@ func presetSidebarOnly() string {
 	return body
 }
 
-func TestWTAdapterRegisteredAlongsideGhostty(t *testing.T) {
-	t.Parallel()
-
-	wt, ok := defaultTerminalRegistry.lookup("windows-terminal")
-	if !ok {
-		t.Fatalf("default registry missing windows-terminal adapter")
-	}
-	if wt.Name() != "windows-terminal" {
-		t.Fatalf("name = %q, want windows-terminal", wt.Name())
-	}
-	if _, ok := defaultTerminalRegistry.lookup("ghostty"); !ok {
-		t.Fatalf("default registry missing ghostty adapter (regression in PR-B)")
-	}
-}
-
 func TestWTAdapterDetect(t *testing.T) {
 	t.Parallel()
 
-	a := NewWindowsTerminalAdapter()
+	a := NewWindowsTerminalAdapter(testWTBindings)
 	cases := []struct {
 		name string
 		env  map[string]string
@@ -90,7 +84,7 @@ func TestWTAdapterDetect(t *testing.T) {
 
 func TestWTAdapterDetectNilEnv(t *testing.T) {
 	t.Parallel()
-	a := NewWindowsTerminalAdapter()
+	a := NewWindowsTerminalAdapter(testWTBindings)
 	if a.Detect(nil) {
 		t.Fatalf("Detect(nil) = true, want false")
 	}
@@ -371,18 +365,18 @@ func TestWTPlanMergeEmptyAddsAllBindings(t *testing.T) {
 			addCount++
 		}
 	}
-	if addCount != len(wtDesiredBindings) {
-		t.Fatalf("add count = %d, want %d", addCount, len(wtDesiredBindings))
+	if addCount != len(testWTBindings) {
+		t.Fatalf("add count = %d, want %d", addCount, len(testWTBindings))
 	}
 	// Verify the merged JSON parses and has the expected entries.
 	root := mustJSON(t, plan.Updated)
 	actions := asObjectArray(root["actions"])
-	if len(actions) != len(wtDesiredBindings) {
-		t.Fatalf("actions len = %d, want %d", len(actions), len(wtDesiredBindings))
+	if len(actions) != len(testWTBindings) {
+		t.Fatalf("actions len = %d, want %d", len(actions), len(testWTBindings))
 	}
 	keybindings := asObjectArray(root["keybindings"])
-	if len(keybindings) != len(wtDesiredBindings) {
-		t.Fatalf("keybindings len = %d, want %d", len(keybindings), len(wtDesiredBindings))
+	if len(keybindings) != len(testWTBindings) {
+		t.Fatalf("keybindings len = %d, want %d", len(keybindings), len(testWTBindings))
 	}
 	// Spot-check one binding round-trips with the expected escape bytes.
 	var foundSidebar bool
@@ -400,16 +394,6 @@ func TestWTPlanMergeEmptyAddsAllBindings(t *testing.T) {
 	}
 	if strings.Contains(plan.Updated, `\u001b[900`) || strings.Contains(plan.Updated, `\u001b[901`) {
 		t.Fatalf("updated settings contains retired app modified-key input:\n%s", plan.Updated)
-	}
-}
-
-func TestWindowsTerminalDesiredBindingsDoNotUseAppCSIu(t *testing.T) {
-	t.Parallel()
-
-	for _, binding := range wtDesiredBindings {
-		if strings.Contains(binding.Input, "\x1b[900") || strings.Contains(binding.Input, "\x1b[901") {
-			t.Fatalf("windows-terminal binding uses retired app modified-key input: %#v", binding)
-		}
 	}
 }
 
@@ -455,8 +439,8 @@ func TestWTPlanMergePartialFillsGaps(t *testing.T) {
 			noopCount++
 		}
 	}
-	if addCount != len(wtDesiredBindings)-1 {
-		t.Fatalf("add count = %d, want %d", addCount, len(wtDesiredBindings)-1)
+	if addCount != len(testWTBindings)-1 {
+		t.Fatalf("add count = %d, want %d", addCount, len(testWTBindings)-1)
 	}
 	if noopCount != 1 {
 		t.Fatalf("noop count = %d, want 1", noopCount)

--- a/internal/app/keybinding_catalog.go
+++ b/internal/app/keybinding_catalog.go
@@ -5,6 +5,8 @@ import (
 	"slices"
 	"sort"
 	"strings"
+
+	"github.com/crevissepartners/projmux/internal/app/initcmd"
 )
 
 type keyBindingScope string
@@ -989,7 +991,16 @@ func filterKeyBindingActions(actions []keyBindingAction, keep func(keyBindingAct
 	return out
 }
 
-func ghosttyBindingsFromCatalog() []ghosttyBinding {
+// newInitCommand wires `projmux init` with the bundled terminal adapters,
+// injecting the desired bindings derived from the keybinding catalog.
+func newInitCommand() *initcmd.Command {
+	return initcmd.New(
+		initcmd.NewGhosttyAdapter(ghosttyBindingsFromCatalog()),
+		initcmd.NewWindowsTerminalAdapter(windowsTerminalBindingsFromCatalog()),
+	)
+}
+
+func ghosttyBindingsFromCatalog() []initcmd.GhosttyBinding {
 	var actions []keyBindingAction
 	for _, action := range defaultKeyBindingCatalog() {
 		if action.GhosttyTrigger == "" || action.GhosttyAction == "" {
@@ -1001,9 +1012,9 @@ func ghosttyBindingsFromCatalog() []ghosttyBinding {
 		return actions[i].GhosttyOrder < actions[j].GhosttyOrder
 	})
 
-	out := make([]ghosttyBinding, 0, len(actions))
+	out := make([]initcmd.GhosttyBinding, 0, len(actions))
 	for _, action := range actions {
-		out = append(out, ghosttyBinding{
+		out = append(out, initcmd.GhosttyBinding{
 			Trigger: action.GhosttyTrigger,
 			Action:  action.GhosttyAction,
 		})
@@ -1011,7 +1022,7 @@ func ghosttyBindingsFromCatalog() []ghosttyBinding {
 	return out
 }
 
-func windowsTerminalBindingsFromCatalog() []wtBinding {
+func windowsTerminalBindingsFromCatalog() []initcmd.WTBinding {
 	var actions []keyBindingAction
 	for _, action := range defaultKeyBindingCatalog() {
 		if action.WTID == "" {
@@ -1023,9 +1034,9 @@ func windowsTerminalBindingsFromCatalog() []wtBinding {
 		return actions[i].WTOrder < actions[j].WTOrder
 	})
 
-	out := make([]wtBinding, 0, len(actions))
+	out := make([]initcmd.WTBinding, 0, len(actions))
 	for _, action := range actions {
-		out = append(out, wtBinding{
+		out = append(out, initcmd.WTBinding{
 			ID:    action.WTID,
 			Keys:  action.WTKeys,
 			Input: action.WTInput,

--- a/internal/app/keybinding_catalog_test.go
+++ b/internal/app/keybinding_catalog_test.go
@@ -1,0 +1,57 @@
+package app
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestGhosttyBindingsFromCatalogUsePlainMeta(t *testing.T) {
+	t.Parallel()
+
+	bindings := ghosttyBindingsFromCatalog()
+	if len(bindings) == 0 {
+		t.Fatal("ghosttyBindingsFromCatalog() is empty, want Alt-1..5 plain Meta mappings")
+	}
+	for _, binding := range bindings {
+		if strings.Contains(binding.Action, "c"+"si:") {
+			t.Fatalf("ghostty binding uses retired CSI action: %#v", binding)
+		}
+		if !strings.HasPrefix(binding.Action, `text:\x1b`) {
+			t.Fatalf("ghostty binding action = %q, want plain Meta text action", binding.Action)
+		}
+	}
+}
+
+func TestWindowsTerminalBindingsFromCatalogDoNotUseAppCSIu(t *testing.T) {
+	t.Parallel()
+
+	bindings := windowsTerminalBindingsFromCatalog()
+	if len(bindings) == 0 {
+		t.Fatal("windowsTerminalBindingsFromCatalog() is empty, want managed WT bindings")
+	}
+	for _, binding := range bindings {
+		if strings.Contains(binding.Input, "\x1b[900") || strings.Contains(binding.Input, "\x1b[901") {
+			t.Fatalf("windows-terminal binding uses retired app modified-key input: %#v", binding)
+		}
+	}
+}
+
+// TestNewInitCommandRegistersBundledTerminals exercises the production wiring:
+// the init command built by newInitCommand must know both bundled adapters,
+// which surfaces in the "unknown terminal" error's known-terminals list.
+func TestNewInitCommandRegistersBundledTerminals(t *testing.T) {
+	t.Parallel()
+
+	cmd := newInitCommand()
+	var stdout, stderr bytes.Buffer
+	err := cmd.Run([]string{"no-such-terminal"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("Run(no-such-terminal) error = nil, want unknown terminal error")
+	}
+	for _, name := range []string{"ghostty", "windows-terminal"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Fatalf("unknown-terminal error %q missing bundled adapter %q", err, name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Second cluster promotion from the "app 패키지 다이어트" track, following the usagecmd precedent (#510): the terminal-init family (`init.go`, `init_terminal.go`, `init_ghostty.go`, `init_windows_terminal.go` + tests) moves to `internal/app/initcmd`, importing stdlib only — zero app symbols.
- The one outbound seam (catalog-derived ghostty/WT bindings) inverts via constructor injection: `New(adapters ...TerminalAdapter)` with `NewGhosttyAdapter(desired)`/`NewWindowsTerminalAdapter(desired)`; the global self-registering adapter registry becomes per-command state. `keybinding_catalog.go` keeps the catalog derivations and the wiring func.
- Evidence-first scope: scratch-package builds with `-gcflags=-e` measured every sub-cluster. setup.go (probe engine shared with the settings hub, ~14 inbound), doctor* (diagnostic hub needing the concrete `aiCommand`, 11 outbound), and trust.go (defines methods on `*settingsCommand`, 30 outbound) all fail the leaf bar and deliberately stay in app.
- End-to-end verified: `projmux init ghostty` dry-run prints real catalog bindings; unknown terminal errors list both bundled adapters.

## Test plan
- [x] make fmt
- [x] make fix (deadcode gate clean)
- [x] make test (incl. new internal/app/initcmd suite)
- [x] manual: `projmux init ghostty` dry-run / unknown-terminal error

## Globalization
- [x] No user-facing string changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
