### PR TITLE
refactor(core): delete dead config and core baseline from deadcode allowlist

### DIFF
--- a/.deadcode-allowlist.txt
+++ b/.deadcode-allowlist.txt
@@ -198,27 +198,14 @@ effectivePaneCount
 # internal/config -- config readers / trust helpers retained for callers.
 IsProjectConfigTrusted
 LoadSessionStateToggleFile
-Paths.PostCreateHookPath
-Paths.ProjdirFile
-Paths.WorkdirsFile
-PostCreateRunner.Run
-PostCreateRunner.runner
-WithPostCreateRunner
 
 # internal/core/usage -- adapter / store / registry surface.
 NewState
 Registry.Lookup
-Registry.Names
 Registry.Replace
 RedactToken
-Store.BaseDir
-Store.Remove
 Store.SaveAll
-Store.Show
 UsageSupported
-
-# internal/core/layout, preview, recentwindows
-RenderFullFrameUpdate
 
 # internal/integrations/hooks -- hook install / trust helpers.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,21 +63,9 @@ func (p Paths) PreviewStateFile() string {
 	return filepath.Join(p.StateDir, PreviewStateFileName)
 }
 
-// ProjdirFile returns the default file used for the persisted
-// PROJMUX_PROJDIR value (the primary project root path).
-func (p Paths) ProjdirFile() string {
-	return filepath.Join(p.ConfigDir, ProjdirFileName)
-}
-
 // KeymapFile returns the user-editable keybinding override file.
 func (p Paths) KeymapFile() string {
 	return filepath.Join(p.ConfigDir, KeymapFileName)
-}
-
-// PostCreateHookPath returns the default location for the optional
-// post-create hook script.
-func (p Paths) PostCreateHookPath() string {
-	return p.HookPath(PostCreateHookFileName)
 }
 
 // HookPath returns the default location for a named global lifecycle hook.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -96,28 +96,6 @@ func TestHomesPathsRequiresHomeDirWhenFallbackNeeded(t *testing.T) {
 	}
 }
 
-func TestPathsProjdirFile(t *testing.T) {
-	t.Parallel()
-
-	paths := Paths{ConfigDir: "/tmp/config/projmux"}
-	if got, want := paths.ProjdirFile(), filepath.Join(paths.ConfigDir, ProjdirFileName); got != want {
-		t.Fatalf("ProjdirFile() = %q, want %q", got, want)
-	}
-}
-
-func TestPathsPostCreateHookPath(t *testing.T) {
-	t.Parallel()
-
-	paths := Paths{ConfigDir: "/tmp/config/projmux"}
-	want := filepath.Join(paths.ConfigDir, HooksDirName, PostCreateHookFileName)
-	if got := paths.PostCreateHookPath(); got != want {
-		t.Fatalf("PostCreateHookPath() = %q, want %q", got, want)
-	}
-	if want != filepath.Join("/tmp/config/projmux", "hooks", "post-create") {
-		t.Fatalf("PostCreateHookPath layout drifted: want %q", want)
-	}
-}
-
 func TestPathsStatusbarDecorationFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/workdirs.go
+++ b/internal/config/workdirs.go
@@ -14,11 +14,6 @@ import (
 // non-empty, non-comment line stores one absolute directory path.
 const WorkdirsFileName = "workdirs"
 
-// WorkdirsFile returns the default file used for the persisted workdirs list.
-func (p Paths) WorkdirsFile() string {
-	return filepath.Join(p.ConfigDir, WorkdirsFileName)
-}
-
 // WorkdirsFile returns the path to the persisted workdirs file rooted at the
 // supplied home directory. An empty homeDir yields an empty string.
 func WorkdirsFile(homeDir string) string {

--- a/internal/config/workdirs_test.go
+++ b/internal/config/workdirs_test.go
@@ -8,15 +8,6 @@ import (
 	"testing"
 )
 
-func TestPathsWorkdirsFile(t *testing.T) {
-	t.Parallel()
-
-	paths := Paths{ConfigDir: "/tmp/config/projmux"}
-	if got, want := paths.WorkdirsFile(), filepath.Join(paths.ConfigDir, WorkdirsFileName); got != want {
-		t.Fatalf("WorkdirsFile() = %q, want %q", got, want)
-	}
-}
-
 func TestWorkdirsFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/layout/layout.go
+++ b/internal/core/layout/layout.go
@@ -197,35 +197,6 @@ func (s Store) Save(name string, preset Preset) error {
 	return nil
 }
 
-func (s Store) Remove(name string) error {
-	path, err := s.Path(name)
-	if err != nil {
-		return err
-	}
-	if err := os.Remove(path); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("%w: %s", ErrNotFound, path)
-		}
-		return fmt.Errorf("layout: remove preset %s: %w", path, err)
-	}
-	return nil
-}
-
-func (s Store) Show(name string) (string, error) {
-	path, err := s.Path(name)
-	if err != nil {
-		return "", err
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("%w: %s", ErrNotFound, path)
-		}
-		return "", fmt.Errorf("layout: read preset %s: %w", path, err)
-	}
-	return string(data), nil
-}
-
 func FromSnapshot(snap sessionstate.Snapshot, projectRoot, description, mode string) Preset {
 	p := Preset{
 		SchemaVersion: SchemaVersion,

--- a/internal/core/usage/registry.go
+++ b/internal/core/usage/registry.go
@@ -113,18 +113,6 @@ func (r *Registry) Lookup(name string) (Adapter, bool) {
 	return a, ok
 }
 
-// Names returns the registered adapter names in lexicographic order.
-func (r *Registry) Names() []string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	names := make([]string, 0, len(r.adapters))
-	for n := range r.adapters {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-	return names
-}
-
 // All returns every registered adapter, ordered by Name().
 func (r *Registry) All() []Adapter {
 	r.mu.RLock()

--- a/internal/core/usage/registry_test.go
+++ b/internal/core/usage/registry_test.go
@@ -2,7 +2,6 @@ package usage
 
 import (
 	"context"
-	"reflect"
 	"testing"
 )
 
@@ -41,10 +40,6 @@ func TestRegistryRegisterAndLookup(t *testing.T) {
 
 	if _, ok := r.Lookup("missing"); ok {
 		t.Fatalf("Lookup(missing) ok=true, want false")
-	}
-
-	if got, want := r.Names(), []string{"claude", "codex"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("Names() = %v, want %v", got, want)
 	}
 }
 

--- a/internal/core/usage/store.go
+++ b/internal/core/usage/store.go
@@ -67,14 +67,6 @@ func (s *Store) FilePath() string {
 	return filepath.Join(s.baseDir, snapshotFileName)
 }
 
-// BaseDir returns the directory the Store is rooted at.
-func (s *Store) BaseDir() string {
-	if s == nil {
-		return ""
-	}
-	return s.baseDir
-}
-
 // State is the rich view the Manager and adapters need: snapshots plus
 // per-adapter throttle/backoff bookkeeping. Returned by LoadState; the
 // older LoadAll wrapper is kept for callers that only want the snapshot

--- a/internal/integrations/hooks/hooks.go
+++ b/internal/integrations/hooks/hooks.go
@@ -97,22 +97,6 @@ type Runner struct {
 // RunnerByEvent is the event-oriented lifecycle hook runner surface.
 type RunnerByEvent = Runner
 
-// PostCreateRunner is a backwards-compatible shim that delegates to Runner
-// for the post-create lifecycle point. It is intentionally thin: callers that
-// want full event coverage should construct *Runner directly.
-type PostCreateRunner struct {
-	GlobalConfigPath     string
-	DiscoverProjectHooks bool
-	ProjectHooksFilePath string
-	TrustStorePath       string
-	ProjectHookPrompt    ProjectHookPrompt
-	PromptReader         io.Reader
-	PromptWriter         io.Writer
-	Logger               io.Writer
-	Timeout              time.Duration
-	Version              string
-}
-
 // Run executes configured lifecycle hooks for event. Hook failures are logged
 // and ignored except for EventPreCreate, where a non-zero exit, exec error, or
 // timeout aborts creation by returning an error.
@@ -259,31 +243,6 @@ func (r *Runner) HasHooks(event Event, cwd string) bool {
 		return false
 	}
 	return cfg.hasEventSurface(event)
-}
-
-// Run executes configured post-create hooks for c. Hook failures
-// (non-zero exit, exec error, timeout) are recorded as a single warning line
-// on Logger and never returned.
-func (r *PostCreateRunner) Run(ctx context.Context, c PostCreateContext) {
-	if r == nil {
-		return
-	}
-	_, _ = r.runner().Run(ctx, EventPostCreate, c)
-}
-
-func (r *PostCreateRunner) runner() *Runner {
-	return &Runner{
-		GlobalConfigPath:     r.GlobalConfigPath,
-		DiscoverProjectHooks: r.DiscoverProjectHooks,
-		ProjectHooksFilePath: r.ProjectHooksFilePath,
-		TrustStorePath:       r.TrustStorePath,
-		ProjectHookPrompt:    r.ProjectHookPrompt,
-		PromptReader:         r.PromptReader,
-		PromptWriter:         r.PromptWriter,
-		Logger:               r.Logger,
-		Timeout:              r.Timeout,
-		Version:              r.Version,
-	}
 }
 
 type outputMode int

--- a/internal/integrations/hooks/hooks_test.go
+++ b/internal/integrations/hooks/hooks_test.go
@@ -12,60 +12,6 @@ import (
 	"time"
 )
 
-// --- PostCreateRunner shim coverage ---------------------------------------
-
-func TestPostCreateRunnerNilReceiverIsNoOp(t *testing.T) {
-	t.Parallel()
-
-	var runner *PostCreateRunner
-	runner.Run(context.Background(), PostCreateContext{SessionName: "workspace"})
-}
-
-func TestPostCreateRunnerEmptyConfigIsNoOp(t *testing.T) {
-	t.Parallel()
-
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{Logger: &logger}
-	runner.Run(context.Background(), PostCreateContext{SessionName: "workspace"})
-
-	if logger.Len() != 0 {
-		t.Fatalf("logger output = %q, want empty", logger.String())
-	}
-}
-
-func TestPostCreateRunnerProjectConfigRunsWithTrust(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash fixtures require POSIX")
-	}
-	t.Parallel()
-
-	cwd := t.TempDir()
-	writeProjectConfig(t, cwd, `
-[hooks.post-create]
-run = "echo from-project"
-`)
-
-	var logger bytes.Buffer
-	runner := &PostCreateRunner{
-		DiscoverProjectHooks: true,
-		ProjectHooksFilePath: testProjectHooksFilePath(t),
-		TrustStorePath:       testTrustStorePath(t),
-		ProjectHookPrompt:    func(ProjectHookPromptRequest) ProjectHookDecision { return ProjectHookAllowOnce },
-		Logger:               &logger,
-	}
-	runner.Run(context.Background(), PostCreateContext{
-		SessionName: "workspace",
-		CWD:         cwd,
-		Kind:        "persistent",
-		Version:     "0.0.0-test",
-	})
-
-	got := logger.String()
-	if !strings.Contains(got, "from-project") {
-		t.Fatalf("logger output missing declarative project hook stdout:\n%s", got)
-	}
-}
-
 // --- Runner declarative behaviour -----------------------------------------
 
 func TestRunnerNoConfigIsNoOp(t *testing.T) {

--- a/internal/integrations/tmux/client.go
+++ b/internal/integrations/tmux/client.go
@@ -76,7 +76,7 @@ func (ExecRunner) Run(ctx context.Context, name string, args ...string) ([]byte,
 	return output, nil
 }
 
-// postCreateRunner is the subset of *hooks.PostCreateRunner that the tmux
+// postCreateRunner is the narrow post-create hook surface that the tmux
 // client invokes after creating a new session. The interface keeps the
 // dependency narrow and lets tests stub it without spinning up real exec.
 type postCreateRunner interface {
@@ -113,18 +113,6 @@ type Client struct {
 
 // ClientOption configures optional Client behavior.
 type ClientOption func(*Client)
-
-// WithPostCreateRunner attaches a hook runner that fires after a tmux
-// session is newly created. Pass nil to disable.
-func WithPostCreateRunner(r *hooks.PostCreateRunner) ClientOption {
-	return func(c *Client) {
-		if r == nil {
-			c.postCreate = nil
-			return
-		}
-		c.postCreate = r
-	}
-}
 
 // WithLifecycleHookRunner attaches the generic lifecycle hook runner.
 func WithLifecycleHookRunner(r *hooks.Runner) ClientOption {

--- a/internal/integrations/tmux/client_test.go
+++ b/internal/integrations/tmux/client_test.go
@@ -2360,8 +2360,8 @@ func (f *fakeLifecycleRunner) StartupCommand(string) (string, bool) {
 	return f.startupCommand, f.startupOK
 }
 
-// withPostCreateRunnerInterface wires a test stub through the same field that
-// WithPostCreateRunner targets without depending on a real *hooks.PostCreateRunner.
+// withPostCreateRunnerInterface wires a test stub into the client's
+// post-create hook field without depending on a real hooks runner.
 func withPostCreateRunnerInterface(r postCreateRunner) ClientOption {
 	return func(c *Client) {
 		c.postCreate = r


### PR DESCRIPTION
## Summary
- Second and final tranche of the deadcode-baseline diet (first: #516, internal/app): the `internal/config`, `internal/core/usage`, and `internal/core/layout…` allowlist groups.
- **10 symbols deleted** (net −222 lines): unused `Paths` method variants shadowed by their package-level equivalents, the never-constructed `PostCreateRunner` compat shim (+3 dedicated shim tests), unused usage-store/registry accessors, and two zero-reference layout store methods. One allowlist-only removal: a duplicate entry whose definition lives in the out-of-scope picker group.
- **8 entries deliberately skipped with recorded reasons**: shared cross-package test helpers/fixtures, `Registry.Replace`/`Lookup` (stub-adapter injection into production Manager wiring — the interface-satisfaction false-positive trap), `RedactToken` (doc-comment planned consumer guarded by a secret-leak invariant test), `SaveAll` (persistence round-trip seeding).
- Roadmap-tied groups (i18n audit, picker parity, mux/psmux backend, MUST-KEEP) remain untouched. Deadcode gate re-verified clean with no new cascades.

## Test plan
- [x] make fmt
- [x] make fix (deadcode gate clean)
- [x] make test (all packages ok)

## Globalization
- [x] No user-facing string changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
