### PR TITLE
fix(sidebar): sidebar live switch = preview, recent record on commit only (Phase 0)

### DIFF
--- a/internal/app/recent_window.go
+++ b/internal/app/recent_window.go
@@ -81,25 +81,27 @@ func printWindowUsage(w io.Writer) {
 }
 
 type recentWindowCommand struct {
-	runner       tmuxRunner
-	opener       recentWindowOpener
-	storeFactory recentWindowStoreFactory
-	nativePicker intpicker.Runner
-	lookupEnv    func(string) string
-	homeDir      func() (string, error)
-	now          func() time.Time
+	runner               tmuxRunner
+	opener               recentWindowOpener
+	storeFactory         recentWindowStoreFactory
+	nativePicker         intpicker.Runner
+	lookupEnv            func(string) string
+	homeDir              func() (string, error)
+	now                  func() time.Time
+	sidebarPreviewActive func() bool
 }
 
 func newRecentWindowCommand() *recentWindowCommand {
 	client := defaultTmuxClient()
 	return &recentWindowCommand{
-		runner:       inttmux.ExecRunner{},
-		opener:       client,
-		storeFactory: defaultRecentWindowStore,
-		nativePicker: intpicker.NativeRunner{In: os.Stdin, Out: os.Stdout},
-		lookupEnv:    os.Getenv,
-		homeDir:      os.UserHomeDir,
-		now:          time.Now,
+		runner:               inttmux.ExecRunner{},
+		opener:               client,
+		storeFactory:         defaultRecentWindowStore,
+		nativePicker:         intpicker.NativeRunner{In: os.Stdin, Out: os.Stdout},
+		lookupEnv:            os.Getenv,
+		homeDir:              os.UserHomeDir,
+		now:                  time.Now,
+		sidebarPreviewActive: isSidebarPreviewActive,
 	}
 }
 
@@ -206,6 +208,14 @@ func (c *recentWindowCommand) RunRecord(args []string, _ io.Writer, stderr io.Wr
 	if fs.NArg() != 0 {
 		printWindowRecordUsage(stderr)
 		return fmt.Errorf("window record does not accept positional arguments")
+	}
+
+	// Sidebar live switches are previews: while the sidebar popup marker
+	// exists, skip recording so peeked sessions never enter the recent
+	// queue. The commit (Enter) path records once explicitly after the
+	// marker is removed, and the cancel restore switch records origin.
+	if c.sidebarPreviewActive != nil && c.sidebarPreviewActive() {
+		return nil
 	}
 
 	ctx := context.Background()

--- a/internal/app/recent_window_test.go
+++ b/internal/app/recent_window_test.go
@@ -1529,3 +1529,55 @@ func (r *recentWindowFakeRunner) sawCall(name string, args ...string) bool {
 	}
 	return false
 }
+
+func TestRecentWindowRecordSkipsWhileSidebarPreviewActive(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux,1,0")
+
+	store := &recentWindowStubStore{}
+	cmd := &recentWindowCommand{
+		runner: &recentWindowFakeRunner{
+			recordOutput: strings.Join([]string{
+				"/tmp/tmux", "repos-projmux", "@6", "agent", "%54",
+				"shell", "topic", "zsh",
+				"/home/es5h/source/repos/projmux",
+				"/home/es5h/source/repos/projmux",
+			}, recentWindowFieldSep) + "\n",
+		},
+		storeFactory:         func(string) (recentWindowStore, error) { return store, nil },
+		now:                  time.Now,
+		sidebarPreviewActive: func() bool { return true },
+	}
+
+	if err := cmd.RunRecord(nil, nil, nil); err != nil {
+		t.Fatalf("RunRecord() error = %v", err)
+	}
+	if len(store.records) != 0 {
+		t.Fatalf("records len = %d, want 0 while the sidebar preview is active", len(store.records))
+	}
+}
+
+func TestRecentWindowRecordRecordsWhenSidebarPreviewInactive(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux,1,0")
+
+	store := &recentWindowStubStore{}
+	cmd := &recentWindowCommand{
+		runner: &recentWindowFakeRunner{
+			recordOutput: strings.Join([]string{
+				"/tmp/tmux", "repos-projmux", "@6", "agent", "%54",
+				"shell", "topic", "zsh",
+				"/home/es5h/source/repos/projmux",
+				"/home/es5h/source/repos/projmux",
+			}, recentWindowFieldSep) + "\n",
+		},
+		storeFactory:         func(string) (recentWindowStore, error) { return store, nil },
+		now:                  time.Now,
+		sidebarPreviewActive: func() bool { return false },
+	}
+
+	if err := cmd.RunRecord(nil, nil, nil); err != nil {
+		t.Fatalf("RunRecord() error = %v", err)
+	}
+	if len(store.records) != 1 {
+		t.Fatalf("records len = %d, want 1 for a regular switch outside the sidebar", len(store.records))
+	}
+}

--- a/internal/app/switch.go
+++ b/internal/app/switch.go
@@ -1470,6 +1470,9 @@ func (c *switchCommand) completePlan(plan switchPlan) (switchPlan, error) {
 
 func (c *switchCommand) execute(ctx context.Context, plan switchPlan, stdout io.Writer) (bool, error) {
 	if plan.Selection == "" {
+		if plan.UI == switchUISidebar {
+			c.cancelSidebarPreview(ctx, plan.OriginSession)
+		}
 		return false, nil
 	}
 	if plan.Selection == switchSettingsSentinel {
@@ -1599,7 +1602,11 @@ func (c *switchCommand) openProjectTargetPathFromSidebar(ctx context.Context, pl
 		return err
 	}
 	if exists {
-		return c.openProjectSession(ctx, sessionName)
+		if err := c.openProjectSession(ctx, sessionName); err != nil {
+			return err
+		}
+		c.commitSidebarPreview(ctx)
+		return nil
 	}
 	mode := projectStartupCandidate{Kind: projectStartupKindEmpty}
 	if sidebarStartupPickerEnabled(c.homeDir, c.lookupEnv) {
@@ -1841,6 +1848,65 @@ func (c *switchCommand) runSidebarFocus(args []string, _ io.Writer, stderr io.Wr
 		return fmt.Errorf("open tmux session %q on sidebar focus: %w", sessionName, err)
 	}
 	return nil
+}
+
+// sidebarPreviewMarkerPath resolves this client's sessionizer-sidebar popup
+// marker. Empty when the switch command runs outside a sidebar popup (no
+// target-client env), which disables the commit/cancel marker handling.
+func (c *switchCommand) sidebarPreviewMarkerPath() string {
+	client := strings.TrimSpace(c.env(inttmux.SwitchTargetClientEnv))
+	if client == "" {
+		return ""
+	}
+	return popupMarkerPath(sanitizePopupKey(client), "sessionizer-sidebar")
+}
+
+// removeSidebarPreviewMarker deletes this client's sidebar popup marker and
+// reports whether one was present. The marker gates `window record`, so it
+// must be gone before the commit/cancel paths trigger any recording.
+func (c *switchCommand) removeSidebarPreviewMarker() bool {
+	marker := c.sidebarPreviewMarkerPath()
+	if marker == "" {
+		return false
+	}
+	return os.Remove(marker) == nil
+}
+
+// commitSidebarPreview finalizes an Enter-confirmed sidebar selection. The
+// live preview already switched the client to that session, so no
+// session-changed hook fires on commit; record the window once explicitly
+// after the gating marker is removed, detached like the tmux record hooks.
+func (c *switchCommand) commitSidebarPreview(ctx context.Context) {
+	if !c.removeSidebarPreviewMarker() {
+		return
+	}
+	if c.tmuxRunner == nil || c.executable == nil {
+		return
+	}
+	binaryPath, err := c.executable()
+	if err != nil {
+		return
+	}
+	command := buildShellCommand(binaryPath, []string{"window", "record"}, nil)
+	_, _ = c.tmuxRunner.Run(ctx, "tmux", "run-shell", "-b", command)
+}
+
+// cancelSidebarPreview restores the origin session after the sidebar closes
+// without a selection (Esc). The marker is removed first so the restore
+// switch records origin naturally via the session-changed hook while peeked
+// sessions stay unrecorded. No-op outside a sidebar popup; a missing origin
+// session (killed while peeking) keeps the client on its current session.
+func (c *switchCommand) cancelSidebarPreview(ctx context.Context, originSession string) {
+	hadMarker := c.removeSidebarPreviewMarker()
+	originSession = strings.TrimSpace(originSession)
+	if !hadMarker || originSession == "" || c.sessions == nil {
+		return
+	}
+	exists, err := c.switchSessionExists(ctx, originSession)
+	if err != nil || !exists {
+		return
+	}
+	_ = c.sessions.OpenSession(ctx, originSession)
 }
 
 func (c *switchCommand) runPicker(plan switchPlan) (intpicker.Result, error) {

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -19,6 +20,7 @@ import (
 	corepreview "github.com/crevissepartners/projmux/internal/core/preview"
 	"github.com/crevissepartners/projmux/internal/integrations/hooks"
 	"github.com/crevissepartners/projmux/internal/integrations/sessionstate"
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 	"github.com/crevissepartners/projmux/internal/theme"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
@@ -3774,5 +3776,182 @@ func TestSwitchCurrentSelectionMatchesSnappedSymlinkCandidate(t *testing.T) {
 	// symlink-form candidate row produced by discovery.
 	if match := bestSwitchCandidateMatch(realCurrent, got); match != symlinkProj {
 		t.Fatalf("bestSwitchCandidateMatch(%q, %q) = %q, want %q", realCurrent, got, match, symlinkProj)
+	}
+}
+
+func TestSwitchSidebarCommitRecordsOnceAfterMarkerRemoval(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	client := "/dev/pts/7"
+	marker := popupMarkerPath(sanitizePopupKey(client), "sessionizer-sidebar")
+	if err := os.WriteFile(marker, []byte("%1\norigin\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingTmuxRunner{}
+	executor := &capturingSwitchSessionExecutor{exists: map[string]bool{"work-session": true}}
+	cmd := &switchCommand{
+		sessions:   executor,
+		tmuxRunner: runner,
+		executable: func() (string, error) { return "/tmp/projmux", nil },
+		lookupEnv: func(key string) string {
+			if key == inttmux.SwitchTargetClientEnv {
+				return client
+			}
+			return ""
+		},
+	}
+
+	plan := switchPlan{UI: switchUISidebar, Selection: "/repo/work", SessionName: "work-session"}
+	if err := cmd.openProjectTargetPathFromSidebar(context.Background(), plan); err != nil {
+		t.Fatalf("openProjectTargetPathFromSidebar() error = %v", err)
+	}
+
+	if got, want := executor.calls, []string{"open:work-session"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("session calls = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("marker stat error = %v, want removed before commit record", err)
+	}
+	want := recordedTmuxCall{name: "tmux", args: []string{"run-shell", "-b", "'/tmp/projmux' 'window' 'record'"}}
+	if len(runner.calls) != 1 || !reflect.DeepEqual(runner.calls[0], want) {
+		t.Fatalf("tmux calls = %#v, want exactly one commit record %#v", runner.calls, want)
+	}
+}
+
+func TestSwitchSidebarCommitSkipsExplicitRecordWithoutMarker(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	runner := &recordingTmuxRunner{}
+	executor := &capturingSwitchSessionExecutor{exists: map[string]bool{"work-session": true}}
+	cmd := &switchCommand{
+		sessions:   executor,
+		tmuxRunner: runner,
+		executable: func() (string, error) { return "/tmp/projmux", nil },
+		lookupEnv:  func(string) string { return "" },
+	}
+
+	plan := switchPlan{UI: switchUISidebar, Selection: "/repo/work", SessionName: "work-session"}
+	if err := cmd.openProjectTargetPathFromSidebar(context.Background(), plan); err != nil {
+		t.Fatalf("openProjectTargetPathFromSidebar() error = %v", err)
+	}
+
+	if got, want := executor.calls, []string{"open:work-session"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("session calls = %q, want %q", got, want)
+	}
+	// Outside a sidebar popup the open switch fires the session-changed hook
+	// itself, so an explicit record would double-record.
+	if len(runner.calls) != 0 {
+		t.Fatalf("tmux calls = %#v, want none without a sidebar popup marker", runner.calls)
+	}
+}
+
+func TestSwitchSidebarCancelRestoresOriginSession(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	client := "/dev/pts/7"
+	marker := popupMarkerPath(sanitizePopupKey(client), "sessionizer-sidebar")
+	if err := os.WriteFile(marker, []byte("%1\norigin-session\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	executor := &capturingSwitchSessionExecutor{exists: map[string]bool{"origin-session": true}}
+	cmd := &switchCommand{
+		sessions: executor,
+		lookupEnv: func(key string) string {
+			if key == inttmux.SwitchTargetClientEnv {
+				return client
+			}
+			return ""
+		},
+	}
+
+	reopen, err := cmd.execute(context.Background(), switchPlan{UI: switchUISidebar, OriginSession: "origin-session"}, io.Discard)
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+	if reopen {
+		t.Fatal("execute() reopen = true, want false on cancel")
+	}
+	if got, want := executor.calls, []string{"open:origin-session"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("session calls = %q, want origin restore %q", got, want)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("marker stat error = %v, want removed before origin restore", err)
+	}
+}
+
+func TestSwitchSidebarCancelSkipsRestoreWhenOriginMissing(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	client := "/dev/pts/7"
+	marker := popupMarkerPath(sanitizePopupKey(client), "sessionizer-sidebar")
+	if err := os.WriteFile(marker, []byte("%1\norigin-session\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	executor := &capturingSwitchSessionExecutor{exists: map[string]bool{}}
+	cmd := &switchCommand{
+		sessions: executor,
+		lookupEnv: func(key string) string {
+			if key == inttmux.SwitchTargetClientEnv {
+				return client
+			}
+			return ""
+		},
+	}
+
+	if _, err := cmd.execute(context.Background(), switchPlan{UI: switchUISidebar, OriginSession: "origin-session"}, io.Discard); err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+	if len(executor.calls) != 0 {
+		t.Fatalf("session calls = %q, want none when the origin session is gone", executor.calls)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("marker stat error = %v, want marker removed even without restore", err)
+	}
+}
+
+func TestSwitchSidebarCancelWithoutMarkerDoesNothing(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	executor := &capturingSwitchSessionExecutor{exists: map[string]bool{"origin-session": true}}
+	cmd := &switchCommand{
+		sessions:  executor,
+		lookupEnv: func(string) string { return "" },
+	}
+
+	if _, err := cmd.execute(context.Background(), switchPlan{UI: switchUISidebar, OriginSession: "origin-session"}, io.Discard); err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+	if len(executor.calls) != 0 {
+		t.Fatalf("session calls = %q, want none outside a sidebar popup", executor.calls)
+	}
+}
+
+func TestSwitchPopupCancelDoesNotRestoreOrigin(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	client := "/dev/pts/7"
+	marker := popupMarkerPath(sanitizePopupKey(client), "sessionizer-sidebar")
+	if err := os.WriteFile(marker, []byte("%1\norigin-session\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	executor := &capturingSwitchSessionExecutor{exists: map[string]bool{"origin-session": true}}
+	cmd := &switchCommand{
+		sessions: executor,
+		lookupEnv: func(key string) string {
+			if key == inttmux.SwitchTargetClientEnv {
+				return client
+			}
+			return ""
+		},
+	}
+
+	if _, err := cmd.execute(context.Background(), switchPlan{UI: switchUIPopup, OriginSession: "origin-session"}, io.Discard); err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+	if len(executor.calls) != 0 {
+		t.Fatalf("session calls = %q, want none for the popup sessionizer", executor.calls)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("marker stat error = %v, want sidebar marker untouched by popup cancel", err)
 	}
 }

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -410,8 +410,13 @@ func (c *tmuxCommand) runPopupToggle(args []string, stderr io.Writer) error {
 	if _, err := os.Stat(marker); err == nil {
 		targetPane := strings.TrimSpace(popupCtx.OriginPane)
 		targetClient := ""
-		if content, readErr := os.ReadFile(marker); readErr == nil && strings.TrimSpace(string(content)) != "" {
-			targetPane = strings.TrimSpace(string(content))
+		originSession := ""
+		if content, readErr := os.ReadFile(marker); readErr == nil {
+			markerPane, markerSession := parsePopupMarkerContent(content)
+			if markerPane != "" {
+				targetPane = markerPane
+			}
+			originSession = markerSession
 		}
 		if mode.Canonical == "notify-sidebar" {
 			targetPane = ""
@@ -426,6 +431,9 @@ func (c *tmuxCommand) runPopupToggle(args []string, stderr io.Writer) error {
 			}
 		} else {
 			_ = os.Remove(marker)
+			if mode.Canonical == "sessionizer-sidebar" {
+				c.restoreSidebarOriginSession(ctx, popupCtx.TargetClient, originSession)
+			}
 			return nil
 		}
 	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -441,7 +449,7 @@ func (c *tmuxCommand) runPopupToggle(args []string, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(marker, []byte(popupCtx.OriginPane+"\n"), 0o644); err != nil {
+	if err := os.WriteFile(marker, []byte(popupCtx.OriginPane+"\n"+popupCtx.OriginSession+"\n"), 0o644); err != nil {
 		return fmt.Errorf("write tmux popup marker: %w", err)
 	}
 	if err := intmux.NewRunner(c.runner).DisplayPopup(ctx, command, intmux.PopupOptions(options)); err != nil {
@@ -1620,6 +1628,53 @@ func buildMarkedPopupCommand(binaryPath string, args []string, marker, cwd strin
 
 func popupMarkerPath(clientKey, mode string) string {
 	return filepath.Join(os.TempDir(), "projmux-tmux-popup-"+sanitizePopupKey(clientKey)+"-"+sanitizePopupKey(mode)+".marker")
+}
+
+// parsePopupMarkerContent splits a popup marker payload into its origin pane
+// (line 1) and origin session (line 2, used by the sessionizer-sidebar cancel
+// restore). Markers written before the session line existed yield an empty
+// session.
+func parsePopupMarkerContent(content []byte) (pane, session string) {
+	lines := strings.Split(string(content), "\n")
+	if len(lines) > 0 {
+		pane = strings.TrimSpace(lines[0])
+	}
+	if len(lines) > 1 {
+		session = strings.TrimSpace(lines[1])
+	}
+	return pane, session
+}
+
+// isSidebarPreviewActive reports whether any client currently has the project
+// sidebar popup open. The sidebar's live switch is a preview: while a sidebar
+// marker exists, `window record` skips so peeked sessions never enter the
+// recent-windows queue. The glob is client-agnostic because the tmux record
+// hook runs without client context.
+func isSidebarPreviewActive() bool {
+	matches, err := filepath.Glob(filepath.Join(os.TempDir(), "projmux-tmux-popup-*-sessionizer-sidebar.marker"))
+	return err == nil && len(matches) > 0
+}
+
+// restoreSidebarOriginSession switches the client back to the session that was
+// active when the sidebar opened. Runs on toggle-off (= cancel) after the
+// popup marker is removed, so this restore switch records origin naturally via
+// the session-changed hook while the peeked sessions stay unrecorded. Best
+// effort: a missing origin session (killed while peeking) keeps the client on
+// its current session.
+func (c *tmuxCommand) restoreSidebarOriginSession(ctx context.Context, targetClient, originSession string) {
+	originSession = strings.TrimSpace(originSession)
+	if originSession == "" || c.runner == nil {
+		return
+	}
+	if _, err := c.runner.Run(ctx, "tmux", "has-session", "-t", "="+originSession); err != nil {
+		return
+	}
+	args := []string{"switch-client"}
+	if client := strings.TrimSpace(targetClient); client != "" {
+		args = append(args, "-c", client)
+	}
+	args = append(args, "-t", "="+originSession)
+	_, _ = c.runner.Run(ctx, "tmux", args...)
 }
 
 func sanitizePopupKey(value string) string {

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -337,7 +337,7 @@ func TestAppRunTmuxPopupToggleOpensStandaloneSidebar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read marker error = %v", err)
 	}
-	if got, want := string(content), "%1\n"; got != want {
+	if got, want := string(content), "%1\nwork\n"; got != want {
 		t.Fatalf("marker content = %q, want %q", got, want)
 	}
 }
@@ -859,7 +859,7 @@ func TestAppRunTmuxPopupToggleOpensRecentWindows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read marker error = %v", err)
 	}
-	if got, want := string(content), "%1\n"; got != want {
+	if got, want := string(content), "%1\n\n"; got != want {
 		t.Fatalf("marker content = %q, want %q", got, want)
 	}
 }
@@ -1038,7 +1038,7 @@ func TestAppRunTmuxPopupToggleRecoversStaleSettingsMarkerAndReopens(t *testing.T
 			if err != nil {
 				t.Fatalf("read marker error = %v", err)
 			}
-			if got, want := string(content), "%active\n"; got != want {
+			if got, want := string(content), "%active\n\n"; got != want {
 				t.Fatalf("marker content = %q, want recovered current pane marker %q", got, want)
 			}
 		})
@@ -2925,4 +2925,146 @@ func containsTmuxArgPair(args []string, key, value string) bool {
 		}
 	}
 	return false
+}
+
+func TestParsePopupMarkerContent(t *testing.T) {
+	t.Parallel()
+
+	pane, session := parsePopupMarkerContent([]byte("%1\nwork\n"))
+	if pane != "%1" || session != "work" {
+		t.Fatalf("parsePopupMarkerContent(two lines) = (%q, %q), want (%q, %q)", pane, session, "%1", "work")
+	}
+	pane, session = parsePopupMarkerContent([]byte("%1\n"))
+	if pane != "%1" || session != "" {
+		t.Fatalf("parsePopupMarkerContent(legacy single line) = (%q, %q), want (%q, %q)", pane, session, "%1", "")
+	}
+	pane, session = parsePopupMarkerContent(nil)
+	if pane != "" || session != "" {
+		t.Fatalf("parsePopupMarkerContent(empty) = (%q, %q), want empty", pane, session)
+	}
+}
+
+func TestIsSidebarPreviewActive(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	if isSidebarPreviewActive() {
+		t.Fatal("isSidebarPreviewActive() = true, want false without markers")
+	}
+	other := popupMarkerPath("tty0", "recent-windows")
+	if err := os.WriteFile(other, []byte("%1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if isSidebarPreviewActive() {
+		t.Fatal("isSidebarPreviewActive() = true, want false for non-sidebar popup markers")
+	}
+	marker := popupMarkerPath("tty0", "sessionizer-sidebar")
+	if err := os.WriteFile(marker, []byte("%1\nwork\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !isSidebarPreviewActive() {
+		t.Fatal("isSidebarPreviewActive() = false, want true while a sidebar marker exists")
+	}
+}
+
+func TestAppRunTmuxPopupToggleCloseRestoresSidebarOriginSession(t *testing.T) {
+	t.Parallel()
+
+	clientKey := "/dev/pts/projmux-test-sidebar-cancel"
+	marker := popupMarkerPath(sanitizePopupKey(clientKey), "sessionizer-sidebar")
+	_ = os.Remove(marker)
+	defer os.Remove(marker)
+	if err := os.WriteFile(marker, []byte("%original\nwork\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingTmuxRunner{formats: map[string]string{
+		"#{client_tty}": clientKey,
+		"#{pane_id}":    "%active",
+	}}
+	cmd := &tmuxCommand{
+		runner:     runner,
+		executable: func() (string, error) { return "/tmp/projmux", nil },
+	}
+
+	if err := cmd.Run([]string{"popup-toggle", "--client", clientKey, "sessionizer-sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("marker stat error = %v, want not exist", err)
+	}
+	var got []recordedTmuxCall
+	for _, call := range runner.calls {
+		if len(call.args) > 0 && (call.args[0] == "has-session" || call.args[0] == "switch-client") {
+			got = append(got, call)
+		}
+	}
+	want := []recordedTmuxCall{
+		{name: "tmux", args: []string{"has-session", "-t", "=work"}},
+		{name: "tmux", args: []string{"switch-client", "-c", clientKey, "-t", "=work"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cancel restore calls = %#v, want origin has-session then switch-client %#v", got, want)
+	}
+}
+
+func TestAppRunTmuxPopupToggleCloseSkipsSidebarRestoreWhenOriginGone(t *testing.T) {
+	t.Parallel()
+
+	clientKey := "/dev/pts/projmux-test-sidebar-cancel-gone"
+	marker := popupMarkerPath(sanitizePopupKey(clientKey), "sessionizer-sidebar")
+	_ = os.Remove(marker)
+	defer os.Remove(marker)
+	if err := os.WriteFile(marker, []byte("%original\nwork\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingTmuxRunner{
+		formats: map[string]string{
+			"#{client_tty}": clientKey,
+			"#{pane_id}":    "%active",
+		},
+		errors: map[string]error{
+			recordedTmuxCallKey("tmux", "has-session", "-t", "=work"): errors.New("can't find session"),
+		},
+	}
+	cmd := &tmuxCommand{
+		runner:     runner,
+		executable: func() (string, error) { return "/tmp/projmux", nil },
+	}
+
+	if err := cmd.Run([]string{"popup-toggle", "--client", clientKey, "sessionizer-sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	for _, call := range runner.calls {
+		if len(call.args) > 0 && call.args[0] == "switch-client" {
+			t.Fatalf("tmux calls = %#v, want no switch-client when origin session is gone", runner.calls)
+		}
+	}
+}
+
+func TestAppRunTmuxPopupToggleCloseSkipsSidebarRestoreForLegacyMarker(t *testing.T) {
+	t.Parallel()
+
+	clientKey := "/dev/pts/projmux-test-sidebar-cancel-legacy"
+	marker := popupMarkerPath(sanitizePopupKey(clientKey), "sessionizer-sidebar")
+	_ = os.Remove(marker)
+	defer os.Remove(marker)
+	if err := os.WriteFile(marker, []byte("%original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingTmuxRunner{formats: map[string]string{
+		"#{client_tty}": clientKey,
+		"#{pane_id}":    "%active",
+	}}
+	cmd := &tmuxCommand{
+		runner:     runner,
+		executable: func() (string, error) { return "/tmp/projmux", nil },
+	}
+
+	if err := cmd.Run([]string{"popup-toggle", "--client", clientKey, "sessionizer-sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	for _, call := range runner.calls {
+		if len(call.args) > 0 && (call.args[0] == "has-session" || call.args[0] == "switch-client") {
+			t.Fatalf("tmux calls = %#v, want no restore attempt without a recorded origin session", runner.calls)
+		}
+	}
 }


### PR DESCRIPTION
## 완료한 Phase

로드맵 `Recent-windows record on sidebar commit` **Phase 0** (recent record + Enter commit / Esc cancel).

확정 결정 준수: **"라이브 switch = preview, preview 는 부작용 0. Enter=확정 / Esc·토글-off=취소(원복)."**

## 수정한 user-facing surface

- **프로젝트 사이드바(Alt-1) peek**: 이동 시 라이브 switch(preview)는 그대로 유지되지만, peek 세션이 더 이상 recent-windows(M-3) 큐에 기록되지 않음.
- **Enter(확정)**: 선택 세션에 머물고 그 세션만 recent 에 1회 기록.
- **Esc / Alt-1 토글-off(취소)**: 사이드바 열 때 있던 origin 세션으로 복귀. 복귀 전환이 origin 을 자연 기록(기존 훅 경로). origin 이 peek 중 kill 된 경우 현재 세션 유지(fallback).

## 구현 요약

| 항목 | 위치 |
|---|---|
| record 게이트 | `recent_window.go RunRecord` → `isSidebarPreviewActive()` (tmux.go, `projmux-tmux-popup-*-sessionizer-sidebar.marker` 글롭) |
| origin 추적 | popup marker 2행: 1행 origin pane(기존), 2행 origin 세션 (`runPopupToggle` 기록, `parsePopupMarkerContent` 파싱) |
| commit 명시 record | `switch.go commitSidebarPreview` — marker 제거 → `tmux run-shell -b '<bin> window record'` 1회 (훅과 동일 형태) |
| cancel 복귀 | Esc: `switch.go cancelSidebarPreview` (marker 제거 → origin `OpenSession`) / 토글-off: `tmux.go restoreSidebarOriginSession` (`has-session` 확인 → `switch-client -c <client>`) |

marker 게이트는 client-agnostic 글롭 (record 훅에 client 컨텍스트가 없음). 새 세션 생성 경로(startup picker → `sidebar-open` continuation)는 continuation 이 trust 단계에서 marker 를 먼저 제거하므로 실제 switch 가 자연 기록됨.

## 명시적으로 제외한 범위 (Phase 1+)

- attention arm/clear churn 억제 (Phase 1 — 같은 `isSidebarPreviewActive()` 게이트 재사용 예정).
- 라이브 switch 제거/지연(A안), 프리뷰 페인/피커 UX, recent-windows 피커(M-3), 다른 popup 모드(notify-sidebar 등) 무변경.
- 사이드바 밖 일반 switch 의 record 동작 무변경 (회귀 테스트로 고정).

## 모델/스키마 제약

recentwindows store/스키마, replay·engine 미변경. record 호출 경로에 게이트만 추가.

## 검증 명령

- `go build ./...`, `go test ./internal/...`, `make fmt`, `make fix`, `make test` 모두 통과.
- 신규 테스트:
  - `TestRecentWindowRecordSkipsWhileSidebarPreviewActive` / `...RecordsWhenSidebarPreviewInactive` (skip + 일반 switch 회귀)
  - `TestSwitchSidebarCommitRecordsOnceAfterMarkerRemoval` / `...SkipsExplicitRecordWithoutMarker` (commit 경로)
  - `TestSwitchSidebarCancelRestoresOriginSession` / `...SkipsRestoreWhenOriginMissing` / `...WithoutMarkerDoesNothing` / `TestSwitchPopupCancelDoesNotRestoreOrigin` (cancel 경로)
  - `TestAppRunTmuxPopupToggleCloseRestoresSidebarOriginSession` / `...SkipsSidebarRestoreWhenOriginGone` / `...ForLegacyMarker`, `TestIsSidebarPreviewActive`, `TestParsePopupMarkerContent` (토글-off + 게이트)
- 기존 popup marker 내용 어서션 3건을 새 2행 포맷에 맞게 갱신.

## 미검증 항목 / e2e 후보

- 수동 e2e (tmux 실동작): Alt-1 로 세션 N개 스크롤 → Enter → recent 최상단에 확정 세션만 / Esc·Alt-1 → origin 복귀 + recent 무변화.
- 알려진 미세 race: preview 마지막 이동의 훅 record(run-shell -b 비동기)가 marker 제거 직후 실행되면 peek 1건이 기록될 수 있음(창이 매우 짧음). 다중 client 동시 사이드바는 글롭 게이트로 서로 record 를 억제함 — 필요 시 client-scoped 정밀화는 후속.

## 후속 Phase

- Phase 1: attention churn 억제 (`pane-focus-in/out`, `after-select-pane` → attention arm/clear 를 같은 marker 게이트로 skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
