### PR TITLE
fix(attention): suppress sidebar-preview attention arm/clear churn (Phase 1)

### DIFF
--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -3874,3 +3874,32 @@ func TestBuildRegisterToastAppIDDoesNotSetToastActivatorCLSID(t *testing.T) {
 		}
 	}
 }
+
+// Regression for the sidebar preview attention gate (Phase 1): the gate lives
+// only in `attention arm`/`attention clear` (focus hooks). The AI ingest path
+// writes attention state directly via set-option, so an AI turning "waiting"
+// while the user is browsing the sidebar must still raise the reply marker.
+func TestAIStatusWaitingSetsReplyDuringSidebarPreview(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	marker := popupMarkerPath("tty0", "sessionizer-sidebar")
+	if err := os.WriteFile(marker, []byte("%1\nwork\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !isSidebarPreviewActive() {
+		t.Fatal("test setup: sidebar preview marker not detected")
+	}
+
+	cmd := testAICommand(t.TempDir())
+
+	if err := cmd.applyAIStatusStateOnly("waiting", "%2", attentionNotifyInput{}); err != nil {
+		t.Fatalf("applyAIStatusStateOnly error = %v", err)
+	}
+
+	commands := cmdRecorder(cmd).commands
+	if !containsAICommandArgs(commands, "tmux", []string{"set-option", "-p", "-t", "%2", "@projmux_attention_state", "reply"}) {
+		t.Fatalf("commands = %#v, want attention_state=reply while sidebar preview marker exists (AI completion attention must not be suppressed)", commands)
+	}
+	if !containsAICommandArgs(commands, "tmux", []string{"set-option", "-p", "-t", "%2", "@projmux_attention_focus_armed", "1"}) {
+		t.Fatalf("commands = %#v, want focus_armed=1 while sidebar preview marker exists", commands)
+	}
+}

--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -44,15 +44,28 @@ var attentionListFormats = []string{
 var attentionListFormat = intmux.JoinFormats(attentionListSeparator, attentionListFormats...)
 
 type attentionCommand struct {
-	runner   tmuxRunner
-	producer attentionNotifyProducer
+	runner               tmuxRunner
+	producer             attentionNotifyProducer
+	sidebarPreviewActive func() bool
 }
 
 func newAttentionCommand() *attentionCommand {
 	return &attentionCommand{
-		runner:   inttmux.ExecRunner{},
-		producer: newAttentionNotifyProducer(),
+		runner:               inttmux.ExecRunner{},
+		producer:             newAttentionNotifyProducer(),
+		sidebarPreviewActive: isSidebarPreviewActive,
 	}
+}
+
+// sidebarPreviewGateActive reports whether focus-hook attention updates must
+// be skipped because the project sidebar popup is previewing sessions. Only
+// `attention arm`/`attention clear` consult this gate: both subcommands are
+// invoked exclusively by the pane-focus-in/out and after-select-pane hooks,
+// so skipping them keeps peeked panes' markers intact. Manual
+// `attention toggle` and the AI ingest path (direct set-option in ai.go)
+// never route through these subcommands and stay live during preview.
+func (c *attentionCommand) sidebarPreviewGateActive() bool {
+	return c != nil && c.sidebarPreviewActive != nil && c.sidebarPreviewActive()
 }
 
 // notifyProducer returns the wired-up producer or a noop when the command
@@ -188,6 +201,9 @@ func (c *attentionCommand) runClear(args []string, stderr io.Writer) error {
 	if err != nil || paneID == "" {
 		return err
 	}
+	if c.sidebarPreviewGateActive() {
+		return nil
+	}
 
 	state := c.paneAttentionState(paneID)
 	if state == attentionStateBusy {
@@ -215,6 +231,9 @@ func (c *attentionCommand) runArm(args []string, stderr io.Writer) error {
 	paneID, err := parseOptionalAttentionTarget(args, "attention arm", stderr)
 	if err != nil || paneID == "" {
 		return err
+	}
+	if c.sidebarPreviewGateActive() {
+		return nil
 	}
 	if c.paneAttentionState(paneID) == attentionStateReply {
 		c.setPaneOption(paneID, attentionFocusArmedOption, "1")

--- a/internal/app/attention_test.go
+++ b/internal/app/attention_test.go
@@ -618,3 +618,125 @@ func (r *recordingAttentionRunner) Run(_ context.Context, name string, args ...s
 	}
 	return r.outputs[name+" "+strings.Join(args, " ")], nil
 }
+
+// Phase 1 (sidebar preview attention gate): the focus hooks are the only
+// callers of `attention arm`/`attention clear`, so gating those subcommands
+// suppresses preview-driven marker churn without touching the AI ingest path.
+
+func TestAttentionClearSkipsDuringSidebarPreview(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingAttentionRunner{
+		outputs: map[string][]byte{
+			"tmux display-message -p -t %3 #{@projmux_attention_state}":       []byte("reply\n"),
+			"tmux display-message -p -t %3 #{@projmux_attention_focus_armed}": []byte("1\n"),
+			"tmux display-message -p -t %3 #{pane_title}":                     []byte("✳ agent\n"),
+		},
+	}
+	cmd := &attentionCommand{runner: runner, sidebarPreviewActive: func() bool { return true }}
+
+	if err := cmd.Run([]string{"clear", "%3"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("calls = %#v, want none while the sidebar preview is active", runner.calls)
+	}
+}
+
+func TestAttentionArmSkipsDuringSidebarPreview(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingAttentionRunner{
+		outputs: map[string][]byte{
+			"tmux display-message -p -t %6 #{@projmux_attention_state}": []byte("reply\n"),
+		},
+	}
+	cmd := &attentionCommand{runner: runner, sidebarPreviewActive: func() bool { return true }}
+
+	if err := cmd.Run([]string{"arm", "%6"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("calls = %#v, want none while the sidebar preview is active", runner.calls)
+	}
+}
+
+func TestAttentionClearRunsWhenSidebarPreviewInactive(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingAttentionRunner{
+		outputs: map[string][]byte{
+			"tmux display-message -p -t %3 #{@projmux_attention_state}":       []byte("reply\n"),
+			"tmux display-message -p -t %3 #{@projmux_attention_focus_armed}": []byte("1\n"),
+			"tmux display-message -p -t %3 #{pane_title}":                     []byte("✔ done\n"),
+		},
+	}
+	cmd := &attentionCommand{runner: runner, sidebarPreviewActive: func() bool { return false }}
+
+	if err := cmd.Run([]string{"clear", "%3"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	want := []attentionCall{
+		{name: "tmux", args: []string{"display-message", "-p", "-t", "%3", "#{@projmux_attention_state}"}},
+		{name: "tmux", args: []string{"display-message", "-p", "-t", "%3", "#{@projmux_attention_focus_armed}"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%3", "@projmux_attention_state"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%3", "@projmux_attention_ack", "1"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%3", "@projmux_attention_focus_armed"}},
+		{name: "tmux", args: []string{"display-message", "-p", "-t", "%3", "#{@projmux_ai_badge_kind}"}},
+		{name: "tmux", args: []string{"display-message", "-p", "-t", "%3", "#{@projmux_ai_state}"}},
+		{name: "tmux", args: []string{"display-message", "-p", "-t", "%3", "#{pane_title}"}},
+		{name: "tmux", args: []string{"select-pane", "-T", "done", "-t", "%3"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+func TestAttentionArmRunsWhenSidebarPreviewInactive(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingAttentionRunner{
+		outputs: map[string][]byte{
+			"tmux display-message -p -t %6 #{@projmux_attention_state}": []byte("reply\n"),
+		},
+	}
+	cmd := &attentionCommand{runner: runner, sidebarPreviewActive: func() bool { return false }}
+
+	if err := cmd.Run([]string{"arm", "%6"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	want := []attentionCall{
+		{name: "tmux", args: []string{"display-message", "-p", "-t", "%6", "#{@projmux_attention_state}"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%6", "@projmux_attention_focus_armed", "1"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+func TestAttentionToggleIgnoresSidebarPreview(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingAttentionRunner{
+		outputs: map[string][]byte{
+			"tmux display-message -p -t %1 #{pane_title}": []byte("server\n"),
+		},
+	}
+	cmd := &attentionCommand{runner: runner, sidebarPreviewActive: func() bool { return true }}
+
+	if err := cmd.Run([]string{"toggle", "%1"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	want := []attentionCall{
+		{name: "tmux", args: []string{"display-message", "-p", "-t", "%1", "#{pane_title}"}},
+		{name: "tmux", args: []string{"set-option", "-p", "-t", "%1", "@projmux_attention_state", "reply"}},
+		{name: "tmux", args: []string{"select-pane", "-T", "✳ server", "-t", "%1"}},
+		{name: "tmux", args: []string{"display-message", "-t", "%1", "attention: needs reply"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v (manual toggle must stay live during sidebar preview)", runner.calls, want)
+	}
+}


### PR DESCRIPTION
## 완료한 Phase

**Phase 1 — attention churn 억제** (로드맵: Recent-windows record on sidebar commit, 마지막 슬라이스). Phase 0(#518)의 `isSidebarPreviewActive()` 게이트를 attention에 재사용.

## 수정한 user-facing surface

- 프로젝트 사이드바(Alt-1) 라이브 preview 중 세션을 peek해도 attention 마커(✳ reply)가 arm/clear되지 않음 — 부작용 0 완성.
- 사이드바 닫힘(commit/취소) 후엔 marker 부재로 게이트 자동 해제, attention 정상 재개.

## 구현: 게이트 위치 = 핸들러 레벨 (attention.go)

먼저 `attention arm`/`attention clear` CLI가 AI 완료 경로와 공유되는지 확인했다:

- **공유 안 함.** 두 subcommand의 유일한 호출처는 생성 config의 포커스 훅 3개(`pane-focus-out → arm`, `pane-focus-in → clear`, `after-select-pane → clear`, `tmux.go`)뿐 (repo 전체 grep로 확인, docs 포함).
- AI 완료 경로(`ai.go applyAIStatusInternal`, `ai_ingest_*`)는 `tmux set-option`으로 `@projmux_attention_state`를 **직접** 기록하며 arm/clear CLI를 거치지 않음.
- 따라서 `--from-focus-hook` 플래그나 훅 레벨 게이트 없이, `attentionCommand.runArm`/`runClear`에 `isSidebarPreviewActive()` skip이 정확히 포커스 훅 경로만 억제.

수동 `attention toggle`(키바인딩)도 게이트 밖 — preview 중에도 정상.

## ★ AI 완료 attention 무영향 (핵심 뉘앙스)

사이드바 브라우징 중 백그라운드 Codex/Claude가 완료되면 reply 마커가 정상적으로 뜬다. 회귀 테스트 `TestAIStatusWaitingSetsReplyDuringSidebarPreview`가 실제 sidebar marker 파일이 존재하는 상태에서 AI waiting 경로가 `attention_state=reply`를 세팅함을 고정 — 이후 누군가 게이트를 공유 경로에 잘못 배선하면 실패한다.

## 명시적으로 제외한 범위 (비목표)

- Phase 0 recent record 동작 변경 없음 (`recent_window.go` 무변경).
- 라이브 switch/피커/preview 자체 변경 없음.
- 사이드바 밖 일반 attention 동작 무변경.

## 검증

- `go build ./...`, `go test ./internal/...`, `make fmt`, `make fix`, `make test` 전부 통과.
- 단위 테스트 (attention_test.go): preview 중 clear/arm skip(tmux 호출 0회), preview 아닐 때 clear/arm 정상 시퀀스, preview 중 수동 toggle 정상.
- 회귀 테스트 (ai_test.go): 위 AI 경로 테스트.

## 미검증 항목 / e2e 후보

- (수동 e2e) attention 마커 있는 세션을 Alt-1 사이드바로 peek → 마커 유지, Enter/Esc 후 포커스 이동 시 정상 clear — tmux 인터랙티브 필요, lead/사용자 라이브 확인 요망.
- 다중 client 동시 사이드바 시 글롭 게이트의 상호 억제 한계는 Phase 0과 동일하게 수용(로드맵 오픈 질문 기재).

이 로드맵의 마지막 phase — 머지 시 전체 Done 처리는 lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)