### PR TITLE
fix(aisessions): unwrap codex XML context from resume titles (Phase 0)

### DIFF
--- a/internal/integrations/agents/aisessions/sessions.go
+++ b/internal/integrations/agents/aisessions/sessions.go
@@ -823,6 +823,12 @@ func titleFromRecord(fields map[string]any) string {
 	recordType := strings.ToLower(stringJSONField(fields, "type"))
 	if recordType == "event_msg" {
 		if payload, ok := fields["payload"].(map[string]any); ok {
+			// codex: only user_message events carry the human prompt; skip
+			// agent_message and other event types so the title is the actual
+			// prompt. Untyped payloads keep the legacy behavior.
+			if payloadType := stringJSONField(payload, "type"); payloadType != "" && !strings.EqualFold(payloadType, "user_message") {
+				return ""
+			}
 			return cleanTitleCandidate(firstNestedString(payload, "message"))
 		}
 	}
@@ -902,11 +908,88 @@ func cleanTitle(title string) string {
 }
 
 func cleanTitleCandidate(title string) string {
+	title = unwrapContextWrappers(title)
 	title = cleanTitle(title)
 	if title == "" || isNoisyTitleCandidate(title) {
 		return ""
 	}
 	return title
+}
+
+// contextWrapperTags are the XML wrapper tags agents inject around context
+// (instructions, environment info) as synthetic user turns. Codex writes them
+// as the first user records of a rollout, which otherwise leak into resume
+// titles as raw "<environment_context>..." text.
+var contextWrapperTags = map[string]bool{
+	"user_instructions":   true,
+	"environment_context": true,
+}
+
+// unwrapContextWrappers strips agent-injected XML context wrapper blocks from
+// a title candidate. Removal is deliberately conservative so user-typed text
+// is never mangled:
+//   - only LEADING `<tag>...</tag>` blocks are removed, and only when the
+//     matching close tag is present;
+//   - the tag must be a known wrapper (contextWrapperTags) or snake_case
+//     (agent wrappers use snake_case names; HTML tags never do);
+//   - `<` anywhere past the leading block is never touched, so prompts like
+//     "why is a < b wrong?" or "<div>x</div> is broken" stay verbatim.
+//
+// If nothing but wrappers remains, the empty result makes the scan move on to
+// the next user candidate.
+func unwrapContextWrappers(text string) string {
+	for {
+		trimmed := strings.TrimSpace(text)
+		rest, ok := stripLeadingWrapperBlock(trimmed)
+		if !ok {
+			return trimmed
+		}
+		text = rest
+	}
+}
+
+// stripLeadingWrapperBlock removes one leading `<tag>...</tag>` wrapper block
+// and reports whether it did. It only fires when text starts with a wrapper
+// tag (see isContextWrapperTag) and the matching close tag exists.
+func stripLeadingWrapperBlock(text string) (string, bool) {
+	if !strings.HasPrefix(text, "<") {
+		return "", false
+	}
+	end := strings.IndexByte(text, '>')
+	if end < 0 {
+		return "", false
+	}
+	name, _, _ := strings.Cut(text[1:end], " ")
+	if !isContextWrapperTag(name) {
+		return "", false
+	}
+	closing := "</" + name + ">"
+	_, after, ok := strings.Cut(text, closing)
+	if !ok {
+		return "", false
+	}
+	return after, true
+}
+
+// isContextWrapperTag reports whether tag names an agent context wrapper:
+// either a known wrapper tag, or a lowercase snake_case name (must contain
+// "_"), which HTML tags and user-typed inline `<` expressions never match.
+func isContextWrapperTag(tag string) bool {
+	if contextWrapperTags[tag] {
+		return true
+	}
+	if !strings.Contains(tag, "_") {
+		return false
+	}
+	if tag == "" || tag[0] < 'a' || tag[0] > 'z' {
+		return false
+	}
+	for _, r := range tag {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '_' {
+			return false
+		}
+	}
+	return true
 }
 
 func isNoisyTitleCandidate(title string) bool {

--- a/internal/integrations/agents/aisessions/sessions_test.go
+++ b/internal/integrations/agents/aisessions/sessions_test.go
@@ -212,6 +212,97 @@ func TestDiscoverSkipsNoisyTitleCandidates(t *testing.T) {
 	}
 }
 
+func TestDiscoverCodexUnwrapsXMLContextTitles(t *testing.T) {
+	t.Parallel()
+
+	root := copyFixture(t, "titles")
+	sessionsDir := filepath.Join(root, "codex", "sessions")
+	day := filepath.Join(sessionsDir, "2026", "07", "27")
+	setModTime(t, filepath.Join(day, "rollout-xml-context.jsonl"), time.Date(2026, 7, 27, 9, 0, 0, 0, time.UTC))
+	setModTime(t, filepath.Join(day, "rollout-plain-prompt.jsonl"), time.Date(2026, 7, 27, 8, 0, 0, 0, time.UTC))
+	setModTime(t, filepath.Join(day, "rollout-inline-lt.jsonl"), time.Date(2026, 7, 27, 7, 0, 0, 0, time.UTC))
+	setModTime(t, filepath.Join(day, "rollout-html-snippet.jsonl"), time.Date(2026, 7, 27, 6, 0, 0, 0, time.UTC))
+
+	got, err := Discover("/workspace/app", DiscoverOptions{
+		CodexSessionsDir: sessionsDir,
+	})
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("Discover() len = %d, want 4: %#v", len(got), got)
+	}
+	wantTitles := map[string]string{
+		// XML-wrapped context turns are skipped; the first real prompt wins.
+		"019f0000-0000-7000-8000-000000000301": "Fix codex resume titles",
+		// Plain prompt sessions are untouched (regression guard).
+		"019f0000-0000-7000-8000-000000000302": "Refactor the session scanner",
+		// Inline "<" typed by the user stays verbatim.
+		"019f0000-0000-7000-8000-000000000303": "why is a < b wrong in this loop?",
+		// A prompt starting with an HTML tag is never unwrapped.
+		"019f0000-0000-7000-8000-000000000304": `<div class="x">hello</div> is not rendering, why?`,
+	}
+	for _, session := range got {
+		want, ok := wantTitles[session.ResumeID]
+		if !ok {
+			t.Fatalf("unexpected session %q: %#v", session.ResumeID, session)
+		}
+		if session.Title != want {
+			t.Fatalf("Title[%s] = %q, want %q", session.ResumeID, session.Title, want)
+		}
+	}
+}
+
+func TestUnwrapContextWrappers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"user instructions only", "<user_instructions>\n# AGENTS.md\n</user_instructions>", ""},
+		{"environment context only", "<environment_context>\n  <cwd>/workspace/app</cwd>\n</environment_context>", ""},
+		{"wrapper then prompt", "<environment_context><cwd>/x</cwd></environment_context>\n\nFix the picker", "Fix the picker"},
+		{"stacked wrappers then prompt", "<user_instructions>rules</user_instructions>\n<environment_context>ctx</environment_context>\nDo the thing", "Do the thing"},
+		{"unknown snake_case wrapper", "<permissions_context>ro</permissions_context>Run tests", "Run tests"},
+		{"inline less-than untouched", "why is a < b wrong?", "why is a < b wrong?"},
+		{"leading html tag untouched", "<div>hello</div> is broken, why?", "<div>hello</div> is broken, why?"},
+		{"html tag with attrs untouched", `<div class="x">hi</div> not rendering`, `<div class="x">hi</div> not rendering`},
+		{"mid-text wrapper untouched", "explain <environment_context>foo</environment_context> please", "explain <environment_context>foo</environment_context> please"},
+		{"unclosed wrapper untouched", "<user_instructions> no close tag here", "<user_instructions> no close tag here"},
+		{"uppercase tag untouched", "<USER_INSTRUCTIONS>x</USER_INSTRUCTIONS> hi", "<USER_INSTRUCTIONS>x</USER_INSTRUCTIONS> hi"},
+		{"plain prompt untouched", "Refactor the session scanner", "Refactor the session scanner"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := unwrapContextWrappers(tt.in); got != tt.want {
+				t.Fatalf("unwrapContextWrappers(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTitleFromRecordSkipsNonUserEventMessages(t *testing.T) {
+	t.Parallel()
+
+	agentRecord := map[string]any{
+		"type":    "event_msg",
+		"payload": map[string]any{"type": "agent_message", "message": "On it"},
+	}
+	if got := titleFromRecord(agentRecord); got != "" {
+		t.Fatalf("titleFromRecord(agent_message) = %q, want empty", got)
+	}
+	legacyRecord := map[string]any{
+		"type":    "event_msg",
+		"payload": map[string]any{"message": "Legacy untyped message"},
+	}
+	if got := titleFromRecord(legacyRecord); got != "Legacy untyped message" {
+		t.Fatalf("titleFromRecord(untyped) = %q, want legacy message", got)
+	}
+}
+
 func TestScanSessionJSONLStopsAfterCwdMismatch(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integrations/agents/aisessions/testdata/titles/codex/sessions/2026/07/27/rollout-html-snippet.jsonl
+++ b/internal/integrations/agents/aisessions/testdata/titles/codex/sessions/2026/07/27/rollout-html-snippet.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-07-27T06:00:00.000Z","type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000304","cwd":"/workspace/app","git_branch":"feat/html"}}
+{"timestamp":"2026-07-27T06:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"<div class=\"x\">hello</div> is not rendering, why?","kind":"plain"}}

--- a/internal/integrations/agents/aisessions/testdata/titles/codex/sessions/2026/07/27/rollout-inline-lt.jsonl
+++ b/internal/integrations/agents/aisessions/testdata/titles/codex/sessions/2026/07/27/rollout-inline-lt.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-07-27T07:00:00.000Z","type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000303","cwd":"/workspace/app","git_branch":"feat/inline"}}
+{"timestamp":"2026-07-27T07:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"why is a < b wrong in this loop?","kind":"plain"}}

--- a/internal/integrations/agents/aisessions/testdata/titles/codex/sessions/2026/07/27/rollout-plain-prompt.jsonl
+++ b/internal/integrations/agents/aisessions/testdata/titles/codex/sessions/2026/07/27/rollout-plain-prompt.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-07-27T08:00:00.000Z","type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000302","cwd":"/workspace/app","git_branch":"feat/plain"}}
+{"timestamp":"2026-07-27T08:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"Refactor the session scanner","kind":"plain"}}

--- a/internal/integrations/agents/aisessions/testdata/titles/codex/sessions/2026/07/27/rollout-xml-context.jsonl
+++ b/internal/integrations/agents/aisessions/testdata/titles/codex/sessions/2026/07/27/rollout-xml-context.jsonl
@@ -1,0 +1,5 @@
+{"timestamp":"2026-07-27T09:00:00.000Z","type":"session_meta","payload":{"id":"019f0000-0000-7000-8000-000000000301","cwd":"/workspace/app","git_branch":"feat/xml"}}
+{"timestamp":"2026-07-27T09:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<user_instructions>\n\n# AGENTS.md instructions for /workspace/app\n\nAlways run make test.\n\n</user_instructions>"}]}}
+{"timestamp":"2026-07-27T09:00:02.000Z","type":"event_msg","payload":{"type":"user_message","message":"<environment_context>\n  <cwd>/workspace/app</cwd>\n  <shell>zsh</shell>\n</environment_context>","kind":"environment_context"}}
+{"timestamp":"2026-07-27T09:00:03.000Z","type":"event_msg","payload":{"type":"user_message","message":"Fix codex resume titles","kind":"plain"}}
+{"timestamp":"2026-07-27T09:00:03.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Fix codex resume titles"}]}}


### PR DESCRIPTION
# fix(aisessions): Codex resume 제목 XML context unwrap (Phase 0)

## 완료한 Phase

**Phase 0 — title unwrap slice.** Codex rollout JSONL이 첫 user 턴으로 주입하는 XML context(`<user_instructions>`, `<environment_context>`)가 resume picker 제목에 원문 그대로 노출되던 문제를 제목 추출 경로에서만 해결.

## 수정한 user-facing surface

- **Resume picker의 Codex 세션 제목**: 이제 XML 래퍼 대신 실제 첫 사용자 프롬프트가 표시됨.
- 변경 지점은 `internal/integrations/agents/aisessions/sessions.go`의 공유 제목 추출 경로 두 곳:
  - `titleFromRecord`: `event_msg` payload에 `type`이 있으면 `user_message`만 제목 후보로 채택 (`agent_message` 등 제외). `type` 없는 legacy payload는 기존 동작 유지.
  - `cleanTitleCandidate` → 신규 `unwrapContextWrappers`: 선두(leading) `<tag>...</tag>` 래퍼 블록 제거. claude/codex/antigravity가 같은 경로를 지나므로 세 에이전트 모두 일관 동작.
- 래퍼만 있고 남는 텍스트가 없으면 후보를 비우고 다음 user 턴으로 진행. 최종 fallback(`shortResumeID`)은 기존 그대로.

## 명시적으로 제외한 범위

- Resume picker 레이아웃/컬럼 변경 없음.
- Usage/weekly 파싱 작업 없음.
- 앱 레이어(`internal/app/ai.go`) 리팩토링 없음 — `cleanAIResumeTitle` 미변경.
- LLM 요약/토픽 생성 없음.
- 세션 discovery / turn-count 시맨틱스(`isUserTurnRecord` 등) 미변경 — 제목 추출만.

## 과제거(over-removal) 회피 제약 준수 — 인라인 `<` 무손상 보장 방식

제거 조건을 3중으로 제한:

1. **선두 위치만**: 텍스트가 `<`로 시작하는 경우에만 검사. 문장 중간의 `<`(`a < b`, `use <strong>bold</strong>`)는 절대 건드리지 않음.
2. **닫는 태그 필수**: 대응하는 `</tag>`가 없으면 제거하지 않음 (미완성 태그 보존).
3. **태그 이름 화이트리스트 + snake_case 휴리스틱**: `user_instructions`/`environment_context`(화이트리스트) 또는 소문자 snake_case(반드시 `_` 포함) 이름만 래퍼로 인정. HTML 태그(`<div>`, `<span class=...>`)는 `_`가 없어 절대 매치되지 않으므로 `<div>x</div> is broken, why?` 같은 프롬프트도 원문 그대로 표시.

테스트로 고정: 인라인 `<` 프롬프트, 선두 HTML 태그 프롬프트, 중간 위치 래퍼, 닫는 태그 없는 래퍼, 대문자 태그가 모두 "무변경" 골든으로 검증됨.

## 검증 명령 및 결과

워크트리(`.wt/fix/codex-resume-title-xml-unwrap`) 루트에서 실행:

| 명령 | 결과 |
| --- | --- |
| `go build ./...` | PASS |
| `go test ./internal/integrations/agents/aisessions/...` | PASS (신규: `TestDiscoverCodexUnwrapsXMLContextTitles`, `TestUnwrapContextWrappers` 12 케이스, `TestTitleFromRecordSkipsNonUserEventMessages`; 기존 claude/antigravity/codex 제목 테스트 전부 그린) |
| `make fmt` | PASS (diff 변화 없음) |
| `make fix` | PASS (deadcode clean) |
| `make test` | `internal/app` 1개 패키지만 FAIL — **pre-existing 환경 이슈**: 로케일이 한국어로 감지되어 영어 문자열 기대 테스트가 깨짐. pristine main에서도 동일하게 FAIL 재현 확인(본 변경과 무관). 그 외 전 패키지 ok |

신규 fixture: `testdata/titles/codex/sessions/2026/07/27/` — XML context rollout, plain prompt, inline `<`, leading HTML tag 4종.

## 미검증 항목 및 후속

- 실기기 tmux resume picker 표시 확인(실제 codex rollout 대상)은 e2e 후보로 남김.
- 후속 아이디어: codex가 새 snake_case 래퍼 태그를 추가해도 휴리스틱이 커버하지만, 화이트리스트 확장이 필요해지면 `contextWrapperTags`에 한 줄 추가로 대응 가능.
- `internal/app` 로케일 의존 테스트의 환경 독립화는 별도 이슈 후보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
