### PR TITLE
test(i18n): isolate real global config in locale TestMain

### DIFF
--- a/internal/app/locale_testmain_test.go
+++ b/internal/app/locale_testmain_test.go
@@ -18,6 +18,11 @@ import (
 // higher rungs stay cleared. This makes the suite locale-deterministic on any
 // host while leaving each test free to opt into another locale explicitly.
 func TestMain(m *testing.M) {
+	// Isolate from the developer machine's real global projmux config
+	// (e.g. locale=ko-KR), which outranks the LANG rung below.
+	if dir, err := os.MkdirTemp("", "projmux-test-xdg"); err == nil {
+		os.Setenv("XDG_CONFIG_HOME", dir)
+	}
 	os.Unsetenv("PROJMUX_LOCALE")
 	os.Unsetenv("LC_ALL")
 	os.Unsetenv("LC_MESSAGES")

--- a/internal/ui/picker/locale_testmain_test.go
+++ b/internal/ui/picker/locale_testmain_test.go
@@ -13,6 +13,11 @@ import (
 // (LANG=en_US.UTF-8) and clearing the higher rungs keeps the suite
 // deterministic while letting any test opt into another locale via t.Setenv.
 func TestMain(m *testing.M) {
+	// Isolate from the developer machine's real global projmux config
+	// (e.g. locale=ko-KR), which outranks the LANG rung below.
+	if dir, err := os.MkdirTemp("", "projmux-test-xdg"); err == nil {
+		os.Setenv("XDG_CONFIG_HOME", dir)
+	}
 	os.Unsetenv("PROJMUX_LOCALE")
 	os.Unsetenv("LC_ALL")
 	os.Unsetenv("LC_MESSAGES")


### PR DESCRIPTION
## 문제
dev box 에서 `go test ./...` 가 i18n 테스트에서 실패(영어 기대 → 한국어 렌더). 원인: projmux locale 우선순위는 **PROJMUX_LOCALE > 글로벌 config > LC_ALL > LANG** 인데, 기존 `locale_testmain_test.go` 는 `LANG=en_US` 만 고정. 사용자 `~/.config/projmux/config.toml` 의 `locale = "ko-KR"` 이 LANG 보다 상위라 새어들어 CI(en-US)와 어긋났다. 해당 작업(툴체인 등)과 무관한 환경 요인.

## 변경 (test-only, +10줄)
- `internal/app` · `internal/ui/picker` 의 locale TestMain 에서 **XDG_CONFIG_HOME 를 빈 temp 로 격리** → 실 글로벌 config 미독. 글로벌 config 경로는 XDG_CONFIG_HOME 우선(`hooks/global_config.go`).
- ko-KR 의도 테스트의 `t.Setenv("LANG", "ko_KR")` override 는 그대로 유효(글로벌 config 부재로 LANG 이 유효 기본).

## 검증
- 기존 실패 5건(hookmaker/settings/switch) 통과.
- `go test ./...` 전체 green(dev box, 한국어 config 유지 상태).
- 프로덕션 코드 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)