### PR TITLE
ci(release-please): bump action v4 -> v5 for node24 runtime

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json


### PR DESCRIPTION
## Node 버전 문제 해소
`googleapis/release-please-action@v4` 는 action 런타임이 **node20** 이라 GitHub 의 node20 deprecation 경고가 뜬다(runner 는 node24 기본, node20 제거 시 하드 실패 예정). v5.0.0 의 **유일한 breaking change 가 node24 업그레이드**(입력 `token`/`config-file`/`manifest-file` 동일) → `@v4`→`@v5` 단일 변경으로 해소. release-please 17.3.0→17.6.0 동반.

## ⚠️ 별개 이슈 (이 PR 범위 아님)
현재 Release Please 워크플로 **실패의 실제 원인은 Node 가 아니라** `##[error]release-please failed: **Bad credentials**` — `secrets.RELEASE_PLEASE_TOKEN` 이 만료/무효다. 이건 코드가 아니라 **레포 시크릿 로테이션**(관리자)이 필요하다. 대안: 워크플로 token 을 `secrets.GITHUB_TOKEN` 으로 전환(단, release PR 이 CI 를 자동 트리거하지 않는 트레이드오프).

이 PR 은 Node deprecation 만 targeted 로 처리한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)