### PR TITLE
feat(tmux): add right-click pane context menu with AI Resume Picker

### DIFF
--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -1422,6 +1422,7 @@ func tmuxStandaloneConfigWithKeymapThemeAIBadgeStyleAndDesktopNotifyMode(binaryP
 	lines = append(lines, tmuxRetiredKeyUnbindLines()...)
 	lines = append(lines, tmuxBindLines(binaryPath, standaloneKeyBindings)...)
 	lines = append(lines, tmuxStatusbarKeyBindings(binaryPath)...)
+	lines = append(lines, tmuxPaneContextMenuBindings(binaryPath)...)
 	return strings.Join(lines, "\n") + "\n"
 }
 
@@ -1600,6 +1601,50 @@ func tmuxStatusbarKeyBindings(binaryPath string) []string {
 		"bind-key -T projmux-status k run-shell " + tmuxConfigQuote(bin+" statusbar click kube"),
 		"bind-key -T projmux-status p run-shell " + tmuxConfigQuote(bin+" statusbar click pwd"),
 		"bind-key -T projmux-status s run-shell " + tmuxConfigQuote(bin+" statusbar click session"),
+	}
+}
+
+// tmuxPaneContextMenuBindings emits the right-click (MouseDown3Pane) pane
+// context menu. tmux ships a stock MouseDown3Pane menu, but overriding a root
+// mouse binding can leave a stale handler on a live server across reloads, so
+// we follow the statusbar pattern: unbind first, then re-install
+// deterministically.
+//
+// The menu reconstructs the useful subset of tmux 3.4's stock pane menu
+// (split, swap, kill, respawn, mark, zoom — with tmux's stock key shortcuts
+// and dim conditions) and adds a projmux `AI Resume Picker` entry at the top
+// that opens the resume picker via `run-shell <bin> ai picker --resume right`.
+//
+// Like the stock binding, the menu only opens when the pane's program is not
+// consuming the mouse (`mouse_any_flag`) and the pane is not in a
+// non-copy/view mode; otherwise the click is forwarded to the application via
+// `send-keys -M` so mouse-aware programs (vim, htop, ...) keep their own
+// right-click behavior. Block syntax (`{ ... }`) keeps the nested `run-shell`
+// quoting flat; blocks require tmux 3.0+ and doctor already enforces 3.4+.
+func tmuxPaneContextMenuBindings(binaryPath string) []string {
+	bin := tmuxShellQuote(binaryPath)
+	// Guard + title + dim conditions mirror tmux 3.4 key-bindings.c: swap
+	// entries are dimmed (`-` prefix) in single-pane windows, Mark/Unmark and
+	// Zoom/Unzoom toggle with pane/window state.
+	menu := "bind-key -n MouseDown3Pane if-shell -F -t = " +
+		tmuxConfigQuote("#{||:#{mouse_any_flag},#{&&:#{pane_in_mode},#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}}}") + " " +
+		"{ select-pane -t = ; send-keys -M } " +
+		"{ display-menu -T " + tmuxConfigQuote("#[align=centre]#{pane_index} (#{pane_id})") + " -t = -x M -y M " +
+		tmuxConfigQuote("AI Resume Picker") + " a { run-shell " + tmuxConfigQuote(bin+" ai picker --resume right") + " } " +
+		"'' " +
+		tmuxConfigQuote("Horizontal Split") + " h { split-window -h } " +
+		tmuxConfigQuote("Vertical Split") + " v { split-window -v } " +
+		"'' " +
+		tmuxConfigQuote("#{?#{>:#{window_panes},1},,-}Swap Up") + " u { swap-pane -U } " +
+		tmuxConfigQuote("#{?#{>:#{window_panes},1},,-}Swap Down") + " d { swap-pane -D } " +
+		"'' " +
+		tmuxConfigQuote("Kill") + " X { kill-pane } " +
+		tmuxConfigQuote("Respawn") + " R { respawn-pane -k } " +
+		tmuxConfigQuote("#{?pane_marked,Unmark,Mark}") + " m { select-pane -m } " +
+		tmuxConfigQuote("#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}") + " z { resize-pane -Z } }"
+	return []string{
+		"unbind-key -q -n MouseDown3Pane",
+		menu,
 	}
 }
 

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -1785,6 +1785,107 @@ func TestTmuxPrintConfigBindsHardcodedStatusbarUsageRefresh(t *testing.T) {
 	}
 }
 
+func TestTmuxPrintConfigBindsPaneContextMenu(t *testing.T) {
+	t.Parallel()
+
+	cmd := &tmuxCommand{executable: func() (string, error) { return "/tmp/proj mux/bin/projmux", nil }}
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"print-config"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		// Stock-style guard: forward the click to mouse-aware applications and
+		// non-copy pane modes instead of opening the menu.
+		"bind-key -n MouseDown3Pane if-shell -F -t = \"#{||:#{mouse_any_flag},#{&&:#{pane_in_mode},#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}}}\"",
+		"{ select-pane -t = ; send-keys -M }",
+		// Menu chrome mirrors tmux 3.4's stock MouseDown3Pane menu.
+		"display-menu -T \"#[align=centre]#{pane_index} (#{pane_id})\" -t = -x M -y M",
+		// projmux entry: opens the AI resume picker via the CLI entrypoint.
+		`"AI Resume Picker" a { run-shell "'/tmp/proj mux/bin/projmux' ai picker --resume right" }`,
+		// Stock split items (stock names + key shortcuts).
+		"\"Horizontal Split\" h { split-window -h }",
+		"\"Vertical Split\" v { split-window -v }",
+		// A few more stock items with their dim/toggle format conditions.
+		"\"#{?#{>:#{window_panes},1},,-}Swap Up\" u { swap-pane -U }",
+		"\"#{?#{>:#{window_panes},1},,-}Swap Down\" d { swap-pane -D }",
+		"\"Kill\" X { kill-pane }",
+		"\"Respawn\" R { respawn-pane -k }",
+		"\"#{?pane_marked,Unmark,Mark}\" m { select-pane -m }",
+		"\"#{?#{>:#{window_panes},1},,-}#{?window_zoomed_flag,Unzoom,Zoom}\" z { resize-pane -Z }",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("print-config output = %q, want substring %q", output, want)
+		}
+	}
+}
+
+func TestTmuxPrintConfigUnbindsPaneContextMenuBeforeBinding(t *testing.T) {
+	t.Parallel()
+
+	// Same unbind-then-reinstall contract as the statusbar MouseDown1Status
+	// binding: the quiet unbind must precede the bind so re-sourcing the config
+	// on a live server deterministically replaces any stale handler.
+	cmd := &tmuxCommand{executable: func() (string, error) { return "/tmp/projmux", nil }}
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"print-config"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	output := stdout.String()
+	unbindIdx := strings.Index(output, "unbind-key -q -n MouseDown3Pane")
+	bindIdx := strings.Index(output, "bind-key -n MouseDown3Pane")
+	if unbindIdx == -1 {
+		t.Fatalf("print-config output = %q, want substring %q", output, "unbind-key -q -n MouseDown3Pane")
+	}
+	if bindIdx == -1 {
+		t.Fatalf("print-config output = %q, want substring %q", output, "bind-key -n MouseDown3Pane")
+	}
+	if unbindIdx > bindIdx {
+		t.Fatalf("unbind-key -q -n MouseDown3Pane (index %d) must precede bind-key -n MouseDown3Pane (index %d)", unbindIdx, bindIdx)
+	}
+
+	// The statusbar binding follows the identical pattern; pin both so the
+	// surfaces cannot drift apart silently.
+	statusUnbindIdx := strings.Index(output, "unbind-key -q -n MouseDown1Status")
+	statusBindIdx := strings.Index(output, "bind-key -n MouseDown1Status")
+	if statusUnbindIdx == -1 || statusBindIdx == -1 || statusUnbindIdx > statusBindIdx {
+		t.Fatalf("statusbar unbind/bind ordering broken: unbind index %d, bind index %d", statusUnbindIdx, statusBindIdx)
+	}
+}
+
+func TestTmuxPrintAppConfigBindsPaneContextMenu(t *testing.T) {
+	t.Parallel()
+
+	// The app config embeds the standalone config lines, so `projmux shell`
+	// sessions must carry the same pane context menu.
+	cmd := &tmuxCommand{
+		executable: func() (string, error) { return "/tmp/proj mux/bin/projmux", nil },
+		homeDir:    func() (string, error) { return t.TempDir(), nil },
+		lookupEnv:  func(string) string { return "" },
+		readFile:   os.ReadFile,
+	}
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"print-app-config"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"unbind-key -q -n MouseDown3Pane",
+		"bind-key -n MouseDown3Pane if-shell -F -t = ",
+		"display-menu -T \"#[align=centre]#{pane_index} (#{pane_id})\" -t = -x M -y M",
+		`"AI Resume Picker" a { run-shell "'/tmp/proj mux/bin/projmux' ai picker --resume right" }`,
+		"\"Horizontal Split\" h { split-window -h }",
+		"\"Vertical Split\" v { split-window -v }",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("print-app-config output = %q, want substring %q", output, want)
+		}
+	}
+}
+
 func TestTmuxRebalancePanesSelectsMultiPaneWindows(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# feat(tmux): right-click pane context menu with AI Resume Picker (Phase 0)

## Phase

Phase 0 of the tmux pane context menu roadmap — completed.

## User-facing surface changed

Right-click (MouseDown3Pane) pane context menu in projmux-generated tmux configs, in both surfaces:

- Standalone config (`projmux tmux install` snippet / `print-config`)
- App config (`projmux shell` / `print-app-config`, which embeds the standalone lines)

The menu reconstructs the useful subset of tmux 3.4's stock pane right-click menu — Horizontal Split (`h`), Vertical Split (`v`), Swap Up (`u`), Swap Down (`d`), Kill (`X`), Respawn (`R`), Mark/Unmark (`m`), Zoom/Unzoom (`z`), with tmux's stock key shortcuts and dim/toggle format conditions — and adds an **AI Resume Picker** entry (`a`) at the top that invokes `run-shell '<bin>' ai picker --resume right`.

Implementation follows the existing `MouseDown1Status` statusbar pattern exactly: `unbind-key -q -n MouseDown3Pane` first, then a deterministic `bind-key -n MouseDown3Pane ...` re-install, so re-sourcing the config on a live server replaces any stale handler. The stock `mouse_any_flag`/`pane_in_mode` guard is preserved, so mouse-aware applications (vim, htop, ...) still receive right-clicks via `send-keys -M`.

Design decision (recorded once for the roadmap): the AI Resume Picker is a **single flat item hardcoded to `right`** — no direction submenu. tmux `display-menu` has no native submenus (a "submenu" is a nested `display-menu` command that costs a second interaction and drops the original mouse-position context), `right` matches projmux's default split direction elsewhere, and Phase 1 will restructure the projmux section of the menu anyway when the other entrypoints land.

## Explicitly out of scope (Phase 1)

- Selective picker menu item
- Agent split menu items (claude/codex/etc.)
- Shell split menu item
- Settings exposure for menu customization

## Unchanged guarantees

- Resume picker UI/behavior: unchanged (no files under the `ai picker` command paths touched).
- CLI signature: `projmux ai picker [--inside] [--shell] [--resume] [right|down]` unchanged; the menu only consumes the existing entrypoint.
- No tmux version gate added (doctor already enforces tmux 3.4+; `display-menu` + block syntax need 3.0+).
- MouseDown3Status and other right-click surfaces untouched. psmux backend untouched.

## Verification

- `make fmt` — clean
- `make fix` — clean (deadcode allowlist clean)
- `make test` — all packages pass, including new tests in `internal/app`:
  - `TestTmuxPrintConfigBindsPaneContextMenu`
  - `TestTmuxPrintConfigUnbindsPaneContextMenuBeforeBinding`
  - `TestTmuxPrintAppConfigBindsPaneContextMenu`
- Real-tmux parse check: generated config sourced into a scratch `tmux -L pmxtest` server (tmux 3.4) with exit 0; `list-keys -T root` shows the binding installed and structurally equivalent to the stock `M-MouseDown3Pane` menu.

## Unverified (e2e candidate)

- Manual real-tmux interaction: right-click on a pane -> menu renders -> selecting "AI Resume Picker" opens the resume picker split. Parse/install is verified; the interactive click path is not (marked as e2e candidate).

## Follow-up

Phase 1: additional projmux entrypoint menu items (selective picker, agent split, shell split) and any menu layout/customization work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
