### PR TITLE
fix(tmux): open pane menu resume picker via popup-toggle entrypoint

### DIFF
--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -1613,7 +1613,16 @@ func tmuxStatusbarKeyBindings(binaryPath string) []string {
 // The menu reconstructs the useful subset of tmux 3.4's stock pane menu
 // (split, swap, kill, respawn, mark, zoom — with tmux's stock key shortcuts
 // and dim conditions) and adds a projmux `AI Resume Picker` entry at the top
-// that opens the resume picker via `run-shell <bin> ai picker --resume right`.
+// that opens the resume picker through the same `tmux popup-toggle
+// ai-split-resume-right` entrypoint as the C-r keybinding. Calling `ai picker`
+// directly does not work here: tmux `run-shell` executes without the TMUX env
+// of a pane shell, so `resolveContextDir` cannot resolve a cwd and the picker
+// exits 1 ("cwd is empty"). `popup-toggle` resolves the origin pane and
+// context dir server-side instead. The item first runs `select-pane -t =` so
+// the clicked pane — not whichever pane happened to be active — becomes the
+// popup's origin; tmux keeps the opening click's mouse target alive for item
+// commands, so `-t =` resolves at selection time for both keyboard and mouse
+// selection (verified on tmux 3.4).
 //
 // Like the stock binding, the menu only opens when the pane's program is not
 // consuming the mouse (`mouse_any_flag`) and the pane is not in a
@@ -1622,7 +1631,12 @@ func tmuxStatusbarKeyBindings(binaryPath string) []string {
 // right-click behavior. Block syntax (`{ ... }`) keeps the nested `run-shell`
 // quoting flat; blocks require tmux 3.0+ and doctor already enforces 3.4+.
 func tmuxPaneContextMenuBindings(binaryPath string) []string {
-	bin := tmuxShellQuote(binaryPath)
+	// Reuse the keybinding catalog's renderer so the menu action stays
+	// byte-identical to the C-r binding's proven run-shell line.
+	resumeAction := renderTmuxBindingBody(binaryPath, keyBindingAction{
+		TmuxKind: tmuxBindingPopupToggle,
+		TmuxBody: "ai-split-resume-right",
+	})
 	// Guard + title + dim conditions mirror tmux 3.4 key-bindings.c: swap
 	// entries are dimmed (`-` prefix) in single-pane windows, Mark/Unmark and
 	// Zoom/Unzoom toggle with pane/window state.
@@ -1630,7 +1644,7 @@ func tmuxPaneContextMenuBindings(binaryPath string) []string {
 		tmuxConfigQuote("#{||:#{mouse_any_flag},#{&&:#{pane_in_mode},#{?#{m/r:(copy|view)-mode,#{pane_mode}},0,1}}}") + " " +
 		"{ select-pane -t = ; send-keys -M } " +
 		"{ display-menu -T " + tmuxConfigQuote("#[align=centre]#{pane_index} (#{pane_id})") + " -t = -x M -y M " +
-		tmuxConfigQuote("AI Resume Picker") + " a { run-shell " + tmuxConfigQuote(bin+" ai picker --resume right") + " } " +
+		tmuxConfigQuote("AI Resume Picker") + " a { select-pane -t = ; " + resumeAction + " } " +
 		"'' " +
 		tmuxConfigQuote("Horizontal Split") + " h { split-window -h } " +
 		tmuxConfigQuote("Vertical Split") + " v { split-window -v } " +

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -1802,8 +1802,11 @@ func TestTmuxPrintConfigBindsPaneContextMenu(t *testing.T) {
 		"{ select-pane -t = ; send-keys -M }",
 		// Menu chrome mirrors tmux 3.4's stock MouseDown3Pane menu.
 		"display-menu -T \"#[align=centre]#{pane_index} (#{pane_id})\" -t = -x M -y M",
-		// projmux entry: opens the AI resume picker via the CLI entrypoint.
-		`"AI Resume Picker" a { run-shell "'/tmp/proj mux/bin/projmux' ai picker --resume right" }`,
+		// projmux entry: selects the clicked pane, then opens the AI resume
+		// picker via the same popup-toggle entrypoint as the C-r keybinding
+		// (`ai picker` directly would fail: run-shell has no TMUX env, so the
+		// picker cannot resolve its context cwd).
+		`"AI Resume Picker" a { select-pane -t = ; run-shell "'/tmp/proj mux/bin/projmux' tmux popup-toggle --client #{client_tty} ai-split-resume-right" }`,
 		// Stock split items (stock names + key shortcuts).
 		"\"Horizontal Split\" h { split-window -h }",
 		"\"Vertical Split\" v { split-window -v }",
@@ -1876,7 +1879,7 @@ func TestTmuxPrintAppConfigBindsPaneContextMenu(t *testing.T) {
 		"unbind-key -q -n MouseDown3Pane",
 		"bind-key -n MouseDown3Pane if-shell -F -t = ",
 		"display-menu -T \"#[align=centre]#{pane_index} (#{pane_id})\" -t = -x M -y M",
-		`"AI Resume Picker" a { run-shell "'/tmp/proj mux/bin/projmux' ai picker --resume right" }`,
+		`"AI Resume Picker" a { select-pane -t = ; run-shell "'/tmp/proj mux/bin/projmux' tmux popup-toggle --client #{client_tty} ai-split-resume-right" }`,
 		"\"Horizontal Split\" h { split-window -h }",
 		"\"Vertical Split\" v { split-window -v }",
 	} {


### PR DESCRIPTION
# fix(tmux): open pane menu resume picker via popup-toggle entrypoint

## Symptom

Selecting **AI Resume Picker** in the right-click pane context menu (added in #543) does not open the picker. Instead tmux drops the pane into view-mode showing:

```
"'<bin>' ai picker --resume right" returned 1
```

## Root cause

The menu item ran `run-shell "'<bin>' ai picker --resume right"`. `ai picker` requires pane-shell context: `resolveContextDir()` (internal/app/ai.go:1701) resolves the cwd from the `TMUX` env var plus `#{pane_current_path}`. tmux `run-shell` executes the command *without* a pane shell's `TMUX` env, so cwd resolution fails and the picker exits 1 with `discover ai sessions: cwd is empty` — which tmux renders as the run-shell error view.

## Fix

Route the menu item through the same entrypoint the `C-r` keybinding already uses in production:

```
{ select-pane -t = ; run-shell "'<bin>' tmux popup-toggle --client #{client_tty} ai-split-resume-right" }
```

`popup-toggle` resolves the origin pane and context dir server-side (sets `TMUX_SPLIT_TARGET_PANE` / `TMUX_SPLIT_CONTEXT_DIR`) and opens `ai picker --resume --inside right` in a popup, so it needs no pane-shell env.

The run-shell string is rendered via the keybinding catalog's `renderTmuxBindingBody` (same helper that renders the `C-r` binding), so the menu action stays byte-identical to the keybinding's proven line and the two surfaces cannot drift apart.

## Pane targeting

`popup-toggle` resolves the origin pane from the client's **active** pane, but a right-click can land on a non-active pane. The item therefore runs `select-pane -t =` before `run-shell`, making the clicked pane the popup's origin.

Verified on a scratch tmux 3.4 server (pty client + synthetic SGR mouse events) that this is reliable: tmux keeps the opening click's mouse target alive for menu item commands, so `-t =` resolves at item-selection time for **both** keyboard (`a`) and mouse-click selection, and `#{client_tty}` expands correctly inside the item's `run-shell`.

## Tests

- `TestTmuxPrintConfigBindsPaneContextMenu` and `TestTmuxPrintAppConfigBindsPaneContextMenu` now pin the corrected action line (`select-pane -t = ; run-shell "... tmux popup-toggle --client #{client_tty} ai-split-resume-right"`); the old `ai picker --resume right` assertion is removed.

## Verification

- `make fmt`, `make fix`, `make test` — all pass.
- Built the binary, generated `tmux print-config`, sourced it into a scratch `tmux -L pmxfixtest` (tmux 3.4) server: `source-file` exit 0, `list-keys -T root` shows the corrected `MouseDown3Pane` binding, and the menu item's run-shell string is byte-identical to the generated `C-r` binding line. Scratch server killed afterwards; the live `-L projmux` server was not touched.
- Empirical menu-selection behavior (`select-pane -t =` at item-selection time, `#{client_tty}` expansion) verified on the scratch server as described above.

## Remaining unverified

- A real interactive right-click on a live projmux session (actual popup opening and picker UX) still needs a quick manual check after install.
