### PR TITLE
fix(theme): light-background contrast corrections for statusbar/notify/trust surfaces (bright preset phase 2)

### DIFF
--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"unicode/utf8"
 
@@ -47,6 +48,8 @@ type attentionCommand struct {
 	runner               tmuxRunner
 	producer             attentionNotifyProducer
 	sidebarPreviewActive func() bool
+	homeDir              func() (string, error)
+	lookupEnv            func(string) string
 }
 
 func newAttentionCommand() *attentionCommand {
@@ -54,6 +57,8 @@ func newAttentionCommand() *attentionCommand {
 		runner:               inttmux.ExecRunner{},
 		producer:             newAttentionNotifyProducer(),
 		sidebarPreviewActive: isSidebarPreviewActive,
+		homeDir:              os.UserHomeDir,
+		lookupEnv:            os.Getenv,
 	}
 }
 
@@ -242,6 +247,9 @@ func (c *attentionCommand) runArm(args []string, stderr io.Writer) error {
 }
 
 func (c *attentionCommand) runWindow(args []string, stdout, stderr io.Writer) error {
+	// Bright Phase 2 (B1): the window badge glyph renders with the resolved
+	// effective theme instead of the zero-value fallback role map.
+	defer applyNativeUIThemeFromConfig(c.homeDir, c.lookupEnv, "")()
 	windowID, style, err := parseAttentionWindowArgs(args, stderr)
 	if err != nil {
 		return err
@@ -263,7 +271,7 @@ func (c *attentionCommand) runWindow(args []string, stdout, stderr io.Writer) er
 			_, err := fmt.Fprint(stdout, " ")
 			return err
 		}
-		_, err := fmt.Fprint(stdout, "#[fg="+tmuxAIBadgeKindFg(badgeKind, theme.RenderRolesFromEffective(theme.EffectiveTheme{}))+"]"+glyph)
+		_, err := fmt.Fprint(stdout, "#[fg="+tmuxAIBadgeKindFg(badgeKind, statusSegmentRoles)+"]"+glyph)
 		return err
 	}
 	_, err = fmt.Fprint(stdout, " ")

--- a/internal/app/bright_phase2_identity_test.go
+++ b/internal/app/bright_phase2_identity_test.go
@@ -1,0 +1,186 @@
+package app
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/core/notify"
+	"github.com/crevissepartners/projmux/internal/theme"
+)
+
+// bright_phase2_identity_test.go pins the generated tmux config byte-identity
+// for the fallback theme and every built-in (dark) preset, and covers the B1
+// theme-threading corrections (bright preset roadmap Phase 2).
+
+// appLightThemeConfig mirrors the light test palette used by the theme package
+// tests. A real light preset is Phase 1 scope and intentionally NOT added to
+// builtinPresets here.
+func appLightThemeConfig() theme.ThemeConfig {
+	return theme.ThemeConfig{
+		Background:       "#f5f5f0",
+		Surface:          "#f2f2ee",
+		StatusBackground: "#e8e8e2",
+		SurfaceActive:    "#d8d8d0",
+		ChromeForeground: "#2a2e32",
+		TextPrimary:      "#1f2428",
+		Foreground:       "#1f2428",
+		Muted:            "#6a7076",
+		Accent:           "#0f7b6c",
+		Critical:         "#c62828",
+		Warning:          "#9a6700",
+		Progress:         "#0757ba",
+		Success:          "#1a7f37",
+		ActionRequired:   "#b35900",
+		PaneActiveBg:     "#e2e2da",
+		Focus:            "#0757ba",
+	}
+}
+
+// brightPhase2ConfigGoldens are SHA-256 digests of the generated tmux configs
+// captured at main fa3da53 (pre-Phase 2), for a fixed binary path, shell, and
+// symbol decorations. The Phase 2 theme threading must not change a single
+// byte for the fallback theme or any current dark preset.
+var brightPhase2ConfigGoldens = map[string]map[string]string{
+	"fallback": {
+		"standalone": "c79647f859befce69975342e2bf3e24468442bdfbbfe9dec07e756973b3e655c",
+		"app":        "5ced3454170716d2f3353d870ea87a848e1c61434feec0c80659ae22c068cbc4",
+	},
+	"projmux": {
+		"standalone": "30ab75b5a69a9cbcba823dd64fee407b347501a52c7de911a092fc59821b5784",
+		"app":        "cfaf26535d15ee278ac2bc6d9f68675ce1b2643514bde23ec856a92ec89963f5",
+	},
+	"blue-hour": {
+		"standalone": "842f69d1c60226b4c45c05aca6e36e25ed1a3d83648e479cee5a6c75672019be",
+		"app":        "1fca935b31b6b14d811ada5276ed3717adbe7360091d7dc60bbc1f1312f3463f",
+	},
+	"carbon-violet": {
+		"standalone": "1e2147056360863b8fae4b15224d48d9fb1d860813363553100faf24c6eb9476",
+		"app":        "2fb60b717a4ccb14bb92b30ee147addbf99c95505731b82622c3e9b5bce0ade9",
+	},
+	"ember": {
+		"standalone": "d4e4253ff880c1732066f91e75eb08179defcf5611c9cce517bed1e8dc1e360a",
+		"app":        "810c695149ba1e562e16613eb255e9133a3b044078aef2239239cc4ee12fc7f5",
+	},
+	"forest": {
+		"standalone": "2ecd073e256af6d4c76f8b4484cdba7e859dd603202eb8e16772dedcc07da804",
+		"app":        "b7de38a717f2e3d573c430c81b8028e94870ae5464fff1f55db434adaea38172",
+	},
+	"rose": {
+		"standalone": "e92826b2ca2f968e6ac2bcd60a817ce976f84f17685bf5e7e54833ff9d76a4f2",
+		"app":        "c391159186d72e0aa49004fdf6c7042f8f2de9c107c35ea0da955636a59d40ca",
+	},
+	"high-contrast": {
+		"standalone": "40a68007c5e12a9f237ff3fd37cadd131f1e29b6b9b9a11c2fc360fe50e12248",
+		"app":        "1dbb1e5477036e1ef9f9c6641a434999f32ee61819477dcf9fd02997591fb7f6",
+	},
+}
+
+// TestBrightPhase2GeneratedConfigByteIdentity regenerates the standalone and
+// app tmux configs for the fallback theme and every built-in preset and
+// compares them against the pre-Phase 2 golden digests.
+func TestBrightPhase2GeneratedConfigByteIdentity(t *testing.T) {
+	t.Parallel()
+
+	decorations := statusbarDecorationSet{
+		Cwd:    config.StatusbarDecorationSymbol,
+		Git:    config.StatusbarDecorationSymbol,
+		Notify: config.StatusbarDecorationSymbol,
+	}
+	for label, goldens := range brightPhase2ConfigGoldens {
+		cfg := theme.ThemeConfig{}
+		if label != "fallback" {
+			cfg.Preset = label
+		}
+		source := newRenderThemeSource(theme.ResolveTheme(cfg))
+		outputs := map[string]string{
+			"standalone": source.tmuxStandaloneConfig("/usr/bin/projmux", decorations, defaultKeyBindingCatalog(), false),
+			"app":        source.tmuxAppConfig("/usr/bin/projmux", "/bin/zsh", decorations, defaultKeyBindingCatalog(), false),
+		}
+		for kind, body := range outputs {
+			sum := sha256.Sum256([]byte(body))
+			if got := hex.EncodeToString(sum[:]); got != goldens[kind] {
+				t.Fatalf("theme %s %s config drifted from the pre-Phase2 golden: sha256 %s, want %s", label, kind, got, goldens[kind])
+			}
+		}
+	}
+}
+
+// TestBrightPhase2StatusSegmentThemeInjection proves the B1 threading: applying
+// a light effective theme repaints the statusbar segment roles (dark-contrast
+// derivations), and restoring the fallback returns the historical literals.
+//
+// NOTE: intentionally NOT t.Parallel() — it mutates the shared status segment
+// role vars under nativeUIThemeMu (see theme_render_native_test.go).
+func TestBrightPhase2StatusSegmentThemeInjection(t *testing.T) {
+	light := theme.ResolveTheme(appLightThemeConfig())
+
+	withNativeUITheme(light, func() {
+		// decoration.cwd is luma-gated: light status background derives hex.
+		if statusSegmentRoles.DecorationCwd == theme.TmuxDecorationCwdFg {
+			t.Fatalf("decoration.cwd still %q under a light theme, want darkened hex", statusSegmentRoles.DecorationCwd)
+		}
+		if !strings.HasPrefix(statusSegmentRoles.DecorationCwd, "#") {
+			t.Fatalf("decoration.cwd = %q, want #rrggbb derivation", statusSegmentRoles.DecorationCwd)
+		}
+		format := statusbarCwdDecoratorFormat(statusSegmentRoles)
+		if strings.Contains(format, theme.TmuxDecorationCwdFg) {
+			t.Fatalf("cwd decorator format still carries %s under a light theme: %q", theme.TmuxDecorationCwdFg, format)
+		}
+		// The notify HUD severity tokens follow the explicit state tokens.
+		if !strings.Contains(notifySeverityWarn, "#9a6700") {
+			t.Fatalf("notify severity warn = %q, want explicit light warning #9a6700", notifySeverityWarn)
+		}
+		if strings.Contains(notifyLineOpen, theme.TmuxStateProgressFg) {
+			t.Fatalf("notify line open still carries fallback progress literal: %q", notifyLineOpen)
+		}
+		// The attention window badge fg follows the explicit AI tokens.
+		if got := tmuxAIBadgeKindFg(aiBadgeKindApprovalRequired, statusSegmentRoles); got != "#b35900" {
+			t.Fatalf("attention badge fg = %q, want explicit action_required #b35900", got)
+		}
+		// statusbar popup severity text adapts the explicit state roles.
+		if !strings.Contains(amberANSI("85%"), "\x1b[38;2;154;103;0m") {
+			t.Fatalf("amberANSI = %q, want truecolor of #9a6700", amberANSI("85%"))
+		}
+		// hook-trust popup muted text follows the muted token.
+		if hookTrustMuted("x") == theme.ANSITextMutedStart+"x"+theme.ANSIReset {
+			t.Fatalf("hookTrustMuted still renders the fallback muted literal under a light theme")
+		}
+	})
+
+	// Everything restored to the historical literals after the scope.
+	if statusSegmentRoles.DecorationCwd != theme.TmuxDecorationCwdFg {
+		t.Fatalf("decoration.cwd not restored: %q", statusSegmentRoles.DecorationCwd)
+	}
+	if want := "#[bg=" + tmuxAccentAttentionBg + ",fg=" + theme.TmuxStateWarningFg + "]"; notifySeverityWarn != want {
+		t.Fatalf("notify severity warn not restored: %q, want %q", notifySeverityWarn, want)
+	}
+	if want := theme.ANSI256FgStart(theme.TmuxStateWarningFg) + "85%" + theme.ANSIReset; amberANSI("85%") != want {
+		t.Fatalf("amberANSI not restored: %q, want %q", amberANSI("85%"), want)
+	}
+	if want := theme.ANSITextMutedStart + "x" + theme.ANSIReset; hookTrustMuted("x") != want {
+		t.Fatalf("hookTrustMuted not restored: %q, want %q", hookTrustMuted("x"), want)
+	}
+	if got := tmuxAIBadgeKindFg(aiBadgeKindApprovalRequired, statusSegmentRoles); got != theme.TmuxAIBadgeActionRequiredFg {
+		t.Fatalf("attention badge fg not restored: %q, want %q", got, theme.TmuxAIBadgeActionRequiredFg)
+	}
+}
+
+// TestBrightPhase2StatusNotifySegmentFallbackByteIdentity locks the notify
+// status segment output under the fallback role state to the exact bytes
+// captured at main fa3da53 (pre-Phase 2).
+func TestBrightPhase2StatusNotifySegmentFallbackByteIdentity(t *testing.T) {
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	entries := []notify.Notification{
+		{ID: "1", Session: "repos-projmux", Text: "claude: reply ready", Source: notify.SourceAI, Severity: notify.SeverityInfo, CreatedAt: now.Add(-3 * time.Minute), Metadata: map[string]string{"state": "need"}},
+		{ID: "2", Session: "repos-x", Text: "warn body", Severity: notify.SeverityWarn, CreatedAt: now.Add(-10 * time.Minute)},
+		{ID: "3", Session: "repos-y", Text: "crit body", Severity: notify.SeverityCritical, CreatedAt: now.Add(-20 * time.Minute)},
+	}
+	want := "#[bg=colour53,fg=colour220]#[bg=colour90,fg=colour231,bold] projmux #[bg=colour53,fg=colour220] claude: reply ready #[bg=colour53,fg=colour153]· 3m ago#[bg=colour53,fg=colour220]   #[bg=colour53,fg=colour220,bold]+2#[bg=colour53,fg=colour220]#[default]"
+	if got := formatStatusNotify(entries, 0, now); got != want {
+		t.Fatalf("fallback notify segment drifted:\n got %q\nwant %q", got, want)
+	}
+}

--- a/internal/app/hook_trust_popup.go
+++ b/internal/app/hook_trust_popup.go
@@ -151,6 +151,9 @@ func (c *tmuxCommand) runHookTrustPrompt(args []string, stdout, stderr io.Writer
 }
 
 func (c *tmuxCommand) runHookTrustPromptWithReader(args []string, reader io.Reader, stdout, stderr io.Writer) error {
+	// Bright Phase 2 (B3): the hook-trust popup renders with the resolved
+	// effective theme instead of the fallback literals.
+	defer applyNativeUIThemeFromConfig(c.homeDir, c.lookupEnv, "")()
 	fs := flag.NewFlagSet("tmux hook-trust-prompt", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	requestPath := fs.String("request", "", "path to project hook trust request JSON")
@@ -178,7 +181,7 @@ func (c *tmuxCommand) runHookTrustPromptWithReader(args []string, reader io.Read
 }
 
 func hookTrustPopupPrompt(reader io.Reader, writer io.Writer, req hooks.ProjectHookPromptRequest) hooks.ProjectHookDecision {
-	fmt.Fprintln(writer, projmuxpicker.CurrentStart+" Trust project automation "+projmuxpicker.Reset)
+	fmt.Fprintln(writer, hookTrustHeaderStart+" Trust project automation "+projmuxpicker.Reset)
 	scope := hookTrustRequestScope(req)
 	fmt.Fprintln(writer, hookTrustMuted(scope.description))
 	fmt.Fprintln(writer)
@@ -266,8 +269,16 @@ func hookTrustActionLine(action, detail string) string {
 	return fmt.Sprintf("  %-12s %s", action, hookTrustMuted(detail))
 }
 
+// hook-trust popup role escapes (bright Phase 2, B3). Defaults are the
+// historical fallback literals (byte-identical); applyNativeUITheme repoints
+// them at the resolved effective theme at command entry.
+var (
+	hookTrustHeaderStart = projmuxpicker.CurrentStart
+	hookTrustMutedStart  = projmuxpicker.MutedStart
+)
+
 func hookTrustMuted(value string) string {
-	return projmuxpicker.MutedStart + value + projmuxpicker.Reset
+	return hookTrustMutedStart + value + projmuxpicker.Reset
 }
 
 func parseHookTrustDecision(value string) hooks.ProjectHookDecision {

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -1276,7 +1276,6 @@ var (
 	notifySidebarGone           = theme.ANSINotifyGoneStart
 	notifySidebarTitle          = theme.ANSINotifyTitleStart
 	notifySidebarAgeOpen        = theme.ANSINotifyAgeStart
-	notifySidebarTopicOpen      = theme.ANSIChipActiveStart
 	notifySidebarAgentOpenStyle = theme.ANSINotifyAgentStart
 )
 

--- a/internal/app/session_popup.go
+++ b/internal/app/session_popup.go
@@ -66,6 +66,9 @@ func newSessionPopupCommand() *sessionPopupCommand {
 
 // Run manages session-popup subcommands.
 func (c *sessionPopupCommand) Run(args []string, stdout, stderr io.Writer) error {
+	// Bright Phase 2 (B3): the session-popup preview renders with the resolved
+	// effective theme instead of the fallback literals.
+	defer applyNativeUIThemeFromConfig(os.UserHomeDir, os.Getenv, "")()
 	fs := flag.NewFlagSet("session-popup", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 

--- a/internal/app/sessions.go
+++ b/internal/app/sessions.go
@@ -106,6 +106,9 @@ func (c *sessionsCommand) Run(args []string, stdout, stderr io.Writer) error {
 		printSessionsUsage(stderr)
 		return err
 	}
+	// Bright Phase 2 (B3): the sessions picker rows render with the resolved
+	// effective theme instead of the fallback literals.
+	defer applyNativeUIThemeFromConfig(c.homeDir, c.lookupEnv, "")()
 
 	if c.recent == nil {
 		return fmt.Errorf("recent tmux session resolver is not configured")

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -29,11 +29,12 @@ const (
 
 // statusbar git segment / kube colors source from the semantic role map
 // (single source shared with the decoration renderer) instead of bare tmux
-// literals. The status segment render path carries no explicit EffectiveTheme
-// today, so the fallback role map is used here; the fallback role values equal
-// the historical literals, so the generated strings are byte-identical.
+// literals. The defaults below are the fallback role map, whose values equal
+// the historical literals (byte-identical); applyStatusSegmentTheme repoints
+// them at the resolved effective theme at command entry (bright Phase 2, B1),
+// so the status/notify subprocess paths no longer pin the zero-value theme.
 var (
-	statusSegmentRoles = theme.RenderRolesFromEffective(theme.EffectiveTheme{})
+	statusSegmentRoles = theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{}))
 
 	tmuxGitSegmentBg = statusSegmentRoles.GitSegmentBg
 	tmuxGitSegmentFg = statusSegmentRoles.GitSegmentFg
@@ -42,6 +43,36 @@ var (
 	tmuxGitAheadFg   = statusSegmentRoles.GitAhead
 	tmuxGitBehindFg  = statusSegmentRoles.GitBehind
 )
+
+// applyStatusSegmentTheme repoints every tmux-side status segment / notify HUD
+// role escape at a resolved effective theme. Call once at command entry (it is
+// wired into applyNativeUITheme). Applying the fallback theme restores the
+// historical literals for every role these paths consume, so fallback and all
+// current dark presets stay byte-identical.
+func applyStatusSegmentTheme(effective theme.EffectiveTheme) {
+	roles := theme.RenderRolesFromEffective(effective)
+	statusSegmentRoles = roles
+
+	tmuxGitSegmentBg = roles.GitSegmentBg
+	tmuxGitSegmentFg = roles.GitSegmentFg
+	tmuxGitDirtyFg = roles.GitDirty
+	tmuxGitStagedFg = roles.GitStaged
+	tmuxGitAheadFg = roles.GitAhead
+	tmuxGitBehindFg = roles.GitBehind
+
+	notifyStateRoles = roles
+	notifyProjectOpen = "#[bg=" + theme.TmuxAttentionProjectBg + ",fg=" + roles.StatusTextPrimary + ",bold]"
+	notifyBadgeStaleOpen = "#[bg=" + theme.TmuxMutedBg + ",fg=" + roles.StatusTextPrimary + ",bold]"
+	notifyBadgeGoneOpen = "#[bg=" + theme.TmuxGoneBg + ",fg=" + roles.StatusTextPrimary + ",dim]"
+	notifyLineOpen = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + roles.StateProgress + "]"
+	notifyLineCountOpen = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + roles.StateProgress + ",bold]"
+	notifyBadgeInfoOpen = "#[bg=" + roles.StateProgress + ",fg=" + theme.TmuxPaneActiveFg + ",bold]"
+	notifyBadgeWarnOpen = "#[bg=" + roles.StateWarning + ",fg=" + theme.TmuxPaneActiveFg + ",bold]"
+	notifyBadgeCritOpen = "#[bg=" + roles.StateCritical + ",fg=" + roles.StatusTextPrimary + ",bold]"
+	notifySeverityInfo = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + roles.StateProgress + "]"
+	notifySeverityWarn = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + roles.StateWarning + "]"
+	notifySeverityCrit = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + roles.StateCritical + ",bold]"
+}
 
 type statusCommand struct {
 	lookupEnv     func(string) string
@@ -80,6 +111,10 @@ func (c *statusCommand) Run(args []string, stdout, stderr io.Writer) error {
 		printStatusUsage(stderr)
 		return errors.New("status requires a subcommand")
 	}
+	// Bright Phase 2 (B1): the status segment subprocesses render with the
+	// resolved effective theme instead of the fallback role map. The restore
+	// keeps the process-global role escapes deterministic.
+	defer applyNativeUIThemeFromConfig(c.homeDir, c.lookupEnv, "")()
 
 	switch args[0] {
 	case "git":
@@ -506,36 +541,42 @@ func (c *statusCommand) notifyStore() (notifyStore, error) {
 // of that same line instead of separate outline glyphs.
 const (
 	notifyLineDimOpen = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + theme.TmuxStateAheadFg + "]"
-	notifyProjectOpen = "#[bg=" + theme.TmuxAttentionProjectBg + ",fg=" + theme.TmuxPrimaryFg + ",bold]"
+	notifyAgentOpen   = "#[bg=" + tmuxAccentAIBg + ",fg=" + theme.TmuxPaneActiveFg + ",bold]"
+	notifyAgentClaude = notifyAgentOpen
+	notifyAgentCodex  = notifyAgentOpen
+	notifyIcon        = "●"
+	notifyMidDot      = "·"
+	notifyEllipsis    = "…"
+	notifyReset       = "#[default]"
+)
+
+// Badge tokens whose foreground migrated from the bare TmuxPrimaryFg literal
+// to the status.text_primary role (bright Phase 2, B1). Defaults equal the
+// historical literals; applyStatusSegmentTheme rebuilds them.
+var (
+	notifyProjectOpen = "#[bg=" + theme.TmuxAttentionProjectBg + ",fg=" + statusSegmentRoles.StatusTextPrimary + ",bold]"
 	// Inactive/gone badges share a muted palette so target-state hints are
 	// visually distinct from the active NEED/INFO/WARN/CRIT badges without
 	// stealing focus. The colours land in the same neutral grey family the
 	// sidebar uses so users learn one visual language for target state.
-	notifyBadgeStaleOpen = "#[bg=" + theme.TmuxMutedBg + ",fg=" + theme.TmuxPrimaryFg + ",bold]"
-	notifyBadgeGoneOpen  = "#[bg=" + theme.TmuxGoneBg + ",fg=" + theme.TmuxPrimaryFg + ",dim]"
-	notifyAgentOpen      = "#[bg=" + tmuxAccentAIBg + ",fg=" + theme.TmuxPaneActiveFg + ",bold]"
-	notifyAgentClaude    = notifyAgentOpen
-	notifyAgentCodex     = notifyAgentOpen
-	notifyIcon           = "●"
-	notifyMidDot         = "·"
-	notifyEllipsis       = "…"
-	notifyReset          = "#[default]"
+	notifyBadgeStaleOpen = "#[bg=" + theme.TmuxMutedBg + ",fg=" + statusSegmentRoles.StatusTextPrimary + ",bold]"
+	notifyBadgeGoneOpen  = "#[bg=" + theme.TmuxGoneBg + ",fg=" + statusSegmentRoles.StatusTextPrimary + ",dim]"
 )
 
 // State/severity-colored notify tokens. These source their state colors from
 // the semantic role map (single source shared with statusbar/usage HUD) instead
-// of the bare tmux literal aliases. The status/notify render path carries no
-// explicit EffectiveTheme today, so the fallback role map is used here; full
-// subprocess theme plumbing is a later phase. The fallback role values equal the
-// historical literals, so the generated strings are byte-identical.
+// of the bare tmux literal aliases. The defaults below use the fallback role
+// map, whose values equal the historical literals (byte-identical);
+// applyStatusSegmentTheme rebuilds them from the resolved effective theme at
+// command entry (bright Phase 2, B1).
 var (
-	notifyStateRoles = theme.RenderRolesFromEffective(theme.EffectiveTheme{})
+	notifyStateRoles = statusSegmentRoles
 
 	notifyLineOpen      = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + notifyStateRoles.StateProgress + "]"
 	notifyLineCountOpen = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + notifyStateRoles.StateProgress + ",bold]"
 	notifyBadgeInfoOpen = "#[bg=" + notifyStateRoles.StateProgress + ",fg=" + theme.TmuxPaneActiveFg + ",bold]"
 	notifyBadgeWarnOpen = "#[bg=" + notifyStateRoles.StateWarning + ",fg=" + theme.TmuxPaneActiveFg + ",bold]"
-	notifyBadgeCritOpen = "#[bg=" + notifyStateRoles.StateCritical + ",fg=" + theme.TmuxPrimaryFg + ",bold]"
+	notifyBadgeCritOpen = "#[bg=" + notifyStateRoles.StateCritical + ",fg=" + notifyStateRoles.StatusTextPrimary + ",bold]"
 	notifySeverityInfo  = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + notifyStateRoles.StateProgress + "]"
 	notifySeverityWarn  = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + notifyStateRoles.StateWarning + "]"
 	notifySeverityCrit  = "#[bg=" + tmuxAccentAttentionBg + ",fg=" + notifyStateRoles.StateCritical + ",bold]"

--- a/internal/app/statusbar.go
+++ b/internal/app/statusbar.go
@@ -96,6 +96,9 @@ func (c *statusbarCommand) Run(args []string, stdout, stderr io.Writer) error {
 		printStatusbarUsage(stderr)
 		return usageError("statusbar requires a subcommand")
 	}
+	// Bright Phase 2 (B3): statusbar popups (pwd/usage/notify) render with the
+	// resolved effective theme instead of the fallback literals.
+	defer applyNativeUIThemeFromConfig(c.homeDir, c.lookupEnv, "")()
 	switch args[0] {
 	case "click":
 		return c.runClick(args[1:], stdout, stderr)
@@ -851,7 +854,7 @@ func statusbarUnsupportedUsageLine(provider usagecmd.UnsupportedProvider) string
 }
 
 func statusbarUsageSyncLine(state statusbarUsageState, now time.Time) string {
-	label := projmuxpicker.MutedStart + "sync" + projmuxpicker.Reset + "  "
+	label := statusbarMutedANSI + "sync" + projmuxpicker.Reset + "  "
 	if state.LastSync.IsZero() {
 		return label + dimANSI("never")
 	}
@@ -921,7 +924,7 @@ func statusbarUsageRows(snaps []coreusage.Snapshot) []statusbarUsageRow {
 }
 
 func statusbarUsageHeaderLine() string {
-	return projmuxpicker.MutedStart +
+	return statusbarMutedANSI +
 		fmt.Sprintf("%-8s %-6s %10s %10s %10s %6s  %-16s", "MODEL", "WIN", "USED", "LIMIT", "LEFT", "PCT", "RESET") +
 		projmuxpicker.Reset
 }
@@ -1022,23 +1025,33 @@ func statusbarUsageErrorSummary(err error) string {
 }
 
 func dimANSI(value string) string {
-	return projmuxpicker.MutedStart + value + projmuxpicker.Reset
+	return statusbarMutedANSI + value + projmuxpicker.Reset
 }
+
+// statusbar popup text role escapes (bright Phase 2, B3). Defaults are the
+// historical fallback literals (byte-identical); applyNativeUITheme repoints
+// them at the resolved effective theme at command entry.
+var (
+	statusbarMutedANSI   = projmuxpicker.MutedStart
+	statusbarSevWarnANSI = theme.ANSI256FgStart(theme.TmuxStateWarningFg)
+	statusbarSevCritANSI = theme.ANSI256FgStart(theme.TmuxStateCriticalFg)
+	statusbarSevOKANSI   = theme.ANSI256FgStart(theme.TmuxStateSuccessFg)
+)
 
 // amberANSI/redANSI/tealANSI tint the native usage statusbar text from the
 // semantic state role map (single source shared with the notify/usage tmux
-// severity cluster). ANSI256FgStart adapts the role's tmux colourN to the
-// 256-color SGR; the fallback role values keep this byte-identical.
+// severity cluster), repointed at the resolved effective theme by
+// applyNativeUITheme; the fallback role values keep this byte-identical.
 func amberANSI(value string) string {
-	return theme.ANSI256FgStart(theme.RenderRolesFromEffective(theme.EffectiveTheme{}).StateWarning) + value + projmuxpicker.Reset
+	return statusbarSevWarnANSI + value + projmuxpicker.Reset
 }
 
 func redANSI(value string) string {
-	return theme.ANSI256FgStart(theme.RenderRolesFromEffective(theme.EffectiveTheme{}).StateCritical) + value + projmuxpicker.Reset
+	return statusbarSevCritANSI + value + projmuxpicker.Reset
 }
 
 func tealANSI(value string) string {
-	return theme.ANSI256FgStart(theme.RenderRolesFromEffective(theme.EffectiveTheme{}).StateSuccess) + value + projmuxpicker.Reset
+	return statusbarSevOKANSI + value + projmuxpicker.Reset
 }
 
 func (c *statusbarCommand) statusbarPathMetadata(ctx context.Context, path string) statusbarPathMetadata {
@@ -1180,7 +1193,7 @@ func statusbarPopupCommand(payload, binaryPath string) string {
 const displayOnlyPopupClosePrompt = "Press any key to close."
 
 func displayOnlyPopupClosePromptLine() string {
-	return projmuxpicker.MutedStart + displayOnlyPopupClosePrompt + projmuxpicker.Reset
+	return statusbarMutedANSI + displayOnlyPopupClosePrompt + projmuxpicker.Reset
 }
 
 func statusbarPopupFooterLines(cols int) []string {
@@ -1204,7 +1217,7 @@ func statusbarFieldLines(label, value string, cols int) []string {
 		wrapped = []string{"-"}
 	}
 	lines := make([]string, 0, len(wrapped))
-	prefix := projmuxpicker.MutedStart + fmt.Sprintf("%-*s", labelWidth, label) + projmuxpicker.Reset + "  "
+	prefix := statusbarMutedANSI + fmt.Sprintf("%-*s", labelWidth, label) + projmuxpicker.Reset + "  "
 	continuation := strings.Repeat(" ", labelWidth+2)
 	for i, line := range wrapped {
 		if i == 0 {

--- a/internal/app/statusbar_decoration.go
+++ b/internal/app/statusbar_decoration.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/theme"
 )
 
 const (
@@ -129,12 +130,12 @@ func statusbarDecorationTmuxOptionForTarget(target statusbarDecorationTarget) st
 	}
 }
 
-func statusbarCwdSegmentFormat() string {
-	return "#[range=user|pwd]" + statusbarCwdDecoratorFormat() + "#[fg=" + tmuxSecondaryFg + "]#{=-28/...:pane_current_path}#[norange]"
+func statusbarCwdSegmentFormat(roles theme.RenderRoles) string {
+	return "#[range=user|pwd]" + statusbarCwdDecoratorFormat(roles) + "#[fg=" + roles.StatusTextSecondary + "]#{=-28/...:pane_current_path}#[norange]"
 }
 
-func statusbarCwdDecoratorFormat() string {
-	return "#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},},#{?#{==:#{" + statusbarDecorationTmuxOption + "},symbol},#[fg=" + statusSegmentRoles.DecorationCwd + "] ,#{?#{==:#{" + statusbarDecorationTmuxOption + "},emoji},#[fg=" + statusSegmentRoles.DecorationCwd + "]📁 ,}},#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},symbol},#[fg=" + statusSegmentRoles.DecorationCwd + "] ,#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},emoji},#[fg=" + statusSegmentRoles.DecorationCwd + "]📁 ,}}}"
+func statusbarCwdDecoratorFormat(roles theme.RenderRoles) string {
+	return "#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},},#{?#{==:#{" + statusbarDecorationTmuxOption + "},symbol},#[fg=" + roles.DecorationCwd + "] ,#{?#{==:#{" + statusbarDecorationTmuxOption + "},emoji},#[fg=" + roles.DecorationCwd + "]📁 ,}},#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},symbol},#[fg=" + roles.DecorationCwd + "] ,#{?#{==:#{" + statusbarDecorationCwdTmuxOption + "},emoji},#[fg=" + roles.DecorationCwd + "]📁 ,}}}"
 }
 
 type gitRemoteProvider string

--- a/internal/app/theme_render_native.go
+++ b/internal/app/theme_render_native.go
@@ -72,7 +72,6 @@ func applyNativeUITheme(effective theme.EffectiveTheme) {
 	notifySidebarGone = roles.NotifyGone
 	notifySidebarTitle = roles.NotifyTitle
 	notifySidebarAgeOpen = roles.NotifyAge
-	notifySidebarTopicOpen = roles.ChipActive
 	notifySidebarAgentOpenStyle = roles.NotifyAgent
 
 	// AI badge palette (recent_window.go)

--- a/internal/app/theme_render_native.go
+++ b/internal/app/theme_render_native.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/crevissepartners/projmux/internal/app/usagecmd"
 	"github.com/crevissepartners/projmux/internal/theme"
 	intrender "github.com/crevissepartners/projmux/internal/ui/render"
 )
@@ -78,6 +79,32 @@ func applyNativeUITheme(effective theme.EffectiveTheme) {
 	appAIBadgeActionRequired = roles.AIBadgeActionRequired
 	appAIBadgeSuccess = roles.AIBadgeSuccess
 	appAIBadgeProgress = roles.AIBadgeProgress
+
+	// statusbar popup text + usage severity (statusbar.go, bright Phase 2 B3).
+	// The severity escapes adapt the tmux-side state roles so the popup text
+	// matches the tmux HUD severity colors; for the fallback theme
+	// ANSIFgFromTmuxColor(colourN) is byte-identical to the historical
+	// ANSI256FgStart literals.
+	renderRoles := theme.RenderRolesFromEffective(effective)
+	statusbarMutedANSI = roles.TextMuted
+	if v := theme.ANSIFgFromTmuxColor(renderRoles.StateWarning); v != "" {
+		statusbarSevWarnANSI = v
+	}
+	if v := theme.ANSIFgFromTmuxColor(renderRoles.StateCritical); v != "" {
+		statusbarSevCritANSI = v
+	}
+	if v := theme.ANSIFgFromTmuxColor(renderRoles.StateSuccess); v != "" {
+		statusbarSevOKANSI = v
+	}
+
+	// hook-trust popup (hook_trust_popup.go, bright Phase 2 B3)
+	hookTrustHeaderStart = roles.SurfaceActive
+	hookTrustMutedStart = roles.TextMuted
+
+	// tmux-side status segment / notify HUD / usage HUD roles (status.go,
+	// usagecmd — bright Phase 2 B1)
+	applyStatusSegmentTheme(effective)
+	usagecmd.ApplyStatusTheme(effective)
 }
 
 // applyNativeUIThemeFromConfig resolves the effective theme from the global user

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -33,7 +33,6 @@ const (
 	tmuxWindowActiveBg   = projmuxpicker.TmuxWindowActiveBg
 	tmuxWindowActiveFg   = projmuxpicker.TmuxWindowActiveFg
 	tmuxWindowTitleWidth = 10
-	tmuxSecondaryFg      = theme.TmuxSecondaryFg
 
 	tmuxAccentAttentionBg = theme.TmuxAccentAttentionBg
 	tmuxAccentAttentionFg = theme.TmuxAccentAttentionFg
@@ -1231,8 +1230,8 @@ func tmuxStandaloneConfig(binaryPath string, decoration config.StatusbarDecorati
 
 const statusbarSettingsIcon = ""
 
-func statusbarSettingsButton(label string) string {
-	return "#[bold,fg=" + statusSegmentRoles.ActionFg + ",bg=" + statusSegmentRoles.ActionBg + "]#[range=user|settings]" + statusbarSettingsButtonBody(label) + "#[norange]#[default]"
+func statusbarSettingsButton(label string, roles theme.RenderRoles) string {
+	return "#[bold,fg=" + roles.ActionFg + ",bg=" + roles.ActionBg + "]#[range=user|settings]" + statusbarSettingsButtonBody(label) + "#[norange]#[default]"
 }
 
 func statusbarSettingsButtonBody(label string) string {
@@ -1253,8 +1252,8 @@ func statusbarSettingsButtonBody(label string) string {
 // project surface. This replaces the former divergent raw `[#S]` (standalone)
 // and tmux-native de-slug `#{s|^[^-]*-||:session_name}` (app) segments; the
 // tmux regex de-slug is gone (naming v2 Phase 1b).
-func statusbarSessionLeftFormat(bin string) string {
-	return "#[range=user|session]#[bold,fg=" + statusSegmentRoles.IdentityFg + ",bg=" + statusSegmentRoles.IdentityBg + "] #(" + bin + " status project) #[default]#[norange] "
+func statusbarSessionLeftFormat(bin string, roles theme.RenderRoles) string {
+	return "#[range=user|session]#[bold,fg=" + roles.IdentityFg + ",bg=" + roles.IdentityBg + "] #(" + bin + " status project) #[default]#[norange] "
 }
 
 func statusbarAuxLineFormat(bin string, autosave bool) string {
@@ -1288,7 +1287,7 @@ func tmuxVisiblePaneLabelFormat() string {
 }
 
 func tmuxStyledVisiblePaneLabelFormat() string {
-	return tmuxStyledVisiblePaneLabelFormatFor(theme.RenderRolesFromEffective(theme.EffectiveTheme{}).StateProgress)
+	return tmuxStyledVisiblePaneLabelFormatFor(theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{})).StateProgress)
 }
 
 func tmuxStyledVisiblePaneLabelFormatFor(styleFg string) string {
@@ -1313,7 +1312,7 @@ func tmuxShellPaneLabelFormat() string {
 }
 
 func tmuxPaneBorderFormat() string {
-	return tmuxPaneBorderFormatWithAIBadgeStyle(config.AIBadgeStyleDot, theme.RenderRolesFromEffective(theme.EffectiveTheme{}))
+	return tmuxPaneBorderFormatWithAIBadgeStyle(config.AIBadgeStyleDot, theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{})))
 }
 
 func tmuxPaneBorderFormatWithAIBadgeStyle(badgeStyle config.AIBadgeStyle, roles theme.RenderRoles) string {
@@ -1322,13 +1321,13 @@ func tmuxPaneBorderFormatWithAIBadgeStyle(badgeStyle config.AIBadgeStyle, roles 
 	promptPaneLabelFormat := tmuxStyledVisiblePaneLabelFormatFor(roles.AIActionRequired)
 	busyPaneLabelFormat := tmuxStyledVisiblePaneLabelFormatFor(roles.AIProgress)
 	replyPaneLabelFormat := tmuxStyledVisiblePaneLabelFormatFor(roles.AISuccess)
-	mutedPaneLabelFormat := tmuxStyledVisiblePaneLabelFormatFor(theme.TmuxMutedFg)
+	mutedPaneLabelFormat := tmuxStyledVisiblePaneLabelFormatFor(roles.PaneBorderMutedFg)
 	panePromptFormat := "#{||:#{==:#{@projmux_ai_badge_kind}," + aiBadgeKindApprovalRequired + "},#{==:#{@projmux_ai_badge_kind}," + aiBadgeKindInputRequired + "}}"
 	paneCompleteFormat := "#{==:#{@projmux_ai_badge_kind}," + aiBadgeKindResponseComplete + "}"
 	paneProgressFormat := "#{==:#{@projmux_ai_badge_kind}," + aiBadgeKindInProgress + "}"
 	paneBusyFormat := "#{==:#{@projmux_attention_state},busy}"
 	paneReplyFormat := "#{==:#{@projmux_attention_state},reply}"
-	inactivePaneBorderFormat := "#{?" + panePromptFormat + ",#[bold#,fg=" + roles.AIActionRequired + "]" + tmuxAIBadgeMarker(aiBadgeKindApprovalRequired, badgeStyle) + promptPaneLabelFormat + " #[default],#{?" + paneCompleteFormat + ",#[bold#,fg=" + roles.AISuccess + "]" + tmuxAIBadgeMarker(aiBadgeKindResponseComplete, badgeStyle) + replyPaneLabelFormat + " #[default],#{?#{||:" + paneProgressFormat + "," + paneBusyFormat + "},#[bold#,fg=" + roles.AIProgress + "]" + tmuxAIBadgeMarker(aiBadgeKindInProgress, badgeStyle) + busyPaneLabelFormat + " #[default],#{?" + paneReplyFormat + ",#[bold#,fg=" + roles.AISuccess + "]" + tmuxAIBadgeMarker(aiBadgeKindResponseComplete, badgeStyle) + replyPaneLabelFormat + " #[default],#[fg=" + theme.TmuxMutedFg + "] " + mutedPaneLabelFormat + " #[default]}}}}"
+	inactivePaneBorderFormat := "#{?" + panePromptFormat + ",#[bold#,fg=" + roles.AIActionRequired + "]" + tmuxAIBadgeMarker(aiBadgeKindApprovalRequired, badgeStyle) + promptPaneLabelFormat + " #[default],#{?" + paneCompleteFormat + ",#[bold#,fg=" + roles.AISuccess + "]" + tmuxAIBadgeMarker(aiBadgeKindResponseComplete, badgeStyle) + replyPaneLabelFormat + " #[default],#{?#{||:" + paneProgressFormat + "," + paneBusyFormat + "},#[bold#,fg=" + roles.AIProgress + "]" + tmuxAIBadgeMarker(aiBadgeKindInProgress, badgeStyle) + busyPaneLabelFormat + " #[default],#{?" + paneReplyFormat + ",#[bold#,fg=" + roles.AISuccess + "]" + tmuxAIBadgeMarker(aiBadgeKindResponseComplete, badgeStyle) + replyPaneLabelFormat + " #[default],#[fg=" + roles.PaneBorderMutedFg + "] " + mutedPaneLabelFormat + " #[default]}}}}"
 	return "#{?pane_active,#[bold#,fg=" + roles.PaneTopicChipFg + "#,bg=" + roles.PaneTopicChipBg + "] > " + activePaneLabelFormat + " #[default]," + inactivePaneBorderFormat + "}"
 }
 
@@ -1403,8 +1402,8 @@ func tmuxStandaloneConfigWithKeymapThemeAIBadgeStyleAndDesktopNotifyMode(binaryP
 		"set -g status 2",
 		"set -g status-left-length 20",
 		"set -g status-right-length 140",
-		"set -g status-left "+tmuxConfigQuote(statusbarSessionLeftFormat(bin)),
-		"set -g status-right "+tmuxConfigQuote(statusbarCwdSegmentFormat()+"#[fg="+roles.DividerFg+"]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]#[fg="+tmuxSecondaryFg+"]   %Y-%m-%d %H:%M "+statusbarSettingsButton(statusbarSettingsIcon+" projmux")),
+		"set -g status-left "+tmuxConfigQuote(statusbarSessionLeftFormat(bin, roles)),
+		"set -g status-right "+tmuxConfigQuote(statusbarCwdSegmentFormat(roles)+"#[fg="+roles.DividerFg+"]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]#[fg="+roles.StatusTextSecondary+"]   %Y-%m-%d %H:%M "+statusbarSettingsButton(statusbarSettingsIcon+" projmux", roles)),
 		// Two-line status bar: line 0 is the notify/HUD control row; line 1 is
 		// tmux's native session/window/path row. Setting both rows explicitly is
 		// required because tmux's built-in row otherwise stays at index 0.
@@ -1527,8 +1526,8 @@ func tmuxAppConfigWithKeymapThemeAIBadgeStyleAndDesktopNotifyMode(binaryPath, de
 	// small buffer while still fitting alongside notify.
 	lines = append(lines,
 		"set -g status 2",
-		"set -g status-left "+tmuxConfigQuote(statusbarSessionLeftFormat(bin)),
-		"set -g status-right "+tmuxConfigQuote(statusbarCwdSegmentFormat()+"#[fg="+roles.DividerFg+"]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]#[fg="+tmuxSecondaryFg+"]   %Y-%m-%d %H:%M "+statusbarSettingsButton(statusbarSettingsIcon)),
+		"set -g status-left "+tmuxConfigQuote(statusbarSessionLeftFormat(bin, roles)),
+		"set -g status-right "+tmuxConfigQuote(statusbarCwdSegmentFormat(roles)+"#[fg="+roles.DividerFg+"]  #[range=user|kube]#("+bin+" status kube)#[norange]#[range=user|git]#("+bin+" status git)#[norange]#[fg="+roles.StatusTextSecondary+"]   %Y-%m-%d %H:%M "+statusbarSettingsButton(statusbarSettingsIcon, roles)),
 		"set -g status-format[0] "+tmuxConfigQuote(statusbarAuxLineFormat(bin, true)),
 		"set -g status-format[1] "+tmuxConfigQuote(statusbarWindowLineFormat()),
 		"set -gu status-format[2]",

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -35,7 +35,6 @@ const (
 	tmuxWindowTitleWidth = 10
 
 	tmuxAccentAttentionBg = theme.TmuxAccentAttentionBg
-	tmuxAccentAttentionFg = theme.TmuxAccentAttentionFg
 	tmuxAccentAIBg        = theme.TmuxAccentAIBg
 	tmuxAccentAIFg        = theme.TmuxAccentAIFg
 	tmuxStateProgressFg   = theme.TmuxStateProgressFg

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -1394,7 +1394,7 @@ func TestTmuxPrintConfigUsesStandaloneBindings(t *testing.T) {
 func TestStatusbarSettingsButtonPaintsCompactPaddingInsideRange(t *testing.T) {
 	t.Parallel()
 
-	got := statusbarSettingsButton(statusbarSettingsIcon)
+	got := statusbarSettingsButton(statusbarSettingsIcon, statusSegmentRoles)
 	want := "#[bold,fg=colour230,bg=colour29]#[range=user|settings]   #[norange]#[default]"
 	if got != want {
 		t.Fatalf("statusbarSettingsButton() = %q, want %q", got, want)
@@ -1404,7 +1404,7 @@ func TestStatusbarSettingsButtonPaintsCompactPaddingInsideRange(t *testing.T) {
 func TestStatusbarSettingsButtonPaintsStandalonePaddingInsideRange(t *testing.T) {
 	t.Parallel()
 
-	got := statusbarSettingsButton(statusbarSettingsIcon + " projmux")
+	got := statusbarSettingsButton(statusbarSettingsIcon+" projmux", statusSegmentRoles)
 	want := "#[bold,fg=colour230,bg=colour29]#[range=user|settings]  projmux #[norange]#[default]"
 	if got != want {
 		t.Fatalf("statusbarSettingsButton() = %q, want %q", got, want)

--- a/internal/app/usagecmd/bright_phase2_test.go
+++ b/internal/app/usagecmd/bright_phase2_test.go
@@ -1,0 +1,90 @@
+package usagecmd
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/theme"
+)
+
+// bright_phase2_test.go covers the B1 theme threading for the usage HUD
+// subprocess (bright preset roadmap Phase 2): ApplyStatusTheme repoints the
+// role map, a light status background derives dark-contrast fg colors, and
+// restoring the fallback theme is byte-identical to the historical literals.
+
+func usageLightThemeConfig() theme.ThemeConfig {
+	return theme.ThemeConfig{
+		Background:       "#f5f5f0",
+		Surface:          "#f2f2ee",
+		StatusBackground: "#e8e8e2",
+		SurfaceActive:    "#d8d8d0",
+		ChromeForeground: "#2a2e32",
+		TextPrimary:      "#1f2428",
+		Foreground:       "#1f2428",
+		Muted:            "#6a7076",
+		Accent:           "#0f7b6c",
+		Critical:         "#c62828",
+		Warning:          "#9a6700",
+		Progress:         "#0757ba",
+		Success:          "#1a7f37",
+		ActionRequired:   "#b35900",
+		PaneActiveBg:     "#e2e2da",
+		Focus:            "#0757ba",
+	}
+}
+
+// withUsageStatusTheme applies a theme, runs fn, and restores the fallback.
+// NOT parallel-safe by design; callers stay serial like the app package's
+// native-UI repaint tests.
+func withUsageStatusTheme(effective theme.EffectiveTheme, fn func()) {
+	ApplyStatusTheme(effective)
+	defer ApplyStatusTheme(theme.ResolveTheme(theme.ThemeConfig{}))
+	fn()
+}
+
+// TestUsageHUDLightThemeDerivesDarkFg: under a light status background the HUD
+// model label, age indicator, and bar colors leave the dark-tuned literals.
+func TestUsageHUDLightThemeDerivesDarkFg(t *testing.T) {
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	models := []modelDisplay{{label: "Claude", shortLabel: "C", hasFive: true, fivePct: 42, showAge: true, lastSync: now.Add(-2 * time.Hour)}}
+
+	withUsageStatusTheme(theme.ResolveTheme(usageLightThemeConfig()), func() {
+		out := renderTierLongHUDWithAge(models, now)
+		if strings.Contains(out, "#[fg="+theme.TmuxAccentAIFg) {
+			t.Fatalf("HUD label still carries %s under a light theme: %q", theme.TmuxAccentAIFg, out)
+		}
+		if strings.Contains(out, "#[fg="+theme.TmuxMutedFg+"]") {
+			t.Fatalf("HUD age indicator still carries %s under a light theme: %q", theme.TmuxMutedFg, out)
+		}
+		if !strings.Contains(out, "#[fg=#") {
+			t.Fatalf("HUD carries no hex-derived fg under a light theme: %q", out)
+		}
+		// Bar fill follows the explicit success token; empty cells leave the
+		// dark colour238 literal.
+		pair := renderHUDPair("5h", 42)
+		if !strings.Contains(pair, "#1a7f37") {
+			t.Fatalf("HUD bar fill = %q, want explicit light success #1a7f37", pair)
+		}
+		if strings.Contains(pair, theme.TmuxUsageEmptyFg) {
+			t.Fatalf("HUD bar empty cells still carry %s under a light theme: %q", theme.TmuxUsageEmptyFg, pair)
+		}
+	})
+}
+
+// TestUsageHUDFallbackByteIdentity locks the HUD output under the fallback
+// role state to the exact bytes captured at main fa3da53 (pre-Phase 2).
+func TestUsageHUDFallbackByteIdentity(t *testing.T) {
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	models := []modelDisplay{
+		{label: "Claude", shortLabel: "C", hasFive: true, fivePct: 42, hasWeek: true, weekPct: 88, showAge: true, lastSync: now.Add(-2 * time.Hour)},
+		{label: "Codex", shortLabel: "X", hasFive: true, fivePct: 97},
+	}
+	want := "#[fg=colour121,bold]Claude#[default] #[fg=colour244](2h)#[default] 5h [#[fg=colour72]████#[fg=colour238]░░░░░░] #[fg=colour72]42%#[default] · weekly [#[fg=colour214]█████████#[fg=colour238]░] #[fg=colour214]88%#[default]#[default]   #[fg=colour121,bold]Codex#[default] 5h [#[fg=colour160]██████████] #[fg=colour160]97%#[default]#[default]#[default]"
+	if got := renderTierLongHUDWithAge(models, now); got != want {
+		t.Fatalf("fallback usage HUD drifted:\n got %q\nwant %q", got, want)
+	}
+	if got, want := renderAgeIndicator(modelDisplay{showAge: true, lastSync: now.Add(-5 * time.Minute)}, now), "#[fg=colour245](5m)#[default]"; got != want {
+		t.Fatalf("fallback age indicator drifted: %q, want %q", got, want)
+	}
+}

--- a/internal/app/usagecmd/usage.go
+++ b/internal/app/usagecmd/usage.go
@@ -49,6 +49,20 @@ func New(now func() time.Time) *Command {
 	}
 }
 
+// statusRoles is the tmux-side semantic role map consumed by the status usage
+// HUD renderers. It defaults to the fallback role map, whose values equal the
+// historical literals (byte-identical); ApplyStatusTheme repoints it at the
+// resolved effective theme at command entry (bright Phase 2, B1). The HUD
+// render is single-threaded per CLI invocation, matching the app package's
+// native-UI role var pattern.
+var statusRoles = theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{}))
+
+// ApplyStatusTheme repoints the usage HUD role map at a resolved effective
+// theme. Applying the fallback theme restores byte-identity.
+func ApplyStatusTheme(effective theme.EffectiveTheme) {
+	statusRoles = theme.RenderRolesFromEffective(effective)
+}
+
 // staleAfter is the age at which a snapshot is considered stale and
 // flagged for the user with a single `~` marker. This is the single
 // source of truth for the HUD and the table — a snapshot older than
@@ -779,7 +793,7 @@ func renderLongHUDInternal(models []modelDisplay, now time.Time, withAge bool) s
 			continue
 		}
 		var b strings.Builder
-		b.WriteString("#[fg=" + theme.TmuxAccentAIFg + ",bold]")
+		b.WriteString("#[fg=" + statusRoles.AccentAIFg + ",bold]")
 		b.WriteString(m.label)
 		b.WriteString(statusDefaultReset)
 		if withAge {
@@ -834,7 +848,7 @@ func renderTierFiveHOnlyHUD(models []modelDisplay, now time.Time) string {
 			continue
 		}
 		var b strings.Builder
-		b.WriteString("#[fg=" + theme.TmuxAccentAIFg + ",bold]")
+		b.WriteString("#[fg=" + statusRoles.AccentAIFg + ",bold]")
 		b.WriteString(m.label)
 		b.WriteString(statusDefaultReset)
 		b.WriteByte(' ')
@@ -906,10 +920,9 @@ func renderTextPair(m modelDisplay, label string) string {
 // escapes. Used for both 5h and weekly pairs in the HUD tiers.
 func renderHUDPair(window string, pct float64) string {
 	// State/severity colors come from the semantic role map (single source
-	// shared with notify/statusbar). The status subprocess does not yet thread
-	// an explicit EffectiveTheme, so the fallback role map is used here; full
-	// runtime theme plumbing for the usage HUD is a later phase.
-	roles := theme.RenderRolesFromEffective(theme.EffectiveTheme{})
+	// shared with notify/statusbar), repointed at the resolved effective theme
+	// by ApplyStatusTheme at command entry (bright Phase 2, B1).
+	roles := statusRoles
 	color := intrender.BarColorForPct(pct, roles)
 	bar := intrender.RenderColoredBar(pct, color, intrender.BarEmptyColorForRoles(roles))
 	// `#[default]` after the bar restores label fg before the weekly text. The
@@ -955,9 +968,9 @@ func renderAgeIndicator(m modelDisplay, now time.Time) string {
 	if text == "" {
 		return ""
 	}
-	color := theme.TmuxSecondaryFg
+	color := statusRoles.StatusTextSecondary
 	if age >= ageWarnAfter {
-		color = theme.TmuxMutedFg
+		color = statusRoles.StatusTextMuted
 	}
 	return fmt.Sprintf("#[fg=%s](%s)%s", color, text, statusDefaultReset)
 }

--- a/internal/theme/ansiroles.go
+++ b/internal/theme/ansiroles.go
@@ -140,16 +140,22 @@ func ANSIRolesFromEffective(effective EffectiveTheme) ANSIRoles {
 		AIBadgeSuccess:        ansiFGOrLiteral(effective.Success, ANSIAIBadgeSuccessStart),
 		AIBadgeActionRequired: ansiFGOrLiteral(effective.ActionRequired, ANSIAIBadgeActionRequiredStart),
 
-		// trust — brand literals (Tier C).
-		TrustTrusted:   ANSITrustTrustedStart,
-		TrustStale:     ANSITrustStaleStart,
-		TrustUntrusted: ANSITrustUntrustedStart,
+		// trust — brand literals (Tier C base color), luma-gated against the
+		// themed surface (bright Phase 2, B2): an explicit LIGHT surface
+		// darkens the brand hue for contrast; the fallback theme and every
+		// dark surface return the historical literal verbatim.
+		TrustTrusted:   ansiLumaContrastFGOrLiteral(effective.Surface, "", 154, 191, 136, ANSITrustTrustedStart),
+		TrustStale:     ansiLumaContrastFGOrLiteral(effective.Surface, "", 177, 139, 212, ANSITrustStaleStart),
+		TrustUntrusted: ansiLumaContrastFGOrLiteral(effective.Surface, "", 210, 139, 88, ANSITrustUntrustedStart),
 
-		// notify — brand/severity literals (Tier C). badge.project stays the
-		// literal on both adapters so the cross-surface sync test holds.
-		NotifyTitle:   ANSINotifyTitleStart,
-		NotifyDim:     ANSINotifyDimStart,
-		NotifyAge:     ANSINotifyAgeStart,
+		// notify — fg-only literals are luma-gated against the themed surface
+		// (bright Phase 2, B2); base RGB values are the xterm-256 colors baked
+		// into the literals (220=255,215,0 / 245=138,138,138 / 153=175,215,255).
+		// badge.project and the bg+fg severity badges stay verbatim so the
+		// cross-surface sync test holds and self-paired badges keep their look.
+		NotifyTitle:   ansiLumaContrastFGOrLiteral(effective.Surface, "1;", 255, 215, 0, ANSINotifyTitleStart),
+		NotifyDim:     ansiLumaContrastFGOrLiteral(effective.Surface, "", 138, 138, 138, ANSINotifyDimStart),
+		NotifyAge:     ansiLumaContrastFGOrLiteral(effective.Surface, "", 175, 215, 255, ANSINotifyAgeStart),
 		NotifyProject: ANSINotifyProjectStart,
 		NotifyInfo:    ANSINotifyInfoStart,
 		NotifyWarn:    ANSINotifyWarnStart,
@@ -165,9 +171,43 @@ func ANSIRolesFromEffective(effective EffectiveTheme) ANSIRoles {
 		SwitchGitInactive:     ANSISwitchGitInactiveStart,
 		SwitchWindowTabActive: ANSISwitchWindowTabActiveStart,
 		SwitchWindowTab:       ANSISwitchWindowTabStart,
-		SwitchAttentionNeeds:  ANSISwitchAttentionNeedsStart,
-		SwitchAttentionReady:  ANSISwitchAttentionReadyStart,
+		// attention dots are fg-only on the themed surface: luma-gated (bright
+		// Phase 2, B2). Base RGB: colour220=255,215,0 / colour82=95,255,0.
+		SwitchAttentionNeeds: ansiLumaContrastFGOrLiteral(effective.Surface, "", 255, 215, 0, ANSISwitchAttentionNeedsStart),
+		SwitchAttentionReady: ansiLumaContrastFGOrLiteral(effective.Surface, "", 95, 255, 0, ANSISwitchAttentionReadyStart),
 	}
+}
+
+// ansiLumaContrastFGOrLiteral is the ANSI-side luma-gated contrast transform
+// (bright Phase 2) for Tier C fg-only literals rendered on the themed
+// `surface`. On an explicit light surface the literal's base color (r,g,b) is
+// darkened hue-preserving and re-emitted as a truecolor escape carrying the
+// same leading attributes (e.g. "1;" keeps bold); on the fallback theme, the
+// terminal-default sentinel, and every dark surface the historical literal is
+// returned verbatim, so all current built-in presets stay byte-identical.
+func ansiLumaContrastFGOrLiteral(surface ColorField, attrs string, r, g, b int, literal string) string {
+	if !colorFieldIsLight(surface) {
+		return literal
+	}
+	dr, dg, db := contrastDarkenRGB(r, g, b)
+	return "\x1b[" + attrs + "38;2;" + strconv.Itoa(dr) + ";" + strconv.Itoa(dg) + ";" + strconv.Itoa(db) + "m"
+}
+
+// ANSIFgFromTmuxColor adapts a RenderRoles tmux color value (a colourN literal
+// or an explicit #RRGGBB hex, optionally carrying a ",style" suffix that is
+// ignored) to an ANSI foreground SGR escape. colourN maps to 38;5;N —
+// byte-identical to ANSI256FgStart for fallback-sourced roles — and hex maps
+// to truecolor 38;2;r;g;b. Unknown forms return "" so callers can keep their
+// current escape.
+func ANSIFgFromTmuxColor(color string) string {
+	base := strings.Split(color, ",")[0]
+	if r, g, b, ok := parseHexRGB(base); ok {
+		return ansiTruecolorFG(r, g, b)
+	}
+	if strings.HasPrefix(base, "colour") {
+		return ANSI256FgStart(base)
+	}
+	return ""
 }
 
 // fgWhite is the historical white foreground baked into ANSISurfaceActiveStart

--- a/internal/theme/bright_phase2_test.go
+++ b/internal/theme/bright_phase2_test.go
@@ -1,0 +1,390 @@
+package theme
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// bright_phase2_test.go covers the light-background contrast corrections
+// (bright preset roadmap Phase 2, clusters B1/B2) and pins dark/fallback
+// byte-identity for every affected role.
+
+// lightThemeConfig is the test-only light palette used to exercise the
+// derivations. A real light preset is Phase 1 scope and intentionally NOT
+// added to builtinPresets here.
+func lightThemeConfig() ThemeConfig {
+	return ThemeConfig{
+		Background:       "#f5f5f0",
+		Surface:          "#f2f2ee",
+		StatusBackground: "#e8e8e2",
+		SurfaceActive:    "#d8d8d0",
+		ChromeForeground: "#2a2e32",
+		TextPrimary:      "#1f2428",
+		Foreground:       "#1f2428",
+		Muted:            "#6a7076",
+		Accent:           "#0f7b6c",
+		Critical:         "#c62828",
+		Warning:          "#9a6700",
+		Progress:         "#0757ba",
+		Success:          "#1a7f37",
+		ActionRequired:   "#b35900",
+		PaneActiveBg:     "#e2e2da",
+		Focus:            "#0757ba",
+	}
+}
+
+// parseANSITruecolorFG extracts (attrs, r, g, b) from an escape of the form
+// \x1b[<attrs>38;2;R;G;Bm.
+func parseANSITruecolorFG(t *testing.T, escape string) (string, int, int, int) {
+	t.Helper()
+	if !strings.HasPrefix(escape, "\x1b[") || !strings.HasSuffix(escape, "m") {
+		t.Fatalf("escape %q is not an SGR sequence", escape)
+	}
+	body := strings.TrimSuffix(strings.TrimPrefix(escape, "\x1b["), "m")
+	before, after, ok := strings.Cut(body, "38;2;")
+	if !ok {
+		t.Fatalf("escape %q is not a truecolor fg sequence", escape)
+	}
+	attrs := before
+	parts := strings.Split(after, ";")
+	if len(parts) != 3 {
+		t.Fatalf("escape %q carries %d channel tokens, want 3", escape, len(parts))
+	}
+	vals := make([]int, 3)
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("escape %q channel %q: %v", escape, p, err)
+		}
+		vals[i] = n
+	}
+	return attrs, vals[0], vals[1], vals[2]
+}
+
+func parseTestHexRGB(t *testing.T, hex string) (int, int, int) {
+	t.Helper()
+	r, g, b, ok := parseHexRGB(hex)
+	if !ok {
+		t.Fatalf("value %q is not a #rrggbb hex color", hex)
+	}
+	return r, g, b
+}
+
+// TestBrightPhase2ANSIRolesDarkByteIdentity pins the B2 cluster: for the
+// fallback theme and EVERY current built-in (dark) preset, the fg-only Tier C
+// literals must be emitted byte-identically.
+func TestBrightPhase2ANSIRolesDarkByteIdentity(t *testing.T) {
+	t.Parallel()
+
+	configs := map[string]ThemeConfig{"fallback": {}}
+	for _, name := range PresetNames() {
+		configs["preset:"+name] = ThemeConfig{Preset: name}
+	}
+	for label, cfg := range configs {
+		roles := ANSIRolesFromEffective(ResolveTheme(cfg))
+		checks := []struct {
+			role string
+			got  string
+			want string
+		}{
+			{"trust.trusted", roles.TrustTrusted, ANSITrustTrustedStart},
+			{"trust.stale", roles.TrustStale, ANSITrustStaleStart},
+			{"trust.untrusted", roles.TrustUntrusted, ANSITrustUntrustedStart},
+			{"notify.title", roles.NotifyTitle, ANSINotifyTitleStart},
+			{"notify.dim", roles.NotifyDim, ANSINotifyDimStart},
+			{"notify.age", roles.NotifyAge, ANSINotifyAgeStart},
+			{"switch.attention_needs", roles.SwitchAttentionNeeds, ANSISwitchAttentionNeedsStart},
+			{"switch.attention_ready", roles.SwitchAttentionReady, ANSISwitchAttentionReadyStart},
+		}
+		for _, c := range checks {
+			if c.got != c.want {
+				t.Fatalf("%s %s = %q, want historical literal %q", label, c.role, c.got, c.want)
+			}
+		}
+	}
+}
+
+// TestBrightPhase2RenderRolesDarkByteIdentity pins the B1 cluster on the tmux
+// side: fallback and every dark preset keep the historical literals for the
+// luma-gated statusbar roles.
+func TestBrightPhase2RenderRolesDarkByteIdentity(t *testing.T) {
+	t.Parallel()
+
+	configs := map[string]ThemeConfig{"fallback": {}}
+	for _, name := range PresetNames() {
+		configs["preset:"+name] = ThemeConfig{Preset: name}
+	}
+	for label, cfg := range configs {
+		roles := RenderRolesFromEffective(ResolveTheme(cfg))
+		checks := []struct {
+			role string
+			got  string
+			want string
+		}{
+			{"decoration.cwd", roles.DecorationCwd, TmuxDecorationCwdFg},
+			{"decoration.gitlab", roles.DecorationGitLab, TmuxDecorationGitLabFg},
+			{"git.staged", roles.GitStaged, TmuxStateStagedFg},
+			{"git.dirty", roles.GitDirty, TmuxStateDirtyFg},
+			{"git.ahead", roles.GitAhead, TmuxStateAheadFg},
+			{"git.behind", roles.GitBehind, TmuxStateBehindFg},
+			{"status.text_primary", roles.StatusTextPrimary, TmuxPrimaryFg},
+			{"status.text_secondary", roles.StatusTextSecondary, TmuxSecondaryFg},
+			{"status.text_muted", roles.StatusTextMuted, TmuxMutedFg},
+			{"accent.ai_fg", roles.AccentAIFg, TmuxAccentAIFg},
+			{"usage.bar_empty", roles.UsageBarEmpty, TmuxUsageEmptyFg},
+			{"pane.border_muted_fg", roles.PaneBorderMutedFg, TmuxMutedFg},
+		}
+		for _, c := range checks {
+			if c.got != c.want {
+				t.Fatalf("%s %s = %q, want historical literal %q", label, c.role, c.got, c.want)
+			}
+		}
+	}
+}
+
+// TestBrightPhase2ANSIRolesLightSurfaceDerivesDarkFg proves the B2 correction:
+// on an explicit light surface every fg-only literal is replaced by a darkened
+// truecolor variant (luma at most the darken target), with leading attributes
+// preserved.
+func TestBrightPhase2ANSIRolesLightSurfaceDerivesDarkFg(t *testing.T) {
+	t.Parallel()
+
+	roles := ANSIRolesFromEffective(ResolveTheme(lightThemeConfig()))
+	checks := []struct {
+		role      string
+		got       string
+		literal   string
+		wantAttrs string
+	}{
+		{"trust.trusted", roles.TrustTrusted, ANSITrustTrustedStart, ""},
+		{"trust.stale", roles.TrustStale, ANSITrustStaleStart, ""},
+		{"trust.untrusted", roles.TrustUntrusted, ANSITrustUntrustedStart, ""},
+		{"notify.title", roles.NotifyTitle, ANSINotifyTitleStart, "1;"},
+		{"notify.dim", roles.NotifyDim, ANSINotifyDimStart, ""},
+		{"notify.age", roles.NotifyAge, ANSINotifyAgeStart, ""},
+		{"switch.attention_needs", roles.SwitchAttentionNeeds, ANSISwitchAttentionNeedsStart, ""},
+		{"switch.attention_ready", roles.SwitchAttentionReady, ANSISwitchAttentionReadyStart, ""},
+	}
+	for _, c := range checks {
+		if c.got == c.literal {
+			t.Fatalf("%s = dark literal %q on light surface, want darkened derivation", c.role, c.got)
+		}
+		attrs, r, g, b := parseANSITruecolorFG(t, c.got)
+		if attrs != c.wantAttrs {
+			t.Fatalf("%s attrs = %q, want %q (escape %q)", c.role, attrs, c.wantAttrs, c.got)
+		}
+		if luma := rec601Luma(r, g, b); luma > contrastDarkenTargetLuma {
+			t.Fatalf("%s = %q with luma %.1f, want <= %.1f on a light surface", c.role, c.got, luma, contrastDarkenTargetLuma)
+		}
+	}
+}
+
+// TestBrightPhase2RenderRolesLightStatusBackgroundDerivesDarkFg proves the B1
+// correction on the tmux side: an explicit light status_background darkens the
+// statusbar text/decoration literals to hex values readable on light chrome.
+func TestBrightPhase2RenderRolesLightStatusBackgroundDerivesDarkFg(t *testing.T) {
+	t.Parallel()
+
+	roles := RenderRolesFromEffective(ResolveTheme(lightThemeConfig()))
+	darkened := []struct {
+		role string
+		got  string
+	}{
+		{"decoration.cwd", roles.DecorationCwd},
+		{"status.text_secondary", roles.StatusTextSecondary},
+		{"status.text_muted", roles.StatusTextMuted},
+		{"accent.ai_fg", roles.AccentAIFg},
+		{"usage.bar_empty", roles.UsageBarEmpty},
+		{"pane.border_muted_fg", roles.PaneBorderMutedFg},
+	}
+	for _, c := range darkened {
+		r, g, b := parseTestHexRGB(t, c.got)
+		if luma := rec601Luma(r, g, b); luma > contrastDarkenTargetLuma {
+			t.Fatalf("%s = %q with luma %.1f, want <= %.1f on a light status background", c.role, c.got, luma, contrastDarkenTargetLuma)
+		}
+	}
+	// Roles rendered inside the fixed dark git segment (bg colour30) must NOT
+	// be darkened even on a light status bar.
+	verbatim := []struct {
+		role string
+		got  string
+		want string
+	}{
+		{"decoration.gitlab", roles.DecorationGitLab, TmuxDecorationGitLabFg},
+		{"git.staged", roles.GitStaged, TmuxStateStagedFg},
+		{"git.dirty", roles.GitDirty, TmuxStateDirtyFg},
+		{"git.ahead", roles.GitAhead, TmuxStateAheadFg},
+		{"git.behind", roles.GitBehind, TmuxStateBehindFg},
+		{"status.text_primary", roles.StatusTextPrimary, TmuxPrimaryFg},
+	}
+	for _, c := range verbatim {
+		if c.got != c.want {
+			t.Fatalf("%s = %q, want verbatim literal %q (renders on a fixed dark badge/segment bg)", c.role, c.got, c.want)
+		}
+	}
+}
+
+// TestBrightPhase2SentinelSurfaceKeepsLiterals: the terminal-default sentinel
+// surface never counts as light — the correction must not fire when the
+// terminal background is unknowable.
+func TestBrightPhase2SentinelSurfaceKeepsLiterals(t *testing.T) {
+	t.Parallel()
+
+	cfg := lightThemeConfig()
+	cfg.Surface = ThemeDefaultSentinel
+	cfg.StatusBackground = ThemeDefaultSentinel
+	cfg.Background = ThemeDefaultSentinel
+	effective := ResolveTheme(cfg)
+
+	ansi := ANSIRolesFromEffective(effective)
+	if ansi.NotifyTitle != ANSINotifyTitleStart {
+		t.Fatalf("notify.title = %q on sentinel surface, want literal %q", ansi.NotifyTitle, ANSINotifyTitleStart)
+	}
+	if ansi.TrustTrusted != ANSITrustTrustedStart {
+		t.Fatalf("trust.trusted = %q on sentinel surface, want literal %q", ansi.TrustTrusted, ANSITrustTrustedStart)
+	}
+	render := RenderRolesFromEffective(effective)
+	if render.DecorationCwd != TmuxDecorationCwdFg {
+		t.Fatalf("decoration.cwd = %q on sentinel status background, want literal %q", render.DecorationCwd, TmuxDecorationCwdFg)
+	}
+	if render.StatusTextSecondary != TmuxSecondaryFg {
+		t.Fatalf("status.text_secondary = %q on sentinel status background, want literal %q", render.StatusTextSecondary, TmuxSecondaryFg)
+	}
+}
+
+// TestBrightPhase2LumaGateBaseColorsMatchLiterals is a self-check: the base
+// RGB values hardcoded into the ANSIRolesFromEffective derivations must match
+// the colors actually baked into the historical literals.
+func TestBrightPhase2LumaGateBaseColorsMatchLiterals(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		role    string
+		literal string
+		r, g, b int
+	}{
+		{"trust.trusted", ANSITrustTrustedStart, 154, 191, 136},
+		{"trust.stale", ANSITrustStaleStart, 177, 139, 212},
+		{"trust.untrusted", ANSITrustUntrustedStart, 210, 139, 88},
+		{"notify.title (colour220)", ANSINotifyTitleStart, 255, 215, 0},
+		{"notify.dim (colour245)", ANSINotifyDimStart, 138, 138, 138},
+		{"notify.age (colour153)", ANSINotifyAgeStart, 175, 215, 255},
+		{"switch.attention_needs (colour220)", ANSISwitchAttentionNeedsStart, 255, 215, 0},
+		{"switch.attention_ready (colour82)", ANSISwitchAttentionReadyStart, 95, 255, 0},
+	}
+	for _, c := range cases {
+		var r, g, b int
+		if strings.Contains(c.literal, "38;2;") {
+			_, r, g, b = parseANSITruecolorFG(t, c.literal)
+		} else {
+			body := strings.TrimSuffix(strings.TrimPrefix(c.literal, "\x1b["), "m")
+			_, after, ok := strings.Cut(body, "38;5;")
+			if !ok {
+				t.Fatalf("%s literal %q is neither truecolor nor 256-color", c.role, c.literal)
+			}
+			n, err := strconv.Atoi(after)
+			if err != nil {
+				t.Fatalf("%s literal %q: %v", c.role, c.literal, err)
+			}
+			r, g, b = xterm256RGB(n)
+		}
+		if r != c.r || g != c.g || b != c.b {
+			t.Fatalf("%s base RGB in derivation = (%d,%d,%d), literal carries (%d,%d,%d)", c.role, c.r, c.g, c.b, r, g, b)
+		}
+	}
+}
+
+// TestContrastDarkenRGBPreservesDarkColors: colors at or below the target luma
+// pass through unchanged; brighter colors are scaled onto the target.
+func TestContrastDarkenRGBPreservesDarkColors(t *testing.T) {
+	t.Parallel()
+
+	if r, g, b := contrastDarkenRGB(40, 60, 50); r != 40 || g != 60 || b != 50 {
+		t.Fatalf("contrastDarkenRGB(dark) = (%d,%d,%d), want unchanged", r, g, b)
+	}
+	r, g, b := contrastDarkenRGB(255, 215, 0)
+	if luma := rec601Luma(r, g, b); luma > contrastDarkenTargetLuma {
+		t.Fatalf("contrastDarkenRGB(gold) luma = %.1f, want <= %.1f", luma, contrastDarkenTargetLuma)
+	}
+	if b != 0 || r <= 0 || g <= 0 || float64(r)/float64(g) < 255.0/215.0-0.05 || float64(r)/float64(g) > 255.0/215.0+0.05 {
+		t.Fatalf("contrastDarkenRGB(gold) = (%d,%d,%d), want hue-preserving scale of (255,215,0)", r, g, b)
+	}
+}
+
+// TestANSIFgFromTmuxColor covers the RenderRoles->ANSI adapter used by the
+// statusbar usage popup severity text.
+func TestANSIFgFromTmuxColor(t *testing.T) {
+	t.Parallel()
+
+	if got, want := ANSIFgFromTmuxColor("colour214"), "\x1b[38;5;214m"; got != want {
+		t.Fatalf("ANSIFgFromTmuxColor(colour214) = %q, want %q", got, want)
+	}
+	if got, want := ANSIFgFromTmuxColor(TmuxStateCriticalFg+",bold"), "\x1b[38;5;160m"; got != want {
+		t.Fatalf("ANSIFgFromTmuxColor(colour160,bold) = %q, want %q", got, want)
+	}
+	if got, want := ANSIFgFromTmuxColor("#ffcc66"), "\x1b[38;2;255;204;102m"; got != want {
+		t.Fatalf("ANSIFgFromTmuxColor(#ffcc66) = %q, want %q", got, want)
+	}
+	if got := ANSIFgFromTmuxColor("red"); got != "" {
+		t.Fatalf("ANSIFgFromTmuxColor(red) = %q, want empty for unknown forms", got)
+	}
+	// Byte-identity bridge: for every fallback state role the adapter emits the
+	// same escape the statusbar popup historically hardcoded.
+	fallback := RenderRolesFromEffective(ResolveTheme(ThemeConfig{}))
+	if got, want := ANSIFgFromTmuxColor(fallback.StateWarning), ANSI256FgStart(TmuxStateWarningFg); got != want {
+		t.Fatalf("fallback state.warning adapter = %q, want %q", got, want)
+	}
+	if got, want := ANSIFgFromTmuxColor(fallback.StateCritical), ANSI256FgStart(TmuxStateCriticalFg); got != want {
+		t.Fatalf("fallback state.critical adapter = %q, want %q", got, want)
+	}
+	if got, want := ANSIFgFromTmuxColor(fallback.StateSuccess), ANSI256FgStart(TmuxStateSuccessFg); got != want {
+		t.Fatalf("fallback state.success adapter = %q, want %q", got, want)
+	}
+}
+
+// TestColorFieldIsLight pins the gate: fallback, sentinel, dark hex -> false;
+// light hex -> true.
+func TestColorFieldIsLight(t *testing.T) {
+	t.Parallel()
+
+	if colorFieldIsLight(ColorField{}) {
+		t.Fatal("zero ColorField must not be light")
+	}
+	if colorFieldIsLight(ColorField{Value: ColorSpec{Hex: "#ffffff"}, Source: SourceFallback}) {
+		t.Fatal("fallback-sourced field must never be light")
+	}
+	if colorFieldIsLight(ColorField{Value: ColorSpec{Tmux: ThemeDefaultSentinel}, Source: SourceGlobal}) {
+		t.Fatal("terminal-default sentinel must never be light")
+	}
+	if colorFieldIsLight(ColorField{Value: ColorSpec{Hex: "#182226"}, Source: SourceGlobal}) {
+		t.Fatal("dark explicit surface must not be light")
+	}
+	if !colorFieldIsLight(ColorField{Value: ColorSpec{Hex: "#f2f2ee"}, Source: SourceGlobal}) {
+		t.Fatal("light explicit surface must be light")
+	}
+}
+
+// TestBrightPhase2LightThemePassesDesignSanity keeps the light test palette
+// honest: all five state colors must stay mutually distinguishable after tmux
+// 256 quantization, mirroring the preset design rubric that a future Phase 1
+// bright preset must pass.
+func TestBrightPhase2LightThemePassesDesignSanity(t *testing.T) {
+	t.Parallel()
+
+	effective := ResolveTheme(lightThemeConfig())
+	seen := map[string]string{}
+	for name, field := range map[string]ColorField{
+		"progress":        effective.Progress,
+		"warning":         effective.Warning,
+		"critical":        effective.Critical,
+		"success":         effective.Success,
+		"action_required": effective.ActionRequired,
+	} {
+		key := field.Value.Tmux
+		if other, dup := seen[key]; dup {
+			t.Fatalf("light test palette: %s and %s collide on %s after quantization", name, other, key)
+		}
+		seen[key] = name
+	}
+}

--- a/internal/theme/palette.go
+++ b/internal/theme/palette.go
@@ -96,7 +96,6 @@ const (
 	TmuxGoneBg      = "colour238"
 
 	TmuxAccentAttentionBg  = "colour53"
-	TmuxAccentAttentionFg  = "colour225"
 	TmuxAttentionProjectBg = "colour90"
 	TmuxAccentAIBg         = "colour37"
 	TmuxAccentAIFg         = "colour121"
@@ -117,11 +116,7 @@ const (
 	TmuxGitSegmentBg = "colour30"
 	TmuxGitSegmentFg = TmuxPrimaryFg
 
-	TmuxUsageEmptyFg        = TmuxGoneBg
-	TmuxUsageOKFg           = TmuxStateSuccessFg
-	TmuxUsageWarningFg      = TmuxStateWarningFg
-	TmuxUsageCriticalFg     = TmuxStateCriticalFg
-	TmuxUsageCriticalBoldFg = TmuxStateCriticalFg + ",bold"
+	TmuxUsageEmptyFg = TmuxGoneBg
 
 	TmuxPaneBorderFg       = "colour236"
 	TmuxPaneActiveBorderFg = "colour51"
@@ -131,10 +126,8 @@ const (
 	TmuxMessageBg          = "colour208"
 	TmuxMessageFg          = "colour16"
 
-	TmuxDecorationCwdFg        = "colour220"
-	TmuxDecorationGitHubFg     = TmuxStateAheadFg
-	TmuxDecorationGitLabFg     = "colour215"
-	TmuxDecorationGenericGitFg = TmuxStateStagedFg
+	TmuxDecorationCwdFg    = "colour220"
+	TmuxDecorationGitLabFg = "colour215"
 
 	// Kube keeps tmux's named red/blue for output compatibility with the
 	// existing status segment until the segment gets a dedicated redesign.

--- a/internal/theme/palette_test.go
+++ b/internal/theme/palette_test.go
@@ -48,7 +48,7 @@ func TestANSI256FgStart(t *testing.T) {
 	if got, want := ANSI256FgStart(TmuxStateWarningFg), "\x1b[38;5;214m"; got != want {
 		t.Fatalf("ANSI256FgStart(warning) = %q, want %q", got, want)
 	}
-	if got, want := ANSI256FgStart(TmuxUsageCriticalBoldFg), "\x1b[38;5;160m"; got != want {
+	if got, want := ANSI256FgStart(TmuxStateCriticalFg+",bold"), "\x1b[38;5;160m"; got != want {
 		t.Fatalf("ANSI256FgStart(critical,bold) = %q, want %q", got, want)
 	}
 }

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -310,6 +310,22 @@ type RenderRoles struct {
 
 	// statusbar divider (Phase 4). Renderer-only literal; kept simple, not derived.
 	DividerFg string // divider.fg Tier C renderer-only (colour239)
+
+	// statusbar/HUD text cluster (bright preset Phase 2, B1). Bare fg literals
+	// migrated from direct palette consumption into roles. StatusTextPrimary is
+	// carried verbatim because its only consumers pair it with fixed dark badge
+	// backgrounds (colour90/240/238 and the severity badge bgs), so its contrast
+	// does not depend on status_background. The remaining roles render directly
+	// on status_background (or the pane body background) and are Tier B
+	// luma-gated: an explicit LIGHT backing token derives a darkened,
+	// hue-preserving variant; the fallback theme and every dark background keep
+	// the historical literal byte-identical.
+	StatusTextPrimary   string // status.text_primary   Tier C verbatim (colour231) — badge fg on fixed dark badge bgs
+	StatusTextSecondary string // status.text_secondary Tier B luma-gated vs status_background (colour245)
+	StatusTextMuted     string // status.text_muted     Tier B luma-gated vs status_background (colour244)
+	AccentAIFg          string // accent.ai_fg          Tier B luma-gated vs status_background (colour121) — usage HUD model label
+	UsageBarEmpty       string // usage.bar_empty       Tier B luma-gated vs status_background (colour238)
+	PaneBorderMutedFg   string // pane.border_muted_fg  Tier B luma-gated vs background (colour244) — inactive pane border label
 }
 
 // RenderRolesFromEffective derives the semantic role map from an effective
@@ -373,10 +389,15 @@ func RenderRolesFromEffective(effective EffectiveTheme) RenderRoles {
 		GitAhead:     TmuxStateAheadFg,
 		GitBehind:    TmuxStateBehindFg,
 
-		// statusbar decoration: cwd is its OWN Tier C role (independent of
-		// state.progress). github/generic-git decorations reuse GitAhead/
-		// GitStaged above, so only cwd/gitlab carry their own literal here.
-		DecorationCwd:    TmuxDecorationCwdFg,
+		// statusbar decoration: cwd is its OWN role (independent of
+		// state.progress). It renders directly on status_background, so it is
+		// Tier B luma-gated (bright Phase 2): light status bar -> darkened
+		// variant, dark/fallback -> historical colour220 verbatim. The gitlab
+		// decoration and the git state fgs (GitStaged/Dirty/Ahead/Behind above)
+		// stay verbatim: they render INSIDE the git segment whose background is
+		// the fixed dark GitSegmentBg (colour30), so their contrast does not
+		// depend on status_background.
+		DecorationCwd:    tmuxLumaContrastOrLiteral(effective.StatusBackground, TmuxDecorationCwdFg),
 		DecorationGitLab: TmuxDecorationGitLabFg,
 
 		// kube: tmux named colors carried verbatim (Tier C).
@@ -391,6 +412,16 @@ func RenderRolesFromEffective(effective EffectiveTheme) RenderRoles {
 
 		// divider: Tier C renderer-only literal.
 		DividerFg: TmuxDividerFg,
+
+		// statusbar/HUD text cluster (bright Phase 2, B1): primary verbatim
+		// (only used on fixed dark badge bgs); the rest luma-gated against the
+		// token that actually backs their render surface.
+		StatusTextPrimary:   TmuxPrimaryFg,
+		StatusTextSecondary: tmuxLumaContrastOrLiteral(effective.StatusBackground, TmuxSecondaryFg),
+		StatusTextMuted:     tmuxLumaContrastOrLiteral(effective.StatusBackground, TmuxMutedFg),
+		AccentAIFg:          tmuxLumaContrastOrLiteral(effective.StatusBackground, TmuxAccentAIFg),
+		UsageBarEmpty:       tmuxLumaContrastOrLiteral(effective.StatusBackground, TmuxUsageEmptyFg),
+		PaneBorderMutedFg:   tmuxLumaContrastOrLiteral(effective.Background, TmuxMutedFg),
 	}
 }
 
@@ -478,6 +509,85 @@ func tmuxContrastFgOrFallback(bg ColorField, fallback string) string {
 		return "colour16"
 	}
 	return "colour231"
+}
+
+// Luma-gated contrast correction (bright preset Phase 2). Tier C renderer
+// literals were tuned for dark chrome; when an explicit theme paints the
+// backing surface LIGHT, the literal is darkened (hue preserved) so it stays
+// readable. The gate is deliberately conservative: fallback-sourced fields,
+// the terminal-default sentinel, and every dark background return the
+// historical literal verbatim, so the fallback theme and all current built-in
+// (dark) presets stay byte-identical.
+const (
+	// lightBackgroundLumaThreshold mirrors tmuxContrastFgOrFallback's split
+	// point: a background at or above this Rec. 601 luma is treated as light.
+	lightBackgroundLumaThreshold = 140.0
+	// contrastDarkenTargetLuma is the luma ceiling applied when darkening a
+	// literal for a light background.
+	contrastDarkenTargetLuma = 96.0
+)
+
+// rec601Luma returns the Rec. 601 luma of an RGB color in [0, 255].
+func rec601Luma(r, g, b int) float64 {
+	return 0.299*float64(r) + 0.587*float64(g) + 0.114*float64(b)
+}
+
+// colorFieldIsLight reports whether an effective background field is an
+// explicit light color. Fallback-sourced fields and the terminal-default
+// sentinel are never light, so every correction gated on this predicate keeps
+// its historical literal for the fallback theme and all dark presets.
+func colorFieldIsLight(field ColorField) bool {
+	if field.Source == SourceFallback || IsThemeDefaultSpec(field.Value) {
+		return false
+	}
+	r, g, b, ok := parseHexRGB(field.Value.Hex)
+	if !ok {
+		return false
+	}
+	return rec601Luma(r, g, b) >= lightBackgroundLumaThreshold
+}
+
+// contrastDarkenRGB scales an RGB color toward black until its luma is at most
+// contrastDarkenTargetLuma, preserving hue. Colors already dark enough pass
+// through unchanged.
+func contrastDarkenRGB(r, g, b int) (int, int, int) {
+	luma := rec601Luma(r, g, b)
+	if luma <= contrastDarkenTargetLuma {
+		return r, g, b
+	}
+	f := contrastDarkenTargetLuma / luma
+	return int(float64(r) * f), int(float64(g) * f), int(float64(b) * f)
+}
+
+// tmuxColourLiteralRGB resolves a tmux colourN literal (optionally carrying a
+// ",style" suffix) to its xterm-256 RGB value.
+func tmuxColourLiteralRGB(literal string) (int, int, int, bool) {
+	base := strings.Split(literal, ",")[0]
+	if !strings.HasPrefix(base, "colour") {
+		return 0, 0, 0, false
+	}
+	n, err := strconv.Atoi(strings.TrimPrefix(base, "colour"))
+	if err != nil || n < 0 || n > 255 {
+		return 0, 0, 0, false
+	}
+	r, g, b := xterm256RGB(n)
+	return r, g, b, true
+}
+
+// tmuxLumaContrastOrLiteral is the Tier B luma-gated contrast transform for
+// statusbar Tier C literals: on an explicit light background the literal is
+// darkened and emitted as exact hex; otherwise the historical literal is
+// returned verbatim (byte-identity).
+func tmuxLumaContrastOrLiteral(bg ColorField, literal string) string {
+	if !colorFieldIsLight(bg) {
+		return literal
+	}
+	r, g, b, ok := tmuxColourLiteralRGB(literal)
+	if !ok {
+		return literal
+	}
+	dr, dg, db := contrastDarkenRGB(r, g, b)
+	return fmt.Sprintf("#%02x%02x%02x", dr, dg, db)
 }
 
 type preset struct {

--- a/internal/theme/resolve_test.go
+++ b/internal/theme/resolve_test.go
@@ -247,6 +247,14 @@ func TestRenderRolesFallbackUsesTerminalDefaultPaneAndPopupBackgrounds(t *testin
 		ActionBg:          TmuxActionBg,
 		ActionFg:          TmuxActionFg,
 		DividerFg:         TmuxDividerFg,
+		// bright Phase 2 statusbar text cluster: fallback keeps the historical
+		// bare literals verbatim.
+		StatusTextPrimary:   TmuxPrimaryFg,
+		StatusTextSecondary: TmuxSecondaryFg,
+		StatusTextMuted:     TmuxMutedFg,
+		AccentAIFg:          TmuxAccentAIFg,
+		UsageBarEmpty:       TmuxUsageEmptyFg,
+		PaneBorderMutedFg:   TmuxMutedFg,
 	}
 	if got != want {
 		t.Fatalf("fallback render roles = %#v, want %#v", got, want)

--- a/internal/ui/render/bright_phase2_test.go
+++ b/internal/ui/render/bright_phase2_test.go
@@ -1,0 +1,92 @@
+package render
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/theme"
+)
+
+// bright_phase2_test.go covers the render-package pieces of the bright preset
+// Phase 2 corrections: the usage bar empty-cell role (B1) and the switch
+// attention dots (B2) under an explicit light theme, plus fallback
+// byte-identity for both.
+
+func renderLightTheme() theme.EffectiveTheme {
+	return theme.ResolveTheme(theme.ThemeConfig{
+		Background:       "#f5f5f0",
+		Surface:          "#f2f2ee",
+		StatusBackground: "#e8e8e2",
+		SurfaceActive:    "#d8d8d0",
+		ChromeForeground: "#2a2e32",
+		TextPrimary:      "#1f2428",
+		Foreground:       "#1f2428",
+		Muted:            "#6a7076",
+		Accent:           "#0f7b6c",
+		Critical:         "#c62828",
+		Warning:          "#9a6700",
+		Progress:         "#0757ba",
+		Success:          "#1a7f37",
+		ActionRequired:   "#b35900",
+		PaneActiveBg:     "#e2e2da",
+		Focus:            "#0757ba",
+	})
+}
+
+// TestBarEmptyColorForRolesFollowsUsageBarEmptyRole: fallback and zero-value
+// roles keep the historical literal; a light status background derives a dark
+// hex.
+func TestBarEmptyColorForRolesFollowsUsageBarEmptyRole(t *testing.T) {
+	t.Parallel()
+
+	fallback := theme.RenderRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{}))
+	if got := BarEmptyColorForRoles(fallback); got != theme.TmuxUsageEmptyFg {
+		t.Fatalf("fallback bar empty color = %q, want %q", got, theme.TmuxUsageEmptyFg)
+	}
+	if got := BarEmptyColorForRoles(theme.RenderRoles{}); got != theme.TmuxUsageEmptyFg {
+		t.Fatalf("zero-roles bar empty color = %q, want %q", got, theme.TmuxUsageEmptyFg)
+	}
+	light := theme.RenderRolesFromEffective(renderLightTheme())
+	got := BarEmptyColorForRoles(light)
+	if got == theme.TmuxUsageEmptyFg || !strings.HasPrefix(got, "#") {
+		t.Fatalf("light bar empty color = %q, want hex derivation distinct from %q", got, theme.TmuxUsageEmptyFg)
+	}
+}
+
+// TestSwitchAttentionDotsRepaintOnLightTheme proves the B2 wiring end to end:
+// ApplyTheme with a light theme repoints the attention dot escapes at the
+// darkened derivations, and reapplying the fallback restores byte-identity.
+//
+// NOTE: intentionally NOT t.Parallel() — ApplyTheme mutates the package-level
+// role escapes consumed by the switch/sessions/popup formatters.
+func TestSwitchAttentionDotsRepaintOnLightTheme(t *testing.T) {
+	fallback := theme.ANSIRolesFromEffective(theme.ResolveTheme(theme.ThemeConfig{}))
+	ApplyTheme(theme.ANSIRolesFromEffective(renderLightTheme()))
+	defer ApplyTheme(fallback)
+
+	needs := formatInlineAttentionBadge("", 2, "dot")
+	ready := formatInlineAttentionBadge("", 1, "dot")
+	if strings.Contains(needs, theme.ANSISwitchAttentionNeedsStart) {
+		t.Fatalf("needs dot still carries the dark literal under a light theme: %q", needs)
+	}
+	if strings.Contains(ready, theme.ANSISwitchAttentionReadyStart) {
+		t.Fatalf("ready dot still carries the dark literal under a light theme: %q", ready)
+	}
+	if !strings.Contains(needs, "\x1b[38;2;") || !strings.Contains(ready, "\x1b[38;2;") {
+		t.Fatalf("attention dots carry no truecolor derivation: %q / %q", needs, ready)
+	}
+
+	// session-popup preview progress text follows the explicit progress token.
+	part := formatPaneStatusPart("state", "thinking", true)
+	if !strings.Contains(part, "\x1b[38;2;7;87;186m") {
+		t.Fatalf("popup progress part = %q, want truecolor of #0757ba", part)
+	}
+
+	ApplyTheme(fallback)
+	if got := formatInlineAttentionBadge("", 2, "dot"); !strings.Contains(got, theme.ANSISwitchAttentionNeedsStart) {
+		t.Fatalf("needs dot not restored to the fallback literal: %q", got)
+	}
+	if got := formatPaneStatusPart("state", "thinking", true); !strings.Contains(got, theme.ANSIStateProgressStart) {
+		t.Fatalf("popup progress part not restored to the fallback literal: %q", got)
+	}
+}

--- a/internal/ui/render/usagebar.go
+++ b/internal/ui/render/usagebar.go
@@ -108,11 +108,15 @@ func BarColorForPct(pct float64, roles theme.RenderRoles) string {
 	}
 }
 
-// BarEmptyColorForRoles returns the tmux color used for empty bar cells. It is
-// the muted/gone bg literal (TmuxUsageEmptyFg = TmuxGoneBg) carried as the
-// usage-empty role; not yet runtime-derived (Phase 6 candidate).
-func BarEmptyColorForRoles(_ theme.RenderRoles) string {
-	return theme.TmuxUsageEmptyFg
+// BarEmptyColorForRoles returns the tmux color used for empty bar cells,
+// sourced from the usage.bar_empty role (bright Phase 2, B1): the fallback and
+// dark themes keep the historical TmuxUsageEmptyFg literal; a light
+// status_background derives a contrast-corrected variant.
+func BarEmptyColorForRoles(roles theme.RenderRoles) string {
+	if roles.UsageBarEmpty == "" {
+		return theme.TmuxUsageEmptyFg
+	}
+	return roles.UsageBarEmpty
 }
 
 // BarEmptyColor is the tmux color used for empty bar cells across the HUD.


### PR DESCRIPTION
## Summary

Implements **Theme bright preset roadmap — Phase 2: light-background contrast corrections** (clusters B1/B2/B3 from the Phase 0 dark-assumption audit), plus an optional dead-code cleanup commit. Phase 1 (adding an actual bright preset to `builtinPresets`) is intentionally **not** included — execution order is Phase 2 → Phase 1 per the roadmap decision.

## What changed (per cluster)

### B1 — statusbar/HUD zero-theme cluster (tmux side)
- Removed every `theme.RenderRolesFromEffective(theme.EffectiveTheme{})` zero-value call site (`status.go`, `statusbar.go`, `usagecmd/usage.go`, `tmux.go`, `attention.go`).
- `projmux status git|kube|notify|usage` and `projmux attention window` subprocesses now apply the resolved effective theme at `Run` entry (`applyNativeUIThemeFromConfig`), rebuilding the status segment / notify HUD / usage HUD role escapes via the new `applyStatusSegmentTheme` + `usagecmd.ApplyStatusTheme`.
- Generated tmux config (session-left, cwd segment, settings button, clock, pane-border muted label) now takes roles derived from the **same** effective theme the config is generated with; bare `TmuxPrimaryFg`/`TmuxSecondaryFg`/`TmuxMutedFg`/`TmuxAccentAIFg`/`TmuxUsageEmptyFg` fg literals migrated to new roles (`StatusTextPrimary/Secondary/Muted`, `AccentAIFg`, `UsageBarEmpty`, `PaneBorderMutedFg`). `BarEmptyColorForRoles` now honors its roles argument.
- Tier C statusbar literal correction: `decoration.cwd` (colour220) is **luma-gated** against `status_background` — an explicit light status bar derives a darkened hue-preserving hex; dark/fallback emits the historical literal verbatim. `decoration.gitlab` and the git state fgs stay verbatim because they render inside the git segment's fixed dark `colour30` background (per the audit's own (a)-class note); darkening them would break contrast on their actual backing surface.

### B2 — native popup fg-only literal cluster (ANSI side)
- `internal/theme/ansiroles.go`: notify title/dim/age, switch attention needs/ready dots, and trust trusted/stale/untrusted are now **surface-luma-gated**: an explicit light `surface` re-emits the literal's base color darkened (hue preserved, leading attributes such as bold kept) as a truecolor escape; fallback, terminal-default sentinel, and every dark surface return the historical literal **byte-for-byte**.
- Design decision: luma-derivation (not public-token derivation) was chosen deliberately — promoting these roles to token derivation would change the emitted bytes for existing explicit dark presets, violating the byte-identity constraint.

### B3 — theme entry-point coverage gaps
- New `applyNativeUIThemeFromConfig` wraps: `projmux sessions`, `projmux session-popup` (preview progress amber), `projmux statusbar` (pwd/usage popups), and the hook-trust prompt — joining the existing settings/switch/recent/notify entry points.
- Statusbar popup direct `ANSITextMutedStart` literals and the zero-theme usage severity colors migrated to themed vars (`statusbarMutedANSI`, `statusbarSev*ANSI` via the new `theme.ANSIFgFromTmuxColor` adapter, byte-identical to `ANSI256FgStart` for fallback roles); hook-trust header/muted likewise.

### Dead-code cleanup (separate commit)
Removed (zero consumers, render output unchanged): `TmuxUsageOKFg/WarningFg/CriticalFg/CriticalBoldFg`, `TmuxDecorationGitHubFg/GenericGitFg`, `TmuxAccentAttentionFg` + app alias, `notifySidebarTopicOpen`.
Deliberately kept: `ANSISurfaceRaisedStart/RuleStart` (picker titlebar consumes them), `ANSIRoles.SurfaceActive` (now consumed by the hook-trust header), `TmuxPaneActiveTintBg` (statically referenced fallback), `fgWhite`, remaining audit-listed `ANSIRoles` fields (existing adapter tests assert them), and the highlight-derivation adapter mismatch (aligning it would change explicit-theme render output → skipped per constraints).

## User-facing surfaces touched
statusbar rows 1–2 (cwd decorator/path, clock, session/settings chrome plumbing), notify HUD segment, usage HUD segment + usage/pwd statusbar popups, notify sidebar (title/dim/age), switch cards (attention dots), trust rows (settings + hook-trust popup), sessions picker rows, session-popup preview. **All of these render byte-identically today** — the corrections only activate when a future light theme paints `surface`/`status_background` light.

## Explicitly out of scope (Phase 1, follow-up)
- No bright preset added to `builtinPresets`; no new public `[theme]` tokens; no preset resolver redesign; no OS light/dark detection or terminal theme sync.
- Follow-up Phase 1: design the light palette against the design rubric (`preset_design_test.go`), add the preset, decide `PresetNames()` priority placement, update `docs/theme-palette.md`.

## Dark preset / fallback byte-identity
Guaranteed and test-pinned:
- `internal/app/bright_phase2_identity_test.go` — SHA-256 goldens of the full generated standalone/app tmux configs for the fallback theme and **all 7 built-in presets**, captured at main `fa3da53` (pre-change), plus an exact-bytes notify segment test.
- `internal/theme/bright_phase2_test.go` — every affected ANSI/tmux role must equal its historical literal for fallback + all presets; sentinel surfaces never trigger the correction; hardcoded derivation base RGBs are cross-checked against the literals.
- `internal/app/usagecmd/bright_phase2_test.go` — exact-bytes usage HUD golden.
- Light-injection unit tests (per acceptance): light `EffectiveTheme` values are injected in tests only; roles/escapes must come out dark-contrast (luma ≤ target) with attributes preserved (`internal/theme`, `internal/app`, `internal/app/usagecmd`, `internal/ui/render`).

## Verification
- `make fmt` — clean.
- `make fix` — `go fix` + deadcode gate clean.
- `make test` — full suite green (run in the worktree).

## Not verified / e2e candidates
- Real tmux rendering was **not** exercised (unit-level only): live statusbar rows 1–2 under a light `status_background`, notify/usage HUD in a running tmux server, `display-popup` body vs picker-frame repaint interplay, hook-trust popup in a real popup client, and per-refresh config-read overhead of `status`/`attention window` subprocesses (one extra global-config TOML read per invocation).
- Bright preset itself (Phase 1) — acceptance "라이트 배경 터미널 실 tmux 가독성 수동 확인" belongs to that phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
