### PR TITLE
feat(theme): add daylight fully-light builtin preset (bright preset Phase 1)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -273,7 +273,10 @@ of these is a public token: leave it unset to keep the historical built-in
 color, or set it to repaint the matching chrome.
 
 Supported presets are `projmux`, `high-contrast`, `blue-hour`, `carbon-violet`,
-`ember`, `forest`, and `rose`. A preset fills
+`daylight`, `ember`, `forest`, and `rose`. `daylight` is the fully-light
+preset; the others are dark. Preset colors paint projmux chrome only (status
+bar, popups, pane borders/tint) — pane contents follow the terminal theme, so
+`daylight` pairs best with a light terminal theme. A preset fills
 missing color tokens, and explicit color tokens override preset values. Tokens
 the global theme leaves unset fall through to the built-in fallback preset.
 Terminal-default backgrounds are configured per token with the `default`

--- a/docs/theme-palette.md
+++ b/docs/theme-palette.md
@@ -159,6 +159,7 @@ Built-in preset config values are:
 - `high-contrast`
 - `blue-hour`
 - `carbon-violet`
+- `daylight`
 - `ember`
 - `forest`
 - `rose`
@@ -167,9 +168,41 @@ Built-in preset config values are:
   and a deep indigo active pane tint.
 - `carbon-violet` — charcoal/violet dark theme with darker popup/status
   surfaces and a black active pane tint.
+- `daylight` — the fully-light preset: warm paper pane/popup surfaces, an
+  explicit light status bar, dark slate text, a teal accent, a strong blue
+  focus border, and darkened saturated state colors (red/amber/blue/green/
+  orange) tuned to stay distinguishable on light chrome after 256-color
+  quantization. The active pane tint sits one tone darker than the pane body
+  (the inverse of the dark presets).
 - `high-contrast` — black surfaces, white text, a dark blue active surface,
   near-black active pane tint, vivid cyan focus, and bright
   cyan/yellow/red/green state colors.
+
+Preset colors paint projmux chrome only — the tmux status bar, picker/popup
+frames, pane borders, and the pane background tint. Pane contents (shell
+prompt, editor, command output) follow the terminal/shell theme, so a fully
+light experience with `daylight` also requires a light terminal theme.
+
+`daylight` palette values:
+
+| Token | Hex | Nearest tmux |
+| --- | --- | --- |
+| `background` | `#f2efe9` | `colour255` |
+| `surface` | `#faf7f1` | `colour255` |
+| `status_background` | `#dfdad0` | `colour188` |
+| `surface_active` | `#cfe0f0` | `colour189` |
+| `chrome_foreground` | `#3a4550` | `colour238` |
+| `text_primary` | `#2c3338` | `colour236` |
+| `foreground` | `#2c3338` | `colour236` |
+| `muted` | `#6b7680` | `colour243` |
+| `accent` | `#0f766e` | `colour6` |
+| `critical` | `#c62828` | `colour160` |
+| `warning` | `#b45309` | `colour130` |
+| `progress` | `#1d4ed8` | `colour26` |
+| `success` | `#15803d` | `colour29` |
+| `action_required` | `#d97706` | `colour172` |
+| `pane_active_bg` | `#e8e4dc` | `colour254` |
+| `focus` | `#2563eb` | `colour26` |
 
 ## Fallback Inventory
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -88,7 +88,8 @@ should visibly sink. The active-pane border (`focus`) defaults to cyan
 `colour51`. Both apply only to tmux pane chrome.
 
 Built-in presets are intentionally small: `projmux`, `high-contrast`,
-`blue-hour`, `carbon-violet`, `ember`, `forest`, and `rose`. Terminal-default
+`blue-hour`, `carbon-violet`, `daylight`, `ember`, `forest`, and `rose`
+(`daylight` is the fully-light one). Terminal-default
 backgrounds are configured per token with the `default` sentinel rather than
 through separate terminal preset variants.
 

--- a/internal/theme/bright_phase2_test.go
+++ b/internal/theme/bright_phase2_test.go
@@ -72,13 +72,15 @@ func parseTestHexRGB(t *testing.T, hex string) (int, int, int) {
 }
 
 // TestBrightPhase2ANSIRolesDarkByteIdentity pins the B2 cluster: for the
-// fallback theme and EVERY current built-in (dark) preset, the fg-only Tier C
-// literals must be emitted byte-identically.
+// fallback theme and EVERY dark built-in preset, the fg-only Tier C
+// literals must be emitted byte-identically. Fully-light presets (Phase 1,
+// e.g. daylight) intentionally trigger the light-surface derivations and are
+// covered by the light-derivation tests below.
 func TestBrightPhase2ANSIRolesDarkByteIdentity(t *testing.T) {
 	t.Parallel()
 
 	configs := map[string]ThemeConfig{"fallback": {}}
-	for _, name := range PresetNames() {
+	for _, name := range darkPresetNames() {
 		configs["preset:"+name] = ThemeConfig{Preset: name}
 	}
 	for label, cfg := range configs {
@@ -105,14 +107,31 @@ func TestBrightPhase2ANSIRolesDarkByteIdentity(t *testing.T) {
 	}
 }
 
+// darkPresetNames returns the built-in presets whose luma-gated backing
+// surfaces are all dark — the presets whose Tier C literals must stay
+// byte-identical. Fully-light presets are excluded: their light backgrounds
+// are exactly what the Phase 2 derivations exist to correct.
+func darkPresetNames() []string {
+	out := make([]string, 0, len(builtinPresets))
+	for _, name := range PresetNames() {
+		effective := ResolveTheme(ThemeConfig{Preset: name})
+		if colorFieldIsLight(effective.Surface) || colorFieldIsLight(effective.StatusBackground) || colorFieldIsLight(effective.Background) {
+			continue
+		}
+		out = append(out, name)
+	}
+	return out
+}
+
 // TestBrightPhase2RenderRolesDarkByteIdentity pins the B1 cluster on the tmux
 // side: fallback and every dark preset keep the historical literals for the
-// luma-gated statusbar roles.
+// luma-gated statusbar roles. Fully-light presets are excluded for the same
+// reason as the ANSI-side test above.
 func TestBrightPhase2RenderRolesDarkByteIdentity(t *testing.T) {
 	t.Parallel()
 
 	configs := map[string]ThemeConfig{"fallback": {}}
-	for _, name := range PresetNames() {
+	for _, name := range darkPresetNames() {
 		configs["preset:"+name] = ThemeConfig{Preset: name}
 	}
 	for label, cfg := range configs {

--- a/internal/theme/daylight_preset_test.go
+++ b/internal/theme/daylight_preset_test.go
@@ -1,0 +1,91 @@
+package theme
+
+import "testing"
+
+// daylight_preset_test.go pins the Phase 1 fully-light built-in preset: every
+// backing surface is a concrete light color (option 2 — no dark status bar, no
+// terminal-default sentinel), foreground text is dark, and the Phase 2
+// light-background derivations actually fire for it.
+
+func TestDaylightPresetIsFullyLight(t *testing.T) {
+	t.Parallel()
+
+	effective := ResolveTheme(ThemeConfig{Preset: "daylight"})
+	for name, field := range map[string]ColorField{
+		"background":        effective.Background,
+		"surface":           effective.Surface,
+		"status_background": effective.StatusBackground,
+		"pane_active_bg":    effective.PaneActiveBg,
+	} {
+		if IsThemeDefaultSpec(field.Value) {
+			t.Fatalf("daylight %s rides the terminal default; a fully-light preset must pin every surface", name)
+		}
+		if !colorFieldIsLight(field) {
+			t.Fatalf("daylight %s = %q is not a light color", name, field.Value.Hex)
+		}
+	}
+	if got, want := effective.Background.Value.Hex, "#f2efe9"; got != want {
+		t.Fatalf("daylight background = %q, want warm paper %q", got, want)
+	}
+	if got, want := effective.StatusBackground.Value.Hex, "#dfdad0"; got != want {
+		t.Fatalf("daylight status_background = %q, want explicit light status surface %q", got, want)
+	}
+	if effective.StatusBackground.Value.Hex == effective.Surface.Value.Hex {
+		t.Fatalf("daylight status_background equals surface %q; it must be defined explicitly, not surface auto-fill", effective.Surface.Value.Hex)
+	}
+
+	// Text tokens must be dark on the light surfaces.
+	for name, field := range map[string]ColorField{
+		"chrome_foreground": effective.ChromeForeground,
+		"text_primary":      effective.TextPrimary,
+		"foreground":        effective.Foreground,
+	} {
+		r, g, b, ok := parseHexRGB(field.Value.Hex)
+		if !ok {
+			t.Fatalf("daylight %s = %q is not a hex color", name, field.Value.Hex)
+		}
+		if luma := rec601Luma(r, g, b); luma >= lightBackgroundLumaThreshold {
+			t.Fatalf("daylight %s = %q luma %.1f; text must be dark on a light background", name, field.Value.Hex, luma)
+		}
+	}
+
+	// pane_active_bg sinks: one tone darker than the pane body background
+	// (inverse of the dark presets' relationship).
+	br, bg, bb, _ := parseHexRGB(effective.Background.Value.Hex)
+	ar, ag, ab, _ := parseHexRGB(effective.PaneActiveBg.Value.Hex)
+	if rec601Luma(ar, ag, ab) >= rec601Luma(br, bg, bb) {
+		t.Fatalf("daylight pane_active_bg %q is not darker than background %q", effective.PaneActiveBg.Value.Hex, effective.Background.Value.Hex)
+	}
+}
+
+func TestDaylightPresetTriggersLightDerivations(t *testing.T) {
+	t.Parallel()
+
+	effective := ResolveTheme(ThemeConfig{Preset: "daylight"})
+
+	render := RenderRolesFromEffective(effective)
+	for role, got := range map[string]string{
+		"decoration.cwd":        render.DecorationCwd,
+		"status.text_secondary": render.StatusTextSecondary,
+		"status.text_muted":     render.StatusTextMuted,
+		"accent.ai_fg":          render.AccentAIFg,
+		"usage.bar_empty":       render.UsageBarEmpty,
+		"pane.border_muted_fg":  render.PaneBorderMutedFg,
+	} {
+		r, g, b, ok := parseHexRGB(got)
+		if !ok {
+			t.Fatalf("daylight %s = %q, want darkened #rrggbb derivation on light chrome", role, got)
+		}
+		if luma := rec601Luma(r, g, b); luma > contrastDarkenTargetLuma {
+			t.Fatalf("daylight %s = %q luma %.1f, want <= %.1f", role, got, luma, contrastDarkenTargetLuma)
+		}
+	}
+
+	ansi := ANSIRolesFromEffective(effective)
+	if ansi.NotifyTitle == ANSINotifyTitleStart {
+		t.Fatalf("daylight notify.title still renders the dark-chrome literal %q", ansi.NotifyTitle)
+	}
+	if ansi.TrustTrusted == ANSITrustTrustedStart {
+		t.Fatalf("daylight trust.trusted still renders the dark-chrome literal %q", ansi.TrustTrusted)
+	}
+}

--- a/internal/theme/resolve.go
+++ b/internal/theme/resolve.go
@@ -637,6 +637,16 @@ var builtinPresets = map[string]preset{
 			TokenPaneActiveBg: "#000000", TokenFocus: "#b48ead",
 		}),
 	},
+	"daylight": {
+		Name: "daylight",
+		Colors: presetColors(map[ColorToken]string{
+			TokenBackground: "#f2efe9", TokenSurface: "#faf7f1", TokenStatusBackground: "#dfdad0", TokenSurfaceActive: "#cfe0f0",
+			TokenChromeForeground: "#3a4550", TokenTextPrimary: "#2c3338", TokenForeground: "#2c3338", TokenMuted: "#6b7680", TokenAccent: "#0f766e",
+			TokenCritical: "#c62828", TokenWarning: "#b45309",
+			TokenProgress: "#1d4ed8", TokenSuccess: "#15803d", TokenActionRequired: "#d97706",
+			TokenPaneActiveBg: "#e8e4dc", TokenFocus: "#2563eb",
+		}),
+	},
 	"ember": {
 		Name: "ember",
 		Colors: presetColors(map[ColorToken]string{


### PR DESCRIPTION
## Summary

Completes **Phase 1 — the final phase of the Theme bright preset roadmap**. Phase 0 (audit) and Phase 2 (light-background contrast corrections / luma-gated derivations, #545) are already merged, so a fully light `status_background` is shippable ("option 2" release shape).

Adds exactly ONE new fully-light builtin preset: **`daylight`**.

### Naming rationale

`daylight` was chosen over `paper`: it is a time-of-day metaphor that pairs naturally with the existing `blue-hour` (dusk) preset, unambiguously signals "light theme", and matches the short lowercase naming of `ember`/`forest`/`rose`. It also alphabetically lands immediately after the `PresetNames()` priority block, giving the only light preset a prominent slot with zero ordering code.

### Palette (all 16 tokens defined explicitly — no sentinels, no surface auto-fill)

| Token | Hex | Nearest tmux |
| --- | --- | --- |
| background | `#f2efe9` | colour255 |
| surface | `#faf7f1` | colour255 |
| status_background | `#dfdad0` | colour188 |
| surface_active | `#cfe0f0` | colour189 |
| chrome_foreground | `#3a4550` | colour238 |
| text_primary | `#2c3338` | colour236 |
| foreground | `#2c3338` | colour236 |
| muted | `#6b7680` | colour243 |
| accent | `#0f766e` | colour6 |
| critical | `#c62828` | colour160 |
| warning | `#b45309` | colour130 |
| progress | `#1d4ed8` | colour26 |
| success | `#15803d` | colour29 |
| action_required | `#d97706` | colour172 |
| pane_active_bg | `#e8e4dc` | colour254 |
| focus | `#2563eb` | colour26 |

**Design rationale**
- Warm paper neutrals for pane/popup surfaces; `status_background #dfdad0` is a distinct light tone (defined explicitly, not surface auto-fill) so the status bar reads as chrome.
- Text tokens are dark slate: `text_primary #2c3338` is ~11:1 WCAG on `background`, `chrome_foreground #3a4550` is ~7:1 on `status_background` (guideline targets 4.5:1 / 3:1 met with margin). `muted #6b7680` is ~4.6:1 — readable but clearly secondary.
- **Quantization-collision handling**: the five state colors were verified through the actual `nearestTmuxColor` path before settling — dark saturated red/amber/blue/green/orange (Tailwind-700-family values) quantize to five distinct colourN: 160 / 130 / 26 / 29 / 172. Design rubric hard rules (a)(b)(c) all pass (muted colour243 ≠ foreground colour236 ≠ background colour255).
- `pane_active_bg #e8e4dc` is one tone darker than `background` — the inverse of the dark presets — so the active pane visibly sinks on light chrome.
- `accent #0f766e` (teal) has luma < 140, so the luma-auto-contrast topic chip fg picks white (≈4.9:1 on the chip).
- `focus #2563eb` shares colour26 with `progress` after quantization; focus is not a state token, so no rubric rule applies, and on RGB-capable terminals both render exact hex.

### Compatibility / constraints

- **No schema change**: no new `[theme]` config tokens; `builtinPresets` map + `presetColors` structure unchanged — this adds one map entry only. No resolver redesign; Phase 2 luma-gate/derivation logic untouched.
- **Dark presets / fallback byte-identity preserved**: no existing preset value changed; the app-level generated-config golden digests (`TestBrightPhase2GeneratedConfigByteIdentity`, fixed per-preset SHA-256 map) pass unchanged; no golden file edited.
- One necessary test adaptation (not a golden edit): the two theme-package tests `TestBrightPhase2ANSIRolesDarkByteIdentity` / `TestBrightPhase2RenderRolesDarkByteIdentity` iterated `PresetNames()` under the documented assumption that every builtin is dark ("EVERY current built-in (dark) preset"). Any fully-light preset makes that iteration self-contradictory: its light surfaces are exactly what the Phase 2 derivations exist to correct. They now iterate `darkPresetNames()` (dynamic luma filter) — the exact same byte-identity assertions still run for the fallback and all 7 existing presets — and the new `daylight` tests assert the light derivations DO fire for the preset.

### PresetNames() ordering decision

No code change. The priority list stays `projmux, high-contrast, blue-hour, carbon-violet`; `daylight` sorts into the alphabetical tail and lands at index 4, immediately after the priority block: `projmux, high-contrast, blue-hour, carbon-violet, daylight, ember, forest, rose`. Existing relative order is untouched, the prefix test passes unchanged, and Settings derives its rows from `PresetNames()` so no other list needed updating (docs lists updated: `docs/theme-palette.md`, `docs/configuration.md`, `docs/upgrading.md`, including the note that themes paint projmux chrome only and pane contents follow the terminal theme).

### Verification

- `go test ./internal/theme/...` — pass (design rubric passes for `daylight`; Phase 2 identity + light-derivation tests pass; new `TestDaylightPresetIsFullyLight` / `TestDaylightPresetTriggersLightDerivations` pass)
- `go test ./internal/app/...` — pass (includes `TestBrightPhase2GeneratedConfigByteIdentity` golden digests, unchanged)
- `make fmt` — pass, no diffs
- `make fix` — pass (deadcode clean)
- `make test` — full suite pass

### Not verified (e2e candidate)

- Manual readability check in a real tmux session on a light-background terminal (statusbar/picker/popup/pane tint with `preset = "daylight"`). Listed for lead e2e QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
