### PR TITLE
fix(keybindings): allow typing in Add-key key-name entry

### DIFF
--- a/internal/app/settings_keybindings.go
+++ b/internal/app/settings_keybindings.go
@@ -469,15 +469,14 @@ func (c *settingsCommand) runKeybindingTyped(actionID string, replace bool, stdo
 		mode = "Replace Keys"
 	}
 	result, err := c.runPicker(intpickercompat.Options{
-		UI:            "settings-keybinding-type",
-		Entries:       []intpickercompat.Entry{c.backEntry(), {Label: c.rowLabelInfo("Action", keyBindingDisplayName(action), keybindingAliasesSummary(action)), Value: settingsNoopValue}},
-		Title:         mode + " - " + keyBindingDisplayName(action),
-		Prompt:        "Enter key > ",
-		Footer:        projmuxFooter("Enter a key such as C-r, M-a, M-S-Left, or C-Space."),
-		ExpectKeys:    []string{"enter"},
-		Bindings:      c.settingsCloseBindings(),
-		AcceptQuery:   true,
-		DisableSearch: true,
+		UI:          "settings-keybinding-type",
+		Entries:     []intpickercompat.Entry{c.backEntry(), {Label: c.rowLabelInfo("Action", keyBindingDisplayName(action), keybindingAliasesSummary(action)), Value: settingsNoopValue}},
+		Title:       mode + " - " + keyBindingDisplayName(action),
+		Prompt:      "Enter key > ",
+		Footer:      projmuxFooter("Enter a key such as C-r, M-a, M-S-Left, or C-Space."),
+		ExpectKeys:  []string{"enter"},
+		Bindings:    c.settingsCloseBindings(),
+		AcceptQuery: true,
 	})
 	if err != nil {
 		return err

--- a/internal/app/settings_test.go
+++ b/internal/app/settings_test.go
@@ -4830,6 +4830,12 @@ func TestSettingsHubKeybindingsTypedTransportKeyWritesOnlyCustomKey(t *testing.T
 			if got, want := options.Prompt, "Enter key > "; got != want {
 				t.Fatalf("typed keybinding prompt = %q, want %q", got, want)
 			}
+			if options.DisableSearch {
+				t.Fatalf("typed keybinding DisableSearch = true, want false so typed input is accepted")
+			}
+			if !options.AcceptQuery {
+				t.Fatalf("typed keybinding AcceptQuery = false, want true")
+			}
 			return intpickercompat.Result{Key: "enter", Query: "M-["}, nil
 		case 7:
 			return intpickercompat.Result{Key: "enter", Value: settingsBackValue}, nil


### PR DESCRIPTION
## 문제
Settings > Keybindings 에서 키 추가 시 "Enter key name" 창이 떠도 **타이핑이 안 먹어** 키 추가 실패 (WSL/Linux, #547 이 라우팅하는 typed 경로).

## 근본 원인
`runKeybindingTyped` 가 `AcceptQuery:true` + **`DisableSearch:true`** 를 함께 설정. 네이티브 picker 는 printable 입력을 `!DisableSearch` 로 게이트(`backend.go:748`)하므로 **DisableSearch:true 면 타이핑 자체가 query 에 안 들어감** → 빈 쿼리 → 저장 없음. (다른 AcceptQuery typed-entry 8곳은 전부 DisableSearch 없음.)

## 수정
`DisableSearch:true` 제거. `AcceptQuery` 는 리스트 필터와 무관하게 Enter 시 타이핑한 쿼리를 돌려줌(`backend.go:652`). → "Enter key name" 에 `M-r` 등 입력 후 Enter → 저장.

## 검증
- 회귀 테스트: typed keybinding picker 가 `DisableSearch` 를 켜지 않고 `AcceptQuery` 를 켜는지 assert.
- `go build/vet`, `go test ./internal/...` 전부 통과.

관련: #547 (물리 캡처 불가 → typed 라우팅) 의 후속 — 라우팅 대상 경로 자체를 수리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)