### PR TITLE
perf(ci): cache pinned security tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,16 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Restore pinned security tools
+        id: security-tools-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .bin/security-tools
+          key: security-tools-${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('go.mod') }}-manifest-${{ hashFiles('.security/security-tools.versions') }}
+
+      - name: Verify pinned security tools
+        run: make security-tools
+
       - name: Install shellcheck
         run: |
           if ! command -v shellcheck >/dev/null 2>&1; then
@@ -36,6 +46,16 @@ jobs:
 
       - name: Run security gates
         run: make security
+
+      # Pull-request caches are scoped to refs/pull/.../merge, so they can warm a
+      # rerun without being restorable by main or another pull request. This save
+      # remains after every security gate and only runs for an exact-key miss.
+      - name: Save pinned security tools
+        if: success() && steps.security-tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: .bin/security-tools
+          key: ${{ steps.security-tools-cache.outputs.cache-primary-key }}
 
   fmt:
     name: Format

--- a/.security/security-tools.versions
+++ b/.security/security-tools.versions
@@ -1,0 +1,5 @@
+govulncheck=v1.6.0
+gosec=v2.28.0
+staticcheck=v0.7.0
+gitleaks=v8.30.1
+actionlint=v1.7.12

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,7 @@ GO_FILES := $(shell find . -type f -name '*.go' \
 DEADCODE_ALLOWLIST ?= .deadcode-allowlist.txt
 
 SECURITY_BIN_DIR ?= $(BUILD_DIR)/security-tools
-GOVULNCHECK_VERSION ?= v1.6.0
-GOSEC_VERSION ?= v2.28.0
-STATICCHECK_VERSION ?= v0.7.0
-GITLEAKS_VERSION ?= v8.30.1
-ACTIONLINT_VERSION ?= v1.7.12
+SECURITY_TOOL_MANIFEST ?= .security/security-tools.versions
 
 .PHONY: fmt fmt-check fix build install npm-pack test test-integration test-install-smoke test-e2e test-e2e-update e2e verify deadcode security security-tools
 
@@ -121,27 +117,61 @@ verify: fmt-check test test-integration test-install-smoke test-e2e
 # checked-in baselines. shellcheck, python3, and git are host dependencies;
 # scripts/security.sh reports actionable installation guidance when missing.
 security-tools:
-	@mkdir -p $(SECURITY_BIN_DIR)
-	@set -e; \
-	versions="govulncheck=$(GOVULNCHECK_VERSION)\ngosec=$(GOSEC_VERSION)\nstaticcheck=$(STATICCHECK_VERSION)\ngitleaks=$(GITLEAKS_VERSION)\nactionlint=$(ACTIONLINT_VERSION)"; \
+	@set -eu; \
+	manifest="$(abspath $(SECURITY_TOOL_MANIFEST))"; \
+	bin_dir="$(abspath $(SECURITY_BIN_DIR))"; \
+	if [ ! -f "$$manifest" ] || [ -L "$$manifest" ]; then \
+		echo "security-tools: canonical manifest is missing or not a regular file: $$manifest" >&2; \
+		exit 2; \
+	fi; \
+	if ! awk -F= 'BEGIN { expected[1]="govulncheck"; expected[2]="gosec"; expected[3]="staticcheck"; expected[4]="gitleaks"; expected[5]="actionlint" } NF != 2 || $$1 != expected[NR] || $$2 !~ /^v[0-9][^[:space:]=]*$$/ { exit 1 } END { if (NR != 5) exit 1 }' "$$manifest"; then \
+		echo "security-tools: invalid canonical manifest (expected exactly five ordered tool=vVERSION entries): $$manifest" >&2; \
+		exit 2; \
+	fi; \
+	mkdir -p "$$bin_dir"; \
+	goos="$$( $(GO) env GOOS )"; \
+	goarch="$$( $(GO) env GOARCH )"; \
 	tools_ok=1; \
-	for tool in govulncheck gosec staticcheck gitleaks actionlint; do \
-		if [ ! -x "$(SECURITY_BIN_DIR)/$$tool" ]; then \
+	while IFS='=' read -r tool version; do \
+		case "$$tool" in \
+			govulncheck) package="golang.org/x/vuln/cmd/govulncheck"; module="golang.org/x/vuln" ;; \
+			gosec) package="github.com/securego/gosec/v2/cmd/gosec"; module="github.com/securego/gosec/v2" ;; \
+			staticcheck) package="honnef.co/go/tools/cmd/staticcheck"; module="honnef.co/go/tools" ;; \
+			gitleaks) package="github.com/zricethezav/gitleaks/v8"; module="github.com/zricethezav/gitleaks/v8" ;; \
+			actionlint) package="github.com/rhysd/actionlint/cmd/actionlint"; module="github.com/rhysd/actionlint" ;; \
+		esac; \
+		if [ ! -f "$$bin_dir/$$tool" ] || [ -L "$$bin_dir/$$tool" ] || [ ! -x "$$bin_dir/$$tool" ] || \
+		   ! $(GO) version -m "$$bin_dir/$$tool" 2>/dev/null | awk -v want_package="$$package" -v want_module="$$module" -v want_version="$$version" -v want_goos="GOOS=$$goos" -v want_goarch="GOARCH=$$goarch" '$$1 == "path" && $$2 == want_package { package_ok=1 } $$1 == "mod" && $$2 == want_module && $$3 == want_version { module_ok=1 } $$1 == "build" && $$2 == want_goos { goos_ok=1 } $$1 == "build" && $$2 == want_goarch { goarch_ok=1 } END { exit(package_ok && module_ok && goos_ok && goarch_ok ? 0 : 1) }'; then \
 			tools_ok=0; \
-			rm -f "$(SECURITY_BIN_DIR)/$$tool"; \
 		fi; \
+	done < "$$manifest"; \
+	if [ ! -f "$$bin_dir/.versions" ] || [ -L "$$bin_dir/.versions" ] || ! cmp -s "$$manifest" "$$bin_dir/.versions"; then \
+		tools_ok=0; \
+	fi; \
+	if [ "$$tools_ok" = "1" ]; then \
+		echo ">> pinned security tools already installed in $$bin_dir"; \
+		exit 0; \
+	fi; \
+	echo ">> installing pinned security tools into $$bin_dir"; \
+	stage="$$(mktemp -d "$$(dirname "$$bin_dir")/.security-tools.XXXXXX")"; \
+	trap 'rm -rf "$$stage"' EXIT HUP INT TERM; \
+	while IFS='=' read -r tool version; do \
+		case "$$tool" in \
+			govulncheck) package="golang.org/x/vuln/cmd/govulncheck" ;; \
+			gosec) package="github.com/securego/gosec/v2/cmd/gosec" ;; \
+			staticcheck) package="honnef.co/go/tools/cmd/staticcheck" ;; \
+			gitleaks) package="github.com/zricethezav/gitleaks/v8" ;; \
+			actionlint) package="github.com/rhysd/actionlint/cmd/actionlint" ;; \
+		esac; \
+		GOBIN="$$stage" $(GO) install "$$package@$$version"; \
+	done < "$$manifest"; \
+	cp "$$manifest" "$$stage/.versions"; \
+	for tool in govulncheck gosec staticcheck gitleaks actionlint; do \
+		mv "$$stage/$$tool" "$$bin_dir/$$tool"; \
 	done; \
-	if [ "$$tools_ok" != "1" ] || [ "$$(cat $(SECURITY_BIN_DIR)/.versions 2>/dev/null)" != "$$(printf '%b' "$$versions")" ]; then \
-		echo ">> installing pinned security tools into $(SECURITY_BIN_DIR)"; \
-		GOBIN="$(abspath $(SECURITY_BIN_DIR))" $(GO) install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION); \
-		GOBIN="$(abspath $(SECURITY_BIN_DIR))" $(GO) install github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION); \
-		GOBIN="$(abspath $(SECURITY_BIN_DIR))" $(GO) install honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION); \
-		GOBIN="$(abspath $(SECURITY_BIN_DIR))" $(GO) install github.com/zricethezav/gitleaks/v8@$(GITLEAKS_VERSION); \
-		GOBIN="$(abspath $(SECURITY_BIN_DIR))" $(GO) install github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION); \
-		printf '%b\n' "$$versions" > $(SECURITY_BIN_DIR)/.versions; \
-	else \
-		echo ">> pinned security tools already installed in $(SECURITY_BIN_DIR)"; \
-	fi
+	mv "$$stage/.versions" "$$bin_dir/.versions"; \
+	rmdir "$$stage"; \
+	trap - EXIT HUP INT TERM
 
 security: security-tools
 	@SECURITY_BIN_DIR="$(abspath $(SECURITY_BIN_DIR))" scripts/security.sh


### PR DESCRIPTION
## Completed phase

- Should 1, 단계 1/1 — Phase 0: pinned security tool cache slice.
- Adds one exact pinned-binary cache contract to the existing Security job.
- Source of truth: `.security/security-tools.versions` for govulncheck, gosec, staticcheck, gitleaks, and actionlint.

## CI surface changed

- `.github/workflows/ci.yml`: restore/save only `.bin/security-tools`; exact key includes `runner.os`, `runner.arch`, `hashFiles('go.mod')` (Go/toolchain input), and `hashFiles('.security/security-tools.versions')`.
- No `restore-keys`.
- `make security-tools` always runs after restore, and `make security` retains its dependency verification.
- Cache save runs only after the full Security gates succeed and only on an exact-key miss.
- `Makefile`: validates the exact ordered canonical manifest, regular non-symlink executables, command package, module version, GOOS, GOARCH, and byte-identical cached `.versions`; mismatches rebuild all five tools in a staging directory before replacement.

## Security policy unchanged

- govulncheck, gosec, staticcheck, full-history and working-tree gitleaks, actionlint, and shellcheck all still run.
- Scanner order/options, baseline fail-closed comparisons, `fetch-depth: 0`, workflow events, and required checks are unchanged.
- Cache excludes scanner results, reports, `.security/*-baseline.json`, checkout source, NPM/Docker/Go-module caches, and every non-tool artifact.

## Trust boundary

GitHub scopes pull-request caches to `refs/pull/<n>/merge`: a PR rerun can restore its own cache, but `main` and sibling PRs cannot restore it. Fork/low-trust runs can read a matching default-branch cache but cannot publish into the default-branch scope. Restored binaries are still treated as untrusted: the exact key plus unconditional package/module/version/GOOS/GOARCH/executable/manifest validation repairs or fails closed before any scanner runs.

References:

- https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache
- https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#cache-access-for-low-trust-workflow-triggers

## Validation

Standard order:

- [x] `make fmt` — 0.29s
- [x] `make fix` — 5.69s
- [x] `make test` — 4.41s with required local socket permissions
- [x] `make test-integration` — 19.20s with Docker access
- [x] `make test-e2e` — 42.68s with Docker access
- [x] `PATH=/tmp/shellcheck-v0.10.0:$PATH make security` — 12.50s final warm run; CI retains its existing shellcheck install step
- [x] `git diff --check`
- [x] Lead review: `make fmt-check`, actionlint through full Security, exact manifest/build-info audit

Local cold/warm evidence using the same temporary `SECURITY_BIN_DIR`:

- Cold `make security`: 49.15s; installed all five pins, then ran every scanner and passed.
- Warm `make security`: 11.57s; printed `pinned security tools already installed`, ran every scanner again, and passed.
- Local elapsed reduction: 76.46%. This is not substituted for the hosted-runner timing gate.

Mismatch/repair evidence:

- Canonical manifest entry change: rebuilt the alternate actionlint pin, then rebuilt back to the canonical pin.
- Binary deletion: deleted gitleaks; rebuilt and restored exact v8.30.1.
- Corrupt `.versions`: detected and restored byte-exact manifest.
- Executable substitution: replaced govulncheck with executable `/bin/true`; build-info verification rejected and repaired it.
- Malformed canonical manifest: exited 2 without changing the prior binary or cached manifest.
- A transient alternate-gosec download failure left the existing cache intact, demonstrating staged fail-closed replacement.

## Hosted CI and timing evidence

- PR #579 CI run `31598830607`, attempt 1, Security job `94120864408` succeeded in `2m12s` on an exact cache miss. The observed key was `security-tools-Linux-X64-go-2774d0...-manifest-40437f...`; the log showed `Cache not found`, installed all five pinned tools, reran the full Security gates, and saved a 59,347,514-byte cache after success.
- Cold major steps: checkout 2s, setup-go 2s, restore <1s, pinned-tool verify/install 1m23s, shellcheck <1s, full Security gates 41s, cache save about 1s.
- Warm reproduction used only the successful Security job: `gh run rerun 31598830607 --repo crevissepartners/projmux --job 94120864408`. Attempt 2 created Security job `94121643488` and restored the exact same 57 MiB key.
- The warm verifier printed `pinned security tools already installed`; the full Security gates printed `security: all gates passed`; cache save was skipped on the exact hit. The warm job succeeded in `1m23s`.
- Warm major steps: checkout 2s, setup-go 1s, cache restore about 1s, pinned-tool verify <1s, shellcheck <1s, full Security gates 1m15s.
- PR #554 baseline `2m04s` to warm `1m23s` is a 41s / 33.1% reduction and is also below `1m30s`, so the Phase timing gate passed. Security remained the PR critical path at 1m23s; the next job was E2E at 1m04s.
- The hosted key visibly includes Linux OS/arch plus exact Go input and manifest hashes. A separate hosted manifest-mutation run was not made; local manifest-entry mismatch/repair and malformed-manifest fail-closed evidence remain the mutation coverage.

## Scope audit

- Current phase only: Phase 0 pinned security tool cache.
- No tool upgrades/finding cleanup, scanner skip, baseline relaxation, report/result caching, job split, required-check change, unrelated workflow refactor, custom runner image, or other CI cache optimization.
- Parallel worker ownership respected: no picker/internal app/config/UI/test/native-picker docs/POC/E2E changes and no `docs/agent-workflow.md` change.
- Changed files are exactly `.github/workflows/ci.yml`, `Makefile`, and `.security/security-tools.versions`.
