### PR TITLE
fix(security): bump Go toolchain to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/crevissepartners/projmux
 
 go 1.25.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 tool golang.org/x/tools/cmd/deadcode
 
 require (


### PR DESCRIPTION
## Phase

Completes **Phase 0 — Go 1.26.6 toolchain patch** for the Go 1.26.6 security baseline.

## Change

- Bumps the single `go.mod` toolchain line from `go1.26.5` to `go1.26.6`.
- Keeps the module language directive at `go 1.25.0`.
- Makes no user-facing behavior or source-code change; the affected surface is the local/CI/release compiler and standard-library baseline selected by `go.mod`.

## Security evidence

PR #597 CI run `31780053454`, Security job `94703647295`, reported four reachable Go standard-library advisories on `go1.26.5`; its log identifies `go1.26.6` as the fixed version for every item:

- `GO-2026-6218`: `net/url@go1.26.5` → fixed in `net/url@go1.26.6`
- `GO-2026-6090`: `crypto/tls@go1.26.5` → fixed in `crypto/tls@go1.26.6`
- `GO-2026-5972`: `encoding/asn1@go1.26.5` → fixed in `encoding/asn1@go1.26.6`
- `GO-2026-5026`: `net/http@go1.26.5` → fixed in `net/http@go1.26.6`

Evidence: https://github.com/crevissepartners/projmux/actions/runs/31780053454/job/94703647295

With the patched toolchain, local `make security` passes and `govulncheck` reports `No vulnerabilities found`.

## Local / CI / release parity

Read-only workflow audit confirms both workflows continue to use `actions/setup-go` with `go-version-file: go.mod`:

- `.github/workflows/ci.yml`: lines 27, 71, 88, 105, 167
- `.github/workflows/release.yml`: lines 23, 40, 105, 166

No workflow semantics or cache policy changed.

## Validation

All required gates passed in repository order:

- `GOTOOLCHAIN=go1.26.6 go version` → `go version go1.26.6 linux/amd64`
- `go env GOTOOLCHAIN` → `auto`
- host-local toolchain is `go1.26.0`; the updated repository directive auto-selected/downloaded `go1.26.6`, and plain repo-scoped `go version` reports `go1.26.6`
- `make fmt`
- `make fix`
- `make test`
- `make test-integration`
- `make test-e2e`
- `make security`
- source build: `go version -m /tmp/projmux-go1266-phase0.DgnNap/projmux` → `go1.26.6`
- `git diff --check origin/main...HEAD`

The initial sandboxed `make fix` could not write the user Go build cache; the same command was rerun through the normal shell credential/filesystem context and passed. All subsequent gates above passed.

## Exclusions and scope audit

- No module dependency upgrades and no `go.sum` churn.
- No source behavior changes.
- No scanner version, baseline, or suppression changes.
- No CI/release workflow semantics or cache changes.
- No PR #597 Session State, Lifecycle hook context, or config symlink writer files.
- `git diff -- go.mod go.sum .github/workflows/ci.yml .github/workflows/release.yml` and the full branch diff show exactly one changed file and one toolchain-line replacement.
- No next Phase exists in this 1/1 track; PR #597 rebase/merge remains the roadmap owner and `%72` follow-up.

## Post-merge installation gate

Completed after squash merge:

- PR #599 merged as `058171267587eba0fc9d4017cada0c63fdc9dba0` before PR #597; #597 remained open at `9ee4510`.
- Primary `main` fast-forward check: `git pull --ff-only` → already up to date at `058171267587eba0fc9d4017cada0c63fdc9dba0`, equal to `origin/main`.
- `make install` → built `.bin/projmux`, atomically replaced `/home/es5h/go/bin/projmux`, applied the live tmux config, and reconciled notifications successfully.
- Installed version smoke: `/home/es5h/go/bin/projmux version` → `projmux 0.10.0`.
- Installed build info: `go version -m /home/es5h/go/bin/projmux` → Go `1.26.6`, module pseudo-version `v0.10.1-0.20260814074832-058171267587`, `vcs.revision=058171267587eba0fc9d4017cada0c63fdc9dba0`, `vcs.modified=false`, `GOOS=linux`, `GOARCH=amd64`.
- Source build `.bin/projmux` reports the same Go version and VCS revision.
