### PR TITLE
docs: align current surfaces with installed CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Six tmux windows. Each one is running Claude Code, Codex, or Antigravity on a
 different repo. Three are idle. One is waiting on a permission prompt. One
 crashed an hour ago and you have no idea which.
 
-projmux ingests Claude Code and Codex hook events directly, accepts manually
-wired Antigravity hook/statusline events, shows live per-pane state in the tmux
+projmux manages Claude Code, Codex, and Antigravity hook integrations, including
+Antigravity's hook/statusline wiring, shows live per-pane state in the tmux
 status bar, and lets one keystroke take you to the pane that actually needs
 you. It also remembers each agent's resume id, so after a reboot every pane
 comes back as the *same* conversation — not a fresh one.
@@ -91,8 +91,8 @@ fallbacks.
 - Pin important projects so they stay easy to reach.
 - Preview windows, panes, git branch, Kubernetes context, and AI pane state
   before switching.
-- Resume an existing Claude or Codex conversation, or open a new managed AI
-  split.
+- Resume an existing Claude, Codex, or Antigravity conversation, or open a new
+  managed AI split.
 - Review permission and completion events in one notification queue, then jump
   directly to the pane that needs attention.
 - Use Settings > Project Picker to add roots and workdirs without editing env

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,19 +46,20 @@ projmux <command> [args...]
 | `update` | Check installer-aware GitHub release update status. |
 | `upgrade` | Self-update via `go install`. |
 | `welcome` | Print the shell onboarding guide again. |
-| `usage` | Report AI usage across fixed windows, context, and named quota buckets. |
+| `usage` | Report AI usage across fixed windows and named account quota buckets. |
 | `version` | Print the current version. |
 
 ## switch
 
 ```
-projmux switch [path]
+projmux switch [--ui=popup|sidebar]
+projmux switch open <path>
 projmux switch toggle-tag | toggle-pin | kill | settings | preview
 projmux switch cycle-pane | cycle-window | sidebar-focus
 ```
 
 Project picker. With no positional argument, opens the configured picker popup
-or sidebar (depending on entry helper). With a path, jumps directly. The
+or sidebar (depending on entry helper). `switch open <path>` jumps directly. The
 sub-verbs are entry hooks invoked by tmux keybindings (e.g.
 `sidebar-focus` is wired to the sidebar's focus binding so navigation keeps
 the active session in sync).
@@ -109,7 +110,7 @@ projmux doctor [--json] [--section deps|runtime|integrations|session-state|logs]
 Runs read-only diagnostics, including a dependency check for `tmux ≥ 3.4`,
 `git`, `stty` (POSIX only), and
 `kubectl` (optional), then reports read-only AI notify integration diagnostics
-for Codex hooks, Claude Code hooks, and the tmux bell
+for Codex hooks, Claude Code hooks, Antigravity hooks/statusline, and the tmux bell
 fallback. AI notify integration statuses are `installed`, `missing`, or
 `conflict`; missing or conflicting integrations are informational and do not
 make doctor fail. It also reports read-only Session State resume metadata
@@ -352,10 +353,12 @@ projmux notify reconcile [--json]
   While open, the native
   sidebar refreshes its row list on successful queue-write events without an
   Alt-2 close/reopen toggle, using the same deferred refresh path as `a` and
-  `x`. The sidebar uses two-line cards with notification text first and
-  compact age/project/window/pane metadata below. Hidden queue ids remain
-  action values, but the sidebar has no search input. `--client` is used by
-  tmux popup launchers to keep row-select focus on the clicked client.
+  `x`. The sidebar is a pane/session-grouped inbox whose collapsed rows are
+  fixed three-line cards: project/session, agent/provider, and newest age on
+  line 1; topic/pane-title/task context plus severity/live-state metadata on
+  line 2; and the latest notification preview on line 3. Hidden queue ids
+  remain action values, but the sidebar has no search input. `--client` is used
+  by tmux popup launchers to keep row-select focus on the clicked client.
 - `ack <id>` removes one entry; `--all` flushes the queue.
 - `reconcile` — walks `tmux list-panes -a` and back-fills entries for
   panes whose attention state is `reply` AND whose AI agent option is
@@ -367,7 +370,7 @@ projmux notify reconcile [--json]
 
 ## usage
 
-Authoritative AI token usage. See [usage-tracking.md](usage-tracking.md)
+Authoritative AI account usage. See [usage-tracking.md](usage-tracking.md)
 for adapter detail.
 
 ```
@@ -423,9 +426,10 @@ core-equivalent CPU. Project and window rows count panes, while pane rows count
 the attributed processes. Pane rows and detail share the resolved pane identity
 and label the tmux current command, PID/SID, pane id, and TTY separately. Memory
 is explicitly an RSS sum (shared pages can be counted more than once) plus its
-host ratio. `Unassigned`,
-`Shared / ambiguous`, and non-drillable `Other / unattributed` remain explicit,
-as do warming, partial, unavailable, unknown, and overage states. No process
+host ratio. `No project match`, `Multiple project matches`, and non-drillable
+`Other / unattributed` remain explicit. The first two are display labels over
+stable internal attribution keys. Warming, partial, unavailable, unknown, and
+overage states also remain explicit. No process
 command list, mutation, history, graph, daemon, persistence, or Session State
 telemetry is created. Linux/tmux provides attribution; unsupported platforms
 show an unavailable reason rather than zero metrics.
@@ -495,10 +499,10 @@ projmux statusbar usage-refresh
 ```
 
 Click/keyboard dispatcher for the two-line status bar. Implemented range ids:
-`session pwd kube git usage notify settings`. The bare `window` /
+`session pwd kube git resources usage notify settings`. The bare `window` /
 `window|<idx>` token (tmux's built-in window-list range) and the empty
 range fall through to `select-window -t @<mouse_window>` so the native
-click-to-switch tab affordance is preserved on row 0. Unknown range ids are
+click-to-switch tab affordance is preserved on row 1. Unknown range ids are
 non-specialized placeholders and no-op. `session` opens the existing-session
 popup; `pwd` shows the current pane path in a native-framed display-only
 popup; `kube` and `git` open the project switcher popup;
@@ -542,11 +546,11 @@ supplied window.
 
 ```
 projmux ai split    [--agent <claude|codex|antigravity|shell|selective|resume>] [--force-agent] [--print-pane-id] [right|down] [-- <extra-arg>...]
-projmux ai picker   [--inside] [--shell] [--resume] <right|down>
-projmux ai settings
-projmux ai status   set <thinking|waiting|idle> [--pane <id>]
-projmux ai notify   <reset|notify> [--pane <id>]
-projmux ai watch-title [--pane <id>]
+projmux ai picker   [--inside] [--shell] [--resume] [right|down]
+projmux ai settings [--get|--set <mode>]
+projmux ai status   set <thinking|waiting|idle> [pane]
+projmux ai notify   [notify|reset] [pane]
+projmux ai watch-title [pane]
 projmux ai ingest   codex-hook < payload.json
 projmux ai ingest   claude-hook < payload.json
 projmux ai ingest   antigravity-hook [--event <PreInvocation|PostInvocation|PostToolUse|Stop|Statusline>] < payload.json

--- a/docs/globalization.md
+++ b/docs/globalization.md
@@ -34,7 +34,7 @@ Classification:
 
 | Family | Examples | Class | Phase 0 policy |
 | --- | --- | --- | --- |
-| Agent names | `Codex`, `Claude`, `AI` | `literal` | Preserve exactly. |
+| Agent names | `Codex`, `Claude`, `Antigravity`, `AI` | `literal` | Preserve exactly. |
 | Category labels | `Response complete`, `Approval required`, `Input required`, `Error`, `Subagent stopped`, `Teammate waiting` | `translate` | English baseline now; catalog keys later. |
 | Review body prefix | `Review pending:` | `translate` | English baseline now; catalog key later. |
 | Tool names | `Bash`, `Read`, `WebFetch`, `Shell` | `literal` | Preserve provider/source spelling. |
@@ -78,7 +78,7 @@ Classification:
 | Row labels and previews | enabled/disabled state, current source, saved values | `translate` | Inventory only; catalog later. |
 | Disabled reasons and warnings | missing project, env override, conflict text | `translate` | Inventory only; catalog later. |
 | Config keys and env vars | `PROJMUX_PROJDIR`, `config.toml`, `ui.locale` | `literal` | Preserve exactly. |
-| Commands shown for copying | `projmux ai integrate codex --dry-run` | `literal` | Preserve exactly. |
+| Commands shown for copying | `projmux ai integrate codex --dry-run`, `projmux ai integrate antigravity --dry-run` | `literal` | Preserve exactly. |
 | Persisted values | `none`, `notify`, `raise`, `auto` | `literal` | Preserve enum values. |
 
 ### Native Picker And Render Surfaces
@@ -124,7 +124,7 @@ Classification:
 
 Do not translate these families:
 
-- Product and agent names: `Codex`, `Claude`, `projmux`, `tmux`,
+- Product and agent names: `Codex`, `Claude`, `Antigravity`, `projmux`, `tmux`,
   `GitHub`, `npm`.
 - Terminal and app names: `Windows Terminal`, `Ghostty`, `WezTerm`, `Kitty`,
   `iTerm2`, `Alacritty`, `Foot`.
@@ -239,7 +239,8 @@ Contribution convention:
 - Add the `en-US` entry in the same change as the key.
 - Add `ko-KR` when the translation is known; otherwise rely on fallback while
   keeping the missing key intentional in review notes.
-- Do not translate product names (`projmux`, `tmux`, `Codex`, `Claude`),
+- Do not translate product names (`projmux`, `tmux`, `Codex`, `Claude`,
+  `Antigravity`),
   commands, paths, config keys, environment variables, provider payloads, or
   source enum values.
 - Runtime migrations should be narrow by surface. Move a string family behind
@@ -296,7 +297,8 @@ Width-safe rendering:
 
 Runtime surfaces migrated:
 
-- AI desktop notification summaries for Codex and Claude hook payloads.
+- AI desktop notification summaries for Codex, Claude, and Antigravity hook
+  payloads.
 - In-app notify queue table/sidebar/statusbar display text for AI entries.
 - Notify live explanation text for `projmux notify list --live`.
 - Sidebar/table/statusbar age formatting and sidebar stale/gone/target labels.
@@ -317,9 +319,9 @@ Literal preservation and parity rules:
 - Translate only catalog-owned category labels such as `Response complete`,
   `Approval required`, `Input required`, `Error`, `Subagent stopped`, and
   `Teammate waiting`.
-- Preserve provider-owned payloads verbatim: `Codex`, `Claude`, tool names,
-  commands, paths, URLs, query strings, transcript excerpts, teammate IDs, and
-  subagent IDs.
+- Preserve provider-owned payloads verbatim: `Codex`, `Claude`, `Antigravity`,
+  tool names, commands, paths, URLs, query strings, transcript excerpts,
+  teammate IDs, and subagent IDs.
 - Desktop notification summaries and in-app queue display text must use the
   same rendered category labels for the same locale while preserving the same
   literal payload body.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -205,11 +205,11 @@ If a `send-noti` hook itself calls `projmux notify push`, projmux sees
 `PROJMUX_NOTIFY_HOOK_DEPTH=1` in the child environment and skips another
 `send-noti` hook fire. The queue write itself still succeeds.
 
-`Settings > Notifications > Delivery sources` surfaces the active Codex hooks,
-Claude, and tmux AI notify diagnostics: status, conflicts, config paths, and
-copyable CLI install/remove/dry-run commands. It also shows whether
+`Settings > Notifications > Delivery sources` surfaces the active Codex,
+Claude, Antigravity, and tmux AI notify diagnostics: status, conflicts, config
+paths, and copyable CLI install/remove/dry-run commands. It also shows whether
 `PROJMUX_NOTIFY_HOOK` overrides the built-in desktop sender. It does not install
-or remove external Codex, Claude, or tmux settings.
+or remove external Codex, Claude, Antigravity, or tmux settings.
 
 `PROJMUX_NOTIFY_HOOK` is separate from `[hooks.send-noti]`: it replaces the
 desktop sender and receives positional arguments

--- a/docs/settings-ia.md
+++ b/docs/settings-ia.md
@@ -71,11 +71,11 @@ view-first layout:
   desktop AI notification collapse window. It stores integer seconds and shows
   the effective source; `PROJMUX_TMUX_NOTIFY_DEDUPE_SECONDS` remains the top
   override. The tmux bell fallback keeps its fixed 5 second window.
-- `Settings > Notifications > Delivery sources` shows Codex hooks, Claude, and
-  tmux producer diagnostics, the effective desktop sender override state, and
-  copyable install/remove/dry-run commands. Settings copies command text only;
-  it does not install or remove external notify wiring. The legacy Codex notify
-  source is intentionally omitted from Settings.
+- `Settings > Notifications > Delivery sources` shows Codex, Claude,
+  Antigravity, and tmux producer diagnostics, the effective desktop sender
+  override state, and copyable install/remove/dry-run commands. Settings copies
+  command text only; it does not install or remove external notify wiring. The
+  legacy Codex notify source is intentionally omitted from Settings.
 - `Settings > Notifications > Hook quiet policy` shows Codex/Claude hook
   runtime action values and writes only
   `${XDG_CONFIG_HOME:-$HOME/.config}/projmux/ai-hook-actions.json`. It does not
@@ -97,7 +97,8 @@ view-first layout:
 - `Settings > Labs > Project Hooks` is overview-first. The Labs root opens the
   overview, and the on/off mutation rows live one level deeper.
 - `Settings > AI Settings` is view-first. The root contains `Default split
-  mode`; the detail contains the `Claude`, `Codex`, and `Shell` choices.
+  mode`, `Enabled agents`, and `Resume picker`; the default-mode detail contains
+  the `Claude`, `Codex`, `Antigravity`, `Shell`, and `Selective` choices.
 - `Settings > Project > Project recipe` is the functional label for
   `.projmux/config.toml`. Search still matches `config.toml` as an alias.
 - `Settings > Project > Project recipe` is view-first. The root contains section
@@ -117,7 +118,7 @@ view-first layout:
   visible as warnings and fall back to `en-US`.
 - Global root descriptions keep ownership explicit: Appearance owns language,
   AI badge style, and status/notification icon decoration; Theme owns presets,
-  color tokens, and font hints. About describes only the surface it retains.
+  and color tokens. About describes only the surface it retains.
 - `Settings > About` is intentionally compact: Version, Source, update
   status/actions (including Latest, Update state, Installer, and Release notes
   when available), Welcome, and Quit. It does not reproduce static key,

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -122,16 +122,16 @@ bind-key -n MouseDown1Status if-shell -F "#{==:#{mouse_status_range},window}" \
 
 ## Range catalogue
 
-| Range id | Row | Click action                              | Keyboard      |
-| -------- | --- | ----------------------------------------- | ------------- |
-| `session` | 0 | `projmux tmux popup-toggle sessionizer-sidebar` | `prefix s s` |
-| `pwd`     | 0 | show a native-framed current-path popup; no clipboard or tmux buffer copy | `prefix s p`  |
-| `kube`    | 0 | `projmux tmux popup-toggle sessionizer`   | `prefix s k`  |
-| `git`     | 0 | `projmux tmux popup-toggle sessionizer`   | `prefix s g`  |
-| `settings` | 0 | `projmux tmux popup-toggle --client <tty> ai-split-settings` | mouse only; `prefix s s` remains `session` |
-| `resources` | 0 | `projmux tmux popup-toggle --client <tty> resource-inspector` | mouse or custom `Resources:Open`; no default key |
-| `usage`   | 1 | show a native-framed usage HUD popup from cached usage state | `prefix s u`  |
-| `notify`  | 1 | `projmux focus --target <newest> --source status-bar --kind segment-click [--client <tty>]`, then ack on focus success | `prefix s n`  |
+| Range id | Generated row | Click action                              | Keyboard      |
+| -------- | ------------- | ----------------------------------------- | ------------- |
+| `notify`  | `status-format[0]` | `projmux focus --target <newest> --source status-bar --kind segment-click [--client <tty>]`, then ack on focus success | `prefix s n`  |
+| `usage`   | `status-format[0]` | show a native-framed usage HUD popup from cached usage state | `prefix s u`  |
+| `session` | `status-format[1]` | `projmux tmux popup-toggle sessionizer-sidebar` | `prefix s s` |
+| `pwd`     | `status-format[1]` | show a native-framed current-path popup; no clipboard or tmux buffer copy | `prefix s p`  |
+| `kube`    | `status-format[1]` | `projmux tmux popup-toggle sessionizer`   | `prefix s k`  |
+| `git`     | `status-format[1]` | `projmux tmux popup-toggle sessionizer`   | `prefix s g`  |
+| `resources` | `status-format[1]` | `projmux tmux popup-toggle --client <tty> resource-inspector` | mouse or custom `Resources:Open`; no default key |
+| `settings` | `status-format[1]` | `projmux tmux popup-toggle --client <tty> ai-split-settings` | mouse only; `prefix s s` remains `session` |
 
 `notify` reads the pending queue only. For a live pane-state view that is
 independent of queued reminders, use `projmux attention list`. To explain why
@@ -284,9 +284,8 @@ updates the matching live tmux option
 (`@projmux_statusbar_decoration_cwd`, `_git`, or `_notify`) when run inside
 tmux. The legacy `~/.config/projmux/statusbar-decoration` and
 `@projmux_statusbar_decoration` remain fallback defaults for older configs.
-Appearance also shows the effective desired theme font. This is a status row,
-not a font editor: tmux status strings and ANSI output cannot force terminal
-font family or size, so unsupported environments report `not applied`.
+Settings > Theme controls the bottom status bar background through
+`status_background`; `surface` controls popup and native frame backgrounds.
 
 Settings > Labs controls the experimental live resource segment. Its saved
 value is `~/.config/projmux/live-resources`; changing it inside tmux updates


### PR DESCRIPTION
## Completed phase

- Must 1 · 단계 1/1 — `Phase 0 — Installed CLI/current docs parity`
- Base: clean `main == origin/main == f00083a4403ef672be1959cf58be1d13fa90406a`
- Scope: docs-only current-surface parity against the installed v0.10.0 CLI, current parser/tests, and generated tmux config.

## User-facing docs surfaces

- `README.md`
- `docs/cli.md`
- `docs/globalization.md`
- `docs/hooks.md`
- `docs/settings-ia.md`
- `docs/statusbar.md`

## Fixed ledger closure

| # | Issue | Closure |
|---:|---|---|
| 1 | Switch canonical open syntax | Replaced bare `switch [path]` with picker `switch [--ui=popup|sidebar]` plus canonical `switch open <path>`. |
| 2 | AI synopsis | Matched optional picker direction, Settings `--get`/`--set`, and positional pane arguments for status/notify/watch-title. |
| 3 | Usage context retirement | Described fixed windows plus named account quotas; retained `context` only as an accepted compatibility filter that returns no Usage rows and as private diagnostic/history terminology. |
| 4 | Notify grouped card | Replaced obsolete two-line copy with the fixed three-line pane/session-grouped card layout. |
| 5 | Resource Inspector labels | Documented visible `No project match` / `Multiple project matches` labels while explicitly preserving stable internal attribution keys. |
| 6 | Status range rows | Mapped `notify`/`usage` to `status-format[0]` and session/window/pwd/kube/git/resources/settings to `status-format[1]`; added the omitted resources range and corrected the window row. |
| 7 | Theme parity | Removed stale Settings/statusbar font copy and documented bottom status bar ownership by `status_background`, with `surface` retained for popup/native frames. |
| 8 | Antigravity capability copy | Updated managed hooks/statusline integration, resume, Delivery-source diagnostics, and globalization/literal coverage across README and current docs. |

## Explicitly excluded

- Product-wide installed UI ledger implementation: locale/layout/focus/empty-state defects.
- CLI/help engine, runtime parser/behavior, flag/help exit behavior, and every-subcommand/generated-reference architecture work.
- Operational event schema/classification, picker/UI behavior, internal Resource stable keys, theme/public config/action/schema changes.
- `docs/agent-workflow.md` maintained-test-list generation changes or opportunistic refactors.
- Backlog work for CLI help/reference architecture and Doctor tmux probe strict no-write behavior.
- Active Obsidian roadmap hub/detail state transitions; the roadmap owner remains the canonical writer.

## Runtime/model/schema scope audit

`git diff f00083a..6d4ad103 --name-only` contains exactly the six Markdown files listed above. There are no Go, test, generated config, config schema, action, workflow, or runtime changes. The current CLI parser/help engine, help exits, operational event model, picker behavior, Resource stable keys, and theme schema are unchanged.

Focused negative audit found no stale current copy for bare `switch [path]`, notify two-line cards, Resource visible `Unassigned` / `Shared / ambiguous` labels in `docs/cli.md`, manually wired Antigravity, Claude/Codex-only resume, Antigravity-omitting Delivery copy, or Settings font hints/effective-font copy.

Intentional residuals are limited to:

- `context`: private Antigravity `context_window` diagnostics, legacy-row suppression/history, and the accepted compatibility filter.
- `Unassigned` / `Shared / ambiguous`: internal attribution/stable-key documentation and maintained test inventory.
- font: removal/migration/ignored-key history in upgrading/theme/configuration docs.
- `surface`: its still-current popup/native-frame token role; statusbar copy now names `status_background`.

Changed-surface Markdown links were extracted, fragments/query strings removed, external URLs excluded, and relative targets resolved from each document directory. All targets exist.

## Installed/source parity evidence

The repo install contract binary was addressed explicitly as `/home/es5h/go/bin/projmux` because the PATH-leading `/usr/local/bin/projmux` npm shim is stale at 0.6.3.

- `/home/es5h/go/bin/projmux version` → `projmux 0.10.0`.
- `switch --help` prints `switch [--ui=popup|sidebar]` and `switch open <path>`.
- `ai --help` prints optional `[right|down]`, `settings [--get|--set <mode>]`, and positional `[pane]` contracts.
- `ai settings --help` prints the `-get` / `-set string` flags.
- `usage --help` prints model `codex|claude|antigravity|all` and window `5h|weekly|context|quota|all` filters.
- `tmux print-app-config` prints `status-format[0]` with notify + usage and `status-format[1]` with session/window/status-left/status-right ranges; the effective status style uses the status-background role.
- Existing help behavior was observed, not changed: `switch --help` and `ai settings --help` return the current `flag: help requested` failure path; `ai --help` and `usage --help` return success.

Source/test anchors reviewed: `internal/app/switch.go`, `internal/app/ai.go`, `internal/app/usagecmd/usage.go`, `internal/app/notify_test.go`, `internal/app/resources.go`, `internal/app/resources_test.go`, `internal/app/tmux.go`, `internal/theme/resolve.go`, `internal/app/ai_integrate_test.go`, and `internal/app/settings_test.go`.

## Validation

All commands were run in repository order after the final docs edit:

1. `GOCACHE=/tmp/projmux-docs-parity-go-cache make fmt` — PASS
2. `GOCACHE=/tmp/projmux-docs-parity-go-cache make fix` — PASS (`go fix`, deadcode baseline clean)
3. `GOCACHE=/tmp/projmux-docs-parity-go-cache make test` — PASS
4. `GOCACHE=/tmp/projmux-docs-parity-go-cache make test-integration` — PASS, including isolated lifecycle socket guard
5. `GOCACHE=/tmp/projmux-docs-parity-go-cache make test-e2e` — PASS, including tmux integration and npm staging-path e2e
6. `GOCACHE=/tmp/projmux-docs-parity-go-cache make security` — PASS (`govulncheck`, `gosec`, `staticcheck`, `gitleaks`, `actionlint`, `shellcheck` clean)

Sandbox-only attempts were not counted as passes: unit tests hit blocked Unix datagram/TCP6 binds, integration/e2e hit denied Docker socket access, and security hit sandbox DNS/network restrictions. Each exact command above was rerun unchanged in the normal user-shell context and passed.

## Unverified items, follow-up, and phase boundary

- No Phase 0 acceptance item remains unverified. The standard integration/e2e suites cover the isolated tmux behavior; no additional live runtime smoke was invented for this docs-only phase.
- Operational risk outside this diff: `/usr/local/bin/projmux` shadows the repo-installed v0.10.0 binary with an old npm shim. The explicit repo install path was used for all evidence.
- There is no next phase in this 1/1 track. Closed/Done reconciliation belongs to the roadmap owner; Product-wide polish and Backlog architecture/Doctor items remain separate scopes.
- The branch contains only Phase 0 current-docs parity and does not advance active roadmap state or enter any excluded follow-up scope.
