### PR TITLE
docs(theme): correct status bar token ownership

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -116,13 +116,14 @@ through separate terminal preset variants.
 
 ### Pane body vs popup backgrounds
 
-The general (pane) background and the popup/chrome background are now driven by
-separate public tokens. The pane body follows `background` (unset keeps the
-terminal default), while the status bar, native popup bodies, and the
-settings/notify/recent/picker frames follow `surface`. Because the `surface`
-fallback equals `background`, leaving both unset looks exactly as before; set
-them to different values to make popups read as a distinct surface from the pane
-body.
+The general pane, bottom status bar, and popup/native frame backgrounds are now
+driven by separate public tokens. The pane body follows `background` (unset
+keeps the terminal default), the status bar follows `status_background`, and
+native popup bodies plus the settings/notify/recent/picker frames follow
+`surface`. Because the `surface` fallback equals `background`, leaving those two
+unset looks exactly as before; set `surface` separately to make popups read as a
+distinct surface from the pane body. Set `status_background` separately to
+repaint only the bottom status bar.
 
 ### Theme font keys removed
 


### PR DESCRIPTION
## Summary
- complete the Phase 0 acceptance corrective missed by merged PR #605
- document that the bottom status bar follows `status_background`, while popup/native frames follow `surface`
- preserve the rest of #605 and keep the corrective to one current-doc paragraph

## Phase and scope
- Completed: Current docs parity cleanup, Phase 0 acceptance corrective (ledger item 7)
- User-facing surface: `docs/upgrading.md` current theme migration guidance
- Preserved constraints: docs-only; no runtime, parser/help engine, UI behavior, public schema, or roadmap transition changes
- Excluded: CLI help/reference architecture, Doctor no-write, native separator/footer overflow, Product-wide UI ledger, and all other roadmap items
- Scope audit: one Markdown file changed; no other #605 document was reverted or rewritten

## Evidence
- installed `/home/es5h/go/bin/projmux tmux print-app-config` emits `status-style bg=#07111f` for the current `blue-hour` `status_background`
- current `docs/theme-palette.md`, `docs/configuration.md`, and `docs/statusbar.md` assign popup/native frames to `surface` and the bottom status bar to `status_background`
- focused stale exact-copy audit returns 0 matches
- remaining broad `surface`/`status_background` co-occurrences are current canonical separation or intentional migration/history
- `docs/upgrading.md` contains no Markdown links; referenced inline repo paths exist

## Test plan
- [x] `make fmt`
- [x] `make fix`
- [x] `make test`
- [x] `make test-integration`
- [x] `make test-e2e`
- [x] `make security`
- [x] focused negative/parity audit and `git diff --check`

## Globalization
- [x] Non-translated strings are classified as literal/data/debug-only.

The changed token names are literal public configuration identifiers; no runtime or catalog string changes.

## Unverified and follow-up
- Unverified items: none for this corrective; all required local gates passed.
- Active roadmap hub/detail/Done transitions remain owner-owned.
- Corrective merge/install/provenance/cleanup evidence will be appended to the existing Current docs parity Archive after merge.

Corrects the owner Must-fix recorded on #605 without reopening the rest of that merged docs change.
