### PR TITLE
docs(readme): refresh agent workflows and Korean copy

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -4,38 +4,43 @@
   <img src="docs/assets/projmux-icon.png" alt="projmux icon" width="112">
 </p>
 
-프로젝트별 tmux workspace를 빠르게 전환하고, Claude Code, Codex,
-Antigravity pane의 preview/status context/attention까지 함께 다루는 터미널
-workspace 도구입니다.
-
-[![npm version](https://img.shields.io/npm/v/projmux?logo=npm)](https://www.npmjs.com/package/projmux)
-[![CI](https://github.com/crevissepartners/projmux/actions/workflows/ci.yml/badge.svg)](https://github.com/crevissepartners/projmux/actions/workflows/ci.yml)
-
-[English README](README.md)
-
 <p align="center">
-  <img src="docs/assets/projmux-ai-attention.gif" alt="projmux AI attention demo" width="820">
+  <strong>여러 AI 에이전트를 함께 쓰는 tmux 기반 개발 작업 공간.</strong>
   <br>
-  <em>기존 AI session을 이어서 열고 다른 project에서 작업하다가, permission이 필요하면 notification list에서 managed pane으로 돌아갑니다.</em>
+  <em>Claude Code, Codex, Antigravity pane을 한곳에서 운영하고, 에이전트가 권한을 요청하거나 작업을 마치면 바로 알려 줍니다.</em>
 </p>
 
-## 무엇인가
+<p align="center">
+  <a href="https://www.npmjs.com/package/projmux"><img src="https://img.shields.io/npm/v/projmux?logo=npm" alt="npm version"></a>
+  <a href="https://github.com/crevissepartners/projmux/actions/workflows/ci.yml"><img src="https://github.com/crevissepartners/projmux/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/crevissepartners/projmux" alt="MIT license"></a>
+  <a href="README.md"><img src="https://img.shields.io/badge/lang-English-blue" alt="English README"></a>
+</p>
 
-`projmux`는 프로젝트 디렉터리를 오래 유지되는 tmux session으로 연결합니다.
-프로젝트 전환, session preview, AI split 실행, tmux 안의 상태 표시를 한
-키보드 중심 workspace 앱으로 묶습니다.
-Claude Code와 Codex hook event를 직접 수집하고, 수동으로 연결한 Antigravity
-hook/statusline event도 같은 notification 흐름으로 다룹니다.
+<p align="center">
+  <img src="docs/assets/projmux-ai-attention.gif" alt="projmux의 AI 세션 재개, 권한 요청, 그룹형 알림 흐름" width="820">
+  <br>
+  <em>기존 AI 세션을 이어서 열고 다른 프로젝트에서 작업하다가, 에이전트가 승인을 요청하면 그룹형 알림에서 확인하고 해당 작업 pane으로 돌아갑니다.</em>
+</p>
 
-터미널 workspace를 한 명령으로 열고, 한 세트의 키로 project/window/pane,
-notification, settings 사이를 오가고 싶을 때 사용합니다.
+## projmux란?
+
+`projmux`는 프로젝트 디렉터리마다 오래 유지되는 tmux 세션을 연결합니다.
+프로젝트 전환, 세션 미리보기, AI 분할 창 실행, 상태 표시를 키보드 중심의
+작업 공간 하나로 묶습니다.
+Claude Code, Codex, Antigravity의 훅 연동을 관리하고, 각 에이전트의 권한
+요청과 작업 완료 알림을 한곳에 모읍니다.
+
+터미널 작업 공간을 명령 하나로 열고, 같은 키 조합으로 프로젝트와 tmux
+창, pane, 알림, 설정 사이를 빠르게 오가고 싶을 때 사용합니다.
 
 ## 요구 사항
 
 - [Node.js](https://nodejs.org/)와 npm: 기본 설치 경로에 필요합니다.
 - [tmux](https://github.com/tmux/tmux/wiki/Installing) **3.4 이상**.
 
-설치 후 `projmux doctor`의 read-only 진단으로 로컬 runtime을 확인하세요.
+설치한 뒤에는 읽기 전용 점검 명령인 `projmux doctor`로 로컬 실행 환경을
+확인하세요.
 
 ## 설치
 
@@ -44,95 +49,107 @@ npm install -g projmux
 projmux version
 ```
 
-npm package는 작은 Node.js shim과 Linux/macOS x64/arm64용 projmux binary를
-설치합니다. 일반 사용자의 기본 배포 경로는 npm입니다.
+npm 패키지는 작은 Node.js 실행 연결부와 Linux/macOS x64·arm64용 projmux
+실행 파일을 함께 설치합니다. 일반 사용자에게는 npm 설치를 권장합니다.
 
-수동 Go 설치, source checkout, GitHub Release, packaging 세부 사항은
-[Install](docs/install.md)을 참고하세요.
+Go 또는 소스 코드로 직접 설치하는 방법, GitHub Release와 패키징에 관한
+내용은 [설치 안내](docs/install.md)를 참고하세요.
 
 ## 빠른 시작
 
-격리된 projmux tmux 앱을 엽니다:
+독립된 projmux용 tmux 환경을 엽니다.
 
 ```sh
 projmux shell
 ```
 
-앱 안에서:
+projmux 안에서는 다음 키를 사용합니다.
 
-- `Alt-1`: project sidebar.
-- `Alt-2`: notification list.
-- `Alt-3`: Recent Windows.
-- `Alt-4`: AI resume session picker.
-- `Alt-5`: settings.
-- `Alt-7`: AI split picker.
+- `Alt-1`: 프로젝트 사이드바를 엽니다.
+- `Alt-2`: 알림 목록을 엽니다.
+- `Alt-3`: 최근 창 목록(`Recent Windows`)을 엽니다.
+- `Alt-4`: 이어서 열 AI 세션을 선택합니다.
+- `Alt-5`: 설정을 엽니다.
+- `Alt-7`: 새 AI 분할 창을 선택합니다.
 
-`Alt-1`부터 `Alt-5`까지는 zero-config 보장 기본값이고, `Alt-7`은 추가로
-편집 가능한 built-in 기본값입니다. 전체 key map은
-[Terminal Keybindings](docs/keybindings.md)를 참고하세요. 키가 동작하지 않으면
-Darwin 배포본의 `projmux shell`에서는 macOS 접근성 권한을 한 번 승인하면
-물리 키 어댑터가 자동으로 동작합니다. 그 밖의 경로에서는 tmux 밖에서
-`projmux setup`을 실행한 뒤, 지원 터미널에서는
-`projmux setup terminal [terminal] --apply`를 사용하세요.
+`Alt-1`부터 `Alt-5`까지는 별도 설정 없이 쓸 수 있는 기본 키입니다. `Alt-7`도
+기본으로 제공되며 설정에서 바꿀 수 있습니다. 전체 키 구성은
+[터미널 키 설정](docs/keybindings.md)을 참고하세요.
+
+키가 동작하지 않는다면 macOS 배포본의 `projmux shell`에서는 접근성 권한을
+한 번 승인하세요. 이후 물리 키 어댑터가 자동으로 동작합니다. 그 밖의
+환경에서는 tmux 밖에서 `projmux setup`을 실행한 다음, 지원되는 터미널에
+`projmux setup terminal [terminal] --apply`를 적용하세요.
 
 ## 일상 사용
 
-- project directory를 고르면 projmux가 tmux session을 만들거나 재사용합니다.
-- 중요한 project는 pin으로 고정합니다.
-- 전환 전에 window, pane, git branch, Kubernetes context, AI pane state를
-  preview합니다.
-- 기존 Claude/Codex conversation을 resume하거나 새 managed AI split을 엽니다.
-- permission/completion event를 하나의 notification queue에서 확인하고 바로
-  attention이 필요한 pane으로 이동합니다.
-- env var를 직접 편집하지 않고 Settings > Project Picker에서 root와 workdir을
-  추가할 수 있습니다.
-- Settings > About > Update 또는 `projmux update apply`로 업그레이드합니다.
+- 프로젝트 디렉터리를 고르면 projmux가 해당 tmux 세션을 만들거나 기존
+  세션을 다시 사용합니다.
+- 자주 쓰는 프로젝트는 `pin`으로 고정해 목록 위쪽에서 쉽게 찾을 수
+  있습니다.
+- 전환하기 전에 창(window)과 pane, Git 브랜치, Kubernetes 컨텍스트, AI pane
+  상태를 미리 확인할 수 있습니다.
+- 기존 Claude, Codex, Antigravity 대화를 이어서 열거나 projmux가 관리하는 새
+  AI 분할 창을 만들 수 있습니다.
+- 권한 요청과 작업 완료 알림을 에이전트별로 묶어 보고, 확인이 필요한
+  pane으로 곧바로 이동할 수 있습니다.
+- 읽기 전용 `Resource Inspector`에서 프로젝트, 창, pane별 CPU와 RSS 사용량을
+  확인할 수 있습니다. 현재 Linux/tmux 환경을 지원합니다.
+- 창과 pane 배치, shell 작업 디렉터리, 지원되는 AI 세션 재개 정보를
+  `Session State` 스냅샷으로 저장하고 미리 볼 수 있습니다.
+- 환경 변수를 직접 편집하지 않고 `Settings > Project Picker`에서 검색 루트와
+  작업 디렉터리를 추가할 수 있습니다.
+- `Settings > About > Update` 또는 `projmux update apply`로 업그레이드할 수
+  있습니다.
 
 <p align="center">
-  <img src="docs/assets/projmux-shell-sidebar.gif" alt="projmux project 전환 및 managed Codex 데모" width="820">
+  <img src="docs/assets/projmux-shell-sidebar.gif" alt="projmux의 프로젝트 전환과 Codex 작업 흐름" width="820">
   <br>
-  <em>project를 전환하고 managed Codex pane을 연 뒤 completion notification을 확인합니다.</em>
+  <em>프로젝트를 전환하고 Codex pane을 연 뒤 완료 알림을 확인합니다.</em>
 </p>
 
-`PROJMUX_PROJDIR`, managed roots, notification, usage tracking 같은 자세한
-설정은 [Configuration](docs/configuration.md)을 참고하세요. installer별 update
-동작은 [Upgrading](docs/upgrading.md)에 있습니다.
+`PROJMUX_PROJDIR`, 관리 루트, 알림, 사용량 추적에 관한 자세한 내용은
+[설정](docs/configuration.md)을 참고하세요. 설치 방식에 따른 업데이트 동작은
+[업그레이드 안내](docs/upgrading.md)에 정리되어 있습니다.
 
 ## 멀티 에이전트 워크플로
 
-하나의 tmux window에 shell과 여러 managed agent를 함께 띄워 둡니다. pane을
-이동하며 독립 작업을 시작하면 projmux가 permission/completion event를 하나의
-notification queue에 모읍니다.
+하나의 tmux 창에 shell과 projmux가 관리하는 Claude, Codex, Antigravity pane을
+나란히 띄울 수 있습니다. 프로젝트와 pane 사이를 오가며 작업해도 projmux가
+에이전트별 권한 요청과 완료 알림을 그룹형 알림함에 모아 줍니다.
 
 <p align="center">
-  <img src="docs/assets/projmux-three-pane-workflow.gif" alt="projmux shell, Codex, Claude 3-pane workflow 데모" width="820">
+  <img src="docs/assets/projmux-three-pane-workflow.gif" alt="projmux의 shell, Codex, Claude 3-pane 작업 흐름" width="820">
   <br>
-  <em>동일 폭의 shell, Codex, Claude pane을 이동하며 독립 작업의 완료 알림을 하나의 notification queue에서 확인합니다.</em>
+  <em>shell, Codex, Claude pane을 오가며 서로 다른 작업을 진행하고, 완료 알림은 한곳에서 확인합니다.</em>
 </p>
 
 ## 에이전트 스킬 자동화
 
-AI 도구도 같은 projmux CLI를 호출해 managed pane을 열고 prompt를 전달할 수
-있습니다:
+AI 도구에서도 같은 projmux 명령줄 도구(CLI)를 호출해 projmux가 관리하는
+pane을 열고 작업 지시를 전달할 수 있습니다.
 
 ```sh
 projmux ai split --agent codex right -- "Review the retry logic."
 ```
 
-Claude, Codex와 다른 agent용 template 및 naming convention은
-[AI Agent Shortcuts](docs/ai-agent-shortcuts.md)에 정리되어 있습니다.
+Claude, Codex를 비롯한 여러 에이전트용 템플릿과 이름 규칙은
+[AI 에이전트 바로가기](docs/ai-agent-shortcuts.md)에 정리되어 있습니다.
 
 ## 추가 문서
 
-- [Install](docs/install.md)
-- [Configuration](docs/configuration.md)
-- [Terminal Keybindings](docs/keybindings.md)
-- [AI Agent Shortcuts](docs/ai-agent-shortcuts.md)
-- [CLI Reference](docs/cli.md)
-- [Statusbar](docs/statusbar.md)
-- [Hooks](docs/hooks.md)
-- [Usage tracking](docs/usage-tracking.md)
-- [Agent Workflow](docs/agent-workflow.md)
+- [설치 안내](docs/install.md)
+- [설정](docs/configuration.md)
+- [터미널 키 설정](docs/keybindings.md)
+- [AI 에이전트 바로가기](docs/ai-agent-shortcuts.md)
+- [CLI 명령어](docs/cli.md)
+- [상태 표시줄](docs/statusbar.md)
+- [훅](docs/hooks.md)
+- [사용량 추적](docs/usage-tracking.md)
+- [Resource Inspector](docs/resource-attribution.md)
+- [Session State](docs/session-restore.md)
+- [운영 진단](docs/operational-diagnostics.md)
+- [에이전트 작업 흐름](docs/agent-workflow.md)
 
 ## 개발
 
@@ -143,8 +160,8 @@ make fix
 make test
 ```
 
-기여자용 세부 사항은 [Testing](docs/testing.md), [Architecture](docs/architecture.md),
-[Repo Layout](docs/repo-layout.md)을 참고하세요.
+기여자를 위한 자세한 내용은 [테스트](docs/testing.md),
+[구조](docs/architecture.md), [저장소 구성](docs/repo-layout.md)을 참고하세요.
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ projmux shell
 ```
 
 <p align="center">
-  <img src="docs/assets/projmux-ai-attention.gif" alt="projmux AI attention demo" width="820">
+  <img src="docs/assets/projmux-ai-attention.gif" alt="projmux AI session resume, agent permission, and grouped notification workflow" width="820">
   <br>
-  <em>Resume an existing AI session, keep working in another project, then jump back when the managed pane needs permission.</em>
+  <em>Resume an existing AI session, keep working in another project, then return through grouped notifications when the agent needs approval.</em>
 </p>
 
 ## Why
@@ -93,14 +93,18 @@ fallbacks.
   before switching.
 - Resume an existing Claude, Codex, or Antigravity conversation, or open a new
   managed AI split.
-- Review permission and completion events in one notification queue, then jump
-  directly to the pane that needs attention.
+- Review grouped permission and completion events, then jump directly to the
+  pane that needs attention.
+- Inspect live project, window, and pane CPU/RSS with the read-only Resource
+  Inspector on Linux/tmux.
+- Save and inspect Session State snapshots for window/pane layouts, shell cwd,
+  and supported AI resumes.
 - Use Settings > Project Picker to add roots and workdirs without editing env
   vars.
 - Use Settings > About > Update or `projmux update apply` to upgrade.
 
 <p align="center">
-  <img src="docs/assets/projmux-shell-sidebar.gif" alt="projmux project switch and managed Codex demo" width="820">
+  <img src="docs/assets/projmux-shell-sidebar.gif" alt="projmux project switch and managed Codex workflow" width="820">
   <br>
   <em>Switch projects, launch a managed Codex pane, and review its completion notification.</em>
 </p>
@@ -111,14 +115,14 @@ For update behavior by installer type, see [Upgrading](docs/upgrading.md).
 
 ## Multi-Agent Workflow
 
-Keep a shell and multiple managed agents visible in the same tmux window.
-Move between panes to start independent tasks while projmux collects their
-permission and completion events in one notification queue.
+Keep a shell and managed Claude, Codex, or Antigravity panes visible in the
+same tmux window. Move between projects and panes while projmux collects agent
+permission and completion events in one grouped inbox.
 
 <p align="center">
-  <img src="docs/assets/projmux-three-pane-workflow.gif" alt="projmux shell, Codex, and Claude 3-pane workflow demo" width="820">
+  <img src="docs/assets/projmux-three-pane-workflow.gif" alt="projmux shell, Codex, and Claude three-pane workflow" width="820">
   <br>
-  <em>Move across equal-width shell, Codex, and Claude panes while independent tasks report back through one notification queue.</em>
+  <em>Move across shell, Codex, and Claude panes while independent tasks report back through one notification queue.</em>
 </p>
 
 ## Automation With Agent Skills
@@ -143,6 +147,9 @@ Templates and naming conventions for Claude, Codex, and other agents are in
 - [Statusbar](docs/statusbar.md)
 - [Hooks](docs/hooks.md)
 - [Usage tracking](docs/usage-tracking.md)
+- [Resource Inspector](docs/resource-attribution.md)
+- [Session State](docs/session-restore.md)
+- [Operational Diagnostics](docs/operational-diagnostics.md)
 - [Agent Workflow](docs/agent-workflow.md)
 
 ## Development


### PR DESCRIPTION
## Summary
- Clarify the README overview around managed Claude, Codex, and Antigravity workflows.
- Add concise Resource Inspector and Session State coverage while keeping the existing GIF assets unchanged.
- Rewrite the Korean README in smoother, more consistent product language.

## Test plan
- [x] make fmt
- [x] make fix
- [x] make test
- [x] make test-integration
- [x] make test-e2e
- [x] git diff --check

## Globalization
- [x] No runtime user-facing string changes; documentation copy is updated in both English and Korean.
- [ ] User-facing strings are behind internal/i18n catalog keys with tests.
- [ ] Non-translated strings are classified as literal/data/debug-only.