### PR TITLE
fix(registry): reclaim a Window primaryPaneRef when a Pane returns

### DIFF
--- a/internal/core/metadata/invariant_pbt_test.go
+++ b/internal/core/metadata/invariant_pbt_test.go
@@ -1,0 +1,165 @@
+package metadata
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// The write-closure property.
+//
+// Validate is the one gate every registry write passes, so the set of registries
+// the Mutator can produce has to be a subset of the set Validate accepts. If it
+// is not, the offending write does not fail at the time it is made: it commits a
+// document that the *next* write rejects, and from that point every mutation of
+// that registry fails until somebody repairs the file by hand. A pair of
+// individually legal commands then adds up to a registry nothing can change.
+//
+// The tests below drive the shipped Mutator rather than building structs, because
+// the question is not whether an invalid registry can be constructed. It is
+// whether the product writes one.
+
+// pbtMutatorOver builds a fully deterministic Mutator over one existing root.
+func pbtMutatorOver(root string) Mutator {
+	counters := map[Kind]int{}
+	clock := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	return Mutator{
+		Now: func() time.Time {
+			clock = clock.Add(time.Second)
+			return clock
+		},
+		NewUID: func(kind Kind) (string, error) {
+			counters[kind]++
+			return fmt.Sprintf("%s-pbt%03d", kind, counters[kind]), nil
+		},
+		DirExists: func(path string) (bool, error) { return path == root, nil },
+	}
+}
+
+func pbtRegistryOver(t *testing.T, root string) (*Registry, Project, Mutator) {
+	t.Helper()
+	mutator := pbtMutatorOver(root)
+	registry := NewRegistry()
+	result, err := mutator.RegisterProject(&registry, RegisterProjectOptions{Root: root, OperationID: "pbt-register"})
+	if err != nil {
+		t.Fatalf("register project: %v", err)
+	}
+	return &registry, result.Project, mutator
+}
+
+// TestDeletedLastPaneThenCreateKeepsRegistryValid pins the exact pair of legal
+// commands that produced an unwritable registry in the field: deleting a Window's
+// last Pane empties primaryPaneRef by design, and the next Pane added under that
+// Window has to reclaim it.
+func TestDeletedLastPaneThenCreateKeepsRegistryValid(t *testing.T) {
+	root := t.TempDir()
+	registry, project, mutator := pbtRegistryOver(t, root)
+
+	window := registry.WindowsOf(project.Metadata.UID)[0]
+	first := registry.PanesOf(window.Metadata.UID)[0]
+	if err := mutator.DeletePane(registry, first.Metadata.UID); err != nil {
+		t.Fatalf("delete last pane: %v", err)
+	}
+	stored, _ := registry.Window(window.Metadata.UID)
+	if stored.Spec.PrimaryPaneRef != "" {
+		t.Fatalf("primaryPaneRef = %q, want empty once the Window owns no Pane", stored.Spec.PrimaryPaneRef)
+	}
+	if err := registry.Validate(); err != nil {
+		t.Fatalf("a Window with no Pane must stay valid: %v", err)
+	}
+
+	added, err := mutator.AddPane(registry, window.Metadata.UID, BootstrapPane{}, "sh", "pbt-add")
+	if err != nil {
+		t.Fatalf("add pane: %v", err)
+	}
+	if err := registry.Validate(); err != nil {
+		t.Fatalf("AddPane committed a registry Validate rejects: %v", err)
+	}
+	stored, _ = registry.Window(window.Metadata.UID)
+	if stored.Spec.PrimaryPaneRef != added.Metadata.UID {
+		t.Fatalf("primaryPaneRef = %q, want the returning Pane %q", stored.Spec.PrimaryPaneRef, added.Metadata.UID)
+	}
+}
+
+// TestAgentPaneReclaimsPrimaryPaneRef pins the same rule for the Agent half.
+// Validate counts a Pane owned by one of the Window's Agents as a Pane the Window
+// owns, so attaching one to an empty Window has to reclaim primaryPaneRef too.
+func TestAgentPaneReclaimsPrimaryPaneRef(t *testing.T) {
+	root := t.TempDir()
+	registry, project, mutator := pbtRegistryOver(t, root)
+
+	window := registry.WindowsOf(project.Metadata.UID)[0]
+	first := registry.PanesOf(window.Metadata.UID)[0]
+	if err := mutator.DeletePane(registry, first.Metadata.UID); err != nil {
+		t.Fatalf("delete last pane: %v", err)
+	}
+	agent, err := mutator.CreateAgent(registry, window.Metadata.UID, CreateAgentOptions{Provider: "codex", OperationID: "pbt-agent"})
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	pane, err := mutator.AttachAgentPane(registry, agent.Metadata.UID, BootstrapPane{}, "pbt-attach")
+	if err != nil {
+		t.Fatalf("attach agent pane: %v", err)
+	}
+	if err := registry.Validate(); err != nil {
+		t.Fatalf("AttachAgentPane committed a registry Validate rejects: %v", err)
+	}
+	stored, _ := registry.Window(window.Metadata.UID)
+	if stored.Spec.PrimaryPaneRef != pane.Metadata.UID {
+		t.Fatalf("primaryPaneRef = %q, want the Agent's Pane %q", stored.Spec.PrimaryPaneRef, pane.Metadata.UID)
+	}
+}
+
+// FuzzMutatorNeverCommitsInvalidRegistry generalizes both. Every operation is one
+// the product exposes and every intermediate registry is asserted valid, so the
+// property is the write closure itself.
+func FuzzMutatorNeverCommitsInvalidRegistry(f *testing.F) {
+	f.Add([]byte{2, 0})
+	f.Add([]byte{1, 2, 3})
+	f.Add([]byte{4, 1, 2, 0, 3})
+	f.Add([]byte{4, 1, 2, 0, 3, 5, 0, 2})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 48 {
+			data = data[:48]
+		}
+		root := t.TempDir()
+		registry, project, mutator := pbtRegistryOver(t, root)
+
+		for step, op := range data {
+			windows := registry.WindowsOf(project.Metadata.UID)
+			if len(windows) == 0 {
+				break
+			}
+			window := windows[int(op)%len(windows)]
+			switch op % 6 {
+			case 0:
+				_, _ = mutator.AddPane(registry, window.Metadata.UID, BootstrapPane{}, "sh", fmt.Sprintf("pbt-pane-%d", step))
+			case 1:
+				if agent, err := mutator.CreateAgent(registry, window.Metadata.UID, CreateAgentOptions{
+					Provider:    "codex",
+					OperationID: fmt.Sprintf("pbt-agent-%d", step),
+				}); err == nil {
+					_, _ = mutator.AttachAgentPane(registry, agent.Metadata.UID, BootstrapPane{}, fmt.Sprintf("pbt-attach-%d", step))
+				}
+			case 2:
+				if panes := registry.PanesOf(window.Metadata.UID); len(panes) > 0 {
+					_ = mutator.DeletePane(registry, panes[0].Metadata.UID)
+				}
+			case 3:
+				if agents := registry.AgentsOf(window.Metadata.UID); len(agents) > 0 {
+					_, _ = mutator.ReleaseAgentPane(registry, agents[0].Metadata.UID, AgentExitNormal, "pbt")
+				}
+			case 4:
+				_, _, _ = mutator.AddWindow(registry, project.Metadata.UID, BootstrapWindow{}, "sh", fmt.Sprintf("pbt-window-%d", step))
+			case 5:
+				if agents := registry.AgentsOf(window.Metadata.UID); len(agents) > 0 {
+					_ = mutator.DeleteAgent(registry, agents[0].Metadata.UID)
+				}
+			}
+			if err := registry.Validate(); err != nil {
+				t.Fatalf("step %d (op %d) committed a registry Validate rejects: %v", step, op, err)
+			}
+		}
+	})
+}

--- a/internal/core/metadata/mutator.go
+++ b/internal/core/metadata/mutator.go
@@ -334,7 +334,43 @@ func (m Mutator) addPaneTx(txn *Transaction, reg *Registry, op, ownerUID string,
 	}
 	reg.Panes = append(reg.Panes, pane)
 	txn.record(KindPane, paneUID)
+	reg.adoptPrimaryPaneRef(ownerUID, ownerKind, paneUID)
 	return pane, nil
+}
+
+// adoptPrimaryPaneRef gives a Window its primaryPaneRef back when this Pane is
+// the first one it owns again.
+//
+// Validate states the rule as a pair: a Window with no owned Pane carries an
+// empty primaryPaneRef, and a Window that owns one carries a resolvable ref.
+// Deleting a Window's last Pane empties the ref by design, so the very next Pane
+// added under that Window has to reclaim it or the registry the caller just wrote
+// is one Validate rejects -- and it is rejected on the *next* write, not this one,
+// which turns a legal `delete pane` followed by a legal `create pane` into a
+// registry nothing can mutate any more.
+//
+// A Pane owned by an Agent counts, because Validate counts it: windowPaneUIDs is
+// transitive through the Window's Agents. Adoption is strictly a repair of the
+// empty case and never re-points a Window that already has a resolvable primary.
+func (r *Registry) adoptPrimaryPaneRef(ownerUID string, ownerKind Kind, paneUID string) {
+	windowUID := ownerUID
+	if ownerKind == KindAgent {
+		agent, ok := r.Agent(ownerUID)
+		if !ok {
+			return
+		}
+		windowUID = agent.Metadata.OwnerUID()
+	}
+	for i := range r.Windows {
+		if r.Windows[i].Metadata.UID != windowUID {
+			continue
+		}
+		if strings.TrimSpace(r.Windows[i].Spec.PrimaryPaneRef) != "" {
+			return
+		}
+		r.Windows[i].Spec.PrimaryPaneRef = paneUID
+		return
+	}
 }
 
 // AddPane creates one offline shell Pane inside an existing Window.


### PR DESCRIPTION
## Summary
- Repair a Window's `primaryPaneRef` when a Pane returns through the canonical Registry mutator.
- Keep committed Registry states inside the Window primary-pane invariant.
- Phase 0 of Declarative contract stabilization; this is the first PR in the local stack.

## Test plan
- [x] `FuzzMutatorNeverCommitsInvalidRegistry`
- [x] `TestDeletedLastPaneThenCreateKeepsRegistryValid`
- [x] `TestAgentPaneReclaimsPrimaryPaneRef`
- [x] Repository validation gates recorded in the Phase 0 roadmap evidence

## Globalization
- [x] No user-facing string changes.
- [ ] User-facing strings are behind `internal/i18n` catalog keys with tests.
- [ ] Non-translated strings are classified as literal/data/debug-only.

## Stack
- Base: `main`
- Next: Phase 1 targets this branch. Merge with squash before rebasing the next PR onto `main`.

Roadmap: Declarative contract stabilization / Phase 0 admission
Contract: C-1 Enforcement
