### PR TITLE
fix(startup): skip refused items instead of refusing the whole Project

### DIFF
--- a/internal/app/registry_topology_invariant_pbt_test.go
+++ b/internal/app/registry_topology_invariant_pbt_test.go
@@ -1,0 +1,350 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	"github.com/crevissepartners/projmux/internal/core/selector"
+)
+
+// The openability property.
+//
+// `Registry.Validate` is the one gate every write passes, and
+// `planRegistryTopology` is what turns a stored Project back into a running one.
+// The two do not share a precondition: Validate accepts a Window with no
+// Window-owned shell Pane, and the planner cannot build one. That difference is
+// reachable through ordinary use, so the property that has to hold is not "the
+// planner refuses nothing" -- it is that no validate-clean Registry can make the
+// Project itself unopenable. An item the planner cannot build is one item; the
+// Project keeps opening with everything else, and the skipped item is disclosed.
+//
+// The tests below state that relation over states the product itself produces.
+// They drive the shipped Mutator rather than hand-building structs, because the
+// question is not "can an invalid Registry be constructed" -- it is "does the
+// product write Registries its own materializer cannot open".
+
+// pbtMutator is a fully deterministic Mutator over one existing root.
+func pbtMutator(root string) coremetadata.Mutator {
+	counters := map[coremetadata.Kind]int{}
+	clock := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	return coremetadata.Mutator{
+		Now: func() time.Time {
+			clock = clock.Add(time.Second)
+			return clock
+		},
+		NewUID: func(kind coremetadata.Kind) (string, error) {
+			counters[kind]++
+			return fmt.Sprintf("%s-pbt%03d", strings.ToLower(string(kind)), counters[kind]), nil
+		},
+		DirExists: func(path string) (bool, error) {
+			return strings.TrimSpace(path) == root, nil
+		},
+	}
+}
+
+// pbtProject registers one Project whose root exists, binds its session name, and
+// returns the registry plus the exact selector the materialize routes take.
+func pbtProject(t *testing.T, root string) (*coremetadata.Registry, coremetadata.Project, coremetadata.Mutator) {
+	t.Helper()
+	mutator := pbtMutator(root)
+	registry := coremetadata.NewRegistry()
+	result, err := mutator.RegisterProject(&registry, coremetadata.RegisterProjectOptions{Root: root, OperationID: "pbt-register"})
+	if err != nil {
+		t.Fatalf("register project: %v", err)
+	}
+	if _, err := mutator.BindProjectSession(&registry, result.Project.Metadata.UID, "pbt-session", false); err != nil {
+		t.Fatalf("bind project session: %v", err)
+	}
+	project, ok := registry.Project(result.Project.Metadata.UID)
+	if !ok {
+		t.Fatalf("registered Project disappeared")
+	}
+	return &registry, *project, mutator
+}
+
+// pbtPlan runs the offline materialize planner the closed-Project startup path
+// runs. No live session is observed, so the plan is the pure desired-topology
+// projection and the runner is never called.
+func pbtPlan(t *testing.T, registry coremetadata.Registry, project coremetadata.Project) *registryTopologyPlan {
+	t.Helper()
+	target, err := tmuxSocketNameTarget(defaultAppSocket)
+	if err != nil {
+		t.Fatalf("socket target: %v", err)
+	}
+	plan, err := planRegistryTopology(context.Background(), nil, registry,
+		selector.UIDPrefix+project.Metadata.UID, nil, nil, target, nil)
+	if err != nil {
+		t.Fatalf("plan registry topology: %v", err)
+	}
+	if plan == nil {
+		t.Fatalf("planner returned no plan for an existing Project")
+	}
+	return plan
+}
+
+// pbtRender renders refused items so a failure names the exact state.
+func pbtRender(items []resourceReconcileItem) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, fmt.Sprintf("%s %s: %s", item.Kind, item.Target, item.Reason))
+	}
+	return out
+}
+
+// pbtPlannedWindows names the Windows the activation will actually build.
+func pbtPlannedWindows(plan *registryTopologyPlan) []string {
+	out := make([]string, 0, len(plan.windows))
+	for _, work := range plan.windows {
+		out = append(out, work.window.Metadata.Name)
+	}
+	return out
+}
+
+// pbtRegistryShape renders the ownership shape of one Project for failure output.
+func pbtRegistryShape(registry coremetadata.Registry, project coremetadata.Project) string {
+	var b strings.Builder
+	for _, window := range registry.WindowsOf(project.Metadata.UID) {
+		fmt.Fprintf(&b, "\n  window %s primaryPaneRef=%q", window.Metadata.Name, window.Spec.PrimaryPaneRef)
+		for _, pane := range registry.PanesOf(window.Metadata.UID) {
+			fmt.Fprintf(&b, "\n    pane %s role=%s owner=window", pane.Metadata.Name, pane.Spec.Role)
+		}
+		for _, agent := range registry.AgentsOf(window.Metadata.UID) {
+			fmt.Fprintf(&b, "\n    agent %s phase=%s", agent.Metadata.Name, agent.Status.Phase)
+			for _, pane := range registry.PanesOf(agent.Metadata.UID) {
+				fmt.Fprintf(&b, "\n      pane %s role=%s owner=agent", pane.Metadata.Name, pane.Spec.Role)
+			}
+		}
+	}
+	return b.String()
+}
+
+// TestTopologyPlanKeepsProjectOpenableWithAgentOnlyWindow pins the state an
+// operator reaches by running an Agent in a Window and closing that Window's
+// shell. The shell Pane is gone, deletePane promotes the Agent's managed Pane to
+// primaryPaneRef, Validate accepts the result, and the planner cannot build a
+// Window from an Agent-owned Pane. The Project still has to open, and the Window
+// it could not build has to be disclosed rather than dropped.
+func TestTopologyPlanKeepsProjectOpenableWithAgentOnlyWindow(t *testing.T) {
+	root := t.TempDir()
+	registry, project, mutator := pbtProject(t, root)
+
+	window := registry.WindowsOf(project.Metadata.UID)[0]
+	shellPane := registry.PanesOf(window.Metadata.UID)[0]
+	agent, err := mutator.CreateAgent(registry, window.Metadata.UID, coremetadata.CreateAgentOptions{
+		Provider:    "codex",
+		OperationID: "pbt-agent",
+	})
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	if _, err := mutator.AttachAgentPane(registry, agent.Metadata.UID, coremetadata.BootstrapPane{}, "pbt-attach"); err != nil {
+		t.Fatalf("attach agent pane: %v", err)
+	}
+	if err := mutator.DeletePane(registry, shellPane.Metadata.UID); err != nil {
+		t.Fatalf("delete shell pane: %v", err)
+	}
+	healthy, _, err := mutator.AddWindow(registry, project.Metadata.UID, coremetadata.BootstrapWindow{Name: "healthy"}, "sh", "pbt-window")
+	if err != nil {
+		t.Fatalf("add healthy window: %v", err)
+	}
+	if err := registry.Validate(); err != nil {
+		t.Fatalf("registry the product wrote is invalid: %v", err)
+	}
+
+	plan := pbtPlan(t, *registry, project)
+	fatal, skipped := plan.refusalScope()
+	if len(fatal) != 0 {
+		t.Fatalf("valid Registry made the Project unopenable: %v\nshape:%s", pbtRender(fatal), pbtRegistryShape(*registry, project))
+	}
+	if planned := pbtPlannedWindows(plan); !slices.Contains(planned, healthy.Metadata.Name) {
+		t.Fatalf("planned windows = %v, want the healthy Window %q to still be built", planned, healthy.Metadata.Name)
+	}
+	if len(skipped) != 1 || !strings.Contains(skipped[0].Reason, "primaryPaneRef") {
+		t.Fatalf("skipped = %v, want exactly the Agent-only Window with a stated reason", pbtRender(skipped))
+	}
+	if !slices.ContainsFunc(plan.skipNotices(), func(n string) bool { return strings.Contains(n, "was not restored") }) {
+		t.Fatalf("skip notices = %v, want the skipped Window disclosed to the operator", plan.skipNotices())
+	}
+}
+
+// TestTopologyPlanKeepsProjectOpenableWithoutPanes pins the same state one step
+// further on: the Agent's Pane is released too, so the Window owns nothing and
+// carries an empty primaryPaneRef, which Validate accepts explicitly.
+func TestTopologyPlanKeepsProjectOpenableWithoutPanes(t *testing.T) {
+	root := t.TempDir()
+	registry, project, mutator := pbtProject(t, root)
+
+	window := registry.WindowsOf(project.Metadata.UID)[0]
+	shellPane := registry.PanesOf(window.Metadata.UID)[0]
+	agent, err := mutator.CreateAgent(registry, window.Metadata.UID, coremetadata.CreateAgentOptions{
+		Provider:    "claude",
+		OperationID: "pbt-agent",
+	})
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	if _, err := mutator.AttachAgentPane(registry, agent.Metadata.UID, coremetadata.BootstrapPane{}, "pbt-attach"); err != nil {
+		t.Fatalf("attach agent pane: %v", err)
+	}
+	if _, err := mutator.ReleaseAgentPane(registry, agent.Metadata.UID, coremetadata.AgentExitNormal, "pbt release"); err != nil {
+		t.Fatalf("release agent pane: %v", err)
+	}
+	if err := mutator.DeletePane(registry, shellPane.Metadata.UID); err != nil {
+		t.Fatalf("delete shell pane: %v", err)
+	}
+	if _, _, err := mutator.AddWindow(registry, project.Metadata.UID, coremetadata.BootstrapWindow{Name: "healthy"}, "sh", "pbt-window"); err != nil {
+		t.Fatalf("add healthy window: %v", err)
+	}
+	if err := registry.Validate(); err != nil {
+		t.Fatalf("registry the product wrote is invalid: %v", err)
+	}
+	stored, _ := registry.Window(window.Metadata.UID)
+	if strings.TrimSpace(stored.Spec.PrimaryPaneRef) != "" {
+		t.Fatalf("primaryPaneRef = %q, want empty for a Window that owns no Pane", stored.Spec.PrimaryPaneRef)
+	}
+
+	plan := pbtPlan(t, *registry, project)
+	if fatal, _ := plan.refusalScope(); len(fatal) != 0 {
+		t.Fatalf("valid Registry made the Project unopenable: %v\nshape:%s", pbtRender(fatal), pbtRegistryShape(*registry, project))
+	}
+	if planned := pbtPlannedWindows(plan); !slices.Contains(planned, "healthy") {
+		t.Fatalf("planned windows = %v, want the healthy Window to still be built", planned)
+	}
+}
+
+// TestTopologyPlanSkipsOnlyTheStaleCWDPane pins the deleted-worktree case: a
+// stored Pane whose cwd no longer exists is left out of the plan, and its Window
+// still comes back with the Panes that can be built.
+func TestTopologyPlanSkipsOnlyTheStaleCWDPane(t *testing.T) {
+	root := t.TempDir()
+	registry, project, mutator := pbtProject(t, root)
+
+	window := registry.WindowsOf(project.Metadata.UID)[0]
+	stale, err := mutator.AddPane(registry, window.Metadata.UID,
+		coremetadata.BootstrapPane{CWD: filepath.Join(root, ".wt", "feat", "removed-worktree")}, "sh", "pbt-stale")
+	if err != nil {
+		t.Fatalf("add stale pane: %v", err)
+	}
+	if err := registry.Validate(); err != nil {
+		t.Fatalf("registry the product wrote is invalid: %v", err)
+	}
+
+	plan := pbtPlan(t, *registry, project)
+	fatal, skipped := plan.refusalScope()
+	if len(fatal) != 0 {
+		t.Fatalf("a stale Pane cwd made the Project unopenable: %v", pbtRender(fatal))
+	}
+	if len(skipped) != 1 || skipped[0].Target != stale.Metadata.Name {
+		t.Fatalf("skipped = %v, want exactly the stale Pane %q", pbtRender(skipped), stale.Metadata.Name)
+	}
+	if planned := pbtPlannedWindows(plan); len(planned) != 1 {
+		t.Fatalf("planned windows = %v, want the Window still built", planned)
+	}
+	for _, work := range plan.windows {
+		for _, paneWork := range work.panes {
+			if paneWork.pane.Metadata.UID == stale.Metadata.UID {
+				t.Fatalf("plan still builds the stale Pane %q, whose cwd does not exist", stale.Metadata.Name)
+			}
+		}
+	}
+}
+
+// pbtOpStream turns fuzz bytes into a bounded operation sequence. It is a stream
+// rather than a decoded struct so the corpus stays minimal and a mutation of one
+// byte changes one decision.
+type pbtOpStream struct {
+	data []byte
+	pos  int
+}
+
+func (s *pbtOpStream) next() (byte, bool) {
+	if s.pos >= len(s.data) {
+		return 0, false
+	}
+	b := s.data[s.pos]
+	s.pos++
+	return b, true
+}
+
+// FuzzTopologyPlanNeverRefusesValidRegistry generalizes the two pinned states.
+//
+// Every operation is one the product exposes, every intermediate Registry is
+// asserted valid, and the property is the set relation itself: a Registry the
+// writer accepted must not be refused by the planner. Filesystem drift is
+// deliberately excluded -- every Pane cwd is the Project root -- so a failure
+// here is a structural contract gap and never a missing directory.
+func FuzzTopologyPlanNeverRefusesValidRegistry(f *testing.F) {
+	f.Add([]byte{0})             // bootstrap topology only
+	f.Add([]byte{1, 2})          // agent attached, shell pane deleted
+	f.Add([]byte{1, 2, 3})       // agent pane released as well
+	f.Add([]byte{4, 1, 2, 0, 3}) // second Window, then the same decay
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 64 {
+			data = data[:64]
+		}
+		root := t.TempDir()
+		registry, project, mutator := pbtProject(t, root)
+		stream := &pbtOpStream{data: data}
+
+		for step := 0; ; step++ {
+			op, ok := stream.next()
+			if !ok {
+				break
+			}
+			windows := registry.WindowsOf(project.Metadata.UID)
+			if len(windows) == 0 {
+				break
+			}
+			window := windows[int(op)%len(windows)]
+			switch op % 6 {
+			case 0:
+				_, _ = mutator.AddPane(registry, window.Metadata.UID, coremetadata.BootstrapPane{}, "sh", fmt.Sprintf("pbt-pane-%d", step))
+			case 1:
+				agent, err := mutator.CreateAgent(registry, window.Metadata.UID, coremetadata.CreateAgentOptions{
+					Provider:    "codex",
+					OperationID: fmt.Sprintf("pbt-agent-%d", step),
+				})
+				if err == nil {
+					_, _ = mutator.AttachAgentPane(registry, agent.Metadata.UID, coremetadata.BootstrapPane{}, fmt.Sprintf("pbt-attach-%d", step))
+				}
+			case 2:
+				if panes := registry.PanesOf(window.Metadata.UID); len(panes) > 0 {
+					_ = mutator.DeletePane(registry, panes[0].Metadata.UID)
+				}
+			case 3:
+				if agents := registry.AgentsOf(window.Metadata.UID); len(agents) > 0 {
+					_, _ = mutator.ReleaseAgentPane(registry, agents[0].Metadata.UID, coremetadata.AgentExitNormal, "pbt")
+				}
+			case 4:
+				_, _, _ = mutator.AddWindow(registry, project.Metadata.UID, coremetadata.BootstrapWindow{}, "sh", fmt.Sprintf("pbt-window-%d", step))
+			case 5:
+				if agents := registry.AgentsOf(window.Metadata.UID); len(agents) > 0 {
+					_ = mutator.DeleteAgent(registry, agents[0].Metadata.UID)
+				}
+			}
+			if err := registry.Validate(); err != nil {
+				t.Fatalf("step %d left an invalid Registry: %v", step, err)
+			}
+		}
+
+		// A Project with no Window declares no desired topology at all, which the
+		// startup path answers by creating a fresh session instead. That disagreement
+		// is tracked as its own contract; it is not what this property is about.
+		if len(registry.WindowsOf(project.Metadata.UID)) == 0 {
+			t.Skip("no Registry Window topology to materialize")
+		}
+
+		plan := pbtPlan(t, *registry, project)
+		if fatal, _ := plan.refusalScope(); len(fatal) != 0 {
+			t.Fatalf("valid Registry made the Project unopenable: %v\nshape:%s",
+				pbtRender(fatal), pbtRegistryShape(*registry, project))
+		}
+	})
+}

--- a/internal/app/registry_topology_materialize.go
+++ b/internal/app/registry_topology_materialize.go
@@ -188,19 +188,32 @@ func planRegistryTopology(
 		}
 		work.primary = *primary
 		eligible := registry.PanesOf(window.Metadata.UID)
+		// A stored Pane whose cwd is gone is one item of the desired topology, not
+		// a verdict on the Project. It is refused here and left out of the plan, so
+		// the tmux pass never tries to open a directory that does not exist and the
+		// Window still comes back with the Panes that can be built. A refused
+		// *primary* is different: the Window is created from its primary Pane's
+		// cwd, so that one takes the Window with it.
+		refusedPanes := map[string]bool{}
 		for _, pane := range eligible {
 			if pane.Spec.Role != coremetadata.PaneRoleShell {
 				continue
 			}
 			if reason := validateMaterializeDirectory(materializePaneCWD(project, pane), "Pane cwd"); reason != "" {
 				plan.refuse(coremetadata.KindPane, pane.Metadata.Name, reason)
+				refusedPanes[pane.Metadata.UID] = true
 			}
+		}
+		if refusedPanes[work.primary.Metadata.UID] {
+			plan.refuse(coremetadata.KindWindow, window.Metadata.Name,
+				"the Window's primary Pane cwd cannot be materialized, so the Window has no cwd to be created from")
+			continue
 		}
 		if work.liveID == "" {
 			work.create = true
 			plan.addItem(wi+1, coremetadata.KindWindow, window.Metadata.Name, window.Metadata.UID, "materialize")
 			for pi, pane := range eligible {
-				if pane.Spec.Role != coremetadata.PaneRoleShell {
+				if pane.Spec.Role != coremetadata.PaneRoleShell || refusedPanes[pane.Metadata.UID] {
 					continue
 				}
 				work.panes = append(work.panes, registryTopologyPanePlan{pane: pane, create: true})
@@ -244,7 +257,7 @@ func planRegistryTopology(
 			}
 		}
 		for pi, pane := range eligible {
-			if pane.Spec.Role != coremetadata.PaneRoleShell {
+			if pane.Spec.Role != coremetadata.PaneRoleShell || refusedPanes[pane.Metadata.UID] {
 				continue
 			}
 			paneWork := registryTopologyPanePlan{pane: pane}
@@ -381,6 +394,63 @@ func (p *registryTopologyPlan) writeNotices(w io.Writer) {
 	for _, notice := range p.notices {
 		fmt.Fprintln(w, notice)
 	}
+	for _, notice := range p.skipNotices() {
+		fmt.Fprintln(w, notice)
+	}
+}
+
+// refusalScope splits one plan's refusals into the ones that end the pass and the
+// ones the pass can skip.
+//
+// A refused Project is the pass. There is no partial answer to "this Project's
+// identity, root, or session projection is wrong", and every item below it was
+// planned against that answer.
+//
+// A refused Window or Pane is one item of the stored topology. Ending the whole
+// activation because one stored item cannot be built is what made a single
+// deleted worktree directory, or one Window that had only ever hosted Agents,
+// fatal to everything else the Project had. The kernel this plan feeds already
+// states the rule the other way round: a refusal is a recorded outcome with a
+// stated reason, not an error.
+//
+// The split is restricted to an offline activation on purpose. Once a live
+// session claims the Project, a refusal is a statement about runtime objects the
+// operator is using right now, and the ownership guards are the only thing
+// keeping this pass out of somebody else's window. That case keeps the
+// all-or-nothing contract it shipped with.
+func (p *registryTopologyPlan) refusalScope() (fatal, skipped []resourceReconcileItem) {
+	if p == nil {
+		return nil, nil
+	}
+	for _, item := range p.items {
+		if !item.refused {
+			continue
+		}
+		if p.sessionLive || item.Kind == string(coremetadata.KindProject) {
+			fatal = append(fatal, item)
+			continue
+		}
+		skipped = append(skipped, item)
+	}
+	return fatal, skipped
+}
+
+// skipNotices renders the operator disclosure for every stored item this pass
+// leaves out.
+//
+// It is derived from the plan rather than accumulated while planning, so a
+// refusal cannot be recorded as a plan item and then quietly fail to be
+// disclosed: the two come from one source. An activation that dropped part of the
+// stored topology in silence would be indistinguishable from one that restored
+// all of it.
+func (p *registryTopologyPlan) skipNotices() []string {
+	_, skipped := p.refusalScope()
+	out := make([]string, 0, len(skipped))
+	for _, item := range skipped {
+		out = append(out, fmt.Sprintf("projmux: %s/%s was not restored: %s",
+			strings.ToLower(item.Kind), item.Target, item.Reason))
+	}
+	return out
 }
 
 func (p *registryTopologyPlan) hasRefusal() bool {
@@ -480,10 +550,17 @@ func (r topologyMaterializeRun) execute(ctx context.Context, planner resourceRec
 		}
 		outcome.plan = current
 		outcome.completed = append(outcome.completed, "plan rechecked under Registry lock")
-		if current.refusedItems() != 0 {
+		fatal, skipped := current.materialization.refusalScope()
+		if current.materialization == nil && current.refusedItems() != 0 {
 			outcome.failedStage = "topology prevalidation"
 			return fmt.Errorf("selected Project topology contains %d refused item(s)", current.refusedItems())
 		}
+		if len(fatal) != 0 {
+			outcome.failedStage = "topology prevalidation"
+			return fmt.Errorf("selected Project topology contains %d refused item(s) that end the activation: %s",
+				len(fatal), describeRefusedItems(fatal))
+		}
+		_ = skipped
 		// The Agent disclosures describe what this pass is about to do, so they
 		// are written only once the pass is going to happen. A refused plan
 		// materializes nothing, and "this Agent starts a new conversation" would
@@ -1045,4 +1122,15 @@ func executeRegistryTopology(
 	// Startup runs only after every created object carries its exact uid, so a
 	// synchronous startup mutation cannot escape the transaction unnoticed.
 	return runtime.finalizeSessionStartup(ctx, created, plan.sessionName, plan.project.Spec.Root, ledger)
+}
+
+// describeRefusedItems renders refused items for one error line. The reasons are
+// the plan's own, so the message an operator sees names the exact stored item and
+// why it was refused rather than a count they then have to go and look up.
+func describeRefusedItems(items []resourceReconcileItem) string {
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		parts = append(parts, fmt.Sprintf("%s %s (%s)", strings.ToLower(item.Kind), item.Target, item.Reason))
+	}
+	return strings.Join(parts, "; ")
 }

--- a/internal/core/metadata/invariant_pbt_test.go
+++ b/internal/core/metadata/invariant_pbt_test.go
@@ -1,0 +1,165 @@
+package metadata
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// The write-closure property.
+//
+// Validate is the one gate every registry write passes, so the set of registries
+// the Mutator can produce has to be a subset of the set Validate accepts. If it
+// is not, the offending write does not fail at the time it is made: it commits a
+// document that the *next* write rejects, and from that point every mutation of
+// that registry fails until somebody repairs the file by hand. A pair of
+// individually legal commands then adds up to a registry nothing can change.
+//
+// The tests below drive the shipped Mutator rather than building structs, because
+// the question is not whether an invalid registry can be constructed. It is
+// whether the product writes one.
+
+// pbtMutatorOver builds a fully deterministic Mutator over one existing root.
+func pbtMutatorOver(root string) Mutator {
+	counters := map[Kind]int{}
+	clock := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	return Mutator{
+		Now: func() time.Time {
+			clock = clock.Add(time.Second)
+			return clock
+		},
+		NewUID: func(kind Kind) (string, error) {
+			counters[kind]++
+			return fmt.Sprintf("%s-pbt%03d", kind, counters[kind]), nil
+		},
+		DirExists: func(path string) (bool, error) { return path == root, nil },
+	}
+}
+
+func pbtRegistryOver(t *testing.T, root string) (*Registry, Project, Mutator) {
+	t.Helper()
+	mutator := pbtMutatorOver(root)
+	registry := NewRegistry()
+	result, err := mutator.RegisterProject(&registry, RegisterProjectOptions{Root: root, OperationID: "pbt-register"})
+	if err != nil {
+		t.Fatalf("register project: %v", err)
+	}
+	return &registry, result.Project, mutator
+}
+
+// TestDeletedLastPaneThenCreateKeepsRegistryValid pins the exact pair of legal
+// commands that produced an unwritable registry in the field: deleting a Window's
+// last Pane empties primaryPaneRef by design, and the next Pane added under that
+// Window has to reclaim it.
+func TestDeletedLastPaneThenCreateKeepsRegistryValid(t *testing.T) {
+	root := t.TempDir()
+	registry, project, mutator := pbtRegistryOver(t, root)
+
+	window := registry.WindowsOf(project.Metadata.UID)[0]
+	first := registry.PanesOf(window.Metadata.UID)[0]
+	if err := mutator.DeletePane(registry, first.Metadata.UID); err != nil {
+		t.Fatalf("delete last pane: %v", err)
+	}
+	stored, _ := registry.Window(window.Metadata.UID)
+	if stored.Spec.PrimaryPaneRef != "" {
+		t.Fatalf("primaryPaneRef = %q, want empty once the Window owns no Pane", stored.Spec.PrimaryPaneRef)
+	}
+	if err := registry.Validate(); err != nil {
+		t.Fatalf("a Window with no Pane must stay valid: %v", err)
+	}
+
+	added, err := mutator.AddPane(registry, window.Metadata.UID, BootstrapPane{}, "sh", "pbt-add")
+	if err != nil {
+		t.Fatalf("add pane: %v", err)
+	}
+	if err := registry.Validate(); err != nil {
+		t.Fatalf("AddPane committed a registry Validate rejects: %v", err)
+	}
+	stored, _ = registry.Window(window.Metadata.UID)
+	if stored.Spec.PrimaryPaneRef != added.Metadata.UID {
+		t.Fatalf("primaryPaneRef = %q, want the returning Pane %q", stored.Spec.PrimaryPaneRef, added.Metadata.UID)
+	}
+}
+
+// TestAgentPaneReclaimsPrimaryPaneRef pins the same rule for the Agent half.
+// Validate counts a Pane owned by one of the Window's Agents as a Pane the Window
+// owns, so attaching one to an empty Window has to reclaim primaryPaneRef too.
+func TestAgentPaneReclaimsPrimaryPaneRef(t *testing.T) {
+	root := t.TempDir()
+	registry, project, mutator := pbtRegistryOver(t, root)
+
+	window := registry.WindowsOf(project.Metadata.UID)[0]
+	first := registry.PanesOf(window.Metadata.UID)[0]
+	if err := mutator.DeletePane(registry, first.Metadata.UID); err != nil {
+		t.Fatalf("delete last pane: %v", err)
+	}
+	agent, err := mutator.CreateAgent(registry, window.Metadata.UID, CreateAgentOptions{Provider: "codex", OperationID: "pbt-agent"})
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	pane, err := mutator.AttachAgentPane(registry, agent.Metadata.UID, BootstrapPane{}, "pbt-attach")
+	if err != nil {
+		t.Fatalf("attach agent pane: %v", err)
+	}
+	if err := registry.Validate(); err != nil {
+		t.Fatalf("AttachAgentPane committed a registry Validate rejects: %v", err)
+	}
+	stored, _ := registry.Window(window.Metadata.UID)
+	if stored.Spec.PrimaryPaneRef != pane.Metadata.UID {
+		t.Fatalf("primaryPaneRef = %q, want the Agent's Pane %q", stored.Spec.PrimaryPaneRef, pane.Metadata.UID)
+	}
+}
+
+// FuzzMutatorNeverCommitsInvalidRegistry generalizes both. Every operation is one
+// the product exposes and every intermediate registry is asserted valid, so the
+// property is the write closure itself.
+func FuzzMutatorNeverCommitsInvalidRegistry(f *testing.F) {
+	f.Add([]byte{2, 0})
+	f.Add([]byte{1, 2, 3})
+	f.Add([]byte{4, 1, 2, 0, 3})
+	f.Add([]byte{4, 1, 2, 0, 3, 5, 0, 2})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 48 {
+			data = data[:48]
+		}
+		root := t.TempDir()
+		registry, project, mutator := pbtRegistryOver(t, root)
+
+		for step, op := range data {
+			windows := registry.WindowsOf(project.Metadata.UID)
+			if len(windows) == 0 {
+				break
+			}
+			window := windows[int(op)%len(windows)]
+			switch op % 6 {
+			case 0:
+				_, _ = mutator.AddPane(registry, window.Metadata.UID, BootstrapPane{}, "sh", fmt.Sprintf("pbt-pane-%d", step))
+			case 1:
+				if agent, err := mutator.CreateAgent(registry, window.Metadata.UID, CreateAgentOptions{
+					Provider:    "codex",
+					OperationID: fmt.Sprintf("pbt-agent-%d", step),
+				}); err == nil {
+					_, _ = mutator.AttachAgentPane(registry, agent.Metadata.UID, BootstrapPane{}, fmt.Sprintf("pbt-attach-%d", step))
+				}
+			case 2:
+				if panes := registry.PanesOf(window.Metadata.UID); len(panes) > 0 {
+					_ = mutator.DeletePane(registry, panes[0].Metadata.UID)
+				}
+			case 3:
+				if agents := registry.AgentsOf(window.Metadata.UID); len(agents) > 0 {
+					_, _ = mutator.ReleaseAgentPane(registry, agents[0].Metadata.UID, AgentExitNormal, "pbt")
+				}
+			case 4:
+				_, _, _ = mutator.AddWindow(registry, project.Metadata.UID, BootstrapWindow{}, "sh", fmt.Sprintf("pbt-window-%d", step))
+			case 5:
+				if agents := registry.AgentsOf(window.Metadata.UID); len(agents) > 0 {
+					_ = mutator.DeleteAgent(registry, agents[0].Metadata.UID)
+				}
+			}
+			if err := registry.Validate(); err != nil {
+				t.Fatalf("step %d (op %d) committed a registry Validate rejects: %v", step, op, err)
+			}
+		}
+	})
+}

--- a/internal/core/metadata/mutator.go
+++ b/internal/core/metadata/mutator.go
@@ -334,7 +334,43 @@ func (m Mutator) addPaneTx(txn *Transaction, reg *Registry, op, ownerUID string,
 	}
 	reg.Panes = append(reg.Panes, pane)
 	txn.record(KindPane, paneUID)
+	reg.adoptPrimaryPaneRef(ownerUID, ownerKind, paneUID)
 	return pane, nil
+}
+
+// adoptPrimaryPaneRef gives a Window its primaryPaneRef back when this Pane is
+// the first one it owns again.
+//
+// Validate states the rule as a pair: a Window with no owned Pane carries an
+// empty primaryPaneRef, and a Window that owns one carries a resolvable ref.
+// Deleting a Window's last Pane empties the ref by design, so the very next Pane
+// added under that Window has to reclaim it or the registry the caller just wrote
+// is one Validate rejects -- and it is rejected on the *next* write, not this one,
+// which turns a legal `delete pane` followed by a legal `create pane` into a
+// registry nothing can mutate any more.
+//
+// A Pane owned by an Agent counts, because Validate counts it: windowPaneUIDs is
+// transitive through the Window's Agents. Adoption is strictly a repair of the
+// empty case and never re-points a Window that already has a resolvable primary.
+func (r *Registry) adoptPrimaryPaneRef(ownerUID string, ownerKind Kind, paneUID string) {
+	windowUID := ownerUID
+	if ownerKind == KindAgent {
+		agent, ok := r.Agent(ownerUID)
+		if !ok {
+			return
+		}
+		windowUID = agent.Metadata.OwnerUID()
+	}
+	for i := range r.Windows {
+		if r.Windows[i].Metadata.UID != windowUID {
+			continue
+		}
+		if strings.TrimSpace(r.Windows[i].Spec.PrimaryPaneRef) != "" {
+			return
+		}
+		r.Windows[i].Spec.PrimaryPaneRef = paneUID
+		return
+	}
 }
 
 // AddPane creates one offline shell Pane inside an existing Window.


### PR DESCRIPTION
## Summary
- Keep a Project open when only individual offline topology items are refused.
- Preserve fatal Project/live-session refusals while publishing item-level skip notices.
- Phase 1 is stacked on the Phase 0 branch and contains one Phase commit.

## Test plan
- [x] `FuzzTopologyPlanNeverRefusesValidRegistry`
- [x] `TestTopologyPlanKeepsProjectOpenableWithAgentOnlyWindow`
- [x] `TestTopologyPlanKeepsProjectOpenableWithoutPanes`
- [x] `TestTopologyPlanSkipsOnlyTheStaleCWDPane`
- [x] Repository validation gates recorded in the Phase 1 roadmap evidence

## Globalization
- [ ] No user-facing string changes.
- [ ] User-facing strings are behind `internal/i18n` catalog keys with tests.
- [x] Non-translated strings are classified as operational diagnostic output.

## Stack
- Base: `fix/registry-primary-pane-adoption`
- Merge Phase 0 with squash, then rebase this branch onto `main` and retarget before merge.

Roadmap: Declarative contract stabilization / Phase 1 convergence
Contract: C-2 Enforcement, C-9 Guarantee
