### PR TITLE
fix(ui): avoid nested native theme deadlock

### DIFF
--- a/internal/app/registry_navigation.go
+++ b/internal/app/registry_navigation.go
@@ -117,6 +117,11 @@ const (
 	navActionRuntime      = "__projmux_nav_runtime__"
 )
 
+type nestedRuntimeCommand interface {
+	rawArgvCommand
+	nestedNativeArgvCommand
+}
+
 // registryNavigationCommand renders the Registry hierarchy of one Project.
 //
 // It is entered from a primary picker and it lists what the Registry says
@@ -136,7 +141,7 @@ type registryNavigationCommand struct {
 	focus   rawArgvCommand
 	attach  rawArgvCommand
 	agent   rawArgvCommand
-	runtime rawArgvCommand
+	runtime nestedRuntimeCommand
 }
 
 func newRegistryNavigationCommand(runner tmuxCommandRunner) *registryNavigationCommand {
@@ -293,7 +298,7 @@ func (c *registryNavigationCommand) runRuntime(stdout, stderr io.Writer) error {
 	if c.runtime == nil {
 		return errors.New("registry navigation: the runtime diagnostics handler is not configured")
 	}
-	return c.runtime.Run([]string{"diagnostics"}, stdout, stderr)
+	return c.runtime.RunNested([]string{"diagnostics"}, stdout, stderr)
 }
 
 func (c *registryNavigationCommand) insideTmux() bool {

--- a/internal/app/registry_navigation_test.go
+++ b/internal/app/registry_navigation_test.go
@@ -205,6 +205,11 @@ func (c *navigationArgvRecorder) Run(args []string, _, _ io.Writer) error {
 	return nil
 }
 
+func (c *navigationArgvRecorder) RunNested(args []string, _, _ io.Writer) error {
+	c.calls = append(c.calls, slices.Clone(args))
+	return nil
+}
+
 // scriptedNavigationPicker returns a picker runner that answers each successive
 // Run with the next scripted value and records the options it was given.
 type scriptedNavigationPicker struct {

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -41,6 +41,17 @@ func newRuntimeCommand() *runtimeCommand {
 
 // Run dispatches one `runtime <subcommand>` invocation.
 func (c *runtimeCommand) Run(args []string, stdout, stderr io.Writer) error {
+	return c.run(args, stdout, stderr, false)
+}
+
+// RunNested dispatches a runtime surface inside an outer native command. Only
+// diagnostics is a nested native surface today; keeping this distinct from Run
+// makes theme ownership explicit across the namespace forwarder.
+func (c *runtimeCommand) RunNested(args []string, stdout, stderr io.Writer) error {
+	return c.run(args, stdout, stderr, true)
+}
+
+func (c *runtimeCommand) run(args []string, stdout, stderr io.Writer, nested bool) error {
 	if len(args) == 0 {
 		return usageError(fmt.Sprintf("runtime requires a subcommand: %s", strings.Join(runtimeSubcommands, ", ")))
 	}
@@ -49,6 +60,9 @@ func (c *runtimeCommand) Run(args []string, stdout, stderr io.Writer) error {
 	case "sessions":
 		return forwardRawArgv(c.sessions, "runtime sessions", "sessions", nil, rest, stdout, stderr)
 	case "diagnostics":
+		if nested {
+			return forwardNestedNativeArgv(c.diagnostics, "runtime diagnostics", "runtime diagnostics", rest, stdout, stderr)
+		}
 		return forwardRawArgv(c.diagnostics, "runtime diagnostics", "runtime diagnostics", nil, rest, stdout, stderr)
 	case "attach":
 		return forwardRawArgv(c.attach, "runtime attach", "attach", []string{"auto"}, rest, stdout, stderr)
@@ -62,6 +76,21 @@ func (c *runtimeCommand) Run(args []string, stdout, stderr io.Writer) error {
 		return usageError(fmt.Sprintf("runtime %s is not available; this release implements: %s",
 			args[0], strings.Join(runtimeSubcommands, ", ")))
 	}
+}
+
+type nestedNativeArgvCommand interface {
+	RunNested(args []string, stdout, stderr io.Writer) error
+}
+
+func forwardNestedNativeArgv(target rawArgvCommand, spelling, route string, args []string, stdout, stderr io.Writer) error {
+	if target == nil {
+		return fmt.Errorf("%s: the %s handler is not configured", spelling, route)
+	}
+	nested, ok := target.(nestedNativeArgvCommand)
+	if !ok {
+		return fmt.Errorf("%s: the %s handler does not declare nested native theme ownership", spelling, route)
+	}
+	return nested.RunNested(args, stdout, stderr)
 }
 
 // forwardRawArgv prefixes the current spelling's leading tokens and hands the

--- a/internal/app/runtime_diagnostics_picker.go
+++ b/internal/app/runtime_diagnostics_picker.go
@@ -70,6 +70,17 @@ func newRuntimeDiagnosticsCommand(runner tmuxCommandRunner) *runtimeDiagnosticsC
 
 // Run opens the diagnostics picker for one exact server.
 func (c *runtimeDiagnosticsCommand) Run(args []string, stdout, stderr io.Writer) error {
+	return c.run(args, stdout, stderr, nativeUIThemeOwned)
+}
+
+// RunNested opens diagnostics inside an outer native surface. The caller owns
+// the package-global theme apply/render/restore section, so this child must not
+// reacquire the non-reentrant nativeUIThemeMu.
+func (c *runtimeDiagnosticsCommand) RunNested(args []string, stdout, stderr io.Writer) error {
+	return c.run(args, stdout, stderr, nativeUIThemeInherited)
+}
+
+func (c *runtimeDiagnosticsCommand) run(args []string, stdout, stderr io.Writer, themeOwnership nativeUIThemeOwnership) error {
 	fs := flag.NewFlagSet("runtime diagnostics", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.Usage = func() { printRuntimeDiagnosticsUsage(stderr) }
@@ -99,7 +110,7 @@ func (c *runtimeDiagnosticsCommand) Run(args []string, stdout, stderr io.Writer)
 		return errors.New("native picker is not configured")
 	}
 
-	defer applyNativeUIThemeFromConfig(c.homeDir, c.lookupEnv, "")()
+	defer applyNativeUIThemeForOwnership(themeOwnership, c.homeDir, c.lookupEnv, "")()
 	locale := appLocale(c.homeDir, c.lookupEnv)
 
 	transport, err := c.reader.transport(request)

--- a/internal/app/runtime_diagnostics_picker_test.go
+++ b/internal/app/runtime_diagnostics_picker_test.go
@@ -51,8 +51,9 @@ func runtimePickerFixture(t *testing.T, host string, answers []intpicker.Result)
 	sibling := runtimeFixtureServer(host)
 	sibling.socketPath = "/tmp/fake-tmux/sibling"
 	runner := &routedTmuxRunner{servers: map[string]*fakeTmux{
-		"-L\x00primary": primary,
-		"-L\x00sibling": sibling,
+		"-L\x00primary":                primary,
+		"-L\x00sibling":                sibling,
+		"-S\x00/tmp/fake-tmux/primary": primary,
 	}}
 	registry := runtimeFixtureRegistry()
 	picker := &scriptedRuntimePicker{answers: answers}

--- a/internal/app/switch_registry_rows_test.go
+++ b/internal/app/switch_registry_rows_test.go
@@ -206,6 +206,51 @@ func TestSwitchRuntimeSelectionOpensTheEscapeHatch(t *testing.T) {
 	}
 }
 
+// TestSwitchRuntimeSelectionRendersDiagnostics exercises the production
+// in-process chain rather than stopping at an argv recorder: switch owns the
+// native theme section, runtime forwards inherited ownership, and diagnostics
+// renders the exact inherited host immediately.
+func TestSwitchRuntimeSelectionRendersDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	inherited := "/tmp/fake-tmux/primary,123,0"
+	command, _ := switchRegistryFixture(t, inherited, []string{"/src/gamma"}, switchRuntimeSentinel)
+	diagnostics, picker, primary, sibling, _ := runtimePickerFixture(t, "1", nil)
+	diagnostics.reader.lookupEnv = func(name string) string {
+		if name == "TMUX" {
+			return inherited
+		}
+		return ""
+	}
+	diagnostics.lookupEnv = diagnostics.reader.lookupEnv
+	command.navigation.runtime = &runtimeCommand{diagnostics: diagnostics}
+
+	before := primary.state()
+	if err := command.Run([]string{"--ui=sidebar"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(picker.rendered) != 1 {
+		t.Fatalf("runtime diagnostics rendered %d pickers, want 1", len(picker.rendered))
+	}
+	options := picker.rendered[0]
+	if got, want := options.Title, "Runtime diagnostics"; got != want {
+		t.Fatalf("runtime title = %q, want %q", got, want)
+	}
+	if !strings.Contains(options.Footer, "Enter: actions") {
+		t.Fatalf("runtime footer = %q, want actions guidance", options.Footer)
+	}
+	labels := strings.Join(pickerLabels(options), "\n")
+	if !strings.Contains(labels, "host app-owned  transport tmux -S /tmp/fake-tmux/primary") {
+		t.Fatalf("runtime picker omitted the exact inherited host:\n%s", labels)
+	}
+	if primary.state() != before {
+		t.Fatalf("switch -> Runtime mutated the exact host:\n--- before ---\n%s\n--- after ---\n%s", before, primary.state())
+	}
+	if len(sibling.calls) != 0 {
+		t.Fatalf("switch -> Runtime contacted the sibling host: %v", sibling.calls)
+	}
+}
+
 // TestSwitchHierarchyKeyOpensTheSelectedProject pins the dedicated key: it
 // resolves the selected row's Project and opens the read-only hierarchy.
 func TestSwitchHierarchyKeyOpensTheSelectedProject(t *testing.T) {

--- a/internal/app/switch_test.go
+++ b/internal/app/switch_test.go
@@ -3342,6 +3342,38 @@ func TestSwitchCommandSettingsSubcommandRunsSettingsMenu(t *testing.T) {
 	}
 }
 
+// TestSwitchSettingsSelectionStaysInsideOuterNativeThemeOwner pins the Settings
+// audit: unlike Runtime, this menu is rendered directly by switchCommand and
+// therefore does not enter a second command-level theme boundary.
+func TestSwitchSettingsSelectionStaysInsideOuterNativeThemeOwner(t *testing.T) {
+	t.Parallel()
+
+	runner, native := scriptedPicker(t, []pickerStep{
+		{reply: intpickercompat.Result{Value: switchSettingsSentinel}},
+		{observe: func(options intpickercompat.Options) {
+			if got, want := options.UI, "settings"; got != want {
+				t.Fatalf("nested picker UI = %q, want %q", got, want)
+			}
+		}},
+	})
+	cmd := &switchCommand{
+		discover:     func(candidates.Inputs) ([]string, error) { return []string{"/tmp/app"}, nil },
+		pinStore:     func() (switchPinStore, error) { return newStubPinStore(), nil },
+		runner:       runner,
+		nativePicker: native,
+		sessions:     &capturingSwitchSessionExecutor{},
+		identity:     stubSwitchIdentityResolver{name: "tmp-app"},
+		validate:     func(string) error { return nil },
+		homeDir:      func() (string, error) { return "/home/tester", nil },
+		workingDir:   func() (string, error) { return "/tmp", nil },
+		lookupEnv:    func(string) string { return "" },
+	}
+
+	if err := cmd.Run(nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+}
+
 func TestSwitchCommandSettingsMenuAddCurrentPin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/theme_render_native.go
+++ b/internal/app/theme_render_native.go
@@ -31,6 +31,21 @@ import (
 // parallel Run; the one repaint test mutates them deliberately under this lock.
 var nativeUIThemeMu sync.Mutex
 
+// nativeUIThemeOwnership states whether a native surface is the outer command
+// boundary that owns the package-global apply/render/restore section, or an
+// in-process child rendered while that section is already active.
+//
+// sync.Mutex is deliberately not made reentrant. Nested surfaces must inherit
+// their caller's theme ownership so the same process acquires this lock once,
+// while standalone command entry points continue to serialize all global role
+// mutations.
+type nativeUIThemeOwnership uint8
+
+const (
+	nativeUIThemeOwned nativeUIThemeOwnership = iota
+	nativeUIThemeInherited
+)
+
 // appAIBadge* are the AI badge role escapes shared by recent_window.go (and
 // kept congruent with the switch renderer). They default to fallback literals.
 var (
@@ -139,6 +154,16 @@ func applyNativeUIThemeFromConfig(homeDir func() (string, error), lookupEnv func
 		resetNativeUIThemeLocked()
 		nativeUIThemeMu.Unlock()
 	}
+}
+
+// applyNativeUIThemeForOwnership applies the theme only at the outer command
+// boundary. An in-process child inherits the already-applied package globals
+// and therefore neither locks nor restores them.
+func applyNativeUIThemeForOwnership(ownership nativeUIThemeOwnership, homeDir func() (string, error), lookupEnv func(string) string, projectPath string) (restore func()) {
+	if ownership == nativeUIThemeInherited {
+		return func() {}
+	}
+	return applyNativeUIThemeFromConfig(homeDir, lookupEnv, projectPath)
 }
 
 func applyNativeUIThemeLocked(effective theme.EffectiveTheme) {

--- a/test/e2e/linux-smoke.sh
+++ b/test/e2e/linux-smoke.sh
@@ -5065,19 +5065,19 @@ echo ">> Runtime diagnostics e2e passed: socket=$rtd_socket path=$rtd_socket_pat
 # its own -L name, the real #{socket_path} is queried and proven to sit inside the
 # smoke root, and only that exact socket is killed.
 # ---------------------------------------------------------------------------
-nav_root="$PROJMUX_SMOKE_WORKDIR/registry-navigation-e2e"
-nav_socket="projmux-registry-nav-$$-$RANDOM"
-nav_other_socket="projmux-registry-nav-other-$$-$RANDOM"
+nav_root="$PROJMUX_SMOKE_WORKDIR/n"
+nav_socket="n-$$"
+nav_other_socket="o-$$"
 nav_session="nav-alpha"
 nav_beta_session="nav-beta"
 nav_driver="home"
-mkdir -p "$nav_root/tmux" "$nav_root/state" "$nav_root/config" "$nav_root/home" \
+mkdir -p "$nav_root/t" "$nav_root/state" "$nav_root/config" "$nav_root/home" \
   "$nav_root/runtime" "$nav_root/nav/alpha" "$nav_root/nav/beta"
 chmod 0700 "$nav_root/runtime"
 nav_real_tmux="$(command -v tmux)"
 
-nav_tmux() { env -u TMUX -u TMUX_PANE TMUX_TMPDIR="$nav_root/tmux" "$nav_real_tmux" -L "$nav_socket" "$@"; }
-nav_other_tmux() { env -u TMUX -u TMUX_PANE TMUX_TMPDIR="$nav_root/tmux" "$nav_real_tmux" -L "$nav_other_socket" "$@"; }
+nav_tmux() { env -u TMUX -u TMUX_PANE TMUX_TMPDIR="$nav_root/t" "$nav_real_tmux" -L "$nav_socket" "$@"; }
+nav_other_tmux() { env -u TMUX -u TMUX_PANE TMUX_TMPDIR="$nav_root/t" "$nav_real_tmux" -L "$nav_other_socket" "$@"; }
 nav_pmx() {
   env -u TMUX -u TMUX_PANE \
     HOME="$nav_root/home" \
@@ -5085,7 +5085,7 @@ nav_pmx() {
     XDG_STATE_HOME="$nav_root/state" \
     XDG_RUNTIME_DIR="$nav_root/runtime" \
     PROJMUX_MANAGED_ROOTS="$nav_root/nav" \
-    TMUX_TMPDIR="$nav_root/tmux" \
+    TMUX_TMPDIR="$nav_root/t" \
     SHELL=/bin/sh \
     "$bin" "$@"
 }
@@ -5120,7 +5120,7 @@ done
 nav_cleanup() {
   local socket actual
   for socket in "$nav_socket" "$nav_other_socket"; do
-    actual="$(env -u TMUX -u TMUX_PANE TMUX_TMPDIR="$nav_root/tmux" tmux -L "$socket" display-message -p '#{socket_path}' 2>/dev/null || true)"
+    actual="$(env -u TMUX -u TMUX_PANE TMUX_TMPDIR="$nav_root/t" tmux -L "$socket" display-message -p '#{socket_path}' 2>/dev/null || true)"
     if [[ -z "$actual" ]]; then
       continue
     fi
@@ -5186,7 +5186,7 @@ nav_client_input="$nav_root/driver-client.in"
 mkfifo "$nav_client_input"
 exec 8<>"$nav_client_input"
 TERM=xterm-256color script -qefc \
-  "TERM=xterm-256color env -u TMUX -u TMUX_PANE TMUX_TMPDIR='$nav_root/tmux' tmux -L '$nav_socket' attach-session -t '$nav_driver'" \
+  "TERM=xterm-256color env -u TMUX -u TMUX_PANE TMUX_TMPDIR='$nav_root/t' tmux -L '$nav_socket' attach-session -t '$nav_driver'" \
   "$nav_client_log" <"$nav_client_input" >/dev/null 2>&1 &
 nav_client_pid=$!
 
@@ -5205,18 +5205,20 @@ nav_wait_for() {
 }
 
 nav_wait_for "attached registry navigation client" sh -c \
-  "test -n \"\$(env -u TMUX -u TMUX_PANE TMUX_TMPDIR='$nav_root/tmux' tmux -L '$nav_socket' list-clients -F '#{client_name}' 2>/dev/null | head -n 1)\""
+  "test -n \"\$(env -u TMUX -u TMUX_PANE TMUX_TMPDIR='$nav_root/t' tmux -L '$nav_socket' list-clients -F '#{client_name}' 2>/dev/null | head -n 1)\""
 nav_client="$(nav_tmux list-clients -F '#{client_name}' | head -n 1)"
 nav_client_is_on_driver() {
   [[ "$(nav_tmux display-message -p -c "$nav_client" '#{session_name}' 2>/dev/null || true)" == "$nav_driver" ]]
 }
 # One 80x24 popup run of the Projects sidebar, rendered through the exact
-# inherited socket the client is attached to.
+# inherited socket the client is attached to. This isolated case uses a short
+# root and socket name so the complete path remains observable in the nested
+# Runtime header without changing the viewport assumptions below.
 nav_open_projects() {
   local offset_var="$1"
   printf -v "$offset_var" '%s' "$(stat -c %s "$nav_client_log")"
   nav_tmux display-popup -c "$nav_client" -T "Projects E2E" -w 80 -h 24 -E \
-    "env -u TMUX_PANE HOME='$nav_root/home' XDG_CONFIG_HOME='$nav_root/config' XDG_STATE_HOME='$nav_root/state' XDG_RUNTIME_DIR='$nav_root/runtime' PROJMUX_MANAGED_ROOTS='$nav_root/nav' TMUX_TMPDIR='$nav_root/tmux' TMUX='$nav_socket_path,$nav_socket_pid,0' SHELL=/bin/sh '$bin' switch --ui=sidebar" &
+    "env -u TMUX_PANE HOME='$nav_root/home' XDG_CONFIG_HOME='$nav_root/config' XDG_STATE_HOME='$nav_root/state' XDG_RUNTIME_DIR='$nav_root/runtime' PROJMUX_MANAGED_ROOTS='$nav_root/nav' TMUX_TMPDIR='$nav_root/t' TMUX='$nav_socket_path,$nav_socket_pid,0' SHELL=/bin/sh '$bin' switch --ui=sidebar" &
   nav_popup_pid=$!
 }
 
@@ -5240,14 +5242,41 @@ nav_wait_for "Runtime link control tally" nav_runtime_filter_has "control 1"
 nav_wait_for "Runtime link ephemeral tally" nav_runtime_filter_has "ephemeral 1"
 nav_wait_for "Runtime link recoverable tally" nav_runtime_filter_has "recoverable 1"
 
-nav_runtime_clear_offset="$(stat -c %s "$nav_client_log")"
-printf '\025' >&8
-nav_runtime_clear_has_home() {
-  tail -c +$((nav_runtime_clear_offset + 1)) "$nav_client_log" | grep -aF "home" >/dev/null &&
-    tail -c +$((nav_runtime_clear_offset + 1)) "$nav_client_log" | grep -aF "~" >/dev/null
+# Entering Runtime is an in-process native-surface transition: switch owns the
+# package-global theme section and diagnostics inherits it. This is the exact
+# path that used to erase the outer popup and deadlock while trying to reacquire
+# the same non-reentrant mutex.
+nav_snapshot >"$nav_root/runtime-transition.before"
+cp "$nav_registry" "$nav_root/runtime-transition-registry.before"
+nav_runtime_enter_offset="$(stat -c %s "$nav_client_log")"
+printf '\r' >&8
+nav_runtime_enter_has() {
+  tail -c +$((nav_runtime_enter_offset + 1)) "$nav_client_log" | grep -aF "$1" >/dev/null
 }
-nav_wait_for "Home root after clearing the Runtime filter" nav_runtime_clear_has_home
-nav_wait_for "Runtime filter clear return to the driver session" nav_client_is_on_driver
+nav_wait_for "nested Runtime diagnostics title" nav_runtime_enter_has "Runtime diagnostics"
+nav_wait_for "nested Runtime diagnostics exact host" nav_runtime_enter_has "host app-owned"
+nav_wait_for "nested Runtime diagnostics exact transport" \
+  nav_runtime_enter_has "transport tmux -S $nav_socket_path"
+nav_wait_for "nested Runtime diagnostics footer" nav_runtime_enter_has "Enter: actions"
+
+# Escape closes diagnostics and therefore the outer switch invocation. Prove
+# completion with the exact popup process and the attached client's unchanged
+# target, then compare both the exact server and sibling before reopening the
+# Projects surface for the remaining navigation assertions.
+printf '\033' >&8
+nav_wait_for "nested Runtime diagnostics popup exit" sh -c "! kill -0 '$nav_popup_pid' 2>/dev/null"
+wait "$nav_popup_pid" || true
+nav_wait_for "nested Runtime diagnostics return to driver" nav_client_is_on_driver
+nav_snapshot >"$nav_root/runtime-transition.after"
+cmp "$nav_root/runtime-transition.before" "$nav_root/runtime-transition.after"
+cmp "$nav_root/runtime-transition-registry.before" "$nav_registry"
+if [[ "$(nav_other_tmux show-options -gqv @projmux_nav_sentinel):$(nav_other_tmux list-windows -a -F '#{session_name}:#{window_name}')" != "$nav_other_before" ]]; then
+  echo "switch -> Runtime touched the sibling socket" >&2
+  exit 1
+fi
+
+nav_open_projects nav_popup_offset
+nav_wait_for "Projects sidebar after nested Runtime exit" nav_screen_has "Projects"
 
 # The managed row is reached through the list's own filter rather than by
 # assuming a viewport. An 80x24 popup shows three cards at a time, so a row's


### PR DESCRIPTION
## Summary
- Prevent the Alt-1 Projects sidebar Runtime transition from reacquiring the non-reentrant native theme mutex by making the outer picker the theme owner and the nested Runtime diagnostics surface inherit that scope.
- Route the Runtime Enter transition through the explicit nested command boundary, while keeping standalone `runtime diagnostics` as an outer owner and auditing the existing Settings nesting path.
- Add unit and exact attached-client regression coverage for Runtime title, app-owned host, exact socket transport, footer, Esc completion, zero Registry writes, unchanged sibling server, and exact socket cleanup.

## Scope
- Branch-only diff is limited to the nine reviewed Runtime/theme/navigation test files (`206 insertions`, `24 deletions`).
- PR #728 pane-menu convergence is inherited byte-for-byte from `main`; no pane-menu corrective logic is duplicated here.
- Runtime/Registry architecture, Codex lifecycle/native code, Phase 15 snapshot/Project-start scope, and PR #684 are unchanged.

## Test plan
- [x] `make fmt` — green (0.21s)
- [x] `make fix` — green (22.04s)
- [x] `make test` — green (3.72s)
- [x] `make test-integration` — green (33.40s)
- [x] `make test-e2e` — green (82.74s)
- [x] All gates ran in repository order with inherited `TMUX`/`TMUX_PANE` removed, one absolute task-specific `GOCACHE`, and an empty task-specific `XDG_CONFIG_HOME`.
- [x] Final E2E includes attached-client Runtime transition, sibling unchanged, Registry writes 0, validated exact-socket cleanup, and inherited managed pane-menu convergence.

The first unit attempt was blocked only by sandbox Unix/TCP listener permissions; the unchanged permission-correct rerun passed. The first E2E attempt observed a transient Registry byte comparison at unchanged topology-startup line 4407, before this branch's first E2E hunk; no edits were made, and the unchanged full rerun passed.

## Globalization
- [x] No user-facing string changes.

Roadmap: Declarative contract stabilization / Phase 15 preflight corrective A
Contract: C-7 Enforcement
