### PR TITLE
feat(lifecycle): define runtime teardown authority kernel

### DIFF
--- a/.deadcode-allowlist.txt
+++ b/.deadcode-allowlist.txt
@@ -34,6 +34,26 @@ tmuxRetiredKeyUnbindLines
 # Operational diagnostics Phase 2 typed no-write seam. Doctor Phase 2 is the
 # planned consumer after this producer contract lands.
 ReadRuntimeHealth
+# MUST-KEEP: Runtime topology exit cascade Phase 0 pure authority, root,
+# reopen, and pin planning seam. Phases 1-3 are the planned consumers; wiring
+# these symbols into production now is intentionally excluded so this Phase
+# can close the decision contract without changing Registry/runtime behavior.
+TeardownEventKinds
+TeardownObservations
+rootDefaults
+validTeardownEventKind
+validTeardownObservation
+validOwnerChain
+observationRefusal
+DecideTeardownEvent
+AggregateTeardownEvents
+genericTeardownRefusal
+PlanProjectCascadeDelete
+projectAgentCount
+projectPreservedAssets
+DecideProjectOpen
+EqualTeardownPlans
+PlanProjectDeletion
 # `projmux://focus?...` encoder. Desktop notification delivery became a
 # two-state model in 0.11.0 (off / notify): Toasts carry no click URI and no
 # protocol handler is registered, so nothing in production emits this URI any

--- a/internal/core/metadata/lifecycle_decision.go
+++ b/internal/core/metadata/lifecycle_decision.go
@@ -1,0 +1,538 @@
+package metadata
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+// TeardownEventKind is the closed set of runtime topology events accepted by
+// the automatic teardown authority kernel. Provider commands, pane contents,
+// prompts, shell history, and transcripts are deliberately not inputs.
+type TeardownEventKind string
+
+const (
+	TeardownEventPaneExited     TeardownEventKind = "pane-exited"
+	TeardownEventWindowUnlinked TeardownEventKind = "window-unlinked"
+)
+
+// TeardownEventKinds returns the closed event vocabulary.
+func TeardownEventKinds() []TeardownEventKind {
+	return []TeardownEventKind{TeardownEventPaneExited, TeardownEventWindowUnlinked}
+}
+
+// TeardownGeneration classifies an event's generation guard.
+type TeardownGeneration string
+
+const (
+	TeardownGenerationCurrent TeardownGeneration = "current"
+	TeardownGenerationStale   TeardownGeneration = "stale"
+)
+
+// TeardownObservation says what the final inventory pass proved about the
+// exact tmux server named by an event. Only ExactSocket is positive authority;
+// every other value is an explicit fail-closed observation, not an absence.
+type TeardownObservation string
+
+const (
+	TeardownObservationExactSocket      TeardownObservation = "exact-socket"
+	TeardownObservationUnavailable      TeardownObservation = "unavailable"
+	TeardownObservationEmpty            TeardownObservation = "empty"
+	TeardownObservationNoServer         TeardownObservation = "no-server"
+	TeardownObservationPermissionDenied TeardownObservation = "permission-denied"
+	TeardownObservationSiblingSocket    TeardownObservation = "sibling-socket"
+	TeardownObservationForeignHost      TeardownObservation = "foreign-host"
+)
+
+// TeardownObservations returns the closed final-observation vocabulary.
+func TeardownObservations() []TeardownObservation {
+	return []TeardownObservation{
+		TeardownObservationExactSocket,
+		TeardownObservationUnavailable,
+		TeardownObservationEmpty,
+		TeardownObservationNoServer,
+		TeardownObservationPermissionDenied,
+		TeardownObservationSiblingSocket,
+		TeardownObservationForeignHost,
+	}
+}
+
+// TeardownAction is the bounded Registry action an authority decision permits.
+type TeardownAction string
+
+const (
+	TeardownRetain          TeardownAction = "retain"
+	TeardownDeletePaneAgent TeardownAction = "delete-pane-agent"
+	TeardownDeleteWindow    TeardownAction = "delete-window"
+	TeardownRefuse          TeardownAction = "refuse"
+)
+
+// RootTeardownAction states what happens at the owner-root boundary.
+type RootTeardownAction string
+
+const (
+	RootTeardownRetainProject        RootTeardownAction = "retain-project"
+	RootTeardownDeleteProject        RootTeardownAction = "delete-project"
+	RootTeardownRetainControlSession RootTeardownAction = "retain-control-session"
+)
+
+// ReopenIdentity states which Registry identity a subsequent open may use.
+type ReopenIdentity string
+
+const (
+	ReopenIdentitySameProjectUID ReopenIdentity = "same-project-uid"
+	ReopenIdentityNewProjectUID  ReopenIdentity = "new-project-uid"
+	ReopenIdentityNotApplicable  ReopenIdentity = "not-applicable"
+)
+
+// AssetDisposition makes every external-asset cell explicit.
+type AssetDisposition string
+
+const (
+	AssetPreserve      AssetDisposition = "preserve"
+	AssetNotApplicable AssetDisposition = "not-applicable"
+)
+
+// ExternalAssetOutcome is the non-Registry boundary of a root decision.
+type ExternalAssetOutcome struct {
+	RootDirectory AssetDisposition
+	GitMetadata   AssetDisposition
+	Worktrees     AssetDisposition
+	SnapshotBytes AssetDisposition
+}
+
+// TeardownReason is a closed diagnostic vocabulary for the decision table.
+type TeardownReason string
+
+const (
+	TeardownReasonInvalidInput          TeardownReason = "invalid-input"
+	TeardownReasonStaleGeneration       TeardownReason = "stale-generation"
+	TeardownReasonUnavailable           TeardownReason = "observation-unavailable"
+	TeardownReasonEmptyObservation      TeardownReason = "empty-observation"
+	TeardownReasonNoServer              TeardownReason = "no-server"
+	TeardownReasonPermissionDenied      TeardownReason = "permission-denied"
+	TeardownReasonSiblingSocket         TeardownReason = "sibling-socket"
+	TeardownReasonForeignHost           TeardownReason = "foreign-host"
+	TeardownReasonNonCausalTermination  TeardownReason = "non-causal-termination"
+	TeardownReasonPaneTeardown          TeardownReason = "pane-teardown"
+	TeardownReasonAwaitingPaneExit      TeardownReason = "awaiting-pane-exit"
+	TeardownReasonAwaitingWindowUnlink  TeardownReason = "awaiting-window-unlink"
+	TeardownReasonLiveSiblingPane       TeardownReason = "live-sibling-pane"
+	TeardownReasonWindowTeardown        TeardownReason = "window-teardown"
+	TeardownReasonProjectTeardown       TeardownReason = "project-teardown"
+	TeardownReasonMixedOwnerChain       TeardownReason = "mixed-owner-chain"
+	TeardownReasonConflictingOwnerFacts TeardownReason = "conflicting-owner-facts"
+)
+
+// TeardownOwnerChain is the exact Registry chain an event claims.
+type TeardownOwnerChain struct {
+	SocketIdentity string
+	PaneHandle     string
+	WindowHandle   string
+	PaneUID        string
+	WindowUID      string
+	RootKind       Kind
+	RootUID        string
+	Generation     string
+}
+
+// TeardownEvent is one bounded input to the pure authority kernel.
+type TeardownEvent struct {
+	Kind                  TeardownEventKind
+	Classification        TerminationClassification
+	Generation            TeardownGeneration
+	Observation           TeardownObservation
+	Chain                 TeardownOwnerChain
+	LiveSiblingPane       bool
+	LiveSiblingRootWindow bool
+}
+
+// TeardownDecision is one total decision-table cell.
+type TeardownDecision struct {
+	Action         TeardownAction
+	RootAction     RootTeardownAction
+	Reason         TeardownReason
+	ExternalAssets ExternalAssetOutcome
+	ReopenIdentity ReopenIdentity
+}
+
+func rootDefaults(kind Kind) (RootTeardownAction, ExternalAssetOutcome, ReopenIdentity, bool) {
+	switch kind {
+	case KindProject:
+		return RootTeardownRetainProject, ExternalAssetOutcome{
+			RootDirectory: AssetPreserve,
+			GitMetadata:   AssetPreserve,
+			Worktrees:     AssetPreserve,
+			SnapshotBytes: AssetPreserve,
+		}, ReopenIdentitySameProjectUID, true
+	case KindControlSession:
+		return RootTeardownRetainControlSession, ExternalAssetOutcome{
+			RootDirectory: AssetNotApplicable,
+			GitMetadata:   AssetNotApplicable,
+			Worktrees:     AssetNotApplicable,
+			SnapshotBytes: AssetNotApplicable,
+		}, ReopenIdentityNotApplicable, true
+	default:
+		return RootTeardownRetainProject, ExternalAssetOutcome{
+			RootDirectory: AssetNotApplicable,
+			GitMetadata:   AssetNotApplicable,
+			Worktrees:     AssetNotApplicable,
+			SnapshotBytes: AssetNotApplicable,
+		}, ReopenIdentityNotApplicable, false
+	}
+}
+
+func validTeardownEventKind(kind TeardownEventKind) bool {
+	return kind == TeardownEventPaneExited || kind == TeardownEventWindowUnlinked
+}
+
+func validTeardownObservation(observation TeardownObservation) bool {
+	return slices.Contains(TeardownObservations(), observation)
+}
+
+func validOwnerChain(chain TeardownOwnerChain) bool {
+	return strings.TrimSpace(chain.SocketIdentity) != "" &&
+		strings.TrimSpace(chain.PaneHandle) != "" &&
+		strings.TrimSpace(chain.WindowHandle) != "" &&
+		strings.TrimSpace(chain.PaneUID) != "" &&
+		strings.TrimSpace(chain.WindowUID) != "" &&
+		strings.TrimSpace(chain.RootUID) != "" &&
+		strings.TrimSpace(chain.Generation) != ""
+}
+
+func observationRefusal(observation TeardownObservation) TeardownReason {
+	switch observation {
+	case TeardownObservationUnavailable:
+		return TeardownReasonUnavailable
+	case TeardownObservationEmpty:
+		return TeardownReasonEmptyObservation
+	case TeardownObservationNoServer:
+		return TeardownReasonNoServer
+	case TeardownObservationPermissionDenied:
+		return TeardownReasonPermissionDenied
+	case TeardownObservationSiblingSocket:
+		return TeardownReasonSiblingSocket
+	case TeardownObservationForeignHost:
+		return TeardownReasonForeignHost
+	default:
+		return TeardownReasonInvalidInput
+	}
+}
+
+// DecideTeardownEvent evaluates one event without mutating Registry or runtime
+// state. A window-unlinked event is never sufficient by itself: aggregation
+// must pair it with the exact causal pane-exited event.
+func DecideTeardownEvent(event TeardownEvent) TeardownDecision {
+	rootAction, assets, reopen, validRoot := rootDefaults(event.Chain.RootKind)
+	out := TeardownDecision{
+		Action:         TeardownRefuse,
+		RootAction:     rootAction,
+		Reason:         TeardownReasonInvalidInput,
+		ExternalAssets: assets,
+		ReopenIdentity: reopen,
+	}
+	if !validRoot || !validTeardownEventKind(event.Kind) ||
+		!ValidTerminationClassification(event.Classification) ||
+		!validTeardownObservation(event.Observation) || !validOwnerChain(event.Chain) {
+		return out
+	}
+	if event.Generation != TeardownGenerationCurrent && event.Generation != TeardownGenerationStale {
+		return out
+	}
+	if event.Generation == TeardownGenerationStale {
+		out.Reason = TeardownReasonStaleGeneration
+		return out
+	}
+	if event.Observation != TeardownObservationExactSocket {
+		out.Reason = observationRefusal(event.Observation)
+		return out
+	}
+	if event.Classification != TerminationNormal && event.Classification != TerminationIntentional {
+		out.Action = TeardownRetain
+		out.Reason = TeardownReasonNonCausalTermination
+		return out
+	}
+	if event.Kind == TeardownEventWindowUnlinked {
+		out.Action = TeardownRetain
+		out.Reason = TeardownReasonAwaitingPaneExit
+		return out
+	}
+	out.Action = TeardownDeletePaneAgent
+	out.Reason = TeardownReasonPaneTeardown
+	if !event.LiveSiblingPane {
+		out.Reason = TeardownReasonAwaitingWindowUnlink
+	}
+	return out
+}
+
+// AggregateTeardownEvents folds the two causal event kinds for one exact owner
+// chain. It is intentionally insensitive to event delivery order.
+func AggregateTeardownEvents(events []TeardownEvent) TeardownDecision {
+	if len(events) == 0 {
+		return genericTeardownRefusal(TeardownReasonInvalidInput)
+	}
+	first := events[0]
+	rootAction, assets, reopen, _ := rootDefaults(first.Chain.RootKind)
+	refused := TeardownDecision{Action: TeardownRefuse, RootAction: rootAction,
+		Reason: TeardownReasonInvalidInput, ExternalAssets: assets, ReopenIdentity: reopen}
+	for _, event := range events[1:] {
+		if event.Chain != first.Chain {
+			return genericTeardownRefusal(TeardownReasonMixedOwnerChain)
+		}
+		if event.LiveSiblingPane != first.LiveSiblingPane ||
+			event.LiveSiblingRootWindow != first.LiveSiblingRootWindow {
+			refused.Reason = TeardownReasonConflictingOwnerFacts
+			return refused
+		}
+	}
+
+	paneExit, windowUnlink := false, false
+	terminalReason := TeardownReason("")
+	terminalDecision := TeardownDecision{}
+	for _, event := range events {
+		decision := DecideTeardownEvent(event)
+		if decision.Action == TeardownRefuse || decision.Reason == TeardownReasonNonCausalTermination {
+			// Pick a stable reason instead of whichever failed event happened to
+			// arrive first. Duplicate and adversarial permutations therefore
+			// produce byte-identical plans.
+			if terminalReason == "" || decision.Reason < terminalReason {
+				terminalReason = decision.Reason
+				terminalDecision = decision
+			}
+			continue
+		}
+		switch event.Kind {
+		case TeardownEventPaneExited:
+			paneExit = true
+		case TeardownEventWindowUnlinked:
+			windowUnlink = true
+		}
+	}
+	if terminalReason != "" {
+		return terminalDecision
+	}
+	if !paneExit {
+		return TeardownDecision{Action: TeardownRetain, RootAction: rootAction,
+			Reason: TeardownReasonAwaitingPaneExit, ExternalAssets: assets, ReopenIdentity: reopen}
+	}
+	if first.LiveSiblingPane {
+		if windowUnlink {
+			refused.Reason = TeardownReasonConflictingOwnerFacts
+			return refused
+		}
+		return TeardownDecision{Action: TeardownDeletePaneAgent, RootAction: rootAction,
+			Reason: TeardownReasonLiveSiblingPane, ExternalAssets: assets, ReopenIdentity: reopen}
+	}
+	if !windowUnlink {
+		return TeardownDecision{Action: TeardownDeletePaneAgent, RootAction: rootAction,
+			Reason: TeardownReasonAwaitingWindowUnlink, ExternalAssets: assets, ReopenIdentity: reopen}
+	}
+
+	out := TeardownDecision{Action: TeardownDeleteWindow, RootAction: rootAction,
+		Reason: TeardownReasonWindowTeardown, ExternalAssets: assets, ReopenIdentity: reopen}
+	if first.Chain.RootKind == KindProject && !first.LiveSiblingRootWindow {
+		out.RootAction = RootTeardownDeleteProject
+		out.Reason = TeardownReasonProjectTeardown
+		out.ReopenIdentity = ReopenIdentityNewProjectUID
+	}
+	return out
+}
+
+func genericTeardownRefusal(reason TeardownReason) TeardownDecision {
+	return TeardownDecision{
+		Action: TeardownRefuse, RootAction: RootTeardownRetainProject, Reason: reason,
+		ExternalAssets: ExternalAssetOutcome{
+			RootDirectory: AssetNotApplicable, GitMetadata: AssetNotApplicable,
+			Worktrees: AssetNotApplicable, SnapshotBytes: AssetNotApplicable,
+		}, ReopenIdentity: ReopenIdentityNotApplicable,
+	}
+}
+
+// ProjectCascadeDeletePlan is a pure desired-Registry plan. The source
+// Registry is never mutated; applying the composite write is a later phase.
+type ProjectCascadeDeletePlan struct {
+	ProjectUID          string
+	Root                string
+	Desired             Registry
+	Changed             bool
+	DeletedProjects     int
+	DeletedWindows      int
+	DeletedPanes        int
+	DeletedAgents       int
+	DeletedReservations int
+	ExternalAssets      ExternalAssetOutcome
+	ReopenIdentity      ReopenIdentity
+}
+
+// PlanProjectCascadeDelete removes one Project graph on a clone and returns the
+// schema-valid desired Registry without touching filesystem or snapshot data.
+func PlanProjectCascadeDelete(registry Registry, projectUID string, now time.Time) (ProjectCascadeDeletePlan, error) {
+	const op = "plan project cascade delete"
+	if now.IsZero() {
+		return ProjectCascadeDeletePlan{}, inputErr(op, ErrInvalidRegistry, "plan timestamp is required")
+	}
+	if err := registry.Validate(); err != nil {
+		return ProjectCascadeDeletePlan{}, fmt.Errorf("%s source Registry: %w", op, err)
+	}
+	project, ok := registry.Project(strings.TrimSpace(projectUID))
+	if !ok {
+		return ProjectCascadeDeletePlan{}, stateErr(op, ErrNotFound, "Project %q does not exist", projectUID)
+	}
+	desired := registry.Clone()
+	if err := (Mutator{Now: func() time.Time { return now.UTC() }}).DeleteProject(&desired, project.Metadata.UID); err != nil {
+		return ProjectCascadeDeletePlan{}, err
+	}
+	if err := desired.Validate(); err != nil {
+		return ProjectCascadeDeletePlan{}, fmt.Errorf("%s desired Registry: %w", op, err)
+	}
+	return ProjectCascadeDeletePlan{
+		ProjectUID: project.Metadata.UID, Root: project.Spec.Root, Desired: desired,
+		Changed: true, DeletedProjects: 1,
+		DeletedWindows:      len(registry.WindowsOf(project.Metadata.UID)),
+		DeletedPanes:        len(registry.projectPanes(project.Metadata.UID)),
+		DeletedAgents:       projectAgentCount(registry, project.Metadata.UID),
+		DeletedReservations: len(registry.NameReservations) - len(desired.NameReservations),
+		ExternalAssets: ExternalAssetOutcome{
+			RootDirectory: AssetPreserve, GitMetadata: AssetPreserve,
+			Worktrees: AssetPreserve, SnapshotBytes: AssetPreserve,
+		},
+		ReopenIdentity: ReopenIdentityNewProjectUID,
+	}, nil
+}
+
+func projectAgentCount(registry Registry, projectUID string) int {
+	count := 0
+	for _, window := range registry.WindowsOf(projectUID) {
+		count += len(registry.AgentsOf(window.Metadata.UID))
+	}
+	return count
+}
+
+// ProjectReopenState is the closed startup state table.
+type ProjectReopenState string
+
+const (
+	ProjectReopenLive                   ProjectReopenState = "live"
+	ProjectReopenClosed                 ProjectReopenState = "closed"
+	ProjectReopenDeletedWithSnapshot    ProjectReopenState = "deleted-with-snapshot"
+	ProjectReopenDeletedWithoutSnapshot ProjectReopenState = "deleted-without-snapshot"
+)
+
+// ProjectOpenAction is the user's one-step startup choice.
+type ProjectOpenAction string
+
+const (
+	ProjectOpenContinue ProjectOpenAction = "continue"
+	ProjectOpenFresh    ProjectOpenAction = "open-fresh"
+)
+
+// ProjectOpenSource is the authority from which topology is opened.
+type ProjectOpenSource string
+
+const (
+	ProjectOpenSourceLiveRuntime      ProjectOpenSource = "live-runtime"
+	ProjectOpenSourceRegistryTopology ProjectOpenSource = "registry-topology"
+	ProjectOpenSourceSnapshot         ProjectOpenSource = "snapshot"
+	ProjectOpenSourceRoot             ProjectOpenSource = "filesystem-root"
+	ProjectOpenSourceNone             ProjectOpenSource = "none"
+)
+
+// ProjectStartupWrite is one member of an atomic startup write set.
+type ProjectStartupWrite string
+
+const (
+	ProjectStartupWriteNone                  ProjectStartupWrite = "no-write"
+	ProjectStartupWriteMaterializeRegistry   ProjectStartupWrite = "materialize-registry-topology"
+	ProjectStartupWriteDeleteProjectGraph    ProjectStartupWrite = "delete-existing-project-graph"
+	ProjectStartupWriteCreateProject         ProjectStartupWrite = "create-project-with-new-uid"
+	ProjectStartupWriteCreateCanonicalWindow ProjectStartupWrite = "create-canonical-window"
+	ProjectStartupWriteCreateCanonicalShell  ProjectStartupWrite = "create-canonical-shell"
+	ProjectStartupWriteRestoreSnapshotGraph  ProjectStartupWrite = "restore-snapshot-topology"
+)
+
+// ProjectOpenReason makes unavailable and invalid cells non-ambiguous.
+type ProjectOpenReason string
+
+const (
+	ProjectOpenReasonAttachLive        ProjectOpenReason = "attach-live-project"
+	ProjectOpenReasonMaterializeClosed ProjectOpenReason = "materialize-closed-project"
+	ProjectOpenReasonRestoreSnapshot   ProjectOpenReason = "restore-usable-snapshot"
+	ProjectOpenReasonNoSnapshot        ProjectOpenReason = "no-usable-snapshot"
+	ProjectOpenReasonFreshReplace      ProjectOpenReason = "replace-existing-project"
+	ProjectOpenReasonFreshCreate       ProjectOpenReason = "create-fresh-project"
+	ProjectOpenReasonInvalid           ProjectOpenReason = "invalid-state-or-action"
+)
+
+// ProjectOpenPlan is one total startup state-table cell.
+type ProjectOpenPlan struct {
+	Available         bool
+	Source            ProjectOpenSource
+	AtomicWriteSet    []ProjectStartupWrite
+	Reason            ProjectOpenReason
+	NewProjectUID     bool
+	AdditionalConfirm bool
+	ExternalAssets    ExternalAssetOutcome
+}
+
+func projectPreservedAssets() ExternalAssetOutcome {
+	return ExternalAssetOutcome{RootDirectory: AssetPreserve, GitMetadata: AssetPreserve,
+		Worktrees: AssetPreserve, SnapshotBytes: AssetPreserve}
+}
+
+// DecideProjectOpen returns the closed live/closed/deleted startup table. Fresh
+// never reads or modifies a snapshot, and unavailable Continue never silently
+// falls back to Fresh.
+func DecideProjectOpen(state ProjectReopenState, action ProjectOpenAction) ProjectOpenPlan {
+	assets := projectPreservedAssets()
+	invalid := ProjectOpenPlan{Available: false, Source: ProjectOpenSourceNone,
+		AtomicWriteSet: []ProjectStartupWrite{ProjectStartupWriteNone},
+		Reason:         ProjectOpenReasonInvalid, ExternalAssets: assets}
+	if action == ProjectOpenFresh {
+		switch state {
+		case ProjectReopenLive, ProjectReopenClosed:
+			return ProjectOpenPlan{Available: true, Source: ProjectOpenSourceRoot,
+				AtomicWriteSet: []ProjectStartupWrite{ProjectStartupWriteDeleteProjectGraph,
+					ProjectStartupWriteCreateProject, ProjectStartupWriteCreateCanonicalWindow,
+					ProjectStartupWriteCreateCanonicalShell},
+				Reason: ProjectOpenReasonFreshReplace, NewProjectUID: true, ExternalAssets: assets}
+		case ProjectReopenDeletedWithSnapshot, ProjectReopenDeletedWithoutSnapshot:
+			return ProjectOpenPlan{Available: true, Source: ProjectOpenSourceRoot,
+				AtomicWriteSet: []ProjectStartupWrite{ProjectStartupWriteCreateProject,
+					ProjectStartupWriteCreateCanonicalWindow, ProjectStartupWriteCreateCanonicalShell},
+				Reason: ProjectOpenReasonFreshCreate, NewProjectUID: true, ExternalAssets: assets}
+		default:
+			return invalid
+		}
+	}
+	if action != ProjectOpenContinue {
+		return invalid
+	}
+	switch state {
+	case ProjectReopenLive:
+		return ProjectOpenPlan{Available: true, Source: ProjectOpenSourceLiveRuntime,
+			AtomicWriteSet: []ProjectStartupWrite{ProjectStartupWriteNone},
+			Reason:         ProjectOpenReasonAttachLive, ExternalAssets: assets}
+	case ProjectReopenClosed:
+		return ProjectOpenPlan{Available: true, Source: ProjectOpenSourceRegistryTopology,
+			AtomicWriteSet: []ProjectStartupWrite{ProjectStartupWriteMaterializeRegistry},
+			Reason:         ProjectOpenReasonMaterializeClosed, ExternalAssets: assets}
+	case ProjectReopenDeletedWithSnapshot:
+		return ProjectOpenPlan{Available: true, Source: ProjectOpenSourceSnapshot,
+			AtomicWriteSet: []ProjectStartupWrite{ProjectStartupWriteCreateProject,
+				ProjectStartupWriteRestoreSnapshotGraph},
+			Reason: ProjectOpenReasonRestoreSnapshot, NewProjectUID: true, ExternalAssets: assets}
+	case ProjectReopenDeletedWithoutSnapshot:
+		return ProjectOpenPlan{Available: false, Source: ProjectOpenSourceNone,
+			AtomicWriteSet: []ProjectStartupWrite{ProjectStartupWriteNone},
+			Reason:         ProjectOpenReasonNoSnapshot, ExternalAssets: assets}
+	default:
+		return invalid
+	}
+}
+
+// EqualTeardownPlans exists for property tests and controller callers that need
+// to compare two delivery orders without depending on serialization.
+func EqualTeardownPlans(left, right TeardownDecision) bool {
+	return left == right
+}

--- a/internal/core/metadata/lifecycle_decision_test.go
+++ b/internal/core/metadata/lifecycle_decision_test.go
@@ -1,0 +1,423 @@
+package metadata
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func decisionEvent() TeardownEvent {
+	return TeardownEvent{
+		Kind:           TeardownEventPaneExited,
+		Classification: TerminationNormal,
+		Generation:     TeardownGenerationCurrent,
+		Observation:    TeardownObservationExactSocket,
+		Chain: TeardownOwnerChain{
+			SocketIdentity: "/tmp/tmux-app/projmux", PaneHandle: "%7", WindowHandle: "@4",
+			PaneUID: "pane-1", WindowUID: "window-1", RootKind: KindProject,
+			RootUID: "project-1", Generation: "gen-1",
+		},
+	}
+}
+
+func assertDecisionFilled(t *testing.T, decision TeardownDecision) {
+	t.Helper()
+	if decision.Action == "" || decision.RootAction == "" || decision.Reason == "" ||
+		decision.ReopenIdentity == "" || decision.ExternalAssets.RootDirectory == "" ||
+		decision.ExternalAssets.GitMetadata == "" || decision.ExternalAssets.Worktrees == "" ||
+		decision.ExternalAssets.SnapshotBytes == "" {
+		t.Fatalf("decision has an empty cell: %+v", decision)
+	}
+}
+
+func TestTeardownDecisionTableIsTotal(t *testing.T) {
+	t.Parallel()
+
+	events := append(TeardownEventKinds(), TeardownEventKind("invalid-event"))
+	classifications := []TerminationClassification{
+		TerminationIntentional, TerminationNormal, TerminationKilled,
+		TerminationAbnormal, TerminationUnknown, "invalid-classification",
+	}
+	observations := append(TeardownObservations(), TeardownObservation("invalid-observation"))
+	generations := []TeardownGeneration{TeardownGenerationCurrent, TeardownGenerationStale, "invalid-generation"}
+	roots := []Kind{KindProject, KindControlSession, Kind("invalid-root")}
+	for _, eventKind := range events {
+		for _, classification := range classifications {
+			for _, generation := range generations {
+				for _, observation := range observations {
+					for _, siblingPane := range []bool{false, true} {
+						for _, siblingWindow := range []bool{false, true} {
+							for _, root := range roots {
+								input := decisionEvent()
+								input.Kind = eventKind
+								input.Classification = classification
+								input.Generation = generation
+								input.Observation = observation
+								input.LiveSiblingPane = siblingPane
+								input.LiveSiblingRootWindow = siblingWindow
+								input.Chain.RootKind = root
+								decision := DecideTeardownEvent(input)
+								assertDecisionFilled(t, decision)
+
+								validClass := ValidTerminationClassification(classification)
+								if eventKind == "invalid-event" || generation == "invalid-generation" ||
+									observation == "invalid-observation" || root == "invalid-root" || !validClass {
+									if decision.Action != TeardownRefuse {
+										t.Fatalf("invalid input produced %+v for event=%q class=%q generation=%q observation=%q root=%q",
+											decision, eventKind, classification, generation, observation, root)
+									}
+									continue
+								}
+								if generation == TeardownGenerationStale || observation != TeardownObservationExactSocket {
+									if decision.Action != TeardownRefuse {
+										t.Fatalf("non-authoritative input produced delete/retain action: %+v", decision)
+									}
+									continue
+								}
+								qualifying := classification == TerminationNormal || classification == TerminationIntentional
+								if !qualifying && decision.Action != TeardownRetain {
+									t.Fatalf("classification %q = %+v, want retain", classification, decision)
+								}
+								if qualifying && eventKind == TeardownEventPaneExited && decision.Action != TeardownDeletePaneAgent {
+									t.Fatalf("qualifying pane event = %+v, want pane/agent delete", decision)
+								}
+								if qualifying && eventKind == TeardownEventWindowUnlinked && decision.Action != TeardownRetain {
+									t.Fatalf("unpaired window event = %+v, want retain", decision)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestCleanShellAndProviderExitHaveTheSameNormalOutcome(t *testing.T) {
+	t.Parallel()
+
+	cleanShell := decisionEvent()
+	providerExit := decisionEvent()
+	// The two inputs are intentionally indistinguishable. No command, content,
+	// prompt, history, or transcript field exists for a caller to fill.
+	if got, want := DecideTeardownEvent(cleanShell), DecideTeardownEvent(providerExit); got != want {
+		t.Fatalf("clean shell = %+v, provider /exit = %+v", got, want)
+	}
+}
+
+func TestTeardownOwnerChainRequiresExactSocketAndRuntimeHandles(t *testing.T) {
+	t.Parallel()
+
+	for _, clear := range []struct {
+		name string
+		set  func(*TeardownOwnerChain)
+	}{
+		{name: "socket identity", set: func(chain *TeardownOwnerChain) { chain.SocketIdentity = " " }},
+		{name: "Pane handle", set: func(chain *TeardownOwnerChain) { chain.PaneHandle = "" }},
+		{name: "Window handle", set: func(chain *TeardownOwnerChain) { chain.WindowHandle = "\t" }},
+	} {
+		t.Run(clear.name, func(t *testing.T) {
+			event := decisionEvent()
+			clear.set(&event.Chain)
+			got := DecideTeardownEvent(event)
+			if got.Action != TeardownRefuse || got.Reason != TeardownReasonInvalidInput {
+				t.Fatalf("missing exact identity = %+v, want invalid refusal", got)
+			}
+		})
+	}
+}
+
+func TestTeardownAggregationIsOrderIndependentAndRootBounded(t *testing.T) {
+	t.Parallel()
+
+	pane := decisionEvent()
+	window := pane
+	window.Kind = TeardownEventWindowUnlinked
+
+	forward := AggregateTeardownEvents([]TeardownEvent{pane, window})
+	reverse := AggregateTeardownEvents([]TeardownEvent{window, pane})
+	if !EqualTeardownPlans(forward, reverse) {
+		t.Fatalf("event order changed plan: forward=%+v reverse=%+v", forward, reverse)
+	}
+	if forward.Action != TeardownDeleteWindow || forward.RootAction != RootTeardownDeleteProject ||
+		forward.ReopenIdentity != ReopenIdentityNewProjectUID {
+		t.Fatalf("last Project Window plan = %+v", forward)
+	}
+	duplicates := AggregateTeardownEvents([]TeardownEvent{window, pane, window, pane})
+	if !EqualTeardownPlans(forward, duplicates) {
+		t.Fatalf("duplicate delivery changed plan: once=%+v duplicates=%+v", forward, duplicates)
+	}
+
+	oneOfMany := pane
+	oneOfMany.LiveSiblingPane = true
+	got := AggregateTeardownEvents([]TeardownEvent{oneOfMany})
+	if got.Action != TeardownDeletePaneAgent || got.RootAction != RootTeardownRetainProject {
+		t.Fatalf("one-of-many plan = %+v", got)
+	}
+	if got == forward {
+		t.Fatal("one-of-many and last-Pane plans collapsed into one outcome")
+	}
+
+	projectSibling := pane
+	projectSibling.LiveSiblingRootWindow = true
+	projectSiblingWindow := window
+	projectSiblingWindow.LiveSiblingRootWindow = true
+	got = AggregateTeardownEvents([]TeardownEvent{projectSiblingWindow, projectSibling})
+	if got.Action != TeardownDeleteWindow || got.RootAction != RootTeardownRetainProject ||
+		got.ReopenIdentity != ReopenIdentitySameProjectUID {
+		t.Fatalf("non-last Project Window plan = %+v", got)
+	}
+
+	controlPane := pane
+	controlPane.Chain.RootKind = KindControlSession
+	controlPane.Chain.RootUID = "control-1"
+	controlWindow := controlPane
+	controlWindow.Kind = TeardownEventWindowUnlinked
+	got = AggregateTeardownEvents([]TeardownEvent{controlPane, controlWindow})
+	if got.Action != TeardownDeleteWindow || got.RootAction != RootTeardownRetainControlSession ||
+		got.ReopenIdentity != ReopenIdentityNotApplicable {
+		t.Fatalf("ControlSession last-Window plan = %+v", got)
+	}
+	if got.ExternalAssets.RootDirectory != AssetNotApplicable {
+		t.Fatalf("ControlSession acquired filesystem assets: %+v", got.ExternalAssets)
+	}
+}
+
+func TestWindowUnlinkAloneAndAdversarialObservationsDeleteNothing(t *testing.T) {
+	t.Parallel()
+
+	window := decisionEvent()
+	window.Kind = TeardownEventWindowUnlinked
+	if got := AggregateTeardownEvents([]TeardownEvent{window}); got.Action != TeardownRetain {
+		t.Fatalf("window-unlinked alone = %+v, want retain", got)
+	}
+
+	for _, observation := range TeardownObservations() {
+		if observation == TeardownObservationExactSocket {
+			continue
+		}
+		event := decisionEvent()
+		event.Observation = observation
+		got := AggregateTeardownEvents([]TeardownEvent{event})
+		if got.Action == TeardownDeletePaneAgent || got.Action == TeardownDeleteWindow ||
+			got.RootAction == RootTeardownDeleteProject {
+			t.Fatalf("observation %q produced a delete plan: %+v", observation, got)
+		}
+	}
+	stale := decisionEvent()
+	stale.Generation = TeardownGenerationStale
+	if got := AggregateTeardownEvents([]TeardownEvent{stale}); got.Action != TeardownRefuse {
+		t.Fatalf("stale generation = %+v, want refuse", got)
+	}
+}
+
+func TestTeardownAggregationRefusesMixedOrConflictingOwnerEvidence(t *testing.T) {
+	t.Parallel()
+
+	pane := decisionEvent()
+	window := pane
+	window.Kind = TeardownEventWindowUnlinked
+	window.Chain.WindowUID = "window-foreign"
+	for _, ordered := range [][]TeardownEvent{{pane, window}, {window, pane}} {
+		got := AggregateTeardownEvents(ordered)
+		if got.Action != TeardownRefuse || got.Reason != TeardownReasonMixedOwnerChain {
+			t.Fatalf("mixed chain = %+v", got)
+		}
+	}
+	foreignRoot := window
+	foreignRoot.Chain.RootKind = KindControlSession
+	foreignRoot.Chain.RootUID = "control-foreign"
+	mixedForward := AggregateTeardownEvents([]TeardownEvent{pane, foreignRoot})
+	mixedReverse := AggregateTeardownEvents([]TeardownEvent{foreignRoot, pane})
+	if !EqualTeardownPlans(mixedForward, mixedReverse) || mixedForward.Reason != TeardownReasonMixedOwnerChain {
+		t.Fatalf("mixed root conflict depends on order: forward=%+v reverse=%+v", mixedForward, mixedReverse)
+	}
+	for _, mutate := range []struct {
+		name string
+		set  func(*TeardownEvent)
+	}{
+		{name: "different exact socket", set: func(event *TeardownEvent) {
+			event.Chain.SocketIdentity = "/tmp/tmux-sibling/projmux"
+		}},
+		{name: "different Pane runtime handle", set: func(event *TeardownEvent) {
+			event.Chain.PaneHandle = "%99"
+		}},
+		{name: "different Window runtime handle", set: func(event *TeardownEvent) {
+			event.Chain.WindowHandle = "@99"
+		}},
+	} {
+		t.Run(mutate.name, func(t *testing.T) {
+			foreign := pane
+			foreign.Kind = TeardownEventWindowUnlinked
+			mutate.set(&foreign)
+			forward := AggregateTeardownEvents([]TeardownEvent{pane, foreign})
+			reverse := AggregateTeardownEvents([]TeardownEvent{foreign, pane})
+			if !EqualTeardownPlans(forward, reverse) || forward.Action != TeardownRefuse ||
+				forward.RootAction == RootTeardownDeleteProject || forward.Reason != TeardownReasonMixedOwnerChain {
+				t.Fatalf("foreign exact identity depends on order or deletes: forward=%+v reverse=%+v", forward, reverse)
+			}
+		})
+	}
+
+	window = pane
+	window.Kind = TeardownEventWindowUnlinked
+	window.LiveSiblingPane = true
+	got := AggregateTeardownEvents([]TeardownEvent{pane, window})
+	if got.Action != TeardownRefuse || got.Reason != TeardownReasonConflictingOwnerFacts {
+		t.Fatalf("conflicting owner facts = %+v", got)
+	}
+}
+
+func TestProjectCascadeDeletePlanPreservesExternalAssetsAndReopensWithNewUID(t *testing.T) {
+	t.Parallel()
+
+	roots := dirSet{"/srv/alpha": true, "/srv/bravo": true}
+	mutator := testMutator(roots)
+	registry := NewRegistry()
+	alpha, err := registerFixture(mutator, &registry, "/srv/alpha")
+	if err != nil {
+		t.Fatalf("register alpha: %v", err)
+	}
+	if _, _, err := mutator.AddWindow(&registry, alpha.Project.Metadata.UID,
+		BootstrapWindow{Name: "second"}, "/bin/zsh", "add-second"); err != nil {
+		t.Fatalf("add second Window: %v", err)
+	}
+	agent, err := mutator.CreateAgent(&registry, alpha.Windows[0].Metadata.UID,
+		CreateAgentOptions{Provider: "codex", OperationID: "add-agent"})
+	if err != nil {
+		t.Fatalf("create Agent: %v", err)
+	}
+	if _, err := mutator.AttachAgentPane(&registry, agent.Metadata.UID,
+		BootstrapPane{CWD: "/srv/alpha"}, "attach-agent"); err != nil {
+		t.Fatalf("attach Agent Pane: %v", err)
+	}
+	bravo, err := registerFixture(mutator, &registry, "/srv/bravo")
+	if err != nil {
+		t.Fatalf("register bravo: %v", err)
+	}
+	before := registry.Clone()
+	deletedUIDs := []string{alpha.Project.Metadata.UID}
+	for _, window := range registry.WindowsOf(alpha.Project.Metadata.UID) {
+		deletedUIDs = append(deletedUIDs, window.Metadata.UID)
+		for _, pane := range registry.PanesOf(window.Metadata.UID) {
+			deletedUIDs = append(deletedUIDs, pane.Metadata.UID)
+		}
+		for _, ownedAgent := range registry.AgentsOf(window.Metadata.UID) {
+			deletedUIDs = append(deletedUIDs, ownedAgent.Metadata.UID)
+			for _, pane := range registry.PanesOf(ownedAgent.Metadata.UID) {
+				deletedUIDs = append(deletedUIDs, pane.Metadata.UID)
+			}
+		}
+	}
+	external := map[string][]byte{
+		"root": []byte("root-bytes"), "git": []byte("git-bytes"),
+		"worktrees": []byte("worktree-bytes"), "snapshot": []byte("snapshot-bytes"),
+	}
+	externalBefore := map[string][]byte{}
+	for key, value := range external {
+		externalBefore[key] = slices.Clone(value)
+	}
+
+	plan, err := PlanProjectCascadeDelete(registry, alpha.Project.Metadata.UID, fixedNow.Add(1))
+	if err != nil {
+		t.Fatalf("PlanProjectCascadeDelete: %v", err)
+	}
+	if !reflect.DeepEqual(registry, before) {
+		t.Fatal("pure delete planning mutated the source Registry")
+	}
+	if !plan.Changed || plan.DeletedProjects != 1 || plan.DeletedWindows != 2 ||
+		plan.DeletedAgents != 1 || plan.ReopenIdentity != ReopenIdentityNewProjectUID {
+		t.Fatalf("delete plan counts/outcome = %+v", plan)
+	}
+	if _, ok := plan.Desired.Project(alpha.Project.Metadata.UID); ok {
+		t.Fatal("deleted Project UID remains in desired Registry")
+	}
+	for _, resource := range deletedUIDs {
+		for _, reservation := range plan.Desired.NameReservations {
+			if reservation.UID == resource || reservation.Scope == resource {
+				t.Fatalf("reservation for deleted graph remains: %+v", reservation)
+			}
+		}
+	}
+	if _, ok := plan.Desired.Project(bravo.Project.Metadata.UID); !ok {
+		t.Fatal("sibling Project was removed")
+	}
+	if err := plan.Desired.Validate(); err != nil {
+		t.Fatalf("desired Registry invalid: %v", err)
+	}
+	if !reflect.DeepEqual(external, externalBefore) {
+		t.Fatalf("external assets changed: before=%v after=%v", externalBefore, external)
+	}
+	if plan.ExternalAssets != projectPreservedAssets() {
+		t.Fatalf("external asset policy = %+v", plan.ExternalAssets)
+	}
+
+	reopenMutator := Mutator{
+		Now: func() time.Time { return fixedNow.Add(2) },
+		NewUID: func(kind Kind) (string, error) {
+			return fmt.Sprintf("%s-reopened", strings.ToLower(string(kind))), nil
+		},
+		DirExists: roots.exists,
+	}
+	reopened := plan.Desired.Clone()
+	result, err := registerFixture(reopenMutator, &reopened, plan.Root)
+	if err != nil {
+		t.Fatalf("reopen deleted root: %v", err)
+	}
+	if result.Project.Metadata.UID == alpha.Project.Metadata.UID || result.Reused {
+		t.Fatalf("reopen reused deleted identity: %+v", result)
+	}
+	if !reflect.DeepEqual(external["snapshot"], externalBefore["snapshot"]) {
+		t.Fatal("reopen changed snapshot bytes")
+	}
+}
+
+func TestProjectOpenStateTableHasNoBlankCells(t *testing.T) {
+	t.Parallel()
+
+	states := []ProjectReopenState{
+		ProjectReopenLive, ProjectReopenClosed, ProjectReopenDeletedWithSnapshot,
+		ProjectReopenDeletedWithoutSnapshot,
+	}
+	actions := []ProjectOpenAction{ProjectOpenContinue, ProjectOpenFresh}
+	for _, state := range states {
+		for _, action := range actions {
+			plan := DecideProjectOpen(state, action)
+			if plan.Source == "" || plan.Reason == "" || len(plan.AtomicWriteSet) == 0 {
+				t.Fatalf("state=%q action=%q has blank cell: %+v", state, action, plan)
+			}
+			for _, write := range plan.AtomicWriteSet {
+				if write == "" {
+					t.Fatalf("state=%q action=%q has blank write: %+v", state, action, plan)
+				}
+			}
+			if plan.ExternalAssets != projectPreservedAssets() || plan.AdditionalConfirm {
+				t.Fatalf("state=%q action=%q crossed asset/confirmation boundary: %+v", state, action, plan)
+			}
+		}
+	}
+
+	without := DecideProjectOpen(ProjectReopenDeletedWithoutSnapshot, ProjectOpenContinue)
+	if without.Available || without.Source != ProjectOpenSourceNone || without.NewProjectUID ||
+		!slices.Equal(without.AtomicWriteSet, []ProjectStartupWrite{ProjectStartupWriteNone}) {
+		t.Fatalf("deleted without snapshot silently fell back: %+v", without)
+	}
+	with := DecideProjectOpen(ProjectReopenDeletedWithSnapshot, ProjectOpenContinue)
+	if !with.Available || with.Source != ProjectOpenSourceSnapshot || !with.NewProjectUID {
+		t.Fatalf("deleted with snapshot continue = %+v", with)
+	}
+	for _, state := range states {
+		fresh := DecideProjectOpen(state, ProjectOpenFresh)
+		if !fresh.Available || fresh.Source != ProjectOpenSourceRoot || !fresh.NewProjectUID ||
+			slices.Contains(fresh.AtomicWriteSet, ProjectStartupWriteRestoreSnapshotGraph) {
+			t.Fatalf("fresh state %q reads snapshot or lacks new identity: %+v", state, fresh)
+		}
+	}
+	invalid := DecideProjectOpen("invalid", "invalid")
+	if invalid.Reason != ProjectOpenReasonInvalid || len(invalid.AtomicWriteSet) == 0 {
+		t.Fatalf("invalid table cell = %+v", invalid)
+	}
+}

--- a/internal/core/pins/lifecycle.go
+++ b/internal/core/pins/lifecycle.go
@@ -1,0 +1,67 @@
+package pins
+
+import "strings"
+
+// ProjectDeletionPlan is the pure pin-store half of a Project cascade. It is a
+// desired ordered set only; persisting it belongs to the later composite
+// mutation phase.
+type ProjectDeletionPlan struct {
+	Desired    Set
+	Changed    bool
+	Replaced   int
+	DeletedUID string
+	PriorRoot  string
+}
+
+// PlanProjectDeletion replaces each exact managed pin for a deleted Project
+// with a candidate pin for its pre-delete exact root, in the same position.
+// There is deliberately no new Project uid input: a later reopen cannot be
+// silently retargeted by this plan.
+func PlanProjectDeletion(set Set, deletedProjectUID, priorRoot string) (ProjectDeletionPlan, error) {
+	managed, err := ProjectPin(strings.TrimSpace(deletedProjectUID))
+	if err != nil {
+		return ProjectDeletionPlan{}, err
+	}
+	candidate, err := CandidatePin(strings.TrimSpace(priorRoot))
+	if err != nil {
+		return ProjectDeletionPlan{}, err
+	}
+	replaced := 0
+	for _, pin := range set.Pins {
+		if pin == managed {
+			replaced++
+		}
+	}
+	desired := Set{Format: set.Format, Pins: make([]Pin, 0, len(set.Pins))}
+	if replaced == 0 {
+		desired.Pins = append(desired.Pins, set.Pins...)
+	} else {
+		candidateWritten := false
+		for _, pin := range set.Pins {
+			switch {
+			case pin == managed && !candidateWritten:
+				// The candidate occupies the deleted managed pin's exact order.
+				desired.Pins = append(desired.Pins, candidate)
+				candidateWritten = true
+			case pin == managed:
+				// A Set is unique by contract; remain duplicate-free if a caller
+				// nevertheless hand-assembles duplicate managed entries.
+			case pin == candidate:
+				// Prefer the converted managed slot over an older duplicate so
+				// the Project pin's ordering preference is preserved.
+			default:
+				desired.Pins = append(desired.Pins, pin)
+			}
+		}
+	}
+	if replaced > 0 {
+		// A project/candidate union requires the typed envelope. A legacy file
+		// cannot contain a managed pin in the first place, but fail closed into
+		// the only format that can represent this desired set if handed one.
+		desired.Format = FormatTyped
+	}
+	return ProjectDeletionPlan{
+		Desired: desired, Changed: replaced > 0, Replaced: replaced,
+		DeletedUID: managed.Value, PriorRoot: candidate.Value,
+	}, nil
+}

--- a/internal/core/pins/lifecycle_test.go
+++ b/internal/core/pins/lifecycle_test.go
@@ -1,0 +1,106 @@
+package pins
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestProjectDeletionPlanPreservesOrderAndPriorRootWithoutRetargeting(t *testing.T) {
+	t.Parallel()
+
+	input := Set{Format: FormatTyped, Pins: []Pin{
+		{Kind: KindCandidate, Value: "/srv/first"},
+		{Kind: KindProject, Value: "proj-deleted"},
+		{Kind: KindProject, Value: "proj-reopened"},
+		{Kind: KindCandidate, Value: "/srv/last"},
+	}}
+	before := Set{Format: input.Format, Pins: append([]Pin(nil), input.Pins...)}
+	plan, err := PlanProjectDeletion(input, "proj-deleted", "/srv/prior-root")
+	if err != nil {
+		t.Fatalf("PlanProjectDeletion: %v", err)
+	}
+	if !reflect.DeepEqual(input, before) {
+		t.Fatal("pure pin planning mutated the source set")
+	}
+	want := []Pin{
+		{Kind: KindCandidate, Value: "/srv/first"},
+		{Kind: KindCandidate, Value: "/srv/prior-root"},
+		{Kind: KindProject, Value: "proj-reopened"},
+		{Kind: KindCandidate, Value: "/srv/last"},
+	}
+	if !plan.Changed || plan.Replaced != 1 || !reflect.DeepEqual(plan.Desired.Pins, want) {
+		t.Fatalf("plan = %+v, want pins %#v", plan, want)
+	}
+	for _, pin := range plan.Desired.Pins {
+		if pin.Kind == KindProject && pin.Value == "proj-deleted" {
+			t.Fatal("deleted Project UID remains dangling")
+		}
+	}
+	if plan.Desired.Pins[1].Kind != KindCandidate || plan.Desired.Pins[1].Value != "/srv/prior-root" {
+		t.Fatal("deleted pin was not replaced in the same order by the prior root")
+	}
+}
+
+func TestProjectDeletionPlanIsAnExactManagedUIDNoOp(t *testing.T) {
+	t.Parallel()
+
+	input := Set{Format: FormatTyped, Pins: []Pin{
+		{Kind: KindProject, Value: "proj-other"},
+		{Kind: KindCandidate, Value: "/srv/prior-root"},
+	}}
+	plan, err := PlanProjectDeletion(input, "proj-deleted", "/srv/prior-root")
+	if err != nil {
+		t.Fatalf("PlanProjectDeletion: %v", err)
+	}
+	if plan.Changed || plan.Replaced != 0 || !reflect.DeepEqual(plan.Desired, input) {
+		t.Fatalf("unmatched exact UID plan = %+v", plan)
+	}
+}
+
+func TestProjectDeletionPlanDeduplicatesAnExistingPriorRootAtTheManagedSlot(t *testing.T) {
+	t.Parallel()
+
+	input := Set{Format: FormatTyped, Pins: []Pin{
+		{Kind: KindCandidate, Value: "/srv/first"},
+		{Kind: KindCandidate, Value: "/srv/prior-root"},
+		{Kind: KindProject, Value: "proj-other"},
+		{Kind: KindProject, Value: "proj-deleted"},
+		{Kind: KindCandidate, Value: "/srv/last"},
+	}}
+	plan, err := PlanProjectDeletion(input, "proj-deleted", "/srv/prior-root")
+	if err != nil {
+		t.Fatalf("PlanProjectDeletion: %v", err)
+	}
+	want := []Pin{
+		{Kind: KindCandidate, Value: "/srv/first"},
+		{Kind: KindProject, Value: "proj-other"},
+		{Kind: KindCandidate, Value: "/srv/prior-root"},
+		{Kind: KindCandidate, Value: "/srv/last"},
+	}
+	if !reflect.DeepEqual(plan.Desired.Pins, want) {
+		t.Fatalf("desired pins = %#v, want %#v", plan.Desired.Pins, want)
+	}
+	seen := 0
+	for _, pin := range plan.Desired.Pins {
+		if pin == (Pin{Kind: KindCandidate, Value: "/srv/prior-root"}) {
+			seen++
+		}
+		if pin == (Pin{Kind: KindProject, Value: "proj-deleted"}) {
+			t.Fatal("deleted managed UID remains dangling")
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("prior-root candidate count = %d, want 1", seen)
+	}
+}
+
+func TestProjectDeletionPlanRejectsMalformedUIDOrRoot(t *testing.T) {
+	t.Parallel()
+
+	if _, err := PlanProjectDeletion(Set{}, "pane-not-project", "/srv/root"); err == nil {
+		t.Fatal("malformed Project UID accepted")
+	}
+	if _, err := PlanProjectDeletion(Set{}, "proj-deleted", "\n"); err == nil {
+		t.Fatal("malformed prior root accepted")
+	}
+}


### PR DESCRIPTION
## Summary
- Define a total pure teardown authority matrix bounded by exact socket, runtime handles, current generation, causal termination evidence, sibling topology, and root kind.
- Add order-independent Pane/Window aggregation plus pure Project cascade, reopen state-table, and managed-pin outcomes without wiring production Registry/runtime mutation.
- Preserve root, Git/worktree, and snapshot assets while making last-Project-Window reopen identity and one-step fresh semantics explicit.

## Test plan
- [x] focused metadata/pins unit matrix (`-parallel=1 -count=1 -timeout=2m`)
- [x] `make fmt`
- [x] `make fix`
- [ ] `make test` — Phase 0 packages and all other packages pass; local-only existing failure `TestUsageStatusSuccessfulEventBatchSkipsCollectorForSourceDecision` reads the real `statusbar-visibility-agent-usage-window-codex-5h=off` because its injected env reader discards isolated XDG paths. Required clean-environment CI is the merge gate.
- [x] `make test-integration`
- [x] `make test-e2e` (first run hit a non-reproduced existing snapshot MissingRoot race; full retry passed)

## Globalization
- [x] No user-facing string changes.

## Scope boundary
- Production Registry/runtime/pin-store mutation remains in Runtime topology exit cascade Phases 1–3.
- Provider commands, pane contents, shell history, prompts, and transcripts are not authority inputs.

Roadmap: Runtime topology exit cascade / Phase 0 teardown-authority-root-outcome-kernel
Contract: C-1 Guarantee