### PR TITLE
fix(attention): resolve omitted target to the active pane

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -367,6 +367,20 @@
   Codex, and npm consumers. Local Security is the exact three-way
   `make security` topology; CI's required branch-protection context is the
   fail-closed aggregate named `Test`.
+- `make test` / `make test-integration`: attention omitted-target convergence
+  is enforced by `TestAttentionMutationOmittedTargetMatchesExplicitPaneLedger`,
+  `TestAttentionMutationOmittedTargetRefusesWithoutExactInvocationPane`, and
+  `TestAttentionMutationHelpUsesOptionalPaneCatalogUsage`; generated/reference/
+  guide parity stays pinned by `TestAttentionMutationOptionalPaneDocsParity`,
+  and generated hook argv by
+  `TestGeneratedAttentionFocusHooksKeepExplicitPaneArgv`. The unit tables pin
+  three-verb explicit/omitted handler-ledger parity, exact `%N` targeted
+  reobservation, no targetless tmux calls, and no-write refusal for outside,
+  missing, blank, malformed, stale, or contradictory inherited evidence. The
+  isolated real-tmux integration runs omitted toggle→clear and arm against one
+  inherited Pane with a sibling unchanged, then proves outside/stale failures
+  have non-zero status, stdout zero, bounded actionable stderr, and unchanged
+  attention state.
 
 ## Review Checklist
 - The branch stays within its stated scope.

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1269,6 +1269,13 @@ projmux attention window [window]
 Toggles the `✳` pane title prefix and the `@projmux_attention_state` pane
 option. `toggle` flips between cleared and `reply`; `clear` always
 clears; `arm` sets a pre-reply armed state used by the AI flow. The
+optional pane is the exact pane invoking the command: when it is omitted,
+Projmux requires inherited `$TMUX` plus an exact `$TMUX_PANE=%N` and verifies
+that same pane with a targeted tmux read before changing attention state. From
+outside tmux, or when that evidence is missing, malformed, or stale, pass an
+explicit pane target instead; the command fails without writing attention
+state. Explicit targets used by generated focus hooks keep their existing
+meaning.
 producer side pushes the matching entry into the notify queue when the pane
 has an associated AI agent option; clearing attention does not ack the queue
 row (manual toggles on shell panes do not push). `list` reads `tmux list-panes -a` and shows live pane

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -229,7 +229,7 @@ Canonical spelling: `projmux attention list`, `projmux attention toggle`, `projm
 Toggle attention state for a pane
 
 ```
-projmux attention toggle
+projmux attention toggle [pane]
 ```
 
 ### `projmux attention clear`
@@ -237,7 +237,7 @@ projmux attention toggle
 Clear attention state for a pane
 
 ```
-projmux attention clear
+projmux attention clear [pane]
 ```
 
 ### `projmux attention arm`
@@ -245,7 +245,7 @@ projmux attention clear
 Arm focus-only attention consumption
 
 ```
-projmux attention arm
+projmux attention arm [pane]
 ```
 
 ### `projmux attention list`

--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -180,7 +180,7 @@ func (c *attentionCommand) runList(args []string, stdout, stderr io.Writer) erro
 }
 
 func (c *attentionCommand) runToggle(args []string, stderr io.Writer) error {
-	paneID, err := parseOptionalAttentionTarget(args, "attention toggle", stderr)
+	paneID, err := c.resolveOptionalAttentionTarget(args, "attention toggle", stderr)
 	if err != nil || paneID == "" {
 		return err
 	}
@@ -202,7 +202,7 @@ func (c *attentionCommand) runToggle(args []string, stderr io.Writer) error {
 }
 
 func (c *attentionCommand) runClear(args []string, stderr io.Writer) error {
-	paneID, err := parseOptionalAttentionTarget(args, "attention clear", stderr)
+	paneID, err := c.resolveOptionalAttentionTarget(args, "attention clear", stderr)
 	if err != nil || paneID == "" {
 		return err
 	}
@@ -233,7 +233,7 @@ func (c *attentionCommand) runClear(args []string, stderr io.Writer) error {
 }
 
 func (c *attentionCommand) runArm(args []string, stderr io.Writer) error {
-	paneID, err := parseOptionalAttentionTarget(args, "attention arm", stderr)
+	paneID, err := c.resolveOptionalAttentionTarget(args, "attention arm", stderr)
 	if err != nil || paneID == "" {
 		return err
 	}
@@ -303,6 +303,40 @@ func parseOptionalAttentionTarget(args []string, command string, stderr io.Write
 		return "", nil
 	}
 	return strings.TrimSpace(args[0]), nil
+}
+
+// resolveOptionalAttentionTarget keeps explicit targets byte-for-byte on their
+// historical path. An omitted target is different: it is authority to mutate
+// only the exact pane that invoked the command, so both halves of tmux's
+// inherited client receipt must be present and the pane must still reobserve as
+// itself before the first attention handler read or write.
+func (c *attentionCommand) resolveOptionalAttentionTarget(args []string, command string, stderr io.Writer) (string, error) {
+	paneID, err := parseOptionalAttentionTarget(args, command, stderr)
+	if err != nil || len(args) != 0 {
+		return paneID, err
+	}
+
+	requireTarget := func(detail string) (string, error) {
+		return "", fmt.Errorf("%s requires an explicit pane or valid inherited TMUX_PANE; %s", command, detail)
+	}
+	if c == nil || c.lookupEnv == nil || strings.TrimSpace(c.lookupEnv("TMUX")) == "" {
+		return requireTarget("run it inside the target tmux pane or pass [pane]")
+	}
+	inherited := c.lookupEnv("TMUX_PANE")
+	if exactTmuxHandle(inherited, "%") == "" || exactTmuxHandle(inherited, "%") != inherited {
+		return requireTarget("TMUX_PANE must be an exact pane id such as %7, or pass [pane]")
+	}
+	if c.runner == nil {
+		return requireTarget("the inherited pane could not be observed; pass [pane]")
+	}
+	observed, observeErr := intmux.NewRunner(c.runner).DisplayMessageTrimmed(context.Background(), intmux.DisplayMessageOptions{
+		Target: inherited,
+		Format: intmux.TmuxFormat("pane_id"),
+	})
+	if observeErr != nil || observed != inherited {
+		return requireTarget("the inherited pane is stale or no longer resolves on this tmux server; pass [pane]")
+	}
+	return inherited, nil
 }
 
 type attentionWindowRow struct {

--- a/internal/app/attention_test.go
+++ b/internal/app/attention_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -584,6 +585,124 @@ func TestAttentionRejectsInvalidUsage(t *testing.T) {
 				t.Fatalf("stderr = %q, want usage", stderr.String())
 			}
 		})
+	}
+}
+
+// TestAttentionMutationOmittedTargetMatchesExplicitPaneLedger is the C-1
+// positive command-boundary table. Each omitted mutation first reobserves the
+// exact inherited pane and then enters the unchanged explicit-target handler.
+func TestAttentionMutationOmittedTargetMatchesExplicitPaneLedger(t *testing.T) {
+	t.Parallel()
+
+	for _, verb := range []string{"toggle", "clear", "arm"} {
+		t.Run(verb, func(t *testing.T) {
+			t.Parallel()
+
+			outputs := map[string][]byte{
+				"tmux display-message -p -t %7 #{pane_id}":                        []byte("%7\n"),
+				"tmux display-message -p -t %7 #{pane_title}":                     []byte("shell\n"),
+				"tmux display-message -p -t %7 #{@projmux_attention_state}":       []byte(map[string]string{"arm": "reply\n"}[verb]),
+				"tmux display-message -p -t %7 #{@projmux_ai_badge_kind}":         nil,
+				"tmux display-message -p -t %7 #{@projmux_ai_state}":              nil,
+				"tmux display-message -p -t %7 #{@projmux_attention_focus_armed}": nil,
+				"tmux display-message -p -t %7 #{@projmux_attention_ack}":         nil,
+				"tmux display-message -p -t %7 #{@projmux_ai_agent}":              nil,
+				"tmux display-message -p -t %7 #{@projmux_ai_topic}":              nil,
+			}
+			explicitRunner := &recordingAttentionRunner{outputs: outputs}
+			explicit := &attentionCommand{runner: explicitRunner}
+			if err := explicit.Run([]string{verb, "%7"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+				t.Fatalf("explicit Run() error = %v", err)
+			}
+
+			omittedRunner := &recordingAttentionRunner{outputs: outputs}
+			omitted := &attentionCommand{
+				runner: omittedRunner,
+				lookupEnv: func(name string) string {
+					return map[string]string{"TMUX": "/tmp/tmux,123,0", "TMUX_PANE": "%7"}[name]
+				},
+			}
+			var stdout, stderr bytes.Buffer
+			if err := omitted.Run([]string{verb}, &stdout, &stderr); err != nil {
+				t.Fatalf("omitted Run() error = %v", err)
+			}
+			if stdout.Len() != 0 || stderr.Len() != 0 {
+				t.Fatalf("omitted streams = stdout %q stderr %q, want empty", stdout.String(), stderr.String())
+			}
+
+			reobserve := attentionCall{name: "tmux", args: []string{"display-message", "-p", "-t", "%7", "#{pane_id}"}}
+			if len(omittedRunner.calls) == 0 || !reflect.DeepEqual(omittedRunner.calls[0], reobserve) {
+				t.Fatalf("first omitted call = %#v, want exact targeted reobserve %#v", omittedRunner.calls, reobserve)
+			}
+			if !reflect.DeepEqual(omittedRunner.calls[1:], explicitRunner.calls) {
+				t.Fatalf("omitted handler ledger = %#v, explicit = %#v", omittedRunner.calls[1:], explicitRunner.calls)
+			}
+			for _, call := range omittedRunner.calls {
+				if call.name == "tmux" && !slices.Contains(call.args, "-t") {
+					t.Fatalf("targetless tmux call escaped despite unrelated client evidence: %#v", call)
+				}
+				if index := slices.Index(call.args, "-t"); index >= 0 && (index+1 >= len(call.args) || call.args[index+1] != "%7") {
+					t.Fatalf("tmux call targeted outside inherited pane: %#v", call)
+				}
+			}
+		})
+	}
+}
+
+// TestAttentionMutationOmittedTargetRefusesWithoutExactInvocationPane is the
+// C-1 negative table. Missing, blank, malformed, stale, and contradictory
+// evidence may perform the one exact read needed to detect staleness, but no
+// attention mutation is allowed.
+func TestAttentionMutationOmittedTargetRefusesWithoutExactInvocationPane(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		tmux    string
+		pane    string
+		outputs map[string][]byte
+		err     error
+	}{
+		{name: "outside tmux"},
+		{name: "blank tmux", tmux: "   ", pane: "%7"},
+		{name: "missing pane", tmux: "/tmp/tmux,123,0"},
+		{name: "blank pane", tmux: "/tmp/tmux,123,0", pane: "   "},
+		{name: "malformed pane", tmux: "/tmp/tmux,123,0", pane: "7"},
+		{name: "non exact pane whitespace", tmux: "/tmp/tmux,123,0", pane: "%7 "},
+		{name: "stale pane", tmux: "/tmp/tmux,123,0", pane: "%7", err: errors.New("can't find pane: %7")},
+		{name: "contradictory reobserve", tmux: "/tmp/tmux,123,0", pane: "%7", outputs: map[string][]byte{"tmux display-message -p -t %7 #{pane_id}": []byte("%8\n")}},
+	}
+
+	for _, verb := range []string{"toggle", "clear", "arm"} {
+		for _, test := range tests {
+			t.Run(verb+"/"+test.name, func(t *testing.T) {
+				t.Parallel()
+
+				runner := &recordingAttentionRunner{outputs: test.outputs, err: test.err}
+				cmd := &attentionCommand{
+					runner: runner,
+					lookupEnv: func(name string) string {
+						return map[string]string{"TMUX": test.tmux, "TMUX_PANE": test.pane}[name]
+					},
+				}
+				var stdout, stderr bytes.Buffer
+				err := cmd.Run([]string{verb}, &stdout, &stderr)
+				if err == nil {
+					t.Fatal("Run() error = nil, want explicit refusal")
+				}
+				if got := err.Error(); !strings.Contains(got, "requires an explicit pane or valid inherited TMUX_PANE") || len(got) > 240 {
+					t.Fatalf("error = %q, want bounded actionable target refusal", got)
+				}
+				if stdout.Len() != 0 || stderr.Len() != 0 {
+					t.Fatalf("streams = stdout %q stderr %q, want command-boundary output 0", stdout.String(), stderr.String())
+				}
+				for _, call := range runner.calls {
+					if !reflect.DeepEqual(call, attentionCall{name: "tmux", args: []string{"display-message", "-p", "-t", "%7", "#{pane_id}"}}) {
+						t.Fatalf("call before refusal = %#v, want only exact targeted reobserve", call)
+					}
+				}
+			})
+		}
 	}
 }
 

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -1737,6 +1737,34 @@ func TestTmuxPrintConfigUsesStandaloneBindings(t *testing.T) {
 	}
 }
 
+// TestGeneratedAttentionFocusHooksKeepExplicitPaneArgv is the acceptance
+// golden for the three generated focus-hook callers. Omitted-target support
+// must not remove, rewrite, or re-quote these exact event-pane arguments.
+func TestGeneratedAttentionFocusHooksKeepExplicitPaneArgv(t *testing.T) {
+	t.Parallel()
+
+	cmd := &tmuxCommand{executable: func() (string, error) { return "/tmp/proj mux/bin/projmux", nil }}
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"print-config"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	var got []string
+	for line := range strings.SplitSeq(strings.TrimSpace(stdout.String()), "\n") {
+		if strings.Contains(line, " attention arm ") || strings.Contains(line, " attention clear ") {
+			got = append(got, line)
+		}
+	}
+	want := []string{
+		`set-hook -g pane-focus-out "run-shell -b \"'/tmp/proj mux/bin/projmux' attention arm #{hook_pane} >/dev/null 2>&1 || true\""`,
+		`set-hook -g pane-focus-in "run-shell -b \"'/tmp/proj mux/bin/projmux' attention clear #{hook_pane} >/dev/null 2>&1 || true\""`,
+		`set-hook -g after-select-pane "run-shell -b \"'/tmp/proj mux/bin/projmux' attention clear #{pane_id} >/dev/null 2>&1 || true\""`,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("generated attention focus-hook argv = %#v, want %#v", got, want)
+	}
+}
+
 func TestTmuxPrintConfigCanonicalizesNpmStagingBinaryPath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -240,9 +240,9 @@ var routes = []Route{
 		Usage:       []string{"projmux attention toggle|clear|arm|list|window"},
 		Canonical:   []string{"attention list", "attention toggle", "attention clear", "attention arm", "attention window"},
 		Children: []Route{
-			{Name: "toggle", Summary: "Toggle attention state for a pane", Canonical: []string{"attention toggle"}},
-			{Name: "clear", Summary: "Clear attention state for a pane", Canonical: []string{"attention clear"}},
-			{Name: "arm", Summary: "Arm focus-only attention consumption", Canonical: []string{"attention arm"}},
+			{Name: "toggle", Summary: "Toggle attention state for a pane", Usage: []string{"projmux attention toggle [pane]"}, Canonical: []string{"attention toggle"}},
+			{Name: "clear", Summary: "Clear attention state for a pane", Usage: []string{"projmux attention clear [pane]"}, Canonical: []string{"attention clear"}},
+			{Name: "arm", Summary: "Arm focus-only attention consumption", Usage: []string{"projmux attention arm [pane]"}, Canonical: []string{"attention arm"}},
 			{Name: "list", Summary: "List live pane attention state", Canonical: []string{"attention list"}},
 			{Name: "window", Summary: "Render window-scoped attention badges", Canonical: []string{"attention window"}},
 		},

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -96,6 +96,31 @@ func TestPadNameMatchesHistoricalColumnRule(t *testing.T) {
 	}
 }
 
+// TestAttentionMutationHelpUsesOptionalPaneCatalogUsage pins the catalog as
+// the single authority for all three runtime help synopses. The generated CLI
+// reference consumes the same Route.Usage values.
+func TestAttentionMutationHelpUsesOptionalPaneCatalogUsage(t *testing.T) {
+	t.Parallel()
+
+	for _, verb := range []string{"toggle", "clear", "arm"} {
+		path, route, ok := Resolve([]string{"attention", verb})
+		if !ok {
+			t.Fatalf("attention %s did not resolve", verb)
+		}
+		wantUsage := "projmux attention " + verb + " [pane]"
+		if !reflect.DeepEqual(route.Usage, []string{wantUsage}) {
+			t.Fatalf("attention %s Usage = %q, want [%q]", verb, route.Usage, wantUsage)
+		}
+		var out bytes.Buffer
+		if err := RenderRouteHelp(&out, path, route); err != nil {
+			t.Fatalf("RenderRouteHelp(attention %s) error = %v", verb, err)
+		}
+		if !strings.Contains(out.String(), "  "+wantUsage+"\n") {
+			t.Fatalf("attention %s runtime help = %q, want optional pane synopsis", verb, out.String())
+		}
+	}
+}
+
 // helpFlagSpellings enumerates every argv spelling the shared boundary must
 // intercept: both dash prefixes of both names, bare and with any `=value`.
 func helpFlagSpellings() []string {

--- a/internal/cli/reference_test.go
+++ b/internal/cli/reference_test.go
@@ -85,6 +85,41 @@ func TestGeneratedReferenceMatchesTheCommandManifest(t *testing.T) {
 	t.Fatalf("%s is stale; run %q", ReferencePath, ReferenceRegenCommand)
 }
 
+// TestAttentionMutationOptionalPaneDocsParity closes the hand-maintained guide
+// side of the catalog/generated/runtime help contract. Route.Usage and runtime
+// rendering are pinned in help_test; this test pins both checked-in documents.
+func TestAttentionMutationOptionalPaneDocsParity(t *testing.T) {
+	t.Parallel()
+
+	reference := readGeneratedReference(t)
+	guidePath := filepath.Join(repoRoot(t), "docs", "cli-guide.md")
+	guideBytes, err := os.ReadFile(guidePath) // #nosec G304 -- repository-relative maintained doc
+	if err != nil {
+		t.Fatalf("read docs/cli-guide.md: %v", err)
+	}
+	guide := string(guideBytes)
+	for _, verb := range []string{"toggle", "clear", "arm"} {
+		spelling := "projmux attention " + verb + " [pane]"
+		if !strings.Contains(reference, spelling) {
+			t.Errorf("generated reference lost %q", spelling)
+		}
+		guideSpelling := regexp.MustCompile(`(?m)^projmux attention ` + verb + `\s+\[pane\]$`)
+		if !guideSpelling.MatchString(guide) {
+			t.Errorf("guide lost optional target spelling for attention %s", verb)
+		}
+	}
+	guideWords := strings.Join(strings.Fields(guide), " ")
+	for _, want := range []string{
+		"optional pane is the exact pane invoking the command",
+		"requires inherited `$TMUX` plus an exact `$TMUX_PANE=%N`",
+		"the command fails without writing attention state",
+	} {
+		if !strings.Contains(guideWords, want) {
+			t.Errorf("guide lost omitted-target meaning %q", want)
+		}
+	}
+}
+
 // TestGeneratedReferenceIsDeterministic proves regeneration on an unchanged
 // tree is a no-op, which is what makes the drift gate above a signal instead of
 // noise. Rendering repeatedly must produce identical bytes: no timestamp, no

--- a/test/integration/linux-smoke.sh
+++ b/test/integration/linux-smoke.sh
@@ -1565,6 +1565,80 @@ assert_automatic_success_no_record() {
   fi
 }
 
+# Omitted attention mutation targets converge on the exact inherited Pane.
+# A sibling Pane stands in for unrelated live topology: it must remain byte
+# unchanged while toggle -> clear and arm run against automatic_pane.
+automatic_sibling="$(env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" split-window -dPF '#{pane_id}' -t "$automatic_pane")"
+env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" select-pane -T attention-target -t "$automatic_pane"
+env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" select-pane -T attention-sibling -t "$automatic_sibling"
+env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" set-option -p -u -t "$automatic_pane" @projmux_attention_state 2>/dev/null || true
+env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" set-option -p -u -t "$automatic_pane" @projmux_attention_focus_armed 2>/dev/null || true
+
+env TMUX="$automatic_tmux_env" TMUX_PANE="$automatic_pane" "$bin" attention toggle \
+  >"$PROJMUX_SMOKE_WORKDIR/automatic-attention-toggle-omitted.out"
+attention_toggle_state="$(env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" show-options -pqv -t "$automatic_pane" @projmux_attention_state)"
+attention_toggle_title="$(env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" display-message -p -t "$automatic_pane" '#{pane_title}')"
+attention_sibling_state="$(env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" show-options -pqv -t "$automatic_sibling" @projmux_attention_state)"
+attention_sibling_title="$(env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" display-message -p -t "$automatic_sibling" '#{pane_title}')"
+if [[ -s "$PROJMUX_SMOKE_WORKDIR/automatic-attention-toggle-omitted.out" ]] ||
+  [[ "$attention_toggle_state" != "reply" ]] ||
+  [[ -n "$attention_sibling_state" ]] ||
+  [[ "$attention_sibling_title" != "attention-sibling" ]]; then
+  echo "omitted attention toggle did not stay on the exact inherited Pane: target=$automatic_pane state=$attention_toggle_state title=$attention_toggle_title sibling=$automatic_sibling sibling_state=$attention_sibling_state sibling_title=$attention_sibling_title" >&2
+  exit 1
+fi
+
+# A detached integration server has no visible client. Arm the reply explicitly
+# so clear exercises its existing mutation path without changing or depending
+# on paneVisibleToClient's intentionally server-wide list-clients semantics.
+env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" set-option -p -t "$automatic_pane" @projmux_attention_focus_armed 1
+assert_automatic_success_no_record attention-clear-omitted \
+  env TMUX="$automatic_tmux_env" TMUX_PANE="$automatic_pane" "$bin" attention clear
+if [[ -n "$(env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" show-options -pqv -t "$automatic_pane" @projmux_attention_state)" ]] ||
+  [[ -n "$(env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" show-options -pqv -t "$automatic_pane" @projmux_attention_focus_armed)" ]]; then
+  echo "omitted attention clear did not clear the exact inherited Pane" >&2
+  exit 1
+fi
+
+env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" set-option -p -t "$automatic_pane" @projmux_attention_state reply
+assert_automatic_success_no_record attention-arm-omitted \
+  env TMUX="$automatic_tmux_env" TMUX_PANE="$automatic_pane" "$bin" attention arm
+if [[ "$(env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" show-options -pqv -t "$automatic_pane" @projmux_attention_focus_armed)" != "1" ]] ||
+  [[ -n "$(env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" show-options -pqv -t "$automatic_sibling" @projmux_attention_focus_armed)" ]]; then
+  echo "omitted attention arm did not stay on the exact inherited Pane" >&2
+  exit 1
+fi
+
+assert_attention_target_refusal() {
+  local label="$1"
+  shift
+  set +e
+  "$@" >"$PROJMUX_SMOKE_WORKDIR/$label.out" 2>"$PROJMUX_SMOKE_WORKDIR/$label.err"
+  local status=$?
+  set -e
+  if [[ "$status" != "1" ]] || [[ -s "$PROJMUX_SMOKE_WORKDIR/$label.out" ]]; then
+    echo "$label exit/stdout contract drifted: status=$status" >&2
+    exit 1
+  fi
+  smoke_assert_file_contains "$PROJMUX_SMOKE_WORKDIR/$label.err" "requires an explicit pane or valid inherited TMUX_PANE"
+  if [[ "$(wc -c <"$PROJMUX_SMOKE_WORKDIR/$label.err")" -gt 512 ]]; then
+    echo "$label stderr was not bounded" >&2
+    exit 1
+  fi
+}
+
+negative_state_before="$(env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" show-options -pqv -t "$automatic_pane" @projmux_attention_state)"
+negative_title_before="$(env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" display-message -p -t "$automatic_pane" '#{pane_title}')"
+assert_attention_target_refusal attention-toggle-outside \
+  env -u TMUX -u TMUX_PANE "$bin" attention toggle
+assert_attention_target_refusal attention-toggle-stale \
+  env TMUX="$automatic_tmux_env" TMUX_PANE="%999999" "$bin" attention toggle
+if [[ "$(env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" show-options -pqv -t "$automatic_pane" @projmux_attention_state)" != "$negative_state_before" ]] ||
+  [[ "$(env -u TMUX -u TMUX_PANE tmux -L "$PROJMUX_SMOKE_TMUX_SOCKET" display-message -p -t "$automatic_pane" '#{pane_title}')" != "$negative_title_before" ]]; then
+  echo "refused omitted attention target wrote to live attention state" >&2
+  exit 1
+fi
+
 assert_automatic_success_no_record agent-hook-ingest \
   env TMUX="$automatic_tmux_env" "$bin" internal agent-hook ingest bell --pane "$automatic_pane"
 assert_automatic_success_no_record attention-arm \


### PR DESCRIPTION
## Summary
- Resolve omitted attention toggle, clear, and arm targets only from non-empty inherited TMUX plus exact TMUX_PANE=%N evidence reobserved with an exact targeted tmux read.
- Fail before attention writes when invocation evidence is missing, malformed, contradictory, or stale while preserving explicit targets and generated focus-hook argv.
- Align catalog child usage, runtime help, generated CLI reference, guide prose, maintained test inventory, and isolated real-tmux coverage.

## Test plan
- [x] make fmt
- [x] make fix
- [x] make test
- [x] make test-integration
- [ ] make test-e2e: local full runs reproduced unrelated L06 registry lock exhaustion twice; official L06-only replay reproduced the same 400-attempt lock exhaustion. Required CI Test must be green before merge.
- [x] Isolated attention smoke: omitted toggle to clear and arm, sibling containment, outside and stale no-write refusal

## Globalization
- [x] Non-translated strings are classified as CLI usage and actionable diagnostic literals.

## Scope
- No Registry selector, Project scope, public env/config/schema, attention queue/badge semantics, AI ingest, or focus-hook generation changes.
- Did not touch the parallel Codex empty-prompt worker ownership under internal/integrations/agents/codexappserver or create/native launch boundary tests.