### PR TITLE
refactor(cli): unify the command graph

### DIFF
--- a/internal/cli/canonical.go
+++ b/internal/cli/canonical.go
@@ -1,286 +1,148 @@
 package cli
 
-// CanonicalRoute pins one canonical CLI information architecture v2 route
-// spelling. Phase 0 owns the spelling, the summary, the projection catalog, and
-// the mapping back to the current routes that reach the same behavior today; it
-// deliberately does not make these routes executable. Later Phases move
-// handlers onto these spellings with parity-first aliases.
+import (
+	"slices"
+	"strings"
+)
+
+// CanonicalRoute is the canonical projection of one executable command-graph
+// node. The graph owns every spelling, summary, source edge, output mode, and
+// field; this value contains no independently maintained command data.
 type CanonicalRoute struct {
-	// Spelling is the canonical argv spelling, for example "rebind project".
 	Spelling string
-	// Summary is the one-line canonical description.
-	Summary string
-	// Sources lists the current top-level route tokens that reach this
-	// behavior today. An empty list means no current public route exists and
-	// the route is introduced by a later Phase.
-	Sources []string
-	// Outputs pins the shared `-o` modes this route accepts. It is parser
-	// input, not advertising: ResolveOutputToken reads it to decide whether a
-	// token is well-formed for the route, and what a well-formed token then
-	// does is the handler's business.
-	//
-	// The distinction is load bearing for `pane-id`. A `%N` handle is a live
-	// transport binding rather than stored metadata, so the registry read path
-	// answers `-o pane-id` with "needs a live transport binding, which is not
-	// wired yet" and exits 1 -- an unimplemented-but-valid token, owned by the
-	// runtime materialization track. Dropping the token from this list would
-	// not make the read routes honest; it would reclassify that invocation as
-	// malformed input and move it to exit 2. The advertising was narrowed
-	// instead, in catalog.go, where readProjectionCatalog omits `pane-id` from
-	// what the read routes list in help and in the generated reference.
-	Outputs []OutputMode
-	// Fields pins route-local field projections outside the shared catalog.
-	Fields []FieldProjection
+	Summary  string
+	Sources  []string
+	Outputs  []OutputMode
+	Fields   []FieldProjection
 }
 
-// projectionCatalog is the shared `-o` catalog shared by result-producing
-// canonical routes.
-var projectionCatalog = sharedOutputModes
-
-// canonicalRoutes is the canonical namespace tree from the CLI information
-// architecture v2 contract. Order follows the canonical tree draft.
-//
-// This manifest is deliberately absent from every user-visible surface. Runtime
-// help renders `routes` in catalog.go; so does the generated reference in
-// docs/cli.md. Neither reads a summary from here. The public-spelling Phase
-// kept that boundary and closed the manifest itself, so the two are now honest
-// for different reasons rather than for the same one.
-//
-// The rule this manifest now holds to: every spelling is executable today.
-// Canonical replacement routes are parity forwarders over an existing handler
-// and leaf parser; they do not duplicate parsing or behavior.
-//
-//   - `config show` named a non-interactive effective-config printer that
-//     exists nowhere, under no spelling. Settings also has no standalone
-//     effective-config dump.
-//   - Phase 1 restored `config edit`, `create notification`, `create snapshot`,
-//     `notification ack`, and `notification reconcile` as handler-parity doors.
-//   - `runtime open`, `runtime quit`, `diagnostics doctor`, `diagnostics
-//     resources`, `setup probe`, and `setup welcome` remain absent because the
-//     six routes that would use them are shortcuts owned outside this
-//     compatibility track; the sixth is the general `settings` shortcut, which
-//     is intentionally broader than the AI-scoped `config edit` route.
-//
-// The routes those deletions leave without a canonical mapping are enumerated
-// and enforced in TestOnlyTheExplicitShortcutSetLeavesARouteUnmapped, so
-// "this route has no canonical v2 spelling" is a checked statement rather than
-// an omission nobody notices.
-//
-// Two divergences remain on purpose, and both name a feature an owning track is
-// building rather than an abandoned plan:
-//
-//   - `agent resume` says "Rebind an Offline or Failed Agent to a new managed
-//     Pane" while the handler resolves the Agent, applies the phase gate, and
-//     stops. The rebind needs runtime materialization.
-//   - `restore snapshot` and `delete pane` likewise describe the whole
-//     operation while only part of it is wired.
-//
-// Their command-tree summaries in catalog.go state the half that ships, which
-// is what users read.
-//
-// TestGeneratedReferenceCarriesNoCanonicalManifestOnlySummary derives the
-// divergent summary set from these two manifests at run time and fails if any
-// of it reaches docs/cli.md, so the boundary is checked rather than trusted.
-var canonicalRoutes = []CanonicalRoute{
-	// get
-	{Spelling: "get projects", Summary: "List Project resources", Sources: []string{"get"}, Outputs: projectionCatalog},
-	{Spelling: "get windows", Summary: "List Window resources", Sources: []string{"window", "get"}, Outputs: projectionCatalog},
-	{Spelling: "get panes", Summary: "List Pane resources", Sources: []string{"get"}, Outputs: projectionCatalog},
-	{Spelling: "get agents", Summary: "List Agent resources", Sources: []string{"get"}, Outputs: projectionCatalog},
-	// The runtime read is not a resource read, and its projection catalog says
-	// so: `uid`, `name`, and `ref` are Registry projections, and most of what
-	// this route reports carries none of them.
-	{Spelling: "get runtime sessions", Summary: "List every tmux session on one exact server with its attribution", Sources: []string{"get"}, Outputs: runtimeProjectionCatalog},
-	{Spelling: "get runtime windows", Summary: "List every tmux window on one exact server with its attribution", Sources: []string{"get"}, Outputs: runtimeProjectionCatalog},
-	{Spelling: "get runtime panes", Summary: "List every tmux pane on one exact server with its attribution", Sources: []string{"get"}, Outputs: runtimeProjectionCatalog},
-	{Spelling: "get notifications", Summary: "List pending notification rows", Sources: []string{"get"}, Outputs: projectionCatalog},
-	{Spelling: "get snapshots", Summary: "List saved session snapshots", Sources: []string{"get"}, Outputs: projectionCatalog},
-	{
-		Spelling: "get pane",
-		Summary:  "Read one Pane resource",
-		Sources:  []string{"get"},
-		Outputs:  projectionCatalog,
-		// `cwd` is a Pane-read route-local field projection. It is not a
-		// member of the shared create output enum, and using it on another
-		// kind or on a mutation route is a usage error.
-		Fields: []FieldProjection{FieldProjectionCWD},
-	},
-
-	// describe
-	{Spelling: "describe project", Summary: "Describe one Project resource", Sources: []string{"describe"}, Outputs: projectionCatalog},
-	{Spelling: "describe window", Summary: "Describe one Window resource", Sources: []string{"window", "describe"}, Outputs: projectionCatalog},
-	{Spelling: "describe pane", Summary: "Describe one Pane resource", Sources: []string{"describe"}, Outputs: projectionCatalog},
-	{Spelling: "describe agent", Summary: "Describe one Agent resource", Sources: []string{"describe"}, Outputs: projectionCatalog},
-
-	// create
-	{Spelling: "create project", Summary: "Register one exact filesystem path as a Registry Project", Sources: []string{"create"}, Outputs: readProjectionCatalog},
-	{Spelling: "create window", Summary: "Create a Window with its initial Pane", Sources: []string{"window", "create"}, Outputs: projectionCatalog},
-	{Spelling: "create pane", Summary: "Create a shell Pane below a Window", Sources: []string{"create"}, Outputs: projectionCatalog},
-	{Spelling: "create agent", Summary: "Create an Agent and its managed Pane", Sources: []string{"create"}, Outputs: projectionCatalog},
-	{Spelling: "create notification", Summary: "Create a pending notification row", Sources: []string{"create"}},
-	{Spelling: "create snapshot", Summary: "Create a session snapshot", Sources: []string{"create"}},
-	{Spelling: "create codex", Summary: "Provider shortcut for create agent --provider codex", Sources: []string{"create"}, Outputs: projectionCatalog},
-	{Spelling: "create claude", Summary: "Provider shortcut for create agent --provider claude", Sources: []string{"create"}, Outputs: projectionCatalog},
-	{Spelling: "create antigravity", Summary: "Provider shortcut for create agent --provider antigravity", Sources: []string{"create"}, Outputs: projectionCatalog},
-
-	// navigation and binding
-	{Spelling: "attach project", Summary: "Enter a Project runtime from outside tmux", Sources: []string{"attach"}},
-	{Spelling: "focus project", Summary: "Move the current client to a live Project", Sources: []string{"focus", "switch"}},
-	{Spelling: "focus window", Summary: "Move the current client to a live Window", Sources: []string{"focus", "window"}},
-	{Spelling: "focus pane", Summary: "Move the current client to a live Pane", Sources: []string{"focus"}},
-
-	// rename / rebind
-	{Spelling: "rename project", Summary: "Rename a Projmux Project resource", Sources: []string{"rename"}},
-	{Spelling: "rename window", Summary: "Rename a Projmux Window resource", Sources: []string{"window", "rename"}},
-	{Spelling: "rename pane", Summary: "Rename a Projmux Pane resource; does not change tmux pane_title", Sources: []string{"internal", "rename"}},
-	{Spelling: "rename agent", Summary: "Rename an Agent stable resource name only", Sources: []string{"rename"}},
-	{Spelling: "rebind project", Summary: "Rebind one Project spec.root to a new absolute directory", Sources: []string{"rebind"}},
-	{Spelling: "reconcile resources", Summary: "Preview or repair Registry and exact tmux resource drift", Sources: []string{"reconcile"}},
-	// The recovery boundary is deliberately a separate spelling. Restoring the
-	// Registry is not a stronger `reconcile resources`: it is the operation that
-	// runs when the Registry the resource planner reads cannot be loaded at all.
-	{Spelling: "reconcile registry", Summary: "Plan Registry state-loss recovery with zero writes, then restore one explicitly named verified source", Sources: []string{"reconcile"}},
-
-	// delete / restore
-	{Spelling: "delete project", Summary: "Unregister a Project and its Registry graph while preserving runtime and external assets", Sources: []string{"delete"}},
-	{Spelling: "delete window", Summary: "Delete a Window and its descendants", Sources: []string{"delete"}},
-	// The live binding half is a feature the runtime materialization track owns:
-	// the handler is registry-only today and makes zero tmux calls, so the live
-	// pane survives a delete. `internal/app/delete.go` and the command-tree
-	// summary in catalog.go both describe the registry half that ships.
-	{Spelling: "delete pane", Summary: "Delete a Pane resource and its live binding", Sources: []string{"delete"}},
-	{Spelling: "delete agent", Summary: "Delete an Agent and its managed Panes", Sources: []string{"delete"}},
-	{Spelling: "delete notification", Summary: "Delete pending notification rows", Sources: []string{"delete"}},
-	{Spelling: "delete snapshot", Summary: "Delete saved session snapshots", Sources: []string{"prune", "delete"}},
-	{Spelling: "restore snapshot", Summary: "Project a saved snapshot into one exact closed Project desired state", Sources: []string{"restore"}},
-
-	// classification
-	//
-	// Both of these name the classification store the route has always managed,
-	// and neither is a Projmux resource. The pin store is a lines file of
-	// directory paths; the tag store is a lines file of live session names. There
-	// is no uid, no ownerRef, and no registry document behind either, and
-	// `pin project` is a self-recursive spelling over the same flat action rather
-	// than a second, resource-aware implementation. The equivalent `tag project`
-	// target was removed from this manifest; the executable compatibility argv
-	// survives, but its canonical replacement is `runtime tag`.
-	//
-	// The persistent Project-metadata tag the earlier draft of this manifest
-	// promised is not a deferred feature. The product decision of 2026-08-15
-	// settled that a tag is an ephemeral session-scoped marker and that the
-	// persistent half will never be built, so the summary states what the route
-	// manages instead of a capability with no owner.
-	{Spelling: "pin project", Summary: "Manage pinned project directories", Sources: []string{"pin"}},
-
-	// prune
-	{Spelling: "prune project", Summary: "Prune Projects whose spec.root has been missing for a bounded age", Sources: []string{"prune"}},
-	{Spelling: "prune snapshot", Summary: "Prune preserved session snapshots", Sources: []string{"prune"}},
-
-	// agent domain
-	{Spelling: "agent status", Summary: "Read or set Agent status state", Sources: []string{"agent"}},
-	{Spelling: "agent topic", Summary: "Read, set, or clear the Agent topic annotation", Sources: []string{"agent"}},
-	{Spelling: "agent resume", Summary: "Rebind an Offline or Failed Agent to a new managed Pane", Sources: []string{"agent"}},
-	{Spelling: "agent turn start", Summary: "Send a new turn to one exact idle Codex thread", Sources: []string{"agent"}},
-	{Spelling: "agent turn steer", Summary: "Steer one exact current Codex turn", Sources: []string{"agent"}},
-	{Spelling: "agent turn interrupt", Summary: "Interrupt one exact current Codex turn", Sources: []string{"agent"}},
-	{Spelling: "agent approval review", Summary: "Review one exact pending native Codex approval", Sources: []string{"agent"}},
-	{Spelling: "agent review", Summary: "Start a native review on an exact-bound Codex Agent", Sources: []string{"agent"}},
-	{Spelling: "agent integrate", Summary: "Install or remove provider hook integrations", Sources: []string{"agent"}},
-	{Spelling: "agent usage", Summary: "Read provider account usage quota snapshots", Sources: []string{"internal", "agent"}},
-
-	// attention domain
-	{Spelling: "attention list", Summary: "List live Pane attention state", Sources: []string{"attention"}},
-	{Spelling: "attention toggle", Summary: "Toggle live Pane attention state", Sources: []string{"attention"}},
-	{Spelling: "attention clear", Summary: "Clear live Pane attention state", Sources: []string{"attention"}},
-	{Spelling: "attention arm", Summary: "Arm focus-only attention consumption", Sources: []string{"attention"}},
-	{Spelling: "attention window", Summary: "Render window-scoped attention badges", Sources: []string{"attention"}},
-
-	// notification domain
-	{Spelling: "notification ack", Summary: "Acknowledge notification rows", Sources: []string{"notification"}},
-	{Spelling: "notification reconcile", Summary: "Reconcile the notification queue against live targets", Sources: []string{"notification"}},
-
-	// hook domain
-	{Spelling: "hook list", Summary: "List lifecycle hook config", Sources: []string{"hook"}},
-	{Spelling: "hook edit", Summary: "Edit lifecycle hook config", Sources: []string{"hook"}},
-	{Spelling: "hook validate", Summary: "Validate lifecycle hook config", Sources: []string{"hook"}},
-	{Spelling: "hook trust", Summary: "Trust the current project hook config", Sources: []string{"hook"}},
-	{Spelling: "hook untrust", Summary: "Revoke project hook config trust", Sources: []string{"hook"}},
-
-	// config domain
-	//
-	// Two spellings, both executable. `render` is one canonical spelling over two
-	// artifacts, which is exactly how the `tmux` route already maps: both
-	// `print-config` and `print-app-config` declare `config render`, because
-	// projmux generates two different tmux configs. The public route takes the
-	// artifact as a positional kind (`config render standalone|app`) so both
-	// halves are reachable and neither is silently the default; the summary says
-	// "a generated tmux config" rather than naming one of them.
-	//
-	// `apply` is 1:1 with `tmux apply`: one artifact, written and reloaded.
-	//
-	// The `tmux` route's remaining two config spellings -- `install` and
-	// `install-app` -- have no canonical entry and no public spelling. They are
-	// installer plumbing whose canonical home is `internal tmux`, which is where
-	// they already resolve.
-	{Spelling: "config edit", Summary: "Edit the AI split-mode configuration", Sources: []string{"config"}},
-	{Spelling: "config render", Summary: "Print a generated tmux config to stdout", Sources: []string{"internal", "config"}},
-	{Spelling: "config apply", Summary: "Write the generated app tmux config and reload the live server", Sources: []string{"internal", "config"}},
-
-	// runtime domain
-	{Spelling: "runtime sessions", Summary: "Pick a live or ephemeral tmux session", Sources: []string{"runtime"}},
-	{Spelling: "runtime diagnostics", Summary: "Inspect every tmux object on one exact server, with attribution and safe actions", Sources: []string{"runtime"}},
-	{Spelling: "runtime attach", Summary: "Attach a live or ephemeral runtime without Project identity", Sources: []string{"runtime"}},
-	{Spelling: "runtime stop", Summary: "Terminate live tmux sessions by tagged selection", Sources: []string{"runtime"}},
-	{Spelling: "runtime tag", Summary: "Manage the ephemeral tagged session selection", Sources: []string{"runtime"}},
-	{Spelling: "runtime prune", Summary: "Trim old ephemeral tmux sessions", Sources: []string{"runtime"}},
-
-	// diagnostics domain
-	{Spelling: "diagnostics log", Summary: "Read the bounded local operations journal", Sources: []string{"diagnostics"}},
-	{Spelling: "diagnostics agent-hook", Summary: "Read the bounded Agent hook ingest journal", Sources: []string{"diagnostics"}},
-	{Spelling: "diagnostics report", Summary: "Create an explicit redacted local support report", Sources: []string{"diagnostics"}},
-
-	// setup domain
-	{Spelling: "setup terminal", Summary: "Show or apply terminal key remediation", Sources: []string{"setup"}},
-
-	// update domain
-	{Spelling: "update status", Summary: "Show read-only update status", Sources: []string{"update"}},
-	{Spelling: "update check", Summary: "Check for a newer release and refresh the cache", Sources: []string{"update"}},
-	{Spelling: "update apply", Summary: "Apply an available update", Sources: []string{"update"}},
-
-	// global information
-	{Spelling: "help", Summary: "Show help for projmux or one route", Sources: []string{"help"}},
-	{Spelling: "version", Summary: "Print the current version", Sources: []string{"version"}},
-
-	// hidden internal namespace
-	//
-	// The internal plumbing Phase made these executable. Each spelling now names
-	// the hidden `internal` route as a source alongside the current spelling it
-	// aliases, and both remain dispatchable until the separate breaking-change
-	// Phase removes the compatibility half.
-	{Spelling: "internal tmux", Summary: "Generated tmux config and popup plumbing", Sources: []string{"internal"}},
-	{Spelling: "internal status", Summary: "tmux status segment renderer", Sources: []string{"internal"}},
-	{Spelling: "internal statusbar", Summary: "tmux status bar click and key dispatcher", Sources: []string{"internal"}},
-	{Spelling: "internal preview", Summary: "Persisted preview cursor plumbing", Sources: []string{"internal"}},
-	{Spelling: "internal session-popup", Summary: "Generated session popup payload", Sources: []string{"internal"}},
-	{Spelling: "internal agent-pane", Summary: "Generated Agent and Pane launch plumbing", Sources: []string{"internal"}},
-	{Spelling: "internal agent-hook", Summary: "Provider hook ingest and title watcher plumbing", Sources: []string{"internal"}},
-	{Spelling: "internal focus", Summary: "Machine focus ingress", Sources: []string{"internal"}},
-	{Spelling: "internal key-broker", Summary: "Darwin physical key transport", Sources: []string{"internal"}},
-	{Spelling: "internal popup-wait-key", Summary: "Display-only popup single-key reader", Sources: []string{"internal"}},
-	{Spelling: "internal supervise", Summary: "Managed Pane process supervisor and termination receipt writer", Sources: []string{"internal"}},
-	{Spelling: "internal activation-exec", Summary: "Exact committed Agent activation admission", Sources: []string{"internal"}},
+type canonicalProjection struct {
+	route     CanonicalRoute
+	order     int
+	nodeOrder int
+	index     int
+	selfFirst bool
 }
 
-// CanonicalRoutes returns the canonical route manifest in contract order.
+// CanonicalRoutes projects the canonical command contract from the executable
+// graph. A node owns a canonical command when its own path appears in its
+// Canonical edges. Canonical family order is carried by the owning top-level
+// graph node; order within a family is the graph's depth-first command order.
 func CanonicalRoutes() []CanonicalRoute {
-	out := make([]CanonicalRoute, len(canonicalRoutes))
-	copy(out, canonicalRoutes)
+	owners := make(map[string]*canonicalProjection)
+	var sequence int
+	walkCanonicalGraph(Routes(), func(path []string, node Route) {
+		spelling := strings.Join(path, " ")
+		if !slices.Contains(node.Canonical, spelling) {
+			return
+		}
+		summary := node.Summary
+		if node.CanonicalSummary != "" {
+			summary = node.CanonicalSummary
+		}
+		outputs := node.Outputs
+		if node.AcceptedOutputs != nil {
+			outputs = node.AcceptedOutputs
+		}
+		owners[spelling] = &canonicalProjection{
+			route: CanonicalRoute{
+				Spelling: spelling,
+				Summary:  summary,
+				Outputs:  slices.Clone(outputs),
+				Fields:   slices.Clone(node.Fields),
+			},
+			order:     canonicalFamilyOrder(path[0]),
+			nodeOrder: node.CanonicalNodeOrder,
+			index:     sequence,
+			selfFirst: node.CanonicalSelfFirst,
+		}
+		sequence++
+	})
+
+	// Source mappings are graph edges too. Keep the historical projection order:
+	// compatibility sources precede the canonical owner except where the owner
+	// explicitly marks itself first.
+	walkCanonicalGraph(Routes(), func(path []string, node Route) {
+		for _, spelling := range node.Canonical {
+			owner, ok := owners[spelling]
+			if !ok {
+				continue
+			}
+			source := path[0]
+			if slices.Contains(owner.route.Sources, source) {
+				continue
+			}
+			owner.route.Sources = append(owner.route.Sources, source)
+		}
+	})
+
+	projected := make([]canonicalProjection, 0, len(owners))
+	for _, owner := range owners {
+		self := strings.Fields(owner.route.Spelling)[0]
+		slices.SortStableFunc(owner.route.Sources, func(a, b string) int {
+			aSelf, bSelf := a == self, b == self
+			if aSelf == bSelf {
+				return 0
+			}
+			if owner.selfFirst {
+				if aSelf {
+					return -1
+				}
+				return 1
+			}
+			if aSelf {
+				return 1
+			}
+			return -1
+		})
+		projected = append(projected, *owner)
+	}
+	slices.SortFunc(projected, func(a, b canonicalProjection) int {
+		if a.order != b.order {
+			return a.order - b.order
+		}
+		if a.nodeOrder != 0 || b.nodeOrder != 0 {
+			if a.nodeOrder == 0 {
+				return 1
+			}
+			if b.nodeOrder == 0 {
+				return -1
+			}
+			return a.nodeOrder - b.nodeOrder
+		}
+		return a.index - b.index
+	})
+	out := make([]CanonicalRoute, len(projected))
+	for i := range projected {
+		out[i] = projected[i].route
+	}
 	return out
 }
 
-// LookupCanonicalRoute returns the canonical route for spelling.
+func walkCanonicalGraph(nodes []Route, visit func(path []string, route Route)) {
+	var walk func(prefix []string, nodes []Route)
+	walk = func(prefix []string, nodes []Route) {
+		for _, node := range nodes {
+			path := append(append([]string{}, prefix...), node.Name)
+			visit(path, node)
+			walk(path, node.Children)
+		}
+	}
+	walk(nil, nodes)
+}
+
+func canonicalFamilyOrder(root string) int {
+	for _, route := range routes {
+		if route.Name == root {
+			return route.CanonicalOrder
+		}
+	}
+	return 0
+}
+
+// LookupCanonicalRoute returns the canonical projection for spelling.
 func LookupCanonicalRoute(spelling string) (CanonicalRoute, bool) {
-	for _, route := range canonicalRoutes {
+	for _, route := range CanonicalRoutes() {
 		if route.Spelling == spelling {
 			return route, true
 		}

--- a/internal/cli/canonical_graph_test.go
+++ b/internal/cli/canonical_graph_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestCanonicalCommandGraphProjectionMatches013Baseline(t *testing.T) {
+	t.Parallel()
+
+	var baseline strings.Builder
+	for _, route := range CanonicalRoutes() {
+		fmt.Fprintf(&baseline, "%s\t%s\t%s\t%s\t%s\n",
+			route.Spelling, route.Summary, strings.Join(route.Sources, ","),
+			outputModesString(route.Outputs), fieldProjectionsString(route.Fields))
+	}
+	const want = "2e87268925f3158f7ab551c6df6d863b16271df004b89577deccb115bda27d5d"
+	if got := fmt.Sprintf("%x", sha256.Sum256([]byte(baseline.String()))); got != want {
+		t.Fatalf("canonical command projection digest = %s, want 0.13 baseline %s\n%s", got, want, baseline.String())
+	}
+}
+
+func TestCanonicalCommandGraphHasOneOwnerPerSpelling(t *testing.T) {
+	t.Parallel()
+
+	owners := map[string][]string{}
+	edges := map[string][]string{}
+	familyOrders := map[int]string{}
+	nodeOrders := map[string]map[int]string{}
+	walkRoutes(Routes(), func(path []string, route Route) {
+		pathSpelling := strings.Join(path, " ")
+		for _, spelling := range route.Canonical {
+			edges[spelling] = append(edges[spelling], pathSpelling)
+			if spelling == pathSpelling {
+				owners[spelling] = append(owners[spelling], pathSpelling)
+			}
+		}
+		if route.CanonicalSummary != "" && !slices.Contains(route.Canonical, pathSpelling) {
+			t.Errorf("non-owner route %q declares canonical summary override %q", pathSpelling, route.CanonicalSummary)
+		}
+		if route.AcceptedOutputs != nil && !slices.Contains(route.Canonical, pathSpelling) {
+			t.Errorf("non-owner route %q declares parser output override %v", pathSpelling, route.AcceptedOutputs)
+		}
+		if len(path) == 1 && route.CanonicalOrder != 0 {
+			if prior := familyOrders[route.CanonicalOrder]; prior != "" {
+				t.Errorf("canonical family order %d is shared by %q and %q", route.CanonicalOrder, prior, pathSpelling)
+			}
+			familyOrders[route.CanonicalOrder] = pathSpelling
+		}
+		if route.CanonicalNodeOrder != 0 {
+			family := path[0]
+			if nodeOrders[family] == nil {
+				nodeOrders[family] = map[int]string{}
+			}
+			if prior := nodeOrders[family][route.CanonicalNodeOrder]; prior != "" {
+				t.Errorf("canonical node order %d in family %q is shared by %q and %q", route.CanonicalNodeOrder, family, prior, pathSpelling)
+			}
+			nodeOrders[family][route.CanonicalNodeOrder] = pathSpelling
+		}
+	})
+
+	projected := CanonicalRoutes()
+	if len(projected) == 0 {
+		t.Fatal("canonical graph projection is empty")
+	}
+	for _, route := range projected {
+		if got := owners[route.Spelling]; len(got) != 1 {
+			t.Errorf("canonical spelling %q owners = %v, want exactly one", route.Spelling, got)
+		}
+		if len(edges[route.Spelling]) == 0 {
+			t.Errorf("canonical spelling %q has no executable source edge", route.Spelling)
+		}
+		if order := canonicalFamilyOrder(strings.Fields(route.Spelling)[0]); order == 0 {
+			t.Errorf("canonical spelling %q belongs to an unordered family", route.Spelling)
+		}
+		delete(owners, route.Spelling)
+		delete(edges, route.Spelling)
+	}
+	for spelling, paths := range owners {
+		t.Errorf("unmapped canonical owner %q at %v", spelling, paths)
+	}
+	for spelling, paths := range edges {
+		t.Errorf("orphan canonical edge %q from %v", spelling, paths)
+	}
+}
+
+func TestCanonicalProjectionHasNoSecondCommandManifest(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(repoRoot(t), "internal", "cli", "canonical.go")
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed repository source path
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"[]CanonicalRoute{", "var canonicalRoutes", `Spelling: "`} {
+		if strings.Contains(string(data), forbidden) {
+			t.Errorf("canonical.go contains %q; command facts must live only in the executable graph", forbidden)
+		}
+	}
+}
+
+func outputModesString(modes []OutputMode) string {
+	out := make([]string, len(modes))
+	for i := range modes {
+		out[i] = string(modes[i])
+	}
+	return strings.Join(out, ",")
+}
+
+func fieldProjectionsString(fields []FieldProjection) string {
+	out := make([]string, len(fields))
+	for i := range fields {
+		out[i] = string(fields[i])
+	}
+	return strings.Join(out, ",")
+}

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -93,9 +93,27 @@ type Route struct {
 	Namespace bool
 	// Usage holds representative synopsis lines (not an exhaustive flag list).
 	Usage []string
-	// Canonical lists the canonical v2 route spellings this node maps onto.
-	// Every entry must resolve against CanonicalRoutes.
+	// Canonical lists the canonical route spellings this executable node reaches.
+	// The node whose own path appears in this list owns that canonical command;
+	// other entries are explicit source aliases. CanonicalRoutes, help hints, and
+	// the source audit are all projections of these edges.
 	Canonical []string
+	// CanonicalOrder orders canonical command families independently of public
+	// root-help order. Only top-level canonical owners set it.
+	CanonicalOrder int
+	// CanonicalNodeOrder overrides depth-first order inside one family without
+	// changing public help order. Zero keeps graph order.
+	CanonicalNodeOrder int
+	// CanonicalSummary overrides Summary only when the canonical contract and
+	// the current help sentence intentionally differ. Empty means Summary.
+	CanonicalSummary string
+	// AcceptedOutputs overrides Outputs only when parser acceptance is wider
+	// than help advertising (notably pane-id on Registry reads). Nil means
+	// Outputs. Both values stay on this one command node.
+	AcceptedOutputs []OutputMode
+	// CanonicalSelfFirst preserves source ordering for the few canonical routes
+	// whose own namespace historically precedes a compatibility source.
+	CanonicalSelfFirst bool
 	// Outputs pins the route-local shared output modes where the contract
 	// fixes them for this node today.
 	Outputs []OutputMode
@@ -111,13 +129,13 @@ type Route struct {
 // A `%N` pane id is a live transport binding rather than stored metadata, so
 // the read path answers `-o pane-id` with "needs a live transport binding,
 // which is not wired yet" and exits 1. The parser still accepts the token --
-// `ResolveOutputToken` consults the canonical manifest, whose Outputs list is
+// `ResolveOutputToken` consults the graph's canonical projection, whose Outputs list is
 // parser input rather than advertising -- but a route may not advertise a
 // projection whose only outcome today is an error. The create routes, where the
 // projection does work, keep the full catalog.
 //
 // Splitting the two is what keeps the error classification stable. Dropping
-// `pane-id` from the manifest would make the token malformed rather than
+// `pane-id` from the accepted graph projection would make the token malformed rather than
 // unimplemented and move `get panes -o pane-id` from exit 1 to exit 2, which is
 // a behavior change; narrowing only what the route lists changes nothing a
 // caller can observe except the help text.
@@ -174,9 +192,10 @@ var routes = []Route{
 		// `resume` is the one route with logic of its own: it resolves exactly
 		// one existing Agent, applies the phase gate, and rebinds it to a new
 		// managed Pane launched with the provider's resume argv.
-		Name:        "agent",
-		Summary:     "Manage Agent state, topic, integrations, and account usage",
-		Disposition: DispositionCanonical,
+		Name:           "agent",
+		CanonicalOrder: 13,
+		Summary:        "Manage Agent state, topic, integrations, and account usage",
+		Disposition:    DispositionCanonical,
 		Usage: []string{
 			"projmux agent status [get [<agent-ref>] | set <unknown|idle|in_progress|approval_required|input_required|response_complete> [<agent-ref>]] [--agent <ref>]",
 			"projmux agent topic get|clear [<agent-ref>] [--agent <ref>]",
@@ -191,19 +210,20 @@ var routes = []Route{
 		},
 		Canonical: []string{"agent status", "agent topic", "agent resume", "agent turn start", "agent turn steer", "agent turn interrupt", "agent approval review", "agent review", "agent integrate", "agent usage"},
 		Children: []Route{
-			{Name: "status", Summary: "Read or set semantic Agent interaction independently of lifecycle", Usage: []string{"projmux agent status [get [<agent-ref>] | set <unknown|idle|in_progress|approval_required|input_required|response_complete> [<agent-ref>]] [--agent <ref>]"}, Canonical: []string{"agent status"}},
-			{Name: "topic", Summary: "Read, set, or clear one exact Agent topic annotation", Usage: []string{"projmux agent topic get|clear [<agent-ref>] [--agent <ref>]", "projmux agent topic set <text> [<agent-ref>] [--agent <ref>]"}, Canonical: []string{"agent topic"}},
+			{Name: "status", Summary: "Read or set semantic Agent interaction independently of lifecycle", CanonicalSummary: "Read or set Agent status state", Usage: []string{"projmux agent status [get [<agent-ref>] | set <unknown|idle|in_progress|approval_required|input_required|response_complete> [<agent-ref>]] [--agent <ref>]"}, Canonical: []string{"agent status"}},
+			{Name: "topic", Summary: "Read, set, or clear one exact Agent topic annotation", CanonicalSummary: "Read, set, or clear the Agent topic annotation", Usage: []string{"projmux agent topic get|clear [<agent-ref>] [--agent <ref>]", "projmux agent topic set <text> [<agent-ref>] [--agent <ref>]"}, Canonical: []string{"agent topic"}},
 			{
 				// This route resolves exactly one existing Agent, refuses a
 				// Running one, and rebinds an Offline or Failed one to a new
 				// managed Pane built from the conversation its `status.sessionRef`
-				// records. The command tree and the canonical manifest now state
+				// records. The help and canonical graph views now state
 				// the same sentence, because the route does what the contract
 				// asked for.
-				Name:      "resume",
-				Summary:   "Rebind an Offline or Failed Agent detached on its Window's exact shell or Agent anchor",
-				Usage:     []string{"projmux agent resume <ref> [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--selector key=value]..."},
-				Canonical: []string{"agent resume"},
+				Name:             "resume",
+				Summary:          "Rebind an Offline or Failed Agent detached on its Window's exact shell or Agent anchor",
+				CanonicalSummary: "Rebind an Offline or Failed Agent to a new managed Pane",
+				Usage:            []string{"projmux agent resume <ref> [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--selector key=value]..."},
+				Canonical:        []string{"agent resume"},
 			},
 			{
 				Name:      "turn",
@@ -234,31 +254,34 @@ var routes = []Route{
 		},
 	},
 	{
-		Name:        "attention",
-		Summary:     "View and manage live tmux pane attention state",
-		Disposition: DispositionCanonical,
-		Usage:       []string{"projmux attention toggle|clear|arm|list|window"},
-		Canonical:   []string{"attention list", "attention toggle", "attention clear", "attention arm", "attention window"},
+		Name:           "attention",
+		CanonicalOrder: 14,
+		Summary:        "View and manage live tmux pane attention state",
+		Disposition:    DispositionCanonical,
+		Usage:          []string{"projmux attention toggle|clear|arm|list|window"},
+		Canonical:      []string{"attention list", "attention toggle", "attention clear", "attention arm", "attention window"},
 		Children: []Route{
-			{Name: "toggle", Summary: "Toggle attention state for a pane", Usage: []string{"projmux attention toggle [pane]"}, Canonical: []string{"attention toggle"}},
-			{Name: "clear", Summary: "Clear attention state for a pane", Usage: []string{"projmux attention clear [pane]"}, Canonical: []string{"attention clear"}},
-			{Name: "arm", Summary: "Arm focus-only attention consumption", Usage: []string{"projmux attention arm [pane]"}, Canonical: []string{"attention arm"}},
-			{Name: "list", Summary: "List live pane attention state", Canonical: []string{"attention list"}},
-			{Name: "window", Summary: "Render window-scoped attention badges", Canonical: []string{"attention window"}},
+			{Name: "toggle", Summary: "Toggle attention state for a pane", CanonicalSummary: "Toggle live Pane attention state", CanonicalNodeOrder: 2, Usage: []string{"projmux attention toggle [pane]"}, Canonical: []string{"attention toggle"}},
+			{Name: "clear", Summary: "Clear attention state for a pane", CanonicalSummary: "Clear live Pane attention state", CanonicalNodeOrder: 3, Usage: []string{"projmux attention clear [pane]"}, Canonical: []string{"attention clear"}},
+			{Name: "arm", Summary: "Arm focus-only attention consumption", CanonicalNodeOrder: 4, Usage: []string{"projmux attention arm [pane]"}, Canonical: []string{"attention arm"}},
+			{Name: "list", Summary: "List live pane attention state", CanonicalSummary: "List live Pane attention state", CanonicalNodeOrder: 1, Canonical: []string{"attention list"}},
+			{Name: "window", Summary: "Render window-scoped attention badges", CanonicalNodeOrder: 5, Canonical: []string{"attention window"}},
 		},
 	},
 	{
-		Name:        "attach",
-		Summary:     "Enter a Project runtime from outside tmux",
-		Disposition: DispositionCanonical,
-		Usage:       []string{"projmux attach project <ref>"},
-		Canonical:   []string{"attach project"},
+		Name:           "attach",
+		CanonicalOrder: 4,
+		Summary:        "Enter a Project runtime from outside tmux",
+		Disposition:    DispositionCanonical,
+		Usage:          []string{"projmux attach project <ref>"},
+		Canonical:      []string{"attach project"},
 		Children: []Route{
 			{
-				Name:      "project",
-				Summary:   "Enter a Project runtime from outside tmux, materializing it when offline",
-				Usage:     []string{"projmux attach project <ref>"},
-				Canonical: []string{"attach project"},
+				Name:             "project",
+				Summary:          "Enter a Project runtime from outside tmux, materializing it when offline",
+				CanonicalSummary: "Enter a Project runtime from outside tmux",
+				Usage:            []string{"projmux attach project <ref>"},
+				Canonical:        []string{"attach project"},
 			},
 		},
 	},
@@ -289,9 +312,10 @@ var routes = []Route{
 		// the hidden `tmux` / `internal tmux` routes, which are unchanged and
 		// undeprecated. The summaries below name the exact artifact each route
 		// touches so the public surface cannot be read as covering them.
-		Name:        "config",
-		Summary:     "Edit AI split-mode settings; render or apply generated tmux configuration",
-		Disposition: DispositionCanonical,
+		Name:           "config",
+		CanonicalOrder: 17,
+		Summary:        "Edit AI split-mode settings; render or apply generated tmux configuration",
+		Disposition:    DispositionCanonical,
 		Usage: []string{
 			"projmux config edit [--get|--set <mode>]",
 			"projmux config render standalone|app [--bin <path>]",
@@ -306,8 +330,9 @@ var routes = []Route{
 				Canonical: []string{"config edit"},
 			},
 			{
-				Name:    "render",
-				Summary: "Print a generated tmux config to stdout; writes nothing",
+				Name:             "render",
+				Summary:          "Print a generated tmux config to stdout; writes nothing",
+				CanonicalSummary: "Print a generated tmux config to stdout",
 				Usage: []string{
 					"projmux config render standalone [--bin <path>]",
 					"projmux config render app [--bin <path>]",
@@ -329,10 +354,11 @@ var routes = []Route{
 				},
 			},
 			{
-				Name:      "apply",
-				Summary:   "Write the generated app tmux config and reload the live projmux server",
-				Usage:     []string{"projmux config apply [--bin <path>] [--config <path>] [--socket <name>]"},
-				Canonical: []string{"config apply"},
+				Name:             "apply",
+				Summary:          "Write the generated app tmux config and reload the live projmux server",
+				CanonicalSummary: "Write the generated app tmux config and reload the live server",
+				Usage:            []string{"projmux config apply [--bin <path>] [--config <path>] [--socket <name>]"},
+				Canonical:        []string{"config apply"},
 			},
 		},
 	},
@@ -349,9 +375,10 @@ var routes = []Route{
 		// The kinds and the provider shortcuts share one handler and one schema.
 		// A shortcut is a spelling of `create agent --provider <id>`, so it is
 		// listed apart from the resource kinds and is never counted as one.
-		Name:        "create",
-		Summary:     "Create Projmux resources",
-		Disposition: DispositionCanonical,
+		Name:           "create",
+		CanonicalOrder: 3,
+		Summary:        "Create Projmux resources",
+		Disposition:    DispositionCanonical,
 		Usage: []string{
 			"projmux create project --root <absolute-path> [--name <name>] [--label key=value]... [-o <mode>]",
 			"projmux create window [--project <ref> | -p <ref>] [--name <name>] [--label key=value]... [-o <mode>] [-- <payload>]",
@@ -372,8 +399,9 @@ var routes = []Route{
 				// Registration is Registry-only -- no session, window or pane is
 				// materialized -- so `-o pane-id` is deliberately absent from the
 				// projections it advertises.
-				Name:    "project",
-				Summary: "Register one exact filesystem path as a Registry Project; no runtime is materialized",
+				Name:             "project",
+				Summary:          "Register one exact filesystem path as a Registry Project; no runtime is materialized",
+				CanonicalSummary: "Register one exact filesystem path as a Registry Project",
 				Usage: []string{
 					"projmux create project --root <absolute-path> [--name <name>] [--label key=value]... [-o <mode>]",
 				},
@@ -385,8 +413,9 @@ var routes = []Route{
 				// owns, and that Pane's uid is stored as the Window's
 				// compatibility shell ref -- the anchor a later `create pane` splits
 				// when no explicit --pane is given.
-				Name:    "window",
-				Summary: "Create a Window and its initial Pane below one Project; the runtime is materialized detached",
+				Name:             "window",
+				Summary:          "Create a Window and its initial Pane below one Project; the runtime is materialized detached",
+				CanonicalSummary: "Create a Window with its initial Pane",
 				Usage: []string{
 					"projmux create window [--project <ref> | -p <ref>] [--name <name>] [--label key=value]... [-o <mode>] [-- <payload>]",
 				},
@@ -401,8 +430,9 @@ var routes = []Route{
 				// all the Project, the Window, and the anchor come from the
 				// active managed runtime, so the split lands where the operator
 				// is looking.
-				Name:    "pane",
-				Summary: "Create a shell Pane detached on an explicit Pane or the Window's exact shell or Agent anchor",
+				Name:             "pane",
+				Summary:          "Create a shell Pane detached on an explicit Pane or the Window's exact shell or Agent anchor",
+				CanonicalSummary: "Create a shell Pane below a Window",
 				Usage: []string{
 					"projmux create pane [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--pane <ref>]... [--selector key=value]... [--create-window] [--name <name>] [--label key=value]... [--placement right|down] [-o <mode>] [-- <payload>]",
 				},
@@ -414,8 +444,9 @@ var routes = []Route{
 				// rule. It allocates a Window-owned Agent plus its managed Pane,
 				// splits the resolved Windows detached, and never moves the
 				// client.
-				Name:    "agent",
-				Summary: "Create an Agent detached on an explicit Pane or the Window's exact shell or Agent anchor; --provider is required",
+				Name:             "agent",
+				Summary:          "Create an Agent detached on an explicit Pane or the Window's exact shell or Agent anchor; --provider is required",
+				CanonicalSummary: "Create an Agent and its managed Pane",
 				Usage: []string{
 					"projmux create agent --provider <provider> [--project <ref> | -p <ref>] [--cwd <path>] [--add-dir <path>]... [--window <ref> | -w <ref>]... [--pane <ref>]... [--selector key=value]... [--create-window] [--name <name>] [--label key=value]... [--placement right|down] [-o <mode>] [-- <payload>]",
 				},
@@ -469,9 +500,10 @@ var routes = []Route{
 	{
 		// The registry-backed kinds own the cascade planner; `notification` and
 		// `snapshot` forward raw argv to the handlers that already own them.
-		Name:        "delete",
-		Summary:     "Delete Projmux resources with an explicit cascade plan",
-		Disposition: DispositionCanonical,
+		Name:           "delete",
+		CanonicalOrder: 9,
+		Summary:        "Delete Projmux resources with an explicit cascade plan",
+		Disposition:    DispositionCanonical,
 		// The `<ref>` is bracketed for the same reason it is on `describe`:
 		// omitting the whole selector is a meaningful invocation inside tmux,
 		// where it addresses the active target. It is spelled `[<ref>...]`
@@ -497,41 +529,46 @@ var routes = []Route{
 		Canonical: []string{"delete project", "delete window", "delete pane", "delete agent", "delete notification", "delete snapshot"},
 		Children: []Route{
 			{
-				Name:      "project",
-				Summary:   "Explicitly unregister Projects and Registry descendants while preserving roots, Git/worktrees, snapshots, and runtime",
-				Aliases:   []string{"projects"},
-				Usage:     []string{"projmux delete project [<ref>...] [--selector key=value]... [--all] [--dry-run] [--yes]"},
-				Canonical: []string{"delete project"},
+				Name:             "project",
+				Summary:          "Explicitly unregister Projects and Registry descendants while preserving roots, Git/worktrees, snapshots, and runtime",
+				CanonicalSummary: "Unregister a Project and its Registry graph while preserving runtime and external assets",
+				Aliases:          []string{"projects"},
+				Usage:            []string{"projmux delete project [<ref>...] [--selector key=value]... [--all] [--dry-run] [--yes]"},
+				Canonical:        []string{"delete project"},
 			},
 			{
-				Name:      "window",
-				Summary:   "Delete Registry Windows and every descendant Agent and Pane, killing an exact live tmux mirror when present; no selector inside tmux means the active Window, and --all means every Window in the registry",
-				Aliases:   []string{"windows"},
-				Usage:     []string{"projmux delete window [<ref>...] [--project <ref> | -p <ref>] [--selector key=value]... [--all] [--socket <name> | --socket-path <absolute>] [--dry-run] [--yes]"},
-				Canonical: []string{"delete window"},
+				Name:             "window",
+				Summary:          "Delete Registry Windows and every descendant Agent and Pane, killing an exact live tmux mirror when present; no selector inside tmux means the active Window, and --all means every Window in the registry",
+				CanonicalSummary: "Delete a Window and its descendants",
+				Aliases:          []string{"windows"},
+				Usage:            []string{"projmux delete window [<ref>...] [--project <ref> | -p <ref>] [--selector key=value]... [--all] [--socket <name> | --socket-path <absolute>] [--dry-run] [--yes]"},
+				Canonical:        []string{"delete window"},
 			},
 			{
-				Name:      "pane",
-				Summary:   "Delete Panes; an Agent-owned current Pane leaves its Agent Offline; no selector inside tmux means the active Pane, and --all means every Pane in the registry",
-				Aliases:   []string{"panes"},
-				Usage:     []string{"projmux delete pane [<ref>...] [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--all] [--socket <name> | --socket-path <absolute>] [--dry-run] [--yes]"},
-				Canonical: []string{"delete pane"},
+				Name:             "pane",
+				Summary:          "Delete Panes; an Agent-owned current Pane leaves its Agent Offline; no selector inside tmux means the active Pane, and --all means every Pane in the registry",
+				CanonicalSummary: "Delete a Pane resource and its live binding",
+				Aliases:          []string{"panes"},
+				Usage:            []string{"projmux delete pane [<ref>...] [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--all] [--socket <name> | --socket-path <absolute>] [--dry-run] [--yes]"},
+				Canonical:        []string{"delete pane"},
 			},
 			{
-				Name:      "agent",
-				Summary:   "Delete Agents and their managed Panes; no selector inside tmux means the active Agent, and --all means every Agent in the registry",
-				Aliases:   []string{"agents"},
-				Usage:     []string{"projmux delete agent [<ref>...] [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--all] [--socket <name> | --socket-path <absolute>] [--dry-run] [--yes]"},
-				Canonical: []string{"delete agent"},
+				Name:             "agent",
+				Summary:          "Delete Agents and their managed Panes; no selector inside tmux means the active Agent, and --all means every Agent in the registry",
+				CanonicalSummary: "Delete an Agent and its managed Panes",
+				Aliases:          []string{"agents"},
+				Usage:            []string{"projmux delete agent [<ref>...] [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--all] [--socket <name> | --socket-path <absolute>] [--dry-run] [--yes]"},
+				Canonical:        []string{"delete agent"},
 			},
 			{Name: "notification", Summary: "Delete pending notification rows", Aliases: []string{"notifications"}, Canonical: []string{"delete notification"}},
 			{Name: "snapshot", Summary: "Delete saved session snapshots", Aliases: []string{"snapshots"}, Canonical: []string{"delete snapshot"}},
 		},
 	},
 	{
-		Name:        "describe",
-		Summary:     "Describe one Projmux resource",
-		Disposition: DispositionCanonical,
+		Name:           "describe",
+		CanonicalOrder: 2,
+		Summary:        "Describe one Projmux resource",
+		Disposition:    DispositionCanonical,
 		// The `<ref>` is bracketed because omitting the whole selector is a
 		// meaningful invocation inside tmux, where it addresses the active
 		// target. Outside tmux it stays the ambiguity error it always was, so
@@ -545,10 +582,10 @@ var routes = []Route{
 		},
 		Canonical: []string{"describe project", "describe window", "describe pane", "describe agent"},
 		Children: []Route{
-			{Name: "project", Summary: "Describe one Project resource; with no selector inside tmux, the active Project", Aliases: []string{"projects"}, Usage: []string{"projmux describe project [<ref>] [--project <ref> | -p <ref>] [-o <mode>]"}, Canonical: []string{"describe project"}, Outputs: readProjectionCatalog},
-			{Name: "window", Summary: "Describe one Window resource; inside tmux a reference resolves within the active Project and no selector means the active Window", Aliases: []string{"windows"}, Usage: []string{"projmux describe window [<ref>] [--project <ref> | -p <ref>] [-o <mode>]"}, Canonical: []string{"describe window"}, Outputs: readProjectionCatalog},
-			{Name: "pane", Summary: "Describe one Pane resource; inside tmux a reference resolves within the active Project and no selector means the active Pane", Aliases: []string{"panes"}, Usage: []string{"projmux describe pane [<ref>] [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [-o <mode>]"}, Canonical: []string{"describe pane"}, Outputs: readProjectionCatalog},
-			{Name: "agent", Summary: "Describe one Agent resource; inside tmux a reference resolves within the active Project and no selector means the Agent owning the active Pane", Aliases: []string{"agents"}, Usage: []string{"projmux describe agent [<ref>] [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [-o <mode>]"}, Canonical: []string{"describe agent"}, Outputs: readProjectionCatalog},
+			{Name: "project", Summary: "Describe one Project resource; with no selector inside tmux, the active Project", CanonicalSummary: "Describe one Project resource", Aliases: []string{"projects"}, Usage: []string{"projmux describe project [<ref>] [--project <ref> | -p <ref>] [-o <mode>]"}, Canonical: []string{"describe project"}, Outputs: readProjectionCatalog, AcceptedOutputs: sharedOutputModes},
+			{Name: "window", Summary: "Describe one Window resource; inside tmux a reference resolves within the active Project and no selector means the active Window", CanonicalSummary: "Describe one Window resource", Aliases: []string{"windows"}, Usage: []string{"projmux describe window [<ref>] [--project <ref> | -p <ref>] [-o <mode>]"}, Canonical: []string{"describe window"}, Outputs: readProjectionCatalog, AcceptedOutputs: sharedOutputModes},
+			{Name: "pane", Summary: "Describe one Pane resource; inside tmux a reference resolves within the active Project and no selector means the active Pane", CanonicalSummary: "Describe one Pane resource", Aliases: []string{"panes"}, Usage: []string{"projmux describe pane [<ref>] [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [-o <mode>]"}, Canonical: []string{"describe pane"}, Outputs: readProjectionCatalog, AcceptedOutputs: sharedOutputModes},
+			{Name: "agent", Summary: "Describe one Agent resource; inside tmux a reference resolves within the active Project and no selector means the Agent owning the active Pane", CanonicalSummary: "Describe one Agent resource", Aliases: []string{"agents"}, Usage: []string{"projmux describe agent [<ref>] [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [-o <mode>]"}, Canonical: []string{"describe agent"}, Outputs: readProjectionCatalog, AcceptedOutputs: sharedOutputModes},
 		},
 	},
 	{
@@ -558,9 +595,10 @@ var routes = []Route{
 		Usage:       []string{"projmux doctor [--json] [--section <name>] [--verbose]"},
 	},
 	{
-		Name:        "diagnostics",
-		Summary:     "Read operational events or create an explicit local support report",
-		Disposition: DispositionCanonical,
+		Name:           "diagnostics",
+		CanonicalOrder: 19,
+		Summary:        "Read operational events or create an explicit local support report",
+		Disposition:    DispositionCanonical,
 		Usage: []string{
 			"projmux diagnostics log [--json] [--tail <n>]",
 			"projmux diagnostics agent-hook [--tail <n>] [--json] [--path]",
@@ -574,9 +612,10 @@ var routes = []Route{
 		},
 	},
 	{
-		Name:        "focus",
-		Summary:     "Move the current client to a live resource",
-		Disposition: DispositionCanonical,
+		Name:           "focus",
+		CanonicalOrder: 5,
+		Summary:        "Move the current client to a live resource",
+		Disposition:    DispositionCanonical,
 		Usage: []string{
 			"projmux focus project <ref>",
 			"projmux focus window <ref> {--project <ref> | -p <ref>}",
@@ -585,22 +624,27 @@ var routes = []Route{
 		Canonical: []string{"focus project", "focus window", "focus pane"},
 		Children: []Route{
 			{
-				Name:      "project",
-				Summary:   "Move the current client to an already-live Project; never materializes",
-				Usage:     []string{"projmux focus project <ref> [--socket <path>] [--client <tty>] [--json]"},
-				Canonical: []string{"focus project"},
+				Name:               "project",
+				Summary:            "Move the current client to an already-live Project; never materializes",
+				CanonicalSummary:   "Move the current client to a live Project",
+				CanonicalSelfFirst: true,
+				Usage:              []string{"projmux focus project <ref> [--socket <path>] [--client <tty>] [--json]"},
+				Canonical:          []string{"focus project"},
 			},
 			{
-				Name:      "window",
-				Summary:   "Move the current client to an already-live Window in an exact live root session; never materializes",
-				Usage:     []string{"projmux focus window <ref> {--project <ref> | -p <ref>} [--socket <path>] [--client <tty>] [--json]"},
-				Canonical: []string{"focus window"},
+				Name:               "window",
+				Summary:            "Move the current client to an already-live Window in an exact live root session; never materializes",
+				CanonicalSummary:   "Move the current client to a live Window",
+				CanonicalSelfFirst: true,
+				Usage:              []string{"projmux focus window <ref> {--project <ref> | -p <ref>} [--socket <path>] [--client <tty>] [--json]"},
+				Canonical:          []string{"focus window"},
 			},
 			{
-				Name:      "pane",
-				Summary:   "Move the current client to an already-live Pane in an exact live root session; never materializes",
-				Usage:     []string{"projmux focus pane <ref> {--project <ref> | -p <ref>} {--window <ref> | -w <ref>} [--socket <path>] [--json]"},
-				Canonical: []string{"focus pane"},
+				Name:             "pane",
+				Summary:          "Move the current client to an already-live Pane in an exact live root session; never materializes",
+				CanonicalSummary: "Move the current client to a live Pane",
+				Usage:            []string{"projmux focus pane <ref> {--project <ref> | -p <ref>} {--window <ref> | -w <ref>} [--socket <path>] [--json]"},
+				Canonical:        []string{"focus pane"},
 			},
 		},
 	},
@@ -617,9 +661,10 @@ var routes = []Route{
 		// Aliasing `pane` onto `panes` would delete a shipped route's meaning, so
 		// the two stay separate canonical children and the asymmetry is
 		// deliberate rather than an omission.
-		Name:        "get",
-		Summary:     "Read Projmux resources by selector",
-		Disposition: DispositionCanonical,
+		Name:           "get",
+		CanonicalOrder: 1,
+		Summary:        "Read Projmux resources by selector",
+		Disposition:    DispositionCanonical,
 		Usage: []string{
 			"projmux get projects [--project <ref> | -p <ref>] [--selector key=value]... [-o <mode>]",
 			"projmux get windows [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--selector key=value]... [--all-projects | -A] [-o <mode>]",
@@ -633,21 +678,24 @@ var routes = []Route{
 			"get runtime sessions", "get runtime windows", "get runtime panes",
 			"get notifications", "get snapshots", "get pane"},
 		Children: []Route{
-			{Name: "projects", Summary: "List Project resources", Aliases: []string{"project"}, Usage: []string{"projmux get projects [--project <ref> | -p <ref>] [--selector key=value]... [-o <mode>]"}, Canonical: []string{"get projects"}, Outputs: readProjectionCatalog},
+			{Name: "projects", Summary: "List Project resources", Aliases: []string{"project"}, Usage: []string{"projmux get projects [--project <ref> | -p <ref>] [--selector key=value]... [-o <mode>]"}, Canonical: []string{"get projects"}, Outputs: readProjectionCatalog, AcceptedOutputs: sharedOutputModes},
 			{
 				Name: "windows", Summary: "List Window resources; inside tmux defaults to the active managed root, and --all-projects lists the whole Registry",
-				Aliases: []string{"window"}, Usage: []string{"projmux get windows [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--selector key=value]... [--all-projects | -A] [-o <mode>]"},
-				Canonical: []string{"get windows"}, Outputs: readProjectionCatalog,
+				CanonicalSummary: "List Window resources",
+				Aliases:          []string{"window"}, Usage: []string{"projmux get windows [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--selector key=value]... [--all-projects | -A] [-o <mode>]"},
+				Canonical: []string{"get windows"}, Outputs: readProjectionCatalog, AcceptedOutputs: sharedOutputModes,
 			},
 			{
 				Name: "panes", Summary: "List Pane resources; inside tmux defaults to the active managed root, and --all-projects lists the whole Registry",
-				Usage:     []string{"projmux get panes [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--pane <ref>]... [--selector key=value]... [--all-projects | -A] [-o <mode>]"},
-				Canonical: []string{"get panes"}, Outputs: readProjectionCatalog,
+				CanonicalSummary: "List Pane resources",
+				Usage:            []string{"projmux get panes [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--pane <ref>]... [--selector key=value]... [--all-projects | -A] [-o <mode>]"},
+				Canonical:        []string{"get panes"}, Outputs: readProjectionCatalog, AcceptedOutputs: sharedOutputModes,
 			},
 			{
 				Name: "agents", Summary: "List Agent resources; inside tmux defaults to the active managed root, and --all-projects lists the whole Registry",
-				Aliases: []string{"agent"}, Usage: []string{"projmux get agents [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--selector key=value]... [--all-projects | -A] [-o <mode>]"},
-				Canonical: []string{"get agents"}, Outputs: readProjectionCatalog,
+				CanonicalSummary: "List Agent resources",
+				Aliases:          []string{"agent"}, Usage: []string{"projmux get agents [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--selector key=value]... [--all-projects | -A] [-o <mode>]"},
+				Canonical: []string{"get agents"}, Outputs: readProjectionCatalog, AcceptedOutputs: sharedOutputModes,
 			},
 			{
 				// The Runtime diagnostics escape hatch. It is a child of `get`
@@ -690,26 +738,29 @@ var routes = []Route{
 					},
 				},
 			},
-			{Name: "notifications", Summary: "List pending notification rows", Aliases: []string{"notification"}, Canonical: []string{"get notifications"}},
-			{Name: "snapshots", Summary: "List saved session snapshots", Aliases: []string{"snapshot"}, Canonical: []string{"get snapshots"}},
+			{Name: "notifications", Summary: "List pending notification rows", Aliases: []string{"notification"}, Canonical: []string{"get notifications"}, AcceptedOutputs: sharedOutputModes},
+			{Name: "snapshots", Summary: "List saved session snapshots", Aliases: []string{"snapshot"}, Canonical: []string{"get snapshots"}, AcceptedOutputs: sharedOutputModes},
 			{
-				Name:      "pane",
-				Summary:   "Read one Pane resource; with no selector inside tmux, the active Pane",
-				Usage:     []string{"projmux get pane [--current] [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--pane <ref>]... [--selector key=value]... [-o <mode>]"},
-				Canonical: []string{"get pane"},
-				Outputs:   readProjectionCatalog,
-				Fields:    []FieldProjection{FieldProjectionCWD},
+				Name:             "pane",
+				Summary:          "Read one Pane resource; with no selector inside tmux, the active Pane",
+				CanonicalSummary: "Read one Pane resource",
+				Usage:            []string{"projmux get pane [--current] [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]... [--pane <ref>]... [--selector key=value]... [-o <mode>]"},
+				Canonical:        []string{"get pane"},
+				Outputs:          readProjectionCatalog,
+				AcceptedOutputs:  sharedOutputModes,
+				Fields:           []FieldProjection{FieldProjectionCWD},
 			},
 		},
 	},
 	{
-		Name:        "hook",
-		Summary:     "List, edit, validate, and trust lifecycle hook config",
-		Disposition: DispositionCanonical,
-		Usage:       []string{"projmux hook list|edit|validate|trust|untrust"},
-		Canonical:   []string{"hook list", "hook edit", "hook validate", "hook trust", "hook untrust"},
+		Name:           "hook",
+		CanonicalOrder: 16,
+		Summary:        "List, edit, validate, and trust lifecycle hook config",
+		Disposition:    DispositionCanonical,
+		Usage:          []string{"projmux hook list|edit|validate|trust|untrust"},
+		Canonical:      []string{"hook list", "hook edit", "hook validate", "hook trust", "hook untrust"},
 		Children: []Route{
-			{Name: "list", Summary: "List global and project lifecycle hooks", Canonical: []string{"hook list"}},
+			{Name: "list", Summary: "List global and project lifecycle hooks", CanonicalSummary: "List lifecycle hook config", Canonical: []string{"hook list"}},
 			{Name: "edit", Summary: "Edit lifecycle hook config", Canonical: []string{"hook edit"}},
 			{Name: "validate", Summary: "Validate lifecycle hook config", Canonical: []string{"hook validate"}},
 			{Name: "trust", Summary: "Trust the current project hook config", Canonical: []string{"hook trust"}},
@@ -717,9 +768,10 @@ var routes = []Route{
 		},
 	},
 	{
-		Name:        "notification",
-		Summary:     "Manage pending notification workflow state",
-		Disposition: DispositionCanonical,
+		Name:           "notification",
+		CanonicalOrder: 15,
+		Summary:        "Manage pending notification workflow state",
+		Disposition:    DispositionCanonical,
 		Usage: []string{
 			"projmux notification ack <id> | --all",
 			"projmux notification reconcile [--json]",
@@ -731,24 +783,26 @@ var routes = []Route{
 		},
 	},
 	{
-		Name:        "pin",
-		Summary:     "Manage pinned project directories",
-		Disposition: DispositionCanonical,
-		Usage:       []string{"projmux pin project list|add|remove|toggle|clear"},
-		Canonical:   []string{"pin project"},
+		Name:           "pin",
+		CanonicalOrder: 11,
+		Summary:        "Manage pinned project directories",
+		Disposition:    DispositionCanonical,
+		Usage:          []string{"projmux pin project list|add|remove|toggle|clear"},
+		Canonical:      []string{"pin project"},
 		Children: []Route{
 			// The store behind this route is a lines file of directory paths, not
 			// a Project registry: there is no uid, no ownerRef, and no resource
 			// document. So the summary says "project directories" like every
 			// sibling below it, rather than "Project resources", which would name
 			// a resource kind the route never touches.
-			{Name: "project", Summary: "Manage pinned project directories (canonical spelling)", Usage: []string{"projmux pin project list|add|remove|toggle|clear"}, Canonical: []string{"pin project"}},
+			{Name: "project", Summary: "Manage pinned project directories (canonical spelling)", CanonicalSummary: "Manage pinned project directories", Usage: []string{"projmux pin project list|add|remove|toggle|clear"}, Canonical: []string{"pin project"}},
 		},
 	},
 	{
-		Name:        "prune",
-		Summary:     "Prune stale Projects and snapshots",
-		Disposition: DispositionCanonical,
+		Name:           "prune",
+		CanonicalOrder: 12,
+		Summary:        "Prune stale Projects and snapshots",
+		Disposition:    DispositionCanonical,
 		Usage: []string{
 			"projmux prune snapshot [--older-than <duration>]",
 			"projmux prune project --missing --older-than <duration> [--yes]",
@@ -756,16 +810,18 @@ var routes = []Route{
 		Canonical: []string{"prune project", "prune snapshot"},
 		Children: []Route{
 			{
-				Name:      "project",
-				Summary:   "Delete Projects whose spec.root has been missing for a bounded age",
-				Usage:     []string{"projmux prune project --missing --older-than <duration> [--yes]"},
-				Canonical: []string{"prune project"},
+				Name:             "project",
+				Summary:          "Delete Projects whose spec.root has been missing for a bounded age",
+				CanonicalSummary: "Prune Projects whose spec.root has been missing for a bounded age",
+				Usage:            []string{"projmux prune project --missing --older-than <duration> [--yes]"},
+				Canonical:        []string{"prune project"},
 			},
 			{
-				Name:      "snapshot",
-				Summary:   "Inspect or delete preserved session snapshots (canonical spelling)",
-				Usage:     []string{"projmux prune snapshot [--older-than <duration>]", "projmux prune snapshot delete <session>..."},
-				Canonical: []string{"prune snapshot", "delete snapshot"},
+				Name:             "snapshot",
+				Summary:          "Inspect or delete preserved session snapshots (canonical spelling)",
+				CanonicalSummary: "Prune preserved session snapshots",
+				Usage:            []string{"projmux prune snapshot [--older-than <duration>]", "projmux prune snapshot delete <session>..."},
+				Canonical:        []string{"prune snapshot", "delete snapshot"},
 			},
 		},
 	},
@@ -776,9 +832,10 @@ var routes = []Route{
 		Usage:       []string{"projmux quit [--yes|--force]"},
 	},
 	{
-		Name:        "reconcile",
-		Summary:     "Preview or repair Registry and exact tmux resource drift",
-		Disposition: DispositionCanonical,
+		Name:           "reconcile",
+		CanonicalOrder: 8,
+		Summary:        "Preview or repair Registry and exact tmux resource drift",
+		Disposition:    DispositionCanonical,
 		Usage: []string{
 			"projmux reconcile resources [--dry-run] [--materialize-project <name|uid:uid>] [--socket <name> | --socket-path <absolute>] [-o json]",
 			"projmux reconcile registry [--dry-run] [--source <name|absolute-path>] [--expect-source-checksum <sha256:hex>] [--expect-current-checksum <sha256:hex>] [--socket <name> | --socket-path <absolute>] [-o json]",
@@ -786,10 +843,11 @@ var routes = []Route{
 		Canonical: []string{"reconcile resources", "reconcile registry"},
 		Children: []Route{
 			{
-				Name:      "resources",
-				Summary:   "Preview or repair exact anchor-aware Registry and tmux topology on one exact socket",
-				Usage:     []string{"projmux reconcile resources [--dry-run] [--materialize-project <name|uid:uid>] [--socket <name> | --socket-path <absolute>] [-o json]"},
-				Canonical: []string{"reconcile resources"},
+				Name:             "resources",
+				Summary:          "Preview or repair exact anchor-aware Registry and tmux topology on one exact socket",
+				CanonicalSummary: "Preview or repair Registry and exact tmux resource drift",
+				Usage:            []string{"projmux reconcile resources [--dry-run] [--materialize-project <name|uid:uid>] [--socket <name> | --socket-path <absolute>] [-o json]"},
+				Canonical:        []string{"reconcile resources"},
 			},
 			{
 				Name:      "registry",
@@ -800,24 +858,27 @@ var routes = []Route{
 		},
 	},
 	{
-		Name:        "rebind",
-		Summary:     "Rebind a Project to a new absolute root without moving files",
-		Disposition: DispositionCanonical,
-		Usage:       []string{"projmux rebind project [<ref>] [--project <ref> | -p <ref>] --root <absolute-path>"},
-		Canonical:   []string{"rebind project"},
+		Name:           "rebind",
+		CanonicalOrder: 7,
+		Summary:        "Rebind a Project to a new absolute root without moving files",
+		Disposition:    DispositionCanonical,
+		Usage:          []string{"projmux rebind project [<ref>] [--project <ref> | -p <ref>] --root <absolute-path>"},
+		Canonical:      []string{"rebind project"},
 		Children: []Route{
 			{
-				Name:      "project",
-				Summary:   "Rewrite one Project spec.root; no filesystem move, no heuristic uid merge",
-				Usage:     []string{"projmux rebind project [<ref>] [--project <ref> | -p <ref>] --root <absolute-path>"},
-				Canonical: []string{"rebind project"},
+				Name:             "project",
+				Summary:          "Rewrite one Project spec.root; no filesystem move, no heuristic uid merge",
+				CanonicalSummary: "Rebind one Project spec.root to a new absolute directory",
+				Usage:            []string{"projmux rebind project [<ref>] [--project <ref> | -p <ref>] --root <absolute-path>"},
+				Canonical:        []string{"rebind project"},
 			},
 		},
 	},
 	{
-		Name:        "rename",
-		Summary:     "Rename a Projmux resource metadata.name",
-		Disposition: DispositionCanonical,
+		Name:           "rename",
+		CanonicalOrder: 6,
+		Summary:        "Rename a Projmux resource metadata.name",
+		Disposition:    DispositionCanonical,
 		Usage: []string{
 			"projmux rename project [<ref>] [--project <ref> | -p <ref>] --name <name>",
 			"projmux rename window [<ref>] --name <name> [--project <ref> | -p <ref>]",
@@ -826,10 +887,10 @@ var routes = []Route{
 		},
 		Canonical: []string{"rename project", "rename window", "rename pane", "rename agent"},
 		Children: []Route{
-			{Name: "project", Summary: "Rename a Projmux Project resource; with no selector inside tmux, the active Project", Aliases: []string{"projects"}, Usage: []string{"projmux rename project [<ref>] [--project <ref> | -p <ref>] --name <name>"}, Canonical: []string{"rename project"}},
-			{Name: "window", Summary: "Rename a Projmux Window resource; inside tmux a reference resolves within the active Project or ControlSession and no selector means the active Window", Aliases: []string{"windows"}, Usage: []string{"projmux rename window [<ref>] --name <name> [--project <ref> | -p <ref>]"}, Canonical: []string{"rename window"}},
-			{Name: "pane", Summary: "Rename a Projmux Pane resource; inside tmux a reference resolves within the active Project or ControlSession and no selector means the active Pane; does not change tmux pane_title", Aliases: []string{"panes"}, Usage: []string{"projmux rename pane [<ref>] --name <name> [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]..."}, Canonical: []string{"rename pane"}},
-			{Name: "agent", Summary: "Rename an Agent stable resource name within the active Project or ControlSession without changing its topic, provider, or managed Pane", Aliases: []string{"agents"}, Usage: []string{"projmux rename agent [<ref>] --name <name> [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]..."}, Canonical: []string{"rename agent"}},
+			{Name: "project", Summary: "Rename a Projmux Project resource; with no selector inside tmux, the active Project", CanonicalSummary: "Rename a Projmux Project resource", Aliases: []string{"projects"}, Usage: []string{"projmux rename project [<ref>] [--project <ref> | -p <ref>] --name <name>"}, Canonical: []string{"rename project"}},
+			{Name: "window", Summary: "Rename a Projmux Window resource; inside tmux a reference resolves within the active Project or ControlSession and no selector means the active Window", CanonicalSummary: "Rename a Projmux Window resource", Aliases: []string{"windows"}, Usage: []string{"projmux rename window [<ref>] --name <name> [--project <ref> | -p <ref>]"}, Canonical: []string{"rename window"}},
+			{Name: "pane", Summary: "Rename a Projmux Pane resource; inside tmux a reference resolves within the active Project or ControlSession and no selector means the active Pane; does not change tmux pane_title", CanonicalSummary: "Rename a Projmux Pane resource; does not change tmux pane_title", Aliases: []string{"panes"}, Usage: []string{"projmux rename pane [<ref>] --name <name> [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]..."}, Canonical: []string{"rename pane"}},
+			{Name: "agent", Summary: "Rename an Agent stable resource name within the active Project or ControlSession without changing its topic, provider, or managed Pane", CanonicalSummary: "Rename an Agent stable resource name only", Aliases: []string{"agents"}, Usage: []string{"projmux rename agent [<ref>] --name <name> [--project <ref> | -p <ref>] [--window <ref> | -w <ref>]..."}, Canonical: []string{"rename agent"}},
 		},
 	},
 	{
@@ -839,11 +900,12 @@ var routes = []Route{
 		Usage:       []string{"projmux resources"},
 	},
 	{
-		Name:        "restore",
-		Summary:     "Project a saved snapshot into one exact closed Project desired state",
-		Disposition: DispositionCanonical,
-		Usage:       []string{"projmux restore snapshot --session <name> [--project <ref> | -p <ref>] [--dry-run | --yes] [--client <tmux-client>]"},
-		Canonical:   []string{"restore snapshot"},
+		Name:           "restore",
+		CanonicalOrder: 10,
+		Summary:        "Project a saved snapshot into one exact closed Project desired state",
+		Disposition:    DispositionCanonical,
+		Usage:          []string{"projmux restore snapshot --session <name> [--project <ref> | -p <ref>] [--dry-run | --yes] [--client <tmux-client>]"},
+		Canonical:      []string{"restore snapshot"},
 		Children: []Route{
 			{
 				Name:      "snapshot",
@@ -858,9 +920,10 @@ var routes = []Route{
 		// carries no uid, name reservation, or ownerRef and is therefore not a
 		// Projmux resource. Every subcommand forwards raw argv to the handler
 		// that already owns the behavior.
-		Name:        "runtime",
-		Summary:     "Manage the live and ephemeral tmux runtime inventory",
-		Disposition: DispositionCanonical,
+		Name:           "runtime",
+		CanonicalOrder: 18,
+		Summary:        "Manage the live and ephemeral tmux runtime inventory",
+		Disposition:    DispositionCanonical,
 		Usage: []string{
 			"projmux runtime sessions [--ui=popup|sidebar]",
 			"projmux runtime diagnostics [--socket <name> | --socket-path <absolute>] [--ui=popup|sidebar]",
@@ -898,9 +961,10 @@ var routes = []Route{
 		Usage:       []string{"projmux settings"},
 	},
 	{
-		Name:        "setup",
-		Summary:     "Probe terminal keys or remediate them with setup terminal",
-		Disposition: DispositionCanonical,
+		Name:           "setup",
+		CanonicalOrder: 20,
+		Summary:        "Probe terminal keys or remediate them with setup terminal",
+		Disposition:    DispositionCanonical,
 		Usage: []string{
 			"projmux setup",
 			"projmux setup terminal [terminal] [--apply]",
@@ -924,11 +988,12 @@ var routes = []Route{
 		Canonical:   []string{"focus project"},
 	},
 	{
-		Name:        "update",
-		Summary:     "Check installer-aware release update status",
-		Disposition: DispositionCanonical,
-		Usage:       []string{"projmux update status|check|apply"},
-		Canonical:   []string{"update status", "update check", "update apply"},
+		Name:           "update",
+		CanonicalOrder: 21,
+		Summary:        "Check installer-aware release update status",
+		Disposition:    DispositionCanonical,
+		Usage:          []string{"projmux update status|check|apply"},
+		Canonical:      []string{"update status", "update check", "update apply"},
 		Children: []Route{
 			{Name: "status", Summary: "Show read-only update status", Canonical: []string{"update status"}},
 			{Name: "check", Summary: "Check for a newer release and refresh the cache", Canonical: []string{"update check"}},
@@ -953,9 +1018,11 @@ var routes = []Route{
 		},
 	},
 	{
-		Name:        "help",
-		Summary:     "Show bootstrap help",
-		Disposition: DispositionCanonical,
+		Name:             "help",
+		CanonicalOrder:   22,
+		Summary:          "Show bootstrap help",
+		CanonicalSummary: "Show help for projmux or one route",
+		Disposition:      DispositionCanonical,
 		Usage: []string{
 			"projmux help",
 			"projmux --help",
@@ -964,9 +1031,10 @@ var routes = []Route{
 		Canonical: []string{"help"},
 	},
 	{
-		Name:        "version",
-		Summary:     "Print the current version",
-		Disposition: DispositionCanonical,
+		Name:           "version",
+		CanonicalOrder: 23,
+		Summary:        "Print the current version",
+		Disposition:    DispositionCanonical,
 		Usage: []string{
 			"projmux version",
 			"projmux --version",
@@ -983,10 +1051,11 @@ var routes = []Route{
 		// Every subcommand forwards raw argv to the handler that owns the
 		// behavior. Old pre-namespace spellings are absent from the public and
 		// hidden route graph; generated config uses only this namespace.
-		Name:        "internal",
-		Summary:     "Internal plumbing invoked by generated tmux config, hooks, and popups",
-		Disposition: DispositionInternal,
-		Hidden:      true,
+		Name:           "internal",
+		CanonicalOrder: 24,
+		Summary:        "Internal plumbing invoked by generated tmux config, hooks, and popups",
+		Disposition:    DispositionInternal,
+		Hidden:         true,
 		Usage: []string{
 			"projmux internal tmux print-config|apply|popup-toggle|rebalance-panes|autosave-session-state ...",
 			"projmux internal status git|project|usage|notify|resources",
@@ -1017,10 +1086,11 @@ var routes = []Route{
 		},
 		Children: []Route{
 			{
-				Name:      "tmux",
-				Summary:   "Generated tmux config, popup, and pane plumbing",
-				Usage:     []string{"projmux internal tmux print-config|print-app-config|install|install-app|apply", "projmux internal tmux popup-preview|popup-switch|popup-sessions|popup-toggle", "projmux internal tmux hook-trust-prompt|rebalance-panes|rename-pane|autosave-session-state"},
-				Canonical: []string{"internal tmux"},
+				Name:             "tmux",
+				Summary:          "Generated tmux config, popup, and pane plumbing",
+				CanonicalSummary: "Generated tmux config and popup plumbing",
+				Usage:            []string{"projmux internal tmux print-config|print-app-config|install|install-app|apply", "projmux internal tmux popup-preview|popup-switch|popup-sessions|popup-toggle", "projmux internal tmux hook-trust-prompt|rebalance-panes|rename-pane|autosave-session-state"},
+				Canonical:        []string{"internal tmux"},
 				Children: []Route{
 					{Name: "hook-trust-prompt", Summary: "Show the project hook trust prompt", Canonical: []string{"internal tmux"}},
 					{Name: "popup-preview", Summary: "Open the preview popup", Canonical: []string{"internal tmux"}},
@@ -1038,10 +1108,11 @@ var routes = []Route{
 				},
 			},
 			{
-				Name:      "status",
-				Summary:   "Render tmux status bar segments",
-				Usage:     []string{"projmux internal status git|project|usage|notify|resources"},
-				Canonical: []string{"internal status", "agent usage"},
+				Name:             "status",
+				Summary:          "Render tmux status bar segments",
+				CanonicalSummary: "tmux status segment renderer",
+				Usage:            []string{"projmux internal status git|project|usage|notify|resources"},
+				Canonical:        []string{"internal status", "agent usage"},
 				Children: []Route{
 					{Name: "git", Summary: "Render the git status segment", Canonical: []string{"internal status"}},
 					{Name: "project", Summary: "Render the project status segment", Canonical: []string{"internal status"}},
@@ -1051,20 +1122,22 @@ var routes = []Route{
 				},
 			},
 			{
-				Name:      "statusbar",
-				Summary:   "Dispatch projmux status bar clicks and shortcuts",
-				Usage:     []string{"projmux internal statusbar click <range-id> ...", "projmux internal statusbar usage-refresh"},
-				Canonical: []string{"internal statusbar"},
+				Name:             "statusbar",
+				Summary:          "Dispatch projmux status bar clicks and shortcuts",
+				CanonicalSummary: "tmux status bar click and key dispatcher",
+				Usage:            []string{"projmux internal statusbar click <range-id> ...", "projmux internal statusbar usage-refresh"},
+				Canonical:        []string{"internal statusbar"},
 				Children: []Route{
 					{Name: "click", Summary: "Dispatch a status bar click range", Canonical: []string{"internal statusbar"}},
 					{Name: "usage-refresh", Summary: "Refresh the AI usage snapshot", Canonical: []string{"internal statusbar"}},
 				},
 			},
 			{
-				Name:      "preview",
-				Summary:   "Manage persisted tmux preview selection",
-				Usage:     []string{"projmux internal preview cycle-pane|cycle-window|select"},
-				Canonical: []string{"internal preview"},
+				Name:             "preview",
+				Summary:          "Manage persisted tmux preview selection",
+				CanonicalSummary: "Persisted preview cursor plumbing",
+				Usage:            []string{"projmux internal preview cycle-pane|cycle-window|select"},
+				Canonical:        []string{"internal preview"},
 				Children: []Route{
 					{Name: "cycle-pane", Summary: "Advance the persisted preview pane cursor", Canonical: []string{"internal preview"}},
 					{Name: "cycle-window", Summary: "Advance the persisted preview window cursor", Canonical: []string{"internal preview"}},
@@ -1072,10 +1145,11 @@ var routes = []Route{
 				},
 			},
 			{
-				Name:      "session-popup",
-				Summary:   "Read tmux popup preview state",
-				Usage:     []string{"projmux internal session-popup preview|open|cycle-pane|cycle-window"},
-				Canonical: []string{"internal session-popup"},
+				Name:             "session-popup",
+				Summary:          "Read tmux popup preview state",
+				CanonicalSummary: "Generated session popup payload",
+				Usage:            []string{"projmux internal session-popup preview|open|cycle-pane|cycle-window"},
+				Canonical:        []string{"internal session-popup"},
 				Children: []Route{
 					{Name: "preview", Summary: "Render the session popup preview", Canonical: []string{"internal session-popup"}},
 					{Name: "open", Summary: "Open the previewed session", Canonical: []string{"internal session-popup"}},
@@ -1098,10 +1172,11 @@ var routes = []Route{
 				// and by the pane title watcher, never by a user, so the Agent
 				// decomposition parks it here rather than in the public `agent`
 				// namespace.
-				Name:      "agent-hook",
-				Summary:   "Provider hook ingest and Agent pane title watcher plumbing",
-				Usage:     []string{"projmux internal agent-hook ingest <source> ...", "projmux internal agent-hook watch-title [pane]"},
-				Canonical: []string{"internal agent-hook"},
+				Name:             "agent-hook",
+				Summary:          "Provider hook ingest and Agent pane title watcher plumbing",
+				CanonicalSummary: "Provider hook ingest and title watcher plumbing",
+				Usage:            []string{"projmux internal agent-hook ingest <source> ...", "projmux internal agent-hook watch-title [pane]"},
+				Canonical:        []string{"internal agent-hook"},
 				Children: []Route{
 					{Name: "ingest", Summary: "Ingest provider hook and log events", Canonical: []string{"internal agent-hook"}},
 					{Name: "watch-title", Summary: "Run the Agent pane title watcher", Canonical: []string{"internal agent-hook"}},
@@ -1114,28 +1189,32 @@ var routes = []Route{
 				Canonical: []string{"internal focus"},
 			},
 			{
-				Name:      "key-broker",
-				Summary:   "Forward captured physical key chords into the tmux root table",
-				Usage:     []string{"projmux internal key-broker [--once]"},
-				Canonical: []string{"internal key-broker"},
+				Name:             "key-broker",
+				Summary:          "Forward captured physical key chords into the tmux root table",
+				CanonicalSummary: "Darwin physical key transport",
+				Usage:            []string{"projmux internal key-broker [--once]"},
+				Canonical:        []string{"internal key-broker"},
 			},
 			{
-				Name:      "popup-wait-key",
-				Summary:   "Read a single key for a display-only tmux popup",
-				Usage:     []string{"projmux internal popup-wait-key"},
-				Canonical: []string{"internal popup-wait-key"},
+				Name:             "popup-wait-key",
+				Summary:          "Read a single key for a display-only tmux popup",
+				CanonicalSummary: "Display-only popup single-key reader",
+				Usage:            []string{"projmux internal popup-wait-key"},
+				Canonical:        []string{"internal popup-wait-key"},
 			},
 			{
-				Name:      "supervise",
-				Summary:   "Supervise one managed Pane process and record its exit evidence",
-				Usage:     []string{"projmux internal supervise --pane-uid <uid> --generation <gen> [--agent-uid <uid> --operation-id <id> --registry-path <absolute>] [--argv0 <name>] -- <command> ..."},
-				Canonical: []string{"internal supervise"},
+				Name:             "supervise",
+				Summary:          "Supervise one managed Pane process and record its exit evidence",
+				CanonicalSummary: "Managed Pane process supervisor and termination receipt writer",
+				Usage:            []string{"projmux internal supervise --pane-uid <uid> --generation <gen> [--agent-uid <uid> --operation-id <id> --registry-path <absolute>] [--argv0 <name>] -- <command> ..."},
+				Canonical:        []string{"internal supervise"},
 			},
 			{
-				Name:      "activation-exec",
-				Summary:   "Admit one exact committed Agent activation before provider exec",
-				Usage:     []string{"projmux internal activation-exec --pane-uid <uid> --agent-uid <uid> --generation <gen> --operation-id <id> --registry-path <absolute> [--failure-fd <fd>] [--argv0 <name>] -- <command> ..."},
-				Canonical: []string{"internal activation-exec"},
+				Name:             "activation-exec",
+				Summary:          "Admit one exact committed Agent activation before provider exec",
+				CanonicalSummary: "Exact committed Agent activation admission",
+				Usage:            []string{"projmux internal activation-exec --pane-uid <uid> --agent-uid <uid> --generation <gen> --operation-id <id> --registry-path <absolute> [--failure-fd <fd>] [--argv0 <name>] -- <command> ..."},
+				Canonical:        []string{"internal activation-exec"},
 			},
 		},
 	},

--- a/internal/cli/reference.go
+++ b/internal/cli/reference.go
@@ -8,19 +8,12 @@ import (
 
 // The generated CLI reference.
 //
-// The compatibility contract makes the command manifest the common source of
-// runtime help and the published reference. The manifest that runtime help
-// actually renders is `routes` -- the Cobra command tree in catalog.go -- so
-// this renderer walks that tree and nothing else.
+// The command graph is the common source of runtime help, canonical audit, and
+// the published reference. This renderer projects the graph's public help view:
+// hidden nodes stay hidden and Summary wins over an explicit CanonicalSummary
+// contract override.
 //
-// It deliberately does not read `canonicalRoutes`. That manifest audits
-// executable canonical spellings and their source namespaces, while `routes`
-// owns user-visible summaries, usage, disposition, and help structure. Keeping
-// the renderer on `routes` prevents internal spellings and audit-only metadata
-// from leaking into public help; tests enforce the boundary. See the header
-// comment in canonical.go.
-//
-// Every byte this renderer emits is a pure function of the manifest: no
+// Every byte this renderer emits is a pure function of the graph: no
 // timestamp, no version string, no host path, no map iteration. Regenerating on
 // a clean tree is a no-op.
 

--- a/internal/cli/reference_test.go
+++ b/internal/cli/reference_test.go
@@ -265,13 +265,13 @@ func TestGeneratedReferenceExcludesEveryHiddenRoute(t *testing.T) {
 	}
 }
 
-// canonicalManifestOnlySummaries returns the canonical-manifest summaries that
-// no command-tree node states verbatim.
+// canonicalOverrideOnlySummaries returns explicit canonical-summary overrides
+// that no help node states verbatim.
 //
 // These are the strings that make the boundary necessary: the command tree says
-// what a route does today, and the canonical manifest says what the contract
-// will eventually require, so the two diverge whenever a spelling is ahead of
-// its handler. `agent resume` used to be the clearest survivor and no longer is
+// what a route does today, and CanonicalSummary says what the contract requires,
+// so the two graph views diverge whenever a spelling is ahead of its handler.
+// `agent resume` used to be the clearest survivor and no longer is
 // -- its owning track landed the rebind, so both surfaces now say "Rebind an
 // Offline or Failed Agent to a new managed Pane" and it left this set by being
 // built. That is the intended way out of it.
@@ -281,7 +281,7 @@ func TestGeneratedReferenceExcludesEveryHiddenRoute(t *testing.T) {
 // target was retired rather than deferred, because the persistent
 // Project-metadata tag is a permanently abandoned plan and not a feature
 // waiting on a Phase.
-func canonicalManifestOnlySummaries() []string {
+func canonicalOverrideOnlySummaries() []string {
 	treeSummaries := map[string]bool{}
 	walkRoutes(Routes(), func(_ []string, route Route) {
 		treeSummaries[route.Summary] = true
@@ -295,22 +295,19 @@ func canonicalManifestOnlySummaries() []string {
 	return out
 }
 
-// TestGeneratedReferenceCarriesNoCanonicalManifestOnlySummary is the enforced
-// boundary between the two manifests.
+// TestGeneratedReferenceCarriesNoCanonicalOverrideOnlySummary enforces the
+// boundary between the public-help and canonical projections of one graph.
 //
-// The generator reads the command tree and never the canonical manifest, but
-// "the current code happens not to import it" is not a contract. This test
-// falsifies the claim directly against the artifact: it derives every summary
-// that exists only in canonical.go and asserts none of them reached the page.
-// Point the renderer at the canonical manifest -- even for one route -- and
-// this fails.
-func TestGeneratedReferenceCarriesNoCanonicalManifestOnlySummary(t *testing.T) {
+// The generator reads Summary rather than CanonicalSummary. This test falsifies
+// that claim against the artifact by deriving every override-only sentence and
+// asserting none of them reached the page.
+func TestGeneratedReferenceCarriesNoCanonicalOverrideOnlySummary(t *testing.T) {
 	t.Parallel()
 
-	divergent := canonicalManifestOnlySummaries()
+	divergent := canonicalOverrideOnlySummaries()
 	if len(divergent) == 0 {
-		t.Fatal("no canonical-manifest-only summary exists, so this assertion proves nothing; " +
-			"if the two manifests have genuinely converged, delete this test with the reason recorded")
+		t.Fatal("no canonical-summary-only override exists, so this assertion proves nothing; " +
+			"if the graph views have genuinely converged, delete this test with the reason recorded")
 	}
 
 	// The known divergences the roadmap owner still has to close, each naming a
@@ -331,7 +328,7 @@ func TestGeneratedReferenceCarriesNoCanonicalManifestOnlySummary(t *testing.T) {
 	}
 	for _, summary := range knownTargetStateSummaries {
 		if !slices.Contains(divergent, summary) {
-			t.Fatalf("the canonical manifest no longer diverges on %q; re-derive the boundary before relaxing it", summary)
+			t.Fatalf("the canonical graph projection no longer diverges on %q; re-derive the boundary before relaxing it", summary)
 		}
 	}
 
@@ -343,7 +340,7 @@ func TestGeneratedReferenceCarriesNoCanonicalManifestOnlySummary(t *testing.T) {
 	rendered := renderedStrings(t)
 	for _, summary := range divergent {
 		if rendered[summary] {
-			t.Errorf("the generated reference renders the canonical-manifest-only summary %q verbatim; "+
+			t.Errorf("the generated reference renders the canonical-override-only summary %q verbatim; "+
 				"the reference must be rendered from the command tree alone", summary)
 		}
 	}


### PR DESCRIPTION
## Summary

- make the executable CLI catalog the single owner of command spelling, summaries, source mappings, output modes, fields, and canonical ordering
- project canonical lookup/audit, output parsing, runtime help, and generated reference from that graph
- remove the second literal canonical route manifest while preserving the 0.13 public and canonical contracts

## Validation

- `make fmt` — passed
- `make fix` — passed
- `make test` — passed
- `make test-integration` — passed
- `go test ./internal/cli -count=1` — passed
- generated `docs/cli.md` diff from the rebased main — zero
- local `make test-e2e` — executed; blocked in the pre-existing L06 concurrent exact-socket create stress after Registry lock retry exhaustion. The Phase diff changes no metadata/resource-controller code; required CI `Test` is the isolated merge gate.

## Scope audit

- no public spelling, alias, summary, output token, field, exit status, schema, or hook environment change
- no handler or flag-parser rewrite; dispatch still invokes the existing handler exactly once
- rebased onto attention PR #785 and preserved its optional-pane Usage and generated docs hunks
- no Settings, transport, keybinding, snapshot, or other parallel-worker files changed

Roadmap: 0.13 이후 개념 단일 소유권 정리 / Phase 1 CLI single command graph
Contract: C-1 Guarantee/Enforcement
