### PR TITLE
test(e2e): add first-failure job log attribution

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -370,6 +370,17 @@
   Codex, and npm consumers. Local Security is the exact three-way
   `make security` topology; CI's required branch-protection context is the
   fail-closed aggregate named `Test`.
+- `test/e2e/evidence-contract.sh` (`make test-e2e-contract`) and
+  `test/e2e/reliability-contract.sh` (`make test-e2e-reliability`) keep the persisted
+  `projmux.e2e-attempt/v1` evidence and success result hash stable while adding
+  a separate stderr-only `projmux.e2e-terminal/v1` first-failure record. Its
+  closed fields identify scenario, phase, owner, shard, status, repository
+  source/line, sanitized single-scenario command, binary/state hashes, and exact
+  replay without raw argv. Synthetic L06/L08/L16 fixtures pin eight-racer lock
+  state, bounded Registry changed paths plus pending owned state, and child/file/
+  exact tmux state plus sanitized hashed tails; denylist checks reject token,
+  raw HOME/path, full Registry, and raw command leakage. Normal scenario meaning,
+  one-build/four-shard topology, and `.bin/e2e-evidence` retention are unchanged.
 - `make test` / `make test-integration`: attention omitted-target convergence
   is enforced by `TestAttentionMutationOmittedTargetMatchesExplicitPaneLedger`,
   `TestAttentionMutationOmittedTargetRefusesWithoutExactInvocationPane`, and

--- a/scripts/e2e-first-failure.py
+++ b/scripts/e2e-first-failure.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Emit bounded, privacy-safe E2E first-failure records to stderr."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+SCENARIO_RE = re.compile(r"^(?:L(?:0[1-9]|1[0-9])|C01|N01)$")
+NAME_RE = re.compile(r"^[a-z][a-z0-9-]{0,47}$")
+SHARD_RE = re.compile(r"^(?:fixture-[1-4]|codex-lifecycle|npm-staging|contract|all)$")
+SOURCE_RE = re.compile(r"^(?:test/e2e|test/lib)/[a-z0-9][a-z0-9._/-]*\.sh$")
+SHA_RE = re.compile(r"^(?:[0-9a-f]{64})?$")
+SECRET_RE = re.compile(
+    r"(?:-----BEGIN [A-Z ]*PRIVATE KEY-----|gh[pousr]_[A-Za-z0-9_]{20,}|"
+    r"github_pat_[A-Za-z0-9_]{20,}|AKIA[0-9A-Z]{16}|(?i:password|token|secret)=)"
+)
+SAFE_OPERATION_RE = re.compile(r"^[a-z][a-z0-9-]{0,47}$")
+SAFE_TMUX_ID_RE = re.compile(r"^(?:\$[0-9]+|@[0-9]+|%[0-9]+|[0-9]+|root|[a-z][a-z0-9_-]{0,31})?$")
+ANSI_RE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))")
+TAIL_WORDS = {
+    "attached", "bootstrap", "candidate", "client", "current", "dead", "discovery",
+    "error", "exact", "exit", "failed", "failure", "for", "frame", "missing", "open",
+    "pane", "present", "process", "session", "state", "status", "terminated", "timed",
+    "tmux", "waiting", "window",
+}
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def file_fact(path_text: str) -> dict[str, Any]:
+    if not path_text:
+        return {"exists": False, "size": 0, "sha256": ""}
+    path = Path(path_text)
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return {"exists": False, "size": 0, "sha256": ""}
+    return {"exists": True, "size": len(data), "sha256": digest(data)}
+
+
+def private_json(record: dict[str, Any]) -> str:
+    serialized = json.dumps(record, sort_keys=True, separators=(",", ":"))
+    if SECRET_RE.search(serialized):
+        raise ValueError("first-failure record contains a secret-shaped value")
+    return serialized
+
+
+def emit(prefix: str, record: dict[str, Any]) -> None:
+    print(f"{prefix} {private_json(record)}", file=sys.stderr)
+
+
+def command_for(scenario: str) -> str:
+    return f"make test-e2e E2E_SCENARIO={scenario}"
+
+
+def terminal_command(args: argparse.Namespace) -> int:
+    if not SCENARIO_RE.fullmatch(args.scenario):
+        raise ValueError("invalid scenario")
+    if not NAME_RE.fullmatch(args.phase) or not NAME_RE.fullmatch(args.owner):
+        raise ValueError("invalid phase or owner")
+    if not SHARD_RE.fullmatch(args.shard):
+        raise ValueError("invalid shard")
+    if not SOURCE_RE.fullmatch(args.source) or ".." in args.source:
+        raise ValueError("source is not an allowlisted repository E2E shell path")
+    if not 1 <= args.status <= 255 or args.line < 1:
+        raise ValueError("invalid terminal status or source line")
+    expected_command = command_for(args.scenario)
+    if args.command != expected_command:
+        raise ValueError("command is not the sanitized single-scenario allowlist shape")
+    if not SHA_RE.fullmatch(args.binary_sha256) or not SHA_RE.fullmatch(args.state_sha256):
+        raise ValueError("invalid binary or state digest")
+    emit("E2E_TERMINAL", {
+        "binary_sha256": args.binary_sha256,
+        "command": args.command,
+        "line": args.line,
+        "owner": args.owner,
+        "phase": args.phase,
+        "replay": expected_command,
+        "scenario": args.scenario,
+        "schema": "projmux.e2e-terminal/v1",
+        "shard": args.shard,
+        "source": args.source,
+        "state_sha256": args.state_sha256,
+        "status": args.status,
+    })
+    return 0
+
+
+def parse_racer(value: str) -> dict[str, Any]:
+    fields = value.split(":", 3)
+    if len(fields) != 4:
+        raise ValueError("racer must be index:pid:status:outcome")
+    index, pid, status = (int(fields[position]) for position in range(3))
+    outcome = fields[3]
+    if index not in range(1, 9) or pid < 0 or status not in range(0, 256):
+        raise ValueError("invalid racer scalar")
+    if outcome not in {"not-started", "completed", "converged", "deferred", "exhausted", "other"}:
+        raise ValueError("invalid racer outcome")
+    return {"index": index, "outcome": outcome, "pid": pid, "status": status}
+
+
+def l06_command(args: argparse.Namespace) -> int:
+    if not SAFE_OPERATION_RE.fullmatch(args.operation):
+        raise ValueError("invalid L06 operation")
+    if args.holder_pid < 0 or args.holder_started_ms < 0:
+        raise ValueError("invalid L06 holder state")
+    racers = sorted((parse_racer(value) for value in args.racer), key=lambda item: item["index"])
+    if [item["index"] for item in racers] != list(range(1, 9)):
+        raise ValueError("L06 diagnostics require exactly racers 1 through 8")
+    if args.acquire not in {"not-started", "acquired", "contended", "unknown"}:
+        raise ValueError("invalid L06 acquire state")
+    if args.release not in {"not-started", "held", "released", "unknown"}:
+        raise ValueError("invalid L06 release state")
+    now_ms = int(time.time() * 1000)
+    holder_started_ms = args.holder_started_ms
+    # GNU date implementations differ on whether a width on %N is honored.
+    # Normalize the nanosecond-shaped value used by the portable smoke helper.
+    if holder_started_ms > now_ms * 100:
+        holder_started_ms //= 1_000_000
+    age_ms = max(0, now_ms - holder_started_ms) if holder_started_ms else 0
+    emit("E2E_DIAGNOSTIC", {
+        "attribution": "l06-lock-exhaustion",
+        "holder": {
+            "acquire": args.acquire,
+            "age_ms": age_ms,
+            "operation": args.operation,
+            "pid": args.holder_pid,
+            "release": args.release,
+        },
+        "racers": racers,
+        "scenario": "L06",
+        "schema": "projmux.e2e-diagnostic/v1",
+    })
+    return 0
+
+
+def json_value(path_text: str) -> Any:
+    if not path_text:
+        return None
+    path = Path(path_text)
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError):
+        return {"_invalid_json_sha256": file_fact(path_text)["sha256"]}
+
+
+def safe_segment(segment: str) -> str:
+    if re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]{0,47}", segment) and not SECRET_RE.search(segment):
+        return segment
+    return f"key-sha256-{digest(segment.encode())[:12]}"
+
+
+def changed_paths(before: Any, after: Any, prefix: str = "$") -> list[str]:
+    if type(before) is not type(after):
+        return [prefix]
+    if isinstance(before, dict):
+        result: list[str] = []
+        for key in sorted(set(before) | set(after), key=str):
+            child = f"{prefix}.{safe_segment(str(key))}"
+            if key not in before or key not in after:
+                result.append(child)
+            else:
+                result.extend(changed_paths(before[key], after[key], child))
+        return result
+    if isinstance(before, list):
+        result = []
+        for index in range(max(len(before), len(after))):
+            child = f"{prefix}[{index}]"
+            if index >= len(before) or index >= len(after):
+                result.append(child)
+            else:
+                result.extend(changed_paths(before[index], after[index], child))
+        return result
+    return [] if before == after else [prefix]
+
+
+def l08_command(args: argparse.Namespace) -> int:
+    for count in (args.controller_entries, args.hook_processes, args.owned_processes, args.socket_entries):
+        if count < 0:
+            raise ValueError("invalid L08 pending count")
+    before_fact = file_fact(args.before)
+    after_fact = file_fact(args.after)
+    paths = sorted(set(changed_paths(json_value(args.before), json_value(args.after))))
+    total = len(paths)
+    paths = paths[:32]
+    emit("E2E_DIAGNOSTIC", {
+        "attribution": "l08-state-drift",
+        "changed_json_paths": paths,
+        "changed_json_paths_omitted": max(0, total - len(paths)),
+        "pending": {
+            "controller_entries": args.controller_entries,
+            "hook_processes": args.hook_processes,
+            "owned_processes": args.owned_processes,
+            "socket_entries": args.socket_entries,
+        },
+        "registry_after_sha256": after_fact["sha256"],
+        "registry_before_sha256": before_fact["sha256"],
+        "scenario": "L08",
+        "schema": "projmux.e2e-diagnostic/v1",
+    })
+    return 0
+
+
+def parse_state_rows(path_text: str, fields: tuple[str, ...]) -> list[dict[str, Any]]:
+    if not path_text:
+        return []
+    try:
+        lines = Path(path_text).read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in lines[:16]:
+        values = line.split("|")
+        if len(values) != len(fields) or not all(SAFE_TMUX_ID_RE.fullmatch(value) for value in values):
+            continue
+        rows.append(dict(zip(fields, values)))
+    return rows
+
+
+def process_fact(pid: int) -> dict[str, Any]:
+    result: dict[str, Any] = {"alive": False, "pid": max(pid, 0), "state": ""}
+    if pid <= 0:
+        return result
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text(encoding="ascii")
+        result["alive"] = True
+        result["state"] = stat.rsplit(") ", 1)[1].split()[0]
+    except (OSError, IndexError):
+        pass
+    return result
+
+
+def sanitized_tail(path_text: str) -> dict[str, Any]:
+    if not path_text:
+        return {"line_count": 0, "lines": [], "source_sha256": "", "truncated": False}
+    try:
+        data = Path(path_text).read_bytes()
+    except OSError:
+        return {"line_count": 0, "lines": [], "source_sha256": "", "truncated": False}
+    bounded = data[-4096:]
+    text = ANSI_RE.sub("", bounded.decode("utf-8", errors="replace"))
+    raw_lines = text.splitlines()[-20:]
+    lines: list[dict[str, str]] = []
+    for raw in raw_lines:
+        words = re.findall(r"[A-Za-z]+", raw.lower())
+        summary = " ".join(word for word in words if word in TAIL_WORDS)[:160]
+        lines.append({"sha256": digest(raw.encode("utf-8", errors="replace")), "summary": summary or "redacted-line"})
+    return {
+        "line_count": len(raw_lines),
+        "lines": lines,
+        "source_sha256": digest(data),
+        "truncated": len(data) > len(bounded) or len(text.splitlines()) > 20,
+    }
+
+
+def l16_command(args: argparse.Namespace) -> int:
+    emit("E2E_DIAGNOSTIC", {
+        "attribution": "l16-semantic-timeout",
+        "child": process_fact(args.child_pid),
+        "files": {
+            "err": file_fact(args.err),
+            "out": file_fact(args.out),
+            "rc": file_fact(args.rc),
+        },
+        "scenario": "L16",
+        "schema": "projmux.e2e-diagnostic/v1",
+        "sanitized_tail": sanitized_tail(args.tail),
+        "tmux": {
+            "clients": parse_state_rows(
+                args.clients,
+                ("client_pid", "session_id", "window_id", "pane_id", "key_table"),
+            ),
+            "panes": parse_state_rows(
+                args.panes,
+                ("pane_pid", "session_id", "window_id", "pane_id", "active", "dead", "dead_status"),
+            ),
+        },
+    })
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser()
+    commands = result.add_subparsers(dest="command_name", required=True)
+
+    terminal = commands.add_parser("terminal")
+    terminal.add_argument("--scenario", required=True)
+    terminal.add_argument("--phase", required=True)
+    terminal.add_argument("--owner", required=True)
+    terminal.add_argument("--shard", required=True)
+    terminal.add_argument("--status", required=True, type=int)
+    terminal.add_argument("--source", required=True)
+    terminal.add_argument("--line", required=True, type=int)
+    terminal.add_argument("--command", required=True)
+    terminal.add_argument("--binary-sha256", default="")
+    terminal.add_argument("--state-sha256", default="")
+    terminal.set_defaults(function=terminal_command)
+
+    l06 = commands.add_parser("l06")
+    l06.add_argument("--holder-pid", required=True, type=int)
+    l06.add_argument("--holder-started-ms", required=True, type=int)
+    l06.add_argument("--operation", required=True)
+    l06.add_argument("--acquire", required=True)
+    l06.add_argument("--release", required=True)
+    l06.add_argument("--racer", action="append", default=[])
+    l06.set_defaults(function=l06_command)
+
+    l08 = commands.add_parser("l08")
+    l08.add_argument("--before", default="")
+    l08.add_argument("--after", default="")
+    l08.add_argument("--controller-entries", required=True, type=int)
+    l08.add_argument("--hook-processes", required=True, type=int)
+    l08.add_argument("--owned-processes", required=True, type=int)
+    l08.add_argument("--socket-entries", required=True, type=int)
+    l08.set_defaults(function=l08_command)
+
+    l16 = commands.add_parser("l16")
+    l16.add_argument("--child-pid", required=True, type=int)
+    l16.add_argument("--rc", default="")
+    l16.add_argument("--out", default="")
+    l16.add_argument("--err", default="")
+    l16.add_argument("--clients", default="")
+    l16.add_argument("--panes", default="")
+    l16.add_argument("--tail", default="")
+    l16.set_defaults(function=l16_command)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        return args.function(args)
+    except (OSError, ValueError) as error:
+        print(f"e2e-first-failure: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/e2e/evidence-contract.sh
+++ b/test/e2e/evidence-contract.sh
@@ -15,6 +15,17 @@ if [[ "${PROJMUX_E2E_INTENTIONAL_FAILURE:-}" == "1" ]]; then
   exit 99
 fi
 
+if [[ "${PROJMUX_E2E_INTENTIONAL_EXIT:-}" == "1" ]]; then
+  source "$root/test/lib/smoke.sh"
+  smoke_setup_env
+  PROJMUX_E2E_SUITE="intentional-failure"
+  export PROJMUX_E2E_SUITE
+  smoke_contract_install_trap
+  trap smoke_cleanup_env EXIT
+  smoke_contract_begin L06 create-materialize resource-controller
+  exit 23
+fi
+
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
@@ -22,6 +33,34 @@ record=(python3 "$root/scripts/e2e-evidence.py" record --directory "$tmp/golden"
 "${record[@]}" --class unattributed --outcome begin --elapsed-ms 0 >"$tmp/begin.out"
 "${record[@]}" --class environment --outcome fail --elapsed-ms 17 >"$tmp/fail.out"
 python3 "$root/scripts/e2e-evidence.py" validate --terminal "$tmp/golden/summary.jsonl"
+
+terminal_command=(python3 "$root/scripts/e2e-first-failure.py" terminal \
+  --scenario L01 --phase bootstrap --owner harness --shard fixture-1 \
+  --status 17 --source test/e2e/linux-smoke.sh --line 123 \
+  --command "make test-e2e E2E_SCENARIO=L01" \
+  --binary-sha256 "$(printf 'a%.0s' {1..64})" \
+  --state-sha256 "$(printf 'b%.0s' {1..64})")
+"${terminal_command[@]}" >"$tmp/terminal-record.out" 2>"$tmp/terminal-record.err"
+[[ ! -s "$tmp/terminal-record.out" ]]
+terminal_golden='E2E_TERMINAL {"binary_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","command":"make test-e2e E2E_SCENARIO=L01","line":123,"owner":"harness","phase":"bootstrap","replay":"make test-e2e E2E_SCENARIO=L01","scenario":"L01","schema":"projmux.e2e-terminal/v1","shard":"fixture-1","source":"test/e2e/linux-smoke.sh","state_sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","status":17}'
+if [[ "$(cat "$tmp/terminal-record.err")" != "$terminal_golden" ]]; then
+  echo "stderr terminal JSON golden mismatch" >&2
+  diff -u <(printf '%s\n' "$terminal_golden") "$tmp/terminal-record.err" >&2 || true
+  exit 1
+fi
+if python3 "$root/scripts/e2e-first-failure.py" terminal \
+  --scenario L01 --phase bootstrap --owner harness --shard fixture-1 \
+  --status 17 --source test/e2e/linux-smoke.sh --line 123 \
+  --command "github_pat_FAKE_SECRET_SHAPED_ARG_1234567890" \
+  >"$tmp/terminal-private.out" 2>"$tmp/terminal-private.err"; then
+  echo "terminal schema accepted a raw non-allowlisted command" >&2
+  exit 1
+fi
+if grep -Fq "github_pat_FAKE_SECRET_SHAPED_ARG_1234567890" \
+  "$tmp/terminal-record.err" "$tmp/terminal-private.err" "$tmp/terminal-private.out"; then
+  echo "terminal schema or its rejection leaked a raw command" >&2
+  exit 1
+fi
 
 golden='{"artifact":"L01-attempt-1.json","attempt":1,"binary_sha256":"","class":"unattributed","elapsed_ms":0,"outcome":"begin","owner":"harness","phase":"bootstrap","replay":"make test-e2e E2E_SCENARIO=L01","route_socket":"","scenario_id":"L01","schema":"projmux.e2e-attempt/v1","state_sha256":"","suite":"linux-bootstrap"}'
 if [[ "$(head -n 1 "$tmp/golden/summary.jsonl")" != "$golden" ]]; then
@@ -90,4 +129,28 @@ fi
 python3 "$root/scripts/e2e-evidence.py" validate --terminal "$tmp/intentional/summary.jsonl"
 grep -Fq 'id=L17 attempt=1 phase=exit-reconcile outcome=fail class=deterministic-regression owner=exit-reconciler' "$tmp/intentional.err"
 
-echo ">> evidence parser/golden/privacy/pass-only aggregation/intentional-failure tests passed"
+set +e
+PROJMUX_E2E_INTENTIONAL_EXIT=1 \
+  PROJMUX_E2E_ARTIFACTS="$tmp/intentional-exit" \
+  "$root/test/e2e/evidence-contract.sh" >"$tmp/intentional-exit.out" 2>"$tmp/intentional-exit.err"
+intentional_exit_status=$?
+set -e
+if [[ "$intentional_exit_status" != "23" ]]; then
+  echo "intentional explicit exit returned $intentional_exit_status, want 23" >&2
+  exit 1
+fi
+python3 - "$tmp/intentional-exit.err" <<'PY'
+import json
+import pathlib
+import sys
+
+lines = pathlib.Path(sys.argv[1]).read_text().splitlines()
+records = [json.loads(line.split(" ", 1)[1]) for line in lines if line.startswith("E2E_TERMINAL ")]
+assert len(records) == 1
+record = records[0]
+assert record["scenario"] == "L06" and record["status"] == 23
+assert record["source"] == "test/e2e/evidence-contract.sh" and record["line"] > 1
+assert record["command"] == record["replay"] == "make test-e2e E2E_SCENARIO=L06"
+PY
+
+echo ">> evidence parser/terminal/golden/privacy/pass-only aggregation/intentional-failure tests passed"

--- a/test/e2e/linux-smoke.sh
+++ b/test/e2e/linux-smoke.sh
@@ -3123,6 +3123,12 @@ done
 if [[ ! -e "$binding_registry.lock" ]]; then
   SMOKE_L06_RELEASE_STATE=released
 fi
+# These variables are consumed indirectly by the failure trap sourced from
+# test/lib/smoke.sh. Keep an explicit no-op read so standalone ShellCheck sees
+# the cross-file diagnostic-state contract.
+: "$SMOKE_L06_HOLDER_PID" "$SMOKE_L06_HOLDER_STARTED_MS" "$SMOKE_L06_OPERATION" \
+  "$SMOKE_L06_ACQUIRE_STATE" "$SMOKE_L06_RELEASE_STATE" \
+  "${SMOKE_L06_RACER_PIDS[*]}" "${SMOKE_L06_RACER_STATUSES[*]}" "${SMOKE_L06_RACER_OUTCOMES[*]}"
 if [[ "$binding_burst_failed" != "0" ]]; then
   echo "a hook burst producer exited non-zero" >&2
   cat "$binding_root"/burst-*.err >&2 || true
@@ -4142,6 +4148,11 @@ if ! awk -v route="-L $delete_product_socket " '
   echo "delete used an unclassified command on default app socket -L $delete_product_socket" >&2
   exit 1
 fi
+
+# See the L06 diagnostic-state receipt above. The sourced failure trap owns
+# these values; this no-op read documents that indirect use for ShellCheck.
+: "$SMOKE_CONTRACT_TERMINAL_STATE_PATH" "$SMOKE_L08_REGISTRY_BEFORE" \
+  "$SMOKE_L08_REGISTRY_AFTER" "$SMOKE_L08_CONTROLLER_ROOT" "$SMOKE_L08_SOCKET_ROOT"
 
 delete_cleanup
 trap smoke_cleanup_env EXIT
@@ -7627,6 +7638,12 @@ if [[ "$disc_other_after" != "$disc_other_before" ]]; then
   echo "discovery authority e2e touched the sibling socket" >&2
   exit 1
 fi
+
+# See the L06 diagnostic-state receipt above. The sourced failure trap owns
+# these values; this no-op read documents that indirect use for ShellCheck.
+: "$SMOKE_CONTRACT_TERMINAL_STATE_PATH" "$SMOKE_L16_TMUX_FUNCTION" \
+  "$SMOKE_L16_TAIL_PATH" "$SMOKE_L16_RC_PATH" "$SMOKE_L16_CHILD_PID_PATH" \
+  "$SMOKE_L16_OUT_PATH" "$SMOKE_L16_ERR_PATH"
 
 exec 9>&-
 kill "$disc_client_pid" >/dev/null 2>&1 || true

--- a/test/e2e/linux-smoke.sh
+++ b/test/e2e/linux-smoke.sh
@@ -1027,6 +1027,7 @@ pmx() {
 }
 
 create_registry="$create_root/state/projmux/metadata/registry.json"
+SMOKE_CONTRACT_TERMINAL_STATE_PATH="$create_registry"
 if [[ -e "$create_registry" ]]; then
   echo "create e2e did not start from an empty registry" >&2
   exit 1
@@ -1552,19 +1553,48 @@ phase0_stress_window_uid_before="$(ctx show-options -wqv -t "$legacy_window_id" 
 phase0_stress_pane_uid_before="$(ctx show-options -pqv -t "$legacy_pane" @projmux_pane_uid)"
 phase0_stress_project_uid_before="$(ctx show-options -qv -t legacy-alpha @projmux_project_uid)"
 phase0_stress_pids=()
+SMOKE_L06_HOLDER_PID=0
+SMOKE_L06_HOLDER_STARTED_MS="$(( $(date +%s) * 1000 ))"
+SMOKE_L06_OPERATION=concurrent-create-pane
+SMOKE_L06_ACQUIRE_STATE=contended
+SMOKE_L06_RELEASE_STATE=held
+SMOKE_L06_RACER_PIDS=(0 0 0 0 0 0 0 0)
+SMOKE_L06_RACER_STATUSES=(0 0 0 0 0 0 0 0)
+SMOKE_L06_RACER_OUTCOMES=(not-started not-started not-started not-started not-started not-started not-started not-started)
 for phase0_racer in {1..8}; do
   pmx create pane --project alpha --window phase0-stress --create-window -o pane-id \
     >"$create_root/phase0-stress-$phase0_racer.out" \
     2>"$create_root/phase0-stress-$phase0_racer.err" &
   phase0_stress_pids+=("$!")
+  SMOKE_L06_RACER_PIDS[phase0_racer - 1]="$!"
 done
 phase0_stress_failed=0
 for phase0_racer in {1..8}; do
-  if ! wait "${phase0_stress_pids[$((phase0_racer - 1))]}"; then
+  phase0_stress_pid="${phase0_stress_pids[phase0_racer - 1]}"
+  if wait "$phase0_stress_pid"; then
+    SMOKE_L06_RACER_STATUSES[phase0_racer - 1]=0
+    SMOKE_L06_RACER_OUTCOMES[phase0_racer - 1]=completed
+  else
+    SMOKE_L06_RACER_STATUSES[phase0_racer - 1]="$?"
     phase0_stress_failed=1
+    if grep -q "acquire lock: exhausted" "$create_root/phase0-stress-$phase0_racer.err"; then
+      SMOKE_L06_RACER_OUTCOMES[phase0_racer - 1]=exhausted
+    else
+      SMOKE_L06_RACER_OUTCOMES[phase0_racer - 1]=other
+    fi
+    if [[ -f "$create_registry.lock" ]]; then
+      phase0_lock_pid="$(sed -n 's/^pid=\([0-9][0-9]*\)$/\1/p' "$create_registry.lock" | head -n 1)"
+      if [[ -n "$phase0_lock_pid" ]]; then
+        SMOKE_L06_HOLDER_PID="$phase0_lock_pid"
+      fi
+      SMOKE_L06_HOLDER_STARTED_MS="$(( $(stat -c %Y "$create_registry.lock") * 1000 ))"
+    fi
     cat "$create_root/phase0-stress-$phase0_racer.err" >&2 || true
   fi
 done
+if [[ ! -e "$create_registry.lock" ]]; then
+  SMOKE_L06_RELEASE_STATE=released
+fi
 if [[ "$phase0_stress_failed" != 0 ]]; then
   echo "concurrent exact-socket create stress had a failed racer" >&2
   exit 1
@@ -3045,18 +3075,54 @@ fi
 # of concurrent workers contending for the one registry lock produces.
 cp "$binding_registry" "$binding_root/registry.before-burst"
 binding_burst_pids=()
+SMOKE_L06_HOLDER_STARTED_MS="$(( $(date +%s) * 1000 ))"
+SMOKE_L06_ACQUIRE_STATE=contended
+SMOKE_L06_RELEASE_STATE=held
+SMOKE_L06_RACER_PIDS=(0 0 0 0 0 0 0 0)
+SMOKE_L06_RACER_STATUSES=(0 0 0 0 0 0 0 0)
+SMOKE_L06_RACER_OUTCOMES=(not-started not-started not-started not-started not-started not-started not-started not-started)
 for binding_burst_index in 1 2 3 4 5 6 7 8; do
   binding_pmx internal tmux converge --socket-path "$binding_socket_path" \
     --session "$binding_session" --reason pane-killed \
     >"$binding_root/burst-$binding_burst_index.out" 2>"$binding_root/burst-$binding_burst_index.err" &
   binding_burst_pids+=("$!")
+  SMOKE_L06_RACER_PIDS[binding_burst_index - 1]="$!"
 done
 binding_burst_failed=0
-for binding_burst_pid in "${binding_burst_pids[@]}"; do
-  if ! wait "$binding_burst_pid"; then
+for binding_burst_index in 1 2 3 4 5 6 7 8; do
+  binding_burst_pid="${binding_burst_pids[binding_burst_index - 1]}"
+  if wait "$binding_burst_pid"; then
+    SMOKE_L06_RACER_STATUSES[binding_burst_index - 1]=0
+  else
+    SMOKE_L06_RACER_STATUSES[binding_burst_index - 1]="$?"
     binding_burst_failed=1
+    if [[ -f "$binding_registry.lock" ]]; then
+      binding_lock_pid="$(sed -n 's/^pid=\([0-9][0-9]*\)$/\1/p' "$binding_registry.lock" | head -n 1)"
+      if [[ -n "$binding_lock_pid" ]]; then
+        SMOKE_L06_HOLDER_PID="$binding_lock_pid"
+      fi
+      SMOKE_L06_HOLDER_STARTED_MS="$(( $(stat -c %Y "$binding_registry.lock") * 1000 ))"
+      SMOKE_L06_ACQUIRE_STATE=contended
+      SMOKE_L06_RELEASE_STATE=held
+    fi
+  fi
+  if grep -q "exhausted" "$binding_root/burst-$binding_burst_index.err"; then
+    SMOKE_L06_RACER_OUTCOMES[binding_burst_index - 1]=exhausted
+  elif grep -q "another controller worker holds" "$binding_root/burst-$binding_burst_index.err"; then
+    SMOKE_L06_RACER_OUTCOMES[binding_burst_index - 1]=deferred
+  elif grep -q "converged=true" "$binding_root/burst-$binding_burst_index.err"; then
+    SMOKE_L06_RACER_OUTCOMES[binding_burst_index - 1]=converged
+    if [[ "$SMOKE_L06_HOLDER_PID" == "0" ]]; then
+      SMOKE_L06_HOLDER_PID="$binding_burst_pid"
+      SMOKE_L06_ACQUIRE_STATE=acquired
+    fi
+  else
+    SMOKE_L06_RACER_OUTCOMES[binding_burst_index - 1]=other
   fi
 done
+if [[ ! -e "$binding_registry.lock" ]]; then
+  SMOKE_L06_RELEASE_STATE=released
+fi
 if [[ "$binding_burst_failed" != "0" ]]; then
   echo "a hook burst producer exited non-zero" >&2
   cat "$binding_root"/burst-*.err >&2 || true
@@ -3153,6 +3219,10 @@ mkdir -p \
   "$delete_root/work/beta" \
   "$delete_root/work/gamma"
 chmod 0700 "$delete_root/runtime" "$delete_root/tmux"
+SMOKE_L08_REGISTRY_BEFORE="$delete_root/registry.phase-start"
+SMOKE_L08_REGISTRY_AFTER="$delete_root/state/projmux/metadata/registry.json"
+SMOKE_L08_CONTROLLER_ROOT="$delete_root/state/projmux/controller"
+SMOKE_L08_SOCKET_ROOT="$delete_root/tmux"
 
 delete_real_tmux="$(command -v tmux)"
 delete_shim="$delete_root/shim"
@@ -3366,7 +3436,9 @@ if [[ "$delete_singular_status" != "0" ]]; then
 fi
 
 delete_registry="$delete_root/state/projmux/metadata/registry.json"
+SMOKE_CONTRACT_TERMINAL_STATE_PATH="$delete_registry"
 cp "$delete_registry" "$delete_root/registry.before-dry-run"
+SMOKE_L08_REGISTRY_BEFORE="$delete_root/registry.before-dry-run"
 delete_tmux list-windows -a -F '#{session_name}:#{window_id}:#{@projmux_window_uid}' \
   >"$delete_root/windows.before-dry-run"
 delete_pmx_delete window "uid:$delete_primary_uid" --dry-run >"$delete_root/external-dry-run.out"
@@ -3630,6 +3702,7 @@ delete_tmux list-panes -a -F '#{session_id}:#{window_id}:#{pane_id}:#{@projmux_p
 } | grep -Fvx -e "$delete_offline_pane_uid" -e "$delete_offline_agent_uid" -e "$delete_offline_agent_pane_uid" | sort >"$delete_root/offline-sibling-graph.before"
 sha256sum "$delete_root/offline-sibling-graph.before" >"$delete_root/offline-sibling-graph.before.sha256"
 cp "$delete_registry" "$delete_root/registry.before-offline-pane-dry-run"
+SMOKE_L08_REGISTRY_BEFORE="$delete_root/registry.before-offline-pane-dry-run"
 delete_pmx_delete pane "uid:$delete_offline_pane_uid" --dry-run >"$delete_root/offline-pane-dry-run.out"
 cmp "$delete_root/registry.before-offline-pane-dry-run" "$delete_registry"
 smoke_assert_file_contains "$delete_root/offline-pane-dry-run.out" "registry-only would delete this Pane; no tmux Pane would be killed"
@@ -3712,6 +3785,7 @@ delete_tmux kill-window -t "$delete_offline_window"
 sleep 0.5
 
 cp "$delete_registry" "$delete_root/registry.before-offline-dry-run"
+SMOKE_L08_REGISTRY_BEFORE="$delete_root/registry.before-offline-dry-run"
 delete_tmux list-windows -a -F '#{session_name}:#{window_id}:#{@projmux_window_uid}' >"$delete_root/windows.before-offline-dry-run"
 delete_pmx_delete window "uid:$delete_offline_window_uid" --project "uid:$delete_alpha_project_uid" --dry-run >"$delete_root/offline-dry-run.out"
 cmp "$delete_root/registry.before-offline-dry-run" "$delete_registry"
@@ -3759,6 +3833,7 @@ for delete_forbidden_route in "-L $delete_socket" "-L $delete_product_socket" "-
 done
 
 cp "$delete_registry" "$delete_root/registry.before-offline-repeat"
+SMOKE_L08_REGISTRY_BEFORE="$delete_root/registry.before-offline-repeat"
 if delete_pmx_delete window "uid:$delete_offline_window_uid" --project "uid:$delete_alpha_project_uid" --yes \
   >"$delete_root/offline-repeat.out" 2>"$delete_root/offline-repeat.err"; then
   echo "repeat offline Window delete unexpectedly succeeded" >&2
@@ -3962,6 +4037,7 @@ delete_tmux kill-server
 delete_settled=0
 delete_stable_samples=0
 cp "$delete_registry" "$delete_root/registry.settle-probe"
+SMOKE_L08_REGISTRY_BEFORE="$delete_root/registry.settle-probe"
 for _ in {1..200}; do
   sleep 0.05
   if cmp -s "$delete_root/registry.settle-probe" "$delete_registry"; then
@@ -3974,12 +4050,14 @@ for _ in {1..200}; do
   fi
   delete_stable_samples=0
   cp "$delete_registry" "$delete_root/registry.settle-probe"
+  SMOKE_L08_REGISTRY_BEFORE="$delete_root/registry.settle-probe"
 done
 if [[ "$delete_settled" != "1" ]]; then
   echo "hook-driven convergence never settled after kill-server" >&2
   exit 1
 fi
 cp "$delete_registry" "$delete_root/registry.before-no-server-dry-run"
+SMOKE_L08_REGISTRY_BEFORE="$delete_root/registry.before-no-server-dry-run"
 if delete_pmx_delete pane "uid:$delete_sibling_shell_uid" --dry-run \
   >"$delete_root/no-server-pane.out" 2>"$delete_root/no-server-pane.err"; then
   echo "absent-server Pane delete incorrectly treated absence as authority" >&2
@@ -7286,8 +7364,10 @@ mkdir -p "$disc_root/home" "$disc_root/config" "$disc_root/state" "$disc_root/ru
   "$disc_root/work/app" "$disc_root/work/scratch" "$disc_root/work/sibling"
 chmod 0700 "$disc_root/runtime" "$disc_root/tmux"
 disc_registry="$disc_root/state/projmux/metadata/registry.json"
+SMOKE_CONTRACT_TERMINAL_STATE_PATH="$disc_registry"
 disc_pins="$disc_root/config/projmux/pins"
 disc_real_tmux="$(command -v tmux)"
+SMOKE_L16_TMUX_FUNCTION=disc_tmux
 
 disc_shell="$disc_root/shim/persistent-shell"
 cat >"$disc_shell" <<'DISC_SHELL_STUB'
@@ -7333,6 +7413,7 @@ chmod 0755 "$disc_root/bin/tmux"
 
 cat >"$disc_root/open-candidate.sh" <<DISC_OPEN_SCRIPT
 #!/usr/bin/env bash
+printf '%s\n' "\$\$" >"$disc_root/open-\$2.pid"
 export HOME="$disc_root/home"
 export XDG_CONFIG_HOME="$disc_root/config"
 export XDG_STATE_HOME="$disc_root/state"
@@ -7402,6 +7483,11 @@ TERM=xterm-256color script -qefc \
   "TERM=xterm-256color env -u TMUX -u TMUX_PANE TMUX_TMPDIR='$disc_root/tmux' tmux -L '$disc_socket' attach-session -t '$disc_driver'" \
   "$disc_client_log" <"$disc_client_input" >/dev/null 2>&1 &
 disc_client_pid=$!
+SMOKE_L16_TAIL_PATH="$disc_client_log"
+SMOKE_L16_CHILD_PID_PATH="$disc_root/open-bootstrap.pid"
+SMOKE_L16_RC_PATH="$disc_root/open-bootstrap.rc"
+SMOKE_L16_OUT_PATH="$disc_root/open-bootstrap.out"
+SMOKE_L16_ERR_PATH="$disc_root/open-bootstrap.err"
 
 disc_wait_for() {
   local description="$1"
@@ -7413,7 +7499,6 @@ disc_wait_for() {
     sleep 0.05
   done
   echo "timed out waiting for $description" >&2
-  tail -c 8000 "$disc_client_log" >&2 || true
   return 1
 }
 
@@ -7426,14 +7511,12 @@ disc_tmux send-keys -t "$disc_driver_pane" "bash '$disc_root/open-candidate.sh' 
 disc_wait_for "candidate bootstrap open" test -s "$disc_root/open-bootstrap.rc"
 if [[ "$(tr -d '[:space:]' <"$disc_root/open-bootstrap.rc")" != "0" ]]; then
   echo "opening an unregistered candidate failed" >&2
-  cat "$disc_root/open-bootstrap.err" >&2 || true
   exit 1
 fi
 
 disc_project_uids="$(disc_pmx get projects -o uid)"
 if [[ "$(printf '%s\n' "$disc_project_uids" | wc -l)" != "1" ]]; then
   echo "one candidate open registered more than one Project: $disc_project_uids" >&2
-  disc_pmx get projects -o json >&2
   exit 1
 fi
 disc_project_uid="$disc_project_uids"
@@ -7455,11 +7538,14 @@ done
 
 # 3. Reopening the now-registered Project is write-free.
 cp "$disc_registry" "$disc_root/registry.after-bootstrap"
+SMOKE_L16_RC_PATH="$disc_root/open-repeat.rc"
+SMOKE_L16_CHILD_PID_PATH="$disc_root/open-repeat.pid"
+SMOKE_L16_OUT_PATH="$disc_root/open-repeat.out"
+SMOKE_L16_ERR_PATH="$disc_root/open-repeat.err"
 disc_tmux send-keys -t "$disc_driver_pane" "bash '$disc_root/open-candidate.sh' '$disc_root/work/app' repeat" Enter
 disc_wait_for "candidate reopen" test -s "$disc_root/open-repeat.rc"
 if [[ "$(tr -d '[:space:]' <"$disc_root/open-repeat.rc")" != "0" ]]; then
   echo "reopening the registered Project failed" >&2
-  cat "$disc_root/open-repeat.err" >&2 || true
   exit 1
 fi
 cmp "$disc_root/registry.after-bootstrap" "$disc_registry"
@@ -7473,6 +7559,10 @@ disc_runtime_before="$(
   disc_tmux list-windows -a -F '#{session_id}|#{window_id}|#{@projmux_window_uid}'
   disc_tmux list-panes -a -F '#{session_id}|#{window_id}|#{pane_id}|#{@projmux_pane_uid}'
 )"
+SMOKE_L16_RC_PATH="$disc_root/open-home.rc"
+SMOKE_L16_CHILD_PID_PATH="$disc_root/open-home.pid"
+SMOKE_L16_OUT_PATH="$disc_root/open-home.out"
+SMOKE_L16_ERR_PATH="$disc_root/open-home.err"
 disc_tmux send-keys -t "$disc_driver_pane" "bash '$disc_root/open-candidate.sh' '$disc_root/home' home" Enter
 disc_wait_for "Home open" test -s "$disc_root/open-home.rc"
 if [[ "$(tr -d '[:space:]' <"$disc_root/open-home.rc")" == "0" ]]; then
@@ -7481,14 +7571,12 @@ if [[ "$(tr -d '[:space:]' <"$disc_root/open-home.rc")" == "0" ]]; then
 fi
 if ! grep -Fq "exact Registry Project UID is unavailable; no runtime was created" "$disc_root/open-home.err"; then
   echo "opening undeclared Home lacked the exact fail-closed diagnostic" >&2
-  cat "$disc_root/open-home.err" >&2 || true
   exit 1
 fi
 cmp "$disc_root/registry.before-home" "$disc_registry"
 disc_pmx get projects -o uid >"$disc_root/projects-after-home.uid"
 if [[ "$(wc -l <"$disc_root/projects-after-home.uid")" != "1" ]]; then
-  echo "opening Home registered a Project:" >&2
-  cat "$disc_root/projects-after-home.uid" >&2
+  echo "opening Home registered an unexpected Project count" >&2
   exit 1
 fi
 if grep -Fq "$disc_root/home" "$disc_root/projects-after-home.uid"; then
@@ -7513,8 +7601,7 @@ smoke_assert_file_contains "$disc_root/pin-managed.out" "pinned: project $disc_p
 disc_pmx pin project add "$disc_root/work/scratch" >"$disc_root/pin-candidate.out"
 smoke_assert_file_contains "$disc_root/pin-candidate.out" "pinned: candidate $disc_root/work/scratch"
 if [[ "$(cat "$disc_pins")" != "$(printf 'projmux-pins v2\nproject %s\ncandidate %s' "$disc_project_uid" "$disc_root/work/scratch")" ]]; then
-  echo "the pin file is not the typed envelope:" >&2
-  cat "$disc_pins" >&2
+  echo "the pin file is not the typed envelope" >&2
   exit 1
 fi
 disc_pmx pin project list >"$disc_root/pin-list.out" 2>"$disc_root/pin-list.err"

--- a/test/e2e/reliability-contract.sh
+++ b/test/e2e/reliability-contract.sh
@@ -101,6 +101,11 @@ for racer in 1 2 3 4 5 6 7 8; do
     SMOKE_L06_RACER_OUTCOMES[racer - 1]=exhausted
   fi
 done
+# The sourced formatter consumes this state indirectly. This explicit no-op
+# read keeps that cross-file contract visible to standalone ShellCheck.
+: "$SMOKE_L06_HOLDER_PID" "$SMOKE_L06_HOLDER_STARTED_MS" "$SMOKE_L06_OPERATION" \
+  "$SMOKE_L06_ACQUIRE_STATE" "$SMOKE_L06_RELEASE_STATE" \
+  "${SMOKE_L06_RACER_PIDS[*]}" "${SMOKE_L06_RACER_STATUSES[*]}" "${SMOKE_L06_RACER_OUTCOMES[*]}"
 smoke_l06_failure_diagnostic >"$diagnostic_root/l06.out" 2>"$diagnostic_root/l06.err"
 [[ ! -s "$diagnostic_root/l06.out" ]]
 

--- a/test/e2e/reliability-contract.sh
+++ b/test/e2e/reliability-contract.sh
@@ -81,4 +81,120 @@ f07=(python3 "$root/scripts/e2e-evidence.py" record --directory "$artifacts/f07"
 "${f07[@]}" --class harness-lifecycle --outcome fail --elapsed-ms 1 >/dev/null
 python3 "$root/scripts/e2e-evidence.py" validate --terminal "$artifacts/f07/summary.jsonl"
 
-echo ">> F01/F02/F04/F06/F07 reliability contracts passed"
+# Phase-0 first-failure diagnostics are synthetic and scenario-owned. They
+# exercise only the log formatter; no product timeout, retry, lock, or Registry
+# semantics are changed to manufacture the failures.
+diagnostic_root="$artifacts/first-failure"
+mkdir -p "$diagnostic_root/controller" "$diagnostic_root/tmux"
+
+SMOKE_L06_HOLDER_PID=4242
+SMOKE_L06_HOLDER_STARTED_MS="$(( $(date +%s) * 1000 - 1250 ))"
+SMOKE_L06_OPERATION=concurrent-create-pane
+SMOKE_L06_ACQUIRE_STATE=acquired
+SMOKE_L06_RELEASE_STATE=held
+for racer in 1 2 3 4 5 6 7 8; do
+  SMOKE_L06_RACER_PIDS[racer - 1]="$((5000 + racer))"
+  SMOKE_L06_RACER_STATUSES[racer - 1]=0
+  SMOKE_L06_RACER_OUTCOMES[racer - 1]=completed
+  if [[ "$racer" == "8" ]]; then
+    SMOKE_L06_RACER_STATUSES[racer - 1]=1
+    SMOKE_L06_RACER_OUTCOMES[racer - 1]=exhausted
+  fi
+done
+smoke_l06_failure_diagnostic >"$diagnostic_root/l06.out" 2>"$diagnostic_root/l06.err"
+[[ ! -s "$diagnostic_root/l06.out" ]]
+
+printf '%s\n' '{"projects":[{"name":"before","root":"/raw/home/private"}],"version":2}' >"$diagnostic_root/registry.before"
+printf '%s\n' '{"projects":[{"name":"after","root":"/raw/home/private"}],"version":2}' >"$diagnostic_root/registry.after"
+touch "$diagnostic_root/controller/pending"
+python3 "$root/scripts/e2e-first-failure.py" l08 \
+  --before "$diagnostic_root/registry.before" --after "$diagnostic_root/registry.after" \
+  --controller-entries 1 --hook-processes 2 --owned-processes 3 --socket-entries 4 \
+  >"$diagnostic_root/l08.out" 2>"$diagnostic_root/l08.err"
+[[ ! -s "$diagnostic_root/l08.out" ]]
+
+printf '0\n' >"$diagnostic_root/child.rc"
+printf 'bounded output\n' >"$diagnostic_root/child.out"
+printf 'bounded error\n' >"$diagnostic_root/child.err"
+# shellcheck disable=SC2016 # Literal tmux IDs exercise the closed state parser.
+printf '%s\n' '6001|$1|@2|%3|root' >"$diagnostic_root/clients"
+# shellcheck disable=SC2016 # Literal tmux IDs exercise the closed state parser.
+printf '%s\n' '6002|$1|@2|%3|1|0|0' >"$diagnostic_root/panes"
+printf '\033[31mtimed out waiting for tmux client\033[0m\nargv: projmux --token github_pat_FAKE_SECRET_SHAPED_ARG_1234567890 --root /raw/home/private\n' \
+  >"$diagnostic_root/client.log"
+python3 "$root/scripts/e2e-first-failure.py" l16 \
+  --child-pid 0 --rc "$diagnostic_root/child.rc" --out "$diagnostic_root/child.out" \
+  --err "$diagnostic_root/child.err" --clients "$diagnostic_root/clients" \
+  --panes "$diagnostic_root/panes" --tail "$diagnostic_root/client.log" \
+  >"$diagnostic_root/l16.out" 2>"$diagnostic_root/l16.err"
+[[ ! -s "$diagnostic_root/l16.out" ]]
+
+for terminal_spec in \
+  "L06:create-materialize:resource-controller:fixture-2:1569" \
+  "L08:canonical-delete:delete-controller:fixture-1:4048" \
+  "L16:discovery-pin:discovery-adapter:fixture-3:7496"; do
+  IFS=: read -r terminal_scenario terminal_phase terminal_owner terminal_shard terminal_line <<<"$terminal_spec"
+  python3 "$root/scripts/e2e-first-failure.py" terminal \
+    --scenario "$terminal_scenario" --phase "$terminal_phase" --owner "$terminal_owner" \
+    --shard "$terminal_shard" --status 1 --source test/e2e/linux-smoke.sh \
+    --line "$terminal_line" --command "make test-e2e E2E_SCENARIO=$terminal_scenario" \
+    --binary-sha256 "$(printf 'a%.0s' {1..64})" --state-sha256 "$(printf 'b%.0s' {1..64})" \
+    2>"$diagnostic_root/$terminal_scenario.terminal"
+done
+
+python3 - "$diagnostic_root" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+
+def record(name):
+    prefix, payload = (root / f"{name}.err").read_text().strip().split(" ", 1)
+    assert prefix == "E2E_DIAGNOSTIC"
+    return json.loads(payload)
+
+l06 = record("l06")
+assert l06["scenario"] == "L06" and l06["attribution"] == "l06-lock-exhaustion"
+assert l06["holder"]["pid"] == 4242 and l06["holder"]["age_ms"] >= 1250
+assert l06["holder"]["operation"] == "concurrent-create-pane"
+assert l06["holder"]["acquire"] == "acquired" and l06["holder"]["release"] == "held"
+assert len(l06["racers"]) == 8 and l06["racers"][0]["outcome"] == "completed"
+assert l06["racers"][-1]["outcome"] == "exhausted"
+
+l08 = record("l08")
+assert l08["scenario"] == "L08" and l08["attribution"] == "l08-state-drift"
+assert l08["registry_before_sha256"] != l08["registry_after_sha256"]
+assert l08["changed_json_paths"] == ["$.projects[0].name"]
+assert l08["pending"] == {"controller_entries": 1, "hook_processes": 2, "owned_processes": 3, "socket_entries": 4}
+
+l16 = record("l16")
+assert l16["scenario"] == "L16" and l16["attribution"] == "l16-semantic-timeout"
+assert l16["child"] == {"alive": False, "pid": 0, "state": ""}
+assert all(l16["files"][name]["exists"] for name in ("rc", "out", "err"))
+assert l16["tmux"]["clients"][0]["pane_id"] == "%3"
+assert l16["tmux"]["panes"][0]["dead"] == "0"
+assert l16["sanitized_tail"]["line_count"] == 2
+
+joined = "\n".join((root / f"{name}.err").read_text() for name in ("l06", "l08", "l16"))
+for forbidden in ("github_pat_", "/raw/home/private", "--token", "--root", "argv: projmux"):
+    assert forbidden not in joined
+assert "registry_before_sha256" in joined and '"projects"' not in joined
+
+# A failed-job-log-only view is sufficient to join the common terminal row to
+# exactly one scenario diagnostic, without asserting product-vs-harness blame.
+for scenario, name, attribution in (
+    ("L06", "l06", "l06-lock-exhaustion"),
+    ("L08", "l08", "l08-state-drift"),
+    ("L16", "l16", "l16-semantic-timeout"),
+):
+    _, terminal_payload = (root / f"{scenario}.terminal").read_text().strip().split(" ", 1)
+    terminal = json.loads(terminal_payload)
+    diagnostic = record(name)
+    assert terminal["scenario"] == diagnostic["scenario"] == scenario
+    assert diagnostic["attribution"] == attribution
+    assert terminal["command"] == terminal["replay"]
+    assert "class" not in terminal and "class" not in diagnostic
+PY
+
+echo ">> F01/F02/F04/F06/F07 and L06/L08/L16 first-failure contracts passed"

--- a/test/lib/smoke.sh
+++ b/test/lib/smoke.sh
@@ -5,8 +5,32 @@ smoke_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SMOKE_CONTRACT_ID=""
 SMOKE_CONTRACT_PHASE=""
 SMOKE_CONTRACT_OWNER=""
+SMOKE_CONTRACT_SOURCE=""
+SMOKE_CONTRACT_TERMINAL_STATE_PATH=""
 SMOKE_CONTRACT_STARTED_MS=0
 SMOKE_CONTRACT_TERMINAL=0
+
+SMOKE_L06_HOLDER_PID=0
+SMOKE_L06_HOLDER_STARTED_MS=0
+SMOKE_L06_OPERATION="controller-trigger-burst"
+SMOKE_L06_ACQUIRE_STATE="not-started"
+SMOKE_L06_RELEASE_STATE="not-started"
+declare -a SMOKE_L06_RACER_PIDS=(0 0 0 0 0 0 0 0)
+declare -a SMOKE_L06_RACER_STATUSES=(0 0 0 0 0 0 0 0)
+declare -a SMOKE_L06_RACER_OUTCOMES=(not-started not-started not-started not-started not-started not-started not-started not-started)
+
+SMOKE_L08_REGISTRY_BEFORE=""
+SMOKE_L08_REGISTRY_AFTER=""
+SMOKE_L08_CONTROLLER_ROOT=""
+SMOKE_L08_SOCKET_ROOT=""
+
+SMOKE_L16_CHILD_PID=0
+SMOKE_L16_CHILD_PID_PATH=""
+SMOKE_L16_RC_PATH=""
+SMOKE_L16_OUT_PATH=""
+SMOKE_L16_ERR_PATH=""
+SMOKE_L16_TAIL_PATH=""
+SMOKE_L16_TMUX_FUNCTION=""
 
 smoke_now_ms() {
   date +%s%3N
@@ -43,6 +67,140 @@ smoke_contract_record() {
     --state-sha256 "$state_hash"
 }
 
+smoke_contract_shard() {
+  if [[ -n "${PROJMUX_E2E_LINUX_SHARD:-}" ]]; then
+    printf '%s\n' "$PROJMUX_E2E_LINUX_SHARD"
+    return
+  fi
+  case "${PROJMUX_E2E_SUITE:-}" in
+    codex*) printf '%s\n' codex-lifecycle ;;
+    npm*) printf '%s\n' npm-staging ;;
+    linux) printf '%s\n' all ;;
+    *) printf '%s\n' contract ;;
+  esac
+}
+
+smoke_contract_terminal() {
+  local status="$1"
+  local line="$2"
+  local state_hash
+  if [[ -n "$SMOKE_CONTRACT_TERMINAL_STATE_PATH" && -f "$SMOKE_CONTRACT_TERMINAL_STATE_PATH" ]]; then
+    state_hash="$(sha256sum "$SMOKE_CONTRACT_TERMINAL_STATE_PATH" | awk '{print $1}')"
+  else
+    state_hash="$(smoke_contract_state_hash)"
+  fi
+  python3 "$smoke_root/scripts/e2e-first-failure.py" terminal \
+    --scenario "$SMOKE_CONTRACT_ID" \
+    --phase "$SMOKE_CONTRACT_PHASE" \
+    --owner "$SMOKE_CONTRACT_OWNER" \
+    --shard "$(smoke_contract_shard)" \
+    --status "$status" \
+    --source "$SMOKE_CONTRACT_SOURCE" \
+    --line "$line" \
+    --command "make test-e2e E2E_SCENARIO=$SMOKE_CONTRACT_ID" \
+    --binary-sha256 "${PROJMUX_SMOKE_BIN_SHA256:-${PROJMUX_SMOKE_EXPECTED_BIN_SHA256:-}}" \
+    --state-sha256 "$state_hash"
+}
+
+smoke_l06_failure_diagnostic() {
+  local index
+  local -a command=(
+    python3 "$smoke_root/scripts/e2e-first-failure.py" l06
+    --holder-pid "$SMOKE_L06_HOLDER_PID"
+    --holder-started-ms "$SMOKE_L06_HOLDER_STARTED_MS"
+    --operation "$SMOKE_L06_OPERATION"
+    --acquire "$SMOKE_L06_ACQUIRE_STATE"
+    --release "$SMOKE_L06_RELEASE_STATE"
+  )
+  for index in {0..7}; do
+    command+=(--racer "$((index + 1)):${SMOKE_L06_RACER_PIDS[$index]}:${SMOKE_L06_RACER_STATUSES[$index]}:${SMOKE_L06_RACER_OUTCOMES[$index]}")
+  done
+  "${command[@]}"
+}
+
+smoke_count_entries() {
+  local root="$1"
+  if [[ ! -d "$root" ]]; then
+    printf '0\n'
+    return
+  fi
+  find "$root" -mindepth 1 -maxdepth 3 -print 2>/dev/null | awk 'NR <= 128 { count++ } END { print count + 0 }'
+}
+
+smoke_l08_failure_diagnostic() {
+  local inventory controller_entries hook_processes owned_processes socket_entries
+  inventory="$(smoke_owned_process_inventory)"
+  owned_processes="$(printf '%s\n' "$inventory" | awk 'NF && NR <= 128 { count++ } END { print count + 0 }')"
+  hook_processes="$(printf '%s\n' "$inventory" | grep -c $'executable=projmux\t' || true)"
+  controller_entries="$(smoke_count_entries "$SMOKE_L08_CONTROLLER_ROOT")"
+  if [[ -d "$SMOKE_L08_SOCKET_ROOT" ]]; then
+    socket_entries="$(find "$SMOKE_L08_SOCKET_ROOT" -mindepth 1 -maxdepth 3 -type s -print 2>/dev/null | awk 'NR <= 128 { count++ } END { print count + 0 }')"
+  else
+    socket_entries=0
+  fi
+  python3 "$smoke_root/scripts/e2e-first-failure.py" l08 \
+    --before "$SMOKE_L08_REGISTRY_BEFORE" \
+    --after "$SMOKE_L08_REGISTRY_AFTER" \
+    --controller-entries "$controller_entries" \
+    --hook-processes "$hook_processes" \
+    --owned-processes "$owned_processes" \
+    --socket-entries "$socket_entries"
+}
+
+smoke_l16_failure_diagnostic() {
+  local child_pid clients panes
+  child_pid="$SMOKE_L16_CHILD_PID"
+  if [[ -f "$SMOKE_L16_CHILD_PID_PATH" ]]; then
+    read -r child_pid <"$SMOKE_L16_CHILD_PID_PATH" || child_pid=0
+    [[ "$child_pid" =~ ^[0-9]+$ ]] || child_pid=0
+  fi
+  clients="$PROJMUX_SMOKE_WORKDIR/l16-clients.failure"
+  panes="$PROJMUX_SMOKE_WORKDIR/l16-panes.failure"
+  : >"$clients"
+  : >"$panes"
+  if [[ -n "$SMOKE_L16_TMUX_FUNCTION" ]] && declare -F "$SMOKE_L16_TMUX_FUNCTION" >/dev/null; then
+    "$SMOKE_L16_TMUX_FUNCTION" list-clients \
+      -F '#{client_pid}|#{session_id}|#{window_id}|#{pane_id}|#{client_key_table}' \
+      >"$clients" 2>/dev/null || true
+    "$SMOKE_L16_TMUX_FUNCTION" list-panes -a \
+      -F '#{pane_pid}|#{session_id}|#{window_id}|#{pane_id}|#{pane_active}|#{pane_dead}|#{pane_dead_status}' \
+      >"$panes" 2>/dev/null || true
+  fi
+  python3 "$smoke_root/scripts/e2e-first-failure.py" l16 \
+    --child-pid "$child_pid" \
+    --rc "$SMOKE_L16_RC_PATH" \
+    --out "$SMOKE_L16_OUT_PATH" \
+    --err "$SMOKE_L16_ERR_PATH" \
+    --clients "$clients" \
+    --panes "$panes" \
+    --tail "$SMOKE_L16_TAIL_PATH"
+}
+
+smoke_contract_failure_diagnostic() {
+  case "$SMOKE_CONTRACT_ID" in
+    L06) smoke_l06_failure_diagnostic ;;
+    L08) smoke_l08_failure_diagnostic ;;
+    L16) smoke_l16_failure_diagnostic ;;
+  esac
+}
+
+# Bash does not run ERR for the explicit `exit 1` branches used by assertion
+# blocks. Keep exit semantics intact while giving those branches the same exact
+# call-site source line as command failures. This function is not exported, so
+# fixture children and product commands retain the shell builtin unchanged.
+exit() {
+  local status="${1:-0}"
+  local line="${BASH_LINENO[0]:-0}"
+  if [[ "$status" != "0" && -n "$SMOKE_CONTRACT_ID" && "$SMOKE_CONTRACT_TERMINAL" != "1" ]]; then
+    set +e
+    smoke_contract_record fail "${PROJMUX_E2E_FAILURE_CLASS:-deterministic-regression}" >&2
+    smoke_contract_terminal "$status" "$line" || true
+    smoke_contract_failure_diagnostic || true
+    SMOKE_CONTRACT_TERMINAL=1
+  fi
+  builtin exit "$status"
+}
+
 smoke_contract_begin() {
   local scenario_id="$1"
   local phase="$2"
@@ -54,6 +212,8 @@ smoke_contract_begin() {
   SMOKE_CONTRACT_ID="$scenario_id"
   SMOKE_CONTRACT_PHASE="$phase"
   SMOKE_CONTRACT_OWNER="$owner"
+  SMOKE_CONTRACT_SOURCE="${BASH_SOURCE[1]#"$smoke_root/"}"
+  SMOKE_CONTRACT_TERMINAL_STATE_PATH=""
   SMOKE_CONTRACT_STARTED_MS="$(smoke_now_ms)"
   SMOKE_CONTRACT_TERMINAL=0
   smoke_contract_record begin environment
@@ -79,6 +239,8 @@ smoke_contract_err() {
   # false deterministic regression.
   if [[ "$had_errexit" == "1" && -n "$SMOKE_CONTRACT_ID" && "$SMOKE_CONTRACT_TERMINAL" != "1" ]]; then
     smoke_contract_record fail "${PROJMUX_E2E_FAILURE_CLASS:-deterministic-regression}" >&2
+    smoke_contract_terminal "$status" "$line" || true
+    smoke_contract_failure_diagnostic || true
     SMOKE_CONTRACT_TERMINAL=1
   elif [[ "$had_errexit" == "1" ]]; then
     echo "E2E_CONTRACT unattributed=1 status=$status line=$line" >&2


### PR DESCRIPTION
## Summary
- emit a bounded machine-readable terminal record to failed job stderr
- add scenario-owned L06, L08, and L16 diagnostics with privacy allowlists
- preserve existing evidence, success hashes, one-build, and four-shard behavior

## Validation
- make fmt
- make fix
- make test
- make test-integration
- make test-e2e-contract
- make test-e2e-reliability
- exact targeted L06/L08/L16 E2E replays
- make test-e2e (21 scenarios, four shards; unchanged-head retry green after attributed L06 recurrence)

## Scope
No workflow artifact upload, semantic retry/timeout change, shard topology change, public CLI/config/hook schema change, or Phase 1 candidate implementation.