### PR TITLE
test(deadcode): enforce exact baseline hygiene

### DIFF
--- a/.deadcode-allowlist.txt
+++ b/.deadcode-allowlist.txt
@@ -1,121 +1,99 @@
 # .deadcode-allowlist.txt
 #
-# Allowlist for `make deadcode` (golang.org/x/tools/cmd/deadcode).
+# Exact current output baseline for `go tool deadcode ./...`.
 #
-# Each non-comment, non-blank line is the EXACT fully-qualified symbol name as
-# emitted by deadcode after "unreachable func: " (e.g. "aiCommand.notifyAIText"
-# or "tmuxTruthy"). A finding is suppressed only when its symbol matches a line
-# here exactly; matching is on the symbol, not the file:line, so the baseline
-# survives line-number drift. New dead code that is NOT listed here makes
-# `make deadcode` exit non-zero.
+# Each non-comment, non-blank line is one exact symbol emitted after
+# "unreachable func: ". This file contains current findings only. The gate
+# rejects duplicates, stale rows, and findings outside the two-file union.
+# Deliberately retained APIs belong in .deadcode-must-keep.txt instead.
 #
-# Lines starting with '#' are comments; blank lines are ignored.
-#
-# This baseline was captured from `go tool deadcode ./...` at the time the
-# detector was introduced. The goal of this phase is to STAND UP detection so
-# only NEW dead code shows up red -- NOT to remove the existing findings.
-# Entries are grouped by intent below.
+# Symbols are sorted bytewise. `Run` is emitted by two packages; this
+# package-agnostic baseline records the symbol once and reports both raw and
+# unique finding counts.
 
-# ---------------------------------------------------------------------------
-# MUST-KEEP: deliberately retained legacy / migration / planned-consumer
-# symbols. These read old persisted state, clean stale bindings, or are
-# planned future consumers. deadcode may flag them as unreachable in some
-# builds, but they MUST NOT be removed. Listed explicitly even when not
-# currently flagged, so a future refactor that makes them unreachable does
-# not turn the baseline red and tempt their removal.
-# ---------------------------------------------------------------------------
-MigrateProjectLegacyScripts
-MigrateGlobalLegacyScripts
-legacyDesktopAppID
-CleanupLegacyArtifacts
-legacyWindowAttentionRows
-formatLegacyPaneSummary
-tmuxRetiredKeyUnbindLines
-# Operational diagnostics Phase 2 typed no-write seam. Doctor Phase 2 is the
-# planned consumer after this producer contract lands.
-ReadRuntimeHealth
-# MUST-KEEP: Runtime topology exit cascade Phase 0 pure authority, root,
-# reopen, and pin planning seam. Phases 1-3 are the planned consumers; wiring
-# these symbols into production now is intentionally excluded so this Phase
-# can close the decision contract without changing Registry/runtime behavior.
-TeardownEventKinds
-TeardownObservations
-rootDefaults
-validTeardownEventKind
-validTeardownObservation
-validOwnerChain
-observationRefusal
-DecideTeardownEvent
-AggregateTeardownEvents
-genericTeardownRefusal
-PlanProjectCascadeDelete
-projectAgentCount
-projectPreservedAssets
-DecideProjectOpen
-EqualTeardownPlans
-PlanProjectDeletion
-# Phase 10 plan-only mutation keeps reobservation/replanning pure and directly
-# exercised by its maintained property and failure tests. Runtime execution
-# reaches the same plan's printable validation; these two helpers deliberately
-# remain a zero-I/O proof surface rather than acquiring a fake production
-# caller that would confuse observation with execution success.
-runtimeMutationPlan.withoutEffects
-runtimeMutationEffectKey
-# `projmux://focus?...` encoder. Desktop notification delivery became a
-# two-state model in 0.11.0 (off / notify): Toasts carry no click URI and no
-# protocol handler is registered, so nothing in production emits this URI any
-# more. `projmux focus --uri` and parseFocusURI stay as a compatibility input
-# for handlers wired before 0.11.0, and this encoder is the canonical
-# round-trip counterpart that keeps the retained parser honest. Do not remove
-# it while the parser is supported.
-buildFocusURI
-# Interactive `run-shell` output ledger. The classification of every generated
-# producer and the registry of source sites that may emit one are declarations,
-# not behavior: they exist so `run_shell_output_ledger_test.go` can prove the
-# set is closed against the generated config and against the package source. A
-# production caller would be a fake -- the enforcement that keeps a producer
-# silent at runtime is the guard in interactive_run_shell.go, which App.Run
-# reaches on every invocation. Removing either function removes the proof that
-# a new producer cannot ship unclassified.
-runShellOutputLedger
-runShellSourceSites
-# "last-pane" action handler: audit shows it as dead but it is a PLANNED
-# consumer and must stay (it is a keybinding catalog string ID, not a func,
-# so deadcode does not flag it by name -- recorded here for intent).
-
-# ---------------------------------------------------------------------------
-# Baseline findings captured at detector introduction. Intentional / false
-# positive / not-yet-wired surfaces; retained as the clean baseline so only
-# NEW dead code is reported. Grouped loosely by package.
-# ---------------------------------------------------------------------------
-
-# internal/i18n -- string-audit and catalog helpers (audit tooling surface)
 All
 AuditGoStringLiterals
 AuditGoStringLiteralsInDir
 AuditGoStrings
-RuntimeKoreanStringAuditOptions
-PickerChromeStringAuditOptions
-StringAuditFinding.IsCandidate
-auditGoStringLiteralsInFile
-classifyStringLiteral
-containsASCIILetter
-containsHangul
-isDataStringLiteral
-isDebugStringContext
-isDebugStringLiteral
-isEnglishUserFacingCandidate
-isPickerChromeFieldContext
-isPreservedLiteralString
-shouldKeepStringAuditFinding
-sortStringAuditFindings
+BuildSwitchPickerItems
+CapturePane
 Catalog.Keys
 Catalog.LocaleKeys
 Catalog.MissingFallbackKeys
 Catalog.MissingLocaleKeys
+ChromeLine
+ClassifySchemaVersion
+ClosePopup
+DecideProjectOpen
+DisplayMessage
+DisplayMessageTrimmed
+DisplayPaneFields
+DisplayPopup
+Dispositions
+EqualTeardownPlans
+FooterBlockLines
+FormatList
 FoundationKeys
+HeaderLine
+InteractiveListLines
+InteractiveRowLines
+InverseSelectedContent
+InverseSelectedContentWithTheme
+IsProjectConfigTrusted
+IsSharedOutputMode
+Kinds
+ListLinesWithScrollbar
+ListPanes
+ListWindows
+LoadSessionStateToggleFile
 Localizer.Locale
 Localizer.Styled
+Matrix
+MigrateRegistry
+NewState
+NewWithConfig
+NewWithRoot
+NextPane
+NextWindow
+PickerChromeStringAuditOptions
+PlanProjectCascadeDelete
+PlanProjectDeletion
+PreviousPane
+PreviousWindow
+PromptLine
+PromptLineWithCursor
+PromptLineWithCursorLabel
+PromptLineWithRenderedQuery
+PromptLineWithRenderedQueryLabel
+QueryWithCursor
+Read
+ReadTrimmed
+RedactToken
+Registry.rebuildMissingReservations
+RenderBar
+RenderFullFrameUpdate
+RenderInlinePreview
+RenderSplitPreview
+RenderSwitchPreview
+RenderableListLine
+RenderableListLines
+RenderableListLinesWithTheme
+Renderer.ContentLayout
+Renderer.RenderFrame
+RouteLocalFieldProjections
+Run
+Runner.ListWindows
+RuntimeKoreanStringAuditOptions
+SchemaAction.String
+SelectPane
+SelectWindow
+SelectedContent
+SelectedContentWithTheme
+SelectedLine
+SetPaneOption
+SharedOutputModes
+ShowPaneOption
+StringAuditFinding.IsCandidate
 StyledFragment.IsANSI
 StyledFragment.IsStyledKind
 StyledFragment.IsTmuxStyle
@@ -123,44 +101,41 @@ StyledFragment.Key
 StyledFragment.Kind
 StyledFragment.Locale
 StyledFragment.String
+SwitchClient
+TeardownEventKinds
 Text.Key
 Text.Locale
-FormatList
-firstRune
-runeLen
-
-# internal/ui/picker, pickercompat, projmuxpicker, render -- native picker
-# rendering surface and internal option/result mapping.
-BuildSwitchPickerItems
-ChromeLine
-FooterBlockLines
-HeaderLine
-InteractiveListLines
-InteractiveRowLines
-InverseSelectedContent
-InverseSelectedContentWithTheme
-ListLinesWithScrollbar
-PromptLine
-PromptLineWithCursor
-PromptLineWithCursorLabel
-PromptLineWithRenderedQuery
-PromptLineWithRenderedQueryLabel
-QueryWithCursor
-RenderBar
-RenderFullFrameUpdate
-RenderInlinePreview
-RenderSplitPreview
-RenderSwitchPreview
-RenderWindowsCommandLine
-RenderableListLine
-RenderableListLines
-RenderableListLinesWithTheme
-Renderer.ContentLayout
-Renderer.RenderFrame
-SelectedContent
-SelectedContentWithTheme
-SelectedLine
+UIDKind
+UnsetPaneOption
+WindowTarget
+WithCodexCatalogThreadReader
+WithFileReader
 WriteContentWithFooter
+aiSummaryForKind
+auditGoStringLiteralsInFile
+buildFocusURI
+buildPopupToggle
+callName
+classifyStringLiteral
+codexHooksBlock
+containsASCIILetter
+containsHangul
+defaultAIHookInstallEvents
+effectivePaneCount
+firstRune
+formatPopupSummary
+formatRelativeAge
+formatSelectedSummary
+formatStatusNotify
+formatStatusNotifyWithLive
+formatTargetSummary
+isDataStringLiteral
+isDebugStringContext
+isDebugStringLiteral
+isEnglishUserFacingCandidate
+isPickerChromeFieldContext
+isPreservedLiteralString
+joinFinal
 nativeAppendPartialNextItemLines
 nativeFooterBlockLines
 nativeHeaderLine
@@ -188,90 +163,7 @@ nativeSearchSeparatorLine
 nativeSelectedContent
 nativeTruncateANSI
 nativeVisibleLen
-renderNativeFrame
-renderNativeInteractive
-renderNativeInteractiveWithCursor
-padsInsideFinalStyle
-joinFinal
-selectionMarker
-writeNativeContentWithFooter
-formatPopupSummary
-formatSelectedSummary
-formatTargetSummary
-sanitizeSwitchPreviewPath
-
-# internal/integrations/mux, psmux, tmux -- mux abstraction methods kept for
-# the pluggable backend surface (not all wired by the live tmux path).
-Command.WindowsCommandLine
-Run
-CapturePane
-ClosePopup
-DisplayMessage
-DisplayMessageTrimmed
-DisplayPaneFields
-DisplayPopup
-ListPanes
-ListWindows
-NewSession
-NewWindow
-NextPane
-NextWindow
-PreviousPane
-PreviousWindow
-Read
-ReadTrimmed
-Runner.ListWindows
-Runner.NewWindow
-SelectPane
-SelectWindow
-SetHook
-SetOption
-SetPaneOption
-ShowPaneOption
-SplitWindow
-SwitchClient
-UnsetPaneOption
-NewWithConfig
-NewWithRoot
-NewWithSocketName
-WithFileReader
-# Test and compatibility seams for content-free AI conversation discovery and
-# exact Session State thread validation. Production uses the context-aware
-# catalog path and the default probe-only reader; in-package tests retain the
-# background-context wrapper and injected reader without manufacturing live
-# callers for either.
-Discover
-WithCodexCatalogThreadReader
-WithSocketName
 newClientWithEnv
-RenderWindowsCommandLine
-windowsCommandLineArg
-effectivePaneCount
-
-# internal/config -- config readers / trust helpers retained for callers.
-IsProjectConfigTrusted
-LoadSessionStateToggleFile
-
-# internal/core/usage -- adapter / store / registry surface.
-NewState
-Registry.Lookup
-Registry.Replace
-RedactToken
-Store.SaveAll
-UsageSupported
-
-# internal/integrations/hooks -- hook install / trust helpers.
-
-# internal/app -- AI / notify / status / settings / tmux / switch surfaces
-# that are not currently reachable from the wired command paths.
-aiSummaryForKind
-callName
-codexHooksBlock
-defaultAIHookInstallEvents
-formatRelativeAge
-formatStatusNotify
-formatStatusNotifyWithLive
-buildPopupToggle
 notifyCommand.buildNotifyLiveReport
 notifyCommand.listNotifyLivePanes
 notifySidebarAgentBadge
@@ -280,14 +172,30 @@ notifySidebarEntriesWithLive
 notifySidebarEntriesWithLiveLocale
 notifySidebarReadModel.CollapsedEntries
 notifySidebarStateBadge
+padsInsideFinalStyle
 pickerOptionsFromCompatPicker
+projectAgentCount
+renderNativeFrame
+renderNativeInteractive
+renderNativeInteractiveWithCursor
 renderNotifyBadge
+renderSettingsNavTree
 renderThemeSource.tmuxAppConfig
 renderThemeSource.tmuxAppConfigWithAIBadgeStyle
 renderThemeSource.tmuxStandaloneConfig
 renderThemeSource.tmuxStandaloneConfigWithAIBadgeStyle
+runShellOutputLedger
+runShellSourceSites
+runeLen
+runtimeMutationEffectKey
+runtimeMutationPlan.withoutEffects
+sanitizeSwitchPreviewPath
+scopeFor
+selectionMarker
 settingsCommand.rootEntries
 settingsCommand.rootEntriesForAxis
+shouldKeepStringAuditFinding
+sortStringAuditFindings
 sortedProbeLabels
 statusbarDecorationSetFromGlobal
 tmuxAppConfig
@@ -300,175 +208,5 @@ tmuxStandaloneConfigWithKeymap
 tmuxStandaloneConfigWithKeymapTheme
 tmuxStandaloneConfigWithKeymapThemeAndAIBadgeStyle
 tmuxStyledVisiblePaneLabelFormat
-
-# ---------------------------------------------------------------------------
-# MUST-KEEP: CLI information architecture v2 Phase 0 command manifest API.
-# internal/cli owns the canonical route catalog, the shared output projection
-# catalog, and the closed disposition set. Runtime help reads the manifest
-# through the unexported package-level tables, so these exported accessors are
-# reachable only from the coverage/orphan audit tests today; the generated CLI
-# reference Phase consumes them next. They MUST NOT be removed.
-# ---------------------------------------------------------------------------
-CanonicalRoutes
-LookupCanonicalRoute
-Dispositions
-Routes
-SharedOutputModes
-IsSharedOutputMode
-RouteLocalFieldProjections
-
-# ---------------------------------------------------------------------------
-# MUST-KEEP: CLI information architecture v2 Phase 1 resource metadata
-# foundation. internal/core/metadata owns the pure Project -> Window ->
-# (Pane | Agent) resource model, its uid/name allocation, schema migration,
-# snapshot reconciliation, and operation transaction; internal/integrations/
-# metadata owns the locked registry file and the tmux transport mirror;
-# app.MapMetadataError is the single seam mapping the core's typed input
-# errors onto the CLI usage-error -> exit 2 path.
-#
-# The public verb-to-kind Phase consumed the mutation, naming, transaction, and
-# registry-write surface of this block through the get/describe/rename/rebind/
-# delete/prune routes. The detached materialization Phase then consumed the whole
-# tmux transport mirror: the resource-backed `create window` / `create pane`
-# routes mirror allocated identity onto live sessions, windows, and panes, and the
-# mutation-route registry reconciliation observes and migrates pre-v2 sessions
-# through it. Both groups of entries were removed from this list.
-#
-# What remains is the surface no production path reaches yet: snapshot
-# reconciliation and the schema migration machinery whose production migration set
-# is still deliberately empty. It MUST NOT be removed; it must instead keep
-# shrinking as later Phases wire it. Symbol matching is exact and
-# package-agnostic, which is the documented limitation of this baseline
-# mechanism.
-# ---------------------------------------------------------------------------
-AttachSnapshotMetadata
-ClassifySchemaVersion
-Kinds
-MigrateRegistry
-ReconcileSnapshot
-Registry.snapshotPanesOf
-SchemaAction.String
-Store.Migrate
-Store.Path
-Store.SetClock
-UIDKind
-WindowTarget
-resolveSnapshotProject
-scopeFor
-Registry.rebuildMissingReservations
-
-# ---------------------------------------------------------------------------
-# MUST-KEEP: CLI information architecture v2 Phase 2 selector and read-only
-# resolution. internal/core/selector owns the pure selector grammar, the fixed
-# name/uid-union -> label-filter -> uid-dedupe pipeline, the live/offline/
-# MissingRoot status interpretation, and the declared <verb, kind> cardinality
-# matrix.
-#
-# The public verb-to-kind Phase wired the Window resolution and the resolved-uid
-# accessor into real routes, so those entries were removed. The detached
-# materialization Phase then settled the two whole-table accessors that were
-# left, one each way.
-#
-# `StageOrder` was retired. Every one of its callers was in this package's own
-# tests, and Go in-package tests read unexported identifiers directly, so the
-# accessor did not need to exist at all: the tests now read the unexported
-# `stageOrder` table itself. Note the mechanism -- unexporting the function would
-# NOT have retired the entry, because deadcode analyses the non-test build and
-# reports an unexported test-only function just the same. Removing the function
-# is what removes the finding, which is the same move the Agent namespace Phase
-# used when it kept in-package tests on an unexported table instead of adding an
-# exported helper.
-#
-# `Matrix` stays, and stays exported, as a permanent cross-package test seam. It
-# is read from internal/app/cardinality_adoption_test.go, which is the record
-# that keeps the declared <verb, kind> matrix and the routes that enforce it from
-# drifting apart; a test in a different package cannot reach an unexported
-# symbol. Production consumes the matrix through `CardinalityFor`/`Enforce` and
-# the pipeline through `Resolution.Trace`, so a whole-table copy has no
-# production caller by design and manufacturing one would be worse than this
-# entry. This is NOT a shrinking-backlog item: it is not expected to be consumed
-# by a later Phase, and its absence from a future Phase's reclaim list is not a
-# signal about anything.
-# ---------------------------------------------------------------------------
-Matrix
-
-# ---------------------------------------------------------------------------
-# Settings IA re-cut Phase 0 — navigation catalog accessors.
-#
-# The navigation catalog is the single structural source of truth for the
-# visible Settings tree. Production renders from the catalog through
-# `settingsNavChildren`/`settingsNavLabel`; these four functions exist for the
-# contract that keeps the catalog honest — the tree golden
-# (internal/app/testdata/settings-nav-tree.golden) and the structural,
-# affordance-exclusivity and control-owner-cardinality tests. Manufacturing a
-# production caller for a renderer whose only job is to freeze the tree would be
-# worse than this entry. This is NOT a shrinking-backlog item.
-settingsNavByID
-settingsNavByValue
-renderSettingsNavTree
+writeNativeContentWithFooter
 writeSettingsNavNode
-
-# ---------------------------------------------------------------------------
-# Registry-first control plane Phase 2 — resolved resource graph producer.
-#
-# `internal/core/resourcegraph` is the pure read model that joins the Registry's
-# desired graph to one exact tmux server, plus the bounded observation adapter
-# that fills it (`InventoryObserver` in internal/integrations/metadata). The
-# phase ships the producer and its contract tests deliberately without a
-# consumer: the controller kernel (Phase 3), the runtime diagnostics route
-# (Phase 4), and the Registry-first primary UI (Phase 5) are the planned
-# consumers, and each is a separate reviewable change. Wiring a call site now
-# would mean changing UI or reconcile semantics inside the phase that is
-# supposed to only define the model.
-#
-# These entries are expected to leave this list as those phases land. They are
-# NOT MUST-KEEP, and they must not be deleted as dead code in the meantime.
-Resolve
-newResolver
-Classes
-Graph.RuntimeOfClass
-ObjectKinds
-objectKindRank
-Scopes
-scopeRank
-Inventory.Clone
-Inventory.Available
-Inventory.Unavailability
-Inventory.withUnavailable
-Inventory.MarkUnavailable
-Session.isControlSession
-resolver.resolveClaims
-resolver.acceptClaim
-resolver.bind
-resolver.reject
-resolver.classify
-resolver.windowContainmentContradiction
-resolver.paneContainmentContradiction
-resolver.paneOwnerChain
-resolver.sessionRef
-resolver.windowRef
-resolver.paneRef
-resolver.buildRegistryNodes
-resolver.buildRuntimeNodes
-resolver.resolvedClass
-resolver.unownedClass
-resolver.rowClass
-resolver.boundRef
-resolver.status
-resolver.projectMissingRootByUID
-projectMissingRoot
-resolver.graph
-compareRuntimeID
-tmuxIDNumber
-sortedKeys
-nonEmpty
-Transport.Present
-Transport.Args
-Transport.String
-ResolveTransport
-HostModeFromAppMarker
-transportRunner.Run
-NewInventoryObserver
-InventoryObserver.Observe
-InventoryObserver.observe
-serverAbsent

--- a/.deadcode-must-keep.txt
+++ b/.deadcode-must-keep.txt
@@ -1,0 +1,35 @@
+# .deadcode-must-keep.txt
+#
+# Proactive maintenance ledger for symbols that are not current deadcode
+# findings but must survive for migration, compatibility, or proof contracts.
+# Each data row is exactly `symbol<TAB>maintenance reason`; reasons are
+# mandatory. This file suppresses only its exact, reason-bearing symbols when
+# they appear in deadcode output; unrelated new findings still fail the gate.
+
+AggregateTeardownEvents	Pure multi-event teardown authority is retained for lifecycle decision proofs and planned consumers.
+CanonicalRoutes	The canonical route table accessor is retained for cross-package coverage and generated-reference consumers.
+CleanupLegacyArtifacts	Persisted usage-state cleanup must remain available across legacy state migrations.
+DecideTeardownEvent	The pure teardown decision API is retained for lifecycle authority proofs and planned consumers.
+Discover	The background-context discovery wrapper is retained as a test and compatibility seam.
+LookupCanonicalRoute	Canonical spelling lookup is retained for route coverage and generated-reference consumers.
+MigrateGlobalLegacyScripts	Global legacy hook migration must remain available while old installations can still be upgraded.
+MigrateProjectLegacyScripts	Project legacy hook migration must remain available while old repositories can still be upgraded.
+ReadRuntimeHealth	The typed no-write runtime-health seam is retained for diagnostics tests and the planned doctor consumer.
+Registry.snapshotPanesOf	Snapshot pane lookup remains part of the retained snapshot reconciliation implementation.
+Routes	The public route table accessor is retained for cross-package coverage and generated-reference consumers.
+Store.Migrate	Registry schema migration must remain available for persisted pre-current Registry files.
+Store.Path	The Registry path accessor is retained for migration and storage-boundary tests.
+Store.SetClock	The injected Registry clock is retained as a deterministic migration and transaction test seam.
+TeardownObservations	The closed teardown-observation catalog is retained for authority proofs and planned consumers.
+WithSocketName	The injected tmux socket option is retained as an exact routing compatibility and test seam.
+formatLegacyPaneSummary	Legacy pane-summary rendering remains required while persisted legacy pane metadata is readable.
+genericTeardownRefusal	The generic refusal constructor is retained inside the pure teardown authority proof surface.
+legacyDesktopAppID	The retired desktop application identifier remains required to recognize and clean legacy integration state.
+legacyWindowAttentionRows	Legacy attention rows remain required while older persisted window attention state is readable.
+observationRefusal	Observation-specific refusal mapping is retained inside the pure teardown authority proof surface.
+projectPreservedAssets	The preserved-assets outcome helper is retained for project teardown authority proofs.
+rootDefaults	Root teardown defaults are retained inside the pure teardown decision authority.
+tmuxRetiredKeyUnbindLines	Retired key cleanup must remain available so old generated tmux bindings can be removed.
+validOwnerChain	Owner-chain validation is retained inside the pure teardown decision authority.
+validTeardownEventKind	The closed event-kind validator is retained inside the pure teardown decision authority.
+validTeardownObservation	The closed observation validator is retained inside the pure teardown decision authority.

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,15 @@ GO_FILES := $(shell find . -type f -name '*.go' \
 	-not -path './.wt/*')
 
 DEADCODE_ALLOWLIST ?= .deadcode-allowlist.txt
+DEADCODE_MUST_KEEP ?= .deadcode-must-keep.txt
+DEADCODE_BASELINE_GATE ?= scripts/deadcode_baseline.py
 
 SECURITY_BIN_DIR ?= $(BUILD_DIR)/security-tools
 SECURITY_TOOL_MANIFEST ?= .security/security-tools.versions
 
 DOCS_REFERENCE ?= docs/cli.md
 
-.PHONY: fmt fmt-check fix build install npm-pack docs test test-integration test-install-smoke test-e2e test-e2e-contract test-e2e-reliability test-e2e-shards test-e2e-manifest test-e2e-coverage test-e2e-update e2e verify deadcode security security-serial security-go security-static security-policy security-contract security-tools
+.PHONY: fmt fmt-check fix build install npm-pack docs test test-integration test-install-smoke test-e2e test-e2e-contract test-e2e-reliability test-e2e-shards test-e2e-manifest test-e2e-coverage test-e2e-update e2e verify deadcode deadcode-contract security security-serial security-go security-static security-policy security-contract security-tools
 
 build:
 	@mkdir -p $(BUILD_DIR)
@@ -87,36 +89,26 @@ fix:
 	$(GO) fix ./...
 	@$(MAKE) --no-print-directory deadcode
 
-# deadcode runs golang.org/x/tools/cmd/deadcode (pinned via the go.mod tool
-# directive) over the module and filters findings against an allowlist of
-# intentional / MUST-KEEP symbols. It exits non-zero only when a NEW
-# (non-allowlisted) unreachable function appears, so the checked-in baseline
-# stays green while genuinely new dead code is surfaced.
-deadcode:
-	@findings="$$( $(GO) tool deadcode ./... )"; \
-	if [ -z "$$findings" ]; then \
-		echo ">> deadcode: no unreachable functions reported"; \
-		exit 0; \
-	fi; \
-	allow="$$(mktemp)"; \
-	grep -v '^[[:space:]]*#' $(DEADCODE_ALLOWLIST) | grep -v '^[[:space:]]*$$' > "$$allow"; \
-	remaining="$$( printf '%s\n' "$$findings" | while IFS= read -r line; do \
-		sym="$${line##*unreachable func: }"; \
-		if grep -Fxq -- "$$sym" "$$allow"; then \
-			continue; \
-		fi; \
-		printf '%s\n' "$$line"; \
-	done )"; \
-	rm -f "$$allow"; \
-	if [ -n "$$remaining" ]; then \
-		echo ">> deadcode: NEW unreachable functions (not in $(DEADCODE_ALLOWLIST)):"; \
-		printf '%s\n' "$$remaining"; \
+# The current baseline is an exact set of symbols reported by deadcode. The
+# proactive file protects migration/compatibility/proof APIs whether currently
+# reachable, test-only, or reported. New findings are rejected against the
+# union, while stale rows are rejected from the current baseline alone.
+deadcode: deadcode-contract
+	@findings="$$(mktemp)"; \
+	trap 'rm -f "$$findings"' EXIT HUP INT TERM; \
+	if ! $(GO) tool deadcode ./... > "$$findings"; then \
+		echo ">> deadcode: tool execution failed; baseline was not evaluated" >&2; \
 		exit 1; \
 	fi; \
-	echo ">> deadcode: clean (all findings allowlisted in $(DEADCODE_ALLOWLIST))"; \
-	exit 0
+	python3 $(DEADCODE_BASELINE_GATE) \
+		--allowlist $(DEADCODE_ALLOWLIST) \
+		--must-keep $(DEADCODE_MUST_KEEP) \
+		--findings "$$findings"
 
-test:
+deadcode-contract:
+	python3 -m unittest discover -s test -p 'deadcode_baseline_test.py'
+
+test: deadcode-contract
 	$(GO) test ./...
 
 test-integration:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,10 +43,15 @@ and humans run the same entrypoints.
   checks scanner/rule/baseline identity, PR-range/full-history secret scans,
   cache miss-to-hit convergence, privacy-safe artifacts, and the fail-closed
   aggregate. CI exposes their stable aggregate as `Test`.
-- `make deadcode` runs `go tool deadcode` (pinned via the go.mod tool
-  directive) over the module and reports unreachable functions, filtering out
-  the intentional/MUST-KEEP baseline in `.deadcode-allowlist.txt`; it fails
-  only on NEW dead code, and `make fix` runs it after `go fix`.
+- `make deadcode` runs the focused baseline-contract fixture, then runs
+  `go tool deadcode` (pinned via the go.mod tool directive) over the module.
+  `.deadcode-allowlist.txt` is exact to current findings: duplicate and stale
+  rows fail. `.deadcode-must-keep.txt` separately records proactive migration,
+  compatibility, and proof APIs as `symbol<TAB>non-empty reason`; duplicates
+  within either file, overlap across files, malformed reasons, and findings
+  outside the two-file union fail deterministically. `make test` also runs the
+  focused fixture, and `make fix` runs the complete deadcode gate after
+  `go fix`.
 
 ## Docker-Covered Checks
 

--- a/scripts/deadcode_baseline.py
+++ b/scripts/deadcode_baseline.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Validate projmux's exact deadcode baseline contract."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SYMBOL_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?")
+FINDING_MARKER = "unreachable func: "
+
+
+@dataclass(frozen=True)
+class ParsedFile:
+    symbols: frozenset[str]
+    errors: tuple[str, ...]
+
+
+def _source_lines(path: Path) -> list[tuple[int, str]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise ValueError(f"{path}: cannot read UTF-8 file: {exc}") from exc
+    return list(enumerate(text.splitlines(), start=1))
+
+
+def _validate_symbol(path: Path, line_number: int, symbol: str) -> str | None:
+    if not SYMBOL_RE.fullmatch(symbol):
+        return f"{path}:{line_number}: malformed symbol {symbol!r}"
+    return None
+
+
+def parse_allowlist(path: Path) -> ParsedFile:
+    symbols: set[str] = set()
+    ordered_symbols: list[str] = []
+    errors: list[str] = []
+    first_line: dict[str, int] = {}
+    for line_number, line in _source_lines(path):
+        if not line or line.startswith("#"):
+            continue
+        if line != line.strip():
+            errors.append(f"{path}:{line_number}: leading/trailing whitespace is not allowed")
+            continue
+        if error := _validate_symbol(path, line_number, line):
+            errors.append(error)
+            continue
+        if line in symbols:
+            errors.append(
+                f"{path}:{line_number}: duplicate symbol {line!r} "
+                f"(first declared on line {first_line[line]})"
+            )
+            continue
+        symbols.add(line)
+        ordered_symbols.append(line)
+        first_line[line] = line_number
+    if ordered_symbols != sorted(ordered_symbols):
+        errors.append(f"{path}: symbols must be sorted bytewise")
+    return ParsedFile(frozenset(symbols), tuple(errors))
+
+
+def parse_must_keep(path: Path) -> ParsedFile:
+    symbols: set[str] = set()
+    ordered_symbols: list[str] = []
+    errors: list[str] = []
+    first_line: dict[str, int] = {}
+    for line_number, line in _source_lines(path):
+        if not line or line.startswith("#"):
+            continue
+        if line != line.strip():
+            errors.append(f"{path}:{line_number}: leading/trailing whitespace is not allowed")
+            continue
+        if line.count("\t") != 1:
+            errors.append(
+                f"{path}:{line_number}: expected exactly 'symbol<TAB>maintenance reason'"
+            )
+            continue
+        symbol, reason = line.split("\t")
+        if error := _validate_symbol(path, line_number, symbol):
+            errors.append(error)
+            continue
+        if not reason.strip():
+            errors.append(f"{path}:{line_number}: maintenance reason must not be empty")
+            continue
+        if reason != reason.strip():
+            errors.append(f"{path}:{line_number}: maintenance reason has edge whitespace")
+            continue
+        if symbol in symbols:
+            errors.append(
+                f"{path}:{line_number}: duplicate symbol {symbol!r} "
+                f"(first declared on line {first_line[symbol]})"
+            )
+            continue
+        symbols.add(symbol)
+        ordered_symbols.append(symbol)
+        first_line[symbol] = line_number
+    if ordered_symbols != sorted(ordered_symbols):
+        errors.append(f"{path}: symbols must be sorted bytewise")
+    return ParsedFile(frozenset(symbols), tuple(errors))
+
+
+def parse_findings(path: Path) -> tuple[frozenset[str], tuple[str, ...], int]:
+    symbols: set[str] = set()
+    errors: list[str] = []
+    finding_count = 0
+    for line_number, line in _source_lines(path):
+        if not line:
+            continue
+        prefix, marker, symbol = line.rpartition(FINDING_MARKER)
+        if not marker or not prefix or symbol != symbol.strip():
+            errors.append(f"{path}:{line_number}: malformed deadcode finding {line!r}")
+            continue
+        if error := _validate_symbol(path, line_number, symbol):
+            errors.append(error)
+            continue
+        finding_count += 1
+        symbols.add(symbol)
+    return frozenset(symbols), tuple(errors), finding_count
+
+
+def validate(allowlist_path: Path, must_keep_path: Path, findings_path: Path) -> list[str]:
+    allowlist = parse_allowlist(allowlist_path)
+    must_keep = parse_must_keep(must_keep_path)
+    findings, finding_errors, _ = parse_findings(findings_path)
+    errors = [*allowlist.errors, *must_keep.errors, *finding_errors]
+
+    overlap = sorted(allowlist.symbols & must_keep.symbols)
+    if overlap:
+        errors.append(
+            "symbols present in both current and proactive baselines: " + ", ".join(overlap)
+        )
+
+    stale = sorted(allowlist.symbols - findings)
+    if stale:
+        errors.append("stale current-baseline symbols: " + ", ".join(stale))
+
+    new = sorted(findings - (allowlist.symbols | must_keep.symbols))
+    if new:
+        errors.append("new deadcode findings: " + ", ".join(new))
+
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--allowlist", required=True, type=Path)
+    parser.add_argument("--must-keep", required=True, type=Path)
+    parser.add_argument("--findings", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        errors = validate(args.allowlist, args.must_keep, args.findings)
+        findings, _, finding_count = parse_findings(args.findings)
+        allowlist = parse_allowlist(args.allowlist)
+        must_keep = parse_must_keep(args.must_keep)
+    except ValueError as exc:
+        print(f">> deadcode baseline: {exc}", file=sys.stderr)
+        return 1
+
+    if errors:
+        print(">> deadcode baseline: contract violation", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(
+        ">> deadcode baseline: exact "
+        f"({finding_count} findings / {len(findings)} symbols, "
+        f"{len(allowlist.symbols)} current, {len(must_keep.symbols)} proactive)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/deadcode_baseline_test.py
+++ b/test/deadcode_baseline_test.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "deadcode_baseline.py"
+SPEC = importlib.util.spec_from_file_location("deadcode_baseline", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+deadcode_baseline = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = deadcode_baseline
+SPEC.loader.exec_module(deadcode_baseline)
+
+
+class DeadcodeBaselineContractTest(unittest.TestCase):
+    def run_gate(self, allowlist: str, must_keep: str, findings: str) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            paths = {
+                "allowlist": root / "allowlist",
+                "must_keep": root / "must-keep",
+                "findings": root / "findings",
+            }
+            paths["allowlist"].write_text(allowlist, encoding="utf-8")
+            paths["must_keep"].write_text(must_keep, encoding="utf-8")
+            paths["findings"].write_text(findings, encoding="utf-8")
+            stderr = io.StringIO()
+            stdout = io.StringIO()
+            with contextlib.redirect_stderr(stderr), contextlib.redirect_stdout(stdout):
+                status = deadcode_baseline.main(
+                    [
+                        "--allowlist",
+                        str(paths["allowlist"]),
+                        "--must-keep",
+                        str(paths["must_keep"]),
+                        "--findings",
+                        str(paths["findings"]),
+                    ]
+                )
+            return status, stdout.getvalue() + stderr.getvalue()
+
+    def test_exact_current_and_proactive_sets_pass(self) -> None:
+        status, output = self.run_gate(
+            "Current\n",
+            "CompatibilityAPI\tRetained compatibility input.\n",
+            "pkg/current.go:1:1: unreachable func: Current\n",
+        )
+        self.assertEqual(status, 0, output)
+        self.assertIn("1 findings / 1 symbols, 1 current, 1 proactive", output)
+
+    def test_duplicate_in_each_file_is_rejected(self) -> None:
+        for allowlist, must_keep in (
+            ("Current\nCurrent\n", "Keep\tReason.\n"),
+            ("Current\n", "Keep\tReason.\nKeep\tReason again.\n"),
+        ):
+            with self.subTest(allowlist=allowlist, must_keep=must_keep):
+                status, output = self.run_gate(
+                    allowlist,
+                    must_keep,
+                    "pkg/current.go:1:1: unreachable func: Current\n",
+                )
+                self.assertEqual(status, 1)
+                self.assertIn("duplicate symbol", output)
+
+    def test_cross_file_duplicate_is_rejected(self) -> None:
+        status, output = self.run_gate(
+            "Current\n",
+            "Current\tCompatibility proof.\n",
+            "pkg/current.go:1:1: unreachable func: Current\n",
+        )
+        self.assertEqual(status, 1)
+        self.assertIn("present in both current and proactive baselines", output)
+
+    def test_proactive_symbol_may_become_a_finding(self) -> None:
+        status, output = self.run_gate(
+            "",
+            "CompatibilityAPI\tRetained compatibility input.\n",
+            "pkg/compat.go:1:1: unreachable func: CompatibilityAPI\n",
+        )
+        self.assertEqual(status, 0, output)
+        self.assertIn("1 findings / 1 symbols, 0 current, 1 proactive", output)
+
+    def test_proactive_finding_does_not_hide_stale_current_row(self) -> None:
+        status, output = self.run_gate(
+            "Stale\n",
+            "CompatibilityAPI\tRetained compatibility input.\n",
+            "pkg/compat.go:1:1: unreachable func: CompatibilityAPI\n",
+        )
+        self.assertEqual(status, 1)
+        self.assertIn("stale current-baseline symbols: Stale", output)
+        self.assertNotIn("new deadcode findings", output)
+
+    def test_stale_current_and_new_finding_are_rejected(self) -> None:
+        status, output = self.run_gate(
+            "Stale\n",
+            "Keep\tMigration seam.\n",
+            "pkg/new.go:1:1: unreachable func: NewFinding\n",
+        )
+        self.assertEqual(status, 1)
+        self.assertIn("stale current-baseline symbols: Stale", output)
+        self.assertIn("new deadcode findings: NewFinding", output)
+
+    def test_malformed_or_empty_must_keep_reason_is_rejected(self) -> None:
+        for must_keep in ("Keep\n", "Keep\t\n", "Keep\t  \n", "Keep\tReason.\textra\n"):
+            with self.subTest(must_keep=must_keep):
+                status, output = self.run_gate(
+                    "Current\n",
+                    must_keep,
+                    "pkg/current.go:1:1: unreachable func: Current\n",
+                )
+                self.assertEqual(status, 1)
+                self.assertRegex(
+                    output,
+                    r"expected exactly|must not be empty|edge whitespace|leading/trailing whitespace",
+                )
+
+    def test_repeated_run_is_byte_identical(self) -> None:
+        fixture = (
+            "Current\n",
+            "Keep\tProof seam.\n",
+            "pkg/current.go:1:1: unreachable func: Current\n",
+        )
+        self.assertEqual(self.run_gate(*fixture), self.run_gate(*fixture))
+
+    def test_unsorted_baseline_is_rejected(self) -> None:
+        status, output = self.run_gate(
+            "Zulu\nAlpha\n",
+            "Keep\tProof seam.\n",
+            "pkg/z.go:1:1: unreachable func: Zulu\n"
+            "pkg/a.go:1:1: unreachable func: Alpha\n",
+        )
+        self.assertEqual(status, 1)
+        self.assertIn("symbols must be sorted bytewise", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Split the mixed deadcode allowlist into a 199-symbol exact current baseline and a 27-symbol proactive must-keep ledger with mandatory reasons.
- Add a deterministic two-file gate and focused fixtures for duplicate, stale, malformed, overlap, proactive, and new-finding behavior.
- Keep production code and public behavior, CLI, and schema unchanged.

## Phase 0 acceptance
- [x] Duplicate rows: 0 within either file and 0 across files.
- [x] Stale current-baseline rows: 0.
- [x] All 93 former allowlist-only symbols classified: 27 proactive must-keep and 66 stale.
- [x] New deadcode findings remain rejected against the two-file union.
- [x] Must-keep APIs were not deleted and no production fake callers were added.
- [x] Repeated deadcode runs on the same head return identical 200 raw / 199 unique results.

## Test plan
- [x] `python3 -m unittest discover -s test -p deadcode_baseline_test.py` (9 fixtures)
- [x] `make deadcode` twice
- [x] `make fmt`
- [x] `make fix`
- [x] `make test`
- [x] `make test-integration`
- [x] Local default-parallel `make test-e2e`: 21/21 scenarios, result SHA-256 `6e950197aba49a737e1838d557ee8d2184bf16d209ed841d1dac813fdad3d378`
- [x] Local focused L04 replay
- [ ] Remote `E2E Tests`: initial attempt failed in Settings-owned L04; failed-job rerun failed in L06 after all eight racers reported completed/status 0 and emitted an invalid terminal source line
- [ ] Required `Test` check
- [x] Docs audit for `docs/testing.md`

## Current merge blocker
- The exact published head is locally green for the full default-parallel E2E suite and focused L04 replay.
- The remote initial run and rerun failed in different scenarios outside this PR diff. The rerun L06 diagnostic reports every racer completed successfully, while the terminal attribution itself is invalid.
- Merge remains blocked pending an E2E-owner fix or explicit disposition. This PR does not change E2E-owned or Settings-owned files.

## Exclusions and scope audit
- No production dead-code deletion, unrelated refactor, deadcode tool replacement, test-only API redesign, or later roadmap Phase work.
- No Go product files changed.
- Did not modify E2E-owned `test/lib/smoke.sh`, `scripts/e2e-evidence.py`, `test/e2e/linux-smoke.sh`, `scripts/test-e2e-docker.sh`, or `docs/agent-workflow.md`.
- Did not modify Invocation-owned selector/authority or CLI route surfaces.
- Did not modify Settings-owned catalog/navigation/i18n files or related tests.

## Globalization
- [x] No user-facing string changes.
