### PR TITLE
fix(metadata): converge concurrent create lock ownership

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -383,6 +383,13 @@
   exact tmux state plus sanitized hashed tails; denylist checks reject token,
   raw HOME/path, full Registry, and raw command leakage. Normal scenario meaning,
   one-build/four-shard topology, and `.bin/e2e-evidence` retention are unchanged.
+- `make test` / `make test-e2e`: L06 Registry lock recurrence applies the
+  unchanged 400-attempt, 2ms/50ms delay, and 30s stale budget to one verified
+  positive-PID owner lease. `TestRegistryLockRetryBudgetTracksVerifiedOwnerLease`
+  permits a waiter to continue across healthy owner turnover while unchanged,
+  empty, malformed, and unreadable owners remain bounded; the real-tmux L06
+  burst requires all eight exact-socket creates to converge on one Window with
+  nine unique mirrored Panes and no lock or staged residue.
 - `make test` / `make test-integration`: attention omitted-target convergence
   is enforced by `TestAttentionMutationOmittedTargetMatchesExplicitPaneLedger`,
   `TestAttentionMutationOmittedTargetRefusesWithoutExactInvocationPane`, and

--- a/internal/integrations/metadata/store.go
+++ b/internal/integrations/metadata/store.go
@@ -1263,8 +1263,30 @@ func (s *Store) tryBreakStaleRecoveryLock() bool {
 }
 
 func (s *Store) acquireLock() error {
+	return s.acquireLockWithPolicy(defaultLockMaxAttempts, defaultLockBaseDelay, defaultLockMaxDelay, time.Sleep)
+}
+
+// acquireLockWithPolicy applies the retry budget to one observed lock owner.
+// A create burst consists of several healthy, serialized owners; charging a
+// waiter for time spent behind owners that have already released the lock can
+// exhaust the budget even though no individual lease is stuck. Only an exact,
+// positive pid transition proves lease progress and resets the attempts. Empty,
+// malformed, or transiently unreadable lock contents keep consuming the current
+// owner's budget instead of manufacturing progress.
+func (s *Store) acquireLockWithPolicy(maxAttempts int, baseDelay, maxDelay time.Duration, sleep func(time.Duration)) error {
+	if sleep == nil {
+		sleep = time.Sleep
+	}
 	delay := defaultLockBaseDelay
-	for range defaultLockMaxAttempts {
+	if baseDelay > 0 {
+		delay = baseDelay
+	}
+	if maxDelay <= 0 {
+		maxDelay = defaultLockMaxDelay
+	}
+	lastOwnerPID := 0
+	attempts := 0
+	for attempts < maxAttempts {
 		f, err := os.OpenFile(s.lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, localstate.PrivateFileMode)
 		if err == nil {
 			_, _ = fmt.Fprintf(f, "pid=%d\n", os.Getpid())
@@ -1274,18 +1296,38 @@ func (s *Store) acquireLock() error {
 		if !errors.Is(err, os.ErrExist) {
 			return fmt.Errorf("metadata: acquire lock: %w", err)
 		}
+		if ownerPID, ok := observedLockOwnerPID(s.lockPath); ok {
+			if lastOwnerPID > 0 && ownerPID != lastOwnerPID {
+				attempts = 0
+			}
+			lastOwnerPID = ownerPID
+		}
+		attempts++
 		if s.tryBreakStaleLock() {
 			continue
 		}
-		time.Sleep(delay + s.lockJitter())
-		if delay < defaultLockMaxDelay {
+		sleep(delay + s.lockJitter())
+		if delay < maxDelay {
 			delay *= 2
-			if delay > defaultLockMaxDelay {
-				delay = defaultLockMaxDelay
+			if delay > maxDelay {
+				delay = maxDelay
 			}
 		}
 	}
-	return fmt.Errorf("metadata: acquire lock: exhausted %d attempts on %s", defaultLockMaxAttempts, s.lockPath)
+	return fmt.Errorf("metadata: acquire lock: exhausted %d attempts on %s", maxAttempts, s.lockPath)
+}
+
+func observedLockOwnerPID(path string) (int, bool) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path is the Store's own private registry lock sibling
+	if err != nil {
+		return 0, false
+	}
+	raw, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "pid=")
+	if !ok || raw == "" || strings.ContainsAny(raw, " \t\r\n") {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(raw)
+	return pid, err == nil && pid > 0
 }
 
 func (s *Store) lockJitter() time.Duration {

--- a/internal/integrations/metadata/store_test.go
+++ b/internal/integrations/metadata/store_test.go
@@ -958,6 +958,131 @@ func TestConcurrentUpdatesSerializeThroughTheRegistryLock(t *testing.T) {
 	}
 }
 
+func TestRegistryLockRetryBudgetTracksVerifiedOwnerLease(t *testing.T) {
+	writeOwner := func(t *testing.T, path string, pid int) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatalf("mkdir lock parent: %v", err)
+		}
+		if err := os.WriteFile(path, fmt.Appendf(nil, "pid=%d\n", pid), 0o600); err != nil {
+			t.Fatalf("write lock owner: %v", err)
+		}
+	}
+	replaceOwner := func(t *testing.T, path string, pid int) {
+		t.Helper()
+		if err := os.Remove(path); err != nil {
+			t.Fatalf("remove prior lock owner: %v", err)
+		}
+		writeOwner(t, path, pid)
+	}
+
+	t.Run("owner turnover resets the unchanged per-lease budget", func(t *testing.T) {
+		store := NewStore(PathFor(t.TempDir()))
+		writeOwner(t, store.lockPath, 1001)
+		sleeps := 0
+		err := store.acquireLockWithPolicy(2, time.Nanosecond, time.Nanosecond, func(time.Duration) {
+			sleeps++
+			switch sleeps {
+			case 1:
+				replaceOwner(t, store.lockPath, 1002)
+			case 2:
+				if err := os.Remove(store.lockPath); err != nil {
+					t.Fatalf("release second owner: %v", err)
+				}
+			}
+		})
+		if err != nil {
+			t.Fatalf("acquire after two healthy owners: %v", err)
+		}
+		if sleeps != 2 {
+			t.Fatalf("contention sleeps = %d, want 2 owner leases", sleeps)
+		}
+		if err := os.Remove(store.lockPath); err != nil {
+			t.Fatalf("release acquired lock: %v", err)
+		}
+		assertNoStagedGarbage(t, store)
+	})
+
+	t.Run("unchanged owner exhausts exactly the production attempt count", func(t *testing.T) {
+		store := NewStore(PathFor(t.TempDir()))
+		writeOwner(t, store.lockPath, 2001)
+		sleeps := 0
+		err := store.acquireLockWithPolicy(defaultLockMaxAttempts, time.Nanosecond, time.Nanosecond, func(time.Duration) {
+			sleeps++
+		})
+		if err == nil || !strings.Contains(err.Error(), "exhausted 400 attempts") {
+			t.Fatalf("stable owner error = %v, want exact 400-attempt exhaustion", err)
+		}
+		if sleeps != defaultLockMaxAttempts {
+			t.Fatalf("stable owner sleeps = %d, want %d", sleeps, defaultLockMaxAttempts)
+		}
+		if err := os.Remove(store.lockPath); err != nil {
+			t.Fatalf("release fixture lock: %v", err)
+		}
+		assertNoStagedGarbage(t, store)
+	})
+
+	for _, test := range []struct {
+		name    string
+		replace func(*testing.T, string)
+	}{
+		{name: "empty owner", replace: func(t *testing.T, path string) {
+			t.Helper()
+			if err := os.Remove(path); err != nil {
+				t.Fatalf("remove valid owner: %v", err)
+			}
+			if err := os.WriteFile(path, nil, 0o600); err != nil {
+				t.Fatalf("write empty owner: %v", err)
+			}
+		}},
+		{name: "malformed owner", replace: func(t *testing.T, path string) {
+			t.Helper()
+			if err := os.WriteFile(path, []byte("owner=not-a-pid\n"), 0o600); err != nil {
+				t.Fatalf("write malformed owner: %v", err)
+			}
+		}},
+		{name: "transiently unreadable owner", replace: func(t *testing.T, path string) {
+			t.Helper()
+			if err := os.Remove(path); err != nil {
+				t.Fatalf("remove valid owner: %v", err)
+			}
+			if err := os.Mkdir(path, 0o700); err != nil {
+				t.Fatalf("replace owner with unreadable directory: %v", err)
+			}
+		}},
+	} {
+		t.Run(test.name+" does not reset", func(t *testing.T) {
+			store := NewStore(PathFor(t.TempDir()))
+			writeOwner(t, store.lockPath, 3001)
+			sleeps := 0
+			err := store.acquireLockWithPolicy(2, time.Nanosecond, time.Nanosecond, func(time.Duration) {
+				sleeps++
+				if sleeps == 1 {
+					test.replace(t, store.lockPath)
+				}
+			})
+			if err == nil || !strings.Contains(err.Error(), "exhausted 2 attempts") {
+				t.Fatalf("invalid owner error = %v, want bounded exhaustion", err)
+			}
+			if sleeps != 2 {
+				t.Fatalf("invalid owner sleeps = %d, want 2 without reset", sleeps)
+			}
+			if err := os.RemoveAll(store.lockPath); err != nil {
+				t.Fatalf("remove invalid owner fixture: %v", err)
+			}
+			assertNoStagedGarbage(t, store)
+		})
+	}
+}
+
+func TestRegistryLockProductionBudgetConstantsRemainUnchanged(t *testing.T) {
+	if defaultLockMaxAttempts != 400 || defaultLockBaseDelay != 2*time.Millisecond ||
+		defaultLockMaxDelay != 50*time.Millisecond || defaultLockStaleAfter != 30*time.Second {
+		t.Fatalf("ordinary Registry lock budget drifted: attempts=%d base=%s max=%s stale=%s",
+			defaultLockMaxAttempts, defaultLockBaseDelay, defaultLockMaxDelay, defaultLockStaleAfter)
+	}
+}
+
 // TestAnAbsentOrContentFreeRegistryFileLoadsAnEmptyRegistry keeps the
 // legitimate empty cases distinct from the fail-closed unknown-document case:
 // only a file with actual content that lacks a usable schemaVersion is


### PR DESCRIPTION
## Summary
- Apply the unchanged Registry lock retry budget per verified positive-PID owner lease, so healthy owner turnover proves progress instead of cumulatively exhausting waiters.
- Keep unchanged-owner, empty, malformed, and unreadable lock observations bounded; preserve create transaction atomicity and exact runtime authority.
- Add deterministic lease-accounting coverage and the minimal maintained E2E test-list entry.

## Test plan
- [x] make fmt
- [x] make fix
- [x] make test
- [x] focused L06 10/10 on one immutable build
- [x] L08/L16 exact replay and first-failure golden/privacy contracts
- [x] make test-integration
- [x] make test-e2e (pre-rebase; rerun on final head in progress)

## Globalization
- [x] No user-facing string changes.

## Scope
- Preserves defaultLockMaxAttempts, base/max delay, stale-after, E2E timeout, Registry schema v2, public CLI/config/hook schema, and #794 bounded/redacted diagnostics.
- Excludes L08/L16 semantic changes, retry/timeout increases, shard topology, and unrelated metadata recovery redesign.

Roadmap: Post-0.13 E2E first-failure attribution and concurrency recurrence / Phase 1a L06 Registry lock recurrence
Contract: C-2 Scenario-owned bounded diagnostics