### PR TITLE
refactor(tmux): unify exact transport routing

### DIFF
--- a/internal/app/agent_control_cli_test.go
+++ b/internal/app/agent_control_cli_test.go
@@ -21,13 +21,13 @@ type staticAgentControlBinding struct {
 }
 
 type exactControlRouteRunner struct {
-	target explicitTmuxTarget
+	target tmuxTransport
 	calls  [][]string
 }
 
 func (r *exactControlRouteRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
 	r.calls = append(r.calls, append([]string(nil), args...))
-	if name != "tmux" || len(args) < 3 || args[0] != r.target.flag || args[1] != r.target.value {
+	if name != "tmux" || len(args) < 3 || args[0] != r.target.Flag() || args[1] != r.target.Value {
 		return nil, errors.New("unexpected control route")
 	}
 	switch args[2] {
@@ -189,11 +189,11 @@ func TestAgentControlCLIStaleBindingCallsNoControl(t *testing.T) {
 }
 
 func TestAgentControlBindingLookupUsesResolvedLogicalRouteOnly(t *testing.T) {
-	for _, target := range []explicitTmuxTarget{
-		{flag: "-L", value: "exact-control"},
-		{flag: "-S", value: "/tmp/exact-control.sock"},
+	for _, target := range []tmuxTransport{
+		{Kind: tmuxSocketName, Value: "exact-control", Source: tmuxSocketNameSource},
+		{Kind: tmuxSocketPath, Value: "/tmp/exact-control.sock", Source: tmuxSocketPathSource},
 	} {
-		t.Run(strings.TrimPrefix(target.flag, "-"), func(t *testing.T) {
+		t.Run(strings.TrimPrefix(target.Flag(), "-"), func(t *testing.T) {
 			cmd, _, _ := exactControlCLICommand(t)
 			tmux := &exactControlRouteRunner{target: target}
 			cmd.controlBinding = nil
@@ -212,7 +212,7 @@ func TestAgentControlBindingLookupUsesResolvedLogicalRouteOnly(t *testing.T) {
 				t.Fatal("control binding performed no tmux reads")
 			}
 			for _, call := range tmux.calls {
-				if len(call) < 2 || call[0] != target.flag || call[1] != target.value {
+				if len(call) < 2 || call[0] != target.Flag() || call[1] != target.Value {
 					t.Fatalf("ambient/default control read = %q", call)
 				}
 			}

--- a/internal/app/agent_interaction.go
+++ b/internal/app/agent_interaction.go
@@ -13,6 +13,7 @@ import (
 
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
 	"github.com/crevissepartners/projmux/internal/core/notify"
+	"github.com/crevissepartners/projmux/internal/core/resourcegraph"
 	"github.com/crevissepartners/projmux/internal/core/selector"
 	"github.com/crevissepartners/projmux/internal/integrations/agents/codexappserver"
 	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
@@ -314,9 +315,8 @@ func inheritedAgentMutationMirror(lookupEnv func(string) string, runner tmuxComm
 	if lookupEnv == nil || runner == nil {
 		return nil
 	}
-	socket, _, _ := strings.Cut(strings.TrimSpace(lookupEnv("TMUX")), ",")
-	target, err := tmuxSocketPathTarget(socket)
-	if err != nil {
+	target, err := resourcegraph.ResolveTransport(resourcegraph.TransportRequest{InheritedTMUX: lookupEnv("TMUX")})
+	if err != nil || !target.Present() {
 		return nil
 	}
 	routed := explicitTmuxRunner{runner: runner, target: target}

--- a/internal/app/agent_pane_binding_test.go
+++ b/internal/app/agent_pane_binding_test.go
@@ -114,19 +114,19 @@ func TestAgentPaneBinderRequiredOptionsAndFailureCompensationOnExactRoutes(t *te
 			ResumeSource: "app-server", ThreadID: "thread-native", NativeCodex: true,
 		}, expected: nativeExpected},
 	}
-	routes := []explicitTmuxTarget{{flag: "-L", value: "phase2"}, {flag: "-S", value: "/tmp/phase2.sock"}}
+	routes := []tmuxTransport{{Kind: tmuxSocketName, Value: "phase2", Source: tmuxSocketNameSource}, {Kind: tmuxSocketPath, Value: "/tmp/phase2.sock", Source: tmuxSocketPathSource}}
 	for _, shape := range shapes {
 		for _, route := range routes {
 			for _, failure := range []struct {
 				name  string
 				write int
 			}{{name: "success"}, {name: "first", write: 2}, {name: "middle", write: 9}, {name: "last", write: 16}} {
-				t.Run(shape.name+"/"+strings.TrimPrefix(route.flag, "-")+"/"+failure.name, func(t *testing.T) {
+				t.Run(shape.name+"/"+strings.TrimPrefix(route.Flag(), "-")+"/"+failure.name, func(t *testing.T) {
 					before := map[string]string{
 						aiPaneManagedOption: "old-managed", aiPaneContextOption: "/old", aiPaneCodexEpochOption: "old-epoch", "@sibling": "keep",
 					}
 					raw := &bindingFailureRunner{
-						targetFlag: route.flag, targetValue: route.value, title: "old-title", options: map[string]string{},
+						targetFlag: route.Flag(), targetValue: route.Value, title: "old-title", options: map[string]string{},
 						failWrite: failure.write, failureCommand: -1,
 					}
 					maps.Copy(raw.options, before)

--- a/internal/app/agent_review.go
+++ b/internal/app/agent_review.go
@@ -12,6 +12,7 @@ import (
 
 	corecap "github.com/crevissepartners/projmux/internal/core/aicapability"
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	"github.com/crevissepartners/projmux/internal/core/resourcegraph"
 	"github.com/crevissepartners/projmux/internal/core/selector"
 	"github.com/crevissepartners/projmux/internal/integrations/agents/codexappserver"
 	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
@@ -46,9 +47,8 @@ func inheritedAgentReviewBindingLookup(lookupEnv func(string) string, runner tmu
 	if lookupEnv == nil || runner == nil {
 		return nil
 	}
-	socket, _, _ := strings.Cut(strings.TrimSpace(lookupEnv("TMUX")), ",")
-	target, err := tmuxSocketPathTarget(socket)
-	if err != nil {
+	target, err := resourcegraph.ResolveTransport(resourcegraph.TransportRequest{InheritedTMUX: lookupEnv("TMUX")})
+	if err != nil || !target.Present() {
 		return nil
 	}
 	routed := explicitTmuxRunner{runner: runner, target: target}

--- a/internal/app/ai_ingest_codex_native.go
+++ b/internal/app/ai_ingest_codex_native.go
@@ -65,11 +65,11 @@ type codexNativeLifecycleStarter interface {
 
 type codexLifecycleObserverTarget struct {
 	Identity codexLifecycleIdentity
-	Route    explicitTmuxTarget
+	Route    tmuxTransport
 }
 
 func (t codexLifecycleObserverTarget) valid() bool {
-	return t.Identity.valid() && t.Route.flag != "" && t.Route.value != ""
+	return t.Identity.valid() && t.Route.Flag() != "" && t.Route.Value != ""
 }
 
 type codexNativeObserver struct {
@@ -900,10 +900,10 @@ func startCodexLifecycleObserverProcess(executable string, target codexLifecycle
 	args := []string{"internal", "agent-hook", "ingest", "codex-appserver-watch",
 		"--agent-uid", identity.AgentUID, "--pane-uid", identity.PaneUID, "--pane", identity.RuntimeID,
 		"--generation", identity.Generation, "--thread", identity.ThreadID}
-	if target.Route.flag == "-L" {
-		args = append(args, "--tmux-socket-name", target.Route.value)
-	} else if target.Route.flag == "-S" {
-		args = append(args, "--tmux-socket-path", target.Route.value)
+	if target.Route.Flag() == "-L" {
+		args = append(args, "--tmux-socket-name", target.Route.Value)
+	} else if target.Route.Flag() == "-S" {
+		args = append(args, "--tmux-socket-path", target.Route.Value)
 	} else {
 		return errors.New("codex native lifecycle observer requires an exact tmux route")
 	}
@@ -990,7 +990,7 @@ func parseCodexNativeLifecycleTarget(args []string) (codexLifecycleObserverTarge
 		case "--thread":
 			target.Identity.ThreadID = value
 		case "--tmux-socket-name":
-			if target.Route.flag != "" {
+			if target.Route.Flag() != "" {
 				return target, errors.New("codex app-server watcher accepts exactly one tmux route")
 			}
 			var err error
@@ -999,7 +999,7 @@ func parseCodexNativeLifecycleTarget(args []string) (codexLifecycleObserverTarge
 				return target, err
 			}
 		case "--tmux-socket-path":
-			if target.Route.flag != "" {
+			if target.Route.Flag() != "" {
 				return target, errors.New("codex app-server watcher accepts exactly one tmux route")
 			}
 			var err error

--- a/internal/app/ai_ingest_codex_native_test.go
+++ b/internal/app/ai_ingest_codex_native_test.go
@@ -157,7 +157,7 @@ func TestCodexObserverStartupUsesExactRouteAndFallsBackAfterProcessFailure(t *te
 		return nil, os.ErrNotExist
 	}
 	cmd.executable = func() (string, error) { return "/tmp/projmux.test", nil }
-	cmd.startNativeCodexLifecycleObserver(codexLifecycleObserverTarget{Identity: identity, Route: explicitTmuxTarget{flag: "-L", value: "exact"}})
+	cmd.startNativeCodexLifecycleObserver(codexLifecycleObserverTarget{Identity: identity, Route: tmuxTransport{Kind: tmuxSocketName, Value: "exact", Source: tmuxSocketNameSource}})
 	commands := cmdRecorder(cmd).commands
 	for _, command := range commands {
 		if len(command.args) < 2 || command.args[0] != "-L" || command.args[1] != "exact" {
@@ -175,7 +175,7 @@ func TestCodexObserverStartupUsesExactRouteAndFallsBackAfterProcessFailure(t *te
 	cmdRecorder(cmd).commands = nil
 	stale := identity
 	stale.Generation = "generation-replaced"
-	cmd.startNativeCodexLifecycleObserver(codexLifecycleObserverTarget{Identity: stale, Route: explicitTmuxTarget{flag: "-L", value: "exact"}})
+	cmd.startNativeCodexLifecycleObserver(codexLifecycleObserverTarget{Identity: stale, Route: tmuxTransport{Kind: tmuxSocketName, Value: "exact", Source: tmuxSocketNameSource}})
 	if commands := cmdRecorder(cmd).commands; len(commands) != 0 {
 		t.Fatalf("stale/reused runtime startup writes = %#v, want zero", commands)
 	}
@@ -201,15 +201,15 @@ func TestCodexLifecycleAuthorityWriteCompensatesFirstMiddleLastOnExactRoutes(t *
 	command := testAICommand(t.TempDir())
 	command.loadRegistry = store.store().load
 	fields := []string{aiPaneCodexAuthorityOption, aiPaneCodexEpochOption, aiPaneCodexReasonOption}
-	for _, route := range []explicitTmuxTarget{{flag: "-L", value: "authority"}, {flag: "-S", value: "/tmp/authority.sock"}} {
+	for _, route := range []tmuxTransport{{Kind: tmuxSocketName, Value: "authority", Source: tmuxSocketNameSource}, {Kind: tmuxSocketPath, Value: "/tmp/authority.sock", Source: tmuxSocketPathSource}} {
 		for failWrite := 1; failWrite <= len(fields); failWrite++ {
-			t.Run(strings.TrimPrefix(route.flag, "-")+fmt.Sprintf("/failure-%d", failWrite), func(t *testing.T) {
+			t.Run(strings.TrimPrefix(route.Flag(), "-")+fmt.Sprintf("/failure-%d", failWrite), func(t *testing.T) {
 				before := map[string]string{
 					tmuxopts.PaneUID: identity.PaneUID, aiPaneCodexAuthorityOption: "old-authority",
 					aiPaneCodexEpochOption: "old-epoch", aiPaneCodexReasonOption: "old-reason", "@sibling": "keep",
 				}
 				raw := &bindingFailureRunner{
-					targetFlag: route.flag, targetValue: route.value, options: maps.Clone(before),
+					targetFlag: route.Flag(), targetValue: route.Value, options: maps.Clone(before),
 					failWrite: failWrite, failureCommand: -1,
 				}
 				sink := aiCodexLifecycleSink{command: command, runner: explicitTmuxRunner{runner: raw, target: route}}
@@ -238,7 +238,7 @@ func TestCodexLifecycleAuthorityWriteCompensatesFirstMiddleLastOnExactRoutes(t *
 					}
 				}
 				for _, command := range raw.commands {
-					if len(command) < 2 || command[0] != route.flag || command[1] != route.value {
+					if len(command) < 2 || command[0] != route.Flag() || command[1] != route.Value {
 						t.Fatalf("authority escaped exact route: %q", raw.commands)
 					}
 				}
@@ -286,7 +286,7 @@ func TestCodexLifecycleObserverTargetRequiresAndPreservesExactRoute(t *testing.T
 		if err != nil {
 			t.Fatal(err)
 		}
-		if target.Identity != phase6Identity() || target.Route.value != routeArgs[1] {
+		if target.Identity != phase6Identity() || target.Route.Value != routeArgs[1] {
 			t.Fatalf("target = %+v, route args = %q", target, routeArgs)
 		}
 	}

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -72,7 +72,7 @@ func TestProductionAIPaneBindersUseOnlySuppliedExactRuntimeRoute(t *testing.T) {
 	tmux := newFakeTmux()
 	session := tmux.addSession("agent-bind")
 	paneID := session.windows[0].panes[0].id
-	routed := explicitTmuxRunner{runner: tmux, target: explicitTmuxTarget{flag: "-S", value: tmux.socketPath}}
+	routed := explicitTmuxRunner{runner: tmux, target: tmuxTransport{Kind: tmuxSocketPath, Value: tmux.socketPath, Source: tmuxSocketPathSource}}
 	cmd := testAICommand(t.TempDir())
 
 	if err := cmd.BindManagedAgentPaneOnRoute(context.Background(), routed, paneID, aiModeCodex, "/repo", "fresh"); err != nil {

--- a/internal/app/binding_convergence.go
+++ b/internal/app/binding_convergence.go
@@ -4,45 +4,37 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
-	"strings"
+
+	"github.com/crevissepartners/projmux/internal/core/resourcegraph"
 )
 
-// explicitTmuxTarget is the closed routing input of binding convergence.
-// Apply supplies a -L socket name; generated lifecycle hooks supply tmux's
-// expanded absolute #{socket_path} and therefore use -S. There is no empty
-// target and no fallback to the default socket or inherited $TMUX.
-type explicitTmuxTarget struct {
-	flag  string
-	value string
+// tmuxTransport is only a package-local spelling of the resourcegraph owner.
+// It adds no fields or routing rules: raw name/path/inherited precedence is
+// decided exclusively by resourcegraph.ResolveTransport.
+type tmuxTransport = resourcegraph.Transport
+
+const (
+	tmuxSocketName       = resourcegraph.TransportSocketName
+	tmuxSocketPath       = resourcegraph.TransportSocketPath
+	tmuxSocketNameSource = resourcegraph.TransportSourceSocketName
+	tmuxSocketPathSource = resourcegraph.TransportSourceSocketPath
+	tmuxInheritedSource  = resourcegraph.TransportSourceInheritedEnv
+)
+
+func tmuxSocketNameTarget(name string) (tmuxTransport, error) {
+	target, err := resourcegraph.ResolveTransport(resourcegraph.TransportRequest{SocketName: name})
+	if err != nil || !target.Present() {
+		return tmuxTransport{}, errors.New("binding convergence requires an explicit tmux socket name")
+	}
+	return target, nil
 }
 
-// label renders the target the way the delete result reports it: the flag the
-// route used and the value it was given, never the app socket's default name.
-// Reporting a fixed `-L/projmux` was accurate only while the delete routes
-// could reach exactly one server; now that they resolve one, saying which is
-// the whole point of the line.
-func (t explicitTmuxTarget) label() string {
-	if t.flag == "" || t.value == "" {
-		return "none"
+func tmuxSocketPathTarget(path string) (tmuxTransport, error) {
+	target, err := resourcegraph.ResolveTransport(resourcegraph.TransportRequest{SocketPath: path})
+	if err != nil || !target.Present() {
+		return tmuxTransport{}, errors.New("binding convergence requires an absolute tmux socket path")
 	}
-	return t.flag + "/" + t.value
-}
-
-func tmuxSocketNameTarget(name string) (explicitTmuxTarget, error) {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return explicitTmuxTarget{}, errors.New("binding convergence requires an explicit tmux socket name")
-	}
-	return explicitTmuxTarget{flag: "-L", value: name}, nil
-}
-
-func tmuxSocketPathTarget(path string) (explicitTmuxTarget, error) {
-	path = strings.TrimSpace(path)
-	if path == "" || !filepath.IsAbs(path) {
-		return explicitTmuxTarget{}, errors.New("binding convergence requires an absolute tmux socket path")
-	}
-	return explicitTmuxTarget{flag: "-S", value: filepath.Clean(path)}, nil
+	return target, nil
 }
 
 // explicitTmuxRunner routes every tmux read and write through one exact server.
@@ -50,7 +42,7 @@ func tmuxSocketPathTarget(path string) (explicitTmuxTarget, error) {
 // so matcher/reconciler/writer behavior is reused without adding a uid writer.
 type explicitTmuxRunner struct {
 	runner tmuxCommandRunner
-	target explicitTmuxTarget
+	target tmuxTransport
 }
 
 func (r explicitTmuxRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
@@ -60,11 +52,11 @@ func (r explicitTmuxRunner) Run(ctx context.Context, name string, args ...string
 	if name != "tmux" {
 		return nil, fmt.Errorf("binding convergence cannot route executable %q", name)
 	}
-	if r.target.flag == "" || r.target.value == "" {
+	if !r.target.Present() {
 		return nil, errors.New("binding convergence has no explicit tmux target")
 	}
 	routed := make([]string, 0, len(args)+2)
-	routed = append(routed, r.target.flag, r.target.value)
+	routed = append(routed, r.target.Args()...)
 	routed = append(routed, args...)
 	return r.runner.Run(ctx, name, routed...)
 }

--- a/internal/app/binding_convergence_test.go
+++ b/internal/app/binding_convergence_test.go
@@ -124,8 +124,8 @@ func (r *recordingTriggering) run(_ context.Context, trigger controllerTrigger) 
 	}, nil
 }
 
-func (r *recordingTriggering) targets() []explicitTmuxTarget {
-	out := make([]explicitTmuxTarget, 0, len(r.triggers))
+func (r *recordingTriggering) targets() []tmuxTransport {
+	out := make([]tmuxTransport, 0, len(r.triggers))
 	for _, trigger := range r.triggers {
 		out = append(out, trigger.target)
 	}
@@ -335,7 +335,7 @@ func TestGeneratedLifecycleTriggersConvergeOnOneEntrypoint(t *testing.T) {
 	if err := cmd.runConverge([]string{"--socket-path", path, "--session", "alpha", "--reason", "runtime-created"}, &stderr); err != nil {
 		t.Fatalf("hidden lifecycle command: %v; stderr=%q", err, stderr.String())
 	}
-	want := []controllerTrigger{{reason: controllerTriggerRuntimeCreated, target: explicitTmuxTarget{flag: "-S", value: path}, session: "alpha"}}
+	want := []controllerTrigger{{reason: controllerTriggerRuntimeCreated, target: tmuxTransport{Kind: tmuxSocketPath, Value: path, Source: tmuxSocketPathSource}, session: "alpha"}}
 	if !reflect.DeepEqual(recorder.triggers, want) {
 		t.Fatalf("trigger = %+v, want %+v", recorder.triggers, want)
 	}
@@ -458,7 +458,7 @@ func TestApplyConvergesOnlyAfterSuccessfulReloadOnTheSameSocket(t *testing.T) {
 	if err := cmd.runApply([]string{"--config", configPath, "--socket", "isolated"}, &stdout, &stderr); err != nil {
 		t.Fatalf("apply: %v; stderr=%q", err, stderr.String())
 	}
-	if want := []explicitTmuxTarget{{flag: "-S", value: "/tmp/tmux-1000/isolated"}}; !reflect.DeepEqual(recorder.targets(), want) {
+	if want := []tmuxTransport{{Kind: tmuxSocketPath, Value: "/tmp/tmux-1000/isolated", Source: tmuxSocketPathSource}}; !reflect.DeepEqual(recorder.targets(), want) {
 		t.Fatalf("convergence targets = %+v, want %+v", recorder.targets(), want)
 	}
 	// Apply carries no hook session: it is not caused by a create, so it has no
@@ -503,7 +503,7 @@ func TestApplyConvergesOnlyAfterSuccessfulReloadOnTheSameSocket(t *testing.T) {
 	if configWrites != 1 {
 		t.Fatalf("repeat apply rewrote generated config: writes=%d", configWrites)
 	}
-	if want := []explicitTmuxTarget{{flag: "-S", value: "/tmp/tmux-1000/isolated"}}; !reflect.DeepEqual(recorder.targets(), want) {
+	if want := []tmuxTransport{{Kind: tmuxSocketPath, Value: "/tmp/tmux-1000/isolated", Source: tmuxSocketPathSource}}; !reflect.DeepEqual(recorder.targets(), want) {
 		t.Fatalf("repeat convergence targets = %+v, want %+v", recorder.targets(), want)
 	}
 

--- a/internal/app/control_session.go
+++ b/internal/app/control_session.go
@@ -130,15 +130,15 @@ func (c *controlSessionConverger) converge(ctx context.Context, socketName, sess
 // convergeTarget is shared by shell lifecycle and config-apply. The caller has
 // already declared both coordinates; there is no inherited/default socket
 // fallback and no session-name inference inside this method.
-func (c *controlSessionConverger) convergeTarget(ctx context.Context, target explicitTmuxTarget, sessionName string) (controlSessionConvergence, error) {
+func (c *controlSessionConverger) convergeTarget(ctx context.Context, target tmuxTransport, sessionName string) (controlSessionConvergence, error) {
 	return c.convergeTargetWithEvidence(ctx, target, sessionName, true)
 }
 
-func (c *controlSessionConverger) convergeTargetWithEvidence(ctx context.Context, target explicitTmuxTarget, sessionName string, declared bool) (controlSessionConvergence, error) {
+func (c *controlSessionConverger) convergeTargetWithEvidence(ctx context.Context, target tmuxTransport, sessionName string, declared bool) (controlSessionConvergence, error) {
 	if c == nil || c.runner == nil {
 		return controlSessionConvergence{}, errors.New("control session convergence requires a tmux runner")
 	}
-	if target.flag == "" || strings.TrimSpace(target.value) == "" || strings.TrimSpace(sessionName) == "" {
+	if target.Flag() == "" || strings.TrimSpace(target.Value) == "" || strings.TrimSpace(sessionName) == "" {
 		return controlSessionConvergence{}, errors.New("control session convergence requires an exact tmux target and session declaration")
 	}
 	mirror := intmetadata.NewMirror(explicitTmuxRunner{runner: c.runner, target: target})
@@ -259,11 +259,11 @@ func controlPlanNeedsBinding(plan controller.ControlTargetPlan) bool {
 		controlPlanHas(plan, controller.ControlEnsurePaneMirror)
 }
 
-func controlTargetControllerState(target explicitTmuxTarget, sessionName string, declared bool, markers intmetadata.ControlSessionMarkers,
+func controlTargetControllerState(target tmuxTransport, sessionName string, declared bool, markers intmetadata.ControlSessionMarkers,
 	registry coremetadata.Registry, observed coremetadata.ControlSessionObservation, targets intmetadata.LegacyTargets,
 ) controller.ControlTargetState {
 	state := controller.ControlTargetState{
-		Declaration: controller.ControlTargetDeclaration{Transport: controllerTransport(target), Session: sessionName, Declared: declared},
+		Declaration: controller.ControlTargetDeclaration{Transport: target.ExplicitProjection(), Session: sessionName, Declared: declared},
 		AppOwned:    markers.AppOwned, Ephemeral: markers.Ephemeral, Role: markers.Role, ProjectUID: markers.ProjectUID,
 	}
 	for _, project := range registry.Projects {
@@ -376,7 +376,7 @@ func observeMirroredUIDs(ctx context.Context, mirror intmetadata.Mirror) (coreme
 // writer with weaker guarantees.
 func executeControlSessionIdentityPlan(
 	ctx context.Context,
-	target explicitTmuxTarget,
+	target tmuxTransport,
 	sessionName string,
 	mirror intmetadata.Mirror,
 	registry coremetadata.Registry,
@@ -393,20 +393,20 @@ func executeControlSessionIdentityPlan(
 	for {
 		switch explicit := transport.(type) {
 		case explicitTmuxRunner:
-			if explicit.target.flag == "-L" && explicit.target != target {
+			if explicit.target.Flag() == "-L" && !explicit.target.SameRoute(target) {
 				return 0, errors.New("ControlSession identity plan route disagrees with its mirror")
 			}
-			if explicit.target.flag == "-S" {
-				boundPaths = append(boundPaths, filepath.Clean(explicit.target.value))
+			if explicit.target.Flag() == "-S" {
+				boundPaths = append(boundPaths, filepath.Clean(explicit.target.Value))
 			}
 			transport = explicit.runner
 			continue
 		case *explicitTmuxRunner:
-			if explicit.target.flag == "-L" && explicit.target != target {
+			if explicit.target.Flag() == "-L" && !explicit.target.SameRoute(target) {
 				return 0, errors.New("ControlSession identity plan route disagrees with its mirror")
 			}
-			if explicit.target.flag == "-S" {
-				boundPaths = append(boundPaths, filepath.Clean(explicit.target.value))
+			if explicit.target.Flag() == "-S" {
+				boundPaths = append(boundPaths, filepath.Clean(explicit.target.Value))
 			}
 			transport = explicit.runner
 			continue
@@ -424,13 +424,13 @@ func executeControlSessionIdentityPlan(
 			return 0, errors.New("ControlSession identity plan physical route disagrees with its mirror")
 		}
 	}
-	routed := explicitTmuxRunner{runner: transport, target: explicitTmuxTarget{flag: "-S", value: expectedSocket}}
+	routed := explicitTmuxRunner{runner: transport, target: tmuxTransport{Kind: tmuxSocketPath, Value: expectedSocket, Source: tmuxSocketPathSource}}
 	sessionOut, err := routed.Run(ctx, "tmux", "display-message", "-p", "-t", sessionName, "-F", "#{session_id}")
 	if err != nil || exactTmuxHandle(strings.TrimSpace(string(sessionOut)), "$") == "" {
 		return 0, errors.New("ControlSession identity plan: exact session handle is unavailable")
 	}
 	sessionID := strings.TrimSpace(string(sessionOut))
-	socket := target.flag + "=" + target.value
+	socket := target.Flag() + "=" + target.Value
 	var steps []runtimeMutationStep
 	logicalWrites := 0
 	appendWrite := func(verb runtimeMutationVerb, stable runtimeMutationTarget, expect string, operands []string,

--- a/internal/app/control_session_test.go
+++ b/internal/app/control_session_test.go
@@ -190,7 +190,7 @@ func TestControlSessionIdentityPlanNormalizesAutomaticRenameFormatBoolean(t *tes
 
 func TestControlSessionIdentityPlanFlattensEquivalentNestedRoutes(t *testing.T) {
 	converger, _, server, runner := controlSessionFixture(t)
-	converger.runner = explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: server.socketPath}}
+	converger.runner = explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: server.socketPath, Source: tmuxSocketPathSource}}
 
 	result, err := converger.converge(context.Background(), controlFixtureSocket, "home")
 	if err != nil {
@@ -208,7 +208,7 @@ func TestControlSessionIdentityPlanRefusesMismatchedNestedPhysicalRoute(t *testi
 	converger, store, _, runner := controlSessionFixture(t)
 	server := runner.servers["-L\x00"+controlFixtureSocket]
 	runner.servers["-S\x00/tmp/foreign-control.sock"] = server
-	converger.runner = explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: "/tmp/foreign-control.sock"}}
+	converger.runner = explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/foreign-control.sock", Source: tmuxSocketPathSource}}
 
 	_, err := converger.converge(context.Background(), controlFixtureSocket, "home")
 	if err == nil || !strings.Contains(err.Error(), "physical route disagrees") {
@@ -270,11 +270,11 @@ func TestControlSessionIdentityConvergenceNeverOverwritesForeignDescendantUID(t 
 			}
 			mirror := intmetadata.NewMirror(explicitTmuxRunner{
 				runner: runner,
-				target: explicitTmuxTarget{flag: "-L", value: controlFixtureSocket},
+				target: tmuxTransport{Kind: tmuxSocketName, Value: controlFixtureSocket, Source: tmuxSocketNameSource},
 			})
 			_, err := executeControlSessionIdentityPlan(
 				context.Background(),
-				explicitTmuxTarget{flag: "-L", value: controlFixtureSocket},
+				tmuxTransport{Kind: tmuxSocketName, Value: controlFixtureSocket, Source: tmuxSocketNameSource},
 				"home",
 				mirror,
 				registry,

--- a/internal/app/controller_events.go
+++ b/internal/app/controller_events.go
@@ -116,16 +116,16 @@ func newControllerEventNonce() (string, error) {
 // not perform, because the log is consulted before any tmux call. Two spellings
 // of one server therefore get two leases, which costs one redundant convergence
 // pass and never loses one.
-func (l controllerEventLog) key(target explicitTmuxTarget) string {
-	sum := sha256.Sum256([]byte(target.flag + "\x00" + target.value))
+func (l controllerEventLog) key(target tmuxTransport) string {
+	sum := sha256.Sum256([]byte(target.Flag() + "\x00" + target.Value))
 	return hex.EncodeToString(sum[:8])
 }
 
-func (l controllerEventLog) eventsDir(target explicitTmuxTarget) string {
+func (l controllerEventLog) eventsDir(target tmuxTransport) string {
 	return filepath.Join(l.dir, l.key(target)+".events")
 }
 
-func (l controllerEventLog) lockPath(target explicitTmuxTarget) string {
+func (l controllerEventLog) lockPath(target tmuxTransport) string {
 	return filepath.Join(l.dir, l.key(target)+".lock")
 }
 
@@ -151,7 +151,7 @@ func (l controllerEventLog) mark(trigger controllerTrigger) error {
 		return errors.New("controller event log has no state directory")
 	}
 	target := trigger.target
-	if target.flag == "" || target.value == "" {
+	if target.Flag() == "" || target.Value == "" {
 		return errors.New("controller event log requires an explicit tmux target")
 	}
 	dir := l.eventsDir(target)
@@ -215,7 +215,7 @@ func (l controllerEventLog) mark(trigger controllerTrigger) error {
 // arrives during a pass count as a new one: the alternative acknowledges work
 // the pass could not have seen, which is precisely the lost-wakeup this loop
 // exists to avoid.
-func (l controllerEventLog) drain(target explicitTmuxTarget) ([]controllerTrigger, error) {
+func (l controllerEventLog) drain(target tmuxTransport) ([]controllerTrigger, error) {
 	dir := l.eventsDir(target)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -271,7 +271,7 @@ func controllerEventPriority(reason controllerTriggerReason) int {
 
 // pending reports whether any event is currently recorded for target. It is a
 // read: it creates nothing and removes nothing.
-func (l controllerEventLog) pending(target explicitTmuxTarget) (bool, error) {
+func (l controllerEventLog) pending(target tmuxTransport) (bool, error) {
 	entries, err := os.ReadDir(l.eventsDir(target))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -293,7 +293,7 @@ func (l controllerEventLog) pending(target explicitTmuxTarget) (bool, error) {
 // another worker holds the lease, and that worker will drain the event this
 // caller just marked. The caller's correct response is to exit, which is what
 // makes the burst cost one convergence instead of one per event.
-func (l controllerEventLog) acquire(target explicitTmuxTarget) (func(), bool, error) {
+func (l controllerEventLog) acquire(target tmuxTransport) (func(), bool, error) {
 	if strings.TrimSpace(l.dir) == "" {
 		return nil, false, errors.New("controller event log has no state directory")
 	}

--- a/internal/app/controller_runtime_mutation.go
+++ b/internal/app/controller_runtime_mutation.go
@@ -18,7 +18,7 @@ import (
 // physical server generation. Explicit standalone reconcile is an internal
 // operator grant over --socket-path only: action-specific graph guards provide
 // the real handle/owner containment, so this route never invents a Pane receipt.
-func resolveControllerRuntimeMutationRoute(ctx context.Context, runner tmuxCommandRunner, target explicitTmuxTarget, lookupEnv func(string) string) (runtimeMutationRoute, error) {
+func resolveControllerRuntimeMutationRoute(ctx context.Context, runner tmuxCommandRunner, target tmuxTransport, lookupEnv func(string) string) (runtimeMutationRoute, error) {
 	route, err := resolveExistingRuntimeMutationRoute(ctx, runner, target, lookupEnv)
 	if err == nil {
 		return route, nil
@@ -26,7 +26,7 @@ func resolveControllerRuntimeMutationRoute(ctx context.Context, runner tmuxComma
 	if !strings.Contains(err.Error(), "standalone authority requires exact inherited TMUX receipt") {
 		return runtimeMutationRoute{}, err
 	}
-	if target.flag != "-S" {
+	if target.Flag() != "-S" {
 		return runtimeMutationRoute{}, errors.New("controller standalone mutation requires explicit --socket-path authority")
 	}
 	routed := explicitTmuxRunner{runner: runner, target: target}
@@ -39,7 +39,7 @@ func resolveControllerRuntimeMutationRoute(ctx context.Context, runner tmuxComma
 	}
 	path, pid := strings.TrimSpace(string(pathOut)), strings.TrimSpace(string(pidOut))
 	parsedPID, parseErr := strconv.Atoi(pid)
-	if !filepath.IsAbs(path) || filepath.Clean(path) != path || path != target.value || parseErr != nil || parsedPID <= 0 {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path || path != target.Value || parseErr != nil || parsedPID <= 0 {
 		return runtimeMutationRoute{}, errors.New("controller standalone authority has no exact physical path/PID receipt")
 	}
 	if strings.TrimSpace(string(appOut)) != "" || strings.TrimSpace(string(logicalOut)) != "" {
@@ -383,7 +383,7 @@ func guardControllerRuntimeMutationFinal(ctx context.Context, runner tmuxCommand
 	if err := guardPrintedRuntimeMutationRoute(ctx, runner, route, action); err != nil {
 		return err
 	}
-	exact := explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}}
+	exact := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}}
 	for _, guard := range write.Guards {
 		out, err := exact.Run(ctx, "tmux", "display-message", "-p", "-t", write.Target, "-F", "#{"+guard.Field+"}")
 		if err != nil || strings.TrimSpace(string(out)) != controllerFinalGuardValue(final, write, guard) {
@@ -397,7 +397,7 @@ func guardControllerRuntimeMutation(ctx context.Context, runner tmuxCommandRunne
 	if err := guardPrintedRuntimeMutationRoute(ctx, runner, route, action); err != nil {
 		return err
 	}
-	exact := explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}}
+	exact := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}}
 	for _, guard := range write.Guards {
 		out, err := exact.Run(ctx, "tmux", "display-message", "-p", "-t", write.Target, "-F", "#{"+guard.Field+"}")
 		if err != nil {
@@ -422,7 +422,7 @@ func observeControllerRuntimeMutation(ctx context.Context, runner tmuxCommandRun
 	if err := guardPrintedRuntimeMutationRoute(ctx, runner, route, action); err != nil {
 		return false, err
 	}
-	exact := explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}}
+	exact := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}}
 	for _, guard := range write.Guards {
 		out, err := exact.Run(ctx, "tmux", "display-message", "-p", "-t", write.Target, "-F", "#{"+guard.Field+"}")
 		if err != nil {
@@ -535,7 +535,7 @@ func executeControllerRuntimeMutations(ctx context.Context, runner tmuxCommandRu
 				if err := guardPrintedRuntimeMutationRoute(ctx, runner, route, action); err != nil {
 					return err
 				}
-				exact := explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}}
+				exact := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}}
 				out, err := exact.Run(ctx, "tmux", "display-message", "-p", "-t", write.Target, "-F", "#{"+write.Field+"}")
 				if err != nil {
 					return errors.New("controller rollback target effect is unreadable")

--- a/internal/app/controller_runtime_mutation_test.go
+++ b/internal/app/controller_runtime_mutation_test.go
@@ -61,7 +61,7 @@ func controllerMutationFixture(t *testing.T) (*fakeTmux, *routedTmuxRunner, runt
 	session.opts[tmuxopts.ProjectNameSession] = "before"
 	runner := &routedTmuxRunner{servers: map[string]*fakeTmux{"-L\x00primary": server}}
 	route := runtimeMutationRoute{
-		target:             explicitTmuxTarget{flag: "-L", value: "primary"},
+		target:             tmuxTransport{Kind: tmuxSocketName, Value: "primary", Source: tmuxSocketNameSource},
 		expectedSocketPath: server.socketPath, socketName: "primary",
 		authority: &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: server.serverPID},
 	}
@@ -128,7 +128,7 @@ func TestControllerRuntimeMutationAcceptsExactSiblingUIDEffectBetweenPlanAndGuar
 		session.opts[tmuxopts.ProjectPathSession] = "/before"
 		runner := &routedTmuxRunner{servers: map[string]*fakeTmux{"-L\x00primary": server}}
 		route := runtimeMutationRoute{
-			target: explicitTmuxTarget{flag: "-L", value: "primary"}, expectedSocketPath: server.socketPath,
+			target: tmuxTransport{Kind: tmuxSocketName, Value: "primary", Source: tmuxSocketNameSource}, expectedSocketPath: server.socketPath,
 			socketName: "primary", authority: &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: server.serverPID},
 		}
 		guard := []controller.Guard{{Field: tmuxopts.ProjectUIDSession, Expect: ""}}
@@ -194,7 +194,7 @@ func TestAuthorshipPromotionRuntimeRollbackIsIndependentOfActionOrder(t *testing
 			pane.opts[tmuxopts.AgentProviderPane] = "codex"
 			pane.opts[tmuxopts.AgentLaunchAuthorshipPane] = "1"
 			runner := &routedTmuxRunner{servers: map[string]*fakeTmux{"-L\x00primary": server}}
-			route := runtimeMutationRoute{target: explicitTmuxTarget{flag: "-L", value: "primary"}, expectedSocketPath: server.socketPath,
+			route := runtimeMutationRoute{target: tmuxTransport{Kind: tmuxSocketName, Value: "primary", Source: tmuxSocketNameSource}, expectedSocketPath: server.socketPath,
 				socketName: "primary", authority: &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: server.serverPID}}
 			values := map[string]string{
 				tmuxopts.AgentUIDPane: "agent-promotion", tmuxopts.PaneOwnerKind: "Agent",
@@ -238,7 +238,7 @@ func TestControllerNonUIDOptionsHaveTypedEffectsRepeatEmptyAndOwnedRollback(t *t
 		base := &routedTmuxRunner{servers: map[string]*fakeTmux{"-L\x00primary": server}}
 		runner := controllerBooleanOptionRunner{base: base}
 		route := runtimeMutationRoute{
-			target: explicitTmuxTarget{flag: "-L", value: "primary"}, expectedSocketPath: server.socketPath, socketName: "primary",
+			target: tmuxTransport{Kind: tmuxSocketName, Value: "primary", Source: tmuxSocketNameSource}, expectedSocketPath: server.socketPath, socketName: "primary",
 			authority: &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: server.serverPID},
 		}
 		guards := []controller.Guard{{Field: tmuxopts.WindowUID, Expect: ""}, {Field: "session_id", Expect: session.id}}
@@ -507,7 +507,7 @@ func TestControllerUIDMintAndUnsetRollbackDistinguishNoEffectFromOwnedEffect(t *
 				session := server.addSession("alpha")
 				session.opts[tmuxopts.ProjectUIDSession] = operation.before
 				runner := &routedTmuxRunner{servers: map[string]*fakeTmux{"-L\x00primary": server}}
-				route := runtimeMutationRoute{target: explicitTmuxTarget{flag: "-L", value: "primary"}, expectedSocketPath: server.socketPath, socketName: "primary", authority: &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: server.serverPID}}
+				route := runtimeMutationRoute{target: tmuxTransport{Kind: tmuxSocketName, Value: "primary", Source: tmuxSocketNameSource}, expectedSocketPath: server.socketPath, socketName: "primary", authority: &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: server.serverPID}}
 				write := controllerClosedWrite(resourcegraph.ObjectSession, session.id, operation.before, tmuxopts.ProjectUIDSession, operation.before, operation.after)
 				server.fail, server.failAfterMutation, server.failMessage = []string{"set-option", tmuxopts.ProjectUIDSession}, failure.afterEffect, "injected UID apply failure"
 				beforeWrites := tmuxMutationCallCount(server)
@@ -541,7 +541,7 @@ func TestRealL8OrphanRecoveryPrintsOwnedUIDForEveryUnset(t *testing.T) {
 		SessionID: "session_id", WindowID: "window_id",
 	}, controller.Grant{}, candidates)
 	route := runtimeMutationRoute{
-		target: explicitTmuxTarget{flag: "-L", value: "primary"}, expectedSocketPath: "/tmp/controller-l8", socketName: "primary",
+		target: tmuxTransport{Kind: tmuxSocketName, Value: "primary", Source: tmuxSocketNameSource}, expectedSocketPath: "/tmp/controller-l8", socketName: "primary",
 		authority: &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: "4242"},
 	}
 	final := map[string]string{}
@@ -665,7 +665,7 @@ func TestControllerExplicitStandaloneAuthorityNeverInfersAPane(t *testing.T) {
 	server.addSession("operator")
 	runner := &routedTmuxRunner{servers: map[string]*fakeTmux{"-S\x00" + server.socketPath: server}}
 	route, err := resolveControllerRuntimeMutationRoute(context.Background(), runner,
-		explicitTmuxTarget{flag: "-S", value: server.socketPath}, func(string) string { return "" })
+		tmuxTransport{Kind: tmuxSocketPath, Value: server.socketPath, Source: tmuxSocketPathSource}, func(string) string { return "" })
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -679,7 +679,7 @@ func TestControllerExplicitStandaloneAuthorityNeverInfersAPane(t *testing.T) {
 		}
 	}
 	if _, err := resolveControllerRuntimeMutationRoute(context.Background(), runner,
-		explicitTmuxTarget{flag: "-L", value: "operator"}, func(string) string { return "" }); err == nil {
+		tmuxTransport{Kind: tmuxSocketName, Value: "operator", Source: tmuxSocketNameSource}, func(string) string { return "" }); err == nil {
 		t.Fatal("logical standalone route acquired internal explicit-path authority")
 	}
 }

--- a/internal/app/controller_trigger.go
+++ b/internal/app/controller_trigger.go
@@ -120,7 +120,7 @@ type controllerTrigger struct {
 	// target is the exact server. There is no zero value and no fallback to the
 	// default socket or to inherited $TMUX: a generated hook passes tmux's own
 	// expanded `#{socket_path}`, and apply passes the `-L` name it reloaded.
-	target explicitTmuxTarget
+	target tmuxTransport
 	// session is a create hook's current `#{session_id}` or window-unlinked's
 	// exact `#{hook_session}`. It is empty for apply and pane-exited.
 	session string
@@ -146,7 +146,7 @@ func (t controllerTrigger) widened() controllerTrigger {
 }
 
 func (t controllerTrigger) describe() string {
-	out := string(t.reason) + " socket=" + t.target.label()
+	out := string(t.reason) + " socket=" + t.target.Label()
 	if session := strings.TrimSpace(t.session); session != "" {
 		out += " session=" + session
 	}
@@ -256,10 +256,10 @@ type controllerTriggerRunner struct {
 	// not be taken is indistinguishable from an empty one, and reading it as
 	// empty would file an unknown termination against every managed Pane on a
 	// machine whose tmux server simply is not up.
-	observe func(explicitTmuxTarget) livePaneInventory
+	observe func(tmuxTransport) livePaneInventory
 	// deferToCreate reports that a live canonical create owns the registry lock
 	// for this hook's session.
-	deferToCreate func(context.Context, explicitTmuxTarget, string) (bool, error)
+	deferToCreate func(context.Context, tmuxTransport, string) (bool, error)
 	// newOperationID labels each pass's registry transaction.
 	newOperationID func() (string, error)
 	// pass is the convergence body. Production leaves it nil and uses converge
@@ -317,7 +317,7 @@ func (r *controllerTriggerRunner) run(ctx context.Context, trigger controllerTri
 	if !slices.Contains(controllerTriggerReasons(), trigger.reason) {
 		return outcome, fmt.Errorf("controller trigger carries no reason: %s", trigger.describe())
 	}
-	if trigger.target.flag == "" || trigger.target.value == "" {
+	if trigger.target.Flag() == "" || trigger.target.Value == "" {
 		return outcome, errors.New("controller trigger requires an explicit tmux target")
 	}
 	if r.runner == nil {
@@ -334,7 +334,7 @@ func (r *controllerTriggerRunner) run(ctx context.Context, trigger controllerTri
 	if session := strings.TrimSpace(trigger.session); session != "" && trigger.reason == controllerTriggerRuntimeCreated {
 		defers := r.deferToCreate
 		if defers == nil {
-			defers = func(ctx context.Context, target explicitTmuxTarget, session string) (bool, error) {
+			defers = func(ctx context.Context, target tmuxTransport, session string) (bool, error) {
 				return deferBindingConvergence(ctx, r.runner, target, session)
 			}
 		}
@@ -621,7 +621,7 @@ func (r *controllerTriggerRunner) converge(ctx context.Context, trigger controll
 	if !trigger.fullReobserve && (trigger.reason == controllerTriggerPaneExited || trigger.reason == controllerTriggerWindowUnlinked) {
 		observe := r.observe
 		if observe == nil {
-			observe = func(target explicitTmuxTarget) livePaneInventory {
+			observe = func(target tmuxTransport) livePaneInventory {
 				return lifecycleInventory(r.runner, target)
 			}
 		}
@@ -652,7 +652,7 @@ func (r *controllerTriggerRunner) converge(ctx context.Context, trigger controll
 	if err != nil {
 		return pass, err
 	}
-	routed := explicitTmuxRunner{runner: r.runner, target: explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}}
+	routed := explicitTmuxRunner{runner: r.runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}}
 	newReconciler := r.newReconciler
 	if newReconciler == nil {
 		reconciler := newRegistryReconcilerWithRoute(routed, inttmux.NewClient(routed), route)
@@ -692,7 +692,7 @@ func (r *controllerTriggerRunner) converge(ctx context.Context, trigger controll
 
 	observe := r.observe
 	if observe == nil {
-		observe = func(target explicitTmuxTarget) livePaneInventory {
+		observe = func(target tmuxTransport) livePaneInventory {
 			return lifecycleInventory(r.runner, target)
 		}
 	}
@@ -715,7 +715,7 @@ func (r *controllerTriggerRunner) converge(ctx context.Context, trigger controll
 // the canonical Home declaration, which is the one authority allowed to mint a
 // missing root; hook triggers may only continue identities the Registry already
 // records.
-func (r *controllerTriggerRunner) convergeControlTargets(ctx context.Context, target explicitTmuxTarget, declareHome bool) (controlSessionConvergence, error) {
+func (r *controllerTriggerRunner) convergeControlTargets(ctx context.Context, target tmuxTransport, declareHome bool) (controlSessionConvergence, error) {
 	routed := explicitTmuxRunner{runner: r.runner, target: target}
 	out, err := routed.Run(ctx, "tmux", "list-sessions", "-F", "#{session_name}")
 	if err != nil {
@@ -778,7 +778,7 @@ func (r *controllerTriggerRunner) convergeControlTargets(ctx context.Context, ta
 // bytes used by the classifier. The callback never changes those bytes, so the
 // convergent store remains a Registry-write no-op.
 func runLockedAutomaticMirrorRecovery(ctx context.Context, store *resourceStore, runner tmuxCommandRunner,
-	target explicitTmuxTarget, trigger controller.RecoveryTrigger, routeHint ...runtimeMutationRoute) (int, error) {
+	target tmuxTransport, trigger controller.RecoveryTrigger, routeHint ...runtimeMutationRoute) (int, error) {
 	if store == nil || store.updateConvergent == nil {
 		return 0, errors.New("automatic recovery write store is not configured")
 	}
@@ -805,7 +805,7 @@ func verifyAutomaticRecoveryRegistryUnchanged(before, after coremetadata.Registr
 	return nil
 }
 
-func runAutomaticMirrorRecovery(ctx context.Context, runner tmuxCommandRunner, target explicitTmuxTarget,
+func runAutomaticMirrorRecovery(ctx context.Context, runner tmuxCommandRunner, target tmuxTransport,
 	registry coremetadata.Registry, trigger controller.RecoveryTrigger, routeHint ...runtimeMutationRoute) (int, error) {
 	if !trigger.Valid() {
 		return 0, fmt.Errorf("automatic recovery trigger %q is outside the closed authority table", trigger)
@@ -831,9 +831,9 @@ func runAutomaticMirrorRecovery(ctx context.Context, runner tmuxCommandRunner, t
 			return 0, err
 		}
 	}
-	exactTarget := explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}
-	inventory := intmetadata.NewInventoryObserver(runner, controllerTransport(exactTarget)).Observe(ctx)
-	inventory.Transport = controllerTransport(target)
+	exactTarget := tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}
+	inventory := intmetadata.NewInventoryObserver(runner, exactTarget.ExplicitProjection()).Observe(ctx)
+	inventory.Transport = target.ExplicitProjection()
 	graph := resourcegraph.Resolve(registry, inventory)
 	candidates := controllerRecoveryCandidates(graph, trigger)
 	if len(candidates) == 0 {
@@ -866,7 +866,7 @@ func (r *controllerTriggerRunner) awaitRuntimeExitTerminationReceipts(ctx contex
 	receipts []coremetadata.TerminationEvidence) ([]coremetadata.TerminationEvidence, error) {
 	observe := r.observe
 	if observe == nil {
-		observe = func(target explicitTmuxTarget) livePaneInventory {
+		observe = func(target tmuxTransport) livePaneInventory {
 			return lifecycleInventory(r.runner, target)
 		}
 	}

--- a/internal/app/controller_trigger_test.go
+++ b/internal/app/controller_trigger_test.go
@@ -27,9 +27,9 @@ import (
 // local to one test.
 type triggerFixture struct {
 	runner *controllerTriggerRunner
-	target explicitTmuxTarget
+	target tmuxTransport
 	// passes records the target of every convergence body invocation.
-	passes []explicitTmuxTarget
+	passes []tmuxTransport
 	// triggers records the scope handed to each convergence body invocation.
 	triggers []controllerTrigger
 	// results is consumed one entry per pass; the last entry repeats.
@@ -514,7 +514,7 @@ func TestTheTriggerRefusesAnythingButOneExactServerAndOneDeclaredReason(t *testi
 	fixture := newTriggerFixture(t)
 	for _, trigger := range []controllerTrigger{
 		{reason: controllerTriggerPaneKilled},
-		{reason: controllerTriggerPaneKilled, target: explicitTmuxTarget{flag: "-L"}},
+		{reason: controllerTriggerPaneKilled, target: tmuxTransport{Kind: tmuxSocketName}},
 		{target: fixture.target},
 		{reason: controllerTriggerReason("made-up"), target: fixture.target},
 	} {

--- a/internal/app/create.go
+++ b/internal/app/create.go
@@ -158,7 +158,7 @@ func (c *createCommand) observeWindowRuntimeBinding(
 
 func newCreateCommand() *createCommand {
 	runner := inttmux.ExecRunner{}
-	target := explicitTmuxTarget{flag: "-L", value: defaultAppSocket}
+	target := tmuxTransport{Kind: tmuxSocketName, Value: defaultAppSocket, Source: tmuxSocketNameSource}
 	routed := explicitTmuxRunner{runner: runner, target: target}
 	client := defaultTmuxClientWithRunner(routed)
 	home, _ := os.UserHomeDir()

--- a/internal/app/create_agent_test.go
+++ b/internal/app/create_agent_test.go
@@ -350,7 +350,7 @@ func TestExactProjectCreateWindowUsesAppRouteDespiteStaleInheritedPane(t *testin
 	if err != nil || stderr != "" || exactTmuxHandle(strings.TrimSpace(stdout), "%") == "" {
 		t.Fatalf("exact Project create-window = stdout=%q stderr=%q err=%v", stdout, stderr, err)
 	}
-	if route.target != (explicitTmuxTarget{flag: "-L", value: "phase1-custom-app"}) || route.expectedSocketPath != tmux.socketPath || route.authority == nil ||
+	if route.target != (tmuxTransport{Kind: tmuxSocketName, Value: "phase1-custom-app", Source: tmuxSocketNameSource}) || route.expectedSocketPath != tmux.socketPath || route.authority == nil ||
 		route.authority.Class != runtimeMutationRouteApp || route.authority.PaneID != "" {
 		t.Fatalf("explicit create-window route = %#v, want validated custom app -L without inherited Pane containment", *route)
 	}
@@ -400,7 +400,7 @@ func TestExactProjectCreateWindowIsByteEquivalentAcrossAmbientPanes(t *testing.T
 		if err != nil {
 			t.Fatal(err)
 		}
-		return stdout + "\x00" + store.snapshot() + "\x00" + route.target.flag + "=" + route.target.value + "\x00" + string(calls)
+		return stdout + "\x00" + store.snapshot() + "\x00" + route.target.Flag() + "=" + route.target.Value + "\x00" + string(calls)
 	}
 
 	current := run(t, false)
@@ -450,7 +450,7 @@ func TestExactProjectWindowAgentCreateIsByteEquivalentAcrossAmbientPaneContainme
 		if err != nil {
 			t.Fatal(err)
 		}
-		return stdout + "\x00" + store.snapshot() + "\x00" + route.target.label() + "\x00" + string(calls)
+		return stdout + "\x00" + store.snapshot() + "\x00" + route.target.Label() + "\x00" + string(calls)
 	}
 	current := run(t, "current")
 	for _, anchor := range []string{"unrelated", "stale"} {
@@ -558,7 +558,7 @@ func TestOutsideTmuxExactThreeUIDCreateAgentUsesOnlyQuietAppRoute(t *testing.T) 
 	if err != nil || stderr != "" || exactTmuxHandle(strings.TrimSpace(stdout), "%") == "" || stdout != strings.TrimSpace(stdout)+"\n" {
 		t.Fatalf("outside exact create = stdout=%q stderr=%q err=%v", stdout, stderr, err)
 	}
-	if route.target != (explicitTmuxTarget{flag: "-L", value: defaultAppSocket}) || route.authority == nil ||
+	if route.target != (tmuxTransport{Kind: tmuxSocketName, Value: defaultAppSocket, Source: tmuxSocketNameSource}) || route.authority == nil ||
 		route.authority.Class != runtimeMutationRouteApp || route.authority.PaneID != "" {
 		t.Fatalf("outside exact app route = %#v", *route)
 	}

--- a/internal/app/create_intent_control_test.go
+++ b/internal/app/create_intent_control_test.go
@@ -411,7 +411,7 @@ func TestCanonicalWindowCreateFeedsExactLastPaneCausalCleanupForManagedRoots(t *
 				windows: liveWindows, windowSessions: windowSessions,
 			}
 			event := lifecycleDirtyEvent{
-				target:        explicitTmuxTarget{flag: "-S", value: fx.tmux.socketPath},
+				target:        tmuxTransport{Kind: tmuxSocketPath, Value: fx.tmux.socketPath, Source: tmuxSocketPathSource},
 				runtimePaneID: pane.Status.Activation.RuntimeID,
 				teardownKind:  coremetadata.TeardownEventPaneExited,
 				receipts:      []coremetadata.TerminationEvidence{receipt},

--- a/internal/app/create_reentrancy.go
+++ b/internal/app/create_reentrancy.go
@@ -52,7 +52,7 @@ func sessionEnvironmentValue(output, name string) string {
 // deferBindingConvergence reports whether session is owned by a live canonical
 // create. Invalid and stale leases are removed before normal convergence so a
 // crashed creator cannot disable lifecycle repair permanently.
-func deferBindingConvergence(ctx context.Context, runner tmuxCommandRunner, target explicitTmuxTarget, session string) (bool, error) {
+func deferBindingConvergence(ctx context.Context, runner tmuxCommandRunner, target tmuxTransport, session string) (bool, error) {
 	session = strings.TrimSpace(session)
 	if session == "" {
 		return false, fmt.Errorf("binding convergence requires an explicit hook session")

--- a/internal/app/create_registry_first_use_test.go
+++ b/internal/app/create_registry_first_use_test.go
@@ -56,7 +56,7 @@ func (f *onDiskFixture) command(observe func(context.Context, string) (coremetad
 	}
 	roots := slices.Clone(f.roots)
 	typedMirror := runtimeMutationMetadataMirror{runner: explicitTmuxRunner{
-		runner: f.tmux, target: explicitTmuxTarget{flag: "-S", value: f.tmux.socketPath},
+		runner: f.tmux, target: tmuxTransport{Kind: tmuxSocketPath, Value: f.tmux.socketPath, Source: tmuxSocketPathSource},
 	}}
 	return &createCommand{
 		store: &resourceStore{
@@ -88,7 +88,7 @@ func (f *onDiskFixture) command(observe func(context.Context, string) (coremetad
 			runner:   f.tmux,
 			mirror:   mirror,
 			sessions: &fakeSessionMaterializer{tmux: f.tmux},
-			target:   explicitTmuxTarget{flag: "-S", value: f.tmux.socketPath},
+			target:   tmuxTransport{Kind: tmuxSocketPath, Value: f.tmux.socketPath, Source: tmuxSocketPathSource},
 			warn:     io.Discard,
 		},
 		shell:          "/bin/zsh",

--- a/internal/app/create_resource_test.go
+++ b/internal/app/create_resource_test.go
@@ -210,7 +210,7 @@ func newTestResourceCreateCommand(t *testing.T, store *fakeResourceStore, tmux *
 			runner:     tmux,
 			mirror:     mirror,
 			sessions:   sessions,
-			target:     explicitTmuxTarget{flag: "-S", value: tmux.socketPath},
+			target:     tmuxTransport{Kind: tmuxSocketPath, Value: tmux.socketPath, Source: tmuxSocketPathSource},
 			socketName: defaultAppSocket,
 			warn:       testWarnWriter{t},
 			executable: func() (string, error) { return testSupervisorBinary, nil },
@@ -1366,7 +1366,7 @@ func TestOperationRollbackRemovesOnlyWhatThisOperationCreated(t *testing.T) {
 		var warnings bytes.Buffer
 		runtime := &materializer{
 			runner: tmux, mirror: intmetadata.NewMirror(tmux), warn: &warnings,
-			target: explicitTmuxTarget{flag: "-S", value: tmux.socketPath}, expectedSocketPath: tmux.socketPath,
+			target: tmuxTransport{Kind: tmuxSocketPath, Value: tmux.socketPath, Source: tmuxSocketPathSource}, expectedSocketPath: tmux.socketPath,
 			socketName:     defaultAppSocket,
 			routeAuthority: &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: tmux.serverPID},
 		}

--- a/internal/app/delete.go
+++ b/internal/app/delete.go
@@ -544,7 +544,7 @@ func (c *deleteCommand) runKind(token string, kind coremetadata.Kind, args []str
 // runtime, close a Window, or touch the root, Git/worktree, or snapshot stores.
 func (c *deleteCommand) runProjectDelete(spelling string, plan deletePlan, resolution selector.Resolution, dryRun, yes bool, stdout io.Writer) error {
 	if dryRun {
-		return writeDeletePlan(stdout, spelling, plan, windowLiveDeletePlan{}, paneLiveDeletePlan{}, explicitTmuxTarget{}, true, false)
+		return writeDeletePlan(stdout, spelling, plan, windowLiveDeletePlan{}, paneLiveDeletePlan{}, tmuxTransport{}, true, false)
 	}
 	prompt := fmt.Sprintf("%s will unregister %d Project%s and %d descendant Registry resources; runtime and external assets are preserved",
 		spelling, len(plan.Targets), plural(len(plan.Targets)), plan.Cascades())
@@ -586,7 +586,7 @@ func (c *deleteCommand) runProjectDelete(spelling string, plan deletePlan, resol
 	}); err != nil {
 		return wrapProjectLifecycleError(coremetadata.ProjectLifecycleDeleteProject, "registry-unregister", strings.Join(oldUIDs, ","), "", err)
 	}
-	if err := writeDeletePlan(stdout, spelling, plan, windowLiveDeletePlan{}, paneLiveDeletePlan{}, explicitTmuxTarget{}, false, false); err != nil {
+	if err := writeDeletePlan(stdout, spelling, plan, windowLiveDeletePlan{}, paneLiveDeletePlan{}, tmuxTransport{}, false, false); err != nil {
 		return wrapProjectLifecycleError(coremetadata.ProjectLifecycleDeleteProject, "result-write", strings.Join(oldUIDs, ","), "", err)
 	}
 	_, err := fmt.Fprintf(stdout, "operation=delete-project stage=registry-unregister old_uid=%s new_uid=%s runtime=preserved external-assets=preserved\n",
@@ -726,7 +726,7 @@ func cascadeOf(registry coremetadata.Registry, kind coremetadata.Kind, uid strin
 }
 
 // writeDeletePlan renders the plan for both the dry run and the executed run.
-func writeDeletePlan(stdout io.Writer, spelling string, plan deletePlan, live windowLiveDeletePlan, panes paneLiveDeletePlan, socket explicitTmuxTarget, dryRun, selfQueued bool) error {
+func writeDeletePlan(stdout io.Writer, spelling string, plan deletePlan, live windowLiveDeletePlan, panes paneLiveDeletePlan, socket tmuxTransport, dryRun, selfQueued bool) error {
 	var b strings.Builder
 	verb := "deleting"
 	if dryRun {
@@ -758,7 +758,7 @@ func writeDeletePlan(stdout io.Writer, spelling string, plan deletePlan, live wi
 				action = "will queue after this result is flushed to kill"
 			}
 			fmt.Fprintf(&b, "  live %s tmux window %s session=%s session-id=%s socket=%s\n",
-				action, liveTarget.WindowID, liveTarget.SessionName, liveTarget.SessionID, socket.label())
+				action, liveTarget.WindowID, liveTarget.SessionName, liveTarget.SessionID, socket.Label())
 			if liveTarget.EndsSession {
 				impact := "ended"
 				if dryRun {
@@ -775,7 +775,7 @@ func writeDeletePlan(stdout io.Writer, spelling string, plan deletePlan, live wi
 			if dryRun {
 				action = "would delete this Window; no tmux Window would be killed"
 			}
-			fmt.Fprintf(&b, "  registry-only %s on socket=%s\n", action, socket.label())
+			fmt.Fprintf(&b, "  registry-only %s on socket=%s\n", action, socket.Label())
 		}
 		for _, liveTarget := range panes.Targets {
 			if liveTarget.ResourceUID != target.Match.UID {
@@ -789,7 +789,7 @@ func writeDeletePlan(stdout io.Writer, spelling string, plan deletePlan, live wi
 			}
 			fmt.Fprintf(&b, "  live %s tmux pane %s pane-uid=%s window=%s session=%s session-id=%s socket=%s\n",
 				action, liveTarget.PaneID, liveTarget.PaneUID, liveTarget.WindowID,
-				liveTarget.SessionName, liveTarget.SessionID, socket.label())
+				liveTarget.SessionName, liveTarget.SessionID, socket.Label())
 			if liveTarget.EndsWindow {
 				impact := "created"
 				if dryRun {
@@ -812,7 +812,7 @@ func writeDeletePlan(stdout io.Writer, spelling string, plan deletePlan, live wi
 				liveImpact = "would be killed"
 			}
 			fmt.Fprintf(&b, "  registry-only %s this %s; no tmux Pane %s on socket=%s evidence=%s owner-window=%s root=%s/%s preserving owner and siblings\n",
-				action, registryTarget.Kind, liveImpact, socket.label(), registryTarget.Evidence,
+				action, registryTarget.Kind, liveImpact, socket.Label(), registryTarget.Evidence,
 				registryTarget.WindowUID, strings.ToLower(string(registryTarget.RootKind)), registryTarget.RootUID)
 		}
 	}

--- a/internal/app/delete_pane_runtime.go
+++ b/internal/app/delete_pane_runtime.go
@@ -26,7 +26,7 @@ const deletedPaneMirrorPrefix = coremetadata.DeletedPaneMirrorPrefix
 type paneDeleteRuntime interface {
 	// useExactTarget pins every read and write of this seam to one resolved
 	// server. It is called before the first inventory of an invocation.
-	useExactTarget(explicitTmuxTarget)
+	useExactTarget(tmuxTransport)
 	preflight(context.Context, coremetadata.Registry, deletePlan) (paneLiveDeletePlan, error)
 	prepareReplacements(context.Context, []paneReplacementShell) (paneReplacementReceipt, error)
 	rollbackReplacements(context.Context, paneReplacementReceipt) error
@@ -131,7 +131,7 @@ func (p paneLiveDeletePlan) hasSelfTarget() bool {
 
 type tmuxPaneDeleteRuntime struct {
 	runner                tmuxCommandRunner
-	target                explicitTmuxTarget
+	target                tmuxTransport
 	expectedSocketPath    string
 	expectedLogicalSocket string
 	routeAuthority        *runtimeMutationRouteAuthority
@@ -149,7 +149,7 @@ func newTmuxPaneDeleteRuntime() *tmuxPaneDeleteRuntime {
 	return &tmuxPaneDeleteRuntime{runner: inttmux.ExecRunner{}, getenv: os.Getenv}
 }
 
-func (r *tmuxPaneDeleteRuntime) useExactTarget(target explicitTmuxTarget) {
+func (r *tmuxPaneDeleteRuntime) useExactTarget(target tmuxTransport) {
 	if r == nil {
 		return
 	}
@@ -175,13 +175,13 @@ type livePaneDeleteRow struct {
 
 func (r *tmuxPaneDeleteRuntime) routed() explicitTmuxRunner {
 	if r.expectedSocketPath != "" {
-		return explicitTmuxRunner{runner: r.runner, target: explicitTmuxTarget{flag: "-S", value: r.expectedSocketPath}}
+		return explicitTmuxRunner{runner: r.runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: r.expectedSocketPath, Source: tmuxSocketPathSource}}
 	}
 	return explicitTmuxRunner{runner: r.runner, target: r.target}
 }
 
 func (r *tmuxPaneDeleteRuntime) mutationAction(kind runtimeMutationVerb, target paneLiveDeleteTarget, guard, _ string, args ...string) plannedRuntimeMutation {
-	logicalRoute := r.target.flag + "=" + r.target.value
+	logicalRoute := r.target.Flag() + "=" + r.target.Value
 	action := newRuntimeMutation(1, kind, runtimeMutationTarget{
 		Socket: logicalRoute, PhysicalSocket: printableRuntimeMutationSocket(r.expectedSocketPath),
 		RouteAuthority: r.routeAuthority.printable(),
@@ -216,7 +216,7 @@ func (r *tmuxPaneDeleteRuntime) mutationSteps(
 		attempted := false
 		guardUID := guardMirror(target)
 		effectUID := effectMirror(target)
-		guardDetail := "socket=" + r.target.flag + "=" + r.target.value +
+		guardDetail := "socket=" + r.target.Flag() + "=" + r.target.Value +
 			";session=" + target.SessionID + "/" + target.SessionName +
 			";window=" + target.WindowID + "/" + target.WindowUID +
 			";pane=" + target.PaneID + "/" + guardUID +
@@ -321,7 +321,7 @@ func (r *tmuxPaneDeleteRuntime) revalidateMutationTarget(ctx context.Context, ta
 	format := tmuxRowFormat(columns...)
 	out, err := r.routed().Run(ctx, "tmux", "display-message", "-p", "-t", target.PaneID, "-F", format)
 	if err != nil {
-		return tmuxError("revalidate exact live Pane %s on %s %s: %v", target.PaneID, r.target.flag, r.target.value, err)
+		return tmuxError("revalidate exact live Pane %s on %s %s: %v", target.PaneID, r.target.Flag(), r.target.Value, err)
 	}
 	rows := splitTmuxRows(strings.ReplaceAll(string(out), tmuxRowSepFormat, tmuxRowSep), len(columns))
 	if len(rows) != 1 {
@@ -368,7 +368,7 @@ func (r *tmuxPaneDeleteRuntime) inventory(ctx context.Context) ([]livePaneDelete
 	if r == nil || r.runner == nil {
 		return nil, errors.New("delete pane: tmux runtime is not configured")
 	}
-	if r.target.flag == "" || r.target.value == "" {
+	if r.target.Flag() == "" || r.target.Value == "" {
 		return nil, errors.New("delete pane: no exact tmux target is bound")
 	}
 	if err := r.observeSocketIdentity(ctx); err != nil {
@@ -439,8 +439,8 @@ func (r *tmuxPaneDeleteRuntime) observeSocketIdentity(ctx context.Context) error
 	if observed == "" {
 		return errors.New("delete pane: exact socket identity is empty")
 	}
-	if r.target.flag == "-S" && observed != r.target.value {
-		return fmt.Errorf("delete pane: exact socket drifted: observed %q, planned %q", observed, r.target.value)
+	if r.target.Flag() == "-S" && observed != r.target.Value {
+		return fmt.Errorf("delete pane: exact socket drifted: observed %q, planned %q", observed, r.target.Value)
 	}
 	if r.expectedSocketPath == "" {
 		r.expectedSocketPath = observed
@@ -696,7 +696,7 @@ func (r *tmuxPaneDeleteRuntime) preflight(ctx context.Context, registry coremeta
 	}
 	if len(rows) == 0 {
 		return paneLiveDeletePlan{}, fmt.Errorf("delete %s: exact tmux inventory on %s was empty; absence is not Registry deletion authority and nothing was changed",
-			strings.ToLower(string(plan.Kind)), r.target.label())
+			strings.ToLower(string(plan.Kind)), r.target.Label())
 	}
 	authority, err := paneDeleteAuthoritySignature(registry, plan)
 	if err != nil {
@@ -785,11 +785,11 @@ func (r *tmuxPaneDeleteRuntime) preflight(ctx context.Context, registry coremeta
 				continue
 			}
 			return paneLiveDeletePlan{}, fmt.Errorf("delete %s: registry Pane uid %q has no exact live tmux Pane mirror on -L %s; nothing was changed",
-				strings.ToLower(string(plan.Kind)), target.paneUID, r.target.value)
+				strings.ToLower(string(plan.Kind)), target.paneUID, r.target.Value)
 		}
 		if len(matches) != 1 {
 			return paneLiveDeletePlan{}, fmt.Errorf("delete %s: registry Pane uid %q has %d live tmux Pane mirrors on -L %s; exact target is ambiguous and nothing was changed",
-				strings.ToLower(string(plan.Kind)), target.paneUID, len(matches), r.target.value)
+				strings.ToLower(string(plan.Kind)), target.paneUID, len(matches), r.target.Value)
 		}
 		row := matches[0]
 		if row.windowUID != window.Metadata.UID {
@@ -802,7 +802,7 @@ func (r *tmuxPaneDeleteRuntime) preflight(ctx context.Context, registry coremeta
 		}
 		if mirrors := len(windowIDsByUID[window.Metadata.UID]); mirrors != 1 {
 			return paneLiveDeletePlan{}, fmt.Errorf("delete %s: registry Window uid %q has %d live tmux Window mirrors on -L %s while resolving Pane uid %q; exact owner is ambiguous and nothing was changed",
-				strings.ToLower(string(plan.Kind)), window.Metadata.UID, mirrors, r.target.value, target.paneUID)
+				strings.ToLower(string(plan.Kind)), window.Metadata.UID, mirrors, r.target.Value, target.paneUID)
 		}
 		spelling := "delete " + strings.ToLower(string(plan.Kind))
 		if err := root.validateLiveSession(spelling, "Pane", row.paneID, target.paneUID, row.projectUID, row.sessionName); err != nil {

--- a/internal/app/delete_pane_runtime_test.go
+++ b/internal/app/delete_pane_runtime_test.go
@@ -33,16 +33,16 @@ func newPaneRuntimeFixture(t *testing.T, inventory string) (*tmuxPaneDeleteRunti
 	// The exact target matches what the route resolves from the hermetic
 	// $TMUX in newTestDeleteCommand, so a runtime fixture and a full route
 	// invocation address the same isolated server.
-	target, err := tmuxSocketPathTarget(testDeleteTarget.value)
+	target, err := tmuxSocketPathTarget(testDeleteTarget.Value)
 	if err != nil {
 		t.Fatal(err)
 	}
 	runtime := &tmuxPaneDeleteRuntime{runner: runner, target: target, getenv: func(string) string { return "" }}
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value,
-		"display-message", "-p", "-F", "#{socket_path}")] = testDeleteTarget.value + "\n"
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value,
+		"display-message", "-p", "-F", "#{socket_path}")] = testDeleteTarget.Value + "\n"
 	format := tmuxRowFormat("#{session_id}", "#{session_name}", "#{window_id}", "#{pane_id}",
 		"#{@projmux_project_uid}", "#{@projmux_window_uid}", "#{@projmux_pane_uid}")
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "list-panes", "-a", "-F", format)] = inventory
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "list-panes", "-a", "-F", format)] = inventory
 	return runtime, runner, resourceFixtureRegistry(t)
 }
 
@@ -96,11 +96,11 @@ func TestPaneDeletePreflightFlattensExitCodeAfterTypedSocketClassification(t *te
 	registry := resourceFixtureRegistry(t)
 	plan := exactPanePlanFor(t, registry, coremetadata.KindPane, "pan-alpha-log")
 	exitFailure := paneDeleteExitCommandFailure{failure: inttmux.CommandFailure{
-		Kind: inttmux.CommandFailureExit, Stderr: "no server running on " + testDeleteTarget.value,
+		Kind: inttmux.CommandFailureExit, Stderr: "no server running on " + testDeleteTarget.Value,
 	}}
 	newRuntime := func() *tmuxPaneDeleteRuntime {
 		runtime, runner, _ := newPaneRuntimeFixture(t, "")
-		key := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value,
+		key := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value,
 			"display-message", "-p", "-F", "#{socket_path}")
 		runner.errors = map[string]error{key: exitFailure}
 		return runtime
@@ -133,7 +133,7 @@ func TestPaneDeletePreflightFlattensOtherSocketExitFailures(t *testing.T) {
 	registry := resourceFixtureRegistry(t)
 	plan := exactPanePlanFor(t, registry, coremetadata.KindPane, "pan-alpha-log")
 	runtime, runner, _ := newPaneRuntimeFixture(t, "")
-	key := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value,
+	key := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value,
 		"display-message", "-p", "-F", "#{socket_path}")
 	runner.errors = map[string]error{key: paneDeleteExitCommandFailure{failure: inttmux.CommandFailure{
 		Kind: inttmux.CommandFailureExit, Stderr: "failed to connect to server: permission denied",
@@ -158,7 +158,7 @@ func TestPaneDeleteDefaultRouteForgedServerRefusesBeforeFirstWrite(t *testing.T)
 		recordedTmuxCallKey("tmux", "-S", path, "show-options", "-gqv", tmuxopts.AppGlobal):                  "0\n",
 	}}
 	runtime := &tmuxPaneDeleteRuntime{
-		runner: runner, target: explicitTmuxTarget{flag: "-L", value: defaultAppSocket}, getenv: func(string) string { return "" },
+		runner: runner, target: tmuxTransport{Kind: tmuxSocketName, Value: defaultAppSocket, Source: tmuxSocketNameSource}, getenv: func(string) string { return "" },
 	}
 	registry := resourceFixtureRegistry(t)
 	_, err := runtime.preflight(context.Background(), registry, panePlanFor(t, registry, coremetadata.KindPane, "pan-alpha-log"))
@@ -175,10 +175,10 @@ func TestPaneDeleteDefaultRouteForgedServerRefusesBeforeFirstWrite(t *testing.T)
 
 func TestPaneDeletePreExecuteNoServerRefusesInsteadOfCompletingAbsence(t *testing.T) {
 	runtime, runner, _ := newPaneRuntimeFixture(t, "")
-	runtime.expectedSocketPath = testDeleteTarget.value
+	runtime.expectedSocketPath = testDeleteTarget.Value
 	runtime.expectedLogicalSocket = defaultAppSocket
 	runtime.routeAuthority = &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: "4242"}
-	key := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-F", "#{socket_path}")
+	key := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-F", "#{socket_path}")
 	runner.errors = map[string]error{key: appTypedCommandFailure{inttmux.CommandFailure{Kind: inttmux.CommandFailureExit, Stderr: "no server running"}}}
 	target := paneLiveDeleteTarget{PaneUID: "pan-alpha-log", PaneID: "%31", WindowUID: "win-alpha-main", WindowID: "@10", SessionName: "alpha", SessionID: "$1", RootKind: coremetadata.KindProject, RootUID: "prj-alpha"}
 	applied, err := runtime.killAll(context.Background(), []paneLiveDeleteTarget{target})
@@ -200,19 +200,19 @@ type lastTargetDeleteRunner struct {
 
 func (r *lastTargetDeleteRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
 	r.calls = append(r.calls, recordedTmuxCall{name: name, args: append([]string(nil), args...)})
-	if name != "tmux" || len(args) < 3 || args[0] != "-S" || args[1] != testDeleteTarget.value {
+	if name != "tmux" || len(args) < 3 || args[0] != "-S" || args[1] != testDeleteTarget.Value {
 		return nil, fmt.Errorf("last-target delete runner requires exact -S routing: %s %v", name, args)
 	}
 	command := args[2]
 	if r.killed && command == "display-message" && args[len(args)-1] == "#{socket_path}" {
 		return nil, appTypedCommandFailure{inttmux.CommandFailure{
-			Kind: inttmux.CommandFailureExit, Stderr: "no server running on " + testDeleteTarget.value,
+			Kind: inttmux.CommandFailureExit, Stderr: "no server running on " + testDeleteTarget.Value,
 		}}
 	}
 	switch command {
 	case "display-message":
 		if args[len(args)-1] == "#{socket_path}" {
-			return []byte(testDeleteTarget.value + "\n"), nil
+			return []byte(testDeleteTarget.Value + "\n"), nil
 		}
 		if args[len(args)-1] == "#{pid}" {
 			return []byte("4242\n"), nil
@@ -251,7 +251,7 @@ func (r *lastTargetDeleteRunner) Run(_ context.Context, name string, args ...str
 func TestPaneDeleteSuccessfulLastKillAcceptsPostApplyNoServerReceipt(t *testing.T) {
 	runner := &lastTargetDeleteRunner{kind: "pane"}
 	runtime := statefulPaneRuntime(t, runner)
-	runtime.expectedSocketPath = testDeleteTarget.value
+	runtime.expectedSocketPath = testDeleteTarget.Value
 	runtime.expectedLogicalSocket = defaultAppSocket
 	target := paneLiveDeleteTarget{
 		PaneUID: "pan-alpha-log", PaneID: "%31", WindowUID: "win-alpha-main", WindowID: "@10",
@@ -383,7 +383,7 @@ func TestPaneDeleteRuntimeRegistryOnlyEvidenceTable(t *testing.T) {
 			t.Fatalf("registry-only Pane preflight: %v", err)
 		}
 		if len(plan.Targets) != 0 || len(plan.RegistryOnly) != 1 ||
-			plan.RegistryOnly[0].Evidence != coremetadata.ConditionMissingRuntime || plan.SocketPath != testDeleteTarget.value {
+			plan.RegistryOnly[0].Evidence != coremetadata.ConditionMissingRuntime || plan.SocketPath != testDeleteTarget.Value {
 			t.Fatalf("registry-only Pane plan = %#v", plan)
 		}
 	})
@@ -502,7 +502,7 @@ func TestPaneDeleteStandaloneSocketAuthorizesOnlyRegistryOnlyEvidence(t *testing
 			test.prepare(&registry)
 			// If the preflight accidentally upgrades this read-only route to
 			// mutation authority, the standalone marker answer must refuse it.
-			runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value,
+			runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value,
 				"show-options", "-gqv", tmuxopts.AppGlobal)] = "\n"
 
 			first, err := runtime.preflight(context.Background(), registry,
@@ -531,7 +531,7 @@ func TestPaneDeleteStandaloneSocketAuthorizesOnlyRegistryOnlyEvidence(t *testing
 func TestPaneDeleteStandaloneSocketRefusesLiveMirrorBeforeWrite(t *testing.T) {
 	runtime, runner, registry := newPaneRuntimeFixture(t, paneRuntimeInventory())
 	markPaneMissingRuntime(t, &registry, "pan-alpha-log")
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value,
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value,
 		"show-options", "-gqv", tmuxopts.AppGlobal)] = "\n"
 
 	_, err := runtime.preflight(context.Background(), registry,
@@ -577,10 +577,10 @@ func TestPaneDeleteRuntimeRefusesNoServerAndSignsOwnerGeneration(t *testing.T) {
 		t.Fatal("owner change did not change the signed plan")
 	}
 
-	socketKey := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value,
+	socketKey := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value,
 		"display-message", "-p", "-F", "#{socket_path}")
 	runner.errors = map[string]error{socketKey: appTypedCommandFailure{failure: inttmux.CommandFailure{
-		Kind: inttmux.CommandFailureExit, Stderr: "no server running on " + testDeleteTarget.value,
+		Kind: inttmux.CommandFailureExit, Stderr: "no server running on " + testDeleteTarget.Value,
 	}}}
 	if _, err := runtime.preflight(context.Background(), registry, plan); err == nil ||
 		!strings.Contains(err.Error(), "unavailable (no-server)") {
@@ -595,7 +595,7 @@ func TestPaneDeleteRuntimeRefusesNoServerAndSignsOwnerGeneration(t *testing.T) {
 
 	format := tmuxRowFormat("#{session_id}", "#{session_name}", "#{window_id}", "#{pane_id}",
 		"#{@projmux_project_uid}", "#{@projmux_window_uid}", "#{@projmux_pane_uid}")
-	inventoryKey := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "list-panes", "-a", "-F", format)
+	inventoryKey := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "list-panes", "-a", "-F", format)
 	runner.errors = map[string]error{inventoryKey: errors.New("inventory unavailable")}
 	if _, err := runtime.preflight(context.Background(), registry, plan); err == nil ||
 		!strings.Contains(err.Error(), "inventory exact tmux socket") {
@@ -653,20 +653,20 @@ func TestPaneDeleteRuntimeImplicitTargetRequiresExactCallerSocketAndPane(t *test
 	runtime.getenv = func(name string) string {
 		switch name {
 		case "TMUX":
-			return testDeleteTarget.value + ",123,0"
+			return testDeleteTarget.Value + ",123,0"
 		case "TMUX_PANE":
 			return "%31"
 		}
 		return ""
 	}
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-F", "#{socket_path}")] = testDeleteTarget.value + "\n"
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-F", "#{pid}")] = "123\n"
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-F", "#{socket_path}")] = testDeleteTarget.Value + "\n"
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-F", "#{pid}")] = "123\n"
 	format := tmuxRowFormat("#{socket_path}", "#{pane_id}")
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-t", "%31", "-F", format)] =
-		livePaneInventoryRow(testDeleteTarget.value, "%31")
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-t", "%31", "-F", format)] =
+		livePaneInventoryRow(testDeleteTarget.Value, "%31")
 	authorityFormat := tmuxRowFormat("#{socket_path}", "#{pid}", "#{session_id}", "#{window_id}", "#{pane_id}")
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-t", "%31", "-F", authorityFormat)] =
-		livePaneInventoryRow(testDeleteTarget.value, "123", "$1", "@10", "%31")
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-t", "%31", "-F", authorityFormat)] =
+		livePaneInventoryRow(testDeleteTarget.Value, "123", "$1", "@10", "%31")
 	plan := panePlanFor(t, registry, coremetadata.KindPane, "pan-alpha-log")
 	plan.Implicit = true
 
@@ -677,7 +677,7 @@ func TestPaneDeleteRuntimeImplicitTargetRequiresExactCallerSocketAndPane(t *test
 	if len(live.Targets) != 1 || !live.Targets[0].Self {
 		t.Fatalf("implicit plan = %#v", live)
 	}
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-F", "#{socket_path}")] = "/tmp/foreign.sock\n"
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-F", "#{socket_path}")] = "/tmp/foreign.sock\n"
 	if _, err := runtime.preflight(context.Background(), registry, plan); err == nil || !strings.Contains(err.Error(), "exact socket drifted") {
 		t.Fatalf("foreign socket error = %v", err)
 	}
@@ -687,15 +687,15 @@ func TestPaneDeleteRuntimeProducerAnchorBindsRouteWithoutInheritedPaneEnv(t *tes
 	runtime, runner, registry := newPaneRuntimeFixture(t, paneRuntimeInventory())
 	runtime.getenv = func(name string) string {
 		if name == "TMUX" {
-			return testDeleteTarget.value + ",123,0"
+			return testDeleteTarget.Value + ",123,0"
 		}
 		return ""
 	}
 	runtime.useRouteAnchor("%31")
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-F", "#{pid}")] = "123\n"
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-F", "#{pid}")] = "123\n"
 	authorityFormat := tmuxRowFormat("#{socket_path}", "#{pid}", "#{session_id}", "#{window_id}", "#{pane_id}")
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-t", "%31", "-F", authorityFormat)] =
-		livePaneInventoryRow(testDeleteTarget.value, "123", "$1", "@10", "%31")
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-t", "%31", "-F", authorityFormat)] =
+		livePaneInventoryRow(testDeleteTarget.Value, "123", "$1", "@10", "%31")
 
 	plan := panePlanFor(t, registry, coremetadata.KindPane, "pan-alpha-log")
 	if _, err := runtime.preflight(context.Background(), registry, plan); err != nil {
@@ -718,14 +718,14 @@ type lifecycleSiblingCleanupRunner struct {
 
 func (r *lifecycleSiblingCleanupRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
 	r.calls = append(r.calls, recordedTmuxCall{name: name, args: slices.Clone(args)})
-	if name != "tmux" || len(args) < 3 || args[0] != "-S" || args[1] != testDeleteTarget.value {
+	if name != "tmux" || len(args) < 3 || args[0] != "-S" || args[1] != testDeleteTarget.Value {
 		return nil, fmt.Errorf("lifecycle cleanup requires exact -S routing: %s %v", name, args)
 	}
 	switch args[2] {
 	case "display-message":
 		switch args[len(args)-1] {
 		case "#{socket_path}":
-			return []byte(testDeleteTarget.value + "\n"), nil
+			return []byte(testDeleteTarget.Value + "\n"), nil
 		case "#{pid}":
 			pid := r.pid
 			if pid == "" {
@@ -770,7 +770,7 @@ func (r *lifecycleSiblingCleanupRunner) Run(_ context.Context, name string, args
 }
 
 func TestLifecycleSiblingCleanupBindsExistingExactSocketBeforeKillPlan(t *testing.T) {
-	target, err := tmuxSocketPathTarget(testDeleteTarget.value)
+	target, err := tmuxSocketPathTarget(testDeleteTarget.Value)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -787,7 +787,7 @@ func TestLifecycleSiblingCleanupBindsExistingExactSocketBeforeKillPlan(t *testin
 	if err := inventory.CleanupLifecycleDeadPane(context.Background(), cleanup); err != nil {
 		t.Fatalf("lifecycle sibling cleanup: %v", err)
 	}
-	if !runner.killed || runtime.routeAnchor != "%31" || runtime.expectedSocketPath != testDeleteTarget.value || runtime.routeAuthority == nil ||
+	if !runner.killed || runtime.routeAnchor != "%31" || runtime.expectedSocketPath != testDeleteTarget.Value || runtime.routeAuthority == nil ||
 		runtime.routeAuthority.ServerPID != "4242" {
 		t.Fatalf("cleanup route killed=%t anchor=%q path=%q authority=%+v",
 			runner.killed, runtime.routeAnchor, runtime.expectedSocketPath, runtime.routeAuthority)
@@ -804,7 +804,7 @@ func TestLifecycleSiblingCleanupBindsExistingExactSocketBeforeKillPlan(t *testin
 }
 
 func TestC2LifecycleFirstWriteGuardRejectsOwnerAndServerPIDDriftWithZeroKill(t *testing.T) {
-	target, err := tmuxSocketPathTarget(testDeleteTarget.value)
+	target, err := tmuxSocketPathTarget(testDeleteTarget.Value)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -826,7 +826,7 @@ func TestC2LifecycleFirstWriteGuardRejectsOwnerAndServerPIDDriftWithZeroKill(t *
 		t.Run(test.name, func(t *testing.T) {
 			runtime := &tmuxPaneDeleteRuntime{runner: test.runner, target: target, getenv: func(string) string { return "" }}
 			if test.prebound {
-				runtime.expectedSocketPath = testDeleteTarget.value
+				runtime.expectedSocketPath = testDeleteTarget.Value
 				runtime.expectedLogicalSocket = defaultAppSocket
 				runtime.routeAuthority = &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: "4242"}
 			}
@@ -843,13 +843,13 @@ func TestC2LifecycleFirstWriteGuardRejectsOwnerAndServerPIDDriftWithZeroKill(t *
 
 func TestPaneDeleteRuntimeQueueRevalidatesTombstonesAndUsesExactSocket(t *testing.T) {
 	runtime, _, _ := newPaneRuntimeFixture(t, "")
-	runtime.expectedSocketPath = testDeleteTarget.value
+	runtime.expectedSocketPath = testDeleteTarget.Value
 	runtime.expectedLogicalSocket = defaultAppSocket
 	runtime.routeAuthority = &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: "4242"}
 	target := paneLiveDeleteTarget{PaneUID: "pan-alpha-log", PaneID: "%31", WindowUID: "win-alpha-main", WindowID: "@10", SessionName: "alpha", SessionID: "$1", RootKind: coremetadata.KindProject, RootUID: "prj-alpha"}
 	action := runtime.mutationAction(mutationQueuePaneKill, target, "", "")
 	action.Target.UID = "deleted:" + target.PaneUID
-	action.Queue = &runtimeMutationQueuedKill{PhysicalSocket: testDeleteTarget.value, LogicalSocket: defaultAppSocket,
+	action.Queue = &runtimeMutationQueuedKill{PhysicalSocket: testDeleteTarget.Value, LogicalSocket: defaultAppSocket,
 		RouteAuthority: action.Target.RouteAuthority,
 		ExpectedUID:    action.Target.UID, SessionID: target.SessionID, WindowID: target.WindowID}
 	action.Queue.Marker = runtimeMutationQueueMarker(action)
@@ -858,7 +858,7 @@ func TestPaneDeleteRuntimeQueueRevalidatesTombstonesAndUsesExactSocket(t *testin
 		t.Fatal(err)
 	}
 	joined := strings.Join(argv, " ")
-	for _, want := range []string{"set-environment -g", "run-shell -b", "-S '" + testDeleteTarget.value + "'", "kill-pane -t %31", tmuxopts.PaneUID} {
+	for _, want := range []string{"set-environment -g", "run-shell -b", "-S '" + testDeleteTarget.Value + "'", "kill-pane -t %31", tmuxopts.PaneUID} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("queued Pane argv = %q, want %q", joined, want)
 		}
@@ -885,7 +885,7 @@ func (r *statefulPaneDeleteRunner) Run(_ context.Context, name string, args ...s
 	switch command {
 	case "display-message":
 		if len(args) > 0 && args[len(args)-1] == "#{socket_path}" {
-			return []byte(testDeleteTarget.value + "\n"), nil
+			return []byte(testDeleteTarget.Value + "\n"), nil
 		}
 		if len(args) > 0 && args[len(args)-1] == "#{pid}" {
 			return []byte("4242\n"), nil
@@ -944,13 +944,13 @@ func (r *statefulPaneDeleteRunner) Run(_ context.Context, name string, args ...s
 
 func statefulPaneRuntime(t *testing.T, runner tmuxCommandRunner) *tmuxPaneDeleteRuntime {
 	t.Helper()
-	target, err := tmuxSocketPathTarget(testDeleteTarget.value)
+	target, err := tmuxSocketPathTarget(testDeleteTarget.Value)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return &tmuxPaneDeleteRuntime{
 		runner: runner, target: target, getenv: func(string) string { return "" },
-		expectedSocketPath: testDeleteTarget.value, expectedLogicalSocket: defaultAppSocket,
+		expectedSocketPath: testDeleteTarget.Value, expectedLogicalSocket: defaultAppSocket,
 		routeAuthority: &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: "4242"},
 	}
 }

--- a/internal/app/delete_test.go
+++ b/internal/app/delete_test.go
@@ -186,7 +186,7 @@ func TestDeleteProjectPostCommitFlushFailureReportsActionStageAndUIDs(t *testing
 var testDeleteEnvironment = map[string]string{"TMUX": "/tmp/projmux-test/isolated,1234,0"}
 
 // testDeleteTarget is the exact target testDeleteEnvironment resolves to.
-var testDeleteTarget = explicitTmuxTarget{flag: "-S", value: "/tmp/projmux-test/isolated"}
+var testDeleteTarget = tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/projmux-test/isolated", Source: tmuxInheritedSource}
 
 type fakePaneDeleteRuntime struct {
 	preflights             int
@@ -212,10 +212,10 @@ type fakePaneDeleteRuntime struct {
 	preflightHook          func(int, *coremetadata.Registry)
 	// boundTarget records the exact server the route installed, so a test can
 	// prove the live half never routes anywhere the invocation did not name.
-	boundTarget explicitTmuxTarget
+	boundTarget tmuxTransport
 }
 
-func (r *fakePaneDeleteRuntime) useExactTarget(target explicitTmuxTarget) { r.boundTarget = target }
+func (r *fakePaneDeleteRuntime) useExactTarget(target tmuxTransport) { r.boundTarget = target }
 
 func newFixturePaneDeleteRuntime() *fakePaneDeleteRuntime { return &fakePaneDeleteRuntime{} }
 
@@ -251,7 +251,7 @@ func (r *fakePaneDeleteRuntime) preflight(_ context.Context, registry coremetada
 	if err != nil {
 		return paneLiveDeletePlan{}, err
 	}
-	out := paneLiveDeletePlan{SocketPath: testDeleteTarget.value, Authority: authority}
+	out := paneLiveDeletePlan{SocketPath: testDeleteTarget.Value, Authority: authority}
 	registryOnly := map[string]bool{}
 	for _, target := range plan.Targets {
 		candidate, ok, err := registryOnlyPaneTarget(registry, plan, target)
@@ -410,10 +410,10 @@ type fakeWindowDeleteRuntime struct {
 	queueHook     func([]windowLiveDeleteTarget)
 	offlineUIDs   map[string]bool
 	preflightHook func(int)
-	boundTarget   explicitTmuxTarget
+	boundTarget   tmuxTransport
 }
 
-func (r *fakeWindowDeleteRuntime) useExactTarget(target explicitTmuxTarget) { r.boundTarget = target }
+func (r *fakeWindowDeleteRuntime) useExactTarget(target tmuxTransport) { r.boundTarget = target }
 
 func newFixtureWindowDeleteRuntime() *fakeWindowDeleteRuntime {
 	return &fakeWindowDeleteRuntime{}
@@ -505,7 +505,7 @@ func TestDeleteOfflineWindowDryRunAndExecutionAreRegistryOnly(t *testing.T) {
 		"cascade pane/log uid=pan-alpha-log",
 		// The reported socket is the one this invocation resolved, not the
 		// app's default name.
-		"registry-only would delete this Window; no tmux Window would be killed on socket=" + testDeleteTarget.label(),
+		"registry-only would delete this Window; no tmux Window would be killed on socket=" + testDeleteTarget.Label(),
 		"dry-run: nothing was deleted",
 	} {
 		if !strings.Contains(stdout, want) {
@@ -609,7 +609,7 @@ func TestDeleteOfflinePaneAndAgentDryRunApplyRepeatAreRegistryOnly(t *testing.T)
 		if err != nil {
 			t.Fatalf("offline Pane dry-run: %v", err)
 		}
-		wantPreview := "  registry-only would delete this Pane; no tmux Pane would be killed on socket=" + testDeleteTarget.label() +
+		wantPreview := "  registry-only would delete this Pane; no tmux Pane would be killed on socket=" + testDeleteTarget.Label() +
 			" evidence=MissingRuntime owner-window=win-alpha-main root=project/prj-alpha preserving owner and siblings\n"
 		for _, want := range []string{wantPreview, "evidence=MissingRuntime", "preserving owner and siblings"} {
 			if !strings.Contains(preview, want) {
@@ -624,7 +624,7 @@ func TestDeleteOfflinePaneAndAgentDryRunApplyRepeatAreRegistryOnly(t *testing.T)
 		if err != nil {
 			t.Fatalf("offline Pane apply: %v", err)
 		}
-		wantApplied := "  registry-only deleted this Pane; no tmux Pane was killed on socket=" + testDeleteTarget.label() +
+		wantApplied := "  registry-only deleted this Pane; no tmux Pane was killed on socket=" + testDeleteTarget.Label() +
 			" evidence=MissingRuntime owner-window=win-alpha-main root=project/prj-alpha preserving owner and siblings\n"
 		if _, ok := store.registry.Pane("pan-alpha-log"); ok || len(runtime.killed) != 0 ||
 			!strings.Contains(applied, wantApplied) {
@@ -661,7 +661,7 @@ func TestDeleteOfflinePaneAndAgentDryRunApplyRepeatAreRegistryOnly(t *testing.T)
 		if err != nil {
 			t.Fatalf("offline Agent dry-run: %v", err)
 		}
-		wantPreview := "  registry-only would delete this Agent; no tmux Pane would be killed on socket=" + testDeleteTarget.label() +
+		wantPreview := "  registry-only would delete this Agent; no tmux Pane would be killed on socket=" + testDeleteTarget.Label() +
 			" evidence=Offline+MissingRuntime owner-window=win-alpha-main root=project/prj-alpha preserving owner and siblings\n"
 		for _, want := range []string{"cascade pane/codex-pane uid=pan-alpha-codex", wantPreview, "evidence=Offline+MissingRuntime"} {
 			if !strings.Contains(preview, want) {
@@ -676,7 +676,7 @@ func TestDeleteOfflinePaneAndAgentDryRunApplyRepeatAreRegistryOnly(t *testing.T)
 		if err != nil {
 			t.Fatalf("offline Agent apply: %v", err)
 		}
-		wantApplied := "  registry-only deleted this Agent; no tmux Pane was killed on socket=" + testDeleteTarget.label() +
+		wantApplied := "  registry-only deleted this Agent; no tmux Pane was killed on socket=" + testDeleteTarget.Label() +
 			" evidence=Offline+MissingRuntime owner-window=win-alpha-main root=project/prj-alpha preserving owner and siblings\n"
 		if registryUIDs(store.registry)["agt-alpha-codex"] || registryUIDs(store.registry)["pan-alpha-codex"] ||
 			len(runtime.killed) != 0 || !strings.Contains(applied, wantApplied) {
@@ -1873,7 +1873,7 @@ func TestDeleteWindowDryRunShowsLiveAndLastSessionCascadeWithoutWrites(t *testin
 		t.Fatalf("dry-run error = %v", err)
 	}
 	for _, want := range []string{
-		"live would kill tmux window @12 session=beta session-id=$21 socket=" + testDeleteTarget.label(),
+		"live would kill tmux window @12 session=beta session-id=$21 socket=" + testDeleteTarget.Label(),
 		"live cascade would end Project session beta because its last live Window is deleted",
 	} {
 		if !strings.Contains(stdout, want) {

--- a/internal/app/delete_transport.go
+++ b/internal/app/delete_transport.go
@@ -1,9 +1,10 @@
 package app
 
 import (
+	"errors"
 	"os"
-	"path/filepath"
-	"strings"
+
+	"github.com/crevissepartners/projmux/internal/core/resourcegraph"
 )
 
 // deleteSocketFlags are the two mutually exclusive exact-target flags every
@@ -24,38 +25,24 @@ type deleteSocketFlags struct {
 // the app's own socket instead: the route asked one server for its resources
 // and answered by mutating another. Refusing outside tmux is the only remaining
 // honest answer, and it names the two flags that fix it.
-func resolveDeleteTarget(spelling string, flags deleteSocketFlags, lookupEnv func(string) string) (explicitTmuxTarget, error) {
-	name := strings.TrimSpace(flags.socket)
-	path := strings.TrimSpace(flags.socketPath)
-	if name != "" && path != "" {
-		return explicitTmuxTarget{}, usageError(spelling + " accepts only one of --socket and --socket-path")
-	}
-	if name != "" {
-		target, err := tmuxSocketNameTarget(name)
-		if err != nil {
-			return explicitTmuxTarget{}, usageError(spelling + ": --socket must not be empty")
-		}
-		return target, nil
-	}
-	if path != "" {
-		target, err := tmuxSocketPathTarget(path)
-		if err != nil {
-			return explicitTmuxTarget{}, usageError(spelling + ": --socket-path must be absolute")
-		}
-		return target, nil
-	}
+func resolveDeleteTarget(spelling string, flags deleteSocketFlags, lookupEnv func(string) string) (tmuxTransport, error) {
 	if lookupEnv == nil {
 		lookupEnv = os.Getenv
 	}
-	inherited, _, _ := strings.Cut(strings.TrimSpace(lookupEnv("TMUX")), ",")
-	inherited = strings.TrimSpace(inherited)
-	if inherited == "" || !filepath.IsAbs(inherited) {
-		return explicitTmuxTarget{}, usageError(spelling +
-			" requires --socket <name> or --socket-path <absolute> outside tmux")
-	}
-	target, err := tmuxSocketPathTarget(inherited)
+	target, err := resourcegraph.ResolveTransport(resourcegraph.TransportRequest{
+		SocketName:    flags.socket,
+		SocketPath:    flags.socketPath,
+		InheritedTMUX: lookupEnv("TMUX"),
+	})
 	if err != nil {
-		return explicitTmuxTarget{}, usageError(spelling + ": inherited $TMUX socket path is not absolute")
+		if errors.Is(err, resourcegraph.ErrTransportConflict) {
+			return tmuxTransport{}, usageError(spelling + " accepts only one of --socket and --socket-path")
+		}
+		return tmuxTransport{}, usageError(spelling + ": --socket-path must be absolute")
+	}
+	if !target.Present() {
+		return tmuxTransport{}, usageError(spelling +
+			" requires --socket <name> or --socket-path <absolute> outside tmux")
 	}
 	return target, nil
 }

--- a/internal/app/delete_transport_test.go
+++ b/internal/app/delete_transport_test.go
@@ -19,25 +19,25 @@ func TestDeleteResolvesOneExactTargetAndNeverTheAppSocket(t *testing.T) {
 		name     string
 		flags    deleteSocketFlags
 		env      string
-		want     explicitTmuxTarget
+		want     tmuxTransport
 		wantFail string
 	}{
 		{
 			name:  "an explicit socket name wins over the inherited client",
 			flags: deleteSocketFlags{socket: "isolated"},
 			env:   "/tmp/tmux-1000/projmux,1,0",
-			want:  explicitTmuxTarget{flag: "-L", value: "isolated"},
+			want:  tmuxTransport{Kind: tmuxSocketName, Value: "isolated", Source: tmuxSocketNameSource},
 		},
 		{
 			name:  "an explicit socket path wins over the inherited client",
 			flags: deleteSocketFlags{socketPath: "/tmp/isolated/socket"},
 			env:   "/tmp/tmux-1000/projmux,1,0",
-			want:  explicitTmuxTarget{flag: "-S", value: "/tmp/isolated/socket"},
+			want:  tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/isolated/socket", Source: tmuxSocketPathSource},
 		},
 		{
 			name: "the inherited client routes when no flag is given",
 			env:  "/tmp/isolated/socket,4242,0",
-			want: explicitTmuxTarget{flag: "-S", value: "/tmp/isolated/socket"},
+			want: tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/isolated/socket", Source: tmuxInheritedSource},
 		},
 		{
 			name:     "both flags together are a usage refusal",
@@ -72,7 +72,7 @@ func TestDeleteResolvesOneExactTargetAndNeverTheAppSocket(t *testing.T) {
 				if err == nil || !IsUsageError(err) || !strings.Contains(err.Error(), test.wantFail) {
 					t.Fatalf("error = %v, want a usage refusal mentioning %q", err, test.wantFail)
 				}
-				if target != (explicitTmuxTarget{}) {
+				if target != (tmuxTransport{}) {
 					t.Fatalf("a refused resolution still produced %#v", target)
 				}
 				return
@@ -83,7 +83,7 @@ func TestDeleteResolvesOneExactTargetAndNeverTheAppSocket(t *testing.T) {
 			if target != test.want {
 				t.Fatalf("target = %#v, want %#v", target, test.want)
 			}
-			if target.flag == "-L" && target.value == defaultAppSocket {
+			if target.Flag() == "-L" && target.Value == defaultAppSocket {
 				t.Fatal("the resolution reached the app socket")
 			}
 		})
@@ -93,7 +93,7 @@ func TestDeleteResolvesOneExactTargetAndNeverTheAppSocket(t *testing.T) {
 func TestExplicitLiveSocketPathIsAmbientInvariant(t *testing.T) {
 	t.Parallel()
 	flags := deleteSocketFlags{socketPath: "/tmp/isolated/socket"}
-	var results []explicitTmuxTarget
+	var results []tmuxTransport
 	for _, ambient := range []string{"", "/tmp/tmux-1000/projmux,1,0", "/tmp/foreign/socket,9999,7"} {
 		target, err := resolveDeleteTarget("delete window", flags, func(name string) string {
 			if name == "TMUX" {
@@ -106,7 +106,7 @@ func TestExplicitLiveSocketPathIsAmbientInvariant(t *testing.T) {
 		}
 		results = append(results, target)
 	}
-	want := explicitTmuxTarget{flag: "-S", value: "/tmp/isolated/socket"}
+	want := tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/isolated/socket", Source: tmuxSocketPathSource}
 	for index, got := range results {
 		if got != want {
 			t.Fatalf("ambient row %d target = %#v, want unchanged live %#v", index, got, want)
@@ -129,7 +129,7 @@ func TestDeleteInstallsTheResolvedTargetOnTheLiveHalf(t *testing.T) {
 			"--socket", "isolated-run", "--dry-run"); err != nil {
 			t.Fatalf("dry-run error = %v", err)
 		}
-		if want := (explicitTmuxTarget{flag: "-L", value: "isolated-run"}); runtime.boundTarget != want {
+		if want := (tmuxTransport{Kind: tmuxSocketName, Value: "isolated-run", Source: tmuxSocketNameSource}); runtime.boundTarget != want {
 			t.Fatalf("pane runtime target = %#v, want %#v", runtime.boundTarget, want)
 		}
 	})
@@ -144,7 +144,7 @@ func TestDeleteInstallsTheResolvedTargetOnTheLiveHalf(t *testing.T) {
 			"--socket-path", "/tmp/isolated/socket", "--dry-run"); err != nil {
 			t.Fatalf("dry-run error = %v", err)
 		}
-		if want := (explicitTmuxTarget{flag: "-S", value: "/tmp/isolated/socket"}); runtime.boundTarget != want {
+		if want := (tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/isolated/socket", Source: tmuxSocketPathSource}); runtime.boundTarget != want {
 			t.Fatalf("window runtime target = %#v, want %#v", runtime.boundTarget, want)
 		}
 	})
@@ -159,7 +159,7 @@ func TestDeleteInstallsTheResolvedTargetOnTheLiveHalf(t *testing.T) {
 			"--socket", "isolated-run", "--dry-run"); err != nil {
 			t.Fatalf("dry-run error = %v", err)
 		}
-		if want := (explicitTmuxTarget{flag: "-L", value: "isolated-run"}); runtime.boundTarget != want {
+		if want := (tmuxTransport{Kind: tmuxSocketName, Value: "isolated-run", Source: tmuxSocketNameSource}); runtime.boundTarget != want {
 			t.Fatalf("agent delete target = %#v, want %#v", runtime.boundTarget, want)
 		}
 	})
@@ -179,7 +179,7 @@ func TestDeleteResultNamesTheResolvedSocket(t *testing.T) {
 	}{
 		{name: "an explicit socket name", args: []string{"--socket", "isolated-run"}, want: "socket=-L/isolated-run"},
 		{name: "an explicit socket path", args: []string{"--socket-path", "/tmp/isolated/socket"}, want: "socket=-S//tmp/isolated/socket"},
-		{name: "the inherited client", want: "socket=" + testDeleteTarget.label()},
+		{name: "the inherited client", want: "socket=" + testDeleteTarget.Label()},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/app/delete_window_runtime.go
+++ b/internal/app/delete_window_runtime.go
@@ -20,7 +20,7 @@ import (
 type windowDeleteRuntime interface {
 	// useExactTarget pins every read and write of this seam to one resolved
 	// server. It is called before the first inventory of an invocation.
-	useExactTarget(explicitTmuxTarget)
+	useExactTarget(tmuxTransport)
 	preflight(context.Context, coremetadata.Registry, deletePlan) (windowLiveDeletePlan, error)
 	killAll(context.Context, []windowLiveDeleteTarget) (int, error)
 	queueSelfKill(context.Context, []windowLiveDeleteTarget) error
@@ -71,7 +71,7 @@ func (p windowLiveDeletePlan) hasSelfTarget() bool {
 
 type tmuxWindowDeleteRuntime struct {
 	runner                tmuxCommandRunner
-	target                explicitTmuxTarget
+	target                tmuxTransport
 	expectedSocketPath    string
 	expectedLogicalSocket string
 	routeAuthority        *runtimeMutationRouteAuthority
@@ -87,7 +87,7 @@ func newTmuxWindowDeleteRuntime() *tmuxWindowDeleteRuntime {
 	}
 }
 
-func (r *tmuxWindowDeleteRuntime) useExactTarget(target explicitTmuxTarget) {
+func (r *tmuxWindowDeleteRuntime) useExactTarget(target tmuxTransport) {
 	if r == nil {
 		return
 	}
@@ -107,7 +107,7 @@ type liveWindowRow struct {
 
 func (r *tmuxWindowDeleteRuntime) routed() explicitTmuxRunner {
 	if r.expectedSocketPath != "" {
-		return explicitTmuxRunner{runner: r.runner, target: explicitTmuxTarget{flag: "-S", value: r.expectedSocketPath}}
+		return explicitTmuxRunner{runner: r.runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: r.expectedSocketPath, Source: tmuxSocketPathSource}}
 	}
 	return explicitTmuxRunner{runner: r.runner, target: r.target}
 }
@@ -116,7 +116,7 @@ func (r *tmuxWindowDeleteRuntime) inventory(ctx context.Context) ([]liveWindowRo
 	if r == nil || r.runner == nil {
 		return nil, false, errors.New("delete window: tmux runtime is not configured")
 	}
-	if r.target.flag == "" || r.target.value == "" {
+	if r.target.Flag() == "" || r.target.Value == "" {
 		return nil, false, errors.New("delete window: no exact tmux target is bound")
 	}
 	if err := r.observeSocketIdentity(ctx, true); err != nil {
@@ -222,13 +222,13 @@ func (r *tmuxWindowDeleteRuntime) preflight(ctx context.Context, registry coreme
 			// zero-match case closed also protects against a caller/window race.
 			if plan.Implicit {
 				return windowLiveDeletePlan{}, fmt.Errorf("delete window: registry window uid %q has no exact live tmux Window mirror on -L %s; nothing was changed",
-					target.Match.UID, r.target.value)
+					target.Match.UID, r.target.Value)
 			}
 			continue
 		}
 		if len(matches) != 1 {
 			return windowLiveDeletePlan{}, fmt.Errorf("delete window: registry window uid %q has %d live tmux Window mirrors on -L %s; exact target is ambiguous and nothing was changed",
-				target.Match.UID, len(matches), r.target.value)
+				target.Match.UID, len(matches), r.target.Value)
 		}
 		row := matches[0]
 		if err := root.validateLiveSession("delete window", "Window", row.windowID, target.Match.UID, row.projectUID, row.sessionName); err != nil {
@@ -426,14 +426,14 @@ func (r *tmuxWindowDeleteRuntime) revalidateQueuedWindow(ctx context.Context, ta
 }
 
 func (r *tmuxWindowDeleteRuntime) mutationAction(verb runtimeMutationVerb, target windowLiveDeleteTarget, mirror string, args ...string) plannedRuntimeMutation {
-	logicalRoute := r.target.flag + "=" + r.target.value
+	logicalRoute := r.target.Flag() + "=" + r.target.Value
 	action := newRuntimeMutation(1, verb, runtimeMutationTarget{
 		Socket: logicalRoute, PhysicalSocket: printableRuntimeMutationSocket(r.expectedSocketPath),
 		RouteAuthority: r.routeAuthority.printable(),
 		Kind:           "window", ID: target.WindowID, UID: target.UID,
 		Parent: target.SessionID + "/" + target.RootUID,
 	})
-	bindRuntimeMutationGuard(&action, "socket="+r.target.flag+"="+r.target.value+
+	bindRuntimeMutationGuard(&action, "socket="+r.target.Flag()+"="+r.target.Value+
 		";session="+target.SessionID+"/"+target.SessionName+
 		";window="+target.WindowID+"/"+mirror+
 		";root="+string(target.RootKind)+"/"+target.RootUID)
@@ -519,8 +519,8 @@ func (r *tmuxWindowDeleteRuntime) observeSocketIdentity(ctx context.Context, all
 	if observed == "" {
 		return errors.New("delete window: exact socket identity is empty")
 	}
-	if r.target.flag == "-S" && observed != r.target.value {
-		return fmt.Errorf("delete window: exact socket drifted: observed %q, planned %q", observed, r.target.value)
+	if r.target.Flag() == "-S" && observed != r.target.Value {
+		return fmt.Errorf("delete window: exact socket drifted: observed %q, planned %q", observed, r.target.Value)
 	}
 	if r.expectedSocketPath == "" {
 		r.expectedSocketPath = observed

--- a/internal/app/delete_window_runtime_test.go
+++ b/internal/app/delete_window_runtime_test.go
@@ -32,17 +32,17 @@ func newWindowRuntimeFixture(t *testing.T, inventory string) (*tmuxWindowDeleteR
 	// The exact target matches what the route resolves from the hermetic
 	// $TMUX in newTestDeleteCommand, so a runtime fixture and a full route
 	// invocation address the same isolated server.
-	target, err := tmuxSocketPathTarget(testDeleteTarget.value)
+	target, err := tmuxSocketPathTarget(testDeleteTarget.Value)
 	if err != nil {
 		t.Fatal(err)
 	}
 	runtime := &tmuxWindowDeleteRuntime{
 		runner: runner, target: target, getenv: func(string) string { return "" },
-		expectedSocketPath: testDeleteTarget.value, expectedLogicalSocket: defaultAppSocket,
+		expectedSocketPath: testDeleteTarget.Value, expectedLogicalSocket: defaultAppSocket,
 	}
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-F", "#{socket_path}")] = testDeleteTarget.value + "\n"
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-F", "#{socket_path}")] = testDeleteTarget.Value + "\n"
 	format := tmuxRowFormat("#{session_id}", "#{session_name}", "#{window_id}", "#{@projmux_project_uid}", "#{@projmux_window_uid}")
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "list-windows", "-a", "-F", format)] = inventory
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "list-windows", "-a", "-F", format)] = inventory
 	return runtime, runner, resourceFixtureRegistry(t)
 }
 
@@ -70,10 +70,10 @@ func TestWindowDeleteRuntimePreflightExactBindingAndSessionImpact(t *testing.T) 
 
 func TestWindowDeletePreExecuteNoServerRefusesInsteadOfCompletingAbsence(t *testing.T) {
 	runtime, runner, _ := newWindowRuntimeFixture(t, "")
-	runtime.expectedSocketPath = testDeleteTarget.value
+	runtime.expectedSocketPath = testDeleteTarget.Value
 	runtime.expectedLogicalSocket = defaultAppSocket
 	runtime.routeAuthority = &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: "4242"}
-	key := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-F", "#{socket_path}")
+	key := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-F", "#{socket_path}")
 	runner.errors = map[string]error{key: appTypedCommandFailure{inttmux.CommandFailure{Kind: inttmux.CommandFailureExit, Stderr: "no server running"}}}
 	target := windowLiveDeleteTarget{UID: "win-alpha-main", WindowID: "@10", SessionName: "alpha", SessionID: "$1", RootKind: coremetadata.KindProject, RootUID: "prj-alpha"}
 	applied, err := runtime.killAll(context.Background(), []windowLiveDeleteTarget{target})
@@ -89,13 +89,13 @@ func TestWindowDeletePreExecuteNoServerRefusesInsteadOfCompletingAbsence(t *test
 
 func TestWindowDeleteSuccessfulLastKillAcceptsPostApplyNoServerReceipt(t *testing.T) {
 	runner := &lastTargetDeleteRunner{kind: "window"}
-	target, err := tmuxSocketPathTarget(testDeleteTarget.value)
+	target, err := tmuxSocketPathTarget(testDeleteTarget.Value)
 	if err != nil {
 		t.Fatal(err)
 	}
 	runtime := &tmuxWindowDeleteRuntime{
 		runner: runner, target: target, getenv: func(string) string { return "" },
-		expectedSocketPath: testDeleteTarget.value, expectedLogicalSocket: defaultAppSocket,
+		expectedSocketPath: testDeleteTarget.Value, expectedLogicalSocket: defaultAppSocket,
 		routeAuthority: &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: "4242"},
 	}
 	live := windowLiveDeleteTarget{
@@ -167,7 +167,7 @@ func TestWindowDeleteRuntimePreflightAllowsExplicitOfflineWindow(t *testing.T) {
 
 func TestDeleteWindowTreatsOnlyTypedNoServerAsOffline(t *testing.T) {
 	inventoryFormat := tmuxRowFormat("#{session_id}", "#{session_name}", "#{window_id}", "#{@projmux_project_uid}", "#{@projmux_window_uid}")
-	inventoryKey := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "list-windows", "-a", "-F", inventoryFormat)
+	inventoryKey := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "list-windows", "-a", "-F", inventoryFormat)
 
 	t.Run("typed no-server permits Registry-only cascade", func(t *testing.T) {
 		store := newFakeResourceStore(t)
@@ -230,17 +230,17 @@ func TestWindowDeleteRuntimeStillRefusesImplicitOfflineWindow(t *testing.T) {
 	runtime.getenv = func(name string) string {
 		switch name {
 		case "TMUX":
-			return testDeleteTarget.value + ",123,0"
+			return testDeleteTarget.Value + ",123,0"
 		case "TMUX_PANE":
 			return "%7"
 		}
 		return ""
 	}
 	format := tmuxRowFormat("#{socket_path}", "#{window_id}")
-	runtime.runner.(*recordingTmuxRunner).outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-F", "#{socket_path}")] =
-		testDeleteTarget.value + "\n"
-	runtime.runner.(*recordingTmuxRunner).outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-t", "%7", "-F", format)] =
-		liveInventoryRow(testDeleteTarget.value, "@10")
+	runtime.runner.(*recordingTmuxRunner).outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-F", "#{socket_path}")] =
+		testDeleteTarget.Value + "\n"
+	runtime.runner.(*recordingTmuxRunner).outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-t", "%7", "-F", format)] =
+		liveInventoryRow(testDeleteTarget.Value, "@10")
 	plan := deleteWindowRuntimePlan("win-alpha-main")
 	plan.Implicit = true
 
@@ -294,21 +294,21 @@ func TestWindowDeleteRuntimeImplicitTargetRequiresExactCallerSocketAndWindow(t *
 	runtime.getenv = func(name string) string {
 		switch name {
 		case "TMUX":
-			return testDeleteTarget.value + ",123,0"
+			return testDeleteTarget.Value + ",123,0"
 		case "TMUX_PANE":
 			return "%7"
 		}
 		return ""
 	}
 	format := tmuxRowFormat("#{socket_path}", "#{window_id}")
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-F", "#{socket_path}")] =
-		testDeleteTarget.value + "\n"
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-F", "#{pid}")] = "123\n"
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-t", "%7", "-F", format)] =
-		liveInventoryRow(testDeleteTarget.value, "@10")
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-F", "#{socket_path}")] =
+		testDeleteTarget.Value + "\n"
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-F", "#{pid}")] = "123\n"
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-t", "%7", "-F", format)] =
+		liveInventoryRow(testDeleteTarget.Value, "@10")
 	authorityFormat := tmuxRowFormat("#{socket_path}", "#{pid}", "#{session_id}", "#{window_id}", "#{pane_id}")
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-t", "%7", "-F", authorityFormat)] =
-		liveInventoryRow(testDeleteTarget.value, "123", "$1", "@10", "%7")
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-t", "%7", "-F", authorityFormat)] =
+		liveInventoryRow(testDeleteTarget.Value, "123", "$1", "@10", "%7")
 	plan := deleteWindowRuntimePlan("win-alpha-main")
 	plan.Implicit = true
 
@@ -320,7 +320,7 @@ func TestWindowDeleteRuntimeImplicitTargetRequiresExactCallerSocketAndWindow(t *
 		t.Fatalf("implicit live plan = %#v", live)
 	}
 
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "display-message", "-p", "-F", "#{socket_path}")] =
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "display-message", "-p", "-F", "#{socket_path}")] =
 		"/tmp/foreign.sock\n"
 	if _, err := runtime.preflight(context.Background(), registry, plan); err == nil || !strings.Contains(err.Error(), "exact socket drifted") {
 		t.Fatalf("foreign caller socket error = %v", err)
@@ -329,12 +329,12 @@ func TestWindowDeleteRuntimeImplicitTargetRequiresExactCallerSocketAndWindow(t *
 
 func TestWindowDeleteRuntimeQueueUsesQuotedExactSocketAndWindow(t *testing.T) {
 	runtime, _, _ := newWindowRuntimeFixture(t, "")
-	runtime.expectedSocketPath = testDeleteTarget.value
+	runtime.expectedSocketPath = testDeleteTarget.Value
 	runtime.expectedLogicalSocket = defaultAppSocket
 	runtime.routeAuthority = &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: "4242"}
 	target := windowLiveDeleteTarget{UID: "win-alpha-main", WindowID: "@12", SessionName: "alpha", SessionID: "$1", RootKind: coremetadata.KindProject, RootUID: "prj-alpha"}
 	action := runtime.mutationAction(mutationQueueWindowKill, target, target.UID)
-	action.Queue = &runtimeMutationQueuedKill{PhysicalSocket: testDeleteTarget.value, LogicalSocket: defaultAppSocket,
+	action.Queue = &runtimeMutationQueuedKill{PhysicalSocket: testDeleteTarget.Value, LogicalSocket: defaultAppSocket,
 		RouteAuthority: action.Target.RouteAuthority,
 		ExpectedUID:    target.UID, SessionID: target.SessionID, WindowID: target.WindowID}
 	action.Queue.Marker = runtimeMutationQueueMarker(action)
@@ -343,7 +343,7 @@ func TestWindowDeleteRuntimeQueueUsesQuotedExactSocketAndWindow(t *testing.T) {
 		t.Fatal(err)
 	}
 	joined := strings.Join(argv, " ")
-	for _, want := range []string{"set-environment -g", "run-shell -b", "-S '" + testDeleteTarget.value + "'", "kill-window -t @12", tmuxopts.WindowUID} {
+	for _, want := range []string{"set-environment -g", "run-shell -b", "-S '" + testDeleteTarget.Value + "'", "kill-window -t @12", tmuxopts.WindowUID} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("queued Window argv = %q, want %q", joined, want)
 		}
@@ -357,11 +357,11 @@ func TestWindowDeleteRuntimeQueueRevalidatesEveryMirrorBeforeQueueing(t *testing
 		{UID: "win-alpha-main", WindowID: "@10", SessionName: "alpha", SessionID: "$1"},
 		{UID: "win-alpha-review", WindowID: "@11", SessionName: "alpha", SessionID: "$1"},
 	}
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "show-options", "-wqv", "-t", "@10", "@projmux_window_uid")] = "win-alpha-main\n"
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "show-options", "-wqv", "-t", "@10", "@projmux_window_uid")] = "win-alpha-main\n"
 	effectFormat := tmuxRowFormat("#{session_id}", "#{window_id}", "#{"+tmuxopts.WindowUID+"}")
-	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "list-windows", "-a", "-F", effectFormat)] =
+	runner.outputs[recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "list-windows", "-a", "-F", effectFormat)] =
 		liveInventoryRow("$1", "@10", "win-alpha-main") + liveInventoryRow("$1", "@11", "win-alpha-review")
-	secondKey := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "show-options", "-wqv", "-t", "@11", "@projmux_window_uid")
+	secondKey := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "show-options", "-wqv", "-t", "@11", "@projmux_window_uid")
 
 	for _, test := range []struct {
 		name     string

--- a/internal/app/exit_reconciliation_test.go
+++ b/internal/app/exit_reconciliation_test.go
@@ -182,18 +182,18 @@ func TestTheReconciliationObservesOneExactHostAndLeavesSiblingsAlone(t *testing.
 
 	for _, test := range []struct {
 		name   string
-		target explicitTmuxTarget
-		other  explicitTmuxTarget
+		target tmuxTransport
+		other  tmuxTransport
 	}{
 		{
 			name:   "an explicit socket name",
-			target: explicitTmuxTarget{flag: "-L", value: "event-host"},
-			other:  explicitTmuxTarget{flag: "-L", value: "sibling-host"},
+			target: tmuxTransport{Kind: tmuxSocketName, Value: "event-host", Source: tmuxSocketNameSource},
+			other:  tmuxTransport{Kind: tmuxSocketName, Value: "sibling-host", Source: tmuxSocketNameSource},
 		},
 		{
 			name:   "an explicit socket path",
-			target: explicitTmuxTarget{flag: "-S", value: "/tmp/event/socket"},
-			other:  explicitTmuxTarget{flag: "-S", value: "/tmp/sibling/socket"},
+			target: tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/event/socket", Source: tmuxSocketPathSource},
+			other:  tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/sibling/socket", Source: tmuxSocketPathSource},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -214,8 +214,8 @@ func TestTheReconciliationObservesOneExactHostAndLeavesSiblingsAlone(t *testing.
 			seedLiveWindow(t, siblingHost, siblingSession, "win-alpha-main", "pan-alpha-codex")
 
 			runner := &routedTmuxRunner{servers: map[string]*fakeTmux{
-				test.target.flag + "\x00" + test.target.value: eventHost,
-				test.other.flag + "\x00" + test.other.value:   siblingHost,
+				test.target.Flag() + "\x00" + test.target.Value: eventHost,
+				test.other.Flag() + "\x00" + test.other.Value:   siblingHost,
 			}}
 
 			store := newFakeResourceStore(t)
@@ -239,10 +239,10 @@ func TestTheReconciliationObservesOneExactHostAndLeavesSiblingsAlone(t *testing.
 			}
 
 			for _, call := range runner.calls {
-				if call.flag == test.other.flag && call.value == test.other.value {
+				if call.flag == test.other.Flag() && call.value == test.other.Value {
 					t.Fatalf("the sibling server was addressed: %s %s %v", call.flag, call.value, call.args)
 				}
-				if call.flag != test.target.flag || call.value != test.target.value {
+				if call.flag != test.target.Flag() || call.value != test.target.Value {
 					t.Fatalf("an unexpected server was addressed: %s %s %v", call.flag, call.value, call.args)
 				}
 			}
@@ -251,8 +251,8 @@ func TestTheReconciliationObservesOneExactHostAndLeavesSiblingsAlone(t *testing.
 			}
 			// The event describes the exact target it routed, so a diagnostic line
 			// names the server the pass actually read.
-			if !strings.Contains(event.describe(), test.target.label()) {
-				t.Fatalf("event.describe() = %q, want it to name %q", event.describe(), test.target.label())
+			if !strings.Contains(event.describe(), test.target.Label()) {
+				t.Fatalf("event.describe() = %q, want it to name %q", event.describe(), test.target.Label())
 			}
 		})
 	}
@@ -276,9 +276,9 @@ func TestTheReconciliationNeverMutatesTmux(t *testing.T) {
 	host := newFakeTmux()
 	session := host.addSession("alpha")
 	seedLiveWindow(t, host, session, "win-alpha-main", "pan-alpha-zsh")
-	target := explicitTmuxTarget{flag: "-L", value: "audit-host"}
+	target := tmuxTransport{Kind: tmuxSocketName, Value: "audit-host", Source: tmuxSocketNameSource}
 	runner := &routedTmuxRunner{servers: map[string]*fakeTmux{
-		target.flag + "\x00" + target.value: host,
+		target.Flag() + "\x00" + target.Value: host,
 	}}
 
 	store := newFakeResourceStore(t)

--- a/internal/app/lifecycle_cascade_test.go
+++ b/internal/app/lifecycle_cascade_test.go
@@ -161,7 +161,7 @@ func activateExactPane(t *testing.T, store *fakeResourceStore, paneUID, agentUID
 
 func exactPaneExitDirty(receipts ...coremetadata.TerminationEvidence) lifecycleDirtyEvent {
 	return lifecycleDirtyEvent{
-		target:        explicitTmuxTarget{flag: "-S", value: "/tmp/phase2-exact.sock"},
+		target:        tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/phase2-exact.sock", Source: tmuxSocketPathSource},
 		runtimePaneID: "%9",
 		teardownKind:  coremetadata.TeardownEventPaneExited,
 		receipts:      receipts,
@@ -366,7 +366,7 @@ func TestWindowUnlinkedConsumesStoredExactTeardownEvidenceOnlyForTargetWindow(t 
 			continue
 		}
 		store.registry.Panes[i].Status.Teardown = &coremetadata.PaneTeardownEvidence{
-			SocketIdentity: event.target.label(), RuntimeSessionID: "$1", RuntimePaneID: "%9", RuntimeWindowID: "@4",
+			SocketIdentity: event.target.Label(), RuntimeSessionID: "$1", RuntimePaneID: "%9", RuntimeWindowID: "@4",
 			WindowUID: "win-alpha-review", RootKind: coremetadata.KindProject, RootUID: "prj-alpha",
 			Generation: "gen-legacy-unlink", Classification: coremetadata.TerminationNormal,
 			ObservedAt: time.Date(2026, 8, 25, 0, 0, 0, 0, time.UTC),

--- a/internal/app/lifecycle_reconcile.go
+++ b/internal/app/lifecycle_reconcile.go
@@ -39,7 +39,7 @@ type lifecycleDirtyEvent struct {
 	// target is the exact tmux server to re-observe. The zero value routes
 	// through the inherited client, which is the absolute socket in $TMUX; a
 	// non-zero value is an explicit -L/-S and addresses that server only.
-	target explicitTmuxTarget
+	target tmuxTransport
 	// paneUID narrows the event to one Pane. Empty means the whole host.
 	paneUID string
 	// runtimePaneID is the exact #{hook_pane} supplied by pane-exited. It is
@@ -74,7 +74,7 @@ type lifecycleDirtyEvent struct {
 
 // describe renders the event for a diagnostic line.
 func (e lifecycleDirtyEvent) describe() string {
-	out := "socket=" + e.target.label()
+	out := "socket=" + e.target.Label()
 	if pane := strings.TrimSpace(e.paneUID); pane != "" {
 		out += " pane=" + pane
 	}
@@ -233,7 +233,7 @@ func planExactLifecycleCascade(
 ) (exactLifecycleCascadePlan, error) {
 	if (event.teardownKind != coremetadata.TeardownEventPaneExited &&
 		event.teardownKind != coremetadata.TeardownEventWindowUnlinked) ||
-		event.target.flag == "" || event.target.value == "" {
+		event.target.Flag() == "" || event.target.Value == "" {
 		return exactLifecycleCascadePlan{}, nil
 	}
 	if event.teardownKind == coremetadata.TeardownEventWindowUnlinked {
@@ -387,7 +387,7 @@ func planExactLifecycleCascade(
 		Kind: event.teardownKind, Classification: classification,
 		Generation: coremetadata.TeardownGenerationCurrent, Observation: observation,
 		Chain: coremetadata.TeardownOwnerChain{
-			SocketIdentity: event.target.label(), SessionHandle: observed.SessionID, PaneHandle: observed.PaneID,
+			SocketIdentity: event.target.Label(), SessionHandle: observed.SessionID, PaneHandle: observed.PaneID,
 			WindowHandle: observed.WindowID, PaneUID: pane.Metadata.UID,
 			WindowUID: windowUID, RootKind: root.Kind, RootUID: root.UID,
 			Generation: pane.Status.Activation.Generation,
@@ -465,7 +465,7 @@ func planExactWindowUnlinkCascade(
 	for i := range registry.Panes {
 		candidate := &registry.Panes[i]
 		evidence := candidate.Status.Teardown
-		if evidence == nil || evidence.SocketIdentity != event.target.label() ||
+		if evidence == nil || evidence.SocketIdentity != event.target.Label() ||
 			evidence.RuntimeSessionID != strings.TrimSpace(event.runtimeSessionID) ||
 			evidence.RuntimeWindowID != strings.TrimSpace(event.runtimeWindowID) {
 			continue
@@ -728,9 +728,9 @@ func lifecycleObservedLiveWindowSessions(ctx context.Context, inventory livePane
 // binding-convergence routes use. A zero target falls through to the bare runner
 // so an in-tmux invocation observes the server $TMUX names -- introducing a
 // default socket here is the exact mistake the delete corrective removed.
-func lifecycleInventory(runner tmuxCommandRunner, target explicitTmuxTarget) livePaneInventory {
+func lifecycleInventory(runner tmuxCommandRunner, target tmuxTransport) livePaneInventory {
 	routed := runner
-	if target.flag != "" && target.value != "" {
+	if target.Flag() != "" && target.Value != "" {
 		routed = explicitTmuxRunner{runner: runner, target: target}
 	}
 	runtime := newTmuxPaneDeleteRuntime()

--- a/internal/app/materialize.go
+++ b/internal/app/materialize.go
@@ -243,7 +243,7 @@ type materializer struct {
 	// target is the immutable logical route shared by runner, mirror, and
 	// sessions. Every printable action carries it and every write reobserves
 	// the server's #{socket_path} through that same route first.
-	target explicitTmuxTarget
+	target tmuxTransport
 	// expectedSocketPath is the exact invocation identity resolved before the
 	// plan. It closes the gap where an -L name could be retargeted between
 	// planning and execution.
@@ -276,9 +276,9 @@ func (m *materializer) routedRunner() tmuxCommandRunner {
 	return m.runner
 }
 
-func (m *materializer) exactMutationRoute() (explicitTmuxTarget, string, error) {
+func (m *materializer) exactMutationRoute() (tmuxTransport, string, error) {
 	target := m.target
-	if target.flag == "" || target.value == "" {
+	if target.Flag() == "" || target.Value == "" {
 		switch runner := m.runner.(type) {
 		case explicitTmuxRunner:
 			target = runner.target
@@ -286,19 +286,19 @@ func (m *materializer) exactMutationRoute() (explicitTmuxTarget, string, error) 
 			target = runner.target
 		}
 	}
-	switch target.flag {
+	switch target.Flag() {
 	case "-L":
-		if strings.TrimSpace(target.value) == "" {
+		if strings.TrimSpace(target.Value) == "" {
 			break
 		}
-		return target, "-L=" + target.value, nil
+		return target, "-L=" + target.Value, nil
 	case "-S":
-		if filepath.IsAbs(target.value) {
-			target.value = filepath.Clean(target.value)
-			return target, "-S=" + target.value, nil
+		if filepath.IsAbs(target.Value) {
+			target.Value = filepath.Clean(target.Value)
+			return target, "-S=" + target.Value, nil
 		}
 	}
-	return explicitTmuxTarget{}, "", errors.New("materializer requires an exact -L socket name or absolute -S socket path")
+	return tmuxTransport{}, "", errors.New("materializer requires an exact -L socket name or absolute -S socket path")
 }
 
 func (m *materializer) boundMutationTarget(kind, id, uid string) runtimeMutationTarget {
@@ -329,7 +329,7 @@ func (m *materializer) targetRouteGuard(action plannedRuntimeMutation) func(cont
 		}
 		if action.Target.PhysicalSocket == runtimeMutationSocketAbsentBeforeCreate {
 			if m.expectedSocketPath != "" || m.routeAuthority != nil ||
-				action.Target.Socket != target.flag+"="+target.value || action.Target.RouteAuthority != "" {
+				action.Target.Socket != target.Flag()+"="+target.Value || action.Target.RouteAuthority != "" {
 				return errors.New("materializer absent-before-create authority disagrees with printable target")
 			}
 			probe := m.runnerAtTarget(target)
@@ -341,7 +341,7 @@ func (m *materializer) targetRouteGuard(action plannedRuntimeMutation) func(cont
 			}
 			return errors.New("materializer absent-before-create server appeared after planning")
 		}
-		wantSocket := target.flag + "=" + target.value
+		wantSocket := target.Flag() + "=" + target.Value
 		if action.Verb == mutationWriteRouteMarker {
 			wantSocket = "-S=" + m.expectedSocketPath
 		}
@@ -376,10 +376,10 @@ func (m *materializer) targetRouteGuard(action plannedRuntimeMutation) func(cont
 }
 
 func (m *materializer) runnerAtPhysicalSocket(path string) tmuxCommandRunner {
-	return m.runnerAtTarget(explicitTmuxTarget{flag: "-S", value: filepath.Clean(path)})
+	return m.runnerAtTarget(tmuxTransport{Kind: tmuxSocketPath, Value: filepath.Clean(path), Source: tmuxSocketPathSource})
 }
 
-func (m *materializer) runnerAtTarget(target explicitTmuxTarget) tmuxCommandRunner {
+func (m *materializer) runnerAtTarget(target tmuxTransport) tmuxCommandRunner {
 	return explicitTmuxRunner{runner: m.baseRunner(), target: target}
 }
 
@@ -497,10 +497,10 @@ func (m *materializer) guardExactRouteOwnership(ctx context.Context, allowNoServ
 			return errors.New("runtime mutation route: exact server is not app-owned")
 		}
 	}
-	switch target.flag {
+	switch target.Flag() {
 	case "-S":
-		if observed != target.value {
-			return fmt.Errorf("tmux socket drifted: observed %q, planned %q", observed, target.value)
+		if observed != target.Value {
+			return fmt.Errorf("tmux socket drifted: observed %q, planned %q", observed, target.Value)
 		}
 	case "-L":
 		// The logical route is proved by expectedSocketPath, which was resolved
@@ -509,12 +509,12 @@ func (m *materializer) guardExactRouteOwnership(ctx context.Context, allowNoServ
 	return nil
 }
 
-func (m *materializer) logicalSocketName(target explicitTmuxTarget) string {
+func (m *materializer) logicalSocketName(target tmuxTransport) string {
 	if strings.TrimSpace(m.socketName) != "" {
 		return strings.TrimSpace(m.socketName)
 	}
-	if target.flag == "-L" {
-		return target.value
+	if target.Flag() == "-L" {
+		return target.Value
 	}
 	return ""
 }
@@ -1304,15 +1304,15 @@ func (m *materializer) writeCreatedProjectRouteMarker(ctx context.Context, resul
 	if err != nil {
 		return err
 	}
-	if target.flag != "-L" || strings.TrimSpace(target.value) == "" || !filepath.IsAbs(m.expectedSocketPath) {
+	if target.Flag() != "-L" || strings.TrimSpace(target.Value) == "" || !filepath.IsAbs(m.expectedSocketPath) {
 		return errors.New("created Project route marker requires an exact logical and physical route")
 	}
-	printableTarget := m.boundMutationTarget("session", result.SessionID, "logical:"+target.value)
+	printableTarget := m.boundMutationTarget("session", result.SessionID, "logical:"+target.Value)
 	printableTarget.Socket = "-S=" + m.expectedSocketPath
 	printableTarget.Parent = result.WindowID + "/" + result.PaneID
 	action := newRuntimeMutation(1, mutationWriteRouteMarker, printableTarget)
 	bindRuntimeMutationGuard(&action, "exact created Project tuple and operation lease="+marker)
-	action.Operands = []string{"-S", m.expectedSocketPath, "-gq", runtimeMutationSocketNameOption, target.value}
+	action.Operands = []string{"-S", m.expectedSocketPath, "-gq", runtimeMutationSocketNameOption, target.Value}
 	observeReceipt := func(ctx context.Context) (bool, error) {
 		if err := m.guardExactAppRoute(ctx, false, action.Target.PhysicalSocket); err != nil {
 			return false, err
@@ -1332,10 +1332,10 @@ func (m *materializer) writeCreatedProjectRouteMarker(ctx context.Context, resul
 				return false, err
 			}
 			current := strings.TrimSpace(string(out))
-			if current != "" && current != target.value {
-				return false, fmt.Errorf("created Project logical route marker is %q, want %q", current, target.value)
+			if current != "" && current != target.Value {
+				return false, fmt.Errorf("created Project logical route marker is %q, want %q", current, target.Value)
 			}
-			return current == target.value, nil
+			return current == target.Value, nil
 		},
 		Guard: func(ctx context.Context) error {
 			owned, err := observeReceipt(ctx)
@@ -1347,7 +1347,7 @@ func (m *materializer) writeCreatedProjectRouteMarker(ctx context.Context, resul
 				return err
 			}
 			current := strings.TrimSpace(string(out))
-			if current != "" && current != target.value {
+			if current != "" && current != target.Value {
 				return fmt.Errorf("created Project logical route marker is %q, want blank or exact", current)
 			}
 			return nil
@@ -1447,14 +1447,14 @@ func (m *materializer) bindCreatedProjectRecoveryRoute(ctx context.Context) (boo
 	if err != nil {
 		return false, err
 	}
-	if target.flag == "-S" {
-		if !filepath.IsAbs(target.value) || filepath.Clean(target.value) != target.value {
-			return false, fmt.Errorf("created Project recovery route is not an absolute clean socket: %q", target.value)
+	if target.Flag() == "-S" {
+		if !filepath.IsAbs(target.Value) || filepath.Clean(target.Value) != target.Value {
+			return false, fmt.Errorf("created Project recovery route is not an absolute clean socket: %q", target.Value)
 		}
-		m.expectedSocketPath = target.value
+		m.expectedSocketPath = target.Value
 		return true, nil
 	}
-	if target.flag != "-L" {
+	if target.Flag() != "-L" {
 		return false, errors.New("created Project recovery requires an exact logical or physical route")
 	}
 	out, err := m.runnerAtTarget(target).Run(ctx, "tmux", "display-message", "-p", "-F", "#{socket_path}")

--- a/internal/app/project_registry_test.go
+++ b/internal/app/project_registry_test.go
@@ -20,7 +20,7 @@ import (
 // in-memory tmux server.
 func newTestReconciler(tmux *fakeTmux, roots []string) *registryReconciler {
 	typed := runtimeMutationMetadataMirror{runner: explicitTmuxRunner{
-		runner: tmux, target: explicitTmuxTarget{flag: "-L", value: defaultAppSocket},
+		runner: tmux, target: tmuxTransport{Kind: tmuxSocketName, Value: defaultAppSocket, Source: tmuxSocketNameSource},
 	}}
 	return &registryReconciler{
 		discoverRoots: func() ([]string, error) { return roots, nil },

--- a/internal/app/project_startup.go
+++ b/internal/app/project_startup.go
@@ -414,7 +414,7 @@ func materializeProjectSessionCanonical(ctx context.Context, store *resourceStor
 	if store == nil || runner == nil {
 		return errors.New("canonical Project session materializer is not configured")
 	}
-	if route.target.flag == "" || route.target.value == "" || strings.TrimSpace(route.socketName) == "" {
+	if route.target.Flag() == "" || route.target.Value == "" || strings.TrimSpace(route.socketName) == "" {
 		return errors.New("canonical Project session materializer has no exact app-owned route")
 	}
 	routed := explicitTmuxRunner{runner: runner, target: route.target}
@@ -632,7 +632,7 @@ func (c *switchCommand) materializeProjectTopology(ctx context.Context, request 
 type registryProjectTopologyMaterializer struct {
 	resources          *resourceStore
 	runner             tmuxCommandRunner
-	target             explicitTmuxTarget
+	target             tmuxTransport
 	expectedSocketPath string
 	socketName         string
 	routeAuthority     *runtimeMutationRouteAuthority

--- a/internal/app/project_startup_fresh.go
+++ b/internal/app/project_startup_fresh.go
@@ -126,7 +126,7 @@ type projectFreshStartCommit struct {
 type registryProjectFreshStarter struct {
 	resources    *resourceStore
 	runner       tmuxRunner
-	target       explicitTmuxTarget
+	target       tmuxTransport
 	shell        string
 	loadSnapshot func(string) (sessionstate.Snapshot, error)
 }
@@ -478,7 +478,7 @@ func (s *registryProjectFreshStarter) requireClosedProject(ctx context.Context, 
 		return nil
 	}
 	target := s.target
-	if target.flag == "" || target.value == "" {
+	if target.Flag() == "" || target.Value == "" {
 		target, err = tmuxSocketNameTarget(defaultAppSocket)
 		if err != nil {
 			return fmt.Errorf("project fresh start: exact tmux target: %w", err)

--- a/internal/app/project_startup_topology_test.go
+++ b/internal/app/project_startup_topology_test.go
@@ -445,7 +445,7 @@ func TestNewSwitchCommandWiresExactSocketTopologyActivation(t *testing.T) {
 	if !ok {
 		t.Fatalf("newSwitchCommand().projectTopology = %T, want the Registry topology activation", newSwitchCommand().projectTopology)
 	}
-	want := explicitTmuxTarget{flag: "-L", value: defaultAppSocket}
+	want := tmuxTransport{Kind: tmuxSocketName, Value: defaultAppSocket, Source: tmuxSocketNameSource}
 	if !reflect.DeepEqual(activation.target, want) {
 		t.Fatalf("activation target = %+v, want %+v", activation.target, want)
 	}

--- a/internal/app/quit_snapshots.go
+++ b/internal/app/quit_snapshots.go
@@ -236,7 +236,7 @@ func (c *quitCommand) saveProjectSnapshotsAndQuit(ctx context.Context, socketNam
 		if deps.now != nil {
 			at = deps.now()
 		}
-		exactRunner := explicitTmuxRunner{runner: c.runner, target: explicitTmuxTarget{flag: "-S", value: path}}
+		exactRunner := explicitTmuxRunner{runner: c.runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: path, Source: tmuxSocketPathSource}}
 		for _, target := range plan.Targets {
 			entry := quitSnapshotLedgerEntry{Target: target}
 			if _, captureErr := deps.capture(ctx, exactRunner, store, target, at); captureErr != nil {

--- a/internal/app/recovery_authority_test.go
+++ b/internal/app/recovery_authority_test.go
@@ -108,8 +108,8 @@ func TestLockedAutomaticRecoveryReclassifiesConcurrentRegistryClaimBeforeL8(t *t
 	session.windows[0].opts[tmuxopts.WindowUID] = full.Windows[0].Metadata.UID
 	session.windows[0].panes[0].opts[tmuxopts.PaneUID] = full.Panes[0].Metadata.UID
 	runner := &routedTmuxRunner{servers: map[string]*fakeTmux{"-L\x00locked-race": server}}
-	target := explicitTmuxTarget{flag: "-L", value: "locked-race"}
-	if got := len(resourcegraph.Resolve(snapshot, intmetadata.NewInventoryObserver(runner, controllerTransport(target)).Observe(context.Background())).RuntimeOfClass(resourcegraph.ClassRecoverable)); got != 1 {
+	target := tmuxTransport{Kind: tmuxSocketName, Value: "locked-race", Source: tmuxSocketNameSource}
+	if got := len(resourcegraph.Resolve(snapshot, intmetadata.NewInventoryObserver(runner, target.ExplicitProjection()).Observe(context.Background())).RuntimeOfClass(resourcegraph.ClassRecoverable)); got != 1 {
 		t.Fatalf("unlocked preview D3 count = %d, want 1", got)
 	}
 	store := &resourceStore{updateConvergent: func(fn func(*coremetadata.Registry) error) (coremetadata.Registry, bool, error) {
@@ -144,7 +144,7 @@ func TestLockedAutomaticRecoveryIgnoresOuterStoreNormalizationChangeSignal(t *te
 		return working, true, nil
 	}}
 	recovered, err := runLockedAutomaticMirrorRecovery(context.Background(), store, runner,
-		explicitTmuxTarget{flag: "-L", value: "outer-normalize"}, controller.RecoveryHookConverge)
+		tmuxTransport{Kind: tmuxSocketName, Value: "outer-normalize", Source: tmuxSocketNameSource}, controller.RecoveryHookConverge)
 	if err != nil || recovered != 0 {
 		t.Fatalf("outer changed=true was attributed to L8: recovered=%d err=%v", recovered, err)
 	}
@@ -222,8 +222,8 @@ func slicesDeleteReservations(in []coremetadata.NameReservation, known map[strin
 func TestIncident20260820ExactD3AutomaticallyRunsL8WhileL7RequiresApproval(t *testing.T) {
 	registry, server, root := incident20260820RecoveryFixture(t)
 	runner := &routedTmuxRunner{servers: map[string]*fakeTmux{"-L\x00incident": server}}
-	target := explicitTmuxTarget{flag: "-L", value: "incident"}
-	inventory := intmetadata.NewInventoryObserver(runner, controllerTransport(target)).Observe(context.Background())
+	target := tmuxTransport{Kind: tmuxSocketName, Value: "incident", Source: tmuxSocketNameSource}
+	inventory := intmetadata.NewInventoryObserver(runner, target.ExplicitProjection()).Observe(context.Background())
 	items := resourcegraph.ClassifyDivergences(registry, inventory)
 	d3 := 0
 	for _, item := range items {

--- a/internal/app/registry_recovery.go
+++ b/internal/app/registry_recovery.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/config"
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	"github.com/crevissepartners/projmux/internal/core/resourcegraph"
 	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
 )
 
@@ -48,7 +49,7 @@ type registryRecoveryCommand struct {
 	// test ever inspects or restores the operator's own Registry.
 	newStore func() (*intmetadata.Store, error)
 	// observeFragments is the mirror seam, resolved against one exact target.
-	observeFragments func(context.Context, explicitTmuxTarget) ([]intmetadata.IdentityFragment, error)
+	observeFragments func(context.Context, tmuxTransport) ([]intmetadata.IdentityFragment, error)
 }
 
 func newRegistryRecoveryCommand(tmux *tmuxCommand) *registryRecoveryCommand {
@@ -65,7 +66,7 @@ func newRegistryRecoveryCommand(tmux *tmuxCommand) *registryRecoveryCommand {
 	if tmux != nil {
 		command.runner = tmux.runner
 	}
-	command.observeFragments = func(ctx context.Context, target explicitTmuxTarget) ([]intmetadata.IdentityFragment, error) {
+	command.observeFragments = func(ctx context.Context, target tmuxTransport) ([]intmetadata.IdentityFragment, error) {
 		if command.runner == nil {
 			return nil, errors.New("no tmux runner is configured")
 		}
@@ -333,7 +334,11 @@ func (c *registryRecoveryCommand) observeMirror(ctx context.Context, opts regist
 		report.Reason = err.Error()
 		return report
 	}
-	report.Target = "tmux " + target.flag + " " + target.value
+	if !target.Present() {
+		report.Reason = "no exact tmux transport: pass --socket <name> or --socket-path <absolute> to inspect a live mirror"
+		return report
+	}
+	report.Target = target.String()
 	if c.observeFragments == nil {
 		report.Reason = "no tmux mirror reader is configured"
 		return report
@@ -366,22 +371,14 @@ func (c *registryRecoveryCommand) observeMirror(ctx context.Context, opts regist
 
 // resolveMirrorTarget picks the exact server to observe. Unlike `reconcile
 // resources` an absent target is not a usage error here; it is a reason.
-func (c *registryRecoveryCommand) resolveMirrorTarget(opts registryRecoveryOptions) (explicitTmuxTarget, error) {
-	if strings.TrimSpace(opts.socket) != "" {
-		return tmuxSocketNameTarget(opts.socket)
-	}
-	if strings.TrimSpace(opts.socketPath) != "" {
-		return tmuxSocketPathTarget(opts.socketPath)
-	}
+func (c *registryRecoveryCommand) resolveMirrorTarget(opts registryRecoveryOptions) (tmuxTransport, error) {
 	tmuxEnv := ""
 	if c.lookupEnv != nil {
-		tmuxEnv = strings.TrimSpace(c.lookupEnv("TMUX"))
+		tmuxEnv = c.lookupEnv("TMUX")
 	}
-	inherited, _, _ := strings.Cut(tmuxEnv, ",")
-	if inherited == "" || !filepath.IsAbs(inherited) {
-		return explicitTmuxTarget{}, errors.New("no exact tmux transport: pass --socket <name> or --socket-path <absolute> to inspect a live mirror")
-	}
-	return tmuxSocketPathTarget(inherited)
+	return resourcegraph.ResolveTransport(resourcegraph.TransportRequest{
+		SocketName: opts.socket, SocketPath: opts.socketPath, InheritedTMUX: tmuxEnv,
+	})
 }
 
 // registryRecoveryGaps is the fixed statement of what no mirror can return.

--- a/internal/app/registry_recovery_test.go
+++ b/internal/app/registry_recovery_test.go
@@ -70,7 +70,7 @@ func newRecoveryHarness(t *testing.T) *recoveryHarness {
 	command.newStore = func() (*intmetadata.Store, error) { return store, nil }
 	command.lookupEnv = func(string) string { return "" }
 	command.runner = runner
-	command.observeFragments = func(ctx context.Context, target explicitTmuxTarget) ([]intmetadata.IdentityFragment, error) {
+	command.observeFragments = func(ctx context.Context, target tmuxTransport) ([]intmetadata.IdentityFragment, error) {
 		return intmetadata.NewMirror(explicitTmuxRunner{runner: runner, target: target}).ObserveIdentityFragments(ctx)
 	}
 	return &recoveryHarness{t: t, command: command, store: store, dir: dir, tmux: runner}

--- a/internal/app/registry_topology_materialize.go
+++ b/internal/app/registry_topology_materialize.go
@@ -75,7 +75,7 @@ func planRegistryTopology(
 	projectRef string,
 	reconciler *registryReconciler,
 	sessions []observedResourceProjectSession,
-	exactTarget explicitTmuxTarget,
+	exactTarget tmuxTransport,
 	launcher topologyAgentLauncher,
 ) (*registryTopologyPlan, error) {
 	if strings.TrimSpace(projectRef) == "" {
@@ -132,7 +132,7 @@ func planRegistryTopology(
 	}
 	if target == nil {
 		plan.addItem(0, coremetadata.KindProject, project.Metadata.Name, project.Metadata.UID, "materialize")
-		if exactTarget.flag == "-S" {
+		if exactTarget.Flag() == "-S" {
 			plan.refuse(resourcegraph.DivergenceUnrealized, coremetadata.KindProject, project.Metadata.Name,
 				"offline Project session creation via --socket-path cannot preserve exact name-only PROJMUX_SOCKET hook re-entry")
 		}
@@ -521,7 +521,7 @@ func isMissingTmuxServer(err error) bool {
 type topologyMaterializeRun struct {
 	resources          *resourceStore
 	runner             tmuxCommandRunner
-	target             explicitTmuxTarget
+	target             tmuxTransport
 	expectedSocketPath string
 	diagnostics        *diagnostics.LifecycleRecorder
 	socketName         string
@@ -558,11 +558,11 @@ type topologyMaterializeOutcome struct {
 // defaultTopologyMaterializer builds the runtime for one exact target. The tmux
 // client is the existing one, so the public pre/post-create and startup hook
 // contract has exactly one implementation.
-func defaultTopologyMaterializer(target explicitTmuxTarget, recorder *diagnostics.LifecycleRecorder) func(tmuxCommandRunner, io.Writer) *materializer {
+func defaultTopologyMaterializer(target tmuxTransport, recorder *diagnostics.LifecycleRecorder) func(tmuxCommandRunner, io.Writer) *materializer {
 	return func(runner tmuxCommandRunner, warn io.Writer) *materializer {
 		opts := []inttmux.ClientOption{}
-		if target.flag == "-L" {
-			opts = append(opts, inttmux.WithSocketName(target.value))
+		if target.Flag() == "-L" {
+			opts = append(opts, inttmux.WithSocketName(target.Value))
 		}
 		if recorder != nil {
 			opts = append(opts, inttmux.WithLifecycleDiagnostics(recorder))
@@ -743,7 +743,7 @@ func requireMaterializeSession(plan *registryTopologyPlan, sessionName string) {
 func (c *resourceReconcileCommand) runMaterializeExecute(
 	ctx context.Context,
 	planner resourceReconcilePlanner,
-	target explicitTmuxTarget,
+	target tmuxTransport,
 	reportTarget resourceReconcileTarget,
 	opts resourceReconcileOptions,
 	stdout, stderr io.Writer,
@@ -789,7 +789,7 @@ func (c *resourceReconcileCommand) runMaterializeExecute(
 	return writeResourceReconcileReport(stdout, opts.output, report)
 }
 
-func bindExplicitMaterializeSocket(ctx context.Context, runner tmuxCommandRunner, target explicitTmuxTarget, lookupEnv func(string) string) (runtimeMutationRoute, error) {
+func bindExplicitMaterializeSocket(ctx context.Context, runner tmuxCommandRunner, target tmuxTransport, lookupEnv func(string) string) (runtimeMutationRoute, error) {
 	if runner == nil {
 		return runtimeMutationRoute{}, errors.New("resource materialization requires a tmux runner")
 	}
@@ -800,12 +800,12 @@ func bindExplicitMaterializeSocket(ctx context.Context, runner tmuxCommandRunner
 			// A fresh logical route has no physical identity until new-session
 			// returns and the materializer binds #{socket_path}. An explicit -S
 			// declaration already names the immutable path the create must use.
-			if target.flag == "-L" {
-				return runtimeMutationRoute{target: target, socketName: target.value}, nil
+			if target.Flag() == "-L" {
+				return runtimeMutationRoute{target: target, socketName: target.Value}, nil
 			}
-			if target.flag == "-S" {
-				path := filepath.Clean(strings.TrimSpace(target.value))
-				if filepath.IsAbs(path) && path == target.value {
+			if target.Flag() == "-S" {
+				path := filepath.Clean(strings.TrimSpace(target.Value))
+				if filepath.IsAbs(path) && path == target.Value {
 					return runtimeMutationRoute{target: target, expectedSocketPath: path, socketName: defaultAppSocket}, nil
 				}
 			}
@@ -816,7 +816,7 @@ func bindExplicitMaterializeSocket(ctx context.Context, runner tmuxCommandRunner
 	if path == "." || !filepath.IsAbs(path) {
 		return runtimeMutationRoute{}, errors.New("resource materialization observed no absolute socket identity")
 	}
-	if target.flag == "-S" && path != filepath.Clean(target.value) {
+	if target.Flag() == "-S" && path != filepath.Clean(target.Value) {
 		return runtimeMutationRoute{}, errors.New("resource materialization physical socket drifted")
 	}
 	route, err := resolveExistingRuntimeMutationRoute(ctx, runner, target, lookupEnv)

--- a/internal/app/rename.go
+++ b/internal/app/rename.go
@@ -232,7 +232,7 @@ func (c *renameCommand) renameRuntimeWindow(ctx context.Context, uid, name strin
 	if route.expectedSocketPath == "" {
 		return nil
 	}
-	routed := explicitTmuxRunner{runner: c.tmuxRunner, target: explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}}
+	routed := explicitTmuxRunner{runner: c.tmuxRunner, target: tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}}
 	observe := func(ctx context.Context) (runtimeWindowRenameObservation, bool, error) {
 		out, err := routed.Run(ctx, "tmux", "list-windows", "-a", "-F", tmuxRowFormat(
 			"#{window_id}", "#{"+tmuxopts.WindowUID+"}", "#{session_id}",

--- a/internal/app/resource_controller.go
+++ b/internal/app/resource_controller.go
@@ -60,7 +60,7 @@ type controllerReobservation struct {
 
 // resourceControllerKernel orchestrates one command against one exact server.
 type resourceControllerKernel struct {
-	target               explicitTmuxTarget
+	target               tmuxTransport
 	runner               tmuxCommandRunner
 	store                *resourceStore
 	planner              resourceReconcilePlanner
@@ -89,7 +89,7 @@ var controllerGuardFields = controller.GuardFields{
 	WindowID:   "window_id",
 }
 
-func newResourceControllerKernel(runner tmuxCommandRunner, store *resourceStore, planner resourceReconcilePlanner, target explicitTmuxTarget) *resourceControllerKernel {
+func newResourceControllerKernel(runner tmuxCommandRunner, store *resourceStore, planner resourceReconcilePlanner, target tmuxTransport) *resourceControllerKernel {
 	kernel := &resourceControllerKernel{
 		target: target, runner: runner, store: store, planner: planner,
 		trigger: controller.RecoveryExplicit, lookupEnv: os.Getenv,
@@ -100,18 +100,18 @@ func newResourceControllerKernel(runner tmuxCommandRunner, store *resourceStore,
 		// stages would make the reobservation report the pre-execute machine.
 		readTarget := kernel.target
 		if kernel.route != nil && kernel.route.expectedSocketPath != "" {
-			readTarget = explicitTmuxTarget{flag: "-S", value: kernel.route.expectedSocketPath}
+			readTarget = tmuxTransport{Kind: tmuxSocketPath, Value: kernel.route.expectedSocketPath, Source: tmuxSocketPathSource}
 		}
-		inventory := intmetadata.NewInventoryObserver(runner, controllerTransport(readTarget)).Observe(ctx)
+		inventory := intmetadata.NewInventoryObserver(runner, readTarget.ExplicitProjection()).Observe(ctx)
 		// The public plan continues to describe the operator's requested route;
 		// the internal typed plan separately prints the physical generation.
-		inventory.Transport = controllerTransport(kernel.target)
+		inventory.Transport = kernel.target.ExplicitProjection()
 		return inventory
 	}
 	kernel.socketPath = func(ctx context.Context) (string, bool) {
 		readTarget := kernel.target
 		if kernel.route != nil && kernel.route.expectedSocketPath != "" {
-			readTarget = explicitTmuxTarget{flag: "-S", value: kernel.route.expectedSocketPath}
+			readTarget = tmuxTransport{Kind: tmuxSocketPath, Value: kernel.route.expectedSocketPath, Source: tmuxSocketPathSource}
 		}
 		routed := explicitTmuxRunner{runner: runner, target: readTarget}
 		out, err := routed.Run(ctx, "tmux", "display-message", "-p", "#{socket_path}")
@@ -137,22 +137,6 @@ func (k *resourceControllerKernel) bindRuntimeRoute(ctx context.Context) error {
 	}
 	k.route = &route
 	return nil
-}
-
-// controllerTransport turns the command's exact routing into the typed
-// transport the graph is resolved against. There is no branch for an absent
-// target: this command refuses one before a kernel is built.
-func controllerTransport(target explicitTmuxTarget) resourcegraph.Transport {
-	if target.flag == "-S" {
-		return resourcegraph.Transport{
-			Kind: resourcegraph.TransportSocketPath, Value: target.value,
-			Source: resourcegraph.TransportSourceSocketPath,
-		}
-	}
-	return resourcegraph.Transport{
-		Kind: resourcegraph.TransportSocketName, Value: target.value,
-		Source: resourcegraph.TransportSourceSocketName,
-	}
 }
 
 // controllerPass is one observe-and-plan cycle: the resolved graph, the
@@ -286,16 +270,16 @@ func (k *resourceControllerKernel) authorize(graph resourcegraph.Graph, registry
 	return plan
 }
 
-func addApprovedD3ImportCommand(plan *resourceReconcilePlan, graph resourcegraph.Graph, target explicitTmuxTarget) {
+func addApprovedD3ImportCommand(plan *resourceReconcilePlan, graph resourcegraph.Graph, target tmuxTransport) {
 	count := len(graph.RuntimeOfClass(resourcegraph.ClassRecoverable))
 	if count == 0 {
 		return
 	}
 	flag := "--socket"
-	if target.flag == "-S" {
+	if target.Flag() == "-S" {
 		flag = "--socket-path"
 	}
-	command := "projmux reconcile resources " + flag + " " + shellQuote(target.value) + " --import-orphan-mirrors --yes"
+	command := "projmux reconcile resources " + flag + " " + shellQuote(target.Value) + " --import-orphan-mirrors --yes"
 	verdict := controller.AuthorizeRecovery(resourcegraph.DivergenceOrphanMirror, controller.RecoveryExplicit, controller.RecoveryImport, false, count)
 	plan.items = append(plan.items, resourceReconcileItem{
 		Key: "recovery:approved:d3-import", Drift: resourceDriftOrphan, Surface: "registry",
@@ -553,11 +537,11 @@ func (k *resourceControllerKernel) guardPlan(ctx context.Context, socket string,
 	if err := guardResolvedRuntimeMutationRoute(ctx, k.runner, *k.route); err != nil {
 		return fmt.Errorf("exact tmux socket changed before repair: %w", err)
 	}
-	routed := explicitTmuxRunner{runner: k.runner, target: explicitTmuxTarget{flag: "-S", value: k.route.expectedSocketPath}}
+	routed := explicitTmuxRunner{runner: k.runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: k.route.expectedSocketPath, Source: tmuxSocketPathSource}}
 	if socket != "" {
 		current, ok := k.socketPath(ctx)
 		if !ok {
-			return fmt.Errorf("exact tmux server %s became unreachable before repair", k.target.value)
+			return fmt.Errorf("exact tmux server %s became unreachable before repair", k.target.Value)
 		}
 		if current != socket {
 			return fmt.Errorf("exact tmux socket changed before repair: #{socket_path} is %q, planned against %q", current, socket)

--- a/internal/app/resource_mutation_mirror.go
+++ b/internal/app/resource_mutation_mirror.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	"github.com/crevissepartners/projmux/internal/core/resourcegraph"
 	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
 )
@@ -36,9 +37,8 @@ func inheritedResourceMutationMirror(lookupEnv func(string) string, runner tmuxC
 	if lookupEnv == nil || runner == nil {
 		return nil
 	}
-	socket, _, _ := strings.Cut(strings.TrimSpace(lookupEnv("TMUX")), ",")
-	target, err := tmuxSocketPathTarget(socket)
-	if err != nil {
+	target, err := resourcegraph.ResolveTransport(resourcegraph.TransportRequest{InheritedTMUX: lookupEnv("TMUX")})
+	if err != nil || !target.Present() {
 		return nil
 	}
 	routed := explicitTmuxRunner{runner: runner, target: target}

--- a/internal/app/resource_reconcile.go
+++ b/internal/app/resource_reconcile.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 
@@ -121,8 +120,8 @@ func (c *resourceReconcileCommand) Run(args []string, stdout, stderr io.Writer) 
 	if c.runner == nil || c.resources == nil {
 		return errors.New("resource reconciliation is not configured")
 	}
-	reportTarget := resourceReconcileTarget{Mode: "socket-name", Flag: target.flag, Value: target.value}
-	if target.flag == "-S" {
+	reportTarget := resourceReconcileTarget{Mode: "socket-name", Flag: target.Flag(), Value: target.Value}
+	if target.Flag() == "-S" {
 		reportTarget.Mode = "socket-path"
 	}
 	planner := resourceReconcilePlanner{
@@ -204,32 +203,19 @@ func firstRepeatedValue(values []string) string {
 	return strings.TrimSpace(values[0])
 }
 
-func (c *resourceReconcileCommand) resolveTarget(opts resourceReconcileOptions) (explicitTmuxTarget, error) {
-	if strings.TrimSpace(opts.socket) != "" {
-		target, err := tmuxSocketNameTarget(opts.socket)
-		if err != nil {
-			return explicitTmuxTarget{}, usageError("reconcile resources: " + err.Error())
-		}
-		return target, nil
-	}
-	if strings.TrimSpace(opts.socketPath) != "" {
-		target, err := tmuxSocketPathTarget(opts.socketPath)
-		if err != nil {
-			return explicitTmuxTarget{}, usageError("reconcile resources: --socket-path must be absolute")
-		}
-		return target, nil
-	}
+func (c *resourceReconcileCommand) resolveTarget(opts resourceReconcileOptions) (tmuxTransport, error) {
 	tmuxEnv := ""
 	if c.lookupEnv != nil {
-		tmuxEnv = strings.TrimSpace(c.lookupEnv("TMUX"))
+		tmuxEnv = c.lookupEnv("TMUX")
 	}
-	inherited, _, _ := strings.Cut(tmuxEnv, ",")
-	if inherited == "" || !filepath.IsAbs(inherited) {
-		return explicitTmuxTarget{}, usageError("reconcile resources requires --socket <name> or --socket-path <absolute> outside tmux")
-	}
-	target, err := tmuxSocketPathTarget(inherited)
+	target, err := resourcegraph.ResolveTransport(resourcegraph.TransportRequest{
+		SocketName: opts.socket, SocketPath: opts.socketPath, InheritedTMUX: tmuxEnv,
+	})
 	if err != nil {
-		return explicitTmuxTarget{}, usageError("reconcile resources: inherited $TMUX socket path is not absolute")
+		return tmuxTransport{}, usageError("reconcile resources: --socket-path must be absolute")
+	}
+	if !target.Present() {
+		return tmuxTransport{}, usageError("reconcile resources requires --socket <name> or --socket-path <absolute> outside tmux")
 	}
 	return target, nil
 }

--- a/internal/app/resource_reconcile_plan.go
+++ b/internal/app/resource_reconcile_plan.go
@@ -188,7 +188,7 @@ type resourceReconcilePlanner struct {
 	// public reconcile route leaves it empty and accepts whatever session the
 	// Registry projects.
 	materializeSession string
-	exactTarget        explicitTmuxTarget
+	exactTarget        tmuxTransport
 	// agents is the provider-launch seam the Agent half of a materialization
 	// plan consumes. It is read-only at plan time: it builds argv and applies
 	// the Settings gate, and creates nothing.

--- a/internal/app/runtime_metadata_mirror.go
+++ b/internal/app/runtime_metadata_mirror.go
@@ -24,7 +24,7 @@ func (m runtimeMutationMetadataMirror) exactRoute(ctx context.Context) (tmuxComm
 		return nil, runtimeMutationRoute{}, errors.New("typed metadata mirror requires a tmux runner")
 	}
 	var base tmuxCommandRunner
-	var target explicitTmuxTarget
+	var target tmuxTransport
 	switch runner := m.runner.(type) {
 	case explicitTmuxRunner:
 		base, target = runner.runner, runner.target
@@ -33,11 +33,11 @@ func (m runtimeMutationMetadataMirror) exactRoute(ctx context.Context) (tmuxComm
 	default:
 		return nil, runtimeMutationRoute{}, errors.New("typed metadata mirror requires an explicit tmux route")
 	}
-	if base == nil || target.flag == "" || target.value == "" {
+	if base == nil || target.Flag() == "" || target.Value == "" {
 		return nil, runtimeMutationRoute{}, errors.New("typed metadata mirror route is incomplete")
 	}
-	if m.route.target.flag != "" {
-		if m.route.target != target || m.route.expectedSocketPath == "" {
+	if m.route.target.Flag() != "" {
+		if !m.route.target.SameRoute(target) || m.route.expectedSocketPath == "" {
 			return nil, runtimeMutationRoute{}, errors.New("typed metadata mirror injected route disagrees with its transport")
 		}
 		if err := guardResolvedRuntimeMutationRoute(ctx, base, m.route); err != nil {
@@ -61,7 +61,7 @@ func (m runtimeMutationMetadataMirror) MirrorProject(ctx context.Context, sessio
 	if sessionName == "" || strings.TrimSpace(project.Metadata.UID) == "" {
 		return errors.New("typed metadata mirror requires a Project UID and session name")
 	}
-	exact := explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}}
+	exact := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}}
 	format := tmuxRowFormat("#{session_id}", "#{session_name}", "#{"+tmuxopts.ProjectUIDSession+"}", "#{"+tmuxopts.ProjectNameSession+"}", "#{"+tmuxopts.SessionRole+"}")
 	observeTuple := func(ctx context.Context) ([]string, error) {
 		if err := guardResolvedRuntimeMutationRoute(ctx, runner, route); err != nil {
@@ -155,7 +155,7 @@ func (m runtimeMutationMetadataMirror) MirrorWindow(ctx context.Context, windowI
 		operands []string
 		observe  func(context.Context) (bool, error)
 	}
-	exact := explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}}
+	exact := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}}
 	observeOwnedTarget := func(ctx context.Context) (bool, error) {
 		if err := guardTypedMetadataWindow(ctx, runner, route, windowID, window); err != nil {
 			return false, err
@@ -217,7 +217,7 @@ func guardTypedMetadataWindow(ctx context.Context, runner tmuxCommandRunner, rou
 	if err := guardResolvedRuntimeMutationRoute(ctx, runner, route); err != nil {
 		return err
 	}
-	exact := explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}}
+	exact := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}}
 	out, err := exact.Run(ctx, "tmux", "display-message", "-p", "-t", windowID, "-F", tmuxRowFormat(
 		"#{window_id}", "#{"+tmuxopts.WindowUID+"}", "#{"+tmuxopts.ProjectUIDSession+"}", "#{"+tmuxopts.SessionRole+"}"))
 	if err != nil {
@@ -251,7 +251,7 @@ func (m runtimeMutationMetadataMirror) MirrorPane(ctx context.Context, paneID, w
 	}
 	target := runtimeMutationTarget{Kind: "pane", ID: paneID, UID: pane.Metadata.UID, Parent: "window/" + windowUID}
 	bindRuntimeMutationRouteTarget(&target, route)
-	exact := explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}}
+	exact := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}}
 	observeOwnedTarget := func(ctx context.Context) (bool, error) {
 		if err := guardTypedMetadataPane(ctx, runner, route, paneID, windowUID, pane.Metadata.UID); err != nil {
 			return false, err
@@ -309,7 +309,7 @@ func guardTypedMetadataPane(ctx context.Context, runner tmuxCommandRunner, route
 	if err := guardResolvedRuntimeMutationRoute(ctx, runner, route); err != nil {
 		return err
 	}
-	exact := explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}}
+	exact := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}}
 	out, err := exact.Run(ctx, "tmux", "display-message", "-p", "-t", paneID, "-F", tmuxRowFormat(
 		"#{pane_id}", "#{"+tmuxopts.PaneUID+"}", "#{"+tmuxopts.WindowUID+"}"))
 	if err != nil {

--- a/internal/app/runtime_metadata_mirror_test.go
+++ b/internal/app/runtime_metadata_mirror_test.go
@@ -101,7 +101,7 @@ func newMetadataMirrorPlanFixture() (*metadataMirrorPlanRunner, runtimeMutationM
 		sessionID: "$1", sessionName: "repo", projectUID: "prj-1",
 		options: map[string]string{},
 	}
-	target := explicitTmuxTarget{flag: "-S", value: runner.path}
+	target := tmuxTransport{Kind: tmuxSocketPath, Value: runner.path, Source: tmuxSocketPathSource}
 	return runner, runtimeMutationMetadataMirror{runner: explicitTmuxRunner{runner: runner, target: target}}
 }
 

--- a/internal/app/runtime_mutation_plan.go
+++ b/internal/app/runtime_mutation_plan.go
@@ -360,7 +360,7 @@ func guardRuntimeMutationQueueRoute(ctx context.Context, runner tmuxCommandRunne
 		return errors.New("runtime mutation queue route has no printable declaration")
 	}
 	route := runtimeMutationRoute{
-		target:             explicitTmuxTarget{flag: "-S", value: action.Queue.PhysicalSocket},
+		target:             tmuxTransport{Kind: tmuxSocketPath, Value: action.Queue.PhysicalSocket, Source: tmuxSocketPathSource},
 		expectedSocketPath: action.Queue.PhysicalSocket,
 		socketName:         action.Queue.LogicalSocket,
 	}

--- a/internal/app/runtime_mutation_plan_test.go
+++ b/internal/app/runtime_mutation_plan_test.go
@@ -1621,7 +1621,7 @@ func TestMaterializerSocketDriftRefusesBeforeFirstWrite(t *testing.T) {
 	session := server.addSession("drift")
 	runtime := &materializer{
 		runner: server, mirror: intmetadata.NewMirror(server), sessions: sessions,
-		target:             explicitTmuxTarget{flag: "-S", value: server.socketPath},
+		target:             tmuxTransport{Kind: tmuxSocketPath, Value: server.socketPath, Source: tmuxSocketPathSource},
 		expectedSocketPath: server.socketPath,
 		socketName:         defaultAppSocket,
 		routeAuthority:     &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: "4242"},
@@ -1644,7 +1644,7 @@ func TestMaterializerAbsentDeclarationRefusesServerAppearingBeforeWrite(t *testi
 	server.addSession("appeared")
 	runtime := &materializer{
 		runner: server,
-		target: explicitTmuxTarget{flag: "-L", value: defaultAppSocket},
+		target: tmuxTransport{Kind: tmuxSocketName, Value: defaultAppSocket, Source: tmuxSocketNameSource},
 	}
 	action := materializeMutationAction(mutationCreateSession, runtime.boundMutationTarget(
 		"project-declaration", "appeared", "prj-appeared",
@@ -1675,7 +1675,7 @@ func TestMaterializerUnsetIdentityRequiresReadableOwnedTargetBeforeReplan(t *tes
 		session.windows[0].opts[tmuxopts.WindowUID] = "win-identity"
 		pane := session.windows[0].panes[0]
 		pane.opts[tmuxopts.PaneUID] = ownerUID
-		target := explicitTmuxTarget{flag: "-S", value: server.socketPath}
+		target := tmuxTransport{Kind: tmuxSocketPath, Value: server.socketPath, Source: tmuxSocketPathSource}
 		return &materializer{
 			runner: explicitTmuxRunner{runner: server, target: target},
 			target: target, expectedSocketPath: server.socketPath,
@@ -1729,7 +1729,7 @@ func TestMaterializerReceiptBearingMatchingEffectsStillRequireExactInvariant(t *
 			Created: true, SessionID: session.id,
 			WindowID: session.windows[0].id, PaneID: session.windows[0].panes[0].id,
 		}
-		target := explicitTmuxTarget{flag: "-S", value: server.socketPath}
+		target := tmuxTransport{Kind: tmuxSocketPath, Value: server.socketPath, Source: tmuxSocketPathSource}
 		sessions := &fakeSessionMaterializer{tmux: server}
 		return &materializer{
 			runner: explicitTmuxRunner{runner: server, target: target}, sessions: sessions,
@@ -1810,7 +1810,7 @@ func TestMaterializerReceiptBearingMatchingEffectsStillRequireExactInvariant(t *
 
 func TestMaterializerFirstSessionBindsPhysicalRouteBeforeFollowUpWrites(t *testing.T) {
 	server := newFakeTmux()
-	target := explicitTmuxTarget{flag: "-L", value: defaultAppSocket}
+	target := tmuxTransport{Kind: tmuxSocketName, Value: defaultAppSocket, Source: tmuxSocketNameSource}
 	routed := explicitTmuxRunner{runner: server, target: target}
 	sessions := &fakeSessionMaterializer{tmux: server}
 	runtime := &materializer{
@@ -1856,7 +1856,7 @@ func TestMaterializerAbsentServerConfigAndRouteMarkerSequence(t *testing.T) {
 		server.serverAbsent = true
 		server.appMarker = appMarker
 		server.socketName = logicalMarker
-		target := explicitTmuxTarget{flag: "-L", value: "phase10-fresh"}
+		target := tmuxTransport{Kind: tmuxSocketName, Value: "phase10-fresh", Source: tmuxSocketNameSource}
 		routed := explicitTmuxRunner{runner: server, target: target}
 		runtime := &materializer{
 			runner: routed, mirror: intmetadata.NewMirror(routed), sessions: &fakeSessionMaterializer{tmux: server},
@@ -2094,7 +2094,7 @@ func TestMaterializerDefaultRouteForgedServerRefusesBeforeFirstWrite(t *testing.
 		recordedTmuxCallKey("tmux", "-L", defaultAppSocket, "show-options", "-gqv", tmuxopts.AppGlobal):      "0\n",
 		recordedTmuxCallKey("tmux", "-S", path, "show-options", "-gqv", tmuxopts.AppGlobal):                  "0\n",
 	}}
-	target := explicitTmuxTarget{flag: "-L", value: defaultAppSocket}
+	target := tmuxTransport{Kind: tmuxSocketName, Value: defaultAppSocket, Source: tmuxSocketNameSource}
 	runtime := &materializer{
 		runner: explicitTmuxRunner{runner: base, target: target}, target: target, expectedSocketPath: path,
 	}
@@ -2134,7 +2134,7 @@ func TestInvocationRoutePreservesNonDefaultLogicalSocketWithoutBasenameInference
 	if err != nil {
 		t.Fatal(err)
 	}
-	if route.target.flag != "-L" || route.target.value != name || route.expectedSocketPath != path || route.socketName != name ||
+	if route.target.Flag() != "-L" || route.target.Value != name || route.expectedSocketPath != path || route.socketName != name ||
 		route.authority == nil || route.authority.Class != runtimeMutationRouteApp || route.authority.ServerPID != "123" || route.authority.PaneID != "%8" {
 		t.Fatalf("resolved route = %#v, want logical -L %s over exact path %s", route, name, path)
 	}
@@ -2164,7 +2164,7 @@ func TestStandaloneInheritedRouteMaterializesWithPrintablePIDAndPaneAuthority(t 
 	if err != nil {
 		t.Fatalf("resolve inherited standalone route: %v", err)
 	}
-	if route.target.flag != "-S" || route.target.value != server.socketPath || route.expectedSocketPath != server.socketPath ||
+	if route.target.Flag() != "-S" || route.target.Value != server.socketPath || route.expectedSocketPath != server.socketPath ||
 		route.socketName != defaultAppSocket || route.authority == nil {
 		t.Fatalf("standalone route = %#v", route)
 	}
@@ -2253,7 +2253,7 @@ func TestNativePrivateActivationAnchorSuppliesExactAppAuthorityWithoutInheritedP
 	if err != nil {
 		t.Fatalf("resolve private-anchored app route: %v", err)
 	}
-	if route.target != (explicitTmuxTarget{flag: "-L", value: server.socketName}) ||
+	if route.target != (tmuxTransport{Kind: tmuxSocketName, Value: server.socketName, Source: tmuxSocketNameSource}) ||
 		route.expectedSocketPath != server.socketPath || route.authority == nil ||
 		route.authority.Class != runtimeMutationRouteApp || route.authority.ServerPID != server.serverPID ||
 		route.authority.SessionID != driver.id || route.authority.WindowID != driver.windows[0].id ||
@@ -2306,7 +2306,7 @@ func TestRuntimeMutationAnchorSourcesRefuseMalformedHigherPrecedenceEvidence(t *
 			if test.existing {
 				_, err = resolveExistingRuntimeMutationRouteWithAnchor(
 					context.Background(), server,
-					explicitTmuxTarget{flag: "-S", value: server.socketPath}, lookup, test.explicit,
+					tmuxTransport{Kind: tmuxSocketPath, Value: server.socketPath, Source: tmuxSocketPathSource}, lookup, test.explicit,
 				)
 			} else {
 				_, err = resolveInvocationRuntimeMutationRouteWithAnchor(context.Background(), server, lookup, test.explicit)
@@ -2437,7 +2437,7 @@ func TestDefaultInvocationAliasRecoversCanonicalAppRouteBidirectionally(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if route.target.flag != "-L" || route.target.value != name || route.socketName != name || route.expectedSocketPath != path ||
+	if route.target.Flag() != "-L" || route.target.Value != name || route.socketName != name || route.expectedSocketPath != path ||
 		route.authority == nil || route.authority.Class != runtimeMutationRouteApp || route.authority.ServerPID != "4242" || route.authority.PaneID != "" {
 		t.Fatalf("canonical alias route = %#v", route)
 	}
@@ -2616,7 +2616,7 @@ func TestOutsideTmuxAppRouteSuppressesOnlyTypedNoServerProbe(t *testing.T) {
 			}}
 			route, err := resolveInvocationRuntimeMutationRoute(context.Background(), runner, func(string) string { return "" })
 			if test.wantOK {
-				if err != nil || route.target != (explicitTmuxTarget{flag: "-L", value: defaultAppSocket}) || route.authority != nil {
+				if err != nil || route.target != (tmuxTransport{Kind: tmuxSocketName, Value: defaultAppSocket, Source: tmuxSocketNameSource}) || route.authority != nil {
 					t.Fatalf("typed no-server route = %#v err=%v", route, err)
 				}
 			} else {
@@ -2701,7 +2701,7 @@ func TestObservationFailureNeverPlansRegistryDeletion(t *testing.T) {
 	runtime, runner, _ := newPaneRuntimeFixture(t, paneRuntimeInventory())
 	format := tmuxRowFormat("#{session_id}", "#{session_name}", "#{window_id}", "#{pane_id}",
 		"#{"+tmuxopts.ProjectUIDSession+"}", "#{"+tmuxopts.WindowUID+"}", "#{"+tmuxopts.PaneUID+"}")
-	listKey := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.value, "list-panes", "-a", "-F", format)
+	listKey := recordedTmuxCallKey("tmux", "-S", testDeleteTarget.Value, "list-panes", "-a", "-F", format)
 	runner.errors = map[string]error{listKey: errPropertyDrift}
 	command := newTestDeleteCommand(store, false, false, nil)
 	command.panes = runtime

--- a/internal/app/runtime_mutation_route.go
+++ b/internal/app/runtime_mutation_route.go
@@ -53,7 +53,7 @@ func missingRuntimeMutationMarker(socketName string) error {
 const runtimeMutationAnchorPaneEnv = "__PROJMUX_RUNTIME_ANCHOR_PANE"
 
 type runtimeMutationRoute struct {
-	target             explicitTmuxTarget
+	target             tmuxTransport
 	expectedSocketPath string
 	socketName         string
 	authority          *runtimeMutationRouteAuthority
@@ -84,7 +84,7 @@ func bindRuntimeMutationRouteTarget(target *runtimeMutationTarget, route runtime
 	if target == nil {
 		return
 	}
-	target.Socket = route.target.flag + "=" + route.target.value
+	target.Socket = route.target.Flag() + "=" + route.target.Value
 	target.PhysicalSocket = printableRuntimeMutationSocket(route.expectedSocketPath)
 	target.RouteAuthority = route.authority.printable()
 }
@@ -131,7 +131,7 @@ func parseInheritedTmuxReceipt(value string) (inheritedTmuxReceipt, error) {
 		return inheritedTmuxReceipt{}, errors.New("runtime mutation route: inherited TMUX must contain exactly path,pid,index")
 	}
 	pathTarget, err := tmuxSocketPathTarget(parts[0])
-	if err != nil || pathTarget.value != parts[0] {
+	if err != nil || pathTarget.Value != parts[0] {
 		return inheritedTmuxReceipt{}, errors.New("runtime mutation route: inherited TMUX socket path is not absolute and clean")
 	}
 	pid, pidErr := strconv.Atoi(parts[1])
@@ -139,7 +139,7 @@ func parseInheritedTmuxReceipt(value string) (inheritedTmuxReceipt, error) {
 	if pidErr != nil || pid <= 0 || indexErr != nil || index < 0 {
 		return inheritedTmuxReceipt{}, errors.New("runtime mutation route: inherited TMUX pid or client index is invalid")
 	}
-	return inheritedTmuxReceipt{SocketPath: pathTarget.value, ServerPID: parts[1], ClientID: parts[2]}, nil
+	return inheritedTmuxReceipt{SocketPath: pathTarget.Value, ServerPID: parts[1], ClientID: parts[2]}, nil
 }
 
 func observeInheritedRuntimeMutationAuthority(
@@ -196,7 +196,7 @@ func observeExplicitAppAnchorAuthority(
 
 func defaultRuntimeMutationRoute() runtimeMutationRoute {
 	return runtimeMutationRoute{
-		target:     explicitTmuxTarget{flag: "-L", value: defaultAppSocket},
+		target:     tmuxTransport{Kind: tmuxSocketName, Value: defaultAppSocket, Source: tmuxSocketNameSource},
 		socketName: defaultAppSocket,
 	}
 }
@@ -209,7 +209,7 @@ func defaultRuntimeMutationRoute() runtimeMutationRoute {
 func resolveExistingRuntimeMutationRoute(
 	ctx context.Context,
 	runner tmuxCommandRunner,
-	target explicitTmuxTarget,
+	target tmuxTransport,
 	lookupEnv func(string) string,
 ) (runtimeMutationRoute, error) {
 	return resolveExistingRuntimeMutationRouteWithAnchor(ctx, runner, target, lookupEnv, "")
@@ -218,7 +218,7 @@ func resolveExistingRuntimeMutationRoute(
 func resolveExistingRuntimeMutationRouteWithAnchor(
 	ctx context.Context,
 	runner tmuxCommandRunner,
-	target explicitTmuxTarget,
+	target tmuxTransport,
 	lookupEnv func(string) string,
 	anchorPaneID string,
 ) (runtimeMutationRoute, error) {
@@ -235,7 +235,7 @@ func resolveExistingRuntimeMutationRouteWithAnchor(
 	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
 		return runtimeMutationRoute{}, errors.New("runtime mutation route: observed socket is not absolute and clean")
 	}
-	physical := explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: path}}
+	physical := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: path, Source: tmuxSocketPathSource}}
 	appOut, appErr := physical.Run(ctx, "tmux", "show-options", "-gqv", tmuxopts.AppGlobal)
 	logicalOut, logicalErr := physical.Run(ctx, "tmux", "show-options", "-gqv", runtimeMutationSocketNameOption)
 	if appErr != nil || logicalErr != nil {
@@ -261,7 +261,7 @@ func resolveExistingRuntimeMutationRouteWithAnchor(
 			return runtimeMutationRoute{}, err
 		}
 		return runtimeMutationRoute{
-			target: explicitTmuxTarget{flag: "-S", value: path}, expectedSocketPath: path,
+			target: tmuxTransport{Kind: tmuxSocketPath, Value: path, Source: tmuxSocketPathSource}, expectedSocketPath: path,
 			socketName: defaultAppSocket, authority: authority,
 		}, nil
 	}
@@ -276,7 +276,7 @@ func resolveExistingRuntimeMutationRouteWithAnchor(
 		return runtimeMutationRoute{}, errors.New("runtime mutation route: app server logical marker is invalid")
 	}
 	routeTarget := target
-	if target.flag == "-L" {
+	if target.Flag() == "-L" {
 		byName, err := (explicitTmuxRunner{runner: runner, target: logicalTarget}).Run(ctx, "tmux", "display-message", "-p", "-F", "#{socket_path}")
 		if err != nil || strings.TrimSpace(string(byName)) != path {
 			return runtimeMutationRoute{}, errors.New("runtime mutation route: app logical alias no longer names the exact server")
@@ -331,7 +331,7 @@ func resolveRuntimeMutationAnchorPane(lookupEnv func(string) string, explicit st
 // guardRuntimeMutationServerOwnership proves that an already-running server is
 // the app-owned server declared by the logical route. A matching socket path is
 // not ownership evidence: a foreign server can be cloned onto the same -L name.
-func guardRuntimeMutationServerOwnership(ctx context.Context, routed tmuxCommandRunner, target explicitTmuxTarget) error {
+func guardRuntimeMutationServerOwnership(ctx context.Context, routed tmuxCommandRunner, target tmuxTransport) error {
 	owned, err := routed.Run(ctx, "tmux", "show-options", "-gqv", tmuxopts.AppGlobal)
 	if err != nil {
 		return fmt.Errorf("runtime mutation route: read app ownership marker: %w", err)
@@ -346,16 +346,16 @@ func guardRuntimeMutationServerOwnership(ctx context.Context, routed tmuxCommand
 	logicalName := strings.TrimSpace(string(logical))
 	if logicalName == "" {
 		name := ""
-		if target.flag == "-L" {
-			name = target.value
+		if target.Flag() == "-L" {
+			name = target.Value
 		}
 		return missingRuntimeMutationMarker(name)
 	}
 	if _, err := tmuxSocketNameTarget(logicalName); err != nil {
 		return errors.New("runtime mutation route: app server logical marker is invalid")
 	}
-	if target.flag == "-L" && logicalName != target.value {
-		return fmt.Errorf("runtime mutation route: logical socket marker is %q, planned %q", logicalName, target.value)
+	if target.Flag() == "-L" && logicalName != target.Value {
+		return fmt.Errorf("runtime mutation route: logical socket marker is %q, planned %q", logicalName, target.Value)
 	}
 	return nil
 }
@@ -465,13 +465,13 @@ func resolveInvocationRuntimeMutationRouteWithPolicy(
 		nameRunner := explicitTmuxRunner{runner: runner, target: nameTarget}
 		byName, err := nameRunner.Run(ctx, "tmux", "display-message", "-p", "-F", "#{socket_path}")
 		if err != nil {
-			return runtimeMutationRoute{}, fmt.Errorf("runtime mutation route: reobserve default server canonical -L %s: %w", nameTarget.value, err)
+			return runtimeMutationRoute{}, fmt.Errorf("runtime mutation route: reobserve default server canonical -L %s: %w", nameTarget.Value, err)
 		}
 		byNamePath := filepath.Clean(strings.TrimSpace(string(byName)))
 		if byNamePath != route.expectedSocketPath {
-			return runtimeMutationRoute{}, fmt.Errorf("runtime mutation route: canonical -L %s resolves to %q, default invocation is %q", nameTarget.value, byNamePath, route.expectedSocketPath)
+			return runtimeMutationRoute{}, fmt.Errorf("runtime mutation route: canonical -L %s resolves to %q, default invocation is %q", nameTarget.Value, byNamePath, route.expectedSocketPath)
 		}
-		physical := explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}}
+		physical := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}}
 		pidOut, err := physical.Run(ctx, "tmux", "display-message", "-p", "-F", "#{pid}")
 		pid := strings.TrimSpace(string(pidOut))
 		parsedPID, pidErr := strconv.Atoi(pid)
@@ -486,7 +486,7 @@ func resolveInvocationRuntimeMutationRouteWithPolicy(
 			}
 		}
 		return runtimeMutationRoute{
-			target: nameTarget, expectedSocketPath: route.expectedSocketPath, socketName: nameTarget.value,
+			target: nameTarget, expectedSocketPath: route.expectedSocketPath, socketName: nameTarget.Value,
 			authority: authority,
 		}, nil
 	}
@@ -504,8 +504,8 @@ func resolveInvocationRuntimeMutationRouteWithPolicy(
 		return runtimeMutationRoute{}, fmt.Errorf("runtime mutation route: reobserve inherited socket: %w", err)
 	}
 	observedPath := filepath.Clean(strings.TrimSpace(string(observed)))
-	if observedPath != pathTarget.value {
-		return runtimeMutationRoute{}, fmt.Errorf("runtime mutation route: inherited socket drifted: observed %q, expected %q", observedPath, pathTarget.value)
+	if observedPath != pathTarget.Value {
+		return runtimeMutationRoute{}, fmt.Errorf("runtime mutation route: inherited socket drifted: observed %q, expected %q", observedPath, pathTarget.Value)
 	}
 	appOwnedOut, err := pathRunner.Run(ctx, "tmux", "show-options", "-gqv", tmuxopts.AppGlobal)
 	if err != nil {
@@ -547,11 +547,11 @@ func resolveInvocationRuntimeMutationRouteWithPolicy(
 	nameRunner := explicitTmuxRunner{runner: runner, target: nameTarget}
 	byName, err := nameRunner.Run(ctx, "tmux", "display-message", "-p", "-F", "#{socket_path}")
 	if err != nil {
-		return runtimeMutationRoute{}, fmt.Errorf("runtime mutation route: reobserve logical socket -L %s: %w", nameTarget.value, err)
+		return runtimeMutationRoute{}, fmt.Errorf("runtime mutation route: reobserve logical socket -L %s: %w", nameTarget.Value, err)
 	}
 	byNamePath := filepath.Clean(strings.TrimSpace(string(byName)))
 	if byNamePath != observedPath {
-		return runtimeMutationRoute{}, fmt.Errorf("runtime mutation route: logical socket -L %s resolves to %q, invocation is %q", nameTarget.value, byNamePath, observedPath)
+		return runtimeMutationRoute{}, fmt.Errorf("runtime mutation route: logical socket -L %s resolves to %q, invocation is %q", nameTarget.Value, byNamePath, observedPath)
 	}
 	var authority *runtimeMutationRouteAuthority
 	if paneID != "" || !allowAppPIDOnly {
@@ -568,7 +568,7 @@ func resolveInvocationRuntimeMutationRouteWithPolicy(
 		authority = &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: pid}
 	}
 	return runtimeMutationRoute{
-		target: nameTarget, expectedSocketPath: observedPath, socketName: nameTarget.value, authority: authority,
+		target: nameTarget, expectedSocketPath: observedPath, socketName: nameTarget.Value, authority: authority,
 	}, nil
 }
 
@@ -579,13 +579,13 @@ func resolveInvocationRuntimeMutationRouteWithPolicy(
 func observeMissingMarkerLogicalSocket(
 	ctx context.Context,
 	runner tmuxCommandRunner,
-	target explicitTmuxTarget,
+	target tmuxTransport,
 	expectedPath string,
 	lookupEnv func(string) string,
 ) string {
 	candidates := make([]string, 0, 3)
-	if target.flag == "-L" {
-		candidates = append(candidates, target.value)
+	if target.Flag() == "-L" {
+		candidates = append(candidates, target.Value)
 	}
 	if lookupEnv != nil {
 		candidates = append(candidates, strings.TrimSpace(lookupEnv("PROJMUX_SOCKET")))

--- a/internal/app/runtime_stop.go
+++ b/internal/app/runtime_stop.go
@@ -142,7 +142,7 @@ func observeExactManagedRuntimeStopTarget(ctx context.Context, runner tmuxComman
 	if target.Route.expectedSocketPath == "" {
 		return false, errors.New("managed runtime stop has no physical socket authority")
 	}
-	exact := explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: filepath.Clean(target.Route.expectedSocketPath)}}
+	exact := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: filepath.Clean(target.Route.expectedSocketPath), Source: tmuxSocketPathSource}}
 	out, err := exact.Run(ctx, "tmux", "list-sessions", "-F", tmuxRowFormat(
 		"#{session_id}", "#{session_name}", "#{"+tmuxopts.ProjectUIDSession+"}", "#{"+tmuxopts.SessionRole+"}"))
 	if err != nil {
@@ -186,7 +186,7 @@ func guardResolvedRuntimeMutationRouteBeforeMarkerWrite(ctx context.Context, run
 }
 
 func guardResolvedRuntimeMutationRouteWithMarkerPolicy(ctx context.Context, runner tmuxCommandRunner, route runtimeMutationRoute, allowMissingLogicalMarker bool) error {
-	if runner == nil || route.target.flag == "" || route.target.value == "" {
+	if runner == nil || route.target.Flag() == "" || route.target.Value == "" {
 		return errors.New("runtime mutation route is not exact")
 	}
 	// Once a physical socket has been observed, it is the execution authority.
@@ -194,7 +194,7 @@ func guardResolvedRuntimeMutationRouteWithMarkerPolicy(ctx context.Context, runn
 	// pre-observation report the effect from the wrong server.
 	probeTarget := route.target
 	if route.expectedSocketPath != "" {
-		probeTarget = explicitTmuxTarget{flag: "-S", value: filepath.Clean(route.expectedSocketPath)}
+		probeTarget = tmuxTransport{Kind: tmuxSocketPath, Value: filepath.Clean(route.expectedSocketPath), Source: tmuxSocketPathSource}
 	}
 	routed := explicitTmuxRunner{runner: runner, target: probeTarget}
 	out, err := routed.Run(ctx, "tmux", "display-message", "-p", "-F", "#{socket_path}")
@@ -207,7 +207,7 @@ func guardResolvedRuntimeMutationRouteWithMarkerPolicy(ctx context.Context, runn
 	}
 	if route.authority != nil {
 		if (route.authority.Class == runtimeMutationRouteStandalone || route.authority.Class == runtimeMutationRouteStandaloneExplicit) &&
-			(route.target.flag != "-S" || route.target.value != route.expectedSocketPath) {
+			(route.target.Flag() != "-S" || route.target.Value != route.expectedSocketPath) {
 			return errors.New("planned standalone runtime route is not exact physical authority")
 		}
 		pidOut, err := routed.Run(ctx, "tmux", "display-message", "-p", "-F", "#{pid}")
@@ -268,7 +268,7 @@ func guardPrintedRuntimeMutationRouteWithMarkerPolicy(ctx context.Context, runne
 		if route.authority == nil || action.Target.RouteAuthority == "" || action.Target.RouteAuthority != route.authority.printable() {
 			return errors.New("printed runtime route authority disagrees with captured server generation")
 		}
-		printedRoute := route.target.flag + "=" + route.target.value
+		printedRoute := route.target.Flag() + "=" + route.target.Value
 		if action.Verb == mutationWriteRouteMarker {
 			printedRoute = "-S=" + route.expectedSocketPath
 		}

--- a/internal/app/runtime_stop_test.go
+++ b/internal/app/runtime_stop_test.go
@@ -66,7 +66,7 @@ func TestManagedRuntimeStopUsesOnePrintedPhysicalObservationAndRegistryAuthority
 	target := managedRuntimeStopTarget{
 		SessionID: "$1", SessionName: "alpha", RootKind: coremetadata.KindProject, RootUID: "prj-alpha",
 		Route: runtimeMutationRoute{
-			target: explicitTmuxTarget{flag: "-L", value: defaultAppSocket}, socketName: defaultAppSocket,
+			target: tmuxTransport{Kind: tmuxSocketName, Value: defaultAppSocket, Source: tmuxSocketNameSource}, socketName: defaultAppSocket,
 			expectedSocketPath: runner.physical,
 			authority:          &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: "4242"},
 		},
@@ -98,7 +98,7 @@ func TestManagedRuntimeStopRegistryAuthorityDriftRefusesBeforeWrite(t *testing.T
 	target := managedRuntimeStopTarget{
 		SessionID: "$1", SessionName: "alpha", RootKind: coremetadata.KindProject, RootUID: "uid:project",
 		Route: runtimeMutationRoute{
-			target: explicitTmuxTarget{flag: "-L", value: defaultAppSocket}, socketName: defaultAppSocket,
+			target: tmuxTransport{Kind: tmuxSocketName, Value: defaultAppSocket, Source: tmuxSocketNameSource}, socketName: defaultAppSocket,
 			expectedSocketPath: runner.physical,
 			authority:          &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: "4242"},
 		},

--- a/internal/app/session_state.go
+++ b/internal/app/session_state.go
@@ -32,7 +32,7 @@ type sessionStateCommand struct {
 	projectTopology switchProjectTopologyMaterializer
 	projectTrust    switchProjectTrustAuthorizer
 	notices         projectStartupReporter
-	target          explicitTmuxTarget
+	target          tmuxTransport
 }
 
 func newSessionStateCommand(recorders ...*diagnostics.LifecycleRecorder) *sessionStateCommand {
@@ -57,7 +57,7 @@ func newSessionStateCommand(recorders ...*diagnostics.LifecycleRecorder) *sessio
 
 func (c *sessionStateCommand) exactRunner() (tmuxRunner, error) {
 	target := c.target
-	if target.flag == "" || target.value == "" {
+	if target.Flag() == "" || target.Value == "" {
 		var err error
 		target, err = tmuxSocketNameTarget(defaultAppSocket)
 		if err != nil {

--- a/internal/app/shell.go
+++ b/internal/app/shell.go
@@ -372,7 +372,7 @@ func (c *shellCommand) observeControlBootstrapAtRoute(ctx context.Context, route
 func (c *shellCommand) controlBootstrapRunner(route runtimeMutationRoute) tmuxCommandRunner {
 	target := route.target
 	if route.expectedSocketPath != "" {
-		target = explicitTmuxTarget{flag: "-S", value: filepath.Clean(route.expectedSocketPath)}
+		target = tmuxTransport{Kind: tmuxSocketPath, Value: filepath.Clean(route.expectedSocketPath), Source: tmuxSocketPathSource}
 	}
 	return explicitTmuxRunner{runner: c.tmuxRunner, target: target}
 }
@@ -445,7 +445,7 @@ func (c *shellCommand) provisionAppSession(ctx context.Context, socketName, conf
 		TargetRouteGuard: func(ctx context.Context) error {
 			if action.Target.PhysicalSocket == runtimeMutationSocketAbsentBeforeCreate {
 				if route.expectedSocketPath != "" || route.authority != nil || action.Target.RouteAuthority != "" ||
-					action.Target.Socket != route.target.flag+"="+route.target.value {
+					action.Target.Socket != route.target.Flag()+"="+route.target.Value {
 					return errors.New("ControlSession bootstrap absent authority disagrees with printable declaration")
 				}
 				return c.guardControlBootstrapAbsentBeforeCreate(ctx, route)
@@ -605,8 +605,8 @@ func (c *shellCommand) listControlBootstrapsByLease(ctx context.Context, route r
 }
 
 func (c *shellCommand) recoverControlBootstrapCreateError(ctx context.Context, socketName, marker string, route runtimeMutationRoute, createErr error) error {
-	if route.target.flag == "" {
-		route = runtimeMutationRoute{target: explicitTmuxTarget{flag: "-L", value: socketName}, socketName: socketName}
+	if route.target.Flag() == "" {
+		route = runtimeMutationRoute{target: tmuxTransport{Kind: tmuxSocketName, Value: socketName, Source: tmuxSocketNameSource}, socketName: socketName}
 	}
 	if bindErr := c.bindControlBootstrapPhysicalRoute(ctx, &route, false); bindErr != nil {
 		if tmuxSessionAbsent(bindErr) || tmuxServerUnreachable(bindErr) {
@@ -690,7 +690,7 @@ func (c *shellCommand) bindControlBootstrapRouteAuthority(
 }
 
 func (c *shellCommand) guardControlBootstrapAbsentBeforeCreate(ctx context.Context, route runtimeMutationRoute) error {
-	if route.target.flag != "-L" || route.target.value == "" || route.expectedSocketPath != "" || route.authority != nil {
+	if route.target.Flag() != "-L" || route.target.Value == "" || route.expectedSocketPath != "" || route.authority != nil {
 		return errors.New("ControlSession bootstrap absent authority is not an exact logical declaration")
 	}
 	probe := explicitTmuxRunner{runner: c.tmuxRunner, target: route.target}
@@ -707,7 +707,7 @@ func (c *shellCommand) guardControlBootstrapAbsentBeforeCreate(ctx context.Conte
 // operation. A no-server create may begin unbound; the first post-create guard
 // records the exact path before route-marker, identity, or rollback actions.
 func (c *shellCommand) guardControlBootstrapRoute(ctx context.Context, route *runtimeMutationRoute, allowNoServer, requireLogical bool) error {
-	if route == nil || route.target.flag != "-L" || route.target.value == "" || route.socketName == "" {
+	if route == nil || route.target.Flag() != "-L" || route.target.Value == "" || route.socketName == "" {
 		return errors.New("ControlSession bootstrap route is not exact")
 	}
 	if err := c.bindControlBootstrapPhysicalRoute(ctx, route, allowNoServer); err != nil {
@@ -736,7 +736,7 @@ func (c *shellCommand) guardControlBootstrapRoute(ctx context.Context, route *ru
 }
 
 func (c *shellCommand) bindControlBootstrapPhysicalRoute(ctx context.Context, route *runtimeMutationRoute, allowNoServer bool) error {
-	if route == nil || route.target.flag != "-L" || route.target.value == "" {
+	if route == nil || route.target.Flag() != "-L" || route.target.Value == "" {
 		return errors.New("ControlSession bootstrap route is not exact")
 	}
 	routed := c.controlBootstrapRunner(*route)
@@ -763,7 +763,7 @@ func (c *shellCommand) bindControlBootstrapPhysicalRoute(ctx context.Context, ro
 }
 
 func (c *shellCommand) guardControlBootstrapRollbackRoute(ctx context.Context, receipt controlBootstrapReceipt) error {
-	if receipt.route.target.flag == "" {
+	if receipt.route.target.Flag() == "" {
 		return nil
 	}
 	routed := c.controlBootstrapRunner(receipt.route)
@@ -797,7 +797,7 @@ func (c *shellCommand) guardControlBootstrapRecoveryRoute(ctx context.Context, r
 		route.authority == nil || route.authority.Class != runtimeMutationRouteApp || route.authority.ServerPID == "" {
 		return errors.New("ControlSession bootstrap recovery route has no exact physical server generation")
 	}
-	exact := explicitTmuxRunner{runner: c.tmuxRunner, target: explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}}
+	exact := explicitTmuxRunner{runner: c.tmuxRunner, target: tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}}
 	pathOut, err := exact.Run(ctx, "tmux", "display-message", "-p", "-F", "#{socket_path}")
 	if err != nil || strings.TrimSpace(string(pathOut)) != route.expectedSocketPath {
 		return errors.New("ControlSession bootstrap rollback socket drifted")
@@ -850,7 +850,7 @@ func (c *shellCommand) rollbackControlBootstrap(ctx context.Context, _ string, r
 			return c.guardControlBootstrapOwnedLease(ctx, receipt)
 		},
 		Apply: func(ctx context.Context) error {
-			_, err := runRuntimeMutationCommand(ctx, explicitTmuxRunner{runner: c.tmuxRunner, target: explicitTmuxTarget{flag: "-S", value: receipt.route.expectedSocketPath}}, action)
+			_, err := runRuntimeMutationCommand(ctx, explicitTmuxRunner{runner: c.tmuxRunner, target: tmuxTransport{Kind: tmuxSocketPath, Value: receipt.route.expectedSocketPath, Source: tmuxSocketPathSource}}, action)
 			return err
 		},
 	}})
@@ -886,7 +886,7 @@ func (c *shellCommand) clearControlBootstrapLease(ctx context.Context, socketNam
 			return c.guardControlBootstrapOwnedLease(ctx, receipt)
 		},
 		Apply: func(ctx context.Context) error {
-			_, err := runRuntimeMutationCommand(ctx, explicitTmuxRunner{runner: c.tmuxRunner, target: explicitTmuxTarget{flag: "-S", value: receipt.route.expectedSocketPath}}, action)
+			_, err := runRuntimeMutationCommand(ctx, explicitTmuxRunner{runner: c.tmuxRunner, target: tmuxTransport{Kind: tmuxSocketPath, Value: receipt.route.expectedSocketPath, Source: tmuxSocketPathSource}}, action)
 			return err
 		},
 	}})

--- a/internal/app/shell_control_session_test.go
+++ b/internal/app/shell_control_session_test.go
@@ -621,7 +621,7 @@ func TestControlBootstrapLeaseClearRefusesPhysicalRouteDriftBeforeWrite(t *testi
 	receipt := controlBootstrapReceipt{
 		created: true, sessionID: "$9", windowID: "@12", paneID: "%15", operationMarker: tmux.operationMarker,
 		route: runtimeMutationRoute{
-			target: explicitTmuxTarget{flag: "-L", value: "projmux"}, socketName: "projmux",
+			target: tmuxTransport{Kind: tmuxSocketName, Value: "projmux", Source: tmuxSocketNameSource}, socketName: "projmux",
 			expectedSocketPath: "/tmp/tmux-1000/original",
 			authority:          &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: "4242", SessionID: "$9", WindowID: "@12", PaneID: "%15"},
 		},

--- a/internal/app/termination_evidence_contract_test.go
+++ b/internal/app/termination_evidence_contract_test.go
@@ -119,7 +119,7 @@ func TestWindowUnlinkedRecordsKillEvidenceWithoutPersistedRuntimeState(t *testin
 		t.Fatalf("read receipts: %v", err)
 	}
 	result, err := reconcileLifecycle(context.Background(), lifecycleDirtyEvent{
-		target:          explicitTmuxTarget{flag: "-S", value: "/tmp/phase6.sock"},
+		target:          tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/phase6.sock", Source: tmuxSocketPathSource},
 		runtimeWindowID: "@12", receipts: receipts,
 	}, &stubPaneInventory{uids: map[string]bool{"pan-alpha-review": true}}, store.store())
 	if err != nil {
@@ -294,7 +294,7 @@ func TestPaneKilledWaitsPastHookDelayForSupervisorReceipt(t *testing.T) {
 	appendDone := make(chan error, 1)
 	runner := &controllerTriggerRunner{
 		store: store.store(), receipts: journal,
-		observe: func(explicitTmuxTarget) livePaneInventory {
+		observe: func(tmuxTransport) livePaneInventory {
 			return &stubPaneInventory{uids: map[string]bool{}}
 		},
 		receiptWaitTimeout: 300 * time.Millisecond,
@@ -313,7 +313,7 @@ func TestPaneKilledWaitsPastHookDelayForSupervisorReceipt(t *testing.T) {
 	}()
 	trigger := controllerTrigger{
 		reason: controllerTriggerPaneKilled,
-		target: explicitTmuxTarget{flag: "-S", value: "/tmp/phase6-delayed-kill.sock"},
+		target: tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/phase6-delayed-kill.sock", Source: tmuxSocketPathSource},
 	}
 	started := time.Now()
 	receipts, err := runner.awaitRuntimeExitTerminationReceipts(context.Background(), trigger, nil)
@@ -347,7 +347,7 @@ func TestPaneKilledReceiptWaitIsBoundedBeforeUnknownProjection(t *testing.T) {
 	activatePaneFixture(t, store, "pan-alpha-codex", "agt-alpha-codex", "gen-no-receipt")
 	runner := &controllerTriggerRunner{
 		store: store.store(), receipts: terminationJournal{path: filepath.Join(t.TempDir(), terminationJournalFile)},
-		observe: func(explicitTmuxTarget) livePaneInventory {
+		observe: func(tmuxTransport) livePaneInventory {
 			return &stubPaneInventory{uids: map[string]bool{}}
 		},
 		receiptWaitTimeout: 70 * time.Millisecond,
@@ -355,7 +355,7 @@ func TestPaneKilledReceiptWaitIsBoundedBeforeUnknownProjection(t *testing.T) {
 	}
 	trigger := controllerTrigger{
 		reason: controllerTriggerPaneKilled,
-		target: explicitTmuxTarget{flag: "-S", value: "/tmp/phase6-no-receipt.sock"},
+		target: tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/phase6-no-receipt.sock", Source: tmuxSocketPathSource},
 	}
 	started := time.Now()
 	receipts, err := runner.awaitRuntimeExitTerminationReceipts(context.Background(), trigger, nil)
@@ -393,7 +393,7 @@ func TestPaneKilledWaitRefinesRacingUnknownWithDelayedSupervisorReceipt(t *testi
 	appendDone := make(chan error, 1)
 	runner := &controllerTriggerRunner{
 		store: store.store(), receipts: journal,
-		observe: func(explicitTmuxTarget) livePaneInventory {
+		observe: func(tmuxTransport) livePaneInventory {
 			return &stubPaneInventory{uids: map[string]bool{}}
 		},
 		receiptWaitTimeout: 300 * time.Millisecond,
@@ -411,7 +411,7 @@ func TestPaneKilledWaitRefinesRacingUnknownWithDelayedSupervisorReceipt(t *testi
 	}()
 	trigger := controllerTrigger{
 		reason: controllerTriggerPaneKilled,
-		target: explicitTmuxTarget{flag: "-S", value: "/tmp/phase6-racing-unknown.sock"},
+		target: tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/phase6-racing-unknown.sock", Source: tmuxSocketPathSource},
 	}
 	receipts, err := runner.awaitRuntimeExitTerminationReceipts(context.Background(), trigger, nil)
 	if err != nil {
@@ -440,14 +440,14 @@ func TestExactPaneExitedReceiptWaitIsBoundedBeforeUnknownProjection(t *testing.T
 	}
 	runner := &controllerTriggerRunner{
 		store: store.store(), receipts: terminationJournal{path: filepath.Join(t.TempDir(), terminationJournalFile)},
-		observe: func(explicitTmuxTarget) livePaneInventory {
+		observe: func(tmuxTransport) livePaneInventory {
 			return &stubPaneInventory{uids: map[string]bool{}}
 		},
 		beforeReceiptWait: func() {}, receiptWaitTimeout: time.Millisecond, receiptPoll: 100 * time.Microsecond,
 	}
 	pass, err := runner.converge(context.Background(), controllerTrigger{
 		reason: controllerTriggerPaneExited, hookPane: "%9", hookWindow: "@4",
-		target: explicitTmuxTarget{flag: "-S", value: "/tmp/phase6-voluntary.sock"},
+		target: tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/phase6-voluntary.sock", Source: tmuxSocketPathSource},
 	})
 	if err != nil {
 		t.Fatalf("exact pane-exited: %v", err)
@@ -465,7 +465,7 @@ func TestExactDeadPaneReceiptWaitUsesLiveMinusDeadObservation(t *testing.T) {
 	appendDone := make(chan error, 1)
 	runner := &controllerTriggerRunner{
 		store: store.store(), receipts: journal,
-		observe: func(explicitTmuxTarget) livePaneInventory {
+		observe: func(tmuxTransport) livePaneInventory {
 			return &exactPaneExitInventory{
 				uids: map[string]bool{"pan-alpha-codex": true},
 				dead: map[string]bool{"pan-alpha-codex": true},
@@ -482,7 +482,7 @@ func TestExactDeadPaneReceiptWaitUsesLiveMinusDeadObservation(t *testing.T) {
 	}()
 	receipts, err := runner.awaitRuntimeExitTerminationReceipts(context.Background(), controllerTrigger{
 		reason: controllerTriggerPaneExited, hookPane: "%9",
-		target: explicitTmuxTarget{flag: "-S", value: "/tmp/phase0-dead-wait.sock"},
+		target: tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/phase0-dead-wait.sock", Source: tmuxSocketPathSource},
 	}, nil)
 	if err != nil {
 		t.Fatalf("wait for dead mirrored Pane receipt: %v", err)

--- a/internal/app/tmux.go
+++ b/internal/app/tmux.go
@@ -1443,7 +1443,7 @@ func bindConfigApplyRuntimeRoute(ctx context.Context, runner tmuxCommandRunner, 
 	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path {
 		return runtimeMutationRoute{}, nil, errors.New("config apply route requires one absolute clean physical socket")
 	}
-	exact := explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: path}}
+	exact := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: path, Source: tmuxSocketPathSource}}
 	pidOut, err := exact.Run(ctx, "tmux", "display-message", "-p", "-F", "#{pid}")
 	pid := strings.TrimSpace(string(pidOut))
 	parsedPID, pidErr := strconv.Atoi(pid)
@@ -1465,7 +1465,7 @@ func bindConfigApplyRuntimeRoute(ctx context.Context, runner tmuxCommandRunner, 
 }
 
 func guardConfigApplyRuntimeRoute(ctx context.Context, runner tmuxCommandRunner, route runtimeMutationRoute, requireLogical bool) error {
-	if route.target.flag != "-L" || route.target.value != route.socketName || route.socketName == "" ||
+	if route.target.Flag() != "-L" || route.target.Value != route.socketName || route.socketName == "" ||
 		route.expectedSocketPath == "" || !filepath.IsAbs(route.expectedSocketPath) || filepath.Clean(route.expectedSocketPath) != route.expectedSocketPath {
 		return errors.New("config apply route is not exact")
 	}
@@ -1474,7 +1474,7 @@ func guardConfigApplyRuntimeRoute(ctx context.Context, runner tmuxCommandRunner,
 	if err != nil || strings.TrimSpace(string(logicalPath)) != route.expectedSocketPath {
 		return errors.New("config apply logical alias no longer names the exact physical socket")
 	}
-	exact := explicitTmuxRunner{runner: runner, target: explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}}
+	exact := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}}
 	pathOut, err := exact.Run(ctx, "tmux", "display-message", "-p", "-F", "#{socket_path}")
 	if err != nil || strings.TrimSpace(string(pathOut)) != route.expectedSocketPath {
 		return errors.New("config apply physical socket drifted")

--- a/internal/app/tmux_test.go
+++ b/internal/app/tmux_test.go
@@ -132,7 +132,7 @@ func TestConfigRouteMarkerMatchingEffectCannotSkipCapturedServerGeneration(t *te
 	server := newFakeTmux()
 	server.socketName = "phase10-config"
 	route := runtimeMutationRoute{
-		target:             explicitTmuxTarget{flag: "-L", value: "phase10-config"},
+		target:             tmuxTransport{Kind: tmuxSocketName, Value: "phase10-config", Source: tmuxSocketNameSource},
 		expectedSocketPath: server.socketPath, socketName: "phase10-config",
 		authority: &runtimeMutationRouteAuthority{Class: runtimeMutationRouteApp, ServerPID: server.serverPID},
 	}

--- a/internal/app/transport_ownership_test.go
+++ b/internal/app/transport_ownership_test.go
@@ -1,0 +1,137 @@
+package app
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type rawTransportNoopRunner struct{}
+
+func (rawTransportNoopRunner) Run(context.Context, string, ...string) ([]byte, error) {
+	return nil, nil
+}
+
+// TestRawTmuxTransportHasOneProductionOwner is the retired-secondary-source
+// audit for the raw routing stage. Commands may translate their own usage
+// vocabulary, but they must pass name/path/inherited inputs to the
+// resourcegraph resolver and carry its Transport without rebuilding it.
+func TestRawTmuxTransportHasOneProductionOwner(t *testing.T) {
+	t.Parallel()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	forbidden := map[string]bool{
+		"explicitTmuxTarget":  true,
+		"controllerTransport": true,
+	}
+	fset := token.NewFileSet()
+	allowedContainmentReaders := map[string]bool{
+		"delete_pane_runtime.go":   true,
+		"delete_window_runtime.go": true,
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			ident, ok := node.(*ast.Ident)
+			if ok && forbidden[ident.Name] {
+				t.Errorf("%s retains retired raw transport owner %s", name, ident.Name)
+			}
+			call, ok := node.(*ast.CallExpr)
+			if !ok || len(call.Args) == 0 {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || selector.Sel.Name != "Cut" {
+				return true
+			}
+			readsTMUX := false
+			ast.Inspect(call.Args[0], func(arg ast.Node) bool {
+				literal, ok := arg.(*ast.BasicLit)
+				if ok && literal.Value == `"TMUX"` {
+					readsTMUX = true
+				}
+				return true
+			})
+			if readsTMUX && !allowedContainmentReaders[name] {
+				t.Errorf("%s manually splits inherited TMUX instead of using resourcegraph.ResolveTransport", name)
+			}
+			return true
+		})
+	}
+
+	for _, name := range []string{
+		"agent_interaction.go",
+		"agent_review.go",
+		"binding_convergence.go",
+		"delete_transport.go",
+		"resource_mutation_mirror.go",
+		"resource_reconcile.go",
+		"registry_recovery.go",
+		"runtime_diagnostics.go",
+	} {
+		source, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if !strings.Contains(string(source), "resourcegraph.ResolveTransport(") {
+			t.Errorf("%s does not project raw routing through resourcegraph.ResolveTransport", name)
+		}
+	}
+}
+
+func TestInheritedRawTransportAdaptersPreserveNoneBehavior(t *testing.T) {
+	t.Parallel()
+	runner := rawTransportNoopRunner{}
+	adapters := map[string]func(func(string) string, tmuxCommandRunner) bool{
+		"resource mutation mirror": func(lookup func(string) string, runner tmuxCommandRunner) bool {
+			return inheritedResourceMutationMirror(lookup, runner) != nil
+		},
+		"agent mutation mirror": func(lookup func(string) string, runner tmuxCommandRunner) bool {
+			return inheritedAgentMutationMirror(lookup, runner) != nil
+		},
+		"agent review binding": func(lookup func(string) string, runner tmuxCommandRunner) bool {
+			return inheritedAgentReviewBindingLookup(lookup, runner) != nil
+		},
+	}
+	for name, adapter := range adapters {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if adapter(nil, runner) || adapter(func(string) string { return "/tmp/projmux,1,0" }, nil) {
+				t.Fatal("nil dependency enabled inherited routing")
+			}
+			for _, inherited := range []string{"", "relative.sock,1,0", "malformed"} {
+				if adapter(func(key string) string {
+					if key == "TMUX" {
+						return inherited
+					}
+					return ""
+				}, runner) {
+					t.Fatalf("TMUX=%q enabled an inherited route", inherited)
+				}
+			}
+			if !adapter(func(key string) string {
+				if key == "TMUX" {
+					return "/tmp/projmux,1,0"
+				}
+				return ""
+			}, runner) {
+				t.Fatal("absolute inherited TMUX did not enable its exact route")
+			}
+		})
+	}
+}

--- a/internal/app/unmanaged_runtime_stop.go
+++ b/internal/app/unmanaged_runtime_stop.go
@@ -34,7 +34,7 @@ func executeUnmanagedRuntimeStop(ctx context.Context, runner tmuxCommandRunner, 
 	}
 	observeTarget := route.target
 	if route.expectedSocketPath != "" {
-		observeTarget = explicitTmuxTarget{flag: "-S", value: route.expectedSocketPath}
+		observeTarget = tmuxTransport{Kind: tmuxSocketPath, Value: route.expectedSocketPath, Source: tmuxSocketPathSource}
 	}
 	routed := explicitTmuxRunner{runner: runner, target: observeTarget}
 	observe := func(ctx context.Context) (unmanagedRuntimeStopObservation, bool, error) {

--- a/internal/core/resourcegraph/transport.go
+++ b/internal/core/resourcegraph/transport.go
@@ -66,7 +66,14 @@ type Transport struct {
 
 // Present reports whether this transport can reach a tmux server at all.
 func (t Transport) Present() bool {
-	return t.Kind != TransportNone && t.Kind != "" && t.Value != ""
+	switch t.Kind {
+	case TransportSocketName:
+		return strings.TrimSpace(t.Value) != "" && strings.TrimSpace(t.Value) == t.Value
+	case TransportSocketPath:
+		return filepath.IsAbs(t.Value) && filepath.Clean(t.Value) == t.Value
+	default:
+		return false
+	}
 }
 
 // Args returns the argv prefix that pins every tmux call to this exact server.
@@ -83,6 +90,51 @@ func (t Transport) Args() []string {
 	default:
 		return nil
 	}
+}
+
+// Flag returns the exact tmux routing flag carried by this transport.
+// It is empty for TransportNone and invalid/unknown kinds.
+func (t Transport) Flag() string {
+	switch {
+	case !t.Present():
+		return ""
+	case t.Kind == TransportSocketName:
+		return "-L"
+	case t.Kind == TransportSocketPath:
+		return "-S"
+	default:
+		return ""
+	}
+}
+
+// Label renders the compact flag/value spelling used by command reports.
+func (t Transport) Label() string {
+	if !t.Present() {
+		return "none"
+	}
+	return t.Flag() + "/" + t.Value
+}
+
+// SameRoute reports whether two transports select the same tmux server shape.
+// Source is diagnostic provenance, not routing identity or mutation authority.
+func (t Transport) SameRoute(other Transport) bool {
+	return t.Kind == other.Kind && t.Value == other.Value
+}
+
+// ExplicitProjection keeps the selected route while describing it as the
+// exact -L/-S command carrier used by mutation plans. Read surfaces retain the
+// original Source; this projection preserves the mutation report vocabulary.
+func (t Transport) ExplicitProjection() Transport {
+	projected := t
+	switch t.Kind {
+	case TransportSocketName:
+		projected.Source = TransportSourceSocketName
+	case TransportSocketPath:
+		projected.Source = TransportSourceSocketPath
+	case TransportNone:
+		projected.Source = TransportSourceNone
+	}
+	return projected
 }
 
 // String renders the transport the way an operator would type it.

--- a/internal/core/resourcegraph/transport_test.go
+++ b/internal/core/resourcegraph/transport_test.go
@@ -48,6 +48,29 @@ func TestResolveTransportPicksExactlyOneServer(t *testing.T) {
 			wantSource: TransportSourceSocketName, wantArgs: []string{"-L", "probe"},
 		},
 		{
+			name:     "blank socket name does not outrank inherited transport",
+			request:  TransportRequest{SocketName: " \t", InheritedTMUX: "/tmp/tmux-1000/projmux,8084,6"},
+			wantKind: TransportSocketPath, wantValue: "/tmp/tmux-1000/projmux",
+			wantSource: TransportSourceInheritedEnv, wantArgs: []string{"-S", "/tmp/tmux-1000/projmux"},
+		},
+		{
+			name:     "blank socket path does not conflict with explicit name",
+			request:  TransportRequest{SocketName: "probe", SocketPath: " \n"},
+			wantKind: TransportSocketName, wantValue: "probe",
+			wantSource: TransportSourceSocketName, wantArgs: []string{"-L", "probe"},
+		},
+		{
+			name:     "blank socket name does not conflict with explicit path",
+			request:  TransportRequest{SocketName: " ", SocketPath: "/tmp/probe"},
+			wantKind: TransportSocketPath, wantValue: "/tmp/probe",
+			wantSource: TransportSourceSocketPath, wantArgs: []string{"-S", "/tmp/probe"},
+		},
+		{
+			name:    "relative explicit path is refused even with valid inherited transport",
+			request: TransportRequest{SocketPath: "relative/probe", InheritedTMUX: "/tmp/tmux-1000/projmux,8084,6"},
+			wantErr: true,
+		},
+		{
 			name:     "inherited $TMUX supplies the absolute socket path",
 			request:  TransportRequest{InheritedTMUX: "/tmp/tmux-1000/projmux,8084,6"},
 			wantKind: TransportSocketPath, wantValue: "/tmp/tmux-1000/projmux",
@@ -56,6 +79,11 @@ func TestResolveTransportPicksExactlyOneServer(t *testing.T) {
 		{
 			name:     "a relative inherited value is discarded, not guessed at",
 			request:  TransportRequest{InheritedTMUX: "projmux,8084,6"},
+			wantKind: TransportNone, wantSource: TransportSourceNone,
+		},
+		{
+			name:     "blank inherited value is no transport",
+			request:  TransportRequest{InheritedTMUX: " \t\n"},
 			wantKind: TransportNone, wantSource: TransportSourceNone,
 		},
 		{
@@ -88,6 +116,9 @@ func TestResolveTransportPicksExactlyOneServer(t *testing.T) {
 			if !slices.Equal(transport.Args(), test.wantArgs) {
 				t.Fatalf("args = %v, want %v", transport.Args(), test.wantArgs)
 			}
+			if transport.Present() && transport.Flag() != test.wantArgs[0] {
+				t.Fatalf("Flag() = %q, want %q", transport.Flag(), test.wantArgs[0])
+			}
 			if transport.Present() != (len(test.wantArgs) > 0) {
 				t.Fatalf("Present() = %v with args %v", transport.Present(), transport.Args())
 			}
@@ -103,6 +134,38 @@ func TestResolveTransportConflictIsTyped(t *testing.T) {
 	_, err := ResolveTransport(TransportRequest{SocketName: "a", SocketPath: "/tmp/b"})
 	if !errors.Is(err, ErrTransportConflict) {
 		t.Fatalf("err = %v, want ErrTransportConflict", err)
+	}
+}
+
+func TestTransportNeverProjectsAnInvalidTargetToBareTmux(t *testing.T) {
+	t.Parallel()
+	for _, transport := range []Transport{
+		{},
+		{Kind: TransportNone, Value: "ignored"},
+		{Kind: TransportKind("future"), Value: "socket"},
+		{Kind: TransportSocketName},
+		{Kind: TransportSocketName, Value: " socket "},
+		{Kind: TransportSocketPath, Value: "relative/socket"},
+		{Kind: TransportSocketPath, Value: "/tmp/../relative/socket"},
+	} {
+		if transport.Present() || transport.Args() != nil || transport.Flag() != "" {
+			t.Fatalf("invalid transport projected a tmux route: %+v args=%v flag=%q", transport, transport.Args(), transport.Flag())
+		}
+	}
+}
+
+func TestTransportSourceIsNotRouteIdentity(t *testing.T) {
+	t.Parallel()
+	explicit := Transport{Kind: TransportSocketPath, Value: "/tmp/projmux", Source: TransportSourceSocketPath}
+	inherited := Transport{Kind: TransportSocketPath, Value: "/tmp/projmux", Source: TransportSourceInheritedEnv}
+	if !explicit.SameRoute(inherited) {
+		t.Fatalf("the same socket path split route identity by diagnostic source: explicit=%+v inherited=%+v", explicit, inherited)
+	}
+	if explicit.SameRoute(Transport{Kind: TransportSocketName, Value: "/tmp/projmux", Source: TransportSourceSocketName}) {
+		t.Fatal("socket name and socket path collapsed into one route")
+	}
+	if projected := inherited.ExplicitProjection(); projected.Source != TransportSourceSocketPath || !projected.SameRoute(inherited) {
+		t.Fatalf("explicit projection = %+v, want the same -S route with explicit-path report source", projected)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make `resourcegraph.TransportRequest -> ResolveTransport -> Transport` the canonical owner of raw tmux name/path/inherited/none routing
- replace app-owned `explicitTmuxTarget`, command-specific precedence parsers, and `controllerTransport` with typed projections or command-specific error adapters
- preserve the separate verified mutation route and its physical `-S`, marker/PID/containment/generation/epoch first-write guards

## Behavior parity

- public CLI spelling, argv, help, stdout/stderr, usage errors, exit behavior, config/schema/hooks are unchanged
- Registry desired, Inventory observed, Graph resolved, Plan authorized remain separate
- read-only `TransportNone` remains legal; mutation commands still refuse no-authority before writes
- explicit and inherited routes still resolve to the same exact server while source provenance remains diagnostic only

## Validation

- `make fmt` — green
- `make fix` — green; deadcode clean
- `make test` — green
- `make test-integration` — green on `4722557e`
- `make test-e2e` — green on `4722557e`; 21 scenarios, four shards, contract-result `6e950197…`
- raw Transport exhaustive table — green
- retired secondary-source AST audit — green
- delete/reconcile/recovery/controller/materialize argv, usage, failure-vocabulary parity tests — green
- absent/relative/conflict/foreign/stale/socket-drift mutation-zero matrix — green
- required `Test` and all remote CI jobs — green
- post-merge installed unique `-L` / absolute `-S` two-socket smoke — green; target hash changed, sibling hash/sentinel byte-identical, exact queried-path cleanup

## Scope audit

- no default socket fallback, authority/first-write relaxation, native epoch redesign, lifecycle/delete policy generalization, public CLI/schema/config/hook change, or generic Resource/Plan/Identity framework
- no edits to parallel-owned deadcode surfaces, `internal/app/create_resource.go`, `internal/integrations/metadata/store.go`, L06 fixtures/diagnostics, `docs/testing.md`, or `docs/agent-workflow.md`
- the two remaining production `$TMUX` splits are delete pane/window caller-containment evidence readers, not raw route constructors or precedence owners

## Post-merge observation / risk

- squash merge `26ab48b4`, clean-main fast-forward, `make install`, and installed SHA `983bda00…` completed
- Linux installed two-socket smoke passed with inherited `TMUX`/`TMUX_PANE` unset; Darwin adapter CI passed, but no local macOS installed smoke was required or run

Roadmap: 0.13 이후 개념 단일 소유권 정리 / Phase 2 Exact tmux transport two-stage model

Contract: C-1 선언형 개념의 단일 소유권

Contract: C-2 서로 다른 상태·권한 단계 보존
