### PR TITLE
fix(codex): parse live control binding from tmux safely

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -307,6 +307,16 @@
   command, path, permission, and request content out of Registry, tmux, notify,
   diagnostics, support, and Archive sinks.
 
+- `make test` / `make test-integration`: Codex public turn control live-binding
+  compatibility uses one strict six-field tmux frame. Unit tests accept only
+  literal `\037` and raw unit-separator spellings without generic escape
+  decoding or value trimming; missing, extra, mixed, multiline, Registry
+  activation, runtime, Pane, thread, generation, and epoch drift all fail
+  closed with zero app-server writes. The isolated real-tmux regression removes
+  inherited `TMUX`/`TMUX_PANE`, uses run-unique `TMUX_TMPDIR` and `-L` names,
+  pins tmux 3.4's literal frame, and cleans only its immediately queried exact
+  socket path.
+
 - `make test`: Invocation-target authority Phase 2 keeps create, topology replay,
   resume, and native Codex on one typed exact-route Pane binder. The maintained
   matrix crosses `-L`/`-S` with success and first/middle/last option-write

--- a/internal/app/agent_control.go
+++ b/internal/app/agent_control.go
@@ -54,21 +54,78 @@ type tmuxAgentControlBindingLookup struct {
 	runner tmuxCommandRunner
 }
 
+// agentControlBindingFrameError is the typed refusal for a live tmux binding
+// that cannot be proven to be one exact six-field frame. Control callers use
+// this boundary before resolving the private app-server route, so malformed or
+// ambiguous output can never become a partial identity or a control write.
+type agentControlBindingFrameError struct {
+	Reason     string
+	FieldCount int
+}
+
+func (e *agentControlBindingFrameError) Error() string {
+	if e.FieldCount > 0 {
+		return fmt.Sprintf("live Codex control binding is malformed: %s (%d fields, want 6)", e.Reason, e.FieldCount)
+	}
+	return "live Codex control binding is malformed: " + e.Reason
+}
+
+// exactAgentControlBindingError is the typed Registry/live-activation refusal.
+// Its text remains the public recovery prefix consumed by the CLI while
+// errors.As can distinguish an identity refusal from transport failure.
+type exactAgentControlBindingError struct{ Reason string }
+
+func (e *exactAgentControlBindingError) Error() string {
+	return "exact Agent native control unavailable: " + e.Reason
+}
+
+// parseAgentControlBindingFrame accepts only the two separator spellings tmux
+// has emitted for this contract: the literal octal spelling used by tmux 3.4
+// and the raw unit-separator used by the supported compatibility fixture. It
+// deliberately does not perform general escape decoding. Apart from the one
+// command-output line ending, field bytes are returned unchanged.
+func parseAgentControlBindingFrame(out []byte) (agentControlLive, error) {
+	frame := string(out)
+	if before, ok := strings.CutSuffix(frame, "\n"); ok {
+		frame = before
+		frame = strings.TrimSuffix(frame, "\r")
+	}
+	if strings.ContainsAny(frame, "\r\n") {
+		return agentControlLive{}, &agentControlBindingFrameError{Reason: "multiple output lines"}
+	}
+	hasEscaped := strings.Contains(frame, tmuxRowSepFormat)
+	hasRaw := strings.Contains(frame, tmuxRowSep)
+	if hasEscaped && hasRaw {
+		return agentControlLive{}, &agentControlBindingFrameError{Reason: "mixed separator spellings"}
+	}
+	separator := tmuxRowSepFormat
+	if hasRaw {
+		separator = tmuxRowSep
+	} else if !hasEscaped {
+		return agentControlLive{}, &agentControlBindingFrameError{Reason: "separator is missing", FieldCount: 1}
+	}
+	fields := strings.Split(frame, separator)
+	if len(fields) != 6 {
+		return agentControlLive{}, &agentControlBindingFrameError{Reason: "field count is not exact", FieldCount: len(fields)}
+	}
+	return agentControlLive{RuntimeID: fields[0], PaneUID: fields[1], ThreadID: fields[2], Authority: fields[3], Epoch: fields[4], Reason: fields[5]}, nil
+}
+
 func (l *tmuxAgentControlBindingLookup) Live(ctx context.Context, paneUID string) (agentControlLive, bool, error) {
 	target, found, err := l.lookup.FindPaneTargetForUID(ctx, paneUID)
 	if err != nil || !found {
 		return agentControlLive{}, found, err
 	}
-	format := strings.Join([]string{"#{pane_id}", "#{@projmux_pane_uid}", "#{" + aiPaneThreadIDOption + "}", "#{" + aiPaneCodexAuthorityOption + "}", "#{" + aiPaneCodexEpochOption + "}", "#{" + aiPaneCodexReasonOption + "}"}, "\x1f")
+	format := tmuxRowFormat("#{pane_id}", "#{@projmux_pane_uid}", "#{"+aiPaneThreadIDOption+"}", "#{"+aiPaneCodexAuthorityOption+"}", "#{"+aiPaneCodexEpochOption+"}", "#{"+aiPaneCodexReasonOption+"}")
 	out, err := l.runner.Run(ctx, "tmux", "display-message", "-p", "-t", target, format)
 	if err != nil {
 		return agentControlLive{}, false, err
 	}
-	fields := strings.Split(strings.TrimSpace(string(out)), "\x1f")
-	if len(fields) != 6 {
-		return agentControlLive{}, false, errors.New("live Codex control binding is malformed")
+	live, err := parseAgentControlBindingFrame(out)
+	if err != nil {
+		return agentControlLive{}, false, err
 	}
-	return agentControlLive{RuntimeID: fields[0], PaneUID: fields[1], ThreadID: fields[2], Authority: fields[3], Epoch: fields[4], Reason: fields[5]}, true, nil
+	return live, true, nil
 }
 
 type exactAgentControlBinding struct {
@@ -81,7 +138,7 @@ type exactAgentControlBinding struct {
 
 func resolveExactAgentControlBinding(registry coremetadata.Registry, agent coremetadata.Agent, live agentControlLive, observed bool, stateDir string) (exactAgentControlBinding, error) {
 	refusal := func(reason string) (exactAgentControlBinding, error) {
-		return exactAgentControlBinding{}, fmt.Errorf("exact Agent native control unavailable: %s", reason)
+		return exactAgentControlBinding{}, &exactAgentControlBindingError{Reason: reason}
 	}
 	if agent.Spec.Provider != aiModeCodex {
 		return refusal("the selected Agent is not Codex")

--- a/internal/app/agent_control_cli_test.go
+++ b/internal/app/agent_control_cli_test.go
@@ -23,6 +23,7 @@ type staticAgentControlBinding struct {
 type exactControlRouteRunner struct {
 	target tmuxTransport
 	calls  [][]string
+	frame  []byte
 }
 
 func (r *exactControlRouteRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
@@ -34,9 +35,58 @@ func (r *exactControlRouteRunner) Run(_ context.Context, name string, args ...st
 	case "list-panes":
 		return []byte("pan-alpha-codex" + tmuxRowSepFormat + "%7\n"), nil
 	case "display-message":
-		return []byte(strings.Join([]string{"%7", "pan-alpha-codex", "thread-1", codexAuthorityControlPlane, "epoch-1", "ready"}, "\x1f") + "\n"), nil
+		if r.frame != nil {
+			return append([]byte(nil), r.frame...), nil
+		}
+		return []byte(strings.Join([]string{"%7", "pan-alpha-codex", "thread-1", codexAuthorityControlPlane, "epoch-1", "ready"}, tmuxRowSepFormat) + "\n"), nil
 	default:
 		return nil, errors.New("unexpected control operation")
+	}
+}
+
+func TestAgentControlBindingFrameAcceptsOnlySupportedExactSixFieldSpellings(t *testing.T) {
+	fields := []string{" %7 ", "pan-alpha-codex", `thread\\literal`, codexAuthorityControlPlane, "epoch-1", ` ready\\n `}
+	want := agentControlLive{RuntimeID: fields[0], PaneUID: fields[1], ThreadID: fields[2], Authority: fields[3], Epoch: fields[4], Reason: fields[5]}
+	for _, test := range []struct {
+		name      string
+		separator string
+		ending    string
+	}{
+		{name: "literal octal", separator: tmuxRowSepFormat, ending: "\n"},
+		{name: "raw unit separator", separator: tmuxRowSep, ending: "\r\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseAgentControlBindingFrame([]byte(strings.Join(fields, test.separator) + test.ending))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != want {
+				t.Fatalf("binding = %#v, want byte-faithful %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestAgentControlBindingFrameRejectsMalformedMissingExtraAndMixedFrames(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		frame string
+	}{
+		{name: "missing literal field", frame: strings.Join([]string{"%7", "pane", "thread", "authority", "epoch"}, tmuxRowSepFormat) + "\n"},
+		{name: "extra literal field", frame: strings.Join([]string{"%7", "pane", "thread", "authority", "epoch", "reason", "extra"}, tmuxRowSepFormat) + "\n"},
+		{name: "missing raw field", frame: strings.Join([]string{"%7", "pane", "thread", "authority", "epoch"}, tmuxRowSep) + "\n"},
+		{name: "extra raw field", frame: strings.Join([]string{"%7", "pane", "thread", "authority", "epoch", "reason", "extra"}, tmuxRowSep) + "\n"},
+		{name: "mixed separators", frame: "%7" + tmuxRowSep + "pane" + strings.Repeat(tmuxRowSepFormat+"field", 4) + "\n"},
+		{name: "separator missing", frame: "one-field\n"},
+		{name: "multiple lines", frame: strings.Join([]string{"%7", "pane", "thread", "authority", "epoch", "reason\nother"}, tmuxRowSepFormat) + "\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseAgentControlBindingFrame([]byte(test.frame))
+			var frameErr *agentControlBindingFrameError
+			if err == nil || !errors.As(err, &frameErr) {
+				t.Fatalf("error = %v, want typed frame refusal", err)
+			}
+		})
 	}
 }
 
@@ -108,6 +158,81 @@ func TestAgentControlCLIExactTurnDispatchAndTextFidelity(t *testing.T) {
 			}
 			if len(calls) != 1 || calls[0].Operation != test.op || calls[0].Text != test.text || calls[0].Identity != phase6CLIIdentity() || calls[0].Epoch != "epoch-1" {
 				t.Fatalf("control calls = %+v", calls)
+			}
+		})
+	}
+}
+
+func TestAgentControlCLIPublicTurnsDispatchFromBothSupportedTmuxFrames(t *testing.T) {
+	for _, frame := range []struct {
+		name      string
+		separator string
+	}{
+		{name: "tmux literal octal", separator: tmuxRowSepFormat},
+		{name: "raw compatibility", separator: tmuxRowSep},
+	} {
+		for _, turn := range []struct {
+			name string
+			args []string
+			op   string
+		}{
+			{name: "start", args: []string{"turn", "start", "uid:agt-alpha-codex", "--", "start exact"}, op: agentControlOpStart},
+			{name: "steer", args: []string{"turn", "steer", "uid:agt-alpha-codex", "--", "steer exact"}, op: agentControlOpSteer},
+			{name: "interrupt", args: []string{"turn", "interrupt", "uid:agt-alpha-codex"}, op: agentControlOpInterrupt},
+		} {
+			t.Run(frame.name+"/"+turn.name, func(t *testing.T) {
+				cmd, _, _ := exactControlCLICommand(t)
+				target := tmuxTransport{Kind: tmuxSocketName, Value: "exact-control", Source: tmuxSocketNameSource}
+				tmux := &exactControlRouteRunner{
+					target: target,
+					frame:  []byte(strings.Join([]string{"%7", "pan-alpha-codex", "thread-1", codexAuthorityControlPlane, "epoch-1", "ready"}, frame.separator) + "\n"),
+				}
+				cmd.controlBinding = nil
+				cmd.controlRunner = tmux
+				cmd.controlRoute = func(context.Context) (runtimeMutationRoute, error) { return runtimeMutationRoute{target: target}, nil }
+				var calls []agentControlRequest
+				cmd.controlCall = func(_ context.Context, stateDir string, identity codexLifecycleIdentity, request agentControlRequest) (agentControlResponse, error) {
+					if stateDir != "/tmp/projmux-phase6-cli" || identity != phase6CLIIdentity() || request.Identity != identity || request.Epoch != "epoch-1" {
+						t.Fatalf("dispatch state=%q identity=%+v request=%+v", stateDir, identity, request)
+					}
+					calls = append(calls, request)
+					return agentControlResponse{OK: true, ThreadID: "thread-1", TurnID: "turn-1"}, nil
+				}
+				if _, _, err := runRoute(t, cmd, turn.args...); err != nil {
+					t.Fatal(err)
+				}
+				if len(calls) != 1 || calls[0].Operation != turn.op {
+					t.Fatalf("control calls = %+v", calls)
+				}
+			})
+		}
+	}
+}
+
+func TestAgentControlCLIMalformedTmuxFramesCallNoAppServer(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		frame string
+	}{
+		{name: "missing", frame: strings.Join([]string{"%7", "pane", "thread", "authority", "epoch"}, tmuxRowSepFormat) + "\n"},
+		{name: "extra", frame: strings.Join([]string{"%7", "pane", "thread", "authority", "epoch", "reason", "extra"}, tmuxRowSepFormat) + "\n"},
+		{name: "mixed", frame: "%7" + tmuxRowSep + "pane" + strings.Repeat(tmuxRowSepFormat+"field", 4) + "\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd, _, _ := exactControlCLICommand(t)
+			target := tmuxTransport{Kind: tmuxSocketName, Value: "exact-control", Source: tmuxSocketNameSource}
+			cmd.controlBinding = nil
+			cmd.controlRunner = &exactControlRouteRunner{target: target, frame: []byte(test.frame)}
+			cmd.controlRoute = func(context.Context) (runtimeMutationRoute, error) { return runtimeMutationRoute{target: target}, nil }
+			calls := 0
+			cmd.controlCall = func(context.Context, string, codexLifecycleIdentity, agentControlRequest) (agentControlResponse, error) {
+				calls++
+				return agentControlResponse{}, errors.New("must not be called")
+			}
+			_, _, err := runRoute(t, cmd, "turn", "interrupt", "uid:agt-alpha-codex")
+			var frameErr *agentControlBindingFrameError
+			if err == nil || !errors.As(err, &frameErr) || calls != 0 {
+				t.Fatalf("error=%v typed=%#v app-server calls=%d", err, frameErr, calls)
 			}
 		})
 	}
@@ -188,6 +313,74 @@ func TestAgentControlCLIStaleBindingCallsNoControl(t *testing.T) {
 	}
 }
 
+func TestAgentControlCLIRegistryAndLiveIdentityMismatchIsTypedAndCallsNoControl(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*fakeResourceStore, *staticAgentControlBinding)
+	}{
+		{name: "runtime", mutate: func(_ *fakeResourceStore, binding *staticAgentControlBinding) { binding.live.RuntimeID = "%8" }},
+		{name: "Pane uid", mutate: func(_ *fakeResourceStore, binding *staticAgentControlBinding) { binding.live.PaneUID = "pan-other" }},
+		{name: "thread", mutate: func(_ *fakeResourceStore, binding *staticAgentControlBinding) { binding.live.ThreadID = "thread-other" }},
+		{name: "unobserved", mutate: func(_ *fakeResourceStore, binding *staticAgentControlBinding) { binding.observed = false }},
+		{name: "activation generation missing", mutate: func(store *fakeResourceStore, _ *staticAgentControlBinding) {
+			pane, _ := store.registry.Pane("pan-alpha-codex")
+			pane.Status.Activation.Generation = ""
+		}},
+		{name: "activation Agent mismatch", mutate: func(store *fakeResourceStore, _ *staticAgentControlBinding) {
+			pane, _ := store.registry.Pane("pan-alpha-codex")
+			pane.Status.Activation.AgentUID = "agt-other"
+		}},
+		{name: "epoch empty", mutate: func(_ *fakeResourceStore, binding *staticAgentControlBinding) { binding.live.Epoch = "" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd, store, binding := exactControlCLICommand(t)
+			test.mutate(store, binding)
+			calls := 0
+			cmd.controlCall = func(context.Context, string, codexLifecycleIdentity, agentControlRequest) (agentControlResponse, error) {
+				calls++
+				return agentControlResponse{}, errors.New("must not be called")
+			}
+			_, _, err := runRoute(t, cmd, "turn", "interrupt", "uid:agt-alpha-codex")
+			var bindingErr *exactAgentControlBindingError
+			if err == nil || !errors.As(err, &bindingErr) || calls != 0 {
+				t.Fatalf("error=%v typed=%#v control calls=%d", err, bindingErr, calls)
+			}
+		})
+	}
+}
+
+func TestAgentControlCLIReplacedGenerationOrEpochWritesNoAppServerControl(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*fakeResourceStore, *staticAgentControlBinding)
+	}{
+		{name: "generation", mutate: func(store *fakeResourceStore, _ *staticAgentControlBinding) {
+			pane, _ := store.registry.Pane("pan-alpha-codex")
+			pane.Status.Activation.Generation = "generation-replaced"
+		}},
+		{name: "epoch", mutate: func(_ *fakeResourceStore, binding *staticAgentControlBinding) { binding.live.Epoch = "epoch-replaced" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd, store, binding := exactControlCLICommand(t)
+			test.mutate(store, binding)
+			wire := &fakeExactControlWire{}
+			epoch := newCodexControlEpoch(wire, phase6CLIIdentity(), "epoch-1", codexappserver.LifecycleSnapshot{
+				ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive,
+				TurnID: "turn-1", TurnState: codexappserver.TurnStateInProgress,
+			}, func(codexLifecycleIdentity) bool { return true })
+			var calls []agentControlRequest
+			cmd.controlCall = func(_ context.Context, _ string, _ codexLifecycleIdentity, request agentControlRequest) (agentControlResponse, error) {
+				calls = append(calls, request)
+				return epoch.Handle(context.Background(), request), nil
+			}
+			_, _, err := runRoute(t, cmd, "turn", "interrupt", "uid:agt-alpha-codex")
+			if err == nil || len(calls) != 1 || wire.writes() != 0 {
+				t.Fatalf("error=%v calls=%+v app-server writes=%d", err, calls, wire.writes())
+			}
+		})
+	}
+}
+
 func TestAgentControlBindingLookupUsesResolvedLogicalRouteOnly(t *testing.T) {
 	for _, target := range []tmuxTransport{
 		{Kind: tmuxSocketName, Value: "exact-control", Source: tmuxSocketNameSource},
@@ -214,6 +407,12 @@ func TestAgentControlBindingLookupUsesResolvedLogicalRouteOnly(t *testing.T) {
 			for _, call := range tmux.calls {
 				if len(call) < 2 || call[0] != target.Flag() || call[1] != target.Value {
 					t.Fatalf("ambient/default control read = %q", call)
+				}
+				if slices.Contains(call, "display-message") {
+					format := call[len(call)-1]
+					if strings.Count(format, tmuxRowSepFormat) != 5 || strings.Contains(format, tmuxRowSep) {
+						t.Fatalf("unsafe control frame format = %q", format)
+					}
 				}
 			}
 		})

--- a/scripts/test-integration-docker.sh
+++ b/scripts/test-integration-docker.sh
@@ -3,4 +3,5 @@ set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 "$root/scripts/test-docker-run.sh" test/integration/linux-smoke.sh "$@"
+"$root/scripts/test-docker-run.sh" test/integration/agent-control-binding-frame.sh "$@"
 exec "$root/scripts/test-docker-run.sh" test/integration/codex-appserver-topology.sh "$@"

--- a/test/integration/agent-control-binding-frame.sh
+++ b/test/integration/agent-control-binding-frame.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pin the real tmux display-message frame used by public Agent control lookup.
+# This harness owns one run-unique socket below one run-unique TMUX_TMPDIR and
+# never follows the invoking client's inherited route.
+unset TMUX TMUX_PANE
+
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/projmux-control-binding.XXXXXX")"
+tmux_root="$test_root/tmux"
+socket_name="control-binding-$$-${RANDOM}"
+session_name="control-binding-$$-${RANDOM}"
+socket_path=""
+mkdir -p "$tmux_root"
+
+cleanup() {
+  local current=""
+  if [[ -n "$socket_path" ]]; then
+    case "$socket_path" in
+      "$tmux_root"/*) ;;
+      *)
+        echo "refusing control-binding cleanup outside isolated tmux root: $socket_path" >&2
+        return 1
+        ;;
+    esac
+    current="$(env -u TMUX -u TMUX_PANE TMUX_TMPDIR="$tmux_root" tmux -S "$socket_path" display-message -p '#{socket_path}' 2>/dev/null || true)"
+    if [[ -n "$current" ]]; then
+      if [[ "$current" != "$socket_path" ]]; then
+        echo "refusing control-binding cleanup after socket identity changed: expected=$socket_path current=$current" >&2
+        return 1
+      fi
+      env -u TMUX -u TMUX_PANE TMUX_TMPDIR="$tmux_root" tmux -S "$socket_path" kill-server
+    fi
+  fi
+  rm -rf -- "$test_root"
+}
+trap cleanup EXIT
+
+tmux_by_name() {
+  env -u TMUX -u TMUX_PANE TMUX_TMPDIR="$tmux_root" tmux -L "$socket_name" "$@"
+}
+
+tmux_by_name new-session -d -s "$session_name" sleep 300
+# Resolve the physical socket immediately after creation. Every later read,
+# write, and cleanup is bound to this validated exact path.
+socket_path="$(tmux_by_name display-message -p -t "=$session_name" '#{socket_path}')"
+case "$socket_path" in
+  "$tmux_root"/*) ;;
+  *)
+    echo "control-binding socket escaped isolated tmux root: $socket_path" >&2
+    exit 1
+    ;;
+esac
+
+tmux_exact() {
+  env -u TMUX -u TMUX_PANE TMUX_TMPDIR="$tmux_root" tmux -S "$socket_path" "$@"
+}
+
+pane_id="$(tmux_exact list-panes -t "=$session_name" -F '#{pane_id}')"
+if [[ -z "$pane_id" || "$pane_id" == *$'\n'* ]]; then
+  echo "control-binding fixture did not resolve exactly one Pane" >&2
+  exit 1
+fi
+pane_uid="pan-control-binding"
+thread_id='thread\literal'
+authority="provider-control-plane"
+epoch="epoch-control-binding"
+reason=' ready\literal '
+tmux_exact set-option -p -t "$pane_id" @projmux_pane_uid "$pane_uid"
+tmux_exact set-option -p -t "$pane_id" @projmux_ai_thread_id "$thread_id"
+tmux_exact set-option -p -t "$pane_id" @projmux_codex_authority "$authority"
+tmux_exact set-option -p -t "$pane_id" @projmux_codex_authority_epoch "$epoch"
+tmux_exact set-option -p -t "$pane_id" @projmux_codex_authority_reason "$reason"
+
+format='#{pane_id}\037#{@projmux_pane_uid}\037#{@projmux_ai_thread_id}\037#{@projmux_codex_authority}\037#{@projmux_codex_authority_epoch}\037#{@projmux_codex_authority_reason}'
+actual="$(tmux_exact display-message -p -t "$pane_id" "$format")"
+expected="${pane_id}\\037${pane_uid}\\037${thread_id}\\037${authority}\\037${epoch}\\037${reason}"
+if [[ "$actual" != "$expected" ]]; then
+  echo "real tmux control-binding frame changed" >&2
+  printf 'actual=%q\nexpected=%q\n' "$actual" "$expected" >&2
+  exit 1
+fi
+
+echo ">> real tmux Agent control-binding literal six-field frame passed"


### PR DESCRIPTION
## Summary
- parse tmux 3.4 literal `\037` and supported raw unit-separator live-binding frames as exact six-field records
- fail closed with typed errors and zero provider writes for malformed or stale control identity
- add isolated actual-tmux integration coverage and maintained workflow documentation

## Validation
- `make fmt`
- `make fix`
- `make test`
- focused Agent control tests
- `shellcheck test/integration/agent-control-binding-frame.sh scripts/test-integration-docker.sh`
- actual host tmux 3.4 isolated regression
- `make test-integration` (running)
- `make test-e2e` (pending)

Roadmap: Codex native observer and app-server recovery reliability / Phase 3 Real-tmux control binding frame compatibility
Contract: C-4 Guarantee Scope Failure