### PR TITLE
docs(codex): document the 0.14.0 native-required migration

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1366,6 +1366,17 @@ the resolved `claude`, `codex`, or `agy` executable inside the managed wrapper;
 projmux still sets the context directory, tmux title, AI pane metadata, and
 split layout.
 
+A prompted Codex create — provider `codex` with exactly one non-empty payload
+operand — requires native authority. If the app-server endpoint is not ready or
+attachable, if `--add-dir` roots cannot be negotiated, or if the selector
+resolves several Windows, the create refuses with zero Registry and zero tmux
+mutations instead of silently producing a plain-CLI Agent with no native turn
+control. `--interactive-only` is the one public spelling that asks for that
+plain Agent on purpose; it is Codex-only and equivalent on `create agent
+--provider codex` and the `create codex` shortcut. Empty-prompt creates,
+multi-operand payloads, `agent resume`, Claude, and Antigravity are unaffected.
+See [Codex Native-Required Create Migration](codex-native-required-migration.md).
+
 Automation callers get the new pane's handle from `-o pane-id` on the canonical
 create routes: `projmux create agent --provider <p> --placement right -o pane-id`
 and `projmux create pane --placement right -o pane-id` each print exactly the

--- a/docs/codex-native-required-migration.md
+++ b/docs/codex-native-required-migration.md
@@ -1,0 +1,175 @@
+# Codex Native-Required Create Migration (0.14.0)
+
+0.14.0 makes native authority a requirement for a *prompted* managed Codex
+create instead of something projmux attempts and silently gives up on. Where an
+earlier release would quietly hand back a plain-CLI Codex Agent — one that looks
+managed, carries no app-server thread binding, and answers no native turn
+control — the create now refuses at the provider-mutation boundary and names the
+one explicit way to ask for that plain Agent.
+
+This note covers only that change. For update mechanics by installer type see
+[Upgrading](upgrading.md); for endpoint readiness diagnosis see
+[Troubleshooting](troubleshooting.md#codex-app-server-install-topology).
+
+## There is nothing to migrate
+
+Upgrading is the whole migration. Every existing resource keeps working as it
+is:
+
+| Surface | Change in 0.14.0 |
+| --- | --- |
+| Registry schema | none — `internal/core/metadata` is byte-identical across the release range |
+| Existing Agents and Panes | none — no stored field is added, read differently, or backfilled |
+| Configuration files | none — no key added, renamed, or removed |
+| Post-create and Agent hook contract | none — no `PROJMUX_*` env var added, renamed, or removed, and no payload schema change |
+
+No command has to be run before or after the upgrade for this change. What
+changes is the answer a *new* prompted Codex create gives when native authority
+cannot be proven.
+
+## The shape that is now gated
+
+Exactly one create shape is native-required. All five conditions must hold:
+
+- provider is `codex`, and
+- the payload is exactly one operand, and
+- that operand is non-empty, and
+- `--interactive-only` is not passed, and
+- the create is not carrying a capability selection from the split-UI picker.
+
+Anything outside that shape keeps its previous behavior unchanged. The closed
+outcome table lives in `internal/app/codex_native_thread.go`
+(`codexNativeLaunchOutcomeTable`) and is pinned by
+`TestCodexNativeLaunchOutcomeTableIsClosed`.
+
+## Calls that now refuse
+
+### 1. Prompted create against an endpoint that is not ready or not attachable
+
+```sh
+projmux create codex -- "review the diff"
+projmux create agent --provider codex -- "review the diff"
+```
+
+Before: native thread preparation failed as a safe fallback and the create
+silently continued on the plain CLI lane, producing a managed Agent with no
+native binding.
+
+Now: the create refuses before the split, before the hook probe, and before the
+Registry commit. Zero threads, zero Panes, zero Registry writes, zero tmux
+objects. The refusal carries the typed reason from the endpoint (for example
+`daemon-not-running`) and names `--interactive-only`. Exit code 1.
+
+Fix it by making the app-server endpoint available — start with
+`projmux doctor --section integrations --verbose` — or ask for the plain lane on
+purpose with `--interactive-only`.
+
+### 2. Prompted create with `--add-dir` against an endpoint that cannot negotiate roots
+
+```sh
+projmux create codex --add-dir /path/to/other-root -- "review the diff"
+```
+
+Additional writable roots travel on the upstream experimental API. Before, the
+create connection never negotiated that capability, so roots always failed the
+request; that failure was classified as a safe fallback and the create silently
+dropped to the plain CLI lane.
+
+Now a rooted create negotiates the capability on its own connection and delivers
+the exact cleaned list. An endpoint that cannot answer the negotiated form
+fails closed with reason `additional-writable-roots-unsupported` rather than
+creating an Agent whose writable workspace is narrower than what was asked for.
+Exit code 1.
+
+A create with no `--add-dir` keeps the plain, non-negotiated connection exactly
+as before.
+
+### 3. Prompted create whose selector resolves several Windows
+
+```sh
+projmux create codex --window main --window side -- "review the diff"
+```
+
+One create owns exactly one native thread, and a Registry rollback cannot delete
+an app-server thread, so a prompted native fan-out has no atomic shape. Before,
+every target dropped to the plain CLI lane. Now the fan-out is refused before
+the first allocation, as a usage error (exit code 2) naming how many Windows the
+selector resolved.
+
+Narrow the selector to one Window, or pass `--interactive-only` to keep the
+previous one-Agent-per-Window cardinality.
+
+### 4. Resume picker: selecting an app-server-sourced Codex row
+
+This is the split-UI resume picker (`Alt-7` / the resume selection surface), not
+the `projmux agent resume` command.
+
+When the picker's Codex rows come from a healthy app-server, selecting one of
+those native rows resumes that exact thread through the native lane. Before, a
+failed native resume preparation silently rebound the selection onto the rollout
+CLI lane — it reported a resume while answering no native turn control. Now it
+refuses. Exit code 1.
+
+There is no `--interactive-only` escape hatch here: the operator picked an
+existing conversation, not a launch mode. Rows that came from the rollout scan
+rather than the app-server are unaffected and keep the current CLI lane.
+
+## The escape hatch: `--interactive-only`
+
+`--interactive-only` is the only public spelling that asks for a plain
+interactive Codex Agent with no native thread binding, and it is the only way to
+reach the plain CLI lane on purpose.
+
+```sh
+projmux create codex --interactive-only -- "interactive task"
+projmux create agent --provider codex --interactive-only -- "interactive task"
+```
+
+- Both spellings are equivalent: identical flag acceptance, identical manifest
+  and rendered help, byte-equal stdout.
+- The native controller is not consulted at all. No thread is created, no native
+  Pane state is bound, and the Agent keeps the existing hook activation contract
+  (`provider-hook`).
+- The payload stays the provider's initial task on the CLI argv, exactly as
+  before.
+- It gives up native turn control for that Agent — start, steer, interrupt, and
+  approval routing through the app-server. That is a deliberate reduced
+  capability, not a defect.
+- It is Codex-only. Passing it to `--provider claude` or `--provider antigravity`,
+  or to the `create claude` / `create antigravity` shortcuts, is a usage error
+  (exit code 2) raised before any transaction opens, so nothing is created.
+- It is a create-time flag and is not stored on the Agent. `projmux agent resume`
+  has no way to tell an interactive-only Agent apart later and does not treat one
+  specially.
+
+## What did not change
+
+| Surface | Behavior |
+| --- | --- |
+| `projmux agent resume` | unchanged. A stored Agent whose native resume cannot be proven keeps its existing safe fallback to one provider resume of the stored conversation. `internal/app/agent_resume.go` has a net diff of zero lines in this release. |
+| Empty-prompt Codex create (`projmux create codex` with no payload) | unchanged byte-for-byte, including argv, hook acknowledgement, output, and late refinement. An empty prompt is not attachable native input, so it was never in the gated shape. |
+| Multi-operand payload (`projmux create codex -- a b`) | unchanged. The legacy CLI owns provider parsing for a multi-operand payload, so it is not a native create candidate and keeps the plain lane. |
+| Claude and Antigravity | unchanged lifecycle, fan-out, and hook activation contract. |
+| Public hook env and payload schema | unchanged. |
+| Post-thread-creation failures | unchanged. A native failure *after* `thread/start` returned still refuses without offering any second lane — including `--interactive-only` — because starting another Codex process could submit the same prompt twice. |
+
+## Verifying this yourself
+
+```sh
+go test ./internal/app/ -run 'TestInteractiveOnlyIsTheOnlyPlainCodexLaneAndBothSpellingsAreEquivalent|TestDefaultNativeCodexFanOutRefusesWithZeroMutationsAndInteractiveOnlyKeepsCardinality|TestEmptyPromptCodexCreateIsByteForByteUnchangedByTheNativeRequiredGate|TestClaudeAndAntigravityLifecycleAndHookContractAreUnchangedByTheNativeGate|TestUnavailableNative|TestCodexNativeLaunchOutcomeTableIsClosed'
+go test ./internal/integrations/agents/codexappserver/ -run TestStartDefaultThread
+```
+
+| Claim in this note | Test |
+| --- | --- |
+| Prompted create refuses instead of silently creating a plain Agent, for both the unavailable-endpoint and unsupported-roots rows | `TestUnavailableNativeCreateRefusesInsteadOfSilentlyCreatingAPlainAgent` |
+| Roots are delivered exactly on a negotiated connection, fail closed otherwise, and stay off the wire when empty | `TestStartDefaultThreadDeliversAdditionalRootsOrFailsClosed` |
+| Prompted fan-out refuses with zero mutations; `--interactive-only` keeps the old cardinality | `TestDefaultNativeCodexFanOutRefusesWithZeroMutationsAndInteractiveOnlyKeepsCardinality` |
+| Picker resume refuses instead of rebinding onto the rollout lane, and offers no launch-mode escape hatch | `TestUnavailableNativePickerResumeRefusesInsteadOfRebindingOntoTheRolloutLane` |
+| `agent resume` keeps its safe fallback to one provider resume | `TestUnavailableNativeResumeKeepsTheStoredConversationOnTheProviderResumeLane` |
+| Both `--interactive-only` spellings are equivalent, and non-Codex providers refuse it at zero transactions | `TestInteractiveOnlyIsTheOnlyPlainCodexLaneAndBothSpellingsAreEquivalent` |
+| Empty-prompt create is unchanged | `TestEmptyPromptCodexCreateIsByteForByteUnchangedByTheNativeRequiredGate` |
+| Claude and Antigravity are unchanged | `TestClaudeAndAntigravityLifecycleAndHookContractAreUnchangedByTheNativeGate` |
+| One payload sends exactly one `turn/start` and never repeats the prompt in Pane argv | `TestPromptedNativeCodexCreateIssuesOneTurnAndNeverRepeatsThePromptInPaneArgv` |
+| The post-mutation row still refuses a second lane | `TestIndeterminateNativeCreateRefusesASecondLaneAndWritesZero` |
+| The outcome table describes exactly these rows and no others | `TestCodexNativeLaunchOutcomeTableIsClosed` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -124,6 +124,13 @@ endpoint, close every sharing client, stop the process through the operator
 that owns it, then run `codex app-server daemon start`. Projmux never performs
 those stop/restart steps or invents an ownership-specific kill command.
 
+A prompted managed Codex create also requires that endpoint. When it is not
+ready or not attachable, `projmux create codex -- "<prompt>"` refuses instead of
+silently creating a plain-CLI Agent, and the refusal carries the same typed
+reason Doctor reports. `--interactive-only` creates that plain Agent on purpose,
+without native turn control. See
+[Codex Native-Required Create Migration](codex-native-required-migration.md).
+
 If native app-server features are needed, review the
 [official Codex CLI installation options](https://learn.chatgpt.com/docs/codex/cli)
 and install or repair the managed standalone payload. Then rerun Doctor. Do not

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -52,6 +52,21 @@ still requires an explicit `PROJMUX_INSTALLER=github-release`.
 
 ## Behavior Changes
 
+### Prompted Codex create requires native authority
+
+A prompted managed Codex create — provider `codex` with exactly one non-empty
+payload operand — no longer degrades to the plain CLI lane when native authority
+cannot be proven. It refuses at the provider-mutation boundary with zero
+threads, zero Panes, and zero Registry writes, and names `--interactive-only` as
+the explicit way to ask for a plain interactive Codex Agent instead.
+
+There is nothing to migrate: no Registry schema, configuration, hook contract,
+or stored Agent changes, and every existing resource keeps working after the
+upgrade. `projmux agent resume`, empty-prompt creates, and the Claude and
+Antigravity providers are unchanged. For the affected calls, the escape hatch,
+and how to verify each claim, see
+[Codex Native-Required Create Migration](codex-native-required-migration.md).
+
 ### Registry schema v2 final Window anchors
 
 The unreleased intermediate schema-v2 Window field `primaryPaneRef` has been


### PR DESCRIPTION
## Summary
- `0.14.0` is a real breaking release with no migration note. The squash commit `e1e0931f` carries no `BREAKING CHANGE:` footer, so the generated `⚠ BREAKING CHANGES` entry is one subject line that names neither the calls that now refuse nor the `--interactive-only` escape hatch. This adds `docs/codex-native-required-migration.md` to close that gap before the release PR merges.
- The note covers what needs no migration (Registry schema, configuration, hook contract, and existing Agents are all unchanged — upgrading is the whole migration), the exact create shape that is now native-required, the four calls that now refuse with their before/after and exit codes, what `--interactive-only` buys and gives up, what is explicitly unchanged, and a claim-to-test table.
- Linked from `docs/upgrading.md` (Behavior Changes), `docs/cli-guide.md` (Agent creation and hook ingress), and `docs/troubleshooting.md` (Codex app-server install topology).

## Accuracy

Every claim was re-derived from the code and tests at `e1e0931f` rather than from the release notes or tracking docs. Two findings worth flagging:

- **A fourth breaking call the tracking notes did not list.** `internal/app/create_intent.go` changed the split-UI resume picker: selecting an app-server-sourced Codex row used to rebind onto the rollout CLI lane on a failed native resume preparation, and now returns a typed refusal. It is documented as its own case and pinned by `TestUnavailableNativePickerResumeRefusesInsteadOfRebindingOntoTheRolloutLane`.
- **`projmux agent resume` is genuinely unchanged**, contrary to the `e1e0931f` commit body's first paragraph (`typed refusals on prompted create and stored resume`). `git diff 0c8635d9 e1e0931f -- internal/app/agent_resume.go` is zero lines; the resume change was reverted by `a15c496b` inside the same PR. The note states the unchanged behavior explicitly, and keeps the picker resume separate from the `agent resume` verb so the two are not conflated again.

Also verified as no-ops for the release range `v0.13.1..e1e0931f`: `internal/core/metadata` has an empty diff (Registry schema), and no `PROJMUX_*` hook env var is added, renamed, or removed.

## Scope

Docs only. No product code changes. `CHANGELOG.md` is untouched — release-please owns it — and release PR #808 is untouched.

## Test plan
- [x] `make fmt`
- [x] `make fix`
- [x] `make test`
- [x] `make docs` — regenerates `docs/cli.md` with no drift
- [x] `make test-integration`
- [x] `make test-e2e`
- [x] Targeted re-run of every test named in the note's claim table, all passing at this head

## Globalization
- [x] No user-facing string changes.
