### PR TITLE
ci(e2e): preserve failing attempt evidence and terminal attribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,10 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
+    # Observed steady-state is about four minutes. The default six-hour job
+    # ceiling turns one wedged container into a burned runner slot with no
+    # evidence, so bound it well above the real distribution instead.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -299,6 +303,32 @@ jobs:
 
       - name: Run e2e tests
         run: make test-e2e
+
+      # The attempt directory dies with the runner, which is why a failing e2e
+      # run leaves nothing to read but the log. Preserve the evidence subtree and
+      # skip binary/: it is 99.8% of the attempt size and is reproducible from the
+      # commit plus the binary_sha256 already recorded in build.json.
+      - name: Preserve failing attempt evidence
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-evidence-failure-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            .bin/e2e-evidence/attempt-*/**
+            !.bin/e2e-evidence/attempt-*/binary/**
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Preserve passing attempt evidence
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-evidence-success-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            .bin/e2e-evidence/attempt-*/**
+            !.bin/e2e-evidence/attempt-*/binary/**
+          if-no-files-found: warn
+          retention-days: 1
 
   test:
     name: Test

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -448,6 +448,18 @@
   exact tmux state plus sanitized hashed tails; denylist checks reject token,
   raw HOME/path, full Registry, and raw command leakage. Normal scenario meaning,
   one-build/four-shard topology, and `.bin/e2e-evidence` retention are unchanged.
+- `test/e2e/evidence-contract.sh` also pins failure-evidence preservation. A
+  failing attempt folds the emitted terminal record and the L06/L08/L16
+  diagnostic into the persisted `projmux.e2e-attempt/v1` artifact as the additive
+  optional `terminal_line`, `terminal_status`, `terminal_source`, and
+  `diagnostic` fields; a begin/pass record keeps its exact prior field set and
+  bytes. Degraded input no longer discards the whole attribution: a zero
+  `BASH_LINENO[0]`, an out-of-range wait status, and a non-allowlisted source
+  path each drop only their own field and mark the terminal record
+  `attribution=partial` while scenario, phase, owner, shard, and replay survive.
+  The `PROJMUX_E2E_INTENTIONAL_ZERO_LINE` fixture drives that path through the
+  real harness, and CI preserves the attempt evidence subtree — excluding
+  `binary/` — as a downloadable artifact on both failing and passing e2e runs.
 - `make test` / `make test-e2e`: L06 Registry lock recurrence applies the
   unchanged 400-attempt, 2ms/50ms delay, and 30s stale budget to one verified
   positive-PID owner lease. `TestRegistryLockRetryBudgetTracksVerifiedOwnerLease`

--- a/scripts/e2e-evidence.py
+++ b/scripts/e2e-evidence.py
@@ -40,15 +40,53 @@ FIELDS = {
     "artifact",
     "replay",
 }
+# Terminal attribution and diagnostics only exist for an attempt that actually
+# ended in a failure, so they are additive and optional. A begin/pass record
+# keeps the exact field set - and therefore the exact serialized bytes - it had
+# before this schema grew.
+OPTIONAL_FIELDS = {
+    "terminal_line",
+    "terminal_status",
+    "terminal_source",
+    "diagnostic",
+}
+SOURCE_RE = re.compile(r"^(?:(?:test/e2e|test/lib)/[a-z0-9][a-z0-9._/-]*\.sh)?$")
 FORBIDDEN_VALUE = re.compile(
     r"(?:-----BEGIN [A-Z ]*PRIVATE KEY-----|gh[pousr]_[A-Za-z0-9_]{20,}|"
     r"github_pat_[A-Za-z0-9_]{20,}|AKIA[0-9A-Z]{16}|(?i:password|token|secret)=)"
 )
 
 
+def validate_terminal_attribution(record: dict[str, object]) -> None:
+    if "terminal_status" in record:
+        terminal_status = record["terminal_status"]
+        if not isinstance(terminal_status, int) or isinstance(terminal_status, bool):
+            raise ValueError("terminal_status must be an integer")
+        if not 0 <= terminal_status <= 255:
+            raise ValueError("terminal_status must be a wait-status byte")
+    if "terminal_line" in record:
+        terminal_line = record["terminal_line"]
+        if not isinstance(terminal_line, int) or isinstance(terminal_line, bool):
+            raise ValueError("terminal_line must be an integer")
+        if terminal_line < 0:
+            raise ValueError("terminal_line must be non-negative")
+    if "terminal_source" in record:
+        terminal_source = record["terminal_source"]
+        if not isinstance(terminal_source, str) or not SOURCE_RE.fullmatch(terminal_source):
+            raise ValueError("terminal_source is not an allowlisted repository E2E shell path")
+        if ".." in terminal_source:
+            raise ValueError("terminal_source must not traverse")
+    if "diagnostic" in record and not isinstance(record["diagnostic"], dict):
+        raise ValueError("diagnostic must be an object")
+
+
 def validate(record: dict[str, object]) -> None:
-    if set(record) != FIELDS:
-        raise ValueError(f"field set mismatch: {sorted(set(record) ^ FIELDS)}")
+    present = set(record)
+    missing = FIELDS - present
+    extra = present - FIELDS - OPTIONAL_FIELDS
+    if missing or extra:
+        raise ValueError(f"field set mismatch: {sorted(missing | extra)}")
+    validate_terminal_attribution(record)
     if record["schema"] != "projmux.e2e-attempt/v1":
         raise ValueError("unsupported schema")
     if not isinstance(record["scenario_id"], str) or not SCENARIO_RE.fullmatch(record["scenario_id"]):
@@ -115,6 +153,37 @@ def write_artifact(directory: Path, record: dict[str, object]) -> None:
             os.unlink(temporary)
 
 
+def decode_object(text: str, label: str) -> dict[str, object]:
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{label} is not JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def terminal_attribution(text: str) -> dict[str, object]:
+    """Project the emitted terminal record onto the attempt evidence fields.
+
+    The terminal record written to stderr by ``e2e-first-failure.py`` is the one
+    authority for what was actually attributed, degraded fields included. Reading
+    it back here keeps the artifact and the log from disagreeing.
+    """
+    if not text:
+        return {}
+    terminal = decode_object(text, "terminal")
+    projected: dict[str, object] = {}
+    for source_field, target_field in (
+        ("line", "terminal_line"),
+        ("status", "terminal_status"),
+        ("source", "terminal_source"),
+    ):
+        if source_field in terminal:
+            projected[target_field] = terminal[source_field]
+    return projected
+
+
 def record_command(args: argparse.Namespace) -> int:
     record = {
         "schema": "projmux.e2e-attempt/v1",
@@ -132,6 +201,9 @@ def record_command(args: argparse.Namespace) -> int:
         "artifact": f"{args.scenario_id}-attempt-{args.attempt}.json",
         "replay": f"make test-e2e E2E_SCENARIO={args.scenario_id}",
     }
+    record.update(terminal_attribution(args.terminal_json))
+    if args.diagnostic:
+        record["diagnostic"] = decode_object(args.diagnostic, "diagnostic")
     validate(record)
     directory = Path(args.directory)
     write_artifact(directory, record)
@@ -265,6 +337,8 @@ def parser() -> argparse.ArgumentParser:
     record_parser.add_argument("--binary-sha256", default="")
     record_parser.add_argument("--route-socket", default="")
     record_parser.add_argument("--state-sha256", default="")
+    record_parser.add_argument("--terminal-json", default="")
+    record_parser.add_argument("--diagnostic", default="")
     record_parser.set_defaults(function=record_command)
     validate_parser = subparsers.add_parser("validate")
     validate_parser.add_argument("--terminal", action="store_true")

--- a/scripts/e2e-first-failure.py
+++ b/scripts/e2e-first-failure.py
@@ -71,28 +71,43 @@ def terminal_command(args: argparse.Namespace) -> int:
         raise ValueError("invalid phase or owner")
     if not SHARD_RE.fullmatch(args.shard):
         raise ValueError("invalid shard")
-    if not SOURCE_RE.fullmatch(args.source) or ".." in args.source:
-        raise ValueError("source is not an allowlisted repository E2E shell path")
-    if not 1 <= args.status <= 255 or args.line < 1:
-        raise ValueError("invalid terminal status or source line")
+    # Source line, wait status, and source path are the degradable half of the
+    # attribution. Bash reports BASH_LINENO[0] as 0 for a top-level failure, and a
+    # trap can fire from a path outside the shell allowlist. Raising there used to
+    # discard the scenario, phase, owner, and shard along with it, which is the
+    # whole record. Drop only the field that failed its own rule and say so.
+    attribution = "complete"
+    source = args.source
+    if not SOURCE_RE.fullmatch(source) or ".." in source:
+        source = ""
+        attribution = "partial"
+    status = args.status
+    if not 1 <= status <= 255:
+        status = 0
+        attribution = "partial"
+    line = args.line
+    if line < 1:
+        line = 0
+        attribution = "partial"
     expected_command = command_for(args.scenario)
     if args.command != expected_command:
         raise ValueError("command is not the sanitized single-scenario allowlist shape")
     if not SHA_RE.fullmatch(args.binary_sha256) or not SHA_RE.fullmatch(args.state_sha256):
         raise ValueError("invalid binary or state digest")
     emit("E2E_TERMINAL", {
+        "attribution": attribution,
         "binary_sha256": args.binary_sha256,
         "command": args.command,
-        "line": args.line,
+        "line": line,
         "owner": args.owner,
         "phase": args.phase,
         "replay": expected_command,
         "scenario": args.scenario,
         "schema": "projmux.e2e-terminal/v1",
         "shard": args.shard,
-        "source": args.source,
+        "source": source,
         "state_sha256": args.state_sha256,
-        "status": args.status,
+        "status": status,
     })
     return 0
 

--- a/test/e2e/evidence-contract.sh
+++ b/test/e2e/evidence-contract.sh
@@ -26,6 +26,21 @@ if [[ "${PROJMUX_E2E_INTENTIONAL_EXIT:-}" == "1" ]]; then
   exit 23
 fi
 
+# Bash reports BASH_LINENO[0] as 0 for a failure raised at the top level of a
+# sourced fixture. This branch forces that exact shape through the real harness
+# path so the degraded attribution stays observable end to end.
+if [[ "${PROJMUX_E2E_INTENTIONAL_ZERO_LINE:-}" == "1" ]]; then
+  source "$root/test/lib/smoke.sh"
+  smoke_setup_env
+  PROJMUX_E2E_SUITE="intentional-failure"
+  export PROJMUX_E2E_SUITE
+  smoke_contract_install_trap
+  trap smoke_cleanup_env EXIT
+  smoke_contract_begin L06 create-materialize resource-controller
+  smoke_contract_fail 42 0
+  exit 42
+fi
+
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
@@ -42,7 +57,7 @@ terminal_command=(python3 "$root/scripts/e2e-first-failure.py" terminal \
   --state-sha256 "$(printf 'b%.0s' {1..64})")
 "${terminal_command[@]}" >"$tmp/terminal-record.out" 2>"$tmp/terminal-record.err"
 [[ ! -s "$tmp/terminal-record.out" ]]
-terminal_golden='E2E_TERMINAL {"binary_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","command":"make test-e2e E2E_SCENARIO=L01","line":123,"owner":"harness","phase":"bootstrap","replay":"make test-e2e E2E_SCENARIO=L01","scenario":"L01","schema":"projmux.e2e-terminal/v1","shard":"fixture-1","source":"test/e2e/linux-smoke.sh","state_sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","status":17}'
+terminal_golden='E2E_TERMINAL {"attribution":"complete","binary_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","command":"make test-e2e E2E_SCENARIO=L01","line":123,"owner":"harness","phase":"bootstrap","replay":"make test-e2e E2E_SCENARIO=L01","scenario":"L01","schema":"projmux.e2e-terminal/v1","shard":"fixture-1","source":"test/e2e/linux-smoke.sh","state_sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","status":17}'
 if [[ "$(cat "$tmp/terminal-record.err")" != "$terminal_golden" ]]; then
   echo "stderr terminal JSON golden mismatch" >&2
   diff -u <(printf '%s\n' "$terminal_golden") "$tmp/terminal-record.err" >&2 || true
@@ -62,6 +77,46 @@ if grep -Fq "github_pat_FAKE_SECRET_SHAPED_ARG_1234567890" \
   exit 1
 fi
 
+# Degraded attribution must never cost the whole record. Each case drops exactly
+# the field that broke its own rule, keeps scenario/phase/owner/shard, and exits 0.
+assert_partial_terminal() {
+  local label="$1"
+  shift
+  if ! python3 "$root/scripts/e2e-first-failure.py" terminal \
+    --scenario L01 --phase bootstrap --owner harness --shard fixture-1 \
+    --command "make test-e2e E2E_SCENARIO=L01" "$@" \
+    >"$tmp/partial-$label.out" 2>"$tmp/partial-$label.err"; then
+    echo "terminal rejected degraded $label instead of recording partial attribution" >&2
+    cat "$tmp/partial-$label.err" >&2
+    exit 1
+  fi
+  [[ ! -s "$tmp/partial-$label.out" ]]
+  python3 - "$tmp/partial-$label.err" "$label" <<'PY'
+import json
+import pathlib
+import sys
+
+lines = pathlib.Path(sys.argv[1]).read_text().splitlines()
+records = [json.loads(line.split(" ", 1)[1]) for line in lines if line.startswith("E2E_TERMINAL ")]
+assert len(records) == 1, f"{sys.argv[2]}: want exactly one terminal record"
+record = records[0]
+assert record["attribution"] == "partial", f"{sys.argv[2]}: {record['attribution']}"
+assert record["scenario"] == "L01" and record["phase"] == "bootstrap"
+assert record["owner"] == "harness" and record["shard"] == "fixture-1"
+assert record["replay"] == "make test-e2e E2E_SCENARIO=L01"
+degraded = {"line": record["line"], "status": record["status"], "source": record["source"]}
+assert sum(1 for value in degraded.values() if value in (0, "")) >= 1, degraded
+PY
+}
+
+assert_partial_terminal line --status 17 --source test/e2e/linux-smoke.sh --line 0
+assert_partial_terminal status --status 0 --source test/e2e/linux-smoke.sh --line 123
+assert_partial_terminal source --status 17 --source ../etc/passwd.sh --line 123
+if grep -Fq "passwd" "$tmp/partial-source.err"; then
+  echo "degraded terminal echoed a non-allowlisted source path" >&2
+  exit 1
+fi
+
 golden='{"artifact":"L01-attempt-1.json","attempt":1,"binary_sha256":"","class":"unattributed","elapsed_ms":0,"outcome":"begin","owner":"harness","phase":"bootstrap","replay":"make test-e2e E2E_SCENARIO=L01","route_socket":"","scenario_id":"L01","schema":"projmux.e2e-attempt/v1","state_sha256":"","suite":"linux-bootstrap"}'
 if [[ "$(head -n 1 "$tmp/golden/summary.jsonl")" != "$golden" ]]; then
   echo "evidence JSONL golden mismatch" >&2
@@ -69,6 +124,37 @@ if [[ "$(head -n 1 "$tmp/golden/summary.jsonl")" != "$golden" ]]; then
   exit 1
 fi
 grep -Fq "id=L01 attempt=1 phase=bootstrap outcome=fail class=environment owner=harness artifact=L01-attempt-1.json replay='make test-e2e E2E_SCENARIO=L01'" "$tmp/fail.out"
+
+# The attempt record carries terminal attribution and diagnostics only when the
+# attempt actually produced them, so a begin/pass record keeps its exact bytes.
+attributed_record=(python3 "$root/scripts/e2e-evidence.py" record --directory "$tmp/attributed" --scenario-id L06 --suite linux-bootstrap --attempt 1 --phase create-materialize --owner resource-controller)
+"${attributed_record[@]}" --class environment --outcome begin --elapsed-ms 0 >/dev/null
+"${attributed_record[@]}" --class product-authority-race --outcome fail --elapsed-ms 5 \
+  --terminal-json "$(sed 's/^E2E_TERMINAL //' "$tmp/terminal-record.err")" \
+  --diagnostic '{"attribution":"l06-lock-exhaustion","racers":[{"index":1,"outcome":"exhausted","pid":7,"status":1}]}' \
+  >"$tmp/attributed.out"
+python3 "$root/scripts/e2e-evidence.py" validate --terminal "$tmp/attributed/summary.jsonl"
+python3 - "$tmp/attributed/summary.jsonl" <<'PY'
+import json
+import pathlib
+import sys
+
+begin, fail = (json.loads(line) for line in pathlib.Path(sys.argv[1]).read_text().splitlines())
+assert not {"terminal_line", "terminal_status", "terminal_source", "diagnostic"} & set(begin), begin
+assert fail["terminal_line"] == 123 and fail["terminal_status"] == 17
+assert fail["terminal_source"] == "test/e2e/linux-smoke.sh"
+assert fail["diagnostic"]["racers"][0]["outcome"] == "exhausted"
+PY
+
+for bad in '{"line":-1}' '{"status":256}' '{"source":"../escape.sh"}' 'not-json'; do
+  if python3 "$root/scripts/e2e-evidence.py" record --directory "$tmp/rejected" \
+    --scenario-id L06 --suite linux-bootstrap --attempt 1 --phase create-materialize \
+    --owner resource-controller --class environment --outcome fail --elapsed-ms 1 \
+    --terminal-json "$bad" >"$tmp/rejected.out" 2>"$tmp/rejected.err"; then
+    echo "attempt schema accepted out-of-contract terminal attribution: $bad" >&2
+    exit 1
+  fi
+done
 
 cp "$tmp/golden/summary.jsonl" "$tmp/private.jsonl"
 sed -i 's/"phase":"bootstrap"/"phase":"token=github_pat_abcdefghijklmnopqrstuvwxyz"/' "$tmp/private.jsonl"
@@ -139,7 +225,8 @@ if [[ "$intentional_exit_status" != "23" ]]; then
   echo "intentional explicit exit returned $intentional_exit_status, want 23" >&2
   exit 1
 fi
-python3 - "$tmp/intentional-exit.err" <<'PY'
+python3 "$root/scripts/e2e-evidence.py" validate --terminal "$tmp/intentional-exit/summary.jsonl"
+python3 - "$tmp/intentional-exit.err" "$tmp/intentional-exit/L06-attempt-1.json" <<'PY'
 import json
 import pathlib
 import sys
@@ -151,6 +238,49 @@ record = records[0]
 assert record["scenario"] == "L06" and record["status"] == 23
 assert record["source"] == "test/e2e/evidence-contract.sh" and record["line"] > 1
 assert record["command"] == record["replay"] == "make test-e2e E2E_SCENARIO=L06"
+assert record["attribution"] == "complete"
+
+diagnostics = [json.loads(line.split(" ", 1)[1]) for line in lines if line.startswith("E2E_DIAGNOSTIC ")]
+assert len(diagnostics) == 1 and diagnostics[0]["attribution"] == "l06-lock-exhaustion"
+
+# The artifact must carry the same attribution and diagnostics the log reported.
+# That equality is the whole point: the log dies with the runner, the file does not.
+artifact = json.loads(pathlib.Path(sys.argv[2]).read_text())
+assert artifact["outcome"] == "fail"
+assert artifact["terminal_status"] == record["status"] == 23
+assert artifact["terminal_line"] == record["line"]
+assert artifact["terminal_source"] == record["source"]
+assert artifact["diagnostic"] == diagnostics[0]
+assert [racer["index"] for racer in artifact["diagnostic"]["racers"]] == list(range(1, 9))
 PY
 
-echo ">> evidence parser/terminal/golden/privacy/pass-only aggregation/intentional-failure tests passed"
+set +e
+PROJMUX_E2E_INTENTIONAL_ZERO_LINE=1 \
+  PROJMUX_E2E_ARTIFACTS="$tmp/zero-line" \
+  "$root/test/e2e/evidence-contract.sh" >"$tmp/zero-line.out" 2>"$tmp/zero-line.err"
+zero_line_status=$?
+set -e
+if [[ "$zero_line_status" != "42" ]]; then
+  echo "zero-line fixture returned $zero_line_status, want 42" >&2
+  cat "$tmp/zero-line.err" >&2
+  exit 1
+fi
+python3 "$root/scripts/e2e-evidence.py" validate --terminal "$tmp/zero-line/summary.jsonl"
+python3 - "$tmp/zero-line.err" "$tmp/zero-line/L06-attempt-1.json" <<'PY'
+import json
+import pathlib
+import sys
+
+lines = pathlib.Path(sys.argv[1]).read_text().splitlines()
+assert not any("invalid terminal status or source line" in line for line in lines), lines
+records = [json.loads(line.split(" ", 1)[1]) for line in lines if line.startswith("E2E_TERMINAL ")]
+assert len(records) == 1 and records[0]["attribution"] == "partial"
+assert records[0]["line"] == 0 and records[0]["scenario"] == "L06"
+
+artifact = json.loads(pathlib.Path(sys.argv[2]).read_text())
+assert artifact["outcome"] == "fail" and artifact["terminal_line"] == 0
+assert artifact["terminal_status"] == 42
+assert artifact["diagnostic"]["attribution"] == "l06-lock-exhaustion"
+PY
+
+echo ">> evidence parser/terminal/golden/privacy/pass-only aggregation/intentional-failure/partial-attribution/preserved-diagnostic tests passed"

--- a/test/lib/smoke.sh
+++ b/test/lib/smoke.sh
@@ -9,6 +9,8 @@ SMOKE_CONTRACT_SOURCE=""
 SMOKE_CONTRACT_TERMINAL_STATE_PATH=""
 SMOKE_CONTRACT_STARTED_MS=0
 SMOKE_CONTRACT_TERMINAL=0
+SMOKE_CONTRACT_TERMINAL_JSON=""
+SMOKE_CONTRACT_DIAGNOSTIC_JSON=""
 
 SMOKE_L06_HOLDER_PID=0
 SMOKE_L06_HOLDER_STARTED_MS=0
@@ -64,7 +66,9 @@ smoke_contract_record() {
     --elapsed-ms "$elapsed" \
     --binary-sha256 "${PROJMUX_SMOKE_BIN_SHA256:-${PROJMUX_SMOKE_EXPECTED_BIN_SHA256:-}}" \
     --route-socket "$route_socket" \
-    --state-sha256 "$state_hash"
+    --state-sha256 "$state_hash" \
+    --terminal-json "$SMOKE_CONTRACT_TERMINAL_JSON" \
+    --diagnostic "$SMOKE_CONTRACT_DIAGNOSTIC_JSON"
 }
 
 smoke_contract_shard() {
@@ -184,6 +188,35 @@ smoke_contract_failure_diagnostic() {
   esac
 }
 
+# Tee one first-failure emitter: its record still reaches the job log on stderr,
+# and the JSON body is returned so the same bytes can be folded into the attempt
+# artifact. A runner disappears at the end of the job; the artifact does not.
+smoke_contract_capture() {
+  local prefix="$1"
+  shift
+  local emitted line
+  emitted="$("$@" 2>&1 >/dev/null)" || true
+  [[ -n "$emitted" ]] || return 0
+  printf '%s\n' "$emitted" >&2
+  while IFS= read -r line; do
+    if [[ "$line" == "$prefix "* ]]; then
+      printf '%s' "${line#"$prefix" }"
+      return 0
+    fi
+  done <<<"$emitted"
+}
+
+# One terminal path for every failure branch: attribute, diagnose, then record.
+# The record runs last so the artifact carries what the log just reported.
+smoke_contract_fail() {
+  local status="$1"
+  local line="$2"
+  SMOKE_CONTRACT_TERMINAL_JSON="$(smoke_contract_capture E2E_TERMINAL smoke_contract_terminal "$status" "$line")"
+  SMOKE_CONTRACT_DIAGNOSTIC_JSON="$(smoke_contract_capture E2E_DIAGNOSTIC smoke_contract_failure_diagnostic)"
+  smoke_contract_record fail "${PROJMUX_E2E_FAILURE_CLASS:-deterministic-regression}" >&2
+  SMOKE_CONTRACT_TERMINAL=1
+}
+
 # Bash does not run ERR for the explicit `exit 1` branches used by assertion
 # blocks. Keep exit semantics intact while giving those branches the same exact
 # call-site source line as command failures. This function is not exported, so
@@ -193,10 +226,7 @@ exit() {
   local line="${BASH_LINENO[0]:-0}"
   if [[ "$status" != "0" && -n "$SMOKE_CONTRACT_ID" && "$SMOKE_CONTRACT_TERMINAL" != "1" ]]; then
     set +e
-    smoke_contract_record fail "${PROJMUX_E2E_FAILURE_CLASS:-deterministic-regression}" >&2
-    smoke_contract_terminal "$status" "$line" || true
-    smoke_contract_failure_diagnostic || true
-    SMOKE_CONTRACT_TERMINAL=1
+    smoke_contract_fail "$status" "$line"
   fi
   builtin exit "$status"
 }
@@ -216,6 +246,8 @@ smoke_contract_begin() {
   SMOKE_CONTRACT_TERMINAL_STATE_PATH=""
   SMOKE_CONTRACT_STARTED_MS="$(smoke_now_ms)"
   SMOKE_CONTRACT_TERMINAL=0
+  SMOKE_CONTRACT_TERMINAL_JSON=""
+  SMOKE_CONTRACT_DIAGNOSTIC_JSON=""
   smoke_contract_record begin environment
 }
 
@@ -238,10 +270,7 @@ smoke_contract_err() {
   # caller's back: doing so turns the expected status capture itself into a
   # false deterministic regression.
   if [[ "$had_errexit" == "1" && -n "$SMOKE_CONTRACT_ID" && "$SMOKE_CONTRACT_TERMINAL" != "1" ]]; then
-    smoke_contract_record fail "${PROJMUX_E2E_FAILURE_CLASS:-deterministic-regression}" >&2
-    smoke_contract_terminal "$status" "$line" || true
-    smoke_contract_failure_diagnostic || true
-    SMOKE_CONTRACT_TERMINAL=1
+    smoke_contract_fail "$status" "$line"
   elif [[ "$had_errexit" == "1" ]]; then
     echo "E2E_CONTRACT unattributed=1 status=$status line=$line" >&2
   fi


### PR DESCRIPTION
## 무엇을

실패한 e2e attempt 의 상태·실패 라인·진단이 CI artifact 하나로 남게 한다.

## 왜

- attempt 디렉터리는 잡이 끝나면 러너와 함께 사라진다. `ci.yml` 의 e2e 잡에 `upload-artifact` 스텝이 없어 실패 run 에서 읽을 수 있는 것은 로그뿐이었다.
- `scripts/e2e-first-failure.py` 가 `args.line < 1` 을 예외로 처리해, bash 가 top-level 실패에서 `BASH_LINENO[0]` 을 0 으로 보고하면 scenario·phase·owner·shard 까지 함께 버렸다. 실패 로그 5건 이상에서 `invalid terminal status or source line` 으로 관측됐다.
- `E2E_TERMINAL`·`E2E_DIAGNOSTIC` 은 stderr 로만 나가고 evidence JSON 에는 담을 필드가 없었다.

## 무엇을 바꿨나

| 파일 | 변경 |
| --- | --- |
| `scripts/e2e-evidence.py` | `terminal_line`·`terminal_status`·`terminal_source`·`diagnostic` 를 **선택 필드**로 추가. `--terminal-json` 은 emit 된 terminal 레코드를 그대로 투영해 로그와 artifact 가 어긋나지 않게 한다. begin/pass 레코드는 필드 집합도 직렬화 바이트도 이전과 동일하다. |
| `scripts/e2e-first-failure.py` | line·status·source 를 예외 대신 부분 강등으로 처리한다. 규칙을 깬 필드만 비우고 `attribution=partial` 을 남기며 scenario/phase/owner/shard/replay 는 보존한다. 허용되지 않은 source 경로는 기록하지 않고 버린다. |
| `test/lib/smoke.sh` | 실패 경로를 `smoke_contract_fail` 하나로 모았다. terminal → diagnostic → record 순으로 실행해 artifact 가 방금 로그에 찍힌 내용을 그대로 담는다. emit 은 여전히 stderr 로 나간다(tee). |
| `.github/workflows/ci.yml` | e2e 잡에 `timeout-minutes: 30` 과 upload 스텝 2개. 실패 run 은 14일, 성공 run 은 1일 보존. 업로드 범위는 attempt 디렉터리에서 `binary/` 제외 — 실측상 attempt 24MB 중 `binary/projmux` 가 23.3MB(99.8%)이고 커밋 + `build.json` 의 `binary_sha256` 으로 재생성 가능하다. |
| `test/e2e/evidence-contract.sh` | 새 필드·부분 귀속 회귀 guard. `PROJMUX_E2E_INTENTIONAL_ZERO_LINE` fixture 가 line=0 경로를 실제 하니스로 통과시킨다. |

## 검증

- `make test-e2e-contract` — green
- `make fmt` / `make fix` / `make test` — green
- `make test-integration` / `make test-e2e` — CI 와 병렬 실행

## 범위 밖 (의도적)

`class` 값의 출처 변경, e2e 잡 matrix 분할, 폴링/대기 헬퍼, Registry 락 구현. 제품 코드는 바꾸지 않았다.
