### PR TITLE
test(e2e): derive the failure class from observed attempts

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -460,6 +460,30 @@
   The `PROJMUX_E2E_INTENTIONAL_ZERO_LINE` fixture drives that path through the
   real harness, and CI preserves the attempt evidence subtree — excluding
   `binary/` — as a downloadable artifact on both failing and passing e2e runs.
+- `test/e2e/evidence-contract.sh` also pins observed failure classification. The
+  `class` field is derived, not declared: the recorder compares the attempts
+  already recorded for the same `binary_sha256` under `--evidence-root` and only
+  falls back to a caller's `--class` when they say nothing. A build seen both
+  failing and passing is nondeterministic and splits by whether the source of
+  that nondeterminism is ours — `flake` for a scenario we own, and
+  `unowned-nondeterminism` for one like `C01` that observes the real Codex model
+  — so a later quarantine policy never sets a deadline nobody here can meet. A
+  failure reproduced on the same build is `deterministic-regression`; a failure
+  nobody has retried is `unrepeated-failure` and no longer borrows the
+  reproduction claim. Where a derivation happened the record carries the
+  additive optional `class_basis` and `prior_outcomes`; where it did not, the
+  record keeps its exact prior field set and bytes. `e2e-evidence.py classify`
+  exposes the predicate as a truth table, and `e2e-evidence.py flake-rate <dir>`
+  reports per-scenario flake rate over downloaded attempt evidence plus an
+  `E2E_FLAKE_FLIP` line for every stored class the other attempts contradict.
+  L06 diagnostics are derived the same way: `attribution` names what the racers
+  were observed to do instead of always claiming lock exhaustion, `acquire` is
+  no longer unconditionally `contended`, and `lock_age_ms` is paired with
+  `lock_observed` so an unread lock file cannot report a scenario timer as lock
+  age. That renamed payload travels as `projmux.e2e-diagnostic/v2` while the
+  unchanged L08/L16 payloads stay `v1`, and evidence retained from before the
+  rename still validates and still aggregates. `PROJMUX_E2E_ATTEMPT` now defaults to `GITHUB_RUN_ATTEMPT`, so a rerun's
+  evidence is no longer written as attempt 1.
 - `make test` / `make test-e2e`: L06 Registry lock recurrence applies the
   unchanged 400-attempt, 2ms/50ms delay, and 30s stale budget to one verified
   positive-PID owner lease. `TestRegistryLockRetryBudgetTracksVerifiedOwnerLease`

--- a/scripts/e2e-evidence.py
+++ b/scripts/e2e-evidence.py
@@ -21,7 +21,24 @@ CLASS_NAMES = {
     "harness-lifecycle",
     "observation-frame",
     "environment",
+    "flake",
+    "unowned-nondeterminism",
+    "unrepeated-failure",
     "unattributed",
+}
+# The classification axis is not "does a retry pass" but "do we own the source of
+# the nondeterminism". L06/L08 flip because of the Registry lock we ship, so a
+# retry that passes names a defect we can remove and an owner who can be held to
+# a deadline. C01 drives the real Codex app-server and observes the model's own
+# judgement; a retry that flips there is an observation we do not own and cannot
+# schedule away. Folding both into one `flake` value would hand a quarantine
+# policy rows whose expiry nobody can meet.
+UNOWNED_NONDETERMINISM_OWNERS = {"codex-appserver-adapter"}
+CLASS_BASES = {
+    "observed-nondeterminism",
+    "reproduced-failure",
+    "declared",
+    "single-observation",
 }
 OUTCOMES = {"begin", "pass", "fail", "cancel"}
 FIELDS = {
@@ -49,12 +66,116 @@ OPTIONAL_FIELDS = {
     "terminal_status",
     "terminal_source",
     "diagnostic",
+    "class_basis",
+    "prior_outcomes",
 }
 SOURCE_RE = re.compile(r"^(?:(?:test/e2e|test/lib)/[a-z0-9][a-z0-9._/-]*\.sh)?$")
 FORBIDDEN_VALUE = re.compile(
     r"(?:-----BEGIN [A-Z ]*PRIVATE KEY-----|gh[pousr]_[A-Za-z0-9_]{20,}|"
     r"github_pat_[A-Za-z0-9_]{20,}|AKIA[0-9A-Z]{16}|(?i:password|token|secret)=)"
 )
+
+
+TERMINAL_OUTCOMES = {"pass", "fail", "cancel"}
+
+
+def attempt_key(path: Path, root: Path) -> str:
+    """Name the retry an evidence file belongs to.
+
+    ``test-e2e-docker.sh`` gives every attempt its own
+    ``attempt-<run>-<run-attempt>-<pid>`` directory, so the directory name is the
+    one durable statement of which retry produced a record - the ``attempt``
+    field inside the record is whatever the harness was told, and a rerun that
+    never learns ``GITHUB_RUN_ATTEMPT`` reports ``1`` forever. When the root is
+    itself a single attempt directory there is nothing above it to compare
+    against and every record shares the empty key.
+    """
+    try:
+        parts = path.relative_to(root).parts
+    except ValueError:
+        return ""
+    for part in parts:
+        if part.startswith("attempt-"):
+            return part
+    return ""
+
+
+def read_summary(path: Path) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return records
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(record, dict):
+            records.append(record)
+    return records
+
+
+def prior_terminal_outcomes(
+    root: Path,
+    current: str,
+    scenario_id: str,
+    binary_sha256: str,
+) -> list[str]:
+    """Terminal outcomes other attempts recorded for this exact binary.
+
+    An empty ``binary_sha256`` is not evidence about a commit, so it never
+    matches: comparing two runs is only meaningful when the same product build
+    produced both.
+    """
+    if not binary_sha256:
+        return []
+    outcomes: set[str] = set()
+    for path in sorted(root.rglob("summary.jsonl")):
+        if attempt_key(path, root) == current:
+            continue
+        for record in read_summary(path):
+            if record.get("scenario_id") != scenario_id:
+                continue
+            if record.get("binary_sha256") != binary_sha256:
+                continue
+            outcome = record.get("outcome")
+            if outcome in TERMINAL_OUTCOMES:
+                outcomes.add(str(outcome))
+    return sorted(outcomes)
+
+
+def classify(
+    outcome: str,
+    declared_class: str,
+    owner: str,
+    prior_outcomes: list[str],
+) -> tuple[str, str]:
+    """Derive the failure class from what the attempts were observed to do.
+
+    A constant is not a predicate. ``deterministic-regression`` is only earned by
+    a failure that was actually seen again on the same build; a single failure
+    says nothing yet about reproduction and must not borrow that claim. When the
+    same build was observed both failing and passing, the split is by whether we
+    own the source of the nondeterminism, never by the retry outcome alone.
+    """
+    prior = set(prior_outcomes)
+    if outcome not in {"fail", "pass"}:
+        return declared_class or "unattributed", "declared"
+    flipped = ("pass" in prior) if outcome == "fail" else ("fail" in prior)
+    if flipped:
+        if owner in UNOWNED_NONDETERMINISM_OWNERS:
+            return "unowned-nondeterminism", "observed-nondeterminism"
+        return "flake", "observed-nondeterminism"
+    if outcome == "fail" and "fail" in prior:
+        return "deterministic-regression", "reproduced-failure"
+    if declared_class:
+        return declared_class, "declared"
+    if outcome == "fail":
+        return "unrepeated-failure", "single-observation"
+    return "environment", "single-observation"
 
 
 def validate_terminal_attribution(record: dict[str, object]) -> None:
@@ -78,6 +199,18 @@ def validate_terminal_attribution(record: dict[str, object]) -> None:
             raise ValueError("terminal_source must not traverse")
     if "diagnostic" in record and not isinstance(record["diagnostic"], dict):
         raise ValueError("diagnostic must be an object")
+    if "class_basis" in record and record["class_basis"] not in CLASS_BASES:
+        raise ValueError("invalid class_basis")
+    if "prior_outcomes" in record:
+        prior_outcomes = record["prior_outcomes"]
+        if not isinstance(prior_outcomes, list) or not prior_outcomes:
+            raise ValueError("prior_outcomes must be a non-empty array")
+        if any(item not in TERMINAL_OUTCOMES for item in prior_outcomes):
+            raise ValueError("prior_outcomes must be terminal outcomes")
+        if list(prior_outcomes) != sorted(set(prior_outcomes)):
+            raise ValueError("prior_outcomes must be sorted and unique")
+        if "class_basis" not in record:
+            raise ValueError("prior_outcomes requires class_basis")
 
 
 def validate(record: dict[str, object]) -> None:
@@ -185,6 +318,19 @@ def terminal_attribution(text: str) -> dict[str, object]:
 
 
 def record_command(args: argparse.Namespace) -> int:
+    directory = Path(args.directory)
+    prior_outcomes: list[str] = []
+    if args.evidence_root and args.outcome in {"fail", "pass"}:
+        root = Path(args.evidence_root)
+        prior_outcomes = prior_terminal_outcomes(
+            root,
+            attempt_key(directory / "summary.jsonl", root),
+            args.scenario_id,
+            args.binary_sha256,
+        )
+    typed_class, class_basis = classify(
+        args.outcome, args.declared_class, args.owner, prior_outcomes
+    )
     record = {
         "schema": "projmux.e2e-attempt/v1",
         "scenario_id": args.scenario_id,
@@ -192,7 +338,7 @@ def record_command(args: argparse.Namespace) -> int:
         "attempt": args.attempt,
         "phase": args.phase,
         "owner": args.owner,
-        "class": args.typed_class,
+        "class": typed_class,
         "outcome": args.outcome,
         "elapsed_ms": args.elapsed_ms,
         "binary_sha256": args.binary_sha256,
@@ -201,11 +347,16 @@ def record_command(args: argparse.Namespace) -> int:
         "artifact": f"{args.scenario_id}-attempt-{args.attempt}.json",
         "replay": f"make test-e2e E2E_SCENARIO={args.scenario_id}",
     }
+    # The derivation trail is only additive where a derivation actually happened.
+    # An attempt with nothing to compare against keeps the exact field set - and
+    # therefore the exact serialized bytes - it had before this schema grew.
+    if prior_outcomes:
+        record["class_basis"] = class_basis
+        record["prior_outcomes"] = prior_outcomes
     record.update(terminal_attribution(args.terminal_json))
     if args.diagnostic:
         record["diagnostic"] = decode_object(args.diagnostic, "diagnostic")
     validate(record)
-    directory = Path(args.directory)
     write_artifact(directory, record)
     atomic_append(directory / "summary.jsonl", json.dumps(record, sort_keys=True, separators=(",", ":")))
     print(
@@ -300,6 +451,88 @@ def result_hash_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def classify_command(args: argparse.Namespace) -> int:
+    """Expose the classification predicate so its truth table is testable alone."""
+    typed_class, basis = classify(
+        args.outcome, args.declared_class, args.owner, sorted(set(args.prior))
+    )
+    print(f"class={typed_class} basis={basis}")
+    return 0
+
+
+def flake_rate_command(args: argparse.Namespace) -> int:
+    """Report per-scenario flake rate across every attempt under a root.
+
+    Record-time classification only sees the attempts a runner can reach. A CI
+    rerun starts on a fresh machine, so the durable cross-attempt view is this
+    pass over downloaded evidence, and it is also where a class recorded by one
+    attempt is confronted with what the other attempts went on to show.
+    """
+    root = Path(args.directory)
+    observed: dict[tuple[str, str], dict[str, dict[str, str]]] = {}
+    owners: dict[tuple[str, str], str] = {}
+    for path in sorted(root.rglob("summary.jsonl")):
+        key_attempt = attempt_key(path, root)
+        for record in read_summary(path):
+            outcome = record.get("outcome")
+            if outcome not in TERMINAL_OUTCOMES:
+                continue
+            scenario = str(record.get("scenario_id", ""))
+            binary = str(record.get("binary_sha256", ""))
+            if not scenario:
+                continue
+            key = (scenario, binary)
+            attempt = key_attempt or f"attempt-{record.get('attempt', 1)}"
+            observed.setdefault(key, {})[attempt] = {
+                "outcome": str(outcome),
+                "class": str(record.get("class", "")),
+            }
+            owners[key] = str(record.get("owner", ""))
+
+    flips = 0
+    nondeterministic = 0
+    for key in sorted(observed):
+        scenario, binary = key
+        attempts = observed[key]
+        outcomes = {entry["outcome"] for entry in attempts.values()}
+        failed = sum(1 for entry in attempts.values() if entry["outcome"] == "fail")
+        passed = sum(1 for entry in attempts.values() if entry["outcome"] == "pass")
+        if "fail" in outcomes and "pass" in outcomes:
+            verdict = (
+                "unowned-nondeterminism"
+                if owners.get(key) in UNOWNED_NONDETERMINISM_OWNERS
+                else "flake"
+            )
+            nondeterministic += 1
+        elif failed:
+            verdict = "deterministic-regression" if failed > 1 else "unrepeated-failure"
+        else:
+            verdict = "stable"
+        total = len(attempts)
+        rate = failed / total if total else 0.0
+        print(
+            f"E2E_FLAKE scenario={scenario} binary={binary[:8] or 'unknown'} "
+            f"attempts={total} pass={passed} fail={failed} "
+            f"flake_rate={rate:.3f} verdict={verdict}"
+        )
+        # A record whose stored class disagrees with what every attempt together
+        # shows is the operator signal this report exists for: the earlier
+        # attempt is not silently overwritten, it is named.
+        for attempt in sorted(attempts):
+            recorded = attempts[attempt]["class"]
+            if verdict in {"flake", "unowned-nondeterminism"} and recorded != verdict:
+                flips += 1
+                print(
+                    f"E2E_FLAKE_FLIP scenario={scenario} binary={binary[:8] or 'unknown'} "
+                    f"attempt={attempt} recorded={recorded} verdict={verdict}"
+                )
+    print(
+        f">> E2E flake report scenarios={len(observed)} "
+        f"nondeterministic={nondeterministic} flips={flips}"
+    )
+    return 0
+
+
 def route_command(args: argparse.Namespace) -> int:
     scenario = args.scenario_id
     if scenario == "C01":
@@ -331,7 +564,11 @@ def parser() -> argparse.ArgumentParser:
     record_parser.add_argument("--attempt", required=True, type=int)
     record_parser.add_argument("--phase", required=True)
     record_parser.add_argument("--owner", required=True)
-    record_parser.add_argument("--class", dest="typed_class", required=True, choices=sorted(CLASS_NAMES))
+    # The class a caller supplies is a declaration, not a verdict. It is used
+    # only where the attempts themselves say nothing, and never outranks an
+    # observed fail/pass split on the same build.
+    record_parser.add_argument("--class", dest="declared_class", default="", choices=sorted(CLASS_NAMES) + [""])
+    record_parser.add_argument("--evidence-root", default="")
     record_parser.add_argument("--outcome", required=True, choices=sorted(OUTCOMES))
     record_parser.add_argument("--elapsed-ms", required=True, type=int)
     record_parser.add_argument("--binary-sha256", default="")
@@ -348,6 +585,15 @@ def parser() -> argparse.ArgumentParser:
     hash_parser.add_argument("--expected", default="")
     hash_parser.add_argument("directory")
     hash_parser.set_defaults(function=result_hash_command)
+    classify_parser = subparsers.add_parser("classify")
+    classify_parser.add_argument("--outcome", required=True, choices=sorted(OUTCOMES))
+    classify_parser.add_argument("--class", dest="declared_class", default="", choices=sorted(CLASS_NAMES) + [""])
+    classify_parser.add_argument("--owner", default="")
+    classify_parser.add_argument("--prior", action="append", default=[], choices=sorted(TERMINAL_OUTCOMES))
+    classify_parser.set_defaults(function=classify_command)
+    flake_parser = subparsers.add_parser("flake-rate")
+    flake_parser.add_argument("directory")
+    flake_parser.set_defaults(function=flake_rate_command)
     route_parser = subparsers.add_parser("route")
     route_parser.add_argument("--manifest", required=True)
     route_parser.add_argument("scenario_id")

--- a/scripts/e2e-first-failure.py
+++ b/scripts/e2e-first-failure.py
@@ -125,6 +125,44 @@ def parse_racer(value: str) -> dict[str, Any]:
     return {"index": index, "outcome": outcome, "pid": pid, "status": status}
 
 
+def l06_acquire_state(racers: list[dict[str, Any]]) -> str:
+    """State what the racers were seen to do, never what the preamble assumed.
+
+    ``acquire`` used to be assigned ``contended`` before a single racer had run,
+    so it said ``contended`` for every L06 failure whether or not anything ever
+    competed for the lock. Every value below is a statement about an observed
+    racer exit: exhaustion is a racer that reported it could not take the lock,
+    ``acquired`` is every racer completing, and anything else is ``unknown``
+    because a racer that failed for another reason never told us whether its
+    acquisition succeeded.
+    """
+    outcomes = [racer["outcome"] for racer in racers]
+    if any(outcome == "exhausted" for outcome in outcomes):
+        return "contended"
+    if all(outcome == "not-started" for outcome in outcomes):
+        return "not-started"
+    if all(racer["outcome"] == "completed" and racer["status"] == 0 for racer in racers):
+        return "acquired"
+    return "unknown"
+
+
+def l06_attribution(racers: list[dict[str, Any]]) -> str:
+    """Name what was observed, not a cause the observation does not support.
+
+    ``l06-lock-exhaustion`` was a constant: every L06 failure called itself lock
+    exhaustion. The first real capture contradicted it - all eight racers
+    completed with status 0 and no racer reported exhaustion - so the label was
+    asserting a mechanism nothing had seen.
+    """
+    if any(racer["outcome"] == "exhausted" for racer in racers):
+        return "l06-lock-exhaustion"
+    if all(racer["outcome"] == "not-started" for racer in racers):
+        return "l06-no-racers-observed"
+    if any(racer["outcome"] != "completed" or racer["status"] != 0 for racer in racers):
+        return "l06-racer-failure"
+    return "l06-no-racer-failure"
+
+
 def l06_command(args: argparse.Namespace) -> int:
     if not SAFE_OPERATION_RE.fullmatch(args.operation):
         raise ValueError("invalid L06 operation")
@@ -133,29 +171,43 @@ def l06_command(args: argparse.Namespace) -> int:
     racers = sorted((parse_racer(value) for value in args.racer), key=lambda item: item["index"])
     if [item["index"] for item in racers] != list(range(1, 9)):
         raise ValueError("L06 diagnostics require exactly racers 1 through 8")
-    if args.acquire not in {"not-started", "acquired", "contended", "unknown"}:
-        raise ValueError("invalid L06 acquire state")
     if args.release not in {"not-started", "held", "released", "unknown"}:
         raise ValueError("invalid L06 release state")
     now_ms = int(time.time() * 1000)
     holder_started_ms = args.holder_started_ms
-    # GNU date implementations differ on whether a width on %N is honored.
-    # Normalize the nanosecond-shaped value used by the portable smoke helper.
+    # Defensive: a caller that computed this stamp with a `date +%s%3N` whose
+    # width the host ignored hands over a nanosecond-shaped value. The smoke
+    # helper no longer produces one, but a stale caller must not be read as a
+    # lock created millions of seconds ago.
     if holder_started_ms > now_ms * 100:
         holder_started_ms //= 1_000_000
-    age_ms = max(0, now_ms - holder_started_ms) if holder_started_ms else 0
+    # The caller supplies a timestamp only when it actually read the lock file's
+    # mtime. The old field was named for lock age but was fed the scenario start
+    # time, so it reported elapsed scenario time and invited comparison against
+    # the 30s stale boundary. An unobserved lock now says so instead.
+    lock_observed = holder_started_ms > 0
     emit("E2E_DIAGNOSTIC", {
-        "attribution": "l06-lock-exhaustion",
+        "attribution": l06_attribution(racers),
         "holder": {
-            "acquire": args.acquire,
-            "age_ms": age_ms,
+            "acquire": l06_acquire_state(racers),
+            "lock_age_ms": max(0, now_ms - holder_started_ms) if lock_observed else 0,
+            "lock_observed": lock_observed,
             "operation": args.operation,
             "pid": args.holder_pid,
             "release": args.release,
         },
         "racers": racers,
         "scenario": "L06",
-        "schema": "projmux.e2e-diagnostic/v1",
+        # v2, while L08/L16 stay v1. One version string across three
+        # structurally different payloads already identifies the scenario's
+        # field set rather than a shared one, and the L06 payload is the only
+        # one that changed: `age_ms` became `lock_age_ms` + `lock_observed`, and
+        # `attribution` gained values it could never previously report. Failing
+        # e2e artifacts are retained 14 days, so v1 and v2 L06 diagnostics
+        # coexist in downloaded evidence for that window; the version is what
+        # tells a reader which field set to expect instead of leaving them to
+        # probe for a key.
+        "schema": "projmux.e2e-diagnostic/v2",
     })
     return 0
 
@@ -328,7 +380,6 @@ def parser() -> argparse.ArgumentParser:
     l06.add_argument("--holder-pid", required=True, type=int)
     l06.add_argument("--holder-started-ms", required=True, type=int)
     l06.add_argument("--operation", required=True)
-    l06.add_argument("--acquire", required=True)
     l06.add_argument("--release", required=True)
     l06.add_argument("--racer", action="append", default=[])
     l06.set_defaults(function=l06_command)

--- a/scripts/test-docker-run.sh
+++ b/scripts/test-docker-run.sh
@@ -145,7 +145,7 @@ docker run --rm \
   -e GOMAXPROCS="$suite_gomaxprocs" \
   -e GOFLAGS="$suite_goflags" \
   -e PROJMUX_E2E_ARTIFACTS=/evidence \
-  -e PROJMUX_E2E_ATTEMPT="${PROJMUX_E2E_ATTEMPT:-1}" \
+  -e PROJMUX_E2E_ATTEMPT="${PROJMUX_E2E_ATTEMPT:-${GITHUB_RUN_ATTEMPT:-1}}" \
   -e PROJMUX_E2E_LINUX_SHARD="${PROJMUX_E2E_LINUX_SHARD:-}" \
   -e E2E_SCENARIO="${E2E_SCENARIO:-}" \
   -v "$root:/workspace:ro" \

--- a/test/e2e/evidence-contract.sh
+++ b/test/e2e/evidence-contract.sh
@@ -213,7 +213,9 @@ if [[ "$intentional_status" != "1" ]]; then
   exit 1
 fi
 python3 "$root/scripts/e2e-evidence.py" validate --terminal "$tmp/intentional/summary.jsonl"
-grep -Fq 'id=L17 attempt=1 phase=exit-reconcile outcome=fail class=deterministic-regression owner=exit-reconciler' "$tmp/intentional.err"
+# A single observed failure no longer borrows the reproduction claim: nothing has
+# been retried, so the class says exactly that.
+grep -Fq 'id=L17 attempt=1 phase=exit-reconcile outcome=fail class=unrepeated-failure owner=exit-reconciler' "$tmp/intentional.err"
 
 set +e
 PROJMUX_E2E_INTENTIONAL_EXIT=1 \
@@ -241,7 +243,10 @@ assert record["command"] == record["replay"] == "make test-e2e E2E_SCENARIO=L06"
 assert record["attribution"] == "complete"
 
 diagnostics = [json.loads(line.split(" ", 1)[1]) for line in lines if line.startswith("E2E_DIAGNOSTIC ")]
-assert len(diagnostics) == 1 and diagnostics[0]["attribution"] == "l06-lock-exhaustion"
+# No racer ran in this fixture, so the diagnostic must not name lock exhaustion.
+assert len(diagnostics) == 1 and diagnostics[0]["attribution"] == "l06-no-racers-observed"
+assert diagnostics[0]["holder"]["acquire"] == "not-started"
+assert diagnostics[0]["holder"]["lock_observed"] is False
 
 # The artifact must carry the same attribution and diagnostics the log reported.
 # That equality is the whole point: the log dies with the runner, the file does not.
@@ -280,7 +285,251 @@ assert records[0]["line"] == 0 and records[0]["scenario"] == "L06"
 artifact = json.loads(pathlib.Path(sys.argv[2]).read_text())
 assert artifact["outcome"] == "fail" and artifact["terminal_line"] == 0
 assert artifact["terminal_status"] == 42
-assert artifact["diagnostic"]["attribution"] == "l06-lock-exhaustion"
+assert artifact["diagnostic"]["attribution"] == "l06-no-racers-observed"
 PY
 
-echo ">> evidence parser/terminal/golden/privacy/pass-only aggregation/intentional-failure/partial-attribution/preserved-diagnostic tests passed"
+# --- observed failure classification -----------------------------------------
+#
+# The classification axis is "do we own the source of the nondeterminism", not
+# "does a retry pass". Every row below is a statement about attempts that were
+# actually observed; none of them may be produced by a constant.
+
+assert_classify() {
+  local want="$1"
+  shift
+  local got
+  got="$(python3 "$root/scripts/e2e-evidence.py" classify "$@")"
+  if [[ "$got" != "$want" ]]; then
+    echo "classify $* -> [$got], want [$want]" >&2
+    exit 1
+  fi
+}
+
+# A failure nobody has retried claims neither reproduction nor flakiness.
+assert_classify "class=unrepeated-failure basis=single-observation" --outcome fail
+# The same build seen both failing and passing is nondeterministic, whichever
+# side of the split the record being written happens to be on.
+assert_classify "class=flake basis=observed-nondeterminism" --outcome fail --prior pass
+assert_classify "class=flake basis=observed-nondeterminism" --outcome pass --prior fail
+assert_classify "class=flake basis=observed-nondeterminism" --outcome fail --prior fail --prior pass
+# Reproduction is earned by being seen again, never assumed.
+assert_classify "class=deterministic-regression basis=reproduced-failure" --outcome fail --prior fail
+# A scenario whose nondeterminism originates outside this repository is kept out
+# of `flake` so a quarantine policy never sets a deadline nobody here can meet.
+assert_classify "class=unowned-nondeterminism basis=observed-nondeterminism" \
+  --outcome fail --owner codex-appserver-adapter --prior pass
+assert_classify "class=unowned-nondeterminism basis=observed-nondeterminism" \
+  --outcome pass --owner codex-appserver-adapter --prior fail
+# A declaration fills the gap only while the attempts are silent. An observed
+# split outranks it.
+assert_classify "class=product-authority-race basis=declared" \
+  --outcome fail --class product-authority-race
+assert_classify "class=flake basis=observed-nondeterminism" \
+  --outcome fail --class product-authority-race --prior pass
+assert_classify "class=environment basis=single-observation" --outcome pass
+assert_classify "class=environment basis=declared" --outcome begin --class environment
+
+# Cross-attempt derivation through the real recorder. Each attempt writes into
+# its own `attempt-*` directory exactly as scripts/test-e2e-docker.sh lays them
+# out, so the recorder learns the earlier result the same way CI evidence does.
+binary="$(printf 'c%.0s' {1..64})"
+attempt_record() {
+  local root_dir="$1"
+  local attempt="$2"
+  local scenario="$3"
+  local owner="$4"
+  local outcome="$5"
+  shift 5
+  python3 "$root/scripts/e2e-evidence.py" record \
+    --directory "$root_dir/attempt-local-$attempt-1/linux-fixture-2" \
+    --evidence-root "$root_dir" \
+    --scenario-id "$scenario" --suite linux-bootstrap --attempt "$attempt" \
+    --phase create-materialize --owner "$owner" --outcome "$outcome" \
+    --elapsed-ms 1 --binary-sha256 "$binary" "$@"
+}
+
+record_class() {
+  python3 - "$1" <<'RECORD_CLASS_PY'
+import json
+import pathlib
+import sys
+
+record = json.loads(pathlib.Path(sys.argv[1]).read_text())
+print(f"{record['class']} {record.get('class_basis', '-')} {','.join(record.get('prior_outcomes', ['-']))}")
+RECORD_CLASS_PY
+}
+
+# 1. attempt-1 fails, attempt-2 passes on the same binary -> owned flake.
+flake_root="$tmp/retry-flake"
+attempt_record "$flake_root" 1 L06 resource-controller begin >/dev/null
+attempt_record "$flake_root" 1 L06 resource-controller fail >/dev/null
+attempt_record "$flake_root" 2 L06 resource-controller begin >/dev/null
+attempt_record "$flake_root" 2 L06 resource-controller pass >"$tmp/retry-flake.out"
+if [[ "$(record_class "$flake_root/attempt-local-2-1/linux-fixture-2/L06-attempt-2.json")" != "flake observed-nondeterminism fail" ]]; then
+  echo "retried-and-passed attempt was not recorded as an owned flake" >&2
+  cat "$flake_root/attempt-local-2-1/linux-fixture-2/L06-attempt-2.json" >&2
+  exit 1
+fi
+grep -Fq "class=flake" "$tmp/retry-flake.out"
+# The first attempt keeps the bytes it was written with. Reclassification is a
+# report, never a rewrite of evidence somebody already downloaded.
+if [[ "$(record_class "$flake_root/attempt-local-1-1/linux-fixture-2/L06-attempt-1.json")" != "unrepeated-failure - -" ]]; then
+  echo "recording a later attempt rewrote the earlier attempt evidence" >&2
+  exit 1
+fi
+
+# 2. the same failure seen twice on the same binary stays a regression.
+regression_root="$tmp/retry-regression"
+attempt_record "$regression_root" 1 L06 resource-controller begin >/dev/null
+attempt_record "$regression_root" 1 L06 resource-controller fail >/dev/null
+attempt_record "$regression_root" 2 L06 resource-controller begin >/dev/null
+attempt_record "$regression_root" 2 L06 resource-controller fail >"$tmp/retry-regression.out"
+if [[ "$(record_class "$regression_root/attempt-local-2-1/linux-fixture-2/L06-attempt-2.json")" != "deterministic-regression reproduced-failure fail" ]]; then
+  echo "a failure reproduced on the same binary was not a deterministic regression" >&2
+  exit 1
+fi
+grep -Fq "class=deterministic-regression" "$tmp/retry-regression.out"
+
+# 3. a scenario whose nondeterminism we do not own is kept separate from flake.
+unowned_root="$tmp/retry-unowned"
+attempt_record "$unowned_root" 1 C01 codex-appserver-adapter begin >/dev/null
+attempt_record "$unowned_root" 1 C01 codex-appserver-adapter fail >/dev/null
+attempt_record "$unowned_root" 2 C01 codex-appserver-adapter begin >/dev/null
+attempt_record "$unowned_root" 2 C01 codex-appserver-adapter pass >"$tmp/retry-unowned.out"
+if [[ "$(record_class "$unowned_root/attempt-local-2-1/linux-fixture-2/C01-attempt-2.json")" != "unowned-nondeterminism observed-nondeterminism fail" ]]; then
+  echo "unowned nondeterminism was folded into the owned flake value" >&2
+  exit 1
+fi
+grep -Fq "class=unowned-nondeterminism" "$tmp/retry-unowned.out"
+
+# A different build is not evidence about this one.
+other_root="$tmp/retry-other-binary"
+python3 "$root/scripts/e2e-evidence.py" record \
+  --directory "$other_root/attempt-local-1-1/linux-fixture-2" --evidence-root "$other_root" \
+  --scenario-id L06 --suite linux-bootstrap --attempt 1 --phase create-materialize \
+  --owner resource-controller --outcome fail --elapsed-ms 1 \
+  --binary-sha256 "$(printf 'd%.0s' {1..64})" >/dev/null
+attempt_record "$other_root" 2 L06 resource-controller begin >/dev/null
+attempt_record "$other_root" 2 L06 resource-controller fail >/dev/null
+if [[ "$(record_class "$other_root/attempt-local-2-1/linux-fixture-2/L06-attempt-2.json")" != "unrepeated-failure - -" ]]; then
+  echo "a different product binary was treated as evidence about this one" >&2
+  exit 1
+fi
+
+# The report is the operator surface for a class that later attempts contradict.
+python3 "$root/scripts/e2e-evidence.py" flake-rate "$flake_root" >"$tmp/flake-report.out"
+grep -Fq "E2E_FLAKE scenario=L06 binary=cccccccc attempts=2 pass=1 fail=1 flake_rate=0.500 verdict=flake" "$tmp/flake-report.out"
+grep -Fq "E2E_FLAKE_FLIP scenario=L06 binary=cccccccc attempt=attempt-local-1-1 recorded=unrepeated-failure verdict=flake" "$tmp/flake-report.out"
+grep -Fq ">> E2E flake report scenarios=1 nondeterministic=1 flips=1" "$tmp/flake-report.out"
+python3 "$root/scripts/e2e-evidence.py" flake-rate "$unowned_root" >"$tmp/flake-unowned.out"
+grep -Fq "verdict=unowned-nondeterminism" "$tmp/flake-unowned.out"
+python3 "$root/scripts/e2e-evidence.py" flake-rate "$regression_root" >"$tmp/flake-regression.out"
+grep -Fq "verdict=deterministic-regression" "$tmp/flake-regression.out"
+if grep -Fq "E2E_FLAKE_FLIP" "$tmp/flake-regression.out"; then
+  echo "the report invented a classification flip for a reproduced failure" >&2
+  exit 1
+fi
+
+# Derivation is additive only where it happened: an attempt with nothing to
+# compare against keeps the exact byte sequence it had before this schema grew.
+lone_root="$tmp/retry-lone"
+attempt_record "$lone_root" 1 L06 resource-controller begin --class environment >/dev/null
+python3 - "$lone_root/attempt-local-1-1/linux-fixture-2/summary.jsonl" <<'LONE_PY'
+import json
+import pathlib
+import sys
+
+record = json.loads(pathlib.Path(sys.argv[1]).read_text().splitlines()[0])
+assert not {"class_basis", "prior_outcomes"} & set(record), record
+assert record["class"] == "environment", record
+LONE_PY
+
+# Out-of-contract derivation trails are rejected the same way every other field is.
+assert_rejects_evidence() {
+  local label="$1"
+  local mutation="$2"
+  cp "$flake_root/attempt-local-2-1/linux-fixture-2/summary.jsonl" "$tmp/derived-$label.jsonl"
+  sed -i "$mutation" "$tmp/derived-$label.jsonl"
+  if python3 "$root/scripts/e2e-evidence.py" validate "$tmp/derived-$label.jsonl" \
+    >"$tmp/derived-$label.out" 2>"$tmp/derived-$label.err"; then
+    echo "evidence validator accepted $label" >&2
+    exit 1
+  fi
+}
+assert_rejects_evidence unknown-basis 's/"class_basis":"observed-nondeterminism"/"class_basis":"guessed"/'
+assert_rejects_evidence unsorted-prior 's/"prior_outcomes":\["fail"\]/"prior_outcomes":["pass","fail"]/'
+assert_rejects_evidence empty-prior 's/"prior_outcomes":\["fail"\]/"prior_outcomes":[]/'
+assert_rejects_evidence orphan-prior 's/"class_basis":"observed-nondeterminism",//'
+
+# Failing e2e artifacts are retained 14 days, so evidence written before the L06
+# diagnostic payload was renamed stays downloadable and mixes with new evidence
+# in the same report root. Aggregation reads attempt records, never the
+# scenario-specific diagnostic payload, so a retained v1 diagnostic must neither
+# fail validation nor drop its attempt out of the flake report.
+legacy_root="$tmp/retained-v1"
+legacy_diagnostic='{"attribution":"l06-lock-exhaustion","holder":{"acquire":"contended","age_ms":37500,"operation":"concurrent-create-pane","pid":0,"release":"held"},"racers":[{"index":1,"outcome":"completed","pid":7,"status":0}],"scenario":"L06","schema":"projmux.e2e-diagnostic/v1"}'
+attempt_record "$legacy_root" 1 L06 resource-controller begin >/dev/null
+attempt_record "$legacy_root" 1 L06 resource-controller fail --diagnostic "$legacy_diagnostic" >/dev/null
+attempt_record "$legacy_root" 2 L06 resource-controller begin >/dev/null
+attempt_record "$legacy_root" 2 L06 resource-controller pass >/dev/null
+python3 "$root/scripts/e2e-evidence.py" validate --terminal "$legacy_root/attempt-local-1-1/linux-fixture-2/summary.jsonl"
+python3 "$root/scripts/e2e-evidence.py" flake-rate "$legacy_root" >"$tmp/flake-legacy.out"
+grep -Fq "E2E_FLAKE scenario=L06 binary=cccccccc attempts=2 pass=1 fail=1 flake_rate=0.500 verdict=flake" "$tmp/flake-legacy.out"
+grep -Fq "E2E_FLAKE_FLIP scenario=L06 binary=cccccccc attempt=attempt-local-1-1 recorded=unrepeated-failure verdict=flake" "$tmp/flake-legacy.out"
+
+# --- derived L06 diagnostic labels -------------------------------------------
+#
+# Every field below used to assert something no observation supported.
+
+l06_diagnostic() {
+  local -a racers=()
+  local index
+  for index in {1..8}; do
+    racers+=(--racer "$index:$2:$3:$4")
+  done
+  python3 "$root/scripts/e2e-first-failure.py" l06 \
+    --holder-pid 0 --holder-started-ms "$1" --operation concurrent-create-pane \
+    --release held "${racers[@]}" 2>&1 >/dev/null | sed 's/^E2E_DIAGNOSTIC //'
+}
+
+l06_diagnostic 0 900 0 completed >"$tmp/l06-completed.json"
+l06_diagnostic 0 900 1 exhausted >"$tmp/l06-exhausted.json"
+l06_diagnostic 0 900 1 other >"$tmp/l06-other.json"
+l06_diagnostic "$(( $(date +%s) * 1000 - 1250 ))" 900 0 completed >"$tmp/l06-observed.json"
+python3 - "$tmp" <<'L06_PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+def diagnostic(name):
+    return json.loads((root / f"l06-{name}.json").read_text())
+
+# The exact shape of the first real capture: eight racers completed with status
+# 0 and no lock file was ever read. The old constants called this lock
+# exhaustion, called it contended, and gave it a lock age measured from the
+# scenario start.
+completed = diagnostic("completed")
+assert completed["schema"] == "projmux.e2e-diagnostic/v2", completed["schema"]
+assert completed["attribution"] == "l06-no-racer-failure", completed["attribution"]
+assert completed["holder"]["acquire"] == "acquired", completed["holder"]
+assert completed["holder"]["lock_observed"] is False
+assert completed["holder"]["lock_age_ms"] == 0
+
+exhausted = diagnostic("exhausted")
+assert exhausted["attribution"] == "l06-lock-exhaustion", exhausted["attribution"]
+assert exhausted["holder"]["acquire"] == "contended", exhausted["holder"]
+
+other = diagnostic("other")
+assert other["attribution"] == "l06-racer-failure", other["attribution"]
+assert other["holder"]["acquire"] == "unknown", other["holder"]
+
+# A lock file that was actually stat-ed is the only thing that makes the age
+# field mean lock age.
+observed = diagnostic("observed")
+assert observed["holder"]["lock_observed"] is True
+assert observed["holder"]["lock_age_ms"] >= 1250
+assert "age_ms" not in observed["holder"], observed["holder"]
+L06_PY
+
+echo ">> evidence parser/terminal/golden/privacy/pass-only aggregation/intentional-failure/partial-attribution/preserved-diagnostic/observed-classification/derived-diagnostic tests passed"

--- a/test/e2e/linux-smoke.sh
+++ b/test/e2e/linux-smoke.sh
@@ -1554,9 +1554,12 @@ phase0_stress_pane_uid_before="$(ctx show-options -pqv -t "$legacy_pane" @projmu
 phase0_stress_project_uid_before="$(ctx show-options -qv -t legacy-alpha @projmux_project_uid)"
 phase0_stress_pids=()
 SMOKE_L06_HOLDER_PID=0
-SMOKE_L06_HOLDER_STARTED_MS="$(( $(date +%s) * 1000 ))"
+# Zero means "no lock file was read". The racer-failure branch below is the only
+# place that has a lock file to stat, so seeding this with the scenario start
+# time made the reported lock age an elapsed-scenario timer wearing a lock's
+# name. Acquire state is derived from the racer outcomes, never preset here.
+SMOKE_L06_HOLDER_STARTED_MS=0
 SMOKE_L06_OPERATION=concurrent-create-pane
-SMOKE_L06_ACQUIRE_STATE=contended
 SMOKE_L06_RELEASE_STATE=held
 SMOKE_L06_RACER_PIDS=(0 0 0 0 0 0 0 0)
 SMOKE_L06_RACER_STATUSES=(0 0 0 0 0 0 0 0)
@@ -3107,8 +3110,9 @@ fi
 # of concurrent workers contending for the one registry lock produces.
 cp "$binding_registry" "$binding_root/registry.before-burst"
 binding_burst_pids=()
-SMOKE_L06_HOLDER_STARTED_MS="$(( $(date +%s) * 1000 ))"
-SMOKE_L06_ACQUIRE_STATE=contended
+# Zero until a lock file is actually stat-ed below; acquire state is derived
+# from the racer outcomes rather than asserted before any racer has run.
+SMOKE_L06_HOLDER_STARTED_MS=0
 SMOKE_L06_RELEASE_STATE=held
 SMOKE_L06_RACER_PIDS=(0 0 0 0 0 0 0 0)
 SMOKE_L06_RACER_STATUSES=(0 0 0 0 0 0 0 0)
@@ -3134,7 +3138,6 @@ for binding_burst_index in 1 2 3 4 5 6 7 8; do
         SMOKE_L06_HOLDER_PID="$binding_lock_pid"
       fi
       SMOKE_L06_HOLDER_STARTED_MS="$(( $(stat -c %Y "$binding_registry.lock") * 1000 ))"
-      SMOKE_L06_ACQUIRE_STATE=contended
       SMOKE_L06_RELEASE_STATE=held
     fi
   fi
@@ -3146,7 +3149,6 @@ for binding_burst_index in 1 2 3 4 5 6 7 8; do
     SMOKE_L06_RACER_OUTCOMES[binding_burst_index - 1]=converged
     if [[ "$SMOKE_L06_HOLDER_PID" == "0" ]]; then
       SMOKE_L06_HOLDER_PID="$binding_burst_pid"
-      SMOKE_L06_ACQUIRE_STATE=acquired
     fi
   else
     SMOKE_L06_RACER_OUTCOMES[binding_burst_index - 1]=other
@@ -3159,7 +3161,7 @@ fi
 # test/lib/smoke.sh. Keep an explicit no-op read so standalone ShellCheck sees
 # the cross-file diagnostic-state contract.
 : "$SMOKE_L06_HOLDER_PID" "$SMOKE_L06_HOLDER_STARTED_MS" "$SMOKE_L06_OPERATION" \
-  "$SMOKE_L06_ACQUIRE_STATE" "$SMOKE_L06_RELEASE_STATE" \
+  "$SMOKE_L06_RELEASE_STATE" \
   "${SMOKE_L06_RACER_PIDS[*]}" "${SMOKE_L06_RACER_STATUSES[*]}" "${SMOKE_L06_RACER_OUTCOMES[*]}"
 if [[ "$binding_burst_failed" != "0" ]]; then
   echo "a hook burst producer exited non-zero" >&2

--- a/test/e2e/reliability-contract.sh
+++ b/test/e2e/reliability-contract.sh
@@ -90,7 +90,6 @@ mkdir -p "$diagnostic_root/controller" "$diagnostic_root/tmux"
 SMOKE_L06_HOLDER_PID=4242
 SMOKE_L06_HOLDER_STARTED_MS="$(( $(date +%s) * 1000 - 1250 ))"
 SMOKE_L06_OPERATION=concurrent-create-pane
-SMOKE_L06_ACQUIRE_STATE=acquired
 SMOKE_L06_RELEASE_STATE=held
 for racer in 1 2 3 4 5 6 7 8; do
   SMOKE_L06_RACER_PIDS[racer - 1]="$((5000 + racer))"
@@ -104,7 +103,7 @@ done
 # The sourced formatter consumes this state indirectly. This explicit no-op
 # read keeps that cross-file contract visible to standalone ShellCheck.
 : "$SMOKE_L06_HOLDER_PID" "$SMOKE_L06_HOLDER_STARTED_MS" "$SMOKE_L06_OPERATION" \
-  "$SMOKE_L06_ACQUIRE_STATE" "$SMOKE_L06_RELEASE_STATE" \
+  "$SMOKE_L06_RELEASE_STATE" \
   "${SMOKE_L06_RACER_PIDS[*]}" "${SMOKE_L06_RACER_STATUSES[*]}" "${SMOKE_L06_RACER_OUTCOMES[*]}"
 smoke_l06_failure_diagnostic >"$diagnostic_root/l06.out" 2>"$diagnostic_root/l06.err"
 [[ ! -s "$diagnostic_root/l06.out" ]]
@@ -161,19 +160,28 @@ def record(name):
 
 l06 = record("l06")
 assert l06["scenario"] == "L06" and l06["attribution"] == "l06-lock-exhaustion"
-assert l06["holder"]["pid"] == 4242 and l06["holder"]["age_ms"] >= 1250
+# The renamed holder field set travels under its own version; L08/L16 are
+# unchanged and stay v1.
+assert l06["schema"] == "projmux.e2e-diagnostic/v2", l06["schema"]
+assert l06["holder"]["pid"] == 4242 and l06["holder"]["lock_age_ms"] >= 1250
+assert l06["holder"]["lock_observed"] is True
 assert l06["holder"]["operation"] == "concurrent-create-pane"
-assert l06["holder"]["acquire"] == "acquired" and l06["holder"]["release"] == "held"
+# The racer that reported exhaustion is what makes this contended. The old
+# fixture declared "acquired" here and the emitter repeated the declaration back
+# even though racer 8 had just said it could not take the lock.
+assert l06["holder"]["acquire"] == "contended" and l06["holder"]["release"] == "held"
 assert len(l06["racers"]) == 8 and l06["racers"][0]["outcome"] == "completed"
 assert l06["racers"][-1]["outcome"] == "exhausted"
 
 l08 = record("l08")
+assert l08["schema"] == "projmux.e2e-diagnostic/v1", l08["schema"]
 assert l08["scenario"] == "L08" and l08["attribution"] == "l08-state-drift"
 assert l08["registry_before_sha256"] != l08["registry_after_sha256"]
 assert l08["changed_json_paths"] == ["$.projects[0].name"]
 assert l08["pending"] == {"controller_entries": 1, "hook_processes": 2, "owned_processes": 3, "socket_entries": 4}
 
 l16 = record("l16")
+assert l16["schema"] == "projmux.e2e-diagnostic/v1", l16["schema"]
 assert l16["scenario"] == "L16" and l16["attribution"] == "l16-semantic-timeout"
 assert l16["child"] == {"alive": False, "pid": 0, "state": ""}
 assert all(l16["files"][name]["exists"] for name in ("rc", "out", "err"))

--- a/test/lib/smoke.sh
+++ b/test/lib/smoke.sh
@@ -15,7 +15,6 @@ SMOKE_CONTRACT_DIAGNOSTIC_JSON=""
 SMOKE_L06_HOLDER_PID=0
 SMOKE_L06_HOLDER_STARTED_MS=0
 SMOKE_L06_OPERATION="controller-trigger-burst"
-SMOKE_L06_ACQUIRE_STATE="not-started"
 SMOKE_L06_RELEASE_STATE="not-started"
 declare -a SMOKE_L06_RACER_PIDS=(0 0 0 0 0 0 0 0)
 declare -a SMOKE_L06_RACER_STATUSES=(0 0 0 0 0 0 0 0)
@@ -34,8 +33,22 @@ SMOKE_L16_ERR_PATH=""
 SMOKE_L16_TAIL_PATH=""
 SMOKE_L16_TMUX_FUNCTION=""
 
+# `date +%s%3N` is not a millisecond clock everywhere. uutils coreutils ignores
+# the %3N field width and prints nanoseconds with leading zeros stripped, so the
+# concatenation loses digits roughly one call in ten and the resulting stamp can
+# be *smaller* than the one before it. Every elapsed_ms in the evidence was that
+# subtraction, which meant a negative elapsed_ms rejected the whole record and
+# left the attempt with no terminal outcome. Read seconds and nanoseconds as two
+# fields of one clock read instead, and pad defensively before truncating.
 smoke_now_ms() {
-  date +%s%3N
+  local stamp seconds nanoseconds
+  stamp="$(date +%s.%N)"
+  seconds="${stamp%%.*}"
+  nanoseconds="${stamp#*.}"
+  while ((${#nanoseconds} < 9)); do
+    nanoseconds="0$nanoseconds"
+  done
+  printf '%s\n' "$((10#$seconds * 1000 + 10#${nanoseconds:0:3}))"
 }
 
 smoke_contract_state_hash() {
@@ -45,9 +58,12 @@ smoke_contract_state_hash() {
   fi
 }
 
+# The second argument is what this call site *declares*, never a verdict. The
+# recorder consults the other attempts recorded for the same product binary and
+# only falls back to the declaration when they say nothing.
 smoke_contract_record() {
   local outcome="$1"
-  local typed_class="$2"
+  local declared_class="$2"
   local now elapsed route_socket state_hash
   [[ -n "$SMOKE_CONTRACT_ID" ]] || return 0
   now="$(smoke_now_ms)"
@@ -56,12 +72,13 @@ smoke_contract_record() {
   state_hash="$(smoke_contract_state_hash)"
   python3 "$smoke_root/scripts/e2e-evidence.py" record \
     --directory "$PROJMUX_E2E_ARTIFACTS" \
+    --evidence-root "${PROJMUX_E2E_EVIDENCE_ROOT:-$PROJMUX_E2E_ARTIFACTS}" \
     --scenario-id "$SMOKE_CONTRACT_ID" \
     --suite "$PROJMUX_E2E_SUITE" \
-    --attempt "${PROJMUX_E2E_ATTEMPT:-1}" \
+    --attempt "${PROJMUX_E2E_ATTEMPT:-${GITHUB_RUN_ATTEMPT:-1}}" \
     --phase "$SMOKE_CONTRACT_PHASE" \
     --owner "$SMOKE_CONTRACT_OWNER" \
-    --class "$typed_class" \
+    --class "$declared_class" \
     --outcome "$outcome" \
     --elapsed-ms "$elapsed" \
     --binary-sha256 "${PROJMUX_SMOKE_BIN_SHA256:-${PROJMUX_SMOKE_EXPECTED_BIN_SHA256:-}}" \
@@ -113,7 +130,6 @@ smoke_l06_failure_diagnostic() {
     --holder-pid "$SMOKE_L06_HOLDER_PID"
     --holder-started-ms "$SMOKE_L06_HOLDER_STARTED_MS"
     --operation "$SMOKE_L06_OPERATION"
-    --acquire "$SMOKE_L06_ACQUIRE_STATE"
     --release "$SMOKE_L06_RELEASE_STATE"
   )
   for index in {0..7}; do
@@ -213,7 +229,7 @@ smoke_contract_fail() {
   local line="$2"
   SMOKE_CONTRACT_TERMINAL_JSON="$(smoke_contract_capture E2E_TERMINAL smoke_contract_terminal "$status" "$line")"
   SMOKE_CONTRACT_DIAGNOSTIC_JSON="$(smoke_contract_capture E2E_DIAGNOSTIC smoke_contract_failure_diagnostic)"
-  smoke_contract_record fail "${PROJMUX_E2E_FAILURE_CLASS:-deterministic-regression}" >&2
+  smoke_contract_record fail "${PROJMUX_E2E_FAILURE_CLASS:-}" >&2
   SMOKE_CONTRACT_TERMINAL=1
 }
 
@@ -476,7 +492,7 @@ smoke_cleanup_env() {
   local cleanup_status=0
   if [[ -n "$SMOKE_CONTRACT_ID" && "$SMOKE_CONTRACT_TERMINAL" != "1" ]]; then
     set +e
-    smoke_contract_record fail "${PROJMUX_E2E_FAILURE_CLASS:-deterministic-regression}" >&2
+    smoke_contract_record fail "${PROJMUX_E2E_FAILURE_CLASS:-}" >&2
     SMOKE_CONTRACT_TERMINAL=1
     set -e
   fi


### PR DESCRIPTION
`class` was a constant, so it was not a predicate. Every failure the harness recorded called itself `deterministic-regression` whether or not anything had ever been retried — and CI run `33234202379` disproved that with downloadable evidence: three attempts on the same `head_sha a8dc9ba7` and the same `binary_sha256 539b5179` went fail, fail, pass, with the first two stored as `deterministic-regression`.

This derives the class from what the attempts were actually observed to do.

## Classification

The axis is **not** "does a retry pass" — it is "do we own the source of the nondeterminism". L06/L08 flip because of the Registry lock we ship, so a retry that passes names a defect we can remove and an owner who can be held to a deadline. `C01` drives the real Codex app-server and observes the model's own judgement; a retry that flips there is an observation we cannot schedule away. Folding both into one `flake` value would hand a later quarantine policy rows whose expiry nobody can meet.

| observed | class | basis |
| --- | --- | --- |
| same build seen failing and passing, scenario we own | `flake` | `observed-nondeterminism` |
| same build seen failing and passing, `C01` | `unowned-nondeterminism` | `observed-nondeterminism` |
| failure seen again on the same build | `deterministic-regression` | `reproduced-failure` |
| failure nobody retried | `unrepeated-failure` | `single-observation` |

An observed fail/pass split outranks any `--class` a caller declares; a declaration only fills the gap while the attempts are silent. `unrepeated-failure` is a distinct value rather than a reuse of `unattributed`, so "we have not retried this" and "we could not attribute this" never share one bucket in the aggregate.

The recorder learns the earlier result by reading the other `attempt-*` directories under `--evidence-root`, matched on `binary_sha256` — a different build is never evidence about this one. Earlier attempt files are never rewritten: reclassification is a report, not an edit to evidence somebody already downloaded.

## Retry awareness and the report

`PROJMUX_E2E_ATTEMPT` now defaults to `GITHUB_RUN_ATTEMPT`. It was read in two places and set in none, which is why attempt 3 of a rerun still wrote `L06-attempt-1.json`.

`e2e-evidence.py flake-rate <dir>` reports per-scenario flake rate over downloaded attempt evidence and emits an `E2E_FLAKE_FLIP` line for every stored class the other attempts contradict. Against the three real artifacts from run `33234202379`:

```
E2E_FLAKE scenario=L06 binary=539b5179 attempts=3 pass=1 fail=2 flake_rate=0.667 verdict=flake
E2E_FLAKE_FLIP scenario=L06 binary=539b5179 attempt=attempt-33234202379-1-2314 recorded=deterministic-regression verdict=flake
E2E_FLAKE_FLIP scenario=L06 binary=539b5179 attempt=attempt-33234202379-2-2081 recorded=deterministic-regression verdict=flake
E2E_FLAKE_FLIP scenario=L06 binary=539b5179 attempt=attempt-33234202379-3-2307 recorded=environment verdict=flake
>> E2E flake report scenarios=21 nondeterministic=1 flips=3
```

`e2e-evidence.py classify` exposes the predicate alone so its truth table is testable without staging directories.

## Diagnostic labels that stopped asserting

Three L06 diagnostic fields stated things no observation supported. The first real capture — eight racers `completed` with status 0 — contradicted all three.

- `attribution` was the constant `l06-lock-exhaustion`; it now names what the racers did (`l06-lock-exhaustion` only when a racer actually reported exhaustion, otherwise `l06-racer-failure`, `l06-no-racer-failure`, or `l06-no-racers-observed`).
- `acquire` was assigned `contended` in the preamble before any racer ran, so it said `contended` for every L06 failure. It is now derived from the racer outcomes.
- `age_ms` was named for lock age but was seeded with the scenario start time, inviting comparison against the 30s stale boundary. It is now `lock_age_ms` paired with `lock_observed`, and the preamble seeds 0 so only a lock file that was actually stat-ed produces an age.

`holder.release` is left alone — it was already derived from the lock file's existence.

## A harness-owned flake this surfaced

`test/e2e/evidence-contract.sh` fails roughly one run in three on `main`, independent of this change. `smoke_now_ms` used `date +%s%3N`; uutils coreutils ignores the `%3N` field width **and** strips leading zeros from the nanoseconds, so the concatenation loses digits about one call in ten and a later stamp can be numerically smaller than an earlier one. The negative `elapsed_ms` was rejected, the terminal record was never written, and the attempt validated as unterminated. Seconds and nanoseconds are now read as two fields of one clock read. 12/12 consecutive runs green after the fix; measured 3 failures in 6 runs before it.

## Scope

`E2E_CONTRACT` stdout shape and field names are unchanged — only values differ. New record fields are optional and appear only where a derivation actually happened, so a begin/pass record with nothing to compare against keeps its exact prior bytes. No product code: the diff has zero Go files.

Roadmap: Test reliability and registry lock fairness / Phase 1 관측 기반 실패 분류
Contract: C-3 Guarantee·Enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
