### PR TITLE
ci(release): gate the GitHub release on npm publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # The release is drafted so `release.yml` can gate its visibility on a
+      # successful npm publish. GitHub does not create the git tag for a draft
+      # release, so the tag that triggers `release.yml` has to be created here.
+      # The step is idempotent, and the PAT is what makes the ref creation
+      # dispatch the tag workflow at all.
+      - name: Create release tag
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          RELEASE_SHA: ${{ steps.release.outputs.sha }}
+        run: |
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "tag ${TAG_NAME} already exists"
+            exit 0
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f "ref=refs/tags/${TAG_NAME}" \
+            -f "sha=${RELEASE_SHA}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,3 +191,22 @@ jobs:
             dist/npm/projmux; do
             npm publish "$dir" --access public
           done
+
+  publish-release:
+    name: Publish GitHub Release
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      # release-please drafts the release, so it is invisible to users until
+      # this step. Gating it on `publish-npm` is what keeps the GitHub release
+      # and the npm `dist-tags.latest` from drifting apart: a failed npm
+      # publish leaves the release drafted and fails the workflow instead of
+      # advertising a version npm cannot install yet.
+      - name: Publish the drafted release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release edit "${GITHUB_REF_NAME}" --draft=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,9 @@
 
 ## Release Flow
 - `release-please-action` watches `main`, accumulates Conventional Commit subjects, and opens or refreshes a "chore(main): release X.Y.Z" PR. That PR contains the version bump (`internal/version/version.go` + `.release-please-manifest.json`), `CHANGELOG.md` updates, and the release notes.
-- Merging the release PR pushes the `vX.Y.Z` tag and creates the GitHub Release with auto-generated notes.
-- `.github/workflows/release.yml` triggers on the tag push, builds the linux/darwin × amd64/arm64 matrix, and uploads tarballs to the release that already exists (`gh release upload --clobber`). Do not add hardcoded notes back to that workflow — release-please owns the notes.
+- Merging the release PR creates the GitHub Release with auto-generated notes as a **draft** (`draft` in `release-please-config.json`). A draft release does not create its git tag, so `.github/workflows/release-please.yml` creates `refs/tags/vX.Y.Z` itself; that ref creation is what triggers the tag workflow, and it uses the release-please PAT because a `GITHUB_TOKEN` push never dispatches another workflow.
+- `.github/workflows/release.yml` triggers on the tag push, builds the linux/darwin × amd64/arm64 matrix, and uploads tarballs to the drafted release (`gh release upload --clobber`). Do not add hardcoded notes back to that workflow — release-please owns the notes.
+- The release becomes visible only in the final `publish-release` job, after `publish-npm` succeeds. That ordering is the contract: users never see a GitHub release for a version npm cannot install yet, and a failed npm publish leaves the release drafted and the workflow red instead of shipping a half-published version.
 - Non-Conventional commit subjects on `main` are silently skipped by release-please. Keep PR titles strict; squash merge ensures the PR title is the only subject that lands.
 
 ## Configuration And Environment

--- a/docs/npm-distribution.md
+++ b/docs/npm-distribution.md
@@ -96,6 +96,12 @@ scripts/package-npm.sh \
 This keeps the npm platform binaries byte-for-byte aligned with the GitHub
 Release binaries, including the `darwin && cgo` native key adapter, then
 publishes each staged package with `npm publish --access public`.
+
+The GitHub release itself stays a draft until that npm job succeeds. release-please
+creates the release with `draft` set, `release.yml` uploads archives to the drafted
+release, and only the final `publish-release` job flips it visible. So by the time a
+user can see release `vX.Y.Z`, npm `dist-tags.latest` already resolves to `X.Y.Z`;
+a failed npm publish keeps the release hidden and the workflow red.
 The npm publish job uses GitHub Actions OIDC (`id-token: write`) instead of a
 long-lived `NPM_TOKEN` secret. PR CI runs `make npm-pack` so package staging and
 dry-run packing fail before release.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
   "bump-patch-for-minor-pre-major": true,
   "packages": {
     ".": {
+      "draft": true,
       "extra-files": [
         "internal/version/version.go",
         "package.json",


### PR DESCRIPTION
## Why

`release-please.yml` — not `release.yml` — owns when a GitHub release becomes
visible. release-please publishes the release and pushes the tag, and only then
does the tag trigger `release.yml`, whose npm publish is the *last* job.

Measured on the last two releases:

| release | release visible | npm published | gap |
| --- | --- | --- | ---: |
| v0.13.1 | `2026-08-28T04:15:59Z` (`isDraft:false`) | `Release` run finished `04:24:50Z` | 8m49s |
| v0.13.0 | — | — | 18m14s |

During that window the shell welcome gate and Settings › About offer `u` for a
version that `npm install -g projmux@latest` cannot install yet. If
`publish-npm` fails outright, the window is unbounded.

## What changes

Draft the release, and make its visibility the last thing that happens.

- **`release-please-config.json`** — `"draft": true`, so release-please creates
  the release hidden.
- **`.github/workflows/release-please.yml`** — a draft release does **not**
  create its git tag, so the workflow now creates `refs/tags/vX.Y.Z` itself
  from the release SHA. It uses `RELEASE_PLEASE_TOKEN` deliberately: a ref
  created with `GITHUB_TOKEN` does not dispatch `release.yml`. The step is
  idempotent — if the tag already exists it exits 0.
- **`.github/workflows/release.yml`** — a final `publish-release` job
  (`needs: publish-npm`) runs `gh release edit "$GITHUB_REF_NAME" --draft=false`.

`gh release upload` and `gh release edit` both resolve a draft by its pending
tag name (gh falls back to a draft lookup when `/releases/tags/{tag}` 404s), so
the existing artifact upload keeps working against the drafted release.

## Result

At the instant a release becomes visible, npm `dist-tags.latest` already holds
that version. A failed npm publish leaves the release drafted and the workflow
red rather than advertising a version npm cannot install.

Out of scope and untouched: release-please version computation and tag naming,
`scripts/package-npm.sh` staging, the build matrix, and the release artifact
format. The only `release.yml` change is an appended job.

## Verification

- `make fmt`, `make fix`, `make test` — green on this head.
- Workflow YAML parsed and the job graph checked:
  `release.yml` jobs resolve to `fmt, unit, integration, e2e, release, publish, publish-npm, publish-release`
  with `publish-release.needs = publish-npm`.
- `make test-integration` / `make test-e2e` are N/A locally for a
  workflow-only change; CI still runs both as required checks.
- Not verifiable before a real release: the actual draft→publish ordering and
  the npm-failure path. Both are exercised by the next release run.
