### PR TITLE
test(e2e): replace raw polling with an explicit wait helper

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -437,6 +437,15 @@
   Codex, and npm consumers. Local Security is the exact three-way
   `make security` topology; CI's required branch-protection context is the
   fail-closed aggregate named `Test`.
+- `test/lib/smoke.sh` owns every scenario wait through `smoke_wait_until
+  <seconds> <description> <command>`; `test/e2e/` holds no raw `for _ in
+  {1..N}` polling loop. A wait that expires fails with the description it was
+  given plus the budget applied, elapsed time, attempt count, and last predicate
+  status, so no scenario can enter its next assertion with the condition still
+  unmet. `E2E_WAIT_SCALE` multiplies every budget for a slow runner.
+  `test/e2e/reliability-contract.sh` F08/F09 pin both halves: a deliberately slow
+  fixture times out with its own description and state dump and then passes once
+  the scale buys it time, and the timeout instant itself moves with the scale.
 - `test/e2e/evidence-contract.sh` (`make test-e2e-contract`) and
   `test/e2e/reliability-contract.sh` (`make test-e2e-reliability`) keep the persisted
   `projmux.e2e-attempt/v1` evidence and success result hash stable while adding

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,6 +33,11 @@ and humans run the same entrypoints.
   suites. CI uses the shard/suite selectors to give every suite its own runner,
   so container isolation and schedule isolation are the same unit there; local
   `make test-e2e` still runs the whole matrix on one machine.
+- Every scenario wait states a budget in seconds rather than a loop count, and
+  `E2E_WAIT_SCALE=<factor>` multiplies all of them at once. Raise it when a
+  runner is slow or loaded; a wait that expires still fails with the description
+  of what it was waiting for, so a slow machine reports a timeout rather than
+  the regression message of the assertion that would have run next.
 - `make test-e2e-contract`, `make test-e2e-reliability`, and
   `make test-e2e-shards` validate typed attempt evidence, bounded semantic
   waits/owned cleanup, and exhaustive four-shard isolation without rerunning

--- a/test/e2e/linux-smoke.sh
+++ b/test/e2e/linux-smoke.sh
@@ -1412,13 +1412,10 @@ run_in_pane() {
   } >"$script"
   chmod 0755 "$script"
   ctx new-window -d -t legacy-alpha: -n "runner-$label" "$script"
-  for _ in {1..200}; do
-    if [[ -f "$create_markers/$label.code" ]]; then
-      return 0
-    fi
-    sleep 0.05
-  done
-  echo "timed out waiting for the $label runner exit-code marker" >&2
+  if smoke_wait_until 10 "the $label runner exit-code marker" \
+    test -f "$create_markers/$label.code"; then
+    return 0
+  fi
   cat "$create_root/run-$label.err" >&2 || true
   return 1
 }
@@ -1744,23 +1741,23 @@ if [[ " \$* " == *" --topic release triage "* ]]; then
   [[ "\${TMUX_PANE:-}" =~ ^%[0-9]+$ ]] || exit 1
   [[ -n "\${PMX_INTERNAL_ACTIVATION_PANE_UID:-}" ]] || exit 1
   [[ -n "\${PMX_INTERNAL_ACTIVATION_GENERATION:-}" ]] || exit 1
-  activation_ready=0
-  for _ in {1..200}; do
-    if HOME=$(printf %q "$agent_home") \
+  # The stub is a real process outside this harness, so it takes the shared wait
+  # helper the same way the scenarios do. A timeout lands in the launch log the
+  # scenario already dumps, instead of a bare exit the caller has to guess at.
+  source $(printf %q "$smoke_root/test/lib/smoke.sh")
+  stub_activation_bound() {
+    HOME=$(printf %q "$agent_home") \
       PATH=$(printf %q "$create_shim:$agent_home/.local/bin"):\$PATH \
       TMUX_TMPDIR=$(printf %q "$create_root/tt") \
       XDG_STATE_HOME=$(printf %q "$create_root/state") \
       XDG_CONFIG_HOME=$(printf %q "$create_root/config") \
       PROJMUX_MANAGED_ROOTS=$(printf %q "$create_root/legacy:$create_root/work") \
       $(printf %q "$bin") describe pane "uid:\$PMX_INTERNAL_ACTIVATION_PANE_UID" -o uid \
-      >$(printf %q "$create_root/agent-activation-poll.out") 2>/dev/null &&
-      [[ "\$(tr -d '[:space:]' <$(printf %q "$create_root/agent-activation-poll.out"))" == "\$PMX_INTERNAL_ACTIVATION_PANE_UID" ]]; then
-      activation_ready=1
-      break
-    fi
-    sleep 0.05
-  done
-  [[ "\$activation_ready" == "1" ]] || exit 1
+      >$(printf %q "$create_root/agent-activation-poll.out") 2>/dev/null || return 1
+    [[ "\$(tr -d '[:space:]' <$(printf %q "$create_root/agent-activation-poll.out"))" == "\$PMX_INTERNAL_ACTIVATION_PANE_UID" ]]
+  }
+  smoke_wait_until 10 "the created Agent Pane uid to bind in the Registry" stub_activation_bound \
+    2>>$(printf %q "$create_root/agent-launch.log") || exit 1
   printf '{"hook_event_name":"UserPromptSubmit","thread_id":"phase6-activation-thread","session_id":"phase6-activation-session","cwd":"%s"}' "\$PWD" |
     HOME=$(printf %q "$agent_home") \
     PATH=$(printf %q "$create_shim:$agent_home/.local/bin"):\$PATH \
@@ -1847,11 +1844,11 @@ if [[ ! "$agent_pane" =~ ^%[0-9]+$ ]]; then
   exit 1
 fi
 
-# The provider really launched inside the pane the create made.
-for _ in {1..200}; do
-  [[ -s "$create_root/agent-launch.log" ]] && break
-  sleep 0.05
-done
+# The provider really launched inside the pane the create made. The wait for the
+# log to appear is its own named failure, so a slow launch cannot be reported
+# below as a provider that started in the wrong directory.
+smoke_wait_until 10 "the provider stub launch log to appear" \
+  test -s "$create_root/agent-launch.log"
 if ! grep -Fq "cwd=$create_root/legacy/alpha" "$create_root/agent-launch.log"; then
   echo "the provider stub did not launch in the project root" >&2
   cat "$create_root/agent-launch.log" >&2 || true
@@ -1897,10 +1894,10 @@ TERM=xterm-256color script -qefc \
   "TERM=xterm-256color env -u TMUX -u TMUX_PANE TMUX_TMPDIR='$create_root/tt' '$create_real_tmux' -L '$create_socket' attach-session -t legacy-alpha" \
   "$create_root/exact-client-two.typescript" >/dev/null 2>&1 &
 create_client_two_pid=$!
-for _ in {1..200}; do
-  [[ "$(ctx list-clients -F '#{client_name}' | wc -l)" -ge 2 ]] && break
-  sleep 0.05
-done
+create_two_clients_attached() {
+  [[ "$(ctx list-clients -F '#{client_name}' | wc -l)" -ge 2 ]]
+}
+smoke_wait_until 10 "two isolated tmux clients to attach" create_two_clients_attached
 mapfile -t exact_clients < <(ctx list-clients -F '#{client_name}' | head -n 2)
 if [[ "${#exact_clients[@]}" != "2" ]]; then
   echo "outside exact create did not establish two isolated clients" >&2
@@ -1938,16 +1935,13 @@ if [[ "$(ctx display-message -p -t "$exact_agent_pane" '#{pane_id}')" != "$exact
   echo "outside exact create returned a Pane outside the app socket: $exact_agent_pane" >&2
   exit 1
 fi
-for _ in {1..200}; do
+create_exact_agent_settled() {
   exact_title="$(ctx display-message -p -t "$exact_agent_pane" '#{pane_title}')"
   exact_launch_log_after="$(wc -l <"$create_root/agent-launch.log" | tr -d '[:space:]')"
-  [[ "$exact_title" == "codex:alpha" && "$exact_launch_log_after" -gt "$exact_launch_log_before" ]] && break
-  sleep 0.05
-done
-if [[ "${exact_title:-}" != "codex:alpha" || "${exact_launch_log_after:-0}" -le "$exact_launch_log_before" ]]; then
-  echo "outside exact create provider/title did not settle on $exact_agent_pane" >&2
-  exit 1
-fi
+  [[ "$exact_title" == "codex:alpha" && "$exact_launch_log_after" -gt "$exact_launch_log_before" ]]
+}
+smoke_wait_until 10 "outside exact create provider/title to settle on $exact_agent_pane" \
+  create_exact_agent_settled
 exact_siblings_after="$({
   ctx display-message -p -t "$agent_pane_before" '#{window_id}|#{pane_id}|#{pane_title}|#{@projmux_ai_topic}|#{@projmux_ai_state}'
   ctx display-message -p -t "$exact_review_pane" '#{window_id}|#{pane_id}|#{pane_title}|#{@projmux_ai_topic}|#{@projmux_ai_state}'
@@ -1998,10 +1992,8 @@ if [[ "$(tr -d '[:space:]' <"$create_root/agent-payload.out")" != "codex-2" ]]; 
   echo "a payload changed the Agent name: $(cat "$create_root/agent-payload.out")" >&2
   exit 1
 fi
-for _ in {1..200}; do
-  [[ -s "$create_root/agent-launch.log" ]] && break
-  sleep 0.05
-done
+smoke_wait_until 10 "the payload-bearing provider stub launch log to appear" \
+  test -s "$create_root/agent-launch.log"
 if ! grep -Fq -- "args=-C $create_root/legacy/alpha -p payload-project -w payload-window --topic release triage" "$create_root/agent-launch.log"; then
   echo "the payload did not reach the provider:" >&2
   cat "$create_root/agent-launch.log" >&2 || true
@@ -2314,11 +2306,11 @@ if [[ ! "$phase15_agent_pane" =~ ^%[0-9]+$ ]] || [[ -s "$create_root/explicit-ow
   cat "$create_root/explicit-owner-agent.err" >&2 || true
   exit 1
 fi
-for _ in {1..200}; do
+phase15_launch_grew() {
   phase15_launch_after="$(wc -l <"$create_root/agent-launch.log" | tr -d '[:space:]')"
-  [[ "$phase15_launch_after" -gt "$phase15_launch_before" ]] && break
-  sleep 0.05
-done
+  [[ "$phase15_launch_after" -gt "$phase15_launch_before" ]]
+}
+smoke_wait_until 10 "the exact-Project create codex provider launch line" phase15_launch_grew
 if [[ "${phase15_launch_after:-0}" -le "$phase15_launch_before" ]] ||
   [[ "$(ctx display-message -p -t "$phase15_agent_pane" '#{session_name}|#{window_name}|#{pane_id}')" != "legacy-alpha|hi|$phase15_agent_pane" ]] ||
   [[ -z "$(ctx show-options -pqv -t "$phase15_agent_pane" @projmux_pane_uid)" ]] ||
@@ -3591,20 +3583,13 @@ if [[ -z "$self_uid" ]] || [[ -z "$self_window" ]]; then
   exit 1
 fi
 touch "$delete_root/self-start"
-for _ in {1..200}; do
-  if [[ -s "$delete_root/self.out" ]] && \
-    [[ "$(delete_tmux display-message -p -t "$self_window" '#{window_id}' 2>/dev/null || true)" != "$self_window" ]]; then
-    break
-  fi
-  sleep 0.05
-done
-if [[ ! -s "$delete_root/self.out" ]]; then
-  echo "self-target delete left no durable stdout" >&2
+delete_self_target_settled() {
+  [[ -s "$delete_root/self.out" ]] || return 1
+  [[ "$(delete_tmux display-message -p -t "$self_window" '#{window_id}' 2>/dev/null || true)" != "$self_window" ]]
+}
+if ! smoke_wait_until 10 "self-target delete to leave durable stdout and close $self_window" \
+  delete_self_target_settled; then
   cat "$delete_root/self.err" >&2 || true
-  exit 1
-fi
-if [[ "$(delete_tmux display-message -p -t "$self_window" '#{window_id}' 2>/dev/null || true)" == "$self_window" ]]; then
-  echo "self-target delete left $self_window live" >&2
   exit 1
 fi
 delete_pmx get windows --all-projects -o uid >"$delete_root/windows.after-self"
@@ -3700,39 +3685,25 @@ if [[ "$(delete_tmux show-options -gqv @projmux_app)" != "1" ]]; then
   exit 1
 fi
 delete_tmux kill-pane -t "$delete_offline_pane"
-delete_offline_pane_ready=0
-for _ in {1..200}; do
-  if delete_pmx describe pane "uid:$delete_offline_pane_uid" -o json >"$delete_root/offline-pane.json" 2>/dev/null && \
-    grep -Fq '"type": "MissingRuntime"' "$delete_root/offline-pane.json" && \
-    grep -Fq '"reason": "RuntimeUnbound"' "$delete_root/offline-pane.json"; then
-    delete_offline_pane_ready=1
-    break
-  fi
-  sleep 0.05
-done
-if [[ "$delete_offline_pane_ready" != "1" ]]; then
-  echo "raw Pane loss did not converge to durable MissingRuntime evidence" >&2
-  exit 1
-fi
+delete_offline_pane_converged() {
+  delete_pmx describe pane "uid:$delete_offline_pane_uid" -o json >"$delete_root/offline-pane.json" 2>/dev/null &&
+    grep -Fq '"type": "MissingRuntime"' "$delete_root/offline-pane.json" &&
+    grep -Fq '"reason": "RuntimeUnbound"' "$delete_root/offline-pane.json"
+}
+smoke_wait_until 10 "raw Pane loss to converge to durable MissingRuntime evidence" \
+  delete_offline_pane_converged
 delete_offline_agent_pane="$(delete_pmx create agent --provider codex --project "uid:$delete_alpha_project_uid" --window "uid:$delete_sibling_uid" -o pane-id)"
 delete_offline_agent_uid="$(delete_pmx get agents --project "uid:$delete_alpha_project_uid" --window "uid:$delete_sibling_uid" -o uid | tail -n 1)"
 delete_offline_agent_pane_uid="$(delete_tmux show-options -pqv -t "$delete_offline_agent_pane" @projmux_pane_uid)"
 delete_tmux kill-pane -t "$delete_offline_agent_pane"
-delete_offline_agent_ready=0
-for _ in {1..200}; do
-  if delete_pmx describe agent "uid:$delete_offline_agent_uid" -o json >"$delete_root/offline-agent.json" 2>/dev/null && \
-    delete_pmx describe pane "uid:$delete_offline_agent_pane_uid" -o json >"$delete_root/offline-agent-pane.json" 2>/dev/null && \
-    grep -Fq '"phase": "Offline"' "$delete_root/offline-agent.json" && \
-    grep -Fq '"type": "MissingRuntime"' "$delete_root/offline-agent-pane.json"; then
-    delete_offline_agent_ready=1
-    break
-  fi
-  sleep 0.05
-done
-if [[ "$delete_offline_agent_ready" != "1" ]]; then
-  echo "raw Agent Pane loss did not converge to Offline/MissingRuntime evidence" >&2
-  exit 1
-fi
+delete_offline_agent_converged() {
+  delete_pmx describe agent "uid:$delete_offline_agent_uid" -o json >"$delete_root/offline-agent.json" 2>/dev/null &&
+    delete_pmx describe pane "uid:$delete_offline_agent_pane_uid" -o json >"$delete_root/offline-agent-pane.json" 2>/dev/null &&
+    grep -Fq '"phase": "Offline"' "$delete_root/offline-agent.json" &&
+    grep -Fq '"type": "MissingRuntime"' "$delete_root/offline-agent-pane.json"
+}
+smoke_wait_until 10 "raw Agent Pane loss to converge to Offline/MissingRuntime evidence" \
+  delete_offline_agent_converged
 delete_tmux list-panes -a -F '#{session_id}:#{window_id}:#{pane_id}:#{@projmux_pane_uid}' | sort >"$delete_root/offline-pane.tmux-before"
 {
   delete_pmx get projects -o uid
@@ -4072,30 +4043,26 @@ delete_tmux kill-server
 # generated hooks background their convergence. Those convergences are the last
 # legitimate writers of this registry, so the byte-identity check below has to
 # start from a settled file rather than from whatever the file held mid-flight.
-# Stability is the honest signal: ten identical 50ms observations establish a
-# 500ms quiet window in which no worker is still landing a pass.
-delete_settled=0
+# Stability is the honest signal: ten identical 50ms-spaced observations
+# establish a roughly half-second quiet window in which no worker is still
+# landing a pass. How long the run may spend looking for that window is the
+# wait budget, which is a separate number and scales with the runner.
 delete_stable_samples=0
-cp "$delete_registry" "$delete_root/registry.settle-probe"
-SMOKE_L08_REGISTRY_BEFORE="$delete_root/registry.settle-probe"
-for _ in {1..200}; do
-  sleep 0.05
+delete_registry_settled() {
   if cmp -s "$delete_root/registry.settle-probe" "$delete_registry"; then
     delete_stable_samples=$((delete_stable_samples + 1))
-    if [[ "$delete_stable_samples" == "10" ]]; then
-      delete_settled=1
-      break
-    fi
-    continue
+    ((delete_stable_samples >= 10))
+    return
   fi
   delete_stable_samples=0
   cp "$delete_registry" "$delete_root/registry.settle-probe"
   SMOKE_L08_REGISTRY_BEFORE="$delete_root/registry.settle-probe"
-done
-if [[ "$delete_settled" != "1" ]]; then
-  echo "hook-driven convergence never settled after kill-server" >&2
-  exit 1
-fi
+  return 1
+}
+cp "$delete_registry" "$delete_root/registry.settle-probe"
+SMOKE_L08_REGISTRY_BEFORE="$delete_root/registry.settle-probe"
+smoke_wait_until 10 "hook-driven convergence to settle after kill-server" \
+  delete_registry_settled
 cp "$delete_registry" "$delete_root/registry.before-no-server-dry-run"
 SMOKE_L08_REGISTRY_BEFORE="$delete_root/registry.before-no-server-dry-run"
 if delete_pmx_delete pane "uid:$delete_sibling_shell_uid" --dry-run \
@@ -5447,15 +5414,7 @@ startup_wait_for() {
   shift
   # Full four-shard Docker load can delay the real attached-client and Project
   # materialization path; keep the same predicate with a bounded 30s budget.
-  for _ in {1..600}; do
-    if "$@"; then
-      return 0
-    fi
-    sleep 0.05
-  done
-  echo "timed out waiting for $description" >&2
-  tail -c 8000 "$startup_client_log" >&2 || true
-  return 1
+  SMOKE_WAIT_DIAGNOSTIC_LOG="$startup_client_log" smoke_wait_until 30 "$description" "$@"
 }
 
 startup_client_is_on() {
@@ -6327,15 +6286,7 @@ fopen_client_pid=$!
 fopen_wait_for() {
   local description="$1"
   shift
-  for _ in {1..200}; do
-    if "$@"; then
-      return 0
-    fi
-    sleep 0.05
-  done
-  echo "timed out waiting for $description" >&2
-  tail -c 8000 "$fopen_client_log" >&2 || true
-  return 1
+  SMOKE_WAIT_DIAGNOSTIC_LOG="$fopen_client_log" smoke_wait_until 10 "$description" "$@"
 }
 
 fopen_wait_for "attached first-open tmux client" sh -c \
@@ -6706,15 +6657,7 @@ rtd_client_pid=$!
 rtd_wait_for() {
   local description="$1"
   shift
-  for _ in {1..200}; do
-    if "$@"; then
-      return 0
-    fi
-    sleep 0.05
-  done
-  echo "timed out waiting for $description" >&2
-  tail -c 12000 "$rtd_client_log" >&2 || true
-  return 1
+  SMOKE_WAIT_DIAGNOSTIC_LOG="$rtd_client_log" smoke_wait_until 10 "$description" "$@"
 }
 
 rtd_wait_for "attached runtime diagnostics client" sh -c \
@@ -6957,15 +6900,7 @@ nav_client_pid=$!
 nav_wait_for() {
   local description="$1"
   shift
-  for _ in {1..200}; do
-    if "$@"; then
-      return 0
-    fi
-    sleep 0.05
-  done
-  echo "timed out waiting for $description" >&2
-  tail -c 12000 "$nav_client_log" >&2 || true
-  return 1
+  SMOKE_WAIT_DIAGNOSTIC_LOG="$nav_client_log" smoke_wait_until 10 "$description" "$@"
 }
 
 nav_wait_for "attached registry navigation client" sh -c \
@@ -7441,14 +7376,7 @@ rtv_list_has_runtime() {
 rtv_wait_for() {
   local description="$1"
   shift
-  for _ in {1..200}; do
-    if "$@"; then
-      return 0
-    fi
-    sleep 0.05
-  done
-  echo "timed out waiting for $description" >&2
-  return 1
+  smoke_wait_until 10 "$description" "$@"
 }
 
 # Default `When needed` on a healthy host: the Project rows are there and the
@@ -7499,15 +7427,7 @@ rtv_client_pid=$!
 rtv_wait_for_client() {
   local description="$1"
   shift
-  for _ in {1..200}; do
-    if "$@"; then
-      return 0
-    fi
-    sleep 0.05
-  done
-  echo "timed out waiting for $description" >&2
-  tail -c 12000 "$rtv_client_log" >&2 || true
-  return 1
+  SMOKE_WAIT_DIAGNOSTIC_LOG="$rtv_client_log" smoke_wait_until 10 "$description" "$@"
 }
 
 rtv_wait_for_client "attached Alt-1 Runtime visibility client" sh -c \
@@ -7752,14 +7672,7 @@ SMOKE_L16_ERR_PATH="$disc_root/open-bootstrap.err"
 disc_wait_for() {
   local description="$1"
   shift
-  for _ in {1..200}; do
-    if "$@"; then
-      return 0
-    fi
-    sleep 0.05
-  done
-  echo "timed out waiting for $description" >&2
-  return 1
+  smoke_wait_until 10 "$description" "$@"
 }
 
 disc_wait_for "attached discovery tmux client" sh -c \

--- a/test/e2e/reliability-contract.sh
+++ b/test/e2e/reliability-contract.sh
@@ -81,6 +81,76 @@ f07=(python3 "$root/scripts/e2e-evidence.py" record --directory "$artifacts/f07"
 "${f07[@]}" --class harness-lifecycle --outcome fail --elapsed-ms 1 >/dev/null
 python3 "$root/scripts/e2e-evidence.py" validate --terminal "$artifacts/f07/summary.jsonl"
 
+# F08: a wait that outlives its budget fails as a named timeout carrying the
+# budget actually applied and the state the wait ended in. It never returns
+# success, so a slow fixture cannot be reported by the next assertion as a
+# product regression. The fixture is slow, not broken: the same predicate
+# succeeds once E2E_WAIT_SCALE buys it enough time.
+f08_marker="$artifacts/f08-slow-marker"
+f08_log="$artifacts/f08-diagnostic.log"
+printf 'f08 fixture diagnostic tail\n' >"$f08_log"
+(
+  sleep 1
+  : >"$f08_marker"
+) &
+f08_fixture_pid=$!
+set +e
+SMOKE_WAIT_DIAGNOSTIC_LOG="$f08_log" \
+  smoke_wait_until 0.2 "the F08 slow fixture marker" test -e "$f08_marker" \
+  2>"$artifacts/f08.err"
+f08_status=$?
+set -e
+if [[ "$f08_status" == "0" ]]; then
+  echo "F08 wait helper reported success before its slow fixture existed" >&2
+  exit 1
+fi
+grep -Fq 'timed out waiting for the F08 slow fixture marker' "$artifacts/f08.err"
+grep -Eq '^  budget=0\.2s scale=1 elapsed_ms=[0-9]+ attempts=[0-9]+ last_status=[1-9][0-9]*$' \
+  "$artifacts/f08.err"
+grep -Fq "command: test -e $f08_marker" "$artifacts/f08.err"
+grep -Fq 'f08 fixture diagnostic tail' "$artifacts/f08.err"
+if ! (
+  SMOKE_WAIT_SCALE=""
+  E2E_WAIT_SCALE=20
+  smoke_wait_until 0.2 "the F08 slow fixture marker under scale" test -e "$f08_marker"
+); then
+  echo "F08 scaled budget did not absorb the slow fixture" >&2
+  exit 1
+fi
+wait "$f08_fixture_pid"
+
+# F09: E2E_WAIT_SCALE moves the timeout instant itself, which is what lets a
+# loaded runner be given time instead of a regression report.
+f09_never_true() { return 7; }
+f09_timeout_ms() {
+  local scale="$1" started
+  started="$(smoke_now_ms)"
+  (
+    SMOKE_WAIT_SCALE=""
+    E2E_WAIT_SCALE="$scale"
+    smoke_wait_until 0.4 "the F09 condition" f09_never_true
+  ) >/dev/null 2>&1 || true
+  printf '%s' "$(($(smoke_now_ms) - started))"
+}
+f09_scale_one="$(f09_timeout_ms 1)"
+f09_scale_five="$(f09_timeout_ms 5)"
+if ((f09_scale_five < f09_scale_one * 3)) || ((f09_scale_five < 1800)); then
+  echo "F09 E2E_WAIT_SCALE did not expand the budget: scale1=${f09_scale_one}ms scale5=${f09_scale_five}ms" >&2
+  exit 1
+fi
+if ! (
+  # shellcheck disable=SC2034 # Both are consumed by the sourced wait helper.
+  SMOKE_WAIT_SCALE=""
+  # shellcheck disable=SC2034
+  E2E_WAIT_SCALE=not-a-number
+  smoke_wait_until 0.1 "the F09 fallback" true
+) 2>"$artifacts/f09-invalid.err"; then
+  echo "F09 invalid E2E_WAIT_SCALE broke the wait instead of falling back" >&2
+  exit 1
+fi
+grep -Fq 'ignoring invalid E2E_WAIT_SCALE=not-a-number; using 1' "$artifacts/f09-invalid.err"
+printf 'F09 wait budget timeout scale1=%sms scale5=%sms\n' "$f09_scale_one" "$f09_scale_five"
+
 # Phase-0 first-failure diagnostics are synthetic and scenario-owned. They
 # exercise only the log formatter; no product timeout, retry, lock, or Registry
 # semantics are changed to manufacture the failures.
@@ -210,4 +280,4 @@ for scenario, name, attribution in (
     assert "class" not in terminal and "class" not in diagnostic
 PY
 
-echo ">> F01/F02/F04/F06/F07 and L06/L08/L16 first-failure contracts passed"
+echo ">> F01/F02/F04/F06/F07/F08/F09 and L06/L08/L16 first-failure contracts passed"

--- a/test/lib/smoke.sh
+++ b/test/lib/smoke.sh
@@ -51,6 +51,109 @@ smoke_now_ms() {
   printf '%s\n' "$((10#$seconds * 1000 + 10#${nanoseconds:0:3}))"
 }
 
+# Wait budgets are stated in seconds of wall clock, not in loop iterations, so a
+# call site declares the time it is willing to spend rather than a count that
+# silently means something different on a slower machine. E2E_WAIT_SCALE
+# multiplies every budget, which is how a loaded runner buys time instead of
+# reporting a product regression.
+SMOKE_WAIT_SCALE=""
+SMOKE_WAIT_ATTEMPTS=0
+SMOKE_WAIT_ELAPSED_MS=0
+SMOKE_WAIT_LAST_STATUS=0
+
+smoke_wait_scale() {
+  if [[ -n "$SMOKE_WAIT_SCALE" ]]; then
+    printf '%s' "$SMOKE_WAIT_SCALE"
+    return 0
+  fi
+  local scale="${E2E_WAIT_SCALE:-1}"
+  if [[ ! "$scale" =~ ^[0-9]+([.][0-9]+)?$ ]] ||
+    [[ "$(awk -v k="$scale" 'BEGIN { print (k > 0) ? "y" : "n" }')" != "y" ]]; then
+    echo "ignoring invalid E2E_WAIT_SCALE=$scale; using 1" >&2
+    scale=1
+  fi
+  SMOKE_WAIT_SCALE="$scale"
+  printf '%s' "$scale"
+}
+
+smoke_wait_budget_ms() {
+  local seconds="$1"
+  if [[ ! "$seconds" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "wait budget must be a number of seconds, got: $seconds" >&2
+    return 2
+  fi
+  awk -v s="$seconds" -v k="$(smoke_wait_scale)" \
+    'BEGIN { ms = s * k * 1000; if (ms < 1) { ms = 1 } printf "%d", ms }'
+}
+
+# smoke_wait_until_quiet <budget-seconds> <command> [args...]
+#
+# The shared polling primitive. It reports nothing, so it is only for waits
+# whose caller handles the timeout as ordinary control flow. Every assertion
+# wait must use smoke_wait_until instead. The command runs in the current shell,
+# so predicate functions can publish what they observed.
+smoke_wait_until_quiet() {
+  local budget_ms started_ms now_ms
+  budget_ms="$(smoke_wait_budget_ms "$1")" || return 2
+  shift
+  SMOKE_WAIT_ATTEMPTS=0
+  SMOKE_WAIT_LAST_STATUS=0
+  started_ms="$(smoke_now_ms)"
+  now_ms="$started_ms"
+  while :; do
+    SMOKE_WAIT_ATTEMPTS=$((SMOKE_WAIT_ATTEMPTS + 1))
+    SMOKE_WAIT_LAST_STATUS=0
+    "$@" || SMOKE_WAIT_LAST_STATUS=$?
+    now_ms="$(smoke_now_ms)"
+    SMOKE_WAIT_ELAPSED_MS=$((now_ms - started_ms))
+    if [[ "$SMOKE_WAIT_LAST_STATUS" == "0" ]]; then
+      return 0
+    fi
+    if ((now_ms >= started_ms + budget_ms)); then
+      SMOKE_WAIT_ELAPSED_MS=$((now_ms - started_ms))
+      return 1
+    fi
+    sleep 0.05
+  done
+}
+
+# smoke_wait_until <budget-seconds> <description> <command> [args...]
+#
+# Waits for <command> to succeed within the scaled budget. A timeout is always
+# an explicit described failure carrying the budget that was actually applied
+# and the state the wait ended in; it never returns success, so the caller
+# cannot walk into the next assertion and report slowness as a regression.
+# Set SMOKE_WAIT_DIAGNOSTIC_LOG to have the timeout tail a scenario log too.
+smoke_wait_until() {
+  local budget="$1"
+  local description="$2"
+  shift 2
+  local quiet_status=0
+  smoke_wait_until_quiet "$budget" "$@" || quiet_status=$?
+  if [[ "$quiet_status" == "0" ]]; then
+    return 0
+  fi
+  # A malformed budget is a harness bug, not a slow runner. Keep it distinct so
+  # it cannot be read as a timeout.
+  if [[ "$quiet_status" == "2" ]]; then
+    return 2
+  fi
+  {
+    printf 'timed out waiting for %s\n' "$description"
+    printf '  budget=%ss scale=%s elapsed_ms=%s attempts=%s last_status=%s\n' \
+      "$budget" "$(smoke_wait_scale)" "$SMOKE_WAIT_ELAPSED_MS" \
+      "$SMOKE_WAIT_ATTEMPTS" "$SMOKE_WAIT_LAST_STATUS"
+    printf '  command:'
+    printf ' %q' "$@"
+    printf '\n'
+  } >&2
+  if [[ -n "${SMOKE_WAIT_DIAGNOSTIC_LOG:-}" && -r "${SMOKE_WAIT_DIAGNOSTIC_LOG:-}" ]]; then
+    printf '  diagnostic tail of %s:\n' "$SMOKE_WAIT_DIAGNOSTIC_LOG" >&2
+    tail -c 12000 "$SMOKE_WAIT_DIAGNOSTIC_LOG" >&2 || true
+  fi
+  return 1
+}
+
 smoke_contract_state_hash() {
   local registry="${XDG_STATE_HOME:-}/projmux/metadata/registry.json"
   if [[ -f "$registry" ]]; then
@@ -439,21 +542,23 @@ smoke_owned_process_inventory() {
   done
 }
 
+smoke_owned_quiet_streak=0
+
+smoke_owned_quiet_sample() {
+  if [[ -n "$(smoke_owned_process_inventory)" ]]; then
+    smoke_owned_quiet_streak=0
+    return 1
+  fi
+  smoke_owned_quiet_streak=$((smoke_owned_quiet_streak + 1))
+  ((smoke_owned_quiet_streak >= 3))
+}
+
+# Cleanup escalation treats a non-quiescent root as ordinary control flow, so
+# this wait stays quiet. It still takes a scaled time budget rather than a fixed
+# sample count, because a loaded machine is exactly when reaping takes longer.
 smoke_wait_owned_quiet() {
-  local stable=0 inventory
-  for _ in {1..10}; do
-    inventory="$(smoke_owned_process_inventory)"
-    if [[ -z "$inventory" ]]; then
-      stable=$((stable + 1))
-      if [[ "$stable" == "3" ]]; then
-        return 0
-      fi
-    else
-      stable=0
-    fi
-    sleep 0.05
-  done
-  return 1
+  smoke_owned_quiet_streak=0
+  smoke_wait_until_quiet 1 smoke_owned_quiet_sample
 }
 
 smoke_reap_owned_processes() {
@@ -524,36 +629,32 @@ smoke_cleanup_env() {
   fi
 }
 
+smoke_current_frame_contains() {
+  local path="$1"
+  local offset="$2"
+  local needle="$3"
+  tail -c "+$((offset + 1))" "$path" 2>/dev/null | grep -aFq "$needle"
+}
+
 smoke_wait_for_current_frame() {
   local description="$1"
   local path="$2"
   local offset="$3"
   local needle="$4"
-  for _ in {1..100}; do
-    if tail -c "+$((offset + 1))" "$path" 2>/dev/null | grep -aFq "$needle"; then
-      return 0
-    fi
-    sleep 0.05
-  done
-  echo "timed out waiting for current-frame $description offset=$offset" >&2
+  if smoke_wait_until 5 "current-frame $description offset=$offset" \
+    smoke_current_frame_contains "$path" "$offset" "$needle"; then
+    return 0
+  fi
   tail -c "+$((offset + 1))" "$path" >&2 || true
   return 1
 }
 
+# The default scenario wait. It is smoke_wait_until with the 5s budget this
+# harness has always used for a settling assertion.
 smoke_wait_for() {
   local description="$1"
   shift
-  for _ in {1..100}; do
-    if "$@"; then
-      return 0
-    fi
-    sleep 0.05
-  done
-  echo "timed out waiting for $description" >&2
-  if [[ -n "${SMOKE_WAIT_DIAGNOSTIC_LOG:-}" ]]; then
-    tail -c 12000 "$SMOKE_WAIT_DIAGNOSTIC_LOG" >&2 || true
-  fi
-  return 1
+  smoke_wait_until 5 "$description" "$@"
 }
 
 smoke_require_uid() {


### PR DESCRIPTION
Every wait in the Linux e2e harness was a `for _ in {1..N}; do ...; sleep 0.05; done` loop. Ten of the eighteen simply fell out of the loop when the condition never held, and the next assertion reported the timeout as a product regression — `linux-smoke.sh` claimed "the provider stub did not launch in the project root" when what actually happened is that the log had not filled within ten seconds.

## What changes

- `test/lib/smoke.sh` gains `smoke_wait_until <seconds> <description> <command...>`. A budget is a number of seconds, not a loop count, so a call site declares the time it is willing to spend. A timeout is always an explicit named failure carrying the budget actually applied, elapsed time, attempt count, last predicate status, and the command it was polling; it never returns success.
- `E2E_WAIT_SCALE=<factor>` multiplies every budget at once, so a slow or loaded runner is given time instead of producing a regression report.
- `test/e2e/linux-smoke.sh` has no raw polling loop left. Seven of the eighteen were per-scenario copies of the shared helper and collapse into it; the rest become named predicates. The provider stub, which runs as its own process in a tmux pane, now sources the shared library and takes the same helper, writing its timeout into the launch log the scenario already dumps.
- `smoke_wait_for`, `smoke_wait_for_current_frame`, and `smoke_wait_owned_quiet` are reimplemented on the new primitive, so the 98 existing `smoke_wait_for` call sites scale with `E2E_WAIT_SCALE` too. Their timeout messages keep their existing first line.

Scenario pass/fail logic is unchanged: `linux-smoke.sh` is not split, no product code is touched, and the only assertions removed are the ones that restated the loop condition they followed and are now unreachable.

## Verification

`make test-e2e-reliability` gains F08 and F09. F08 points a 0.2s budget at a marker that appears after one second: the wait fails with `timed out waiting for the F08 slow fixture marker`, a `budget=0.2s scale=1 elapsed_ms=... attempts=... last_status=...` line, the polled command, and the diagnostic tail — and then the same predicate succeeds once `E2E_WAIT_SCALE=20` is applied. F09 compares the timeout instant across scales (measured 440ms at scale 1 against 2021ms at scale 5) and pins the fallback when the variable is not a number.

`test/install/smoke.sh` keeps two polling loops. They belong to the install suite rather than the e2e wait budget and are out of this scope.

Roadmap: Test reliability and registry lock fairness / Phase 3 e2e 대기 예산
Contract: C-4 Guarantee·Failure.Detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
