### PR TITLE
test(e2e): forward the wait budget scale into the e2e container

### DIFF
--- a/scripts/test-docker-run.sh
+++ b/scripts/test-docker-run.sh
@@ -148,6 +148,7 @@ docker run --rm \
   -e PROJMUX_E2E_ATTEMPT="${PROJMUX_E2E_ATTEMPT:-${GITHUB_RUN_ATTEMPT:-1}}" \
   -e PROJMUX_E2E_LINUX_SHARD="${PROJMUX_E2E_LINUX_SHARD:-}" \
   -e E2E_SCENARIO="${E2E_SCENARIO:-}" \
+  -e E2E_WAIT_SCALE="${E2E_WAIT_SCALE:-}" \
   -v "$root:/workspace:ro" \
   -v "$modcache:/gomodcache:ro" \
   -v "$evidence:/evidence:rw" \

--- a/test/e2e/reliability-contract.sh
+++ b/test/e2e/reliability-contract.sh
@@ -151,6 +151,15 @@ fi
 grep -Fq 'ignoring invalid E2E_WAIT_SCALE=not-a-number; using 1' "$artifacts/f09-invalid.err"
 printf 'F09 wait budget timeout scale1=%sms scale5=%sms\n' "$f09_scale_one" "$f09_scale_five"
 
+# F10: the budget scale is only useful where the e2e actually runs. `docker run`
+# passes exactly the env it is told to, so a helper that reads E2E_WAIT_SCALE
+# and a runner that never forwards it would leave every containerized wait
+# pinned at scale 1 with nothing to show for it.
+if ! grep -Eq '^[[:space:]]*-e E2E_WAIT_SCALE=' "$root/scripts/test-docker-run.sh"; then
+  echo "F10 test-docker-run.sh does not forward E2E_WAIT_SCALE into the container" >&2
+  exit 1
+fi
+
 # Phase-0 first-failure diagnostics are synthetic and scenario-owned. They
 # exercise only the log formatter; no product timeout, retry, lock, or Registry
 # semantics are changed to manufacture the failures.
@@ -280,4 +289,4 @@ for scenario, name, attribution in (
     assert "class" not in terminal and "class" not in diagnostic
 PY
 
-echo ">> F01/F02/F04/F06/F07/F08/F09 and L06/L08/L16 first-failure contracts passed"
+echo ">> F01/F02/F04/F06/F07/F08/F09/F10 and L06/L08/L16 first-failure contracts passed"


### PR DESCRIPTION
`E2E_WAIT_SCALE` landed in #829 and works everywhere the harness runs on the host, but `make test-e2e` runs the scenarios inside Docker and `scripts/test-docker-run.sh` passes exactly the environment it is told to — `HOME`, `GOMAXPROCS`, `PROJMUX_E2E_ATTEMPT`, `PROJMUX_E2E_LINUX_SHARD`, `E2E_SCENARIO`, each its own `-e` line. Without one more line the variable never crossed the container boundary, so every containerized wait stayed pinned at scale 1 no matter what the caller set.

- `scripts/test-docker-run.sh` forwards `E2E_WAIT_SCALE`. Unset stays the empty string, which the helper already reads as 1, so the default run is byte-for-byte what it was.
- `test/e2e/reliability-contract.sh` gains F10, which fails if that forwarding disappears. A helper that reads a variable a runner never sends is the same shape of defect this suite exists to catch, and it is invisible from inside the container.

Verified by running `E2E_WAIT_SCALE=not-a-number E2E_SCENARIO=L01 make test-e2e`: the in-container harness emitted its own `ignoring invalid E2E_WAIT_SCALE=not-a-number; using 1` fallback, which only code running inside the container can print, and the scenario still passed.

Setting an actual factor in CI is deliberately not here — `ci.yml` is held by another slice, and the factor needs runner-speed measurements that do not exist yet.

Roadmap: Test reliability and registry lock fairness / Phase 3 e2e 대기 예산
Contract: C-4 Scope(시간)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
