### PR TITLE
fix(metadata): acquire the registry lock by deadline instead of attempts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,34 @@ jobs:
       - name: Run unit tests
         run: make test
 
+  # The registry lock is the only mutual exclusion the whole application layer
+  # stands on, and its correctness is a property of concurrent execution, not of
+  # any single call. `make test` runs without the detector so the ordinary unit
+  # gate stays fast; this job runs the detector over the packages whose tests
+  # actually create contention. It is scoped on purpose -- `-race` across the
+  # full suite buys coverage of code that never runs concurrently at the cost of
+  # every contributor's feedback loop.
+  race:
+    name: Race Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run concurrency tests under the race detector
+        run: |
+          go test -race -count=2 \
+            ./internal/integrations/metadata/... \
+            ./internal/core/notify/... \
+            ./internal/core/recentwindows/...
+
   darwin-native:
     name: Darwin Native Key Adapter
     runs-on: macos-15
@@ -433,6 +461,7 @@ jobs:
       - security-policy
       - fmt
       - unit
+      - race
       - darwin-native
       - npm-pack
       - integration
@@ -455,6 +484,7 @@ jobs:
             --required security-policy \
             --required fmt \
             --required unit \
+            --required race \
             --required darwin-native \
             --required npm-pack \
             --required integration \

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -495,13 +495,28 @@
   unchanged L08/L16 payloads stay `v1`, and evidence retained from before the
   rename still validates and still aggregates. `PROJMUX_E2E_ATTEMPT` now defaults to `GITHUB_RUN_ATTEMPT`, so a rerun's
   evidence is no longer written as attempt 1.
-- `make test` / `make test-e2e`: L06 Registry lock recurrence applies the
-  unchanged 400-attempt, 2ms/50ms delay, and 30s stale budget to one verified
-  positive-PID owner lease. `TestRegistryLockRetryBudgetTracksVerifiedOwnerLease`
-  permits a waiter to continue across healthy owner turnover while unchanged,
-  empty, malformed, and unreadable owners remain bounded; the real-tmux L06
-  burst requires all eight exact-socket creates to converge on one Window with
-  nine unique mirrored Panes and no lock or staged residue.
+- `make test` / `go test -race` / `make test-e2e`: the Registry mutation lock
+  succeeds on a deadline, not on an attempt budget. `acquireLockWithDeadline`
+  blocks on `flock(LOCK_EX)` against a persistent `registry.json.flock`
+  descriptor so the kernel owns the wait queue, keeps writing the legacy
+  `registry.json.lock` O_EXCL marker for the compatibility window an older
+  install still observes, and treats a marker as stale only when its recorded
+  pid is gone rather than after 30s of wall clock. The separate recovery lock
+  (`acquireRecoveryLock`) keeps its 200-attempt budget and wall-clock stale
+  window. `TestRegistryLockFailsOnItsDeadlineNotOnAnAttemptBudget` pins
+  `ErrLockTimeout` and the absence of any attempt count in the failure,
+  `TestRegistryLockDeadlineIsMeasuredOnTheInjectedClock` spends a whole budget
+  in simulated time, `TestRegistryLockReclaimsAMarkerOnlyWhenItsOwnerIsGone`
+  reclaims a reaped owner at once while a live, empty, malformed, or unreadable
+  owner is never reclaimed, `TestRegistryLockKeepsMutualExclusionWithAMarkerOnlyInstall`
+  covers the compatibility window in both directions, and
+  `TestRegistryLockGrantsEveryWriterUnderDeliberateContention` plus the fixed-clock
+  `TestConcurrentUpdatesSerializeThroughTheRegistryLock` require every contending
+  writer to be granted with no overlapping critical sections. The `Race Tests`
+  CI job runs the metadata, notify, and recent-window packages under `-race`.
+  The real-tmux L06 burst still requires all eight exact-socket creates to
+  converge on one Window with nine unique mirrored Panes and no lock or staged
+  residue; it is a regression guard, not the evidence for the lock change.
 - `make test` / `make test-integration`: attention omitted-target convergence
 - `make test` / `make test-e2e`: Closed-Project startup mode selection is one adjudication shared by both entry points. `switch sidebar-open` re-execs across a process boundary, and before this change the picker-off sidebar always emitted `continue` and the re-exec trusted that token verbatim, so an unregistered root on a fresh install failed in `ContinueProject` with `continue project unavailable: no usable snapshot`. `defaultProjectStartupMode` now owns the picker-off decision -- the Settings/runtime sentinels, the `$HOME` guard, and the single `ProjectRegistered` read -- and all three closed-Project entry points call it: `openProjectTarget`, the sidebar emit point `openProjectTargetPathFromSidebar` that builds the `--mode` token, and `runSidebarOpen`, which re-adjudicates a `continue` that crossed the re-exec boundary. `TestProjectStartupModeSelectionIsOneDecisionAcrossEntryPoints` drives the (registered root) x (picker on/off) x (explicit picker choice) table through the in-process open, the sidebar emit point, and the sidebar continuation, requiring the emitted `--mode` token and the mode the continuation acts on to agree with the in-process choice. `TestSidebarOpenPromotesUnregisteredRootToFreshWhenPickerIsOff` is the regression guard, `TestSidebarOpenKeepsRegisteredRootOnContinue` keeps a registered root and its retained topology on `continue`, `TestSidebarOpenHonorsExplicitPickerChoice` proves an explicit picker-on choice is never promoted, `TestSidebarOpenNeverDemotesAnArrivingFreshMode` keeps the re-adjudication one-directional, `TestSidebarOpenSurfacesRegistrationReadFailure` refuses to answer an unreadable Registry with a mode, and `TestSidebarOpenContinueOnUnregisteredRootKeepsTheSnapshotRefusal` pins the no-usable-snapshot message for the continue that is still reachable by explicit choice. The L11 closed-startup e2e keeps its direct `--mode fresh` / `--mode continue` execution paths and adds step 9, `Closed Project startup mode selection`, which covers the arrival half of the decision: the picker-off sidebar now emits `fresh`, so the step deliberately forwards the legacy neutral `continue` token an older client can still send, against an unregistered root in an empty Registry on its own isolated socket/HOME/XDG/TMUX_TMPDIR, and requires the continuation to re-decide it so the Project is minted and its session opened rather than the snapshot refusal. The emitted half is covered by the unit tests through `sidebarEmittedStartupMode`.
   is enforced by `TestAttentionMutationOmittedTargetMatchesExplicitPaneLedger`,

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -512,8 +512,16 @@
   covers the compatibility window in both directions, and
   `TestRegistryLockGrantsEveryWriterUnderDeliberateContention` plus the fixed-clock
   `TestConcurrentUpdatesSerializeThroughTheRegistryLock` require every contending
-  writer to be granted with no overlapping critical sections. The `Race Tests`
-  CI job runs the metadata, notify, and recent-window packages under `-race`.
+  writer to be granted with no overlapping critical sections. The degraded-mode
+  gate in front of an ordinary mutation is now a suspicion confirmed under the
+  lock rather than an immediate refusal: a commit publishes the initialized
+  marker before it renames the staged registry into place, so an unlocked
+  observer could read a healthy neighbour's in-flight commit as state loss and
+  refuse a writer that never reached the lock.
+  `TestAConcurrentWriterIsNotRefusedInsideAnotherCommitsMarkerWindow` builds that
+  window directly and requires the second writer to wait through it. The
+  `Race Tests` CI job runs the metadata, notify, and recent-window packages
+  under `-race`.
   The real-tmux L06 burst still requires all eight exact-socket creates to
   converge on one Window with nine unique mirrored Panes and no lock or staged
   residue; it is a regression guard, not the evidence for the lock change.

--- a/internal/integrations/metadata/store.go
+++ b/internal/integrations/metadata/store.go
@@ -381,11 +381,8 @@ func (s *Store) Update(fn func(*coremetadata.Registry) error) (coremetadata.Regi
 	if s == nil {
 		return coremetadata.Registry{}, errors.New("metadata: nil registry store")
 	}
-	if err := s.refuseDegradedMutation(); err != nil {
-		return coremetadata.Registry{}, err
-	}
 	var out coremetadata.Registry
-	err := s.withLock(func() error {
+	err := s.withMutationLock(func() error {
 		registry, onDiskVersion, existed, report, err := s.readWithReport()
 		if err != nil {
 			return s.mapDegradedMutationError(err)
@@ -428,12 +425,10 @@ func (s *Store) UpdateConvergent(fn func(*coremetadata.Registry) error) (coremet
 	if s == nil {
 		return coremetadata.Registry{}, false, errors.New("metadata: nil registry store")
 	}
-	if err := s.refuseDegradedMutation(); err != nil {
-		return coremetadata.Registry{}, false, err
-	}
+
 	var out coremetadata.Registry
 	changed := false
-	err := s.withLock(func() error {
+	err := s.withMutationLock(func() error {
 		registry, onDiskVersion, existed, report, err := s.readWithReport()
 		if err != nil {
 			return s.mapDegradedMutationError(err)
@@ -619,10 +614,10 @@ func (s *Store) stateLossError(state string) error {
 		ErrRegistryStateLost, s.markerPath, s.path, state, s.recoveryDir)
 }
 
-// refuseDegradedMutation is the lock-free gate in front of every ordinary
-// write. It keeps a damaged Registry from waiting behind (or entering) the
-// normal mutation transaction and turns the content classification into one
-// actionable recovery instruction.
+// refuseDegradedMutation classifies a damaged Registry into one actionable
+// recovery instruction. It reads without the lock, so a positive answer is a
+// suspicion rather than a verdict: see withMutationLock, which confirms it under
+// the lock before any mutation is refused.
 func (s *Store) refuseDegradedMutation() error {
 	inspection, err := s.InspectRecovery()
 	if err != nil {
@@ -1215,6 +1210,33 @@ func (s *Store) backup(fromVersion int) (string, error) {
 		return "", fmt.Errorf("metadata: write registry backup %s: %w", path, err)
 	}
 	return path, nil
+}
+
+// withMutationLock runs an ordinary mutation under the write lock and refuses a
+// degraded Registry with the same actionable error the lock-free gate produces.
+//
+// The refusal is confirmed a second time, under the lock, before it is
+// returned. A commit publishes the initialized marker before it renames the
+// staged registry into place, so an observer without the lock can catch a
+// healthy writer inside that window and read it as "the marker records a
+// completed write but registry.json is missing" -- the state-loss signature.
+// Inside the lock no transaction is in flight, so the second look tells a real
+// loss apart from a neighbour's commit in progress.
+//
+// This is the same contract the deadline gives the lock itself: a writer that is
+// alive and progressing is what a waiter is supposed to wait for, not a reason
+// to fail. The cost is that a genuinely degraded Registry now queues for the
+// lock before it is refused, which the deadline bounds.
+func (s *Store) withMutationLock(fn func() error) error {
+	suspected := s.refuseDegradedMutation()
+	return s.withLock(func() error {
+		if suspected != nil {
+			if confirmed := s.refuseDegradedMutation(); confirmed != nil {
+				return confirmed
+			}
+		}
+		return fn()
+	})
 }
 
 func (s *Store) withLock(fn func() error) error {

--- a/internal/integrations/metadata/store.go
+++ b/internal/integrations/metadata/store.go
@@ -20,6 +20,7 @@ package metadata
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -35,6 +36,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/crevissepartners/projmux/internal/config"
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
 	localstate "github.com/crevissepartners/projmux/internal/state"
@@ -44,6 +47,11 @@ const (
 	stateDirName   = "metadata"
 	registryFile   = "registry.json"
 	lockFileSuffix = ".lock"
+	// flockFileSuffix names the persistent descriptor the kernel lock queue is
+	// attached to. Unlike the marker it is never unlinked: an advisory flock
+	// belongs to an open file description, so a lock file that can be removed
+	// and recreated between two waiters is a lock two writers can hold at once.
+	flockFileSuffix = ".flock"
 	// markerFileName records that at least one registry write has completed.
 	// It is the boundary between "this operator has never registered a
 	// resource" and "the registry that existed is gone".
@@ -62,10 +70,18 @@ const (
 )
 
 var (
-	// Runtime mutation plans deliberately keep exact guard, execute, and
-	// reobserve work inside one Registry transaction. Allow an eight-writer
-	// create burst to serialize without crossing the 30s stale-break boundary.
-	defaultLockMaxAttempts         = 400
+	// defaultLockTimeout is the time budget one Registry mutation is allowed to
+	// spend waiting for the lock. It is deliberately a deadline and not a retry
+	// count: a mutation plan keeps exact guard, execute, and reobserve work
+	// inside one transaction, so what a waiter needs is a bound on how long a
+	// healthy queue may hold it up, not a bound on how many times it managed to
+	// poll while the machine was busy. Under an attempt budget a loaded machine
+	// changes the outcome of a write; under a deadline it changes only latency.
+	defaultLockTimeout = 30 * time.Second
+	// The recovery lock still spends an attempt budget against the wall clock.
+	// It is a separate lock on a separate path taken by explicit recovery
+	// operations, not by the eight-writer create burst, and it is out of this
+	// contract's scope; see withRecoveryLock.
 	defaultRecoveryLockMaxAttempts = 200
 	defaultLockBaseDelay           = 2 * time.Millisecond
 	defaultLockMaxDelay            = 50 * time.Millisecond
@@ -115,9 +131,13 @@ type storeHooks struct {
 type Store struct {
 	path           string
 	lockPath       string
+	flockPath      string
 	repairLockPath string
 	markerPath     string
 	recoveryDir    string
+	// lockTimeout bounds one mutation's wait for the lock. Tests shorten it;
+	// nothing in production overrides the default.
+	lockTimeout time.Duration
 	// retention is the number of recovery copies kept after a semantic write.
 	retention int
 	clock     func() time.Time
@@ -139,10 +159,12 @@ func NewStore(path string) *Store {
 	return &Store{
 		path:           path,
 		lockPath:       path + lockFileSuffix,
+		flockPath:      path + flockFileSuffix,
 		repairLockPath: path + ".repair" + lockFileSuffix,
 		markerPath:     filepath.Join(dir, markerFileName),
 		recoveryDir:    filepath.Join(dir, recoveryDirName),
 		retention:      defaultRecoveryRetention,
+		lockTimeout:    defaultLockTimeout,
 		clock:          time.Now,
 		migrations:     coremetadata.ProductionMigrationSet(),
 		// #nosec G404 -- lock retry jitter is scheduling noise, not a secret;
@@ -173,8 +195,9 @@ func (s *Store) Path() string {
 	return s.path
 }
 
-// SetClock overrides the timestamp source used for backups and stale-lock
-// breaking.
+// SetClock overrides the timestamp source used for backups, recovery stamps,
+// and the mutation lock deadline. Injecting a clock is what lets a test pin the
+// deadline without waiting on the real one.
 func (s *Store) SetClock(clock func() time.Time) {
 	if s != nil && clock != nil {
 		s.clock = clock
@@ -1198,12 +1221,11 @@ func (s *Store) withLock(fn func() error) error {
 	if err := localstate.EnsurePrivateDir(filepath.Dir(s.lockPath)); err != nil {
 		return fmt.Errorf("metadata: create lock dir: %w", err)
 	}
-	if err := s.acquireLock(); err != nil {
+	lease, err := s.acquireLock(context.Background())
+	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = os.Remove(s.lockPath)
-	}()
+	defer lease.release()
 	return fn()
 }
 
@@ -1262,59 +1284,199 @@ func (s *Store) tryBreakStaleRecoveryLock() bool {
 	return os.Remove(s.repairLockPath) == nil
 }
 
-func (s *Store) acquireLock() error {
-	return s.acquireLockWithPolicy(defaultLockMaxAttempts, defaultLockBaseDelay, defaultLockMaxDelay, time.Sleep)
+// ErrLockTimeout marks a Registry mutation that gave up waiting for the lock.
+// It is the deadline outcome, not a retry budget outcome: the operation was
+// allowed a fixed amount of time and the lock did not become available inside
+// it. Callers that distinguish "busy" from "broken" match on this.
+var ErrLockTimeout = errors.New("registry lock acquisition timed out")
+
+// registryLease is one held Registry mutation lock. It is two things at once
+// during the compatibility window: the kernel flock every current install
+// queues on, and the legacy O_EXCL marker that an older install on the same
+// Registry is still the only thing able to observe.
+type registryLease struct {
+	store  *Store
+	flock  *os.File
+	marker bool
 }
 
-// acquireLockWithPolicy applies the retry budget to one observed lock owner.
-// A create burst consists of several healthy, serialized owners; charging a
-// waiter for time spent behind owners that have already released the lock can
-// exhaust the budget even though no individual lease is stuck. Only an exact,
-// positive pid transition proves lease progress and resets the attempts. Empty,
-// malformed, or transiently unreadable lock contents keep consuming the current
-// owner's budget instead of manufacturing progress.
-func (s *Store) acquireLockWithPolicy(maxAttempts int, baseDelay, maxDelay time.Duration, sleep func(time.Duration)) error {
+// release drops exactly what this lease took. The marker is removed only when
+// this lease created it, because removing a marker we do not own would hand a
+// second writer the lock the real owner still holds.
+func (l *registryLease) release() {
+	if l == nil {
+		return
+	}
+	if l.marker && l.store != nil {
+		_ = os.Remove(l.store.lockPath)
+	}
+	if l.flock != nil {
+		_ = unix.Flock(int(l.flock.Fd()), unix.LOCK_UN)
+		_ = l.flock.Close()
+	}
+}
+
+func (s *Store) acquireLock(ctx context.Context) (*registryLease, error) {
+	return s.acquireLockWithDeadline(ctx, s.lockTimeout, time.Sleep)
+}
+
+// acquireLockWithDeadline takes the Registry mutation lock under an explicit
+// time budget.
+//
+// Mutual exclusion between current installs is the kernel's LOCK_EX wait queue,
+// so a waiter cannot be starved by contention and the success of a mutation no
+// longer depends on how many times it managed to poll before a budget ran out.
+// The legacy O_EXCL marker is still written, and still waited for, because an
+// install from before this change observes nothing else; that wait shares the
+// same deadline and reclaims a marker whose recorded owner is gone.
+//
+// Ordering is flock first and marker second in every current install, so the
+// two lock layers cannot be taken in opposite orders. An older install takes
+// only the marker and never waits on the flock, which leaves no cycle to
+// deadlock on.
+func (s *Store) acquireLockWithDeadline(ctx context.Context, timeout time.Duration, sleep func(time.Duration)) (*registryLease, error) {
+	if timeout <= 0 {
+		timeout = defaultLockTimeout
+	}
+	deadline := s.clock().Add(timeout)
+
+	held, err := s.acquireRegistryFlock(ctx, deadline, timeout)
+	if err != nil {
+		return nil, err
+	}
+	lease := &registryLease{store: s, flock: held}
+	if err := s.acquireLegacyMarker(ctx, deadline, timeout, sleep); err != nil {
+		lease.release()
+		return nil, err
+	}
+	lease.marker = true
+	return lease, nil
+}
+
+// acquireRegistryFlock blocks on the kernel lock queue for the persistent lock
+// descriptor until it is granted, the caller's context ends, or the deadline
+// passes.
+func (s *Store) acquireRegistryFlock(ctx context.Context, deadline time.Time, timeout time.Duration) (*os.File, error) {
+	held, err := os.OpenFile(s.flockPath, os.O_CREATE|os.O_RDWR, localstate.PrivateFileMode) // #nosec G304 -- path is the Store's own private registry lock sibling
+	if err != nil {
+		return nil, fmt.Errorf("metadata: open registry lock: %w", err)
+	}
+	fd := int(held.Fd())
+	// The uncontended path is the common one and costs nothing but the
+	// non-blocking attempt: no goroutine, no timer, no clock read.
+	switch err := unix.Flock(fd, unix.LOCK_EX|unix.LOCK_NB); {
+	case err == nil:
+		return held, nil
+	case !errors.Is(err, unix.EWOULDBLOCK):
+		_ = held.Close()
+		return nil, fmt.Errorf("metadata: acquire registry lock: %w", err)
+	}
+
+	remaining := deadline.Sub(s.clock())
+	if remaining <= 0 {
+		_ = held.Close()
+		return nil, s.lockTimeoutError(timeout, "another writer holds the registry lock")
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, remaining)
+	defer cancel()
+
+	granted := make(chan error, 1)
+	go func() { granted <- unix.Flock(fd, unix.LOCK_EX) }()
+
+	select {
+	case err := <-granted:
+		if err != nil {
+			_ = held.Close()
+			return nil, fmt.Errorf("metadata: acquire registry lock: %w", err)
+		}
+		return held, nil
+	case <-waitCtx.Done():
+		// The kernel wait outlives our deadline, so the descriptor is handed to
+		// a releaser instead of abandoned: a grant that arrives after we gave up
+		// must not leave the Registry locked by a mutation that is no longer
+		// running. Closing the descriptor is what ends the lock either way, and
+		// it happens only after the blocking call has returned.
+		go func() {
+			if err := <-granted; err == nil {
+				_ = unix.Flock(fd, unix.LOCK_UN)
+			}
+			_ = held.Close()
+		}()
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("metadata: acquire registry lock on %s: %w", s.flockPath, err)
+		}
+		return nil, s.lockTimeoutError(timeout, "another writer holds the registry lock")
+	}
+}
+
+// acquireLegacyMarker takes the O_EXCL marker file the pre-flock installs use.
+// Holding the kernel lock already excludes every current writer, so the only
+// contention left here is an older install, and the only reason the marker is
+// still written is that such an install has no other way to see us.
+func (s *Store) acquireLegacyMarker(ctx context.Context, deadline time.Time, timeout time.Duration, sleep func(time.Duration)) error {
 	if sleep == nil {
 		sleep = time.Sleep
 	}
 	delay := defaultLockBaseDelay
-	if baseDelay > 0 {
-		delay = baseDelay
-	}
-	if maxDelay <= 0 {
-		maxDelay = defaultLockMaxDelay
-	}
-	lastOwnerPID := 0
-	attempts := 0
-	for attempts < maxAttempts {
-		f, err := os.OpenFile(s.lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, localstate.PrivateFileMode)
-		if err == nil {
-			_, _ = fmt.Fprintf(f, "pid=%d\n", os.Getpid())
-			_ = f.Close()
+	for {
+		acquired, err := s.tryCreateLegacyMarker()
+		if err != nil {
+			return err
+		}
+		if !acquired && s.tryBreakStaleLock() {
+			// The recorded owner is gone, so try again inside this iteration
+			// rather than paying backoff for a holder that no longer exists.
+			if acquired, err = s.tryCreateLegacyMarker(); err != nil {
+				return err
+			}
+		}
+		if acquired {
 			return nil
 		}
-		if !errors.Is(err, os.ErrExist) {
-			return fmt.Errorf("metadata: acquire lock: %w", err)
-		}
-		if ownerPID, ok := observedLockOwnerPID(s.lockPath); ok {
-			if lastOwnerPID > 0 && ownerPID != lastOwnerPID {
-				attempts = 0
-			}
-			lastOwnerPID = ownerPID
-		}
-		attempts++
-		if s.tryBreakStaleLock() {
-			continue
+		if err := s.lockWaitExpired(ctx, deadline, timeout); err != nil {
+			return err
 		}
 		sleep(delay + s.lockJitter())
-		if delay < maxDelay {
+		if delay < defaultLockMaxDelay {
 			delay *= 2
-			if delay > maxDelay {
-				delay = maxDelay
+			if delay > defaultLockMaxDelay {
+				delay = defaultLockMaxDelay
 			}
 		}
 	}
-	return fmt.Errorf("metadata: acquire lock: exhausted %d attempts on %s", maxAttempts, s.lockPath)
+}
+
+// tryCreateLegacyMarker reports whether this call is the one that created the
+// marker. A marker that already exists is contention, not an error.
+func (s *Store) tryCreateLegacyMarker() (bool, error) {
+	marker, err := os.OpenFile(s.lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, localstate.PrivateFileMode)
+	switch {
+	case err == nil:
+		_, _ = fmt.Fprintf(marker, "pid=%d\n", os.Getpid())
+		_ = marker.Close()
+		return true, nil
+	case errors.Is(err, os.ErrExist):
+		return false, nil
+	default:
+		return false, fmt.Errorf("metadata: acquire lock: %w", err)
+	}
+}
+
+// lockWaitExpired reports the reason to stop waiting, or nil to keep waiting.
+// The deadline is read through s.clock() so the production code path and the
+// tests that pin it share one time source.
+func (s *Store) lockWaitExpired(ctx context.Context, deadline time.Time, timeout time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("metadata: acquire lock on %s: %w", s.lockPath, err)
+	}
+	if s.clock().Before(deadline) {
+		return nil
+	}
+	return s.lockTimeoutError(timeout, "an install without the kernel lock still holds the marker")
+}
+
+func (s *Store) lockTimeoutError(timeout time.Duration, cause string) error {
+	return fmt.Errorf("metadata: acquire lock on %s: %w after %s: %s", s.lockPath, ErrLockTimeout, timeout, cause)
 }
 
 func observedLockOwnerPID(path string) (int, bool) {
@@ -1336,13 +1498,34 @@ func (s *Store) lockJitter() time.Duration {
 	return time.Duration(s.rng.Int63n(int64(defaultLockBaseDelay) + 1))
 }
 
+// tryBreakStaleLock reclaims a marker whose recorded owner is gone.
+//
+// The predicate is the owner pid's liveness, not elapsed wall-clock time. A
+// holder that died a millisecond ago is exactly as absent as one that died a
+// minute ago, and a holder still running is never stale no matter how long its
+// transaction legitimately takes. The wall-clock predicate it replaces forced
+// production to read the real clock, which is what made the test that pinned
+// this behavior depend on the machine's load.
+//
+// An unreadable or malformed marker proves nothing about its owner and is never
+// reclaimed; the deadline ends that wait instead of a guess. The liveness read
+// and the removal are not atomic, so a marker created between them can be
+// removed -- the same narrow window the mtime predicate had, now measured
+// against a fact about the owner rather than against elapsed time.
 func (s *Store) tryBreakStaleLock() bool {
-	info, err := os.Stat(s.lockPath)
-	if err != nil {
-		return false
-	}
-	if s.clock().Sub(info.ModTime()) < defaultLockStaleAfter {
+	pid, ok := observedLockOwnerPID(s.lockPath)
+	if !ok || processAlive(pid) {
 		return false
 	}
 	return os.Remove(s.lockPath) == nil
+}
+
+// processAlive reports whether pid still names a live process. EPERM means the
+// process exists but belongs to another user, which is a live holder too.
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := unix.Kill(pid, 0)
+	return err == nil || errors.Is(err, unix.EPERM)
 }

--- a/internal/integrations/metadata/store_test.go
+++ b/internal/integrations/metadata/store_test.go
@@ -1014,10 +1014,25 @@ func holdRegistryFlock(t *testing.T, store *Store) {
 	if err := unix.Flock(int(held.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
 		t.Fatalf("hold registry flock: %v", err)
 	}
-	t.Cleanup(func() {
+	release := sync.OnceFunc(func() {
 		_ = unix.Flock(int(held.Fd()), unix.LOCK_UN)
 		_ = held.Close()
 	})
+	heldRegistryFlocks.Store(store, release)
+	t.Cleanup(release)
+}
+
+// heldRegistryFlocks lets a test release the stand-in holder before its cleanup
+// runs, for the cases that need the wait to end inside the test body.
+var heldRegistryFlocks sync.Map
+
+func releaseRegistryFlock(t *testing.T, store *Store) {
+	t.Helper()
+	release, ok := heldRegistryFlocks.Load(store)
+	if !ok {
+		t.Fatal("no registry flock is held for this store")
+	}
+	release.(func())()
 }
 
 // writeLegacyMarker reproduces exactly what an install from before the kernel
@@ -1321,6 +1336,77 @@ func TestRegistryLockGrantsEveryWriterUnderDeliberateContention(t *testing.T) {
 	}
 	if _, err := os.Stat(store.lockPath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("the marker survived the contended rounds: %v", err)
+	}
+	assertNoStagedGarbage(t, store)
+}
+
+// TestAConcurrentWriterIsNotRefusedInsideAnotherCommitsMarkerWindow pins the
+// C-1 assumption against the one window where a healthy Registry looks lost.
+//
+// A commit publishes the initialized marker before it renames the staged
+// registry into place. An observer without the lock that lands in that window
+// sees "the marker records a completed write but registry.json is missing" --
+// byte for byte the state-loss signature -- while nothing is wrong at all. The
+// degraded gate must not turn a neighbour's in-flight commit into a refusal: a
+// writer that is alive and progressing is exactly what the deadline says a
+// waiter should wait for.
+//
+// The window is built directly rather than raced into: the kernel lock stands in
+// for the committing writer, and the registry file is moved aside to reproduce
+// what that writer's transaction would transiently leave on disk.
+func TestAConcurrentWriterIsNotRefusedInsideAnotherCommitsMarkerWindow(t *testing.T) {
+	t.Parallel()
+
+	store := testStore(t)
+	registerProject(t, store, "/src/first")
+	staged := store.Path() + ".staged-by-the-committing-writer"
+	if err := os.Rename(store.Path(), staged); err != nil {
+		t.Fatalf("open the marker window: %v", err)
+	}
+	holdRegistryFlock(t, store)
+
+	done := make(chan error, 1)
+	go func() {
+		mutator := coremetadata.Mutator{
+			Now:       func() time.Time { return fixedNow },
+			NewUID:    coremetadata.NewUID,
+			DirExists: func(path string) (bool, error) { return path == "/src/second", nil },
+		}
+		_, err := store.Update(func(registry *coremetadata.Registry) error {
+			_, err := mutator.RegisterProject(registry, coremetadata.RegisterProjectOptions{
+				Root:         "/src/second",
+				DefaultShell: "/bin/zsh",
+				OperationID:  "op-second",
+			})
+			return err
+		})
+		done <- err
+	}()
+
+	// The refusal this guards against is immediate -- the gate only stats two
+	// paths -- so an answer arriving at all inside this window is the defect.
+	select {
+	case err := <-done:
+		t.Fatalf("the second writer answered inside another commit's marker window: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// The committing writer finishes: the staged bytes become the registry and
+	// its lock is released.
+	if err := os.Rename(staged, store.Path()); err != nil {
+		t.Fatalf("close the marker window: %v", err)
+	}
+	releaseRegistryFlock(t, store)
+
+	if err := <-done; err != nil {
+		t.Fatalf("the second writer was refused by a window that had closed: %v", err)
+	}
+	registry, err := store.Load()
+	if err != nil {
+		t.Fatalf("load after the window: %v", err)
+	}
+	if len(registry.Projects) != 2 {
+		t.Fatalf("projects = %d, want both writers' registrations", len(registry.Projects))
 	}
 	assertNoStagedGarbage(t, store)
 }

--- a/internal/integrations/metadata/store_test.go
+++ b/internal/integrations/metadata/store_test.go
@@ -7,16 +7,21 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	localstate "github.com/crevissepartners/projmux/internal/state"
 )
 
 var fixedNow = time.Date(2026, 8, 15, 9, 30, 0, 0, time.UTC)
@@ -50,6 +55,12 @@ func writeRegistryFile(t *testing.T, store *Store, contents string) {
 	}
 }
 
+// dirListing reports the registry state a directory holds. The persistent lock
+// descriptor is skipped: an advisory flock belongs to an open file description,
+// so that file is created once and never unlinked, and its appearance the first
+// time a store touches the directory says nothing about whether an operation
+// wrote registry state. Every other name -- staged temps, backups, quarantine
+// copies, the initialized marker -- is still reported.
 func dirListing(t *testing.T, dir string) []string {
 	t.Helper()
 	entries, err := os.ReadDir(dir)
@@ -58,6 +69,9 @@ func dirListing(t *testing.T, dir string) []string {
 	}
 	var names []string
 	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), flockFileSuffix) {
+			continue
+		}
 		names = append(names, entry.Name())
 	}
 	sort.Strings(names)
@@ -896,9 +910,12 @@ func TestConcurrentUpdatesSerializeThroughTheRegistryLock(t *testing.T) {
 	for i := range 8 {
 		roots[fmt.Sprintf("/src/p%d", i)] = true
 	}
-	// The lock's stale-breaking window is measured against the wall clock, so
-	// this test deliberately keeps the real clock instead of the fixed one.
+	// Nothing on the lock path reads the wall clock any more: exclusion is the
+	// kernel queue and staleness is the owner pid's liveness, so this test runs
+	// on the fixed clock like every other store test. Its outcome no longer
+	// depends on how much CPU the eight writers were given.
 	store := NewStore(PathFor(t.TempDir()))
+	store.SetClock(func() time.Time { return fixedNow })
 
 	var wg sync.WaitGroup
 	errs := make([]error, 8)
@@ -956,130 +973,373 @@ func TestConcurrentUpdatesSerializeThroughTheRegistryLock(t *testing.T) {
 	if _, err := os.Stat(store.markerPath); err != nil {
 		t.Fatalf("the concurrent updates did not establish the initialized marker: %v", err)
 	}
+	// Every lease released its kernel lock too, so the next writer is granted
+	// without waiting at all.
+	lease, err := store.acquireLock(t.Context())
+	if err != nil {
+		t.Fatalf("acquire after the concurrent updates: %v", err)
+	}
+	lease.release()
 }
 
-func TestRegistryLockRetryBudgetTracksVerifiedOwnerLease(t *testing.T) {
-	writeOwner := func(t *testing.T, path string, pid int) {
-		t.Helper()
-		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-			t.Fatalf("mkdir lock parent: %v", err)
-		}
-		if err := os.WriteFile(path, fmt.Appendf(nil, "pid=%d\n", pid), 0o600); err != nil {
-			t.Fatalf("write lock owner: %v", err)
-		}
+// steppingClock returns a clock that advances by step on every read. It is how
+// a deadline test reaches its deadline: the lock's time budget is spent in
+// simulated time, so the assertions never depend on how fast the machine ran
+// the loop.
+func steppingClock(start time.Time, step time.Duration) func() time.Time {
+	var mu sync.Mutex
+	now := start
+	return func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		reading := now
+		now = now.Add(step)
+		return reading
 	}
-	replaceOwner := func(t *testing.T, path string, pid int) {
-		t.Helper()
-		if err := os.Remove(path); err != nil {
-			t.Fatalf("remove prior lock owner: %v", err)
-		}
-		writeOwner(t, path, pid)
-	}
+}
 
-	t.Run("owner turnover resets the unchanged per-lease budget", func(t *testing.T) {
-		store := NewStore(PathFor(t.TempDir()))
-		writeOwner(t, store.lockPath, 1001)
-		sleeps := 0
-		err := store.acquireLockWithPolicy(2, time.Nanosecond, time.Nanosecond, func(time.Duration) {
-			sleeps++
-			switch sleeps {
-			case 1:
-				replaceOwner(t, store.lockPath, 1002)
-			case 2:
-				if err := os.Remove(store.lockPath); err != nil {
-					t.Fatalf("release second owner: %v", err)
-				}
-			}
-		})
-		if err != nil {
-			t.Fatalf("acquire after two healthy owners: %v", err)
-		}
-		if sleeps != 2 {
-			t.Fatalf("contention sleeps = %d, want 2 owner leases", sleeps)
-		}
-		if err := os.Remove(store.lockPath); err != nil {
-			t.Fatalf("release acquired lock: %v", err)
-		}
-		assertNoStagedGarbage(t, store)
+// holdRegistryFlock takes the kernel lock through an independent descriptor, the
+// way a second process would. flock is owned by the open file description, not
+// by the process, so this contends with the store under test exactly as another
+// install does.
+func holdRegistryFlock(t *testing.T, store *Store) {
+	t.Helper()
+	if err := localstate.EnsurePrivateDir(filepath.Dir(store.flockPath)); err != nil {
+		t.Fatalf("create lock dir: %v", err)
+	}
+	held, err := os.OpenFile(store.flockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open registry flock: %v", err)
+	}
+	if err := unix.Flock(int(held.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		t.Fatalf("hold registry flock: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = unix.Flock(int(held.Fd()), unix.LOCK_UN)
+		_ = held.Close()
 	})
+}
 
-	t.Run("unchanged owner exhausts exactly the production attempt count", func(t *testing.T) {
+// writeLegacyMarker reproduces exactly what an install from before the kernel
+// lock writes: the O_EXCL marker file and nothing else.
+func writeLegacyMarker(t *testing.T, store *Store, contents string) {
+	t.Helper()
+	if err := localstate.EnsurePrivateDir(filepath.Dir(store.lockPath)); err != nil {
+		t.Fatalf("create lock dir: %v", err)
+	}
+	if err := os.WriteFile(store.lockPath, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write legacy marker: %v", err)
+	}
+}
+
+// exitedPID returns the pid of a process that has really been reaped, so the
+// liveness predicate is exercised against an absent owner rather than against a
+// number chosen in the hope that nothing is using it.
+func exitedPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start throwaway process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("reap throwaway process: %v", err)
+	}
+	return pid
+}
+
+// TestRegistryLockFailsOnItsDeadlineNotOnAnAttemptBudget pins the failure
+// condition the C-1 contract now states: a mutation is allowed a fixed amount
+// of time, and running out of it is reported as that timeout. The old budget
+// reported "exhausted N attempts", which named how busy the machine was rather
+// than anything the caller decided.
+func TestRegistryLockFailsOnItsDeadlineNotOnAnAttemptBudget(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore(PathFor(t.TempDir()))
+	holdRegistryFlock(t, store)
+	// The first reading starts the budget and the second is already past it, so
+	// the contended wait ends on the deadline without any real elapsed time.
+	store.SetClock(steppingClock(fixedNow, time.Minute))
+
+	sleeps := 0
+	lease, err := store.acquireLockWithDeadline(t.Context(), 30*time.Second, func(time.Duration) { sleeps++ })
+	if lease != nil {
+		lease.release()
+		t.Fatal("a lease was granted while another writer held the kernel lock")
+	}
+	if !errors.Is(err, ErrLockTimeout) {
+		t.Fatalf("contended acquire error = %v, want %v", err, ErrLockTimeout)
+	}
+	if got := err.Error(); !strings.Contains(got, "after 30s") || strings.Contains(got, "attempt") {
+		t.Fatalf("timeout error = %q, want the granted budget and no attempt count", got)
+	}
+	if sleeps != 0 {
+		t.Fatalf("backoff sleeps = %d, want 0 before the kernel lock is granted", sleeps)
+	}
+	assertNoStagedGarbage(t, store)
+}
+
+// TestRegistryLockDeadlineIsMeasuredOnTheInjectedClock is the test that the
+// wall-clock stale window used to make impossible. Nothing here reads the real
+// clock, so the result cannot change with machine load.
+func TestRegistryLockDeadlineIsMeasuredOnTheInjectedClock(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore(PathFor(t.TempDir()))
+	writeLegacyMarker(t, store, fmt.Sprintf("pid=%d\n", os.Getpid()))
+	store.SetClock(steppingClock(fixedNow, 250*time.Millisecond))
+
+	start := time.Now()
+	sleeps := 0
+	lease, err := store.acquireLockWithDeadline(t.Context(), time.Second, func(time.Duration) { sleeps++ })
+	if lease != nil {
+		lease.release()
+		t.Fatal("a lease was granted while a live legacy holder owned the marker")
+	}
+	if !errors.Is(err, ErrLockTimeout) {
+		t.Fatalf("legacy contention error = %v, want %v", err, ErrLockTimeout)
+	}
+	if sleeps == 0 {
+		t.Fatal("the legacy marker wait never backed off, so it never actually waited")
+	}
+	// A one-second budget spent entirely in simulated time: the real clock
+	// barely moved, which is the property that removes the load dependency.
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("real elapsed time = %s, want a deadline spent on the injected clock", elapsed)
+	}
+	assertNoStagedGarbage(t, store)
+}
+
+// TestRegistryLockReclaimsAMarkerOnlyWhenItsOwnerIsGone covers the stale
+// predicate from both sides. A dead owner is reclaimed immediately instead of
+// after a fixed wall-clock window, and everything that does not prove the owner
+// is gone -- a live pid, an empty file, a malformed line, an unreadable path --
+// keeps the marker, because reclaiming on a guess hands two writers the lock.
+func TestRegistryLockReclaimsAMarkerOnlyWhenItsOwnerIsGone(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a reaped owner is reclaimed at once", func(t *testing.T) {
+		t.Parallel()
+
 		store := NewStore(PathFor(t.TempDir()))
-		writeOwner(t, store.lockPath, 2001)
+		writeLegacyMarker(t, store, fmt.Sprintf("pid=%d\n", exitedPID(t)))
+		store.SetClock(steppingClock(fixedNow, time.Minute))
+
 		sleeps := 0
-		err := store.acquireLockWithPolicy(defaultLockMaxAttempts, time.Nanosecond, time.Nanosecond, func(time.Duration) {
-			sleeps++
-		})
-		if err == nil || !strings.Contains(err.Error(), "exhausted 400 attempts") {
-			t.Fatalf("stable owner error = %v, want exact 400-attempt exhaustion", err)
+		lease, err := store.acquireLockWithDeadline(t.Context(), 30*time.Second, func(time.Duration) { sleeps++ })
+		if err != nil {
+			t.Fatalf("acquire over a dead owner's marker: %v", err)
 		}
-		if sleeps != defaultLockMaxAttempts {
-			t.Fatalf("stable owner sleeps = %d, want %d", sleeps, defaultLockMaxAttempts)
+		if sleeps != 0 {
+			t.Fatalf("backoff sleeps = %d, want 0 for an owner already gone", sleeps)
 		}
-		if err := os.Remove(store.lockPath); err != nil {
-			t.Fatalf("release fixture lock: %v", err)
+		owner, ok := observedLockOwnerPID(store.lockPath)
+		if !ok || owner != os.Getpid() {
+			t.Fatalf("marker owner = %d (parsed=%t), want this process %d", owner, ok, os.Getpid())
+		}
+		lease.release()
+		if _, err := os.Stat(store.lockPath); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("the marker survived release: %v", err)
 		}
 		assertNoStagedGarbage(t, store)
 	})
 
 	for _, test := range []struct {
-		name    string
-		replace func(*testing.T, string)
+		name  string
+		write func(*testing.T, *Store)
 	}{
-		{name: "empty owner", replace: func(t *testing.T, path string) {
+		{name: "a live owner", write: func(t *testing.T, store *Store) {
 			t.Helper()
-			if err := os.Remove(path); err != nil {
-				t.Fatalf("remove valid owner: %v", err)
-			}
-			if err := os.WriteFile(path, nil, 0o600); err != nil {
-				t.Fatalf("write empty owner: %v", err)
-			}
+			writeLegacyMarker(t, store, fmt.Sprintf("pid=%d\n", os.Getpid()))
 		}},
-		{name: "malformed owner", replace: func(t *testing.T, path string) {
+		{name: "an empty marker", write: func(t *testing.T, store *Store) {
 			t.Helper()
-			if err := os.WriteFile(path, []byte("owner=not-a-pid\n"), 0o600); err != nil {
-				t.Fatalf("write malformed owner: %v", err)
-			}
+			writeLegacyMarker(t, store, "")
 		}},
-		{name: "transiently unreadable owner", replace: func(t *testing.T, path string) {
+		{name: "a malformed marker", write: func(t *testing.T, store *Store) {
 			t.Helper()
-			if err := os.Remove(path); err != nil {
-				t.Fatalf("remove valid owner: %v", err)
+			writeLegacyMarker(t, store, "owner=not-a-pid\n")
+		}},
+		{name: "an unreadable marker", write: func(t *testing.T, store *Store) {
+			t.Helper()
+			if err := localstate.EnsurePrivateDir(filepath.Dir(store.lockPath)); err != nil {
+				t.Fatalf("create lock dir: %v", err)
 			}
-			if err := os.Mkdir(path, 0o700); err != nil {
-				t.Fatalf("replace owner with unreadable directory: %v", err)
+			if err := os.Mkdir(store.lockPath, 0o700); err != nil {
+				t.Fatalf("replace the marker with an unreadable directory: %v", err)
 			}
 		}},
 	} {
-		t.Run(test.name+" does not reset", func(t *testing.T) {
+		t.Run(test.name+" is never reclaimed", func(t *testing.T) {
+			t.Parallel()
+
 			store := NewStore(PathFor(t.TempDir()))
-			writeOwner(t, store.lockPath, 3001)
-			sleeps := 0
-			err := store.acquireLockWithPolicy(2, time.Nanosecond, time.Nanosecond, func(time.Duration) {
-				sleeps++
-				if sleeps == 1 {
-					test.replace(t, store.lockPath)
-				}
-			})
-			if err == nil || !strings.Contains(err.Error(), "exhausted 2 attempts") {
-				t.Fatalf("invalid owner error = %v, want bounded exhaustion", err)
+			test.write(t, store)
+			store.SetClock(steppingClock(fixedNow, time.Minute))
+
+			lease, err := store.acquireLockWithDeadline(t.Context(), 30*time.Second, func(time.Duration) {})
+			if lease != nil {
+				lease.release()
+				t.Fatal("the marker was reclaimed without proof that its owner is gone")
 			}
-			if sleeps != 2 {
-				t.Fatalf("invalid owner sleeps = %d, want 2 without reset", sleeps)
+			if !errors.Is(err, ErrLockTimeout) {
+				t.Fatalf("error = %v, want %v", err, ErrLockTimeout)
 			}
 			if err := os.RemoveAll(store.lockPath); err != nil {
-				t.Fatalf("remove invalid owner fixture: %v", err)
+				t.Fatalf("remove marker fixture: %v", err)
 			}
 			assertNoStagedGarbage(t, store)
 		})
 	}
 }
 
-func TestRegistryLockProductionBudgetConstantsRemainUnchanged(t *testing.T) {
-	if defaultLockMaxAttempts != 400 || defaultLockBaseDelay != 2*time.Millisecond ||
-		defaultLockMaxDelay != 50*time.Millisecond || defaultLockStaleAfter != 30*time.Second {
-		t.Fatalf("ordinary Registry lock budget drifted: attempts=%d base=%s max=%s stale=%s",
-			defaultLockMaxAttempts, defaultLockBaseDelay, defaultLockMaxDelay, defaultLockStaleAfter)
+// TestRegistryLockKeepsMutualExclusionWithAMarkerOnlyInstall covers the
+// compatibility window in both directions. An older install sees only the
+// marker, so the marker must still be written while the kernel lock is held;
+// and an older install that took the marker first must still exclude us even
+// though it never touches the kernel lock.
+func TestRegistryLockKeepsMutualExclusionWithAMarkerOnlyInstall(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a held lease blocks the marker-only path", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewStore(PathFor(t.TempDir()))
+		if err := localstate.EnsurePrivateDir(filepath.Dir(store.lockPath)); err != nil {
+			t.Fatalf("create lock dir: %v", err)
+		}
+		store.SetClock(func() time.Time { return fixedNow })
+
+		lease, err := store.acquireLockWithDeadline(t.Context(), 30*time.Second, func(time.Duration) {})
+		if err != nil {
+			t.Fatalf("acquire on an idle registry: %v", err)
+		}
+		// This is the whole of the older install's acquisition.
+		legacy, err := os.OpenFile(store.lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			_ = legacy.Close()
+			t.Fatal("a marker-only install acquired the lock while a lease was held")
+		}
+		if !errors.Is(err, os.ErrExist) {
+			t.Fatalf("marker-only acquisition error = %v, want %v", err, os.ErrExist)
+		}
+		lease.release()
+		// Once the lease is released the older install proceeds, so the
+		// compatibility window costs it nothing but the wait it already had.
+		reopened, err := os.OpenFile(store.lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatalf("marker-only acquisition after release: %v", err)
+		}
+		_ = reopened.Close()
+		if err := os.Remove(store.lockPath); err != nil {
+			t.Fatalf("release the marker-only lock: %v", err)
+		}
+		assertNoStagedGarbage(t, store)
+	})
+
+	t.Run("a marker-only holder blocks a lease", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewStore(PathFor(t.TempDir()))
+		writeLegacyMarker(t, store, fmt.Sprintf("pid=%d\n", os.Getpid()))
+		store.SetClock(steppingClock(fixedNow, time.Minute))
+
+		lease, err := store.acquireLockWithDeadline(t.Context(), 30*time.Second, func(time.Duration) {})
+		if lease != nil {
+			lease.release()
+			t.Fatal("a lease was granted while a marker-only install held the lock")
+		}
+		if !errors.Is(err, ErrLockTimeout) {
+			t.Fatalf("error = %v, want %v", err, ErrLockTimeout)
+		}
+		// The refused acquisition must leave the older install's marker alone.
+		owner, ok := observedLockOwnerPID(store.lockPath)
+		if !ok || owner != os.Getpid() {
+			t.Fatalf("marker owner after a refused acquire = %d (parsed=%t), want it untouched", owner, ok)
+		}
+		if err := os.Remove(store.lockPath); err != nil {
+			t.Fatalf("remove marker fixture: %v", err)
+		}
+		assertNoStagedGarbage(t, store)
+	})
+}
+
+// TestRegistryLockGrantsEveryWriterUnderDeliberateContention is the direct
+// enforcement of the C-1 guarantee. Contention is created on purpose -- every
+// worker loops on acquire and release with no pacing at all -- and the
+// assertions are that every acquisition eventually succeeds and that no two
+// critical sections overlap.
+//
+// The occupancy counter is atomic rather than plain. A file lock is invisible
+// to the race detector, which builds its happens-before edges out of Go
+// synchronization only, so a plain counter here would be reported as a race
+// even when exclusion is perfect. What `-race` contributes to this test is
+// coverage of the store's own concurrent internals; the exclusion itself is
+// asserted by the counter.
+func TestRegistryLockGrantsEveryWriterUnderDeliberateContention(t *testing.T) {
+	t.Parallel()
+
+	const (
+		writers = 8
+		rounds  = 16
+	)
+	store := NewStore(PathFor(t.TempDir()))
+	store.SetClock(func() time.Time { return fixedNow })
+	if err := localstate.EnsurePrivateDir(filepath.Dir(store.lockPath)); err != nil {
+		t.Fatalf("create lock dir: %v", err)
+	}
+
+	var inside, overlaps atomic.Int32
+	errs := make([]error, writers)
+	var wg sync.WaitGroup
+	for worker := range writers {
+		wg.Go(func() {
+			for range rounds {
+				lease, err := store.acquireLock(t.Context())
+				if err != nil {
+					errs[worker] = err
+					return
+				}
+				if inside.Add(1) != 1 {
+					overlaps.Add(1)
+				}
+				inside.Add(-1)
+				lease.release()
+			}
+		})
+	}
+	wg.Wait()
+
+	for worker, err := range errs {
+		if err != nil {
+			t.Fatalf("writer %d never acquired the lock: %v", worker, err)
+		}
+	}
+	if overlaps.Load() != 0 {
+		t.Fatalf("overlapping critical sections = %d, want 0", overlaps.Load())
+	}
+	if _, err := os.Stat(store.lockPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("the marker survived the contended rounds: %v", err)
+	}
+	assertNoStagedGarbage(t, store)
+}
+
+// TestRegistryLockProductionDeadlineConstantsRemainUnchanged pins the budget the
+// production path grants, and pins that this change left the separate recovery
+// lock's attempt budget exactly where it was.
+func TestRegistryLockProductionDeadlineConstantsRemainUnchanged(t *testing.T) {
+	if defaultLockTimeout != 30*time.Second || defaultLockBaseDelay != 2*time.Millisecond ||
+		defaultLockMaxDelay != 50*time.Millisecond {
+		t.Fatalf("ordinary Registry lock budget drifted: timeout=%s base=%s max=%s",
+			defaultLockTimeout, defaultLockBaseDelay, defaultLockMaxDelay)
+	}
+	if store := NewStore(PathFor(t.TempDir())); store.lockTimeout != defaultLockTimeout {
+		t.Fatalf("store lock timeout = %s, want the production default %s", store.lockTimeout, defaultLockTimeout)
+	}
+	if defaultRecoveryLockMaxAttempts != 200 || defaultLockStaleAfter != 30*time.Second {
+		t.Fatalf("the out-of-scope recovery lock budget drifted: attempts=%d stale=%s",
+			defaultRecoveryLockMaxAttempts, defaultLockStaleAfter)
 	}
 }
 


### PR DESCRIPTION
## What

The Registry mutation lock succeeded when it managed to create the `O_EXCL`
marker inside 400 polls. That makes the *outcome* of a write depend on how busy
the machine was: a queue of eight perfectly healthy writers can exhaust a
waiter's budget even though every individual lease was short. The C-1 contract
assumes "if the other writers are alive and progressing, my mutation eventually
gets the lock", and an attempt budget cannot promise that.

The success condition is now the time the operation was granted.

- `acquireLockWithDeadline` blocks on `flock(LOCK_EX)` against a persistent
  `registry.json.flock` descriptor. The kernel owns the wait queue, so no waiter
  is starved and load changes latency instead of the result.
- The legacy `registry.json.lock` `O_EXCL` marker is still written and still
  waited for. An install from before this change observes nothing else, so the
  marker is what keeps mutual exclusion intact across the mixed-install window.
  Order is flock-then-marker in every current install and marker-only in an old
  one, so there is no cycle to deadlock on.
- A marker is stale when its recorded pid is gone, not after 30s of wall clock.
  A holder that died a millisecond ago is exactly as absent as one that died a
  minute ago, and a live holder is never stale however long its transaction
  legitimately takes. An unreadable or malformed marker proves nothing about its
  owner and is never reclaimed -- the deadline ends that wait instead of a guess.

The separate recovery lock (`acquireRecoveryLock`) keeps its 200-attempt budget
and wall-clock stale window. It is a different lock on a different path, taken
by explicit recovery operations rather than by the create burst, and it is out
of scope here.

## Why the wall clock had to go

`TestConcurrentUpdatesSerializeThroughTheRegistryLock` carried a comment saying
it deliberately kept the real clock, because the behavior it pinned was defined
in terms of the real clock. That is the enforcement point for C-1 inheriting the
same defect as the contract. With staleness expressed as pid liveness, nothing
on the lock path reads the wall clock, and the test runs on the fixed clock like
every other store test.

## Tests

- `TestRegistryLockFailsOnItsDeadlineNotOnAnAttemptBudget` -- the contended
  failure is `ErrLockTimeout` naming the granted budget, with no attempt count.
- `TestRegistryLockDeadlineIsMeasuredOnTheInjectedClock` -- a whole one-second
  budget is spent in simulated time; real elapsed time stays under 500ms.
- `TestRegistryLockReclaimsAMarkerOnlyWhenItsOwnerIsGone` -- a genuinely reaped
  pid is reclaimed with zero backoff; live, empty, malformed, and unreadable
  owners are never reclaimed.
- `TestRegistryLockKeepsMutualExclusionWithAMarkerOnlyInstall` -- both
  directions of the compatibility window.
- `TestRegistryLockGrantsEveryWriterUnderDeliberateContention` -- 8 writers x 16
  rounds with no pacing; every acquisition is granted and no two critical
  sections overlap. The occupancy counter is atomic because a file lock is
  invisible to the race detector.
- `TestConcurrentUpdatesSerializeThroughTheRegistryLock` -- converted to the
  fixed clock, plus an acquire-after to prove every lease released its flock.
- `TestRegistryLockProductionDeadlineConstantsRemainUnchanged` -- pins the new
  budget and pins that the recovery lock's budget did not move.

New `Race Tests` CI job runs the metadata, notify, and recent-window packages
under `-race -count=2`, and is registered as a child of the `Test` aggregate.
No existing job name was renamed or removed.

`dirListing` in the test helpers now skips the `.flock` sibling: an advisory
flock lives on the open file description, so that file is created once and never
unlinked, and its appearance says nothing about whether an operation wrote
registry state. Every other name is still reported.

Registry JSON schema and the recovery retention policy are unchanged.

## Verification

- `make fmt`, `make fix`, `make test` -- green
- `go test -race -count=2` over the three concurrency packages -- green
- `make test-integration`, `make test-e2e` -- see the PR checks and comments

L06 is kept as a regression guard only. It has not failed since #822, so its
passing is not offered as evidence for this change; the evidence is the
deliberate-contention tests and the race job.

Roadmap: Test reliability and registry lock fairness / Phase 4 Registry 락 공정성
Contract: C-1 Guarantee·Scope·Failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second commit: the degraded gate had to be confirmed under the lock

The first CI run failed `Unit Tests` on
`TestConcurrentUpdatesSerializeThroughTheRegistryLock` with a signature that is
not lock exhaustion at all:

```
registry.initialized records a completed registry write but registry.json is missing
```

`refuseDegradedMutation` reads without the lock. A commit publishes the
initialized marker *before* it renames the staged registry into place, so an
observer landing in that window sees the state-loss signature while the
neighbour whose commit it saw is perfectly healthy -- and refuses a writer that
never got as far as the lock. That is the C-1 assumption failing for a reason
other than the retry budget.

The lock-free look stays as the fast path, but a positive answer is now a
suspicion confirmed under the lock before any mutation is refused. Inside the
lock no transaction is in flight, so the second look tells a real loss apart from
a commit in progress. A genuinely degraded Registry now queues for the lock
before it is refused, which the deadline bounds.

### Where the signature came from

It predates this branch: CI run `33235198748`, on a branch whose only changed
file was `ci.yml`, hit the identical failure in the same test. What this branch
changes is the *rate* -- the kernel queue hands the lock over with no backoff
gap, which packs the burst tightly enough for a late writer's pre-lock gate to
land inside the window.

Measured with `taskset -c 0,1`, 300 runs of the eight-writer test:

| head | failures / 300 |
| --- | ---: |
| `main` (df15ba03) | 0 |
| this branch, before the fix | 2 |
| this branch, after the fix | 0 |

`TestAConcurrentWriterIsNotRefusedInsideAnotherCommitsMarkerWindow` builds the
window directly rather than racing into it, and reproduces the exact CI error
when the fix is reverted. 60 runs of the whole package under `-race` on two CPUs
are green.

This is worth recording beyond this PR: the reliability report attributed this
test's flakiness to lock exhaustion, and `acquire lock: exhausted` has never been
observed in CI. The signature that actually shows up is a write lost after the
lock was granted.
