### PR TITLE
chore(build): enforce tidy go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,9 @@ jobs:
       - name: Check formatting
         run: make fmt-check
 
+      - name: Check module tidiness
+        run: make mod-tidy-check
+
   unit:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ SECURITY_TOOL_MANIFEST ?= .security/security-tools.versions
 
 DOCS_REFERENCE ?= docs/cli.md
 
-.PHONY: fmt fmt-check fix build install npm-pack docs test test-integration test-install-smoke test-e2e test-e2e-contract test-e2e-reliability test-e2e-shards test-e2e-manifest test-e2e-coverage test-e2e-update e2e verify deadcode deadcode-contract release-contract security security-serial security-go security-static security-policy security-contract security-tools
+.PHONY: fmt fmt-check mod-tidy-check fix build install npm-pack docs test test-integration test-install-smoke test-e2e test-e2e-contract test-e2e-reliability test-e2e-shards test-e2e-manifest test-e2e-coverage test-e2e-update e2e verify deadcode deadcode-contract release-contract security security-serial security-go security-static security-policy security-contract security-tools
 
 build:
 	@mkdir -p $(BUILD_DIR)
@@ -84,6 +84,9 @@ fmt-check:
 	else \
 		echo "no Go files to check"; \
 	fi
+
+mod-tidy-check:
+	$(GO) mod tidy -diff
 
 fix:
 	$(GO) fix ./...

--- a/go.mod
+++ b/go.mod
@@ -6,14 +6,16 @@ toolchain go1.26.6
 
 tool golang.org/x/tools/cmd/deadcode
 
-require github.com/spf13/cobra v1.10.2
+require (
+	github.com/spf13/cobra v1.10.2
+	golang.org/x/mod v0.37.0
+	golang.org/x/sys v0.46.0
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260610154732-fb80ec83bdd9 // indirect
 	golang.org/x/tools v0.46.0 // indirect
 )


### PR DESCRIPTION
## Summary

- accept the current Go toolchain tidy classification for direct x/mod and x/sys imports
- add a read-only mod-tidy-check Make target
- run the tidy gate inside the existing Format CI job

## Validation

- make fmt
- make fix
- make test
- make mod-tidy-check
- focused Format job structural assertion

Local integration and E2E gates will run while CI evaluates this head.