### PR TITLE
test(ci): close reliability residual policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,12 @@ jobs:
 
       - name: Run e2e Linux shard
         env:
+          # Across the 57-run Phase 5 evidence window, the slowest shard was
+          # fixture-3 (p50 167s, p95 177s, max 201s); the widest scenario tail
+          # was L12 (p50 7.185s, p95 8.081s, max 10.188s, max/p50 1.42).
+          # Scale 2 covers the measured wait-bearing tail without adopting the
+          # earlier unmeasured 3-5x suggestion; named timeouts still fail closed.
+          E2E_WAIT_SCALE: "2"
           PROJMUX_E2E_LINUX_SHARD: ${{ matrix.shard }}
         run: make test-e2e
 
@@ -401,6 +407,8 @@ jobs:
 
       - name: Run e2e suite
         env:
+          # Keep every required E2E child on the same measured wait policy.
+          E2E_WAIT_SCALE: "2"
           PROJMUX_E2E_SUITE: ${{ matrix.suite }}
         run: make test-e2e
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ SECURITY_TOOL_MANIFEST ?= .security/security-tools.versions
 
 DOCS_REFERENCE ?= docs/cli.md
 
-.PHONY: fmt fmt-check mod-tidy-check fix build install npm-pack docs test test-integration test-install-smoke test-e2e test-e2e-contract test-e2e-reliability test-e2e-shards test-e2e-manifest test-e2e-coverage test-e2e-update e2e verify deadcode deadcode-contract release-contract security security-serial security-go security-static security-policy security-contract security-tools
+.PHONY: fmt fmt-check mod-tidy-check fix build install npm-pack docs test test-integration test-install-smoke test-e2e test-e2e-contract test-e2e-reliability test-e2e-residual-policy test-e2e-shards test-e2e-manifest test-e2e-coverage test-e2e-update e2e verify deadcode deadcode-contract release-contract security security-serial security-go security-static security-policy security-contract security-tools
 
 build:
 	@mkdir -p $(BUILD_DIR)
@@ -131,6 +131,9 @@ test-e2e-contract:
 
 test-e2e-reliability:
 	test/e2e/reliability-contract.sh
+
+test-e2e-residual-policy:
+	test/e2e/residual-policy-contract.sh
 
 test-e2e-shards:
 	test/e2e/shard-contract.sh

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -454,6 +454,31 @@
   `test/e2e/reliability-contract.sh` F08/F09 pin both halves: a deliberately slow
   fixture times out with its own description and state dump and then passes once
   the scale buys it time, and the timeout instant itself moves with the scale.
+  CI sets that scale to `2` for both required E2E child families. The Phase 5
+  sample covered 57 runs: the slowest job family (`fixture-3`) had p50 167s,
+  p95 177s, and max 201s. Because the scale applies to scenario waits rather
+  than whole jobs, the deciding tail is the widest scenario distribution: L12
+  had p50 7.185s, p95 8.081s, and max 10.188s (`max/p50=1.42`). Rounding that up
+  to 2 gives headroom while retaining the named fail-closed timeout; the former
+  3-5x suggestion had no runner measurement and is not the configured policy.
+- `make test-e2e-residual-policy` pins the Phase 5 residual decision. The exact
+  required inventory remains `L01`-`L19`/`C01`/`N01` (21 scenarios), and
+  `test/e2e/quarantine.tsv` is empty because the 57-run, 1,128-group evidence
+  corpus found no scenario with three observed flakes. The companion
+  `test/e2e/residual-observations.tsv` records each scenario's actual terminal
+  attempt denominator (51-54 after whole-run self-regression exclusion), and
+  the contract requires its complete inventory and threshold-derived eligible
+  set to equal the quarantine ledger. A row is invalid without
+  a stable scenario ID, owner, ISO-8601 deadline, and at least three observations;
+  this closed zero-set contract rejects a non-empty row until execution/evidence
+  and non-gating wiring exist. Therefore the quarantine execution Negative is
+  N/A: its antecedent does not exist. Instead, the contract proves that both E2E
+  child families still feed the exact `E2E Tests` compatibility context and the
+  project-wide `Test` gate. Go `Unit Tests` remain an exact required child and
+  outside automatic classification/quarantine: they have no per-test attempt
+  artifact or `class` surface, so assigning an observed-flake count would invent
+  evidence. A future unit quarantine first needs attempt-preserving per-test
+  evidence and a separate contract.
 - `test/e2e/evidence-contract.sh` (`make test-e2e-contract`) and
   `test/e2e/reliability-contract.sh` (`make test-e2e-reliability`) keep the persisted
   `projmux.e2e-attempt/v1` evidence and success result hash stable while adding

--- a/test/e2e/quarantine.tsv
+++ b/test/e2e/quarantine.tsv
@@ -1,0 +1,4 @@
+# scenario_id	owner	deadline	observed_flakes
+# Phase 5 evidence (57 CI runs, 1,128 scenario/binary groups) found no scenario
+# with three observed flakes. The quarantine set is therefore intentionally
+# empty; entries require evidence, an owner, and an ISO-8601 deadline.

--- a/test/e2e/residual-observations.tsv
+++ b/test/e2e/residual-observations.tsv
@@ -1,0 +1,27 @@
+# scenario_id	attempts	observed_flakes
+# Window: CI runs with evidence since 2026-08-29T05:38Z through run 33293818203.
+# Method: count terminal scenario records after excluding the complete #840
+# two-head and #847 intermediate-head runs from both numerator and denominator.
+# Cancelled/early-exit runs contribute only scenarios that emitted a terminal
+# record, so each scenario keeps its own actual attempt denominator.
+C01	53	0
+L01	53	0
+L02	53	0
+L03	53	0
+L04	53	0
+L05	51	0
+L06	53	0
+L07	53	0
+L08	53	0
+L09	53	0
+L10	53	0
+L11	51	0
+L12	51	0
+L13	51	0
+L14	51	0
+L15	51	0
+L16	51	0
+L17	53	0
+L18	53	0
+L19	53	0
+N01	54	0

--- a/test/e2e/residual-policy-contract.sh
+++ b/test/e2e/residual-policy-contract.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+workflow="$root/.github/workflows/ci.yml"
+manifest="$root/test/e2e/linux-shards.tsv"
+quarantine="$root/test/e2e/quarantine.tsv"
+observations="$root/test/e2e/residual-observations.tsv"
+
+job_block() {
+	awk -v job="$1" '
+    $0 == "  " job ":" { inside = 1; next }
+    inside && /^  [^ ]/ { inside = 0 }
+    inside { print }
+  ' "$workflow"
+}
+
+linux_block="$(job_block e2e-linux)"
+suite_block="$(job_block e2e-suite)"
+e2e_gate_block="$(job_block e2e-tests)"
+test_gate_block="$(job_block test)"
+unit_block="$(job_block unit)"
+
+for pair in "e2e-linux:$linux_block" "e2e-suite:$suite_block"; do
+	job="${pair%%:*}"
+	body="${pair#*:}"
+	[[ "$(grep -Fxc '          E2E_WAIT_SCALE: "2"' <<<"$body")" == "1" ]] || {
+		echo "$job must apply the measured CI E2E_WAIT_SCALE=2 exactly once" >&2
+		exit 1
+	}
+done
+
+python3 - "$manifest" "$quarantine" "$observations" <<'PY'
+import datetime
+import pathlib
+import re
+import sys
+
+manifest = pathlib.Path(sys.argv[1])
+quarantine = pathlib.Path(sys.argv[2])
+observations = pathlib.Path(sys.argv[3])
+
+linux_ids = []
+for line in manifest.read_text(encoding="utf-8").splitlines():
+    shard, ids = line.split("\t", 1)
+    if not shard or not ids:
+        raise SystemExit("empty Linux shard manifest row")
+    linux_ids.extend(ids.split())
+
+required = linux_ids + ["C01", "N01"]
+expected = [f"L{number:02d}" for number in range(1, 20)] + ["C01", "N01"]
+if sorted(required) != sorted(expected) or len(required) != len(set(required)):
+    raise SystemExit("required E2E scenario mapping is not exact L01-L19/C01/N01")
+
+rows = []
+for number, line in enumerate(quarantine.read_text(encoding="utf-8").splitlines(), 1):
+    if not line or line.startswith("#"):
+        continue
+    fields = line.split("\t")
+    if len(fields) != 4:
+        raise SystemExit(f"quarantine row {number} must have four tab-separated fields")
+    scenario, owner, deadline, observed = fields
+    if scenario not in expected:
+        raise SystemExit(f"quarantine row {number} names an unknown scenario: {scenario}")
+    if not re.fullmatch(r"[a-z][a-z0-9-]{0,47}", owner):
+        raise SystemExit(f"quarantine row {number} has an invalid owner")
+    try:
+        datetime.date.fromisoformat(deadline)
+    except ValueError as error:
+        raise SystemExit(f"quarantine row {number} has an invalid deadline") from error
+    try:
+        observed_count = int(observed)
+    except ValueError as error:
+        raise SystemExit(f"quarantine row {number} has a non-integer observation count") from error
+    if observed_count < 3:
+        raise SystemExit(f"quarantine row {number} has fewer than three observed flakes")
+    rows.append(scenario)
+
+if len(rows) != len(set(rows)):
+    raise SystemExit("quarantine contains a duplicate scenario")
+
+observed = {}
+for number, line in enumerate(observations.read_text(encoding="utf-8").splitlines(), 1):
+    if not line or line.startswith("#"):
+        continue
+    fields = line.split("\t")
+    if len(fields) != 3:
+        raise SystemExit(f"observation row {number} must have three tab-separated fields")
+    scenario, attempts_text, flakes_text = fields
+    if scenario in observed or scenario not in expected:
+        raise SystemExit(f"observation row {number} has a duplicate or unknown scenario")
+    try:
+        attempts = int(attempts_text)
+        flakes = int(flakes_text)
+    except ValueError as error:
+        raise SystemExit(f"observation row {number} has a non-integer count") from error
+    if attempts < 1 or flakes < 0 or flakes > attempts:
+        raise SystemExit(f"observation row {number} has an invalid denominator/numerator")
+    observed[scenario] = (attempts, flakes)
+
+if set(observed) != set(expected):
+    raise SystemExit("residual observations do not cover exact L01-L19/C01/N01")
+eligible = sorted(scenario for scenario, (_, flakes) in observed.items() if flakes >= 3)
+if sorted(rows) != eligible:
+    raise SystemExit(
+        f"quarantine/evidence mismatch: quarantine={sorted(rows)} eligible={eligible}"
+    )
+if rows:
+    raise SystemExit(
+        "Phase 5 has no evidence-backed quarantine entries; add execution/evidence "
+        "and non-gating wiring before changing this closed mapping"
+    )
+
+print(
+    f">> residual policy required={len(required)} quarantine={len(rows)} "
+    f"threshold=3 scenario_attempts={sum(attempts for attempts, _ in observed.values())}"
+)
+print(
+    ">> Negative N/A: quarantine is empty, so no quarantined execution route exists; "
+    "required mapping remains exact L01-L19/C01/N01"
+)
+PY
+
+# Empty quarantine means the existing fail-closed topology must be byte-for-byte
+# present: both E2E child families still feed the exact required compatibility
+# context and the project-wide Test aggregate.
+grep -Fqx '    name: E2E Tests' <<<"$e2e_gate_block"
+grep -Fqx '    if: always()' <<<"$e2e_gate_block"
+for child in e2e-linux e2e-suite; do
+	grep -Fqx "      - $child" <<<"$e2e_gate_block"
+	grep -Fq -- "--required $child" <<<"$e2e_gate_block"
+	grep -Fqx "      - $child" <<<"$test_gate_block"
+	grep -Fq -- "--required $child" <<<"$test_gate_block"
+done
+
+# Go unit tests have no attempt evidence/classification surface. Phase 5 keeps
+# that blind spot outside automatic quarantine and leaves the exact required
+# child in place instead of inventing observations.
+grep -Fqx '    name: Unit Tests' <<<"$unit_block"
+grep -Fqx '      - unit' <<<"$test_gate_block"
+grep -Fq -- '--required unit' <<<"$test_gate_block"
+
+echo ">> Unit Tests remains required; classification/quarantine is N/A without per-test attempt evidence"


### PR DESCRIPTION
## Summary
- set `E2E_WAIT_SCALE=2` from the 57-run runner/scenario timing distribution instead of the earlier unmeasured 3-5x suggestion
- pin the 21-scenario residual denominator and evidence-derived zero quarantine set while preserving the exact `E2E Tests` context and aggregate children
- document that `Unit Tests` remains required and outside automatic classification until per-test attempt evidence exists

## Evidence
- 57 evidence-bearing CI runs since `2026-08-29T05:38Z`; 1,128 scenario/binary groups, nondeterministic 0, flips 0
- exclude PR #840's two L12 self-regression runs and PR #847's intermediate L10/L11 self-regression run from both residual numerator and denominator
- release-please after Phase 1: 0/11 failures, compared with the prior 9/72 (12.5%) baseline
- quarantine threshold: observed flaky at least 3 times; qualifying scenarios: 0

## Test plan
- [x] `make test-e2e-residual-policy`
- [x] `make test-e2e-contract`
- [x] `make test-e2e-reliability`
- [x] `make test-e2e-shards`
- [x] `make fmt`
- [x] `make fix`
- [x] `make test`
- [x] `make test-integration`
- [x] `make test-e2e`

## Globalization
- [x] No user-facing string changes.

## Scope
- No scenario fixes or shard rebalance.
- No recovery, notify, recentwindows, or Registry lock changes.
- No required status-context rename/removal; `E2E Tests` remains exact.

Roadmap: Test reliability and registry lock fairness / Phase 5 잔량 판정과 quarantine
Contract: C-3 Failure.Recovery
