### PR TITLE
fix(broker): synchronize host startup and shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,15 +186,12 @@ jobs:
       - name: Run unit tests
         run: make test
 
-  # The registry lock is the only mutual exclusion the whole application layer
-  # stands on, and its correctness is a property of concurrent execution, not of
-  # any single call. `make test` runs without the detector so the ordinary unit
-  # gate stays fast; this job runs the detector over the packages whose tests
-  # actually create contention. It is scoped on purpose -- `-race` across the
-  # full suite buys coverage of code that never runs concurrently at the cost of
-  # every contributor's feedback loop.
-  race:
-    name: Race Tests
+  # `make test` runs without the detector so the ordinary unit gate stays fast.
+  # Keep the detector on the packages whose contracts actually create
+  # contention, with the broker and its app-server transport isolated from the
+  # existing core set so neither child can mask the other's result.
+  race-core:
+    name: Race / Core concurrency
     runs-on: ubuntu-latest
 
     steps:
@@ -213,6 +210,65 @@ jobs:
             ./internal/integrations/metadata/... \
             ./internal/core/notify/... \
             ./internal/core/recentwindows/...
+
+  race-broker:
+    name: Race / Codex broker
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run broker concurrency tests under the race detector
+        run: go test -race -count=2 ./internal/integrations/agents/codexbroker/...
+
+  race-appserver:
+    name: Race / Codex app-server
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run app-server concurrency tests under the race detector
+        run: go test -race -count=2 ./internal/integrations/agents/codexappserver/...
+
+  # Keep the stable Race Tests context while reducing every detector child
+  # through the same fail-closed policy used by the other CI aggregates.
+  race:
+    name: Race Tests
+    if: always()
+    needs:
+      - race-core
+      - race-broker
+      - race-appserver
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout aggregate policy
+        uses: actions/checkout@v6
+
+      - name: Require every race child to succeed
+        env:
+          REQUIRED_RESULTS: ${{ toJSON(needs) }}
+        run: |
+          python3 scripts/required-gate.py \
+            --results-json "$REQUIRED_RESULTS" \
+            --required race-core \
+            --required race-broker \
+            --required race-appserver
 
   darwin-native:
     name: Darwin Native Key Adapter

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ SECURITY_TOOL_MANIFEST ?= .security/security-tools.versions
 
 DOCS_REFERENCE ?= docs/cli.md
 
-.PHONY: fmt fmt-check mod-tidy-check fix build install npm-pack docs test test-integration test-install-smoke test-e2e test-e2e-contract test-e2e-reliability test-e2e-residual-policy test-e2e-shards test-e2e-manifest test-e2e-coverage test-e2e-update e2e verify deadcode deadcode-contract release-contract security security-serial security-go security-static security-policy security-contract security-tools
+.PHONY: fmt fmt-check mod-tidy-check fix build install npm-pack docs test test-integration test-install-smoke test-e2e test-e2e-contract test-e2e-reliability test-e2e-residual-policy test-e2e-shards test-e2e-manifest test-e2e-coverage test-e2e-update e2e verify deadcode deadcode-contract release-contract ci-contract security security-serial security-go security-static security-policy security-contract security-tools
 
 build:
 	@mkdir -p $(BUILD_DIR)
@@ -111,11 +111,14 @@ deadcode: deadcode-contract
 deadcode-contract:
 	python3 -m unittest discover -s test -p 'deadcode_baseline_test.py'
 
-test: deadcode-contract release-contract
+test: deadcode-contract release-contract ci-contract
 	$(GO) test ./...
 
 release-contract:
 	python3 -m unittest discover -s test -p 'release_workflow_contract_test.py'
+
+ci-contract:
+	python3 -m unittest discover -s test -p 'ci_workflow_contract_test.py'
 
 test-integration:
 	scripts/test-integration-docker.sh

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -554,8 +554,16 @@
   refuse a writer that never reached the lock.
   `TestAConcurrentWriterIsNotRefusedInsideAnotherCommitsMarkerWindow` builds that
   window directly and requires the second writer to wait through it. The
-  `Race Tests` CI job runs the metadata, notify, and recent-window packages
-  under `-race`.
+  `TestHostStartupAndShutdownHaveDeterministicHappensBefore` pins `StartHost`
+  return as the startup barrier: immediate and concurrent `Close` stop accept
+  before waiting for sessions, stop the broker before publishing the shared
+  terminal `Done`, and return every caller through that same channel.
+  `TestStaleRuntimeArtifactsAreReclaimedOnlyByExactOwnerProof/late_old_host_close_preserves_replacement_artifacts`
+  keeps shutdown cleanup behind `SameFile`, so an old Host cannot remove or
+  change a replacement socket or record. The stable `Race Tests` CI aggregate
+  now fails closed over separate core, Codex broker, and Codex app-server
+  children; the core child preserves metadata, notify, and recent-window
+  coverage, and `CIWorkflowContractTest` pins both Codex failure paths red.
   The real-tmux L06 burst still requires all eight exact-socket creates to
   converge on one Window with nine unique mirrored Panes and no lock or staged
   residue; it is a regression guard, not the evidence for the lock change.

--- a/internal/integrations/agents/codexbroker/host.go
+++ b/internal/integrations/agents/codexbroker/host.go
@@ -95,9 +95,11 @@ type Host struct {
 	socketInfo os.FileInfo
 	recordInfo os.FileInfo
 
-	done      chan struct{}
-	closeOnce sync.Once
-	sessions  sync.WaitGroup
+	done        chan struct{}
+	acceptReady chan struct{}
+	acceptDone  chan struct{}
+	closeOnce   sync.Once
+	sessions    sync.WaitGroup
 
 	mu       sync.Mutex
 	closing  bool
@@ -141,15 +143,17 @@ func StartHost(cfg HostConfig) (*Host, error) {
 		return nil, refuse(RefusalRuntimeExists, err)
 	}
 	host := &Host{
-		discovery:  cfg.Discovery,
-		broker:     cfg.Broker,
-		idle:       cfg.IdleTimeout,
-		protocol:   cfg.Protocol.normalize(),
-		runtimeID:  runtimeID,
-		credential: credential,
-		listener:   listener,
-		live:       make(map[*net.UnixConn]struct{}),
-		done:       make(chan struct{}),
+		discovery:   cfg.Discovery,
+		broker:      cfg.Broker,
+		idle:        cfg.IdleTimeout,
+		protocol:    cfg.Protocol.normalize(),
+		runtimeID:   runtimeID,
+		credential:  credential,
+		listener:    listener,
+		live:        make(map[*net.UnixConn]struct{}),
+		done:        make(chan struct{}),
+		acceptReady: make(chan struct{}),
+		acceptDone:  make(chan struct{}),
 	}
 	if host.idle == 0 {
 		host.idle = defaultIdleTimeout
@@ -159,8 +163,17 @@ func StartHost(cfg HostConfig) (*Host, error) {
 		removeIfSame(path, host.socketInfo)
 		return nil, err
 	}
-	host.armIdle()
+	// Keep the default auto-unlink through publication failures. Once the Host
+	// is fully published, disable path-based listener cleanup so removeIfSame
+	// is the only shutdown owner and a late old Host cannot delete a replacement.
+	listener.SetUnlinkOnClose(false)
 	go host.accept()
+	// StartHost is the public startup barrier. Waiting for acceptReady makes
+	// the accept owner visible before the Host escapes to a caller that may
+	// immediately call Close; acceptDone then gives Close an exact proof that
+	// no session can be added before it waits for them.
+	<-host.acceptReady
+	host.armIdle()
 	return host, nil
 }
 
@@ -234,6 +247,10 @@ func (h *Host) Close() error {
 			timer.Stop()
 		}
 		_ = h.listener.Close()
+		// The accept loop is the only owner allowed to add a session. Once it
+		// has stopped, sessions.Wait cannot race a future Add or return before
+		// an already-accepted session has been accounted for.
+		<-h.acceptDone
 		removeIfSame(h.discovery.SocketPath(), h.socketInfo)
 		removeIfSame(h.discovery.RecordPath(), h.recordInfo)
 		for _, conn := range live {
@@ -249,6 +266,8 @@ func (h *Host) Close() error {
 
 // accept serves connections until the listener closes.
 func (h *Host) accept() {
+	defer close(h.acceptDone)
+	close(h.acceptReady)
 	for {
 		conn, err := h.listener.AcceptUnix()
 		if err != nil {

--- a/internal/integrations/agents/codexbroker/runtime_test.go
+++ b/internal/integrations/agents/codexbroker/runtime_test.go
@@ -9,11 +9,109 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/crevissepartners/projmux/internal/integrations/agents/codexappserver"
 )
+
+// TestHostStartupAndShutdownHaveDeterministicHappensBefore is the public Host
+// lifecycle boundary. StartHost does not return until the accept owner exists;
+// Close stops that owner before waiting for sessions, then stops the broker,
+// and only then publishes the one terminal Done observed by every caller.
+func TestHostStartupAndShutdownHaveDeterministicHappensBefore(t *testing.T) {
+	t.Run("immediate close orders accept broker and done", func(t *testing.T) {
+		discovery := newRuntimeDiscovery(t)
+		broker, _, _ := newTestBroker(t, 8)
+		host, err := StartHost(HostConfig{Discovery: discovery, Broker: broker, IdleTimeout: -1})
+		if err != nil {
+			t.Fatalf("StartHost() = %v", err)
+		}
+		t.Cleanup(func() { _ = host.Close() })
+
+		select {
+		case <-host.acceptReady:
+		default:
+			t.Fatal("StartHost returned before the accept owner was ready")
+		}
+		if err := host.Close(); err != nil {
+			t.Fatalf("Close() = %v", err)
+		}
+		select {
+		case <-host.acceptDone:
+		default:
+			t.Fatal("Done closed before the accept owner stopped")
+		}
+		select {
+		case <-broker.exit:
+		default:
+			t.Fatal("Done closed before the broker stopped")
+		}
+		select {
+		case <-host.Done():
+		default:
+			t.Fatal("Close returned before Done closed")
+		}
+		assertNoRuntimeArtifacts(t, discovery)
+	})
+
+	t.Run("concurrent callers observe one terminal done", func(t *testing.T) {
+		discovery := newRuntimeDiscovery(t)
+		broker, _, _ := newTestBroker(t, 8)
+		host, err := StartHost(HostConfig{Discovery: discovery, Broker: broker, IdleTimeout: -1})
+		if err != nil {
+			t.Fatalf("StartHost() = %v", err)
+		}
+		t.Cleanup(func() { _ = host.Close() })
+		terminal := host.Done()
+
+		const callers = 8
+		type closeResult struct {
+			done   <-chan struct{}
+			closed bool
+			err    error
+		}
+		start := make(chan struct{})
+		results := make(chan closeResult, callers)
+		var ready sync.WaitGroup
+		ready.Add(callers)
+		for range callers {
+			go func() {
+				observed := host.Done()
+				ready.Done()
+				<-start
+				err := host.Close()
+				closed := false
+				select {
+				case <-observed:
+					closed = true
+				default:
+				}
+				results <- closeResult{done: observed, closed: closed, err: err}
+			}()
+		}
+		ready.Wait()
+		close(start)
+		for range callers {
+			select {
+			case result := <-results:
+				if result.err != nil {
+					t.Fatalf("concurrent Close() = %v", result.err)
+				}
+				if result.done != terminal {
+					t.Fatal("concurrent Close caller observed a different Done channel")
+				}
+				if !result.closed {
+					t.Fatal("concurrent Close returned before the shared Done closed")
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatal("concurrent Close callers did not terminate")
+			}
+		}
+		assertNoRuntimeArtifacts(t, discovery)
+	})
+}
 
 // TestConcurrentClientsShareOneRuntimeProcessAndOneUpstreamConnection is the
 // singleton contract across real processes.
@@ -94,12 +192,13 @@ func TestConcurrentClientsShareOneRuntimeProcessAndOneUpstreamConnection(t *test
 			t.Fatalf("client %d exited with %v", index, err)
 		}
 	}
-	// Every client is gone, so the runtime holds no binding. Its bounded idle
-	// shutdown must remove exactly what it published and leave no process.
+	// Every client is gone, so the runtime holds no binding. The unique boundary
+	// here is process-level singleton convergence: the shared runtime must stop.
+	// Exact idle-shutdown artifact cleanup is owned by
+	// TestLastBindingRemovalIdlesTheRuntimeOutAndLeavesNoArtifact.
 	waitFor(t, "the shared runtime to idle out", func() bool {
 		return countLedger(t, ledger, "stopped ") == 1
 	})
-	assertNoRuntimeArtifacts(t, discovery)
 }
 
 // TestStaleRuntimeArtifactsAreReclaimedOnlyByExactOwnerProof is the ownership
@@ -192,6 +291,56 @@ func TestStaleRuntimeArtifactsAreReclaimedOnlyByExactOwnerProof(t *testing.T) {
 				}
 				assertNoRuntimeArtifacts(t, discovery)
 			})
+		}
+	})
+
+	t.Run("late old host close preserves replacement artifacts", func(t *testing.T) {
+		discovery := newRuntimeDiscovery(t)
+		oldHost, _ := startTestHost(t, discovery, -1, ProtocolRange{})
+		// The open old listener keeps its unlinked socket allocated. Keep the
+		// removed record inode allocated too, so the replacement fixture has
+		// distinct exact owners on both paths.
+		oldRecord, err := os.Open(discovery.RecordPath()) // #nosec G304 -- test-owned record path.
+		if err != nil {
+			t.Fatalf("pin old record: %v", err)
+		}
+		defer oldRecord.Close()
+		if err := os.Remove(discovery.SocketPath()); err != nil {
+			t.Fatalf("unlink old socket: %v", err)
+		}
+		if err := os.Remove(discovery.RecordPath()); err != nil {
+			t.Fatalf("unlink old record: %v", err)
+		}
+
+		replacement, _ := startTestHost(t, discovery, -1, ProtocolRange{})
+		replacementSocket := lstatOf(t, discovery.SocketPath())
+		replacementRecord := lstatOf(t, discovery.RecordPath())
+		if os.SameFile(oldHost.socketInfo, replacementSocket) || os.SameFile(oldHost.recordInfo, replacementRecord) {
+			t.Fatal("replacement fixture did not establish distinct exact owners")
+		}
+		recordBefore, err := os.ReadFile(discovery.RecordPath()) // #nosec G304 -- test-owned record path.
+		if err != nil {
+			t.Fatalf("read replacement record: %v", err)
+		}
+
+		if err := oldHost.Close(); err != nil {
+			t.Fatalf("old Host.Close() = %v", err)
+		}
+		if current := lstatOf(t, discovery.SocketPath()); !os.SameFile(replacementSocket, current) {
+			t.Fatal("late old Host.Close removed the replacement socket")
+		}
+		if current := lstatOf(t, discovery.RecordPath()); !os.SameFile(replacementRecord, current) {
+			t.Fatal("late old Host.Close removed the replacement record")
+		}
+		recordAfter, err := os.ReadFile(discovery.RecordPath()) // #nosec G304 -- test-owned record path.
+		if err != nil {
+			t.Fatalf("read replacement record after old Close: %v", err)
+		}
+		if string(recordAfter) != string(recordBefore) {
+			t.Fatal("late old Host.Close changed the replacement record")
+		}
+		if replacement.RuntimeID() == oldHost.RuntimeID() {
+			t.Fatal("replacement reused the old Host runtime identity")
 		}
 	})
 }

--- a/test/ci_workflow_contract_test.py
+++ b/test/ci_workflow_contract_test.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def workflow_job(workflow: str, job: str) -> str:
+    lines = workflow.splitlines()
+    marker = f"  {job}:"
+    try:
+        start = lines.index(marker) + 1
+    except ValueError as exc:
+        raise AssertionError(f"workflow job is missing: {job}") from exc
+    end = next(
+        (
+            index
+            for index in range(start, len(lines))
+            if lines[index].startswith("  ")
+            and not lines[index].startswith("   ")
+        ),
+        len(lines),
+    )
+    return "\n".join(lines[start:end])
+
+
+class CIWorkflowContractTest(unittest.TestCase):
+    def test_race_children_preserve_coverage_behind_the_stable_aggregate(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        core = workflow_job(workflow, "race-core")
+        broker = workflow_job(workflow, "race-broker")
+        appserver = workflow_job(workflow, "race-appserver")
+        aggregate = workflow_job(workflow, "race")
+        required_test = workflow_job(workflow, "test")
+
+        for package in (
+            "./internal/integrations/metadata/...",
+            "./internal/core/notify/...",
+            "./internal/core/recentwindows/...",
+        ):
+            self.assertIn(package, core)
+        self.assertIn(
+            "go test -race -count=2 ./internal/integrations/agents/codexbroker/...",
+            broker,
+        )
+        self.assertIn(
+            "go test -race -count=2 ./internal/integrations/agents/codexappserver/...",
+            appserver,
+        )
+
+        self.assertIn("    name: Race Tests", aggregate)
+        self.assertIn("    if: always()", aggregate)
+        for child in ("race-core", "race-broker", "race-appserver"):
+            self.assertIn(f"      - {child}", aggregate)
+            self.assertIn(f"--required {child}", aggregate)
+        self.assertIn("      - race", required_test)
+        self.assertIn("--required race", required_test)
+        self.assertNotIn("      - race-broker", required_test)
+        self.assertNotIn("      - race-appserver", required_test)
+
+    def test_broker_and_appserver_failure_make_race_tests_red(self) -> None:
+        children = ("race-core", "race-broker", "race-appserver")
+        gate = ROOT / "scripts/required-gate.py"
+        for failed in ("race-broker", "race-appserver"):
+            with self.subTest(failed=failed):
+                results = {
+                    child: {"result": "failure" if child == failed else "success"}
+                    for child in children
+                }
+                command = [
+                    sys.executable,
+                    str(gate),
+                    "--results-json",
+                    json.dumps(results),
+                ]
+                for child in children:
+                    command.extend(("--required", child))
+                completed = subprocess.run(
+                    command,
+                    cwd=ROOT,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(completed.returncode, 1)
+                self.assertIn(
+                    f"required gate: unsuccessful children: {failed}=failure",
+                    completed.stderr,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make `StartHost` return a deterministic startup boundary and order accept/session/broker/Done shutdown
- keep concurrent and repeated `Host.Close` callers on one terminal `Done`
- preserve replacement discovery socket/record through `SameFile` exact-owner cleanup
- add broker and app-server race children behind the fail-closed stable `Race Tests` aggregate
- consolidate duplicate lifecycle assertions under canonical owners

## Test ownership receipt

- removed the duplicate artifact-zero assertion from `TestConcurrentClientsShareOneRuntimeProcessAndOneUpstreamConnection`; `TestLastBindingRemovalIdlesTheRuntimeOutAndLeavesNoArtifact` remains its canonical owner
- merged late-old-Host replacement preservation into `TestStaleRuntimeArtifactsAreReclaimedOnlyByExactOwnerProof`
- mutants for listener auto-unlink, Host artifact cleanup, and missing race-child aggregation all failed in the surviving canonical owners and were reverted

## Validation

- `make fmt`
- `make fix`
- `make test`
- `python3 -m unittest discover -s test -p 'ci_workflow_contract_test.py'`
- `go test -race -count=2 ./internal/integrations/agents/codexbroker/... ./internal/integrations/agents/codexappserver/...`

Roadmap: Deterministic test gates and concurrency budget / Phase 1 Broker Host happens-before
Contract: C-2 Guarantee, Scope, Failure.Recovery, Enforcement
