### PR TITLE
fix(e2e): bound local suite concurrency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,9 +127,10 @@ test-install-smoke:
 	scripts/test-install-smoke.sh
 
 test-e2e: test-e2e-manifest
-	scripts/test-e2e-docker.sh
+	scripts/test-e2e-admission.sh scripts/test-e2e-docker.sh
 
 test-e2e-contract:
+	test/e2e/admission-contract.sh
 	test/e2e/evidence-contract.sh
 
 test-e2e-reliability:

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -477,13 +477,27 @@
   a stable scenario ID, owner, ISO-8601 deadline, and at least three observations;
   this closed zero-set contract rejects a non-empty row until execution/evidence
   and non-gating wiring exist. Therefore the quarantine execution Negative is
-  N/A: its antecedent does not exist. Instead, the contract proves that both E2E
-  child families still feed the exact `E2E Tests` compatibility context and the
-  project-wide `Test` gate. Go `Unit Tests` remain an exact required child and
-  outside automatic classification/quarantine: they have no per-test attempt
-  artifact or `class` surface, so assigning an observed-flake count would invent
-  evidence. A future unit quarantine first needs attempt-preserving per-test
-  evidence and a separate contract.
+  N/A: its antecedent does not exist. `test/e2e/shard-contract.sh` is the single
+  canonical owner proving that both E2E child families still feed the exact
+  `E2E Tests` compatibility context and the project-wide `Test` gate. Go
+  `Unit Tests` remain an exact required child and outside automatic
+  classification/quarantine: they have no per-test attempt artifact or `class`
+  surface, so assigning an observed-flake count would invent evidence. A future
+  unit quarantine first needs attempt-preserving per-test evidence and a separate
+  contract.
+- `test/e2e/admission-contract.sh` (`make test-e2e-contract`) pins the local
+  full-suite capacity boundary used by default `make test-e2e`: one invocation
+  owns the active state while another waits, and the wait diagnostic plus state
+  file expose `reason=local-full-suite-capacity`, capacity one, owner pid,
+  start time, cwd, and exact state path. Both callers retain their own terminal
+  status after admission. `PROJMUX_E2E_ADMISSION_BYPASS=1` is the explicit
+  stress path and is required to overlap a live admitted owner. Single-scenario
+  replay and CI shard/suite selectors remain outside this local full-suite
+  boundary; `test/e2e/shard-contract.sh` keeps the four Linux plus two suite
+  jobs on independent runners with `fail-fast: false` and the stable required
+  name `E2E Tests`, while also proving both selector families enter with a local
+  slot already occupied. A dead owner is diagnosed as `stale-owner` and reclaimed
+  only while the active hard link still identifies its exact owner record.
 - `test/e2e/evidence-contract.sh` (`make test-e2e-contract`) and
   `test/e2e/reliability-contract.sh` (`make test-e2e-reliability`) keep the persisted
   `projmux.e2e-attempt/v1` evidence and success result hash stable while adding

--- a/scripts/test-e2e-admission.sh
+++ b/scripts/test-e2e-admission.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (($# == 0)); then
+  echo "usage: test-e2e-admission.sh <command> [args...]" >&2
+  exit 2
+fi
+
+# CI already gives every selected shard/suite its own runner. A single-scenario
+# replay is similarly below the full-suite capacity boundary. Admitting either
+# here would silently turn independent CI jobs into a machine-global queue.
+if [[ -n "${PROJMUX_E2E_LINUX_SHARD:-}" ||
+  -n "${PROJMUX_E2E_SUITE:-}" ||
+  -n "${E2E_SCENARIO:-}" ]]; then
+  exec "$@"
+fi
+
+case "${PROJMUX_E2E_ADMISSION_BYPASS:-0}" in
+  0 | "") ;;
+  1)
+    echo ">> E2E_ADMISSION state=bypass reason=explicit-stress owner_pid=$$ owner_cwd=$PWD" >&2
+    exec "$@"
+    ;;
+  *)
+    echo "invalid PROJMUX_E2E_ADMISSION_BYPASS=${PROJMUX_E2E_ADMISSION_BYPASS}; expected 0 or 1" >&2
+    exit 2
+    ;;
+esac
+
+poll_seconds="${PROJMUX_E2E_ADMISSION_POLL_SECONDS:-0.2}"
+if [[ ! "$poll_seconds" =~ ^[0-9]+([.][0-9]+)?$ || "$poll_seconds" == "0" ]]; then
+  echo "invalid PROJMUX_E2E_ADMISSION_POLL_SECONDS=$poll_seconds; expected a positive number" >&2
+  exit 2
+fi
+
+if [[ -n "${PROJMUX_E2E_ADMISSION_STATE_DIR:-}" ]]; then
+  state_dir="$PROJMUX_E2E_ADMISSION_STATE_DIR"
+elif [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+  state_dir="$XDG_RUNTIME_DIR/projmux/e2e-admission"
+elif [[ -n "${XDG_STATE_HOME:-}" ]]; then
+  state_dir="$XDG_STATE_HOME/projmux/e2e-admission"
+elif [[ -n "${HOME:-}" ]]; then
+  state_dir="$HOME/.local/state/projmux/e2e-admission"
+else
+  state_dir="${TMPDIR:-/tmp}/projmux-e2e-admission-$(id -u)"
+fi
+active_state="$state_dir/active"
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+owner_record="$state_dir/owner-$$-$(date +%s)-${RANDOM}"
+acquired=0
+
+umask 077
+mkdir -p "$state_dir"
+chmod 0700 "$state_dir"
+{
+  printf 'owner_pid=%s\n' "$$"
+  printf 'owner_started=%s\n' "$started_at"
+  printf 'owner_cwd=%s\n' "$PWD"
+  printf 'owner_record=%s\n' "$owner_record"
+  printf 'reason=local-full-suite-capacity\n'
+  printf 'capacity=1\n'
+} >"$owner_record"
+
+# shellcheck disable=SC2317 # Invoked indirectly by the EXIT trap.
+release_admission() {
+  if [[ "$acquired" == "1" && -e "$active_state" && "$active_state" -ef "$owner_record" ]]; then
+    rm -f "$active_state"
+  fi
+  rm -f "$owner_record"
+}
+trap release_admission EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+record_value() {
+  local key="$1"
+  awk -F= -v key="$key" '
+    $1 == key {
+      sub(/^[^=]*=/, "")
+      print
+      exit
+    }
+  '
+}
+
+last_wait_owner=""
+while true; do
+  if ln "$owner_record" "$active_state" 2>/dev/null; then
+    acquired=1
+    echo ">> E2E_ADMISSION state=acquired reason=local-full-suite-capacity capacity=1 owner_pid=$$ owner_started=$started_at owner_cwd=$PWD active_state=$active_state" >&2
+    break
+  fi
+
+  active_record="$(cat "$active_state" 2>/dev/null || true)"
+  [[ -n "$active_record" ]] || continue
+  active_pid="$(record_value owner_pid <<<"$active_record")"
+  active_started="$(record_value owner_started <<<"$active_record")"
+  active_cwd="$(record_value owner_cwd <<<"$active_record")"
+  active_owner_record="$(record_value owner_record <<<"$active_record")"
+
+  if [[ "$active_pid" =~ ^[1-9][0-9]*$ ]] && ! kill -0 "$active_pid" 2>/dev/null; then
+    echo ">> E2E_ADMISSION state=reclaiming reason=stale-owner owner_pid=$active_pid owner_started=${active_started:-unknown} owner_cwd=${active_cwd:-unknown} active_state=$active_state" >&2
+    if [[ -n "$active_owner_record" && -e "$active_owner_record" &&
+      -e "$active_state" && "$active_state" -ef "$active_owner_record" ]]; then
+      rm -f "$active_state" "$active_owner_record"
+    fi
+    continue
+  fi
+
+  wait_owner="${active_pid:-unknown}|${active_started:-unknown}|${active_cwd:-unknown}"
+  if [[ "$wait_owner" != "$last_wait_owner" ]]; then
+    echo ">> E2E_ADMISSION state=waiting reason=local-full-suite-capacity capacity=1 owner_pid=${active_pid:-unknown} owner_started=${active_started:-unknown} owner_cwd=${active_cwd:-unknown} active_state=$active_state" >&2
+    last_wait_owner="$wait_owner"
+  fi
+  sleep "$poll_seconds"
+done
+
+status=0
+"$@" || status=$?
+exit "$status"

--- a/test/e2e/admission-contract.sh
+++ b/test/e2e/admission-contract.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016 # bash -c fixtures intentionally expand in the child.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+admission="$root/scripts/test-e2e-admission.sh"
+contract_root="$(mktemp -d)"
+worker_pids=()
+
+cleanup() {
+  touch "$contract_root/default-release" "$contract_root/bypass-owner-release" \
+    "$contract_root/bypass-release" 2>/dev/null || true
+  for worker_pid in "${worker_pids[@]}"; do
+    kill "$worker_pid" 2>/dev/null || true
+    wait "$worker_pid" 2>/dev/null || true
+  done
+  rm -rf "$contract_root"
+}
+trap cleanup EXIT
+
+wait_for_file() {
+  local path="$1"
+  local attempt
+  for ((attempt = 0; attempt < 200; attempt++)); do
+    [[ -e "$path" ]] && return 0
+    sleep 0.02
+  done
+  echo "admission contract timed out waiting for $path" >&2
+  return 1
+}
+
+wait_for_text() {
+  local text="$1"
+  local path="$2"
+  local attempt
+  for ((attempt = 0; attempt < 200; attempt++)); do
+    grep -Fq "$text" "$path" 2>/dev/null && return 0
+    sleep 0.02
+  done
+  echo "admission contract timed out waiting for '$text' in $path" >&2
+  return 1
+}
+
+assert_state_files_cleaned() {
+  local state_dir="$1"
+  local survivor
+  survivor="$(find "$state_dir" -type f -print -quit)"
+  if [[ -n "$survivor" ]]; then
+    echo "admission state file survived cleanup: $survivor" >&2
+    return 1
+  fi
+}
+
+state_dir="$contract_root/default-state"
+PROJMUX_E2E_ADMISSION_STATE_DIR="$state_dir" \
+  PROJMUX_E2E_ADMISSION_POLL_SECONDS=0.02 \
+  "$admission" bash -c '
+    printf "started\n" >"$1"
+    while [[ ! -e "$2" ]]; do sleep 0.02; done
+    printf "finished\n" >"$3"
+  ' bash "$contract_root/default-first-start" "$contract_root/default-release" \
+  "$contract_root/default-first-finish" >"$contract_root/default-first.log" 2>&1 &
+first_pid=$!
+worker_pids+=("$first_pid")
+wait_for_file "$contract_root/default-first-start"
+
+PROJMUX_E2E_ADMISSION_STATE_DIR="$state_dir" \
+  PROJMUX_E2E_ADMISSION_POLL_SECONDS=0.02 \
+  "$admission" bash -c '
+    printf "started\n" >"$1"
+    printf "finished\n" >"$2"
+  ' bash "$contract_root/default-second-start" "$contract_root/default-second-finish" \
+  >"$contract_root/default-second.log" 2>&1 &
+second_pid=$!
+worker_pids+=("$second_pid")
+
+wait_for_text 'state=waiting reason=local-full-suite-capacity capacity=1' \
+  "$contract_root/default-second.log"
+grep -Fq "owner_pid=$first_pid" "$contract_root/default-second.log"
+grep -Fq "owner_cwd=$root" "$contract_root/default-second.log"
+grep -Fq "active_state=$state_dir/active" "$contract_root/default-second.log"
+[[ -f "$state_dir/active" ]]
+grep -Fqx "owner_pid=$first_pid" "$state_dir/active"
+grep -Fqx 'reason=local-full-suite-capacity' "$state_dir/active"
+grep -Fqx 'capacity=1' "$state_dir/active"
+if [[ -e "$contract_root/default-second-start" ]]; then
+  echo "default second full suite crossed the capacity-one admission boundary" >&2
+  exit 1
+fi
+
+E2E_SCENARIO=L06 \
+  PROJMUX_E2E_ADMISSION_STATE_DIR="$state_dir" \
+  "$admission" bash -c 'printf "selected\n" >"$1"' \
+  bash "$contract_root/replay-selected"
+[[ -e "$contract_root/replay-selected" && -f "$state_dir/active" ]]
+kill -0 "$first_pid"
+
+touch "$contract_root/default-release"
+wait "$first_pid"
+wait "$second_pid"
+worker_pids=()
+wait_for_file "$contract_root/default-second-finish"
+[[ ! -e "$state_dir/active" ]]
+assert_state_files_cleaned "$state_dir"
+echo ">> default full-suite admission waits with an exact active owner/reason and both callers finish"
+echo ">> a single-scenario replay enters while the local full-suite slot is occupied"
+
+bypass_state_dir="$contract_root/bypass-state"
+PROJMUX_E2E_ADMISSION_STATE_DIR="$bypass_state_dir" \
+  PROJMUX_E2E_ADMISSION_POLL_SECONDS=0.02 \
+  "$admission" bash -c '
+    printf "started\n" >"$1"
+    while [[ ! -e "$2" ]]; do sleep 0.02; done
+  ' bash "$contract_root/bypass-owner-start" "$contract_root/bypass-owner-release" \
+  >"$contract_root/bypass-owner.log" 2>&1 &
+bypass_owner_pid=$!
+worker_pids+=("$bypass_owner_pid")
+wait_for_file "$contract_root/bypass-owner-start"
+
+PROJMUX_E2E_ADMISSION_STATE_DIR="$bypass_state_dir" \
+  PROJMUX_E2E_ADMISSION_POLL_SECONDS=0.02 \
+  PROJMUX_E2E_ADMISSION_BYPASS=1 \
+  "$admission" bash -c '
+    printf "started\n" >"$1"
+    while [[ ! -e "$2" ]]; do sleep 0.02; done
+  ' bash "$contract_root/bypass-start" "$contract_root/bypass-release" \
+  >"$contract_root/bypass.log" 2>&1 &
+bypass_pid=$!
+worker_pids+=("$bypass_pid")
+wait_for_file "$contract_root/bypass-start"
+
+[[ -e "$contract_root/bypass-owner-start" && -f "$bypass_state_dir/active" ]]
+kill -0 "$bypass_owner_pid"
+kill -0 "$bypass_pid"
+grep -Fq 'state=bypass reason=explicit-stress' "$contract_root/bypass.log"
+touch "$contract_root/bypass-release" "$contract_root/bypass-owner-release"
+wait "$bypass_pid"
+wait "$bypass_owner_pid"
+worker_pids=()
+[[ ! -e "$bypass_state_dir/active" ]]
+assert_state_files_cleaned "$bypass_state_dir"
+echo ">> explicit stress bypass overlaps an admitted full-suite owner"
+
+set +e
+PROJMUX_E2E_ADMISSION_STATE_DIR="$contract_root/failure-state" \
+  "$admission" bash -c 'exit 17' >"$contract_root/failure.log" 2>&1
+failure_status=$?
+set -e
+[[ "$failure_status" == "17" ]]
+[[ ! -e "$contract_root/failure-state/active" ]]
+assert_state_files_cleaned "$contract_root/failure-state"
+echo ">> terminal child status is preserved and admission state is released"
+
+stale_state_dir="$contract_root/stale-state"
+mkdir -p "$stale_state_dir"
+stale_record="$stale_state_dir/stale-owner"
+{
+  printf 'owner_pid=99999999\n'
+  printf 'owner_started=2000-01-01T00:00:00Z\n'
+  printf 'owner_cwd=/stale-owner\n'
+  printf 'owner_record=%s\n' "$stale_record"
+  printf 'reason=local-full-suite-capacity\n'
+  printf 'capacity=1\n'
+} >"$stale_record"
+ln "$stale_record" "$stale_state_dir/active"
+PROJMUX_E2E_ADMISSION_STATE_DIR="$stale_state_dir" \
+  PROJMUX_E2E_ADMISSION_POLL_SECONDS=0.02 \
+  "$admission" bash -c 'printf "recovered\n" >"$1"' \
+  bash "$contract_root/stale-recovered" >"$contract_root/stale.log" 2>&1
+grep -Fq 'state=reclaiming reason=stale-owner owner_pid=99999999' \
+  "$contract_root/stale.log"
+[[ -e "$contract_root/stale-recovered" && ! -e "$stale_state_dir/active" ]]
+assert_state_files_cleaned "$stale_state_dir"
+echo ">> a dead active owner is diagnosed and reclaimed before the next suite starts"

--- a/test/e2e/residual-policy-contract.sh
+++ b/test/e2e/residual-policy-contract.sh
@@ -17,7 +17,6 @@ job_block() {
 
 linux_block="$(job_block e2e-linux)"
 suite_block="$(job_block e2e-suite)"
-e2e_gate_block="$(job_block e2e-tests)"
 test_gate_block="$(job_block test)"
 unit_block="$(job_block unit)"
 
@@ -121,21 +120,11 @@ print(
 )
 PY
 
-# Empty quarantine means the existing fail-closed topology must be byte-for-byte
-# present: both E2E child families still feed the exact required compatibility
-# context and the project-wide Test aggregate.
-grep -Fqx '    name: E2E Tests' <<<"$e2e_gate_block"
-grep -Fqx '    if: always()' <<<"$e2e_gate_block"
-for child in e2e-linux e2e-suite; do
-	grep -Fqx "      - $child" <<<"$e2e_gate_block"
-	grep -Fq -- "--required $child" <<<"$e2e_gate_block"
-	grep -Fqx "      - $child" <<<"$test_gate_block"
-	grep -Fq -- "--required $child" <<<"$test_gate_block"
-done
-
 # Go unit tests have no attempt evidence/classification surface. Phase 5 keeps
 # that blind spot outside automatic quarantine and leaves the exact required
-# child in place instead of inventing observations.
+# child in place instead of inventing observations. The exact E2E matrix,
+# compatibility context, and project-wide aggregate are owned once by
+# shard-contract.sh rather than restated by this residual evidence policy.
 grep -Fqx '    name: Unit Tests' <<<"$unit_block"
 grep -Fqx '      - unit' <<<"$test_gate_block"
 grep -Fq -- '--required unit' <<<"$test_gate_block"

--- a/test/e2e/shard-contract.sh
+++ b/test/e2e/shard-contract.sh
@@ -143,6 +143,79 @@ fi
 echo ">> CI schedules one runner per suite: ${job_shards[*]} ${job_suites[*]}"
 echo ">> the required E2E Tests context still reports over the split shards"
 
+# The local full-suite capacity guard must not turn the already-isolated CI
+# matrix back into one machine-global queue. Hold its capacity slot and prove
+# both selector families still enter immediately. The exact matrix shape and
+# required aggregate above remain the canonical owners of the CI topology.
+(
+  set -euo pipefail
+  admission="$root/scripts/test-e2e-admission.sh"
+  selector_root="$(mktemp -d)"
+  holder_pid=""
+  selected_pid=""
+  # shellcheck disable=SC2317 # Invoked indirectly by the subshell EXIT trap.
+  cleanup_selector_contract() {
+    touch "$selector_root/release" 2>/dev/null || true
+    if [[ -n "$selected_pid" ]]; then
+      kill "$selected_pid" 2>/dev/null || true
+      wait "$selected_pid" 2>/dev/null || true
+    fi
+    if [[ -n "$holder_pid" ]]; then
+      kill "$holder_pid" 2>/dev/null || true
+      wait "$holder_pid" 2>/dev/null || true
+    fi
+    rm -rf "$selector_root"
+  }
+  trap cleanup_selector_contract EXIT
+
+  PROJMUX_E2E_ADMISSION_STATE_DIR="$selector_root/state" \
+    PROJMUX_E2E_ADMISSION_POLL_SECONDS=0.02 \
+    "$admission" bash -c '
+      printf "ready\n" >"$1"
+      while [[ ! -e "$2" ]]; do sleep 0.02; done
+    ' bash "$selector_root/holder-ready" "$selector_root/release" \
+    >"$selector_root/holder.log" 2>&1 &
+  holder_pid=$!
+  for _ in {1..200}; do
+    [[ -e "$selector_root/holder-ready" ]] && break
+    sleep 0.02
+  done
+  [[ -e "$selector_root/holder-ready" && -e "$selector_root/state/active" ]]
+
+  PROJMUX_E2E_ADMISSION_STATE_DIR="$selector_root/state" \
+    PROJMUX_E2E_LINUX_SHARD=fixture-1 \
+    "$admission" bash -c 'printf "selected\n" >"$1"' \
+    bash "$selector_root/linux-selected" &
+  selected_pid=$!
+  for _ in {1..200}; do
+    [[ -e "$selector_root/linux-selected" ]] && break
+    sleep 0.02
+  done
+  [[ -e "$selector_root/linux-selected" ]]
+  wait "$selected_pid"
+  selected_pid=""
+
+  PROJMUX_E2E_ADMISSION_STATE_DIR="$selector_root/state" \
+    PROJMUX_E2E_SUITE=codex-lifecycle \
+    "$admission" bash -c 'printf "selected\n" >"$1"' \
+    bash "$selector_root/suite-selected" &
+  selected_pid=$!
+  for _ in {1..200}; do
+    [[ -e "$selector_root/suite-selected" ]] && break
+    sleep 0.02
+  done
+  [[ -e "$selector_root/suite-selected" ]]
+  wait "$selected_pid"
+  selected_pid=""
+
+  [[ -e "$selector_root/linux-selected" && -e "$selector_root/suite-selected" ]]
+  kill -0 "$holder_pid"
+  touch "$selector_root/release"
+  wait "$holder_pid"
+  holder_pid=""
+)
+echo ">> CI shard/suite selectors bypass the local full-suite admission boundary"
+
 # The tag workflow uses the same selectors and manifest, but its aggregate is
 # a release gate rather than a branch-ruleset compatibility context. Build
 # Release must depend on only that aggregate so every matrix result is reduced
@@ -269,4 +342,5 @@ grep -Fq 'export PROJMUX_TEST_PREBUILT_SHA256="$binary_sha"' "$root/scripts/test
 grep -Fq -- '-e E2E_SCENARIO="${E2E_SCENARIO:-}"' "$docker_runner"
 grep -Fq 'suite="${PROJMUX_E2E_SUITE:-}"' "$root/scripts/test-e2e-docker.sh"
 grep -Fq 'suite="linux-${PROJMUX_E2E_LINUX_SHARD}"' "$root/scripts/test-e2e-docker.sh"
+grep -Fqx $'\tscripts/test-e2e-admission.sh scripts/test-e2e-docker.sh' "$root/Makefile"
 echo ">> module cache topology is one setup writer; E2E exports the immutable binary path/hash pair to read-only consumers"


### PR DESCRIPTION
## Summary
- Bound concurrent default local full E2E invocations to one active suite with exact owner/reason diagnostics.
- Preserve explicit stress overlap and keep scenario replay plus CI shard/suite selectors outside local admission.
- Consolidate duplicate CI topology assertions under the canonical shard contract.

## Test plan
- [x] make fmt
- [x] make fix
- [x] make test
- [x] make test-e2e-contract test-e2e-residual-policy test-e2e-shards
- [x] make test-integration
- [x] paired default full make test-e2e: both exit 0; waiter owner/reason observed
- [x] explicit-bypass full-suite overlap: both actually overlapped and reproduced the baseline L06 stress failure
- [ ] required CI five plus aggregate Test green

## CI blocker
- Run 33533522452 has all Phase 2-owned and non-C01 jobs green, but C01 failed three attempts at test/e2e/codex-lifecycle.sh:583 with the pre-existing sibling epoch drift signature (writes 0,1).
- C01/lifecycle authority is explicitly owned by the sibling Must 2 track, so this PR does not change that oracle or bypass the gate.

## Globalization
- [x] Non-translated strings are internal test-gate diagnostics and environment literals.

Roadmap: Deterministic test gates and concurrency budget / Phase 2 Bounded local E2E admission
Contract: C-1 Guarantee, Failure.Detection