### PR TITLE
test(codex): record installed capability ledger

### DIFF
--- a/.deadcode-must-keep.txt
+++ b/.deadcode-must-keep.txt
@@ -13,17 +13,20 @@ CanonicalRoutes	The canonical route table accessor is retained for cross-package
 CleanupLegacyArtifacts	Persisted usage-state cleanup must remain available across legacy state migrations.
 CurrentProtocol	The build's local IPC version window accessor is retained as the negotiation input an explicit caller supplies.
 DecideTeardownEvent	The pure teardown decision API is retained for lifecycle authority proofs and planned consumers.
+DecodeCapabilityLedger	Test-only installed qualification API retained for strict checked-in capability-ledger validation.
 DirectEndpoint.Close	Test-only installed qualification API retained for bounded direct endpoint cleanup proof.
 DirectEndpoint.Health	Test-only installed qualification API retained for canonical direct readiness evidence.
 DirectEndpoint.forceCleanup	Test-only installed qualification helper retained for injected direct startup-failure cleanup proof.
 DirectEndpoint.markClosed	Test-only installed qualification helper retained for single-consumer bounded direct exit finalization proof.
 Discover	The background-context discovery wrapper is retained as a test and compatibility seam.
+EvaluateTurnFreeThreadLiveAttach	Test-only installed qualification API retained for method-independent semantic capability reduction.
 Fixture.ApplyEnv	Test-only installed qualification API retained for isolated environment containment proof.
 Fixture.Cleanup	Test-only installed qualification API retained for exact owned-artifact cleanup proof.
 Fixture.Ledger	Test-only installed qualification API retained for semantic ambient non-mutation proof.
 Fixture.ProvisionManagedPayload	Test-only installed qualification API retained for managed provision classification proof.
 Fixture.RunManagedLifecycle	Test-only installed qualification API retained for managed start/reuse/retire proof.
 Fixture.StartDirect	Test-only installed qualification API retained for disposable direct endpoint readiness proof.
+Fixture.StartTurnFreeAttachPane	Test-only installed qualification API retained for exact isolated live-Pane capability evidence.
 Fixture.Versions	Test-only installed qualification API retained for complete version-tuple evidence.
 Fixture.cleanupSupportArtifacts	Test-only installed qualification helper retained for exact ledger and shim cleanup proof.
 Fixture.discoverCLI	Test-only installed qualification helper retained for installed CLI version evidence.
@@ -34,6 +37,10 @@ Fixture.readManagedPID	Test-only installed qualification helper retained for con
 Fixture.readManagedStartResult	Test-only installed qualification helper retained for exact managed start PID proof.
 Fixture.retireAfterFailure	Test-only installed qualification helper retained for bounded exact managed failure cleanup proof.
 Host.RuntimeID	The runtime identity accessor is retained as the authority axis clients present alongside both epochs.
+IsolatedPane.Alive	Test-only installed qualification API retained for exact pane-dead and socket-identity observation.
+IsolatedPane.Close	Test-only installed qualification API retained for contained exact tmux server cleanup.
+IsolatedPane.ID	Test-only installed qualification API retained for content-free exact Pane evidence.
+IsolatedPane.run	Test-only installed qualification helper retained for inherited tmux identity stripping on every command.
 Ledger.AmbientMutations	Test-only installed qualification API retained for typed ambient mutation counting proof.
 Ledger.AssertNoAmbientMutation	Test-only installed qualification API retained for zero ambient mutation proof.
 Ledger.AssertNoLifecycleMutation	Test-only installed qualification API retained for broker-smoke lifecycle non-mutation proof.
@@ -71,9 +78,11 @@ legacyWindowAttentionRows	Legacy attention rows remain required while older pers
 newFixture	Test-only installed qualification helper retained as the common clean/existing fixture constructor.
 newLedger	Test-only installed qualification helper retained for canonical semantic command evidence.
 observationRefusal	Observation-specific refusal mapping is retained inside the pure teardown authority proof surface.
+pathWithin	Test-only installed qualification helper retained for tmux socket containment proof.
 projectPreservedAssets	The preserved-assets outcome helper is retained for project teardown authority proofs.
 removeExactResidualSocket	Test-only installed qualification helper retained for ready-time socket identity cleanup proof.
 rootDefaults	Root teardown defaults are retained inside the pure teardown decision authority.
+tmuxCapabilityEnvironment	Test-only installed qualification helper retained for per-command tmux and CODEX_HOME isolation.
 tmuxRetiredKeyUnbindLines	Retired key cleanup must remain available so old generated tmux bindings can be removed.
 validOwnerChain	Owner-chain validation is retained inside the pure teardown decision authority.
 validTeardownEventKind	The closed event-kind validator is retained inside the pure teardown decision authority.

--- a/.github/workflows/installed-codex.yml
+++ b/.github/workflows/installed-codex.yml
@@ -73,6 +73,7 @@ jobs:
           CODEX_TOKEN: ""
           PROJMUX_CODEX_INSTALL_OUTCOME: ${{ steps.install-codex.outcome }}
           PROJMUX_CODEX_EXPECTED_VERSION: ${{ matrix.codex-version }}
+          PROJMUX_CODEX_EVIDENCE_RUN: github-actions:${{ github.run_id }}:${{ github.run_attempt }}
         run: |
           scripts/test-installed-codex-qualification.sh \
             run \

--- a/docs/codex-installed-capabilities.json
+++ b/docs/codex-installed-capabilities.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "capabilities": [
+    {
+      "versions": {
+        "cli": "0.152.0",
+        "managed": "0.152.0",
+        "app_server": "0.152.0"
+      },
+      "capability": "turn-free-thread-live-attach",
+      "method": {
+        "attach": "cli-remote-resume",
+        "loaded": "rpc-thread-loaded-list",
+        "runtime": "rpc-thread-read"
+      },
+      "result": "supported",
+      "reason": "live-pane-attached",
+      "evidence": {
+        "endpoint_ready": true,
+        "thread_created_without_turn": true,
+        "loaded_before_attach": true,
+        "attach_attempted": true,
+        "loaded_after_attach": true,
+        "runtime_status_after_attach": "idle",
+        "pane_observed": true,
+        "pane_alive": true
+      },
+      "last_observed": {
+        "probe": "TestInstalledIsolatedPreTurnBootstrapSmoke",
+        "run": "github-actions:33566050834:1"
+      }
+    }
+  ]
+}

--- a/docs/codex-installed-compatibility.md
+++ b/docs/codex-installed-compatibility.md
@@ -1,0 +1,61 @@
+# Installed Codex compatibility
+
+The machine-readable last-observed ledger is
+[`codex-installed-capabilities.json`](codex-installed-capabilities.json). Its
+schema separates method evidence from the semantic result:
+
+- `method` records the CLI/RPC spellings used by one observation. Changing a
+  wire method does not itself change capability support.
+- `result` is exactly `supported`, `unsupported`, or `infra-error`.
+  An unavailable endpoint and incomplete evidence are infrastructure errors,
+  never evidence that the upstream capability is unsupported.
+- `evidence` contains only content-free semantic facts. A supported turn-free
+  attach requires an exact living tmux Pane and the same no-turn thread to stay
+  loaded with runtime state `idle` or `active` after the creator connection is
+  closed.
+- `versions` independently records the installed CLI, managed payload, and
+  running app-server tuple. `last_observed` names the canonical probe and run.
+
+## Last observation
+
+On 2026-09-02, installed tuple `0.152.0 / 0.152.0 / 0.152.0` was
+`supported` for `turn-free-thread-live-attach` with reason
+`live-pane-attached`. The canonical
+`TestInstalledIsolatedPreTurnBootstrapSmoke` created a thread without a turn,
+observed it in `thread/loaded/list`, started `codex resume --remote unix://` in
+an exact isolated tmux Pane, closed the creating connection, then passed two
+fresh loaded/runtime observations while the exact Pane remained alive. Runtime
+status was `idle`; model, turn, and network calls were zero.
+
+The checked-in observation is the exact branch-head evidence from hosted
+[Actions run 33566050834](https://github.com/crevissepartners/projmux/actions/runs/33566050834),
+attempt 1. Aggregate artifact `9823166206`
+(`installed-codex-qualification-33566050834-1`) is the durable last
+observation; the roadmap gate must cite that same run, artifact, and canonical
+probe.
+
+The observation extends the Phase 1 `pre-turn-attach` owner instead of adding a
+second protocol body. Phase 1 hosted evidence remains run `33560743314`,
+aggregate artifact `9821171919`, where the same tuple's direct pre-turn
+qualification was `pass`. That pass is an input only: the ledger's supported
+result additionally requires the Phase 2 loaded/runtime and living-Pane facts.
+
+Scheduled and manual `Installed Codex Qualification` artifacts use
+qualification schema v2 and embed this schema-versioned capability ledger.
+`PROJMUX_CODEX_EVIDENCE_RUN` records the exact Actions run/attempt; this ledger
+records `github-actions:33566050834:1`.
+
+## Canonical test list
+
+- `TestCapabilityReducerSeparatesMethodFromSemanticResult` — method changes do
+  not alter supported/unsupported/infra-error reduction.
+- `TestCapabilityReducerKeepsUnavailableEndpointAsInfraError` — an unavailable
+  endpoint cannot become unsupported.
+- `TestInstalledIsolatedPreTurnBootstrapSmoke` — the sole installed owner for
+  turn-free start/read/loaded observation and live-Pane attach.
+- `TestInstalledCensusDeletionReceiptHasOneOwnerPerPrimitive` — topology and
+  protocol ownership plus the Phase 2 merge receipt.
+
+The maintained repository-wide list in `docs/agent-workflow.md` should gain the
+same Phase 2 row only after its parallel owner has merged; this change does not
+edit that shared file.

--- a/internal/integrations/agents/codexappserver/attach_installed_test.go
+++ b/internal/integrations/agents/codexappserver/attach_installed_test.go
@@ -2,6 +2,8 @@ package codexappserver_test
 
 import (
 	"context"
+	"os"
+	"slices"
 	"testing"
 	"time"
 
@@ -16,11 +18,12 @@ import (
 // root, so it can never touch an ambient shared endpoint's state.
 //
 // It proves the upstream facts this Phase depends on: a thread exists before
-// its first turn, and that pre-turn thread's includeTurns=false snapshot is
-// readable from a second connection with no materialized turn. The explicit
-// thread/resume subscription leg is recorded as typed evidence rather than
-// asserted, because installed Codex 0.150.1 answers thread/resume only for a
-// thread whose rollout already exists. Everything it records is content-free.
+// its first turn, that thread is loaded, and its includeTurns=false snapshot is
+// readable from a second connection with no materialized turn. It then closes
+// the creating connection and asks the installed CLI to attach in one exact
+// isolated tmux Pane. The semantic capability is supported only when that Pane
+// survives two independent loaded/runtime observation barriers. The CLI/RPC
+// spellings are evidence metadata; the reducer never branches on them.
 func TestInstalledIsolatedPreTurnBootstrapSmoke(t *testing.T) {
 	root, enabled, err := codexinstalled.SmokeRoot("PROJMUX_CODEX_BROKER_SMOKE_ROOT")
 	if err != nil {
@@ -40,6 +43,18 @@ func TestInstalledIsolatedPreTurnBootstrapSmoke(t *testing.T) {
 		}
 	})
 	_ = fixture.ProvisionManagedPayload()
+	method := codexinstalled.CapabilityMethod{
+		Attach: "cli-remote-resume", Loaded: "rpc-thread-loaded-list", Runtime: "rpc-thread-read",
+	}
+	evidence := codexinstalled.CapabilityEvidence{}
+	observation := codexinstalled.CapabilityObservation{
+		Probe: "TestInstalledIsolatedPreTurnBootstrapSmoke",
+		Run:   os.Getenv("PROJMUX_CODEX_EVIDENCE_RUN"),
+	}
+	defer func() {
+		result := codexinstalled.EvaluateTurnFreeThreadLiveAttach(fixture.Versions(), method, evidence, observation)
+		logInstalledCapability(t, result)
+	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -49,6 +64,7 @@ func TestInstalledIsolatedPreTurnBootstrapSmoke(t *testing.T) {
 		logInstalledResult(t, ready)
 		t.Fatalf("pre-turn direct endpoint = %+v", ready)
 	}
+	evidence.EndpointReady = true
 	t.Cleanup(func() {
 		closeCtx, closeCancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer closeCancel()
@@ -78,18 +94,13 @@ func TestInstalledIsolatedPreTurnBootstrapSmoke(t *testing.T) {
 		_ = creator.Close()
 		t.Fatalf("pre-turn binding = %+v, want a thread with no turn", binding)
 	}
-	// Close the creating connection so the bootstrap runs against a genuinely
-	// second connection, which is the case a broker has to survive. Closing the
-	// owned stdio proxy kills that process, so its exit status is the expected
-	// outcome of the close rather than a failure.
-	_ = creator.Close()
+	evidence.ThreadCreatedWithoutTurn = true
 
 	reader, _, err := codexappserver.AttachDefaultEndpoint(ctx, "installed-pre-turn-smoke",
 		codexappserver.AttachOptions{Timeout: 10 * time.Second, ExperimentalAPI: true})
 	if err != nil {
 		t.Fatalf("second attach: %v", err)
 	}
-	defer reader.Close()
 	thread, err := reader.ReadCatalogThread(ctx, binding.ThreadID)
 	if err != nil {
 		t.Fatalf("pre-turn includeTurns=false snapshot: %v", err)
@@ -101,16 +112,70 @@ func TestInstalledIsolatedPreTurnBootstrapSmoke(t *testing.T) {
 		t.Fatalf("snapshot is missing content-free identity: %+v", thread)
 	}
 	t.Logf("pre-turn snapshot status=%s flags=%v", thread.RuntimeStatus, thread.ActiveFlags)
+	loaded, err := reader.ListLoadedThreadIDs(ctx)
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("pre-turn loaded identity: %v", err)
+	}
+	evidence.LoadedBeforeAttach = slices.Contains(loaded, binding.ThreadID)
+	if !evidence.LoadedBeforeAttach {
+		_ = reader.Close()
+		t.Fatalf("turn-free thread is absent from the loaded runtime")
+	}
+	_ = reader.Close()
 
-	// Typed evidence for the subscription leg. Installed 0.150.1 has no rollout
-	// for a thread whose first turn never ran, so thread/resume is refused here
-	// while the same call succeeds once the thread has materialized. Recording
-	// it keeps the unsupported item visible without asserting an outcome the
-	// upstream does not offer before the first turn.
-	if _, err := reader.BootstrapThread(ctx, binding.ThreadID, fixture.Workspace, nil); err != nil {
-		t.Logf("pre-turn explicit resume subscription unsupported: %v", err)
-	} else {
-		t.Log("pre-turn explicit resume subscription established")
+	pane, err := fixture.StartTurnFreeAttachPane(ctx, binding.ThreadID)
+	if err != nil {
+		_ = creator.Close()
+		t.Fatalf("pre-turn Pane attach: %v", err)
+	}
+	evidence.AttachAttempted = true
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer closeCancel()
+		if err := pane.Close(closeCtx); err != nil {
+			t.Errorf("pre-turn Pane cleanup: %v", err)
+		}
+	})
+	// The creator is the only known subscription before the CLI Pane starts.
+	// Closing it makes post-attach loaded/runtime evidence attributable to the
+	// candidate carrier instead of to the Phase 1 setup connection.
+	_ = creator.Close()
+
+	probeCtx, probeCancel := context.WithTimeout(ctx, 15*time.Second)
+	defer probeCancel()
+	for {
+		alive, paneErr := pane.Alive(probeCtx)
+		if paneErr != nil {
+			t.Fatalf("observe exact pre-turn Pane %s: %v", pane.ID(), paneErr)
+		}
+		evidence.PaneObserved = true
+		evidence.PaneAlive = alive
+		if !alive {
+			t.Log("turn-free attach reached a terminal unsupported Pane exit")
+			break
+		}
+
+		loadedAfter, runtimeStatus, observationErr := observeTurnFreeRuntime(probeCtx, binding.ThreadID)
+		if observationErr == nil && loadedAfter && (runtimeStatus == "idle" || runtimeStatus == "active") {
+			// A fresh connection and a second exact Pane query form the independent
+			// barrier. One transient sample is not living-Pane evidence.
+			loadedAgain, statusAgain, secondErr := observeTurnFreeRuntime(probeCtx, binding.ThreadID)
+			aliveAgain, paneAgainErr := pane.Alive(probeCtx)
+			if secondErr == nil && paneAgainErr == nil && aliveAgain && loadedAgain && statusAgain == runtimeStatus {
+				evidence.LoadedAfterAttach = true
+				evidence.RuntimeStatusAfterAttach = statusAgain
+				evidence.PaneObserved = true
+				evidence.PaneAlive = true
+				t.Logf("turn-free attach supported: pane=%s loaded=true runtime=%s", pane.ID(), statusAgain)
+				break
+			}
+		}
+		select {
+		case <-probeCtx.Done():
+			t.Fatalf("turn-free attach evidence deadline: %v", probeCtx.Err())
+		case <-time.After(25 * time.Millisecond):
+		}
 	}
 
 	// A no-turn thread produces no inbound server request, so the response-once
@@ -124,7 +189,41 @@ func TestInstalledIsolatedPreTurnBootstrapSmoke(t *testing.T) {
 	default:
 		t.Log("no inbound server request during a no-turn bootstrap, as expected")
 	}
+	if recorded, err := fixture.Ledger().HasOperation("pre-turn-cli-remote-resume"); err != nil || !recorded {
+		t.Fatalf("turn-free CLI attach command ledger: recorded=%t err=%v", recorded, err)
+	}
+	if err := fixture.Ledger().AssertNoAmbientMutation(); err != nil {
+		t.Fatal(err)
+	}
 	result := codexinstalled.NewResult(fixture.Versions(), codexinstalled.TopologyDirect,
 		codexinstalled.StageReady, codexinstalled.ResultPass, "pre-turn-second-attach-thread-read-compatible")
 	logInstalledResult(t, result)
+}
+
+func observeTurnFreeRuntime(ctx context.Context, threadID string) (bool, string, error) {
+	reader, _, err := codexappserver.AttachDefaultEndpoint(ctx, "installed-pre-turn-capability-observer",
+		codexappserver.AttachOptions{Timeout: 5 * time.Second, ExperimentalAPI: true})
+	if err != nil {
+		return false, "", err
+	}
+	defer reader.Close()
+	loaded, err := reader.ListLoadedThreadIDs(ctx)
+	if err != nil {
+		return false, "", err
+	}
+	thread, err := reader.ReadCatalogThread(ctx, threadID)
+	if err != nil {
+		return false, "", err
+	}
+	return slices.Contains(loaded, threadID), thread.RuntimeStatus, nil
+}
+
+func logInstalledCapability(t *testing.T, result codexinstalled.CapabilityResult) {
+	t.Helper()
+	encoded, err := result.JSON()
+	if err != nil {
+		t.Errorf("invalid installed capability result: %v", err)
+		return
+	}
+	t.Logf("installed-capability: %s", encoded)
 }

--- a/internal/integrations/agents/codexappserver/catalog.go
+++ b/internal/integrations/agents/codexappserver/catalog.go
@@ -39,6 +39,30 @@ type CatalogPage struct {
 	NextCursor *string
 }
 
+// ListLoadedThreadIDs returns only the opaque identities currently resident in
+// the app-server runtime. It is a read-only observation primitive for installed
+// capability qualification; it never resumes, subscribes, or mutates a thread.
+func (c *Client) ListLoadedThreadIDs(ctx context.Context) ([]string, error) {
+	var result threadLoadedListResult
+	if err := c.Request(ctx, methodThreadLoadedList, threadLoadedListParams{}, &result); err != nil {
+		return nil, err
+	}
+	loaded := make([]string, 0, len(result.Data))
+	seen := make(map[string]struct{}, len(result.Data))
+	for _, raw := range result.Data {
+		id := strings.TrimSpace(raw)
+		if id == "" {
+			return nil, fmt.Errorf("%w: thread/loaded/list returned a blank thread id", ErrProtocol)
+		}
+		if _, duplicate := seen[id]; duplicate {
+			return nil, fmt.Errorf("%w: thread/loaded/list returned a duplicate thread id", ErrProtocol)
+		}
+		seen[id] = struct{}{}
+		loaded = append(loaded, id)
+	}
+	return loaded, nil
+}
+
 // CatalogPreview is the bounded content projection for one exact thread. It is
 // separate from CatalogThread so content cannot enter discovery metadata.
 type CatalogPreview struct {

--- a/internal/integrations/agents/codexappserver/catalog_test.go
+++ b/internal/integrations/agents/codexappserver/catalog_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"reflect"
 	"testing"
@@ -81,6 +82,48 @@ func TestCatalogRejectsMalformedRuntimeStatus(t *testing.T) {
 		base.Status = wireThreadStatus{Type: status}
 		if _, err := normalizeCatalogThread(base); err != nil {
 			t.Fatalf("closed runtime status %q rejected: %v", status, err)
+		}
+	}
+}
+
+func TestLoadedThreadListIsReadOnlyIdentityEvidence(t *testing.T) {
+	client, collect := scriptedEndpoint(t, map[string]string{
+		methodThreadLoadedList: `{"data":["thread-a","thread-b"],"nextCursor":null}`,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	loaded, err := client.ListLoadedThreadIDs(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(loaded, []string{"thread-a", "thread-b"}) {
+		t.Fatalf("loaded ids = %v", loaded)
+	}
+	methods, params := collect()
+	if !reflect.DeepEqual(methods, []string{methodThreadLoadedList}) {
+		t.Fatalf("methods = %v", methods)
+	}
+	var loadedParams threadLoadedListParams
+	if err := json.Unmarshal(params[0], &loadedParams); err != nil {
+		t.Fatal(err)
+	}
+	if loadedParams.Cursor != nil || loadedParams.Limit != nil {
+		t.Fatalf("loaded params = %+v, want one identity-only request", loadedParams)
+	}
+}
+
+func TestLoadedThreadListRejectsBlankAndDuplicateIdentity(t *testing.T) {
+	for _, payload := range []string{
+		`{"data":["thread-a",""]}`,
+		`{"data":["thread-a","thread-a"]}`,
+	} {
+		client, collect := scriptedEndpoint(t, map[string]string{methodThreadLoadedList: payload})
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		_, err := client.ListLoadedThreadIDs(ctx)
+		cancel()
+		collect()
+		if !errors.Is(err, ErrProtocol) {
+			t.Fatalf("payload %s = %v, want protocol refusal", payload, err)
 		}
 	}
 }

--- a/internal/integrations/agents/codexappserver/wire.go
+++ b/internal/integrations/agents/codexappserver/wire.go
@@ -8,6 +8,7 @@ const (
 	methodModelList               = "model/list"
 	methodReviewStart             = "review/start"
 	methodThreadList              = "thread/list"
+	methodThreadLoadedList        = "thread/loaded/list"
 	methodThreadRead              = "thread/read"
 	methodThreadStart             = "thread/start"
 	methodThreadResume            = "thread/resume"
@@ -142,6 +143,16 @@ type threadListParams struct {
 type threadListResult struct {
 	Data       []wireCatalogThread `json:"data"`
 	NextCursor *string             `json:"nextCursor"`
+}
+
+type threadLoadedListParams struct {
+	Cursor *string `json:"cursor,omitempty"`
+	Limit  *uint32 `json:"limit,omitempty"`
+}
+
+type threadLoadedListResult struct {
+	Data       []string `json:"data"`
+	NextCursor *string  `json:"nextCursor"`
 }
 
 type threadReadParams struct {

--- a/internal/testutil/codexinstalled/capability.go
+++ b/internal/testutil/codexinstalled/capability.go
@@ -1,0 +1,242 @@
+package codexinstalled
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"slices"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+const CapabilitySchemaVersion = 1
+
+type SemanticCapability string
+
+const CapabilityTurnFreeThreadLiveAttach SemanticCapability = "turn-free-thread-live-attach"
+
+type CapabilityStatus string
+
+const (
+	CapabilitySupported   CapabilityStatus = "supported"
+	CapabilityUnsupported CapabilityStatus = "unsupported"
+	CapabilityInfraError  CapabilityStatus = "infra-error"
+)
+
+type CapabilityReason string
+
+const (
+	CapabilityReasonLivePaneAttached    CapabilityReason = "live-pane-attached"
+	CapabilityReasonAttachRefused       CapabilityReason = "attach-refused"
+	CapabilityReasonEndpointUnavailable CapabilityReason = "endpoint-unavailable"
+	CapabilityReasonEvidenceIncomplete  CapabilityReason = "evidence-incomplete"
+	CapabilityReasonProbeInvalid        CapabilityReason = "probe-invalid"
+	CapabilityReasonTerminalMissing     CapabilityReason = "terminal-result-missing"
+	CapabilityReasonTerminalInvalid     CapabilityReason = "terminal-result-invalid"
+	CapabilityReasonVersionMismatch     CapabilityReason = "version-tuple-mismatch"
+)
+
+// CapabilityMethod records how one observation was made. Semantic reduction
+// never branches on these values: an upstream wire or CLI rename changes this
+// metadata, not the supported/unsupported decision.
+type CapabilityMethod struct {
+	Attach  string `json:"attach"`
+	Loaded  string `json:"loaded"`
+	Runtime string `json:"runtime"`
+}
+
+type CapabilityEvidence struct {
+	EndpointReady            bool   `json:"endpoint_ready"`
+	ThreadCreatedWithoutTurn bool   `json:"thread_created_without_turn"`
+	LoadedBeforeAttach       bool   `json:"loaded_before_attach"`
+	AttachAttempted          bool   `json:"attach_attempted"`
+	LoadedAfterAttach        bool   `json:"loaded_after_attach"`
+	RuntimeStatusAfterAttach string `json:"runtime_status_after_attach"`
+	PaneObserved             bool   `json:"pane_observed"`
+	PaneAlive                bool   `json:"pane_alive"`
+}
+
+type CapabilityObservation struct {
+	Probe string `json:"probe"`
+	Run   string `json:"run"`
+}
+
+type CapabilityResult struct {
+	Versions     VersionTuple          `json:"versions"`
+	Capability   SemanticCapability    `json:"capability"`
+	Method       CapabilityMethod      `json:"method"`
+	Result       CapabilityStatus      `json:"result"`
+	Reason       CapabilityReason      `json:"reason"`
+	Evidence     CapabilityEvidence    `json:"evidence"`
+	LastObserved CapabilityObservation `json:"last_observed"`
+}
+
+type CapabilityLedger struct {
+	SchemaVersion int                `json:"schema_version"`
+	Capabilities  []CapabilityResult `json:"capabilities"`
+}
+
+var capabilityMethodPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
+var capabilityProbePattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{0,127}$`)
+var capabilityRunPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9:@._-]{0,127}$`)
+
+// EvaluateTurnFreeThreadLiveAttach reduces only semantic facts. The Method
+// object is preserved verbatim after structural validation and is deliberately
+// absent from every decision below.
+func EvaluateTurnFreeThreadLiveAttach(
+	versions VersionTuple,
+	method CapabilityMethod,
+	evidence CapabilityEvidence,
+	observation CapabilityObservation,
+) CapabilityResult {
+	result := CapabilityResult{
+		Versions: versions.normalized(), Capability: CapabilityTurnFreeThreadLiveAttach,
+		Method: method, Evidence: evidence, LastObserved: normalizeCapabilityObservation(observation),
+	}
+	switch {
+	case !evidence.EndpointReady:
+		result.Result, result.Reason = CapabilityInfraError, CapabilityReasonEndpointUnavailable
+	case !evidence.ThreadCreatedWithoutTurn || !evidence.LoadedBeforeAttach || !evidence.AttachAttempted:
+		result.Result, result.Reason = CapabilityInfraError, CapabilityReasonEvidenceIncomplete
+	case evidence.PaneObserved && evidence.PaneAlive && evidence.LoadedAfterAttach &&
+		slices.Contains([]string{"idle", "active"}, evidence.RuntimeStatusAfterAttach):
+		result.Result, result.Reason = CapabilitySupported, CapabilityReasonLivePaneAttached
+	case evidence.PaneObserved && !evidence.PaneAlive:
+		result.Result, result.Reason = CapabilityUnsupported, CapabilityReasonAttachRefused
+	default:
+		result.Result, result.Reason = CapabilityInfraError, CapabilityReasonEvidenceIncomplete
+	}
+	return result
+}
+
+func InfraErrorCapability(versions VersionTuple, reason CapabilityReason, observation CapabilityObservation) CapabilityResult {
+	return CapabilityResult{
+		Versions: versions.normalized(), Capability: CapabilityTurnFreeThreadLiveAttach,
+		Method: CapabilityMethod{Attach: "unobserved", Loaded: "unobserved", Runtime: "unobserved"},
+		Result: CapabilityInfraError, Reason: reason,
+		LastObserved: normalizeCapabilityObservation(observation),
+	}
+}
+
+// EnforceCapabilityVersion preserves the independently observed tuple but
+// prevents a scheduled matrix declaration from qualifying a different one.
+func EnforceCapabilityVersion(result CapabilityResult, expected string) CapabilityResult {
+	if result.Result == CapabilityInfraError {
+		return result
+	}
+	if !semver.IsValid("v"+expected) ||
+		result.Versions.CLI != expected || result.Versions.Managed != expected || result.Versions.AppServer != expected {
+		result.Result = CapabilityInfraError
+		result.Reason = CapabilityReasonVersionMismatch
+	}
+	return result
+}
+
+func (result CapabilityResult) Validate() error {
+	if result.Versions != result.Versions.normalized() {
+		return fmt.Errorf("installed capability contains a blank version")
+	}
+	if result.Capability != CapabilityTurnFreeThreadLiveAttach {
+		return fmt.Errorf("installed capability %q is unknown", result.Capability)
+	}
+	for _, version := range []string{result.Versions.CLI, result.Versions.Managed, result.Versions.AppServer} {
+		if version != UnknownVersion && !semver.IsValid("v"+version) {
+			return fmt.Errorf("installed capability contains a non-semver version")
+		}
+	}
+	for _, method := range []string{result.Method.Attach, result.Method.Loaded, result.Method.Runtime} {
+		if !capabilityMethodPattern.MatchString(method) {
+			return fmt.Errorf("installed capability method %q is invalid", method)
+		}
+	}
+	if !capabilityProbePattern.MatchString(result.LastObserved.Probe) ||
+		!capabilityRunPattern.MatchString(result.LastObserved.Run) {
+		return fmt.Errorf("installed capability last-observed evidence is incomplete")
+	}
+	switch result.Result {
+	case CapabilitySupported:
+		if result.Reason != CapabilityReasonLivePaneAttached ||
+			result.Versions.CLI == UnknownVersion || result.Versions.Managed == UnknownVersion || result.Versions.AppServer == UnknownVersion ||
+			!result.Evidence.EndpointReady || !result.Evidence.ThreadCreatedWithoutTurn ||
+			!result.Evidence.LoadedBeforeAttach || !result.Evidence.AttachAttempted ||
+			!result.Evidence.LoadedAfterAttach || !result.Evidence.PaneObserved || !result.Evidence.PaneAlive ||
+			!slices.Contains([]string{"idle", "active"}, result.Evidence.RuntimeStatusAfterAttach) {
+			return fmt.Errorf("installed supported capability lacks live no-turn Pane evidence")
+		}
+	case CapabilityUnsupported:
+		if result.Reason != CapabilityReasonAttachRefused ||
+			result.Versions.CLI == UnknownVersion || result.Versions.Managed == UnknownVersion || result.Versions.AppServer == UnknownVersion ||
+			!result.Evidence.EndpointReady || !result.Evidence.ThreadCreatedWithoutTurn ||
+			!result.Evidence.LoadedBeforeAttach || !result.Evidence.AttachAttempted ||
+			!result.Evidence.PaneObserved || result.Evidence.PaneAlive {
+			return fmt.Errorf("installed unsupported capability lacks a terminal attach refusal")
+		}
+	case CapabilityInfraError:
+		if !slices.Contains([]CapabilityReason{
+			CapabilityReasonEndpointUnavailable,
+			CapabilityReasonEvidenceIncomplete,
+			CapabilityReasonProbeInvalid,
+			CapabilityReasonTerminalMissing,
+			CapabilityReasonTerminalInvalid,
+			CapabilityReasonVersionMismatch,
+		}, result.Reason) {
+			return fmt.Errorf("installed capability infrastructure result has reason %q", result.Reason)
+		}
+	default:
+		return fmt.Errorf("installed capability result %q is not terminal", result.Result)
+	}
+	return nil
+}
+
+func (result CapabilityResult) JSON() (string, error) {
+	if err := result.Validate(); err != nil {
+		return "", err
+	}
+	encoded, err := json.Marshal(result)
+	return string(encoded), err
+}
+
+func (ledger CapabilityLedger) Validate() error {
+	if ledger.SchemaVersion != CapabilitySchemaVersion {
+		return fmt.Errorf("installed capability ledger schema version = %d", ledger.SchemaVersion)
+	}
+	if len(ledger.Capabilities) != 1 {
+		return fmt.Errorf("installed capability ledger entries = %d, want 1", len(ledger.Capabilities))
+	}
+	return ledger.Capabilities[0].Validate()
+}
+
+func (ledger CapabilityLedger) JSON() ([]byte, error) {
+	if err := ledger.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(ledger, "", "  ")
+}
+
+func DecodeCapabilityLedger(encoded []byte) (CapabilityLedger, error) {
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.DisallowUnknownFields()
+	var ledger CapabilityLedger
+	if err := decoder.Decode(&ledger); err != nil {
+		return CapabilityLedger{}, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err == nil {
+		return CapabilityLedger{}, fmt.Errorf("installed capability ledger contains trailing JSON")
+	} else if err != io.EOF {
+		return CapabilityLedger{}, err
+	}
+	if err := ledger.Validate(); err != nil {
+		return CapabilityLedger{}, err
+	}
+	return ledger, nil
+}
+
+func normalizeCapabilityObservation(observation CapabilityObservation) CapabilityObservation {
+	observation.Probe = strings.TrimSpace(observation.Probe)
+	observation.Run = strings.TrimSpace(observation.Run)
+	return observation
+}

--- a/internal/testutil/codexinstalled/capability_test.go
+++ b/internal/testutil/codexinstalled/capability_test.go
@@ -1,0 +1,161 @@
+package codexinstalled
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func TestCapabilityReducerSeparatesMethodFromSemanticResult(t *testing.T) {
+	versions := VersionTuple{CLI: "0.152.0", Managed: "0.152.0", AppServer: "0.152.0"}
+	evidence := CapabilityEvidence{
+		EndpointReady: true, ThreadCreatedWithoutTurn: true, LoadedBeforeAttach: true,
+		AttachAttempted: true, LoadedAfterAttach: true, RuntimeStatusAfterAttach: "idle", PaneObserved: true, PaneAlive: true,
+	}
+	observation := CapabilityObservation{Probe: "TestInstalledIsolatedPreTurnBootstrapSmoke", Run: "fixture-run"}
+	methods := []CapabilityMethod{
+		{Attach: "cli-remote-resume", Loaded: "rpc-thread-loaded-list", Runtime: "rpc-thread-read"},
+		{Attach: "rpc-subscribe-thread", Loaded: "cli-loaded-list", Runtime: "wire-thread-state"},
+	}
+	results := make([]CapabilityResult, 0, len(methods))
+	for _, method := range methods {
+		result := EvaluateTurnFreeThreadLiveAttach(versions, method, evidence, observation)
+		if err := result.Validate(); err != nil {
+			t.Fatal(err)
+		}
+		results = append(results, result)
+	}
+	if results[0].Result != CapabilitySupported || results[0].Reason != CapabilityReasonLivePaneAttached ||
+		results[1].Result != results[0].Result || results[1].Reason != results[0].Reason {
+		t.Fatalf("method changed semantic result: %+v", results)
+	}
+	if reflect.DeepEqual(results[0].Method, results[1].Method) {
+		t.Fatal("method evidence was not retained separately")
+	}
+}
+
+func TestCapabilityReducerKeepsUnavailableEndpointAsInfraError(t *testing.T) {
+	result := EvaluateTurnFreeThreadLiveAttach(
+		VersionTuple{},
+		CapabilityMethod{Attach: "cli-remote-resume", Loaded: "rpc-thread-loaded-list", Runtime: "rpc-thread-read"},
+		CapabilityEvidence{},
+		CapabilityObservation{Probe: "UnavailableEndpointNegative", Run: "fixture-run"},
+	)
+	if result.Result != CapabilityInfraError || result.Reason != CapabilityReasonEndpointUnavailable {
+		t.Fatalf("unavailable endpoint = %+v, want infra-error", result)
+	}
+	if err := result.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCapabilityReducerRequiresLoadedRuntimeAndLivingPane(t *testing.T) {
+	versions := VersionTuple{CLI: "0.152.0", Managed: "0.152.0", AppServer: "0.152.0"}
+	method := CapabilityMethod{Attach: "cli-remote-resume", Loaded: "rpc-thread-loaded-list", Runtime: "rpc-thread-read"}
+	observation := CapabilityObservation{Probe: "fixture", Run: "fixture-run"}
+	base := CapabilityEvidence{
+		EndpointReady: true, ThreadCreatedWithoutTurn: true, LoadedBeforeAttach: true, AttachAttempted: true, PaneObserved: true,
+	}
+	dead := EvaluateTurnFreeThreadLiveAttach(versions, method, base, observation)
+	if dead.Result != CapabilityUnsupported || dead.Reason != CapabilityReasonAttachRefused {
+		t.Fatalf("dead Pane = %+v, want unsupported", dead)
+	}
+	if err := dead.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	unobserved := base
+	unobserved.PaneObserved = false
+	missingPaneEvidence := EvaluateTurnFreeThreadLiveAttach(versions, method, unobserved, observation)
+	if missingPaneEvidence.Result != CapabilityInfraError || missingPaneEvidence.Reason != CapabilityReasonEvidenceIncomplete {
+		t.Fatalf("unobserved Pane = %+v, want infra-error", missingPaneEvidence)
+	}
+	partial := base
+	partial.PaneAlive = true
+	partial.LoadedAfterAttach = true
+	partial.RuntimeStatusAfterAttach = "notLoaded"
+	incomplete := EvaluateTurnFreeThreadLiveAttach(versions, method, partial, observation)
+	if incomplete.Result != CapabilityInfraError || incomplete.Reason != CapabilityReasonEvidenceIncomplete {
+		t.Fatalf("incomplete runtime = %+v, want infra-error", incomplete)
+	}
+}
+
+func TestCapabilityLedgerIsStrictAndVersioned(t *testing.T) {
+	result := EvaluateTurnFreeThreadLiveAttach(
+		VersionTuple{CLI: "0.152.0", Managed: "0.152.0", AppServer: "0.152.0"},
+		CapabilityMethod{Attach: "cli-remote-resume", Loaded: "rpc-thread-loaded-list", Runtime: "rpc-thread-read"},
+		CapabilityEvidence{
+			EndpointReady: true, ThreadCreatedWithoutTurn: true, LoadedBeforeAttach: true,
+			AttachAttempted: true, LoadedAfterAttach: true, RuntimeStatusAfterAttach: "idle", PaneObserved: true, PaneAlive: true,
+		},
+		CapabilityObservation{Probe: "fixture", Run: "fixture-run"},
+	)
+	ledger := CapabilityLedger{SchemaVersion: CapabilitySchemaVersion, Capabilities: []CapabilityResult{result}}
+	encoded, err := ledger.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecodeCapabilityLedger(encoded); err != nil {
+		t.Fatal(err)
+	}
+	unknown := append(encoded[:len(encoded)-1], []byte(`,"unexpected":true}`)...)
+	if _, err := DecodeCapabilityLedger(unknown); err == nil {
+		t.Fatal("unknown capability ledger field was accepted")
+	}
+	result.LastObserved.Run = "/private/path"
+	if err := result.Validate(); err == nil {
+		t.Fatal("content-bearing last-observed evidence was accepted")
+	}
+}
+
+func TestSupportedCapabilityRejectsBlankLastObservedEvidence(t *testing.T) {
+	base := EvaluateTurnFreeThreadLiveAttach(
+		VersionTuple{CLI: "0.152.0", Managed: "0.152.0", AppServer: "0.152.0"},
+		CapabilityMethod{Attach: "cli-remote-resume", Loaded: "rpc-thread-loaded-list", Runtime: "rpc-thread-read"},
+		CapabilityEvidence{
+			EndpointReady: true, ThreadCreatedWithoutTurn: true, LoadedBeforeAttach: true,
+			AttachAttempted: true, LoadedAfterAttach: true, RuntimeStatusAfterAttach: "idle",
+			PaneObserved: true, PaneAlive: true,
+		},
+		CapabilityObservation{Probe: "fixture", Run: "fixture-run"},
+	)
+	for _, test := range []struct {
+		name        string
+		observation CapabilityObservation
+	}{
+		{name: "probe", observation: CapabilityObservation{Run: "fixture-run"}},
+		{name: "run", observation: CapabilityObservation{Probe: "fixture"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := base
+			result.LastObserved = normalizeCapabilityObservation(test.observation)
+			if err := result.Validate(); err == nil {
+				t.Fatal("supported capability accepted blank last-observed evidence")
+			}
+		})
+	}
+}
+
+func TestCheckedInCapabilityLedgerMatchesCurrentInstalledGate(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate capability ledger contract test")
+	}
+	path := filepath.Join(filepath.Dir(currentFile), "..", "..", "..", "docs", "codex-installed-capabilities.json")
+	encoded, err := os.ReadFile(path) // #nosec G304 -- path is derived from this tracked source file.
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger, err := DecodeCapabilityLedger(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := ledger.Capabilities[0]
+	wantVersions := VersionTuple{CLI: "0.152.0", Managed: "0.152.0", AppServer: "0.152.0"}
+	if result.Versions != wantVersions || result.Result != CapabilitySupported ||
+		result.Reason != CapabilityReasonLivePaneAttached ||
+		result.LastObserved.Probe != "TestInstalledIsolatedPreTurnBootstrapSmoke" {
+		t.Fatalf("checked-in current capability gate = %+v", result)
+	}
+}

--- a/internal/testutil/codexinstalled/cmd/qualification/main.go
+++ b/internal/testutil/codexinstalled/cmd/qualification/main.go
@@ -77,12 +77,14 @@ func runPrimitive(primitive codexinstalled.QualificationPrimitive, preflight, ex
 	}
 	if preflight != "success" {
 		result := codexinstalled.InstallationFailureQualification(spec)
-		return childArtifact(result), fmt.Errorf("declared Codex installation did not succeed")
+		return childArtifact(result, capabilityLedgerForFailure(spec, result.Versions,
+			codexinstalled.CapabilityReasonEndpointUnavailable)), fmt.Errorf("declared Codex installation did not succeed")
 	}
 	root, err := os.MkdirTemp("", "projmux-installed-qualification-")
 	if err != nil {
 		result := codexinstalled.ReduceQualification(spec, nil, false)
-		return childArtifact(result), err
+		return childArtifact(result, capabilityLedgerForFailure(spec, result.Versions,
+			codexinstalled.CapabilityReasonEndpointUnavailable)), err
 	}
 
 	command := exec.Command("go", "test", "-count=1", "-timeout=3m", "-json", // #nosec G204 -- fixed command and canonical test spec.
@@ -114,6 +116,7 @@ func runPrimitive(primitive codexinstalled.QualificationPrimitive, preflight, ex
 		retireProcessGroup(command.Process.Pid)
 	}
 	observed := decodeInstalledResults(output.Bytes())
+	capabilities := decodeInstalledCapabilities(output.Bytes())
 	if output.truncated {
 		observed = append(observed, codexinstalled.Result{})
 	}
@@ -129,20 +132,87 @@ func runPrimitive(primitive codexinstalled.QualificationPrimitive, preflight, ex
 
 	result := codexinstalled.ReduceQualification(spec, observed, succeeded)
 	result = codexinstalled.EnforceQualificationVersion(result, expectedVersion)
-	artifact := childArtifact(result)
+	ledger, capabilityErr := reduceCapabilityLedger(spec, capabilities, result.Versions, expectedVersion)
+	artifact := childArtifact(result, ledger)
 	if err := result.Validate(); err != nil {
 		return artifact, err
 	}
 	if result.Class != codexinstalled.ResultPass {
 		return artifact, fmt.Errorf("qualification primitive is %s", result.Class)
 	}
+	if capabilityErr != nil {
+		return artifact, capabilityErr
+	}
 	return artifact, nil
 }
 
-func childArtifact(result codexinstalled.QualificationResult) codexinstalled.QualificationArtifact {
+func childArtifact(result codexinstalled.QualificationResult, ledger *codexinstalled.CapabilityLedger) codexinstalled.QualificationArtifact {
 	return codexinstalled.QualificationArtifact{
-		SchemaVersion: codexinstalled.QualificationSchemaVersion,
-		Results:       []codexinstalled.QualificationResult{result},
+		SchemaVersion:    codexinstalled.QualificationSchemaVersion,
+		Results:          []codexinstalled.QualificationResult{result},
+		CapabilityLedger: ledger,
+	}
+}
+
+func capabilityLedgerForFailure(
+	spec codexinstalled.QualificationSpec,
+	versions codexinstalled.VersionTuple,
+	reason codexinstalled.CapabilityReason,
+) *codexinstalled.CapabilityLedger {
+	if spec.Primitive != codexinstalled.PrimitivePreTurnAttach {
+		return nil
+	}
+	result := codexinstalled.InfraErrorCapability(versions, reason, capabilityObservation(spec))
+	return &codexinstalled.CapabilityLedger{
+		SchemaVersion: codexinstalled.CapabilitySchemaVersion,
+		Capabilities:  []codexinstalled.CapabilityResult{result},
+	}
+}
+
+func reduceCapabilityLedger(
+	spec codexinstalled.QualificationSpec,
+	observed []codexinstalled.CapabilityResult,
+	versions codexinstalled.VersionTuple,
+	expectedVersion string,
+) (*codexinstalled.CapabilityLedger, error) {
+	if spec.Primitive != codexinstalled.PrimitivePreTurnAttach {
+		if len(observed) != 0 {
+			return nil, fmt.Errorf("non-capability primitive emitted capability evidence")
+		}
+		return nil, nil
+	}
+	var result codexinstalled.CapabilityResult
+	var reduceErr error
+	switch len(observed) {
+	case 0:
+		result = codexinstalled.InfraErrorCapability(versions, codexinstalled.CapabilityReasonTerminalMissing, capabilityObservation(spec))
+		reduceErr = fmt.Errorf("pre-turn capability result is missing")
+	case 1:
+		result = observed[0]
+		if err := result.Validate(); err != nil {
+			result = codexinstalled.InfraErrorCapability(versions, codexinstalled.CapabilityReasonTerminalInvalid, capabilityObservation(spec))
+			reduceErr = err
+		} else {
+			result = codexinstalled.EnforceCapabilityVersion(result, expectedVersion)
+			if result.Result == codexinstalled.CapabilityInfraError {
+				reduceErr = fmt.Errorf("pre-turn capability is infrastructure-error")
+			}
+		}
+	default:
+		result = codexinstalled.InfraErrorCapability(versions, codexinstalled.CapabilityReasonTerminalInvalid, capabilityObservation(spec))
+		reduceErr = fmt.Errorf("pre-turn capability emitted %d terminal results", len(observed))
+	}
+	ledger := &codexinstalled.CapabilityLedger{
+		SchemaVersion: codexinstalled.CapabilitySchemaVersion,
+		Capabilities:  []codexinstalled.CapabilityResult{result},
+	}
+	return ledger, reduceErr
+}
+
+func capabilityObservation(spec codexinstalled.QualificationSpec) codexinstalled.CapabilityObservation {
+	return codexinstalled.CapabilityObservation{
+		Probe: spec.TestName,
+		Run:   os.Getenv("PROJMUX_CODEX_EVIDENCE_RUN"),
 	}
 }
 
@@ -205,6 +275,29 @@ func decodeInstalledResults(encoded []byte) []codexinstalled.Result {
 		var result codexinstalled.Result
 		if err := json.Unmarshal([]byte(strings.TrimSpace(event.Output[index+len(marker):])), &result); err != nil {
 			results = append(results, codexinstalled.Result{})
+			continue
+		}
+		results = append(results, result)
+	}
+	return results
+}
+
+func decodeInstalledCapabilities(encoded []byte) []codexinstalled.CapabilityResult {
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	results := make([]codexinstalled.CapabilityResult, 0)
+	const marker = "installed-capability: "
+	for {
+		var event testEvent
+		if err := decoder.Decode(&event); err != nil {
+			break
+		}
+		index := strings.Index(event.Output, marker)
+		if index < 0 {
+			continue
+		}
+		var result codexinstalled.CapabilityResult
+		if err := json.Unmarshal([]byte(strings.TrimSpace(event.Output[index+len(marker):])), &result); err != nil {
+			results = append(results, codexinstalled.CapabilityResult{})
 			continue
 		}
 		results = append(results, result)

--- a/internal/testutil/codexinstalled/cmd/qualification/main_test.go
+++ b/internal/testutil/codexinstalled/cmd/qualification/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/testutil/codexinstalled"
+)
+
+func TestCapabilityMarkerReductionPreservesTerminalUnsupported(t *testing.T) {
+	spec, _ := codexinstalled.QualificationSpecFor(codexinstalled.PrimitivePreTurnAttach)
+	versions := codexinstalled.VersionTuple{CLI: "0.152.0", Managed: "0.152.0", AppServer: "0.152.0"}
+	result := codexinstalled.EvaluateTurnFreeThreadLiveAttach(
+		versions,
+		codexinstalled.CapabilityMethod{Attach: "cli-remote-resume", Loaded: "rpc-thread-loaded-list", Runtime: "rpc-thread-read"},
+		codexinstalled.CapabilityEvidence{
+			EndpointReady: true, ThreadCreatedWithoutTurn: true, LoadedBeforeAttach: true,
+			AttachAttempted: true, PaneObserved: true,
+		},
+		codexinstalled.CapabilityObservation{Probe: spec.TestName, Run: "fixture-run"},
+	)
+	ledger, err := reduceCapabilityLedger(spec, []codexinstalled.CapabilityResult{result}, versions, "0.152.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ledger.Capabilities[0]; got.Result != codexinstalled.CapabilityUnsupported ||
+		got.Reason != codexinstalled.CapabilityReasonAttachRefused || got.Method != result.Method {
+		t.Fatalf("terminal unsupported reduction = %+v", got)
+	}
+}
+
+func TestCapabilityMarkerReductionMakesMissingEvidenceInfraError(t *testing.T) {
+	t.Setenv("PROJMUX_CODEX_EVIDENCE_RUN", "fixture-run")
+	spec, _ := codexinstalled.QualificationSpecFor(codexinstalled.PrimitivePreTurnAttach)
+	versions := codexinstalled.VersionTuple{CLI: "0.152.0", Managed: "0.152.0", AppServer: "0.152.0"}
+	ledger, err := reduceCapabilityLedger(spec, nil, versions, "0.152.0")
+	if err == nil {
+		t.Fatal("missing capability marker passed reduction")
+	}
+	if got := ledger.Capabilities[0]; got.Result != codexinstalled.CapabilityInfraError ||
+		got.Reason != codexinstalled.CapabilityReasonTerminalMissing {
+		t.Fatalf("missing capability marker = %+v", got)
+	}
+	if err := ledger.Validate(); err != nil {
+		t.Fatalf("strict failure ledger did not retain exact runner evidence: %v", err)
+	}
+}
+
+func TestCapabilityMarkerDecoderUsesItsTypedMarkerOnly(t *testing.T) {
+	result := codexinstalled.EvaluateTurnFreeThreadLiveAttach(
+		codexinstalled.VersionTuple{CLI: "0.152.0", Managed: "0.152.0", AppServer: "0.152.0"},
+		codexinstalled.CapabilityMethod{Attach: "cli-remote-resume", Loaded: "rpc-thread-loaded-list", Runtime: "rpc-thread-read"},
+		codexinstalled.CapabilityEvidence{
+			EndpointReady: true, ThreadCreatedWithoutTurn: true, LoadedBeforeAttach: true,
+			AttachAttempted: true, LoadedAfterAttach: true, RuntimeStatusAfterAttach: "idle",
+			PaneObserved: true, PaneAlive: true,
+		},
+		codexinstalled.CapabilityObservation{Probe: "FixtureProbe", Run: "fixture-run"},
+	)
+	encoded, err := result.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := fmt.Sprintf("{\"Output\":\"installed-result: {}\\n\"}\n{\"Output\":%q}\n",
+		"installed-capability: "+encoded+"\n")
+	got := decodeInstalledCapabilities([]byte(events))
+	if len(got) != 1 || got[0].Result != codexinstalled.CapabilitySupported {
+		t.Fatalf("decoded capabilities = %+v", got)
+	}
+}

--- a/internal/testutil/codexinstalled/ledger.go
+++ b/internal/testutil/codexinstalled/ledger.go
@@ -163,6 +163,8 @@ func classifyCodexCommand(scope CommandScope, argv []string) Command {
 		command.Operation = "managed-stop"
 	case equalArgv(argv, "app-server", "--listen", "unix://"):
 		command.Operation = "direct-start"
+	case len(argv) == 4 && argv[0] == "resume" && argv[1] == "--remote" && argv[2] == "unix://" && strings.TrimSpace(argv[3]) != "":
+		command.Operation, command.Mutation = "pre-turn-cli-remote-resume", MutationProtocolSession
 	}
 	return command
 }

--- a/internal/testutil/codexinstalled/pane.go
+++ b/internal/testutil/codexinstalled/pane.go
@@ -1,0 +1,156 @@
+package codexinstalled
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const capabilityTmuxSocket = "projmux-installed-capability"
+
+// IsolatedPane is the exact tmux Pane used as carrier evidence for one
+// installed capability probe. It owns its server below the fixture root and
+// never addresses the caller's tmux socket.
+type IsolatedPane struct {
+	tmpdir      string
+	socketPath  string
+	paneID      string
+	environment []string
+	closed      bool
+}
+
+func (fixture *Fixture) StartTurnFreeAttachPane(ctx context.Context, threadID string) (*IsolatedPane, error) {
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" {
+		return nil, fmt.Errorf("turn-free attach Pane requires thread id")
+	}
+	tmpdir := filepath.Join(fixture.Root, "tmux")
+	if err := os.MkdirAll(tmpdir, 0o700); err != nil {
+		return nil, fmt.Errorf("create capability tmux root: %w", err)
+	}
+	environment := tmuxCapabilityEnvironment(os.Environ(), fixture.CodexHome, tmpdir)
+	pane := &IsolatedPane{tmpdir: tmpdir, environment: environment}
+	keeper, err := pane.run(ctx, "-L", capabilityTmuxSocket, "-f", "/dev/null", "new-session", "-d",
+		"-s", "installed-capability-keeper", "-P", "-F", "#{pane_id}", "tail", "-f", "/dev/null")
+	if err != nil {
+		_ = os.RemoveAll(tmpdir)
+		return nil, fmt.Errorf("start capability tmux keeper: %w", err)
+	}
+	if strings.TrimSpace(string(keeper)) == "" {
+		_ = pane.Close(context.Background())
+		return nil, fmt.Errorf("capability tmux keeper returned no Pane")
+	}
+	socket, err := pane.run(ctx, "-L", capabilityTmuxSocket, "display-message", "-p", "#{socket_path}")
+	if err != nil {
+		_ = pane.Close(context.Background())
+		return nil, fmt.Errorf("observe capability tmux socket: %w", err)
+	}
+	pane.socketPath = filepath.Clean(strings.TrimSpace(string(socket)))
+	if !pathWithin(pane.tmpdir, pane.socketPath) {
+		_ = pane.Close(context.Background())
+		return nil, fmt.Errorf("capability tmux socket escaped its fixture root")
+	}
+	if _, err := pane.run(ctx, "-L", capabilityTmuxSocket, "set-option", "-g", "remain-on-exit", "on"); err != nil {
+		_ = pane.Close(context.Background())
+		return nil, fmt.Errorf("enable capability Pane exit evidence: %w", err)
+	}
+	created, err := pane.run(ctx, "-L", capabilityTmuxSocket, "new-session", "-d",
+		"-s", "installed-capability-attach", "-c", fixture.Workspace,
+		"-P", "-F", "#{pane_id}", "codex", "resume", "--remote", "unix://", threadID)
+	if err != nil {
+		_ = pane.Close(context.Background())
+		return nil, fmt.Errorf("start turn-free attach Pane: %w", err)
+	}
+	pane.paneID = strings.TrimSpace(string(created))
+	if !strings.HasPrefix(pane.paneID, "%") {
+		_ = pane.Close(context.Background())
+		return nil, fmt.Errorf("turn-free attach returned an invalid Pane id")
+	}
+	return pane, nil
+}
+
+func (pane *IsolatedPane) ID() string { return pane.paneID }
+
+// Alive observes only the exact Pane returned by new-session. pane_dead is the
+// carrier liveness authority; pane order, screen contents, and send-keys are
+// intentionally absent.
+func (pane *IsolatedPane) Alive(ctx context.Context) (bool, error) {
+	if pane == nil || pane.closed || pane.paneID == "" {
+		return false, fmt.Errorf("capability Pane is not open")
+	}
+	output, err := pane.run(ctx, "-L", capabilityTmuxSocket, "display-message", "-p", "-t", pane.paneID,
+		"#{pane_dead}\t#{pane_pid}\t#{socket_path}")
+	if err != nil {
+		return false, err
+	}
+	fields := strings.Split(strings.TrimSpace(string(output)), "\t")
+	if len(fields) != 3 || filepath.Clean(fields[2]) != pane.socketPath {
+		return false, fmt.Errorf("capability Pane observation is malformed")
+	}
+	pid, err := strconv.Atoi(fields[1])
+	if err != nil || pid <= 0 {
+		return false, fmt.Errorf("capability Pane has no process identity")
+	}
+	switch fields[0] {
+	case "0":
+		return true, nil
+	case "1":
+		return false, nil
+	default:
+		return false, fmt.Errorf("capability Pane returned unknown dead state")
+	}
+}
+
+func (pane *IsolatedPane) Close(ctx context.Context) error {
+	if pane == nil || pane.closed {
+		return nil
+	}
+	pane.closed = true
+	if pane.socketPath == "" || !pathWithin(pane.tmpdir, pane.socketPath) {
+		return fmt.Errorf("refuse capability tmux cleanup without contained socket proof")
+	}
+	observed, err := pane.run(ctx, "-L", capabilityTmuxSocket, "display-message", "-p", "#{socket_path}")
+	if err != nil {
+		return fmt.Errorf("observe capability tmux socket before cleanup: %w", err)
+	}
+	if filepath.Clean(strings.TrimSpace(string(observed))) != pane.socketPath {
+		return fmt.Errorf("capability tmux socket identity changed before cleanup")
+	}
+	_, killErr := pane.run(ctx, "-L", capabilityTmuxSocket, "kill-server")
+	removeErr := os.RemoveAll(pane.tmpdir)
+	return errors.Join(killErr, removeErr)
+}
+
+func (pane *IsolatedPane) run(ctx context.Context, args ...string) ([]byte, error) {
+	command := exec.CommandContext(ctx, "tmux", args...) // #nosec G204 -- executable is fixed tmux; argv is internal structured arguments and never enters a shell.
+	command.Env = pane.environment
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return output, fmt.Errorf("tmux %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+	}
+	return output, nil
+}
+
+func tmuxCapabilityEnvironment(environment []string, codexHome, tmpdir string) []string {
+	filtered := make([]string, 0, len(environment)+2)
+	for _, entry := range environment {
+		key, _, _ := strings.Cut(entry, "=")
+		switch key {
+		case "CODEX_HOME", "TMUX", "TMUX_PANE", "TMUX_TMPDIR",
+			"OPENAI_API_KEY", "CODEX_API_KEY", "CODEX_TOKEN":
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return append(filtered, "CODEX_HOME="+codexHome, "TMUX_TMPDIR="+tmpdir)
+}
+
+func pathWithin(root, path string) bool {
+	root, path = filepath.Clean(root), filepath.Clean(path)
+	return filepath.IsAbs(root) && filepath.IsAbs(path) && path != root && strings.HasPrefix(path, root+string(filepath.Separator))
+}

--- a/internal/testutil/codexinstalled/pane_test.go
+++ b/internal/testutil/codexinstalled/pane_test.go
@@ -1,0 +1,56 @@
+package codexinstalled
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTurnFreeAttachPaneCommandExcludesCredentialsAndAmbientIdentity(t *testing.T) {
+	binDir := t.TempDir()
+	tmuxPath := filepath.Join(binDir, "tmux")
+	if err := os.WriteFile(tmuxPath, []byte("#!/bin/sh\n/usr/bin/env\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+	pane := IsolatedPane{environment: tmuxCapabilityEnvironment([]string{
+		"PATH=" + binDir,
+		"PROJMUX_SAFE=retained",
+		"CODEX_HOME=/ambient/codex",
+		"TMUX=/ambient/tmux,1,0",
+		"TMUX_PANE=%42",
+		"TMUX_TMPDIR=/ambient/tmux-root",
+		"OPENAI_API_KEY=openai-secret",
+		"CODEX_API_KEY=codex-secret",
+		"CODEX_TOKEN=codex-token-secret",
+	}, "/isolated/codex", "/isolated/tmux-root")}
+	output, err := pane.run(context.Background(), "display-message")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := make(map[string]string, len(pane.environment))
+	for entry := range strings.SplitSeq(strings.TrimSpace(string(output)), "\n") {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			t.Fatalf("environment entry %q has no value", entry)
+		}
+		got[key] = value
+		if strings.Contains(value, "secret") || strings.Contains(value, "/ambient/") || value == "%42" {
+			t.Fatalf("caller identity reached capability Pane environment: %q", entry)
+		}
+	}
+	for _, key := range []string{"TMUX", "TMUX_PANE", "OPENAI_API_KEY", "CODEX_API_KEY", "CODEX_TOKEN"} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("capability Pane inherited %s", key)
+		}
+	}
+	if got["CODEX_HOME"] != "/isolated/codex" || got["TMUX_TMPDIR"] != "/isolated/tmux-root" {
+		t.Fatalf("capability Pane isolation roots = %+v", got)
+	}
+	if got["PATH"] != binDir || got["PROJMUX_SAFE"] != "retained" {
+		t.Fatalf("non-sensitive environment was not preserved: %+v", got)
+	}
+}

--- a/internal/testutil/codexinstalled/qualification.go
+++ b/internal/testutil/codexinstalled/qualification.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-const QualificationSchemaVersion = 1
+const QualificationSchemaVersion = 2
 
 type QualificationPrimitive string
 
@@ -63,8 +63,9 @@ type QualificationResult struct {
 }
 
 type QualificationArtifact struct {
-	SchemaVersion int                   `json:"schema_version"`
-	Results       []QualificationResult `json:"results"`
+	SchemaVersion    int                   `json:"schema_version"`
+	Results          []QualificationResult `json:"results"`
+	CapabilityLedger *CapabilityLedger     `json:"capability_ledger"`
 }
 
 // QualificationSpec binds each scheduled matrix leg to its existing
@@ -188,6 +189,15 @@ func (artifact QualificationArtifact) Validate(expected []QualificationPrimitive
 			return fmt.Errorf("installed qualification artifact is missing primitive %q", primitive)
 		}
 	}
+	wantsCapability := slices.Contains(expected, PrimitivePreTurnAttach)
+	if wantsCapability != (artifact.CapabilityLedger != nil) {
+		return fmt.Errorf("installed qualification capability ledger presence does not match pre-turn primitive")
+	}
+	if artifact.CapabilityLedger != nil {
+		if err := artifact.CapabilityLedger.Validate(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -283,6 +293,14 @@ func AggregateQualificationArtifacts(children map[QualificationPrimitive][]byte)
 				spec, VersionTuple{}.normalized(), ResultInfraError, QualificationReasonChildArtifactMissing,
 			))
 			invalidChildren++
+			if spec.Primitive == PrimitivePreTurnAttach {
+				ledger := CapabilityLedger{SchemaVersion: CapabilitySchemaVersion, Capabilities: []CapabilityResult{
+					InfraErrorCapability(VersionTuple{}, CapabilityReasonTerminalMissing, CapabilityObservation{
+						Probe: spec.TestName, Run: "aggregate-missing-child",
+					}),
+				}}
+				artifact.CapabilityLedger = &ledger
+			}
 			continue
 		}
 		child, err := DecodeQualificationArtifact(encoded, []QualificationPrimitive{spec.Primitive})
@@ -291,9 +309,25 @@ func AggregateQualificationArtifacts(children map[QualificationPrimitive][]byte)
 				spec, VersionTuple{}.normalized(), ResultInfraError, QualificationReasonChildArtifactInvalid,
 			))
 			invalidChildren++
+			if spec.Primitive == PrimitivePreTurnAttach {
+				ledger := CapabilityLedger{SchemaVersion: CapabilitySchemaVersion, Capabilities: []CapabilityResult{
+					InfraErrorCapability(VersionTuple{}, CapabilityReasonTerminalInvalid, CapabilityObservation{
+						Probe: spec.TestName, Run: "aggregate-invalid-child",
+					}),
+				}}
+				artifact.CapabilityLedger = &ledger
+			}
 			continue
 		}
 		artifact.Results = append(artifact.Results, child.Results[0])
+		if child.CapabilityLedger != nil {
+			if artifact.CapabilityLedger != nil {
+				return QualificationArtifact{}, fmt.Errorf("installed qualification has duplicate capability ledgers")
+			}
+			ledger := *child.CapabilityLedger
+			ledger.Capabilities = append([]CapabilityResult(nil), child.CapabilityLedger.Capabilities...)
+			artifact.CapabilityLedger = &ledger
+		}
 	}
 	expected := qualificationPrimitives()
 	if err := artifact.Validate(expected); err != nil {

--- a/internal/testutil/codexinstalled/qualification_test.go
+++ b/internal/testutil/codexinstalled/qualification_test.go
@@ -7,8 +7,9 @@ import (
 
 func TestQualificationArtifactSchemaIsStructurallyContentFree(t *testing.T) {
 	assertQualificationFields(t, reflect.TypeFor[QualificationArtifact](), map[string]reflect.Type{
-		"schema_version": reflect.TypeFor[int](),
-		"results":        reflect.TypeFor[[]QualificationResult](),
+		"schema_version":    reflect.TypeFor[int](),
+		"results":           reflect.TypeFor[[]QualificationResult](),
+		"capability_ledger": reflect.TypeFor[*CapabilityLedger](),
 	})
 	assertQualificationFields(t, reflect.TypeFor[QualificationResult](), map[string]reflect.Type{
 		"versions":  reflect.TypeFor[VersionTuple](),
@@ -143,6 +144,10 @@ func TestQualificationReducerEmitsOneTerminalRecordPerMatrixLeg(t *testing.T) {
 			spec, _ := QualificationSpecFor(test.primitive)
 			result := ReduceQualification(spec, test.observed, test.succeeded)
 			artifact := QualificationArtifact{SchemaVersion: QualificationSchemaVersion, Results: []QualificationResult{result}}
+			if test.primitive == PrimitivePreTurnAttach {
+				ledger := supportedCapabilityLedger(versions)
+				artifact.CapabilityLedger = &ledger
+			}
 			if err := artifact.Validate([]QualificationPrimitive{test.primitive}); err != nil {
 				t.Fatal(err)
 			}
@@ -218,7 +223,7 @@ func TestQualificationAggregateSynthesizesEveryMissingMatrixChild(t *testing.T) 
 }
 
 func TestQualificationDecoderRejectsUnknownFieldsInsteadOfScanningValues(t *testing.T) {
-	encoded := []byte(`{"schema_version":1,"results":[],"extra":"opaque"}`)
+	encoded := []byte(`{"schema_version":2,"results":[],"extra":"opaque"}`)
 	if _, err := DecodeQualificationArtifact(encoded, nil); err == nil {
 		t.Fatal("an undeclared artifact field passed structural decoding")
 	}
@@ -244,4 +249,19 @@ func assertQualificationFields(t *testing.T, typ reflect.Type, want map[string]r
 
 func installedQualificationVersions() VersionTuple {
 	return VersionTuple{CLI: "0.152.0", Managed: "0.152.0", AppServer: "0.152.0"}
+}
+
+func supportedCapabilityLedger(versions VersionTuple) CapabilityLedger {
+	return CapabilityLedger{
+		SchemaVersion: CapabilitySchemaVersion,
+		Capabilities: []CapabilityResult{EvaluateTurnFreeThreadLiveAttach(
+			versions,
+			CapabilityMethod{Attach: "cli-remote-resume", Loaded: "rpc-thread-loaded-list", Runtime: "rpc-thread-read"},
+			CapabilityEvidence{
+				EndpointReady: true, ThreadCreatedWithoutTurn: true, LoadedBeforeAttach: true,
+				AttachAttempted: true, LoadedAfterAttach: true, RuntimeStatusAfterAttach: "idle", PaneObserved: true, PaneAlive: true,
+			},
+			CapabilityObservation{Probe: "TestInstalledIsolatedPreTurnBootstrapSmoke", Run: "fixture-run"},
+		)},
+	}
 }

--- a/internal/testutil/codexinstalled/result_test.go
+++ b/internal/testutil/codexinstalled/result_test.go
@@ -388,6 +388,7 @@ func TestInstalledCensusDeletionReceiptHasOneOwnerPerPrimitive(t *testing.T) {
 		{"catalog setup/readiness/socket assertions", "codexinstalled.Fixture", "thread/list", "direct startup failure is terminal"},
 		{"pre-turn setup/readiness/attach skip", "codexinstalled.Fixture", "thread/start + second attach + thread/read", "attach failure is terminal"},
 		{"scheduled daemon-lifecycle/thread-list/pre-turn-attach matrix entries (merged; no protocol bodies added)", "the three surviving Phase 0 canonical tests", "matrix invocation + typed reduction only", "missing or invalid terminal evidence is typed infra-error"},
+		{"pre-turn optional RPC resume log (merged into the existing canary)", "TestInstalledIsolatedPreTurnBootstrapSmoke", "turn-free CLI attach + exact Pane + loaded/runtime semantic reduction", "dead Pane is unsupported while an unavailable endpoint is infra-error"},
 		{"installCodexArgvLedger + codexInstalledSmokeReadOnlyArgv", "codexinstalled.Ledger", "native binding and exact-turn control", "ambient semantic mutation count is zero"},
 		{"retirement smoke root/readiness/argv blocks", "codexinstalled.Fixture + Ledger", "two-Agent shared connection and sibling fencing", "endpoint lifecycle mutation is rejected"},
 		{"approval smoke root/readiness/argv blocks", "codexinstalled.Fixture + Ledger", "approval lease response-once", "endpoint lifecycle mutation is rejected"},
@@ -410,6 +411,8 @@ func TestInstalledCensusDeletionReceiptHasOneOwnerPerPrimitive(t *testing.T) {
 		{"direct", "thread-list", "TestInstalledIsolatedConversationCatalogSmoke"},
 		{"direct", "thread-start", "TestInstalledIsolatedPreTurnBootstrapSmoke"},
 		{"direct", "thread-read", "TestInstalledIsolatedPreTurnBootstrapSmoke"},
+		{"direct", "thread-loaded-list", "TestInstalledIsolatedPreTurnBootstrapSmoke"},
+		{"direct-real-tmux", "turn-free-live-pane-attach", "TestInstalledIsolatedPreTurnBootstrapSmoke"},
 		{"direct", "native-binding-control", "TestInstalledIsolatedBrokerNativeBindingSmoke"},
 		{"direct", "shared-connection-retirement", "TestInstalledIsolatedRetiredObserverMatrixSmoke"},
 		{"direct", "approval-lease", "TestInstalledIsolatedBrokerApprovalLeaseSmoke"},
@@ -423,5 +426,15 @@ func TestInstalledCensusDeletionReceiptHasOneOwnerPerPrimitive(t *testing.T) {
 			t.Fatalf("installed primitive %q has duplicate owners %q and %q", key, previous, item.owner)
 		}
 		seenPrimitive[key] = item.owner
+	}
+}
+
+func TestTurnFreeCLIResumeIsProtocolMutationNotEndpointLifecycle(t *testing.T) {
+	command := classifyCodexCommand(ScopeIsolated, []string{"resume", "--remote", "unix://", "thread-opaque"})
+	if command.Operation != "pre-turn-cli-remote-resume" || command.Mutation != MutationProtocolSession {
+		t.Fatalf("turn-free CLI attach = %+v", command)
+	}
+	if command.Scope != ScopeIsolated {
+		t.Fatalf("turn-free CLI attach escaped isolated scope: %+v", command)
 	}
 }

--- a/test/ci_workflow_contract_test.py
+++ b/test/ci_workflow_contract_test.py
@@ -78,6 +78,11 @@ class CIWorkflowContractTest(unittest.TestCase):
             "          PROJMUX_CODEX_EXPECTED_VERSION: ${{ matrix.codex-version }}",
             installed,
         )
+        self.assertIn(
+            "          PROJMUX_CODEX_EVIDENCE_RUN: "
+            "github-actions:${{ github.run_id }}:${{ github.run_attempt }}",
+            installed,
+        )
         self.assertIn("          OPENAI_API_KEY: \"\"", installed)
         self.assertIn("          CODEX_API_KEY: \"\"", installed)
         self.assertIn("          CODEX_TOKEN: \"\"", installed)


### PR DESCRIPTION
## Summary

- record a schema-versioned installed Codex capability ledger that separates method metadata from semantic `supported` / `unsupported` / `infra-error`
- extend the single canonical pre-turn installed probe with loaded/runtime and exact living-Pane evidence, without duplicating its protocol body
- embed the capability ledger in scheduled/manual installed qualification artifacts and document the current tuple

## Capability result

- installed tuple: CLI/managed/app-server `0.152.0/0.152.0/0.152.0`, ready/current, ownership `unmanaged`
- semantic result: `supported / live-pane-attached`
- methods (metadata only): attach `cli-remote-resume`, loaded `rpc-thread-loaded-list`, runtime `rpc-thread-read`
- hosted evidence: run `33566050834`, aggregate artifact `9823166206`, ledger run `github-actions:33566050834:1`
- unavailable endpoint negative: `infra-error / endpoint-unavailable`, never reduced to `unsupported`

## Final verification

- base `a86c2ee73093072e1ca14736c7aa99f8deac2ea4`, head `d1e5b84412959a1cc27c960b720b5c0b4a2a89a8`
- `make fmt`: PASS
- `make fix`: PASS
- `make test`: PASS
- `make test-integration`: PASS, including `Codex app-server topology integration passed`
- selectorless `make test-e2e`: PASS on the first and only final-head run; attempt `attempt-local-1-3941759`, all L01-L19 + C01 + N01, binary SHA `274b2388df6d5107e4f1e683f993563d82bd5bdfbd9caeef9c8e1bc3a3071834`, result SHA `1293da9ea3ef517c5c46cfc61cd2b15c12f0fd0dee4d53f81118a3f4856643d3`
- isolated installed final-head probe `local-phase2-final-premerge`: qualification schema 2 / ledger schema 1, exact tuple, `supported / live-pane-attached`, exact Pane alive and loaded/runtime `idle`
- fresh CI run `33597055285`: required `Format`, `Unit Tests`, `NPM Packages`, `Integration Tests`, `E2E Tests` and aggregate `Test` PASS; all security/race/Darwin children PASS

## Scope

- capability probe actual model/turn/network calls: 0
- isolated roots only; ambient endpoint remained version/status read-only
- no empty-prompt implementation, C01/#862/#867 semantic changes, #860 admission changes, ruleset change, or Backlog 14 restart/takeover/ownership work
- parallel-owned files are untouched

## Post-merge receipt

- squash merge `33a99daf0910d692d7b20d43ea5b8a70b86212e5`; primary fast-forwarded clean to the same `origin/main`
- merged-main `make install`: PASS; `/home/es5h/go/bin/projmux` atomically replaced and live config verified
- ambient read-only observation: CLI/managed/running app-server `0.152.0/0.152.0/0.152.0`, ready/current, ownership `unmanaged`, lifecycle `not-attempted/read-only`
- isolated post-install probe `local-phase2-post-install`: `supported / live-pane-attached`, exact Pane alive, loaded before/after true, runtime `idle`
- exact worktree plus local/remote `test/installed-codex-capability-ledger` branch removed preview-first
