### PR TITLE
fix(codex): fence reconnect-gap hook projection

### DIFF
--- a/internal/app/agent_session_ref_test.go
+++ b/internal/app/agent_session_ref_test.go
@@ -112,6 +112,9 @@ func newSessionRefHarness(t *testing.T, provider string) *sessionRefHarness {
 			if len(args) >= 5 && args[0] == "display-message" && args[4] == "#{"+tmuxopts.PaneUID+"}" {
 				return []byte(h.paneUID + "\n"), nil
 			}
+			if len(args) >= 5 && args[0] == "display-message" && args[4] == "#{"+aiPaneCodexAuthorityOption+"}" {
+				return []byte(codexAuthorityHook + "\n"), nil
+			}
 			return nil, os.ErrNotExist
 		},
 		loadRegistry: func() (coremetadata.Registry, error) {

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -112,7 +112,10 @@ type aiCommand struct {
 	readResumeDetail              func(context.Context, aisessions.ResumeDetailRef, aisessions.OpenCodexCatalog) (aisessions.ResumeDetail, error)
 	// readResumePreview is retained as a narrow test seam for fixtures that
 	// exercise preview timing without the metadata projection.
-	readResumePreview          func(context.Context, aisessions.ResumeDetailRef, aisessions.OpenCodexCatalog) (aisessions.Preview, error)
+	readResumePreview func(context.Context, aisessions.ResumeDetailRef, aisessions.OpenCodexCatalog) (aisessions.Preview, error)
+	// acquireCodexAuthority replaces only the kernel fence acquisition boundary
+	// in tests that force a cross-process ordering.
+	acquireCodexAuthority      func(string) (func(), error)
 	codexCapabilityCache       *corecap.Cache
 	codexCapabilitySessionMu   sync.Mutex
 	codexCapabilitySession     codexCapabilitySession

--- a/internal/app/ai_ingest_codex.go
+++ b/internal/app/ai_ingest_codex.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -46,9 +47,38 @@ func (c *aiCommand) ingestCodexHook(data []byte) error {
 		c.appendAIIngestLog(aiIngestLogEntry{Source: "codex-hook", Event: payload.EventName, Result: "ignored", Reason: "no matching pane", CWD: payload.CWD, ThreadID: payload.matchThreadID(), SessionID: payload.SessionID, TurnID: payload.TurnID})
 		return nil
 	}
-	if authority := c.readTmuxPaneOption(paneID, aiPaneCodexAuthorityOption); codexAuthoritySuppressesHooks(authority) {
+	authority, authorityErr := c.muxRunner().ShowPaneOption(context.Background(), paneID, aiPaneCodexAuthorityOption)
+	if nativeRouted && (authorityErr != nil || authority != codexAuthorityHook) {
+		reason := "native authority unavailable"
+		if authorityErr == nil {
+			reason = "provider-control-plane authority: " + authority
+		}
+		c.appendAIIngestLog(aiIngestLogEntry{Source: "codex-hook", Event: payload.EventName, Result: "ignored", Reason: reason, Pane: paneID, ThreadID: payload.matchThreadID(), TurnID: payload.TurnID})
+		return nil
+	}
+	if !nativeRouted && codexAuthoritySuppressesHooks(authority) {
 		c.appendAIIngestLog(aiIngestLogEntry{Source: "codex-hook", Event: payload.EventName, Result: "ignored", Reason: "provider-control-plane authority: " + authority, Pane: paneID, ThreadID: payload.matchThreadID(), TurnID: payload.TurnID})
 		return nil
+	}
+	if nativeRouted {
+		release, err := c.acquireCodexAuthorityFence(c.env(internalActivationPaneUIDEnv))
+		if err != nil {
+			c.appendAIIngestLog(aiIngestLogEntry{Source: "codex-hook", Event: payload.EventName, Result: "error", Reason: err.Error(), Pane: paneID, ThreadID: payload.matchThreadID(), TurnID: payload.TurnID})
+			return err
+		}
+		defer release()
+		// SetAuthority owns the same fence. Revalidate after waiting so a hook
+		// that observed provider-hook before an invalidation cannot commit any
+		// Registry, tmux, queue, or desktop write after that invalidation.
+		authority, err = c.muxRunner().ShowPaneOption(context.Background(), paneID, aiPaneCodexAuthorityOption)
+		if err != nil || authority != codexAuthorityHook {
+			reason := "native authority unavailable"
+			if err == nil {
+				reason = "provider-control-plane authority: " + authority
+			}
+			c.appendAIIngestLog(aiIngestLogEntry{Source: "codex-hook", Event: payload.EventName, Result: "ignored", Reason: reason, Pane: paneID, ThreadID: payload.matchThreadID(), TurnID: payload.TurnID})
+			return nil
+		}
 	}
 	if allowed, reason := c.nativeCodexHookAllowed(paneID, payload.matchThreadID()); !allowed {
 		c.appendAIIngestLog(aiIngestLogEntry{Source: "codex-hook", Event: payload.EventName, Result: "ignored", Reason: reason, Pane: paneID, ThreadID: payload.matchThreadID(), TurnID: payload.TurnID})

--- a/internal/app/ai_ingest_codex_native.go
+++ b/internal/app/ai_ingest_codex_native.go
@@ -776,7 +776,7 @@ func exactCodexLifecycleBinding(registry coremetadata.Registry, identity codexLi
 
 func (s aiCodexLifecycleSink) SetAuthority(identity codexLifecycleIdentity, source, epoch, reason string) error {
 	if s.command == nil {
-		return errors.New("Codex lifecycle authority requires command")
+		return errors.New("codex lifecycle authority requires command")
 	}
 	release, err := s.command.acquireCodexAuthorityFence(identity.PaneUID)
 	if err != nil {

--- a/internal/app/ai_ingest_codex_native.go
+++ b/internal/app/ai_ingest_codex_native.go
@@ -775,6 +775,14 @@ func exactCodexLifecycleBinding(registry coremetadata.Registry, identity codexLi
 }
 
 func (s aiCodexLifecycleSink) SetAuthority(identity codexLifecycleIdentity, source, epoch, reason string) error {
+	if s.command == nil {
+		return errors.New("Codex lifecycle authority requires command")
+	}
+	release, err := s.command.acquireCodexAuthorityFence(identity.PaneUID)
+	if err != nil {
+		return err
+	}
+	defer release()
 	if !s.BindingCurrent(identity) {
 		return errManagedAgentObservationIgnored
 	}

--- a/internal/app/ai_ingest_codex_native_test.go
+++ b/internal/app/ai_ingest_codex_native_test.go
@@ -33,100 +33,296 @@ func (r phase3StaticTmuxRunner) Run(context.Context, string, ...string) ([]byte,
 	return []byte(r.output), nil
 }
 
-func TestCodexHooksWriteZeroDuringControlPlaneAuthority(t *testing.T) {
-	for _, event := range []string{"UserPromptSubmit", "PermissionRequest", "Stop", "SessionStart", "PreToolUse", "PostToolUse", "PreCompact", "PostCompact"} {
-		t.Run(event, func(t *testing.T) {
-			cmd := testAICommand(t.TempDir())
-			store := &stubNotifyStore{}
-			cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
-			cmd.stdin = bytes.NewBufferString(fmt.Sprintf(`{"hook_event_name":%q,"session_id":"codex-session","turn_id":"turn-1","cwd":"/repo/projmux"}`, event))
-			fallbackRead := codexHookIngestReadCommand("%7")
+func phase0RNativeCodexFixture(t *testing.T) (*fakeResourceStore, codexLifecycleIdentity) {
+	t.Helper()
+	store := newFakeResourceStore(t)
+	identity := codexLifecycleIdentity{
+		AgentUID: "agt-alpha-codex", PaneUID: "pan-alpha-codex", RuntimeID: "%7",
+		Generation: "generation-phase0r", ThreadID: "thread-phase0r",
+	}
+	mutator := store.mutator()
+	if _, err := mutator.RecordPaneActivation(&store.registry, identity.PaneUID, coremetadata.PaneActivationOptions{
+		Generation: identity.Generation, RuntimeID: identity.RuntimeID, AgentUID: identity.AgentUID, OperationID: "phase0r-authority",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mutator.BindCodexActivation(&store.registry, coremetadata.CodexActivationObservation{
+		AgentUID: identity.AgentUID, PaneUID: identity.PaneUID, Generation: identity.Generation, ThreadID: identity.ThreadID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return store, identity
+}
+
+func phase0RSemanticPaneWrites(commands []recordedAICommand) map[string][]string {
+	writes := map[string][]string{}
+	for _, command := range commands {
+		if command.name != "tmux" || len(command.args) < 5 || command.args[0] != "set-option" {
+			continue
+		}
+		option := command.args[len(command.args)-2]
+		value := command.args[len(command.args)-1]
+		if slices.Contains(command.args, "-u") {
+			option, value = command.args[len(command.args)-1], ""
+		}
+		if slices.Contains([]string{aiPaneStateOption, aiPaneBadgeKindOption, attentionStateOption}, option) {
+			writes[option] = append(writes[option], value)
+		}
+	}
+	return writes
+}
+
+func TestNativeCodexHookAuthoritySemanticWriteSet(t *testing.T) {
+	for _, test := range []struct {
+		authority  string
+		readErr    bool
+		wantCommit bool
+	}{
+		{authority: codexAuthorityPending},
+		{authority: codexAuthorityControlPlane},
+		{authority: codexAuthorityInvalidating},
+		{authority: ""},
+		{authority: "unknown-authority"},
+		{authority: "unavailable", readErr: true},
+		{authority: codexAuthorityHook, wantCommit: true},
+	} {
+		name := test.authority
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			store, identity := phase0RNativeCodexFixture(t)
+			beforeAgent, _ := store.registry.Agent(identity.AgentUID)
+			home := t.TempDir()
+			queue := &stubNotifyStore{}
+			cmd := testAICommand(home)
+			cmd.loadRegistry = store.store().load
+			cmd.updateRegistry = store.store().update
+			cmd.notifyStore = queue
+			cmd.producer = &storeAttentionNotifyProducer{store: queue, ttl: time.Minute}
+			cmd.stdin = bytes.NewBufferString(`{"hook_event_name":"Stop","thread_id":"thread-phase0r","turn_id":"turn-phase0r","cwd":"/repo/projmux"}`)
+			baseRead := codexHookIngestReadCommand(identity.RuntimeID)
 			cmd.readCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
-				if name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%7", "#{" + aiPaneCodexAuthorityOption + "}"}) {
-					return []byte(codexAuthorityControlPlane + "\n"), nil
+				switch {
+				case name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-t", identity.RuntimeID, "#{" + aiPaneCodexAuthorityOption + "}"}):
+					if test.readErr {
+						return nil, os.ErrNotExist
+					}
+					return []byte(test.authority + "\n"), nil
+				case name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-t", identity.RuntimeID, "#{" + tmuxopts.PaneUID + "}"}):
+					return []byte(identity.PaneUID + "\n"), nil
+				default:
+					return baseRead(ctx, name, args...)
 				}
-				return fallbackRead(ctx, name, args...)
 			}
+			desktopWrites := 0
+			baseLookup := cmd.lookupEnv
+			cmd.lookupEnv = func(name string) string {
+				switch name {
+				case internalActivationPaneUIDEnv:
+					return identity.PaneUID
+				case internalActivationGenerationEnv:
+					return identity.Generation
+				case "PROJMUX_NOTIFY_HOOK":
+					return "/tmp/projmux-phase0r-notify-recorder"
+				default:
+					return baseLookup(name)
+				}
+			}
+			cmd.runCommand = func(_ context.Context, name string, args ...string) error {
+				if name == "/tmp/projmux-phase0r-notify-recorder" {
+					desktopWrites++
+				}
+				cmdRecorder(cmd).commands = append(cmdRecorder(cmd).commands, recordedAICommand{name: name, args: append([]string(nil), args...)})
+				return nil
+			}
+
 			if err := cmd.Run([]string{"ingest", "codex-hook"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 				t.Fatal(err)
 			}
-			if commands := cmdRecorder(cmd).commands; len(commands) != 0 {
-				t.Fatalf("control-plane hook commands = %#v, want zero", commands)
+			paneWrites := phase0RSemanticPaneWrites(cmdRecorder(cmd).commands)
+			agent, _ := store.registry.Agent(identity.AgentUID)
+			if !test.wantCommit {
+				if len(paneWrites) != 0 || store.writes != 0 || len(queue.pushed) != 0 || len(queue.ackedIDs) != 0 || desktopWrites != 0 || !reflect.DeepEqual(agent.Status.Interaction, beforeAgent.Status.Interaction) {
+					t.Fatalf("suppressed hook write ledger authority=%q pane=%#v Registry=%d interaction=%#v queue=%#v ack=%#v desktop=%d", test.authority, paneWrites, store.writes, agent.Status.Interaction, queue.pushed, queue.ackedIDs, desktopWrites)
+				}
+				return
 			}
-			if len(store.pushed) != 0 {
-				t.Fatalf("control-plane hook queue writes = %#v, want zero", store.pushed)
+			wantPane := map[string][]string{
+				aiPaneStateOption:     {"waiting"},
+				aiPaneBadgeKindOption: {aiBadgeKindResponseComplete},
+				attentionStateOption:  {attentionStateReply},
+			}
+			if !reflect.DeepEqual(paneWrites, wantPane) || store.writes != 1 ||
+				agent.Status.Interaction.Kind != coremetadata.InteractionResponseComplete || agent.Status.Interaction.Source != string(coremetadata.InteractionSourceProviderHook) ||
+				len(queue.pushed) != 1 || desktopWrites != 1 {
+				t.Fatalf("fallback hook write ledger pane=%#v Registry=%d interaction=%#v queue=%#v desktop=%d", paneWrites, store.writes, agent.Status.Interaction, queue.pushed, desktopWrites)
 			}
 		})
 	}
 }
 
-func TestCodexAuthorityHookSuppressionClosesStartupAndInvalidationGaps(t *testing.T) {
-	for _, source := range []string{codexAuthorityPending, codexAuthorityControlPlane, codexAuthorityInvalidating} {
-		if !codexAuthoritySuppressesHooks(source) {
-			t.Fatalf("source %q must suppress hooks", source)
-		}
-	}
-	if codexAuthoritySuppressesHooks(codexAuthorityHook) || codexAuthoritySuppressesHooks("") {
-		t.Fatal("hook fallback must accept hooks only after explicit or compatibility fallback")
-	}
+type phase0RTmuxRunner func(context.Context, string, ...string) ([]byte, error)
+
+func (f phase0RTmuxRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return f(ctx, name, args...)
 }
 
-func TestCodexSemanticHooksStaySuppressedAcrossNonHookAuthorityWithRawNotify(t *testing.T) {
-	for _, authority := range []string{codexAuthorityPending, codexAuthorityControlPlane, codexAuthorityInvalidating} {
-		for _, event := range []string{"PermissionRequest", "Stop"} {
-			t.Run(authority+"/"+event, func(t *testing.T) {
-				home := t.TempDir()
-				paths := config.DefaultPaths(filepath.Join(home, ".config"), filepath.Join(home, ".local", "state"))
-				if err := config.SaveAIHookActionsFile(paths.AIHookActionsFile(), config.AIHookActionsFile{
-					Version: 1,
-					Providers: map[string]config.AIHookProviderActions{
-						aiHookProviderCodex: {Events: map[string]string{event: aiHookActionNotify}},
-					},
-				}); err != nil {
-					t.Fatal(err)
-				}
-				store := &stubNotifyStore{}
-				cmd := testAICommand(home)
-				cmd.notifyStore = store
-				cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: time.Minute}
-				cmd.readFile = os.ReadFile
-				cmd.stdin = bytes.NewBufferString(fmt.Sprintf(`{"hook_event_name":%q,"session_id":"codex-session","turn_id":"turn-1","cwd":"/repo/projmux"}`, event))
-				fallbackRead := codexHookIngestReadCommand("%7")
-				cmd.readCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
-					if name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%7", "#{" + aiPaneCodexAuthorityOption + "}"}) {
-						return []byte(authority + "\n"), nil
-					}
-					return fallbackRead(ctx, name, args...)
-				}
-				desktopCalls := 0
-				cmd.lookupEnv = func(name string) string {
-					switch name {
-					case "HOME":
-						return home
-					case "PROJMUX_NOTIFY_HOOK":
-						return "/tmp/projmux-phase3-notify-spy"
-					default:
-						return ""
-					}
-				}
-				cmd.runCommand = func(_ context.Context, name string, args ...string) error {
-					if name == "/tmp/projmux-phase3-notify-spy" {
-						desktopCalls++
-					}
-					cmdRecorder(cmd).commands = append(cmdRecorder(cmd).commands, recordedAICommand{name: name, args: append([]string(nil), args...)})
-					return nil
-				}
-				if err := cmd.Run([]string{"ingest", "codex-hook"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
-					t.Fatal(err)
-				}
-				if commands := cmdRecorder(cmd).commands; len(commands) != 0 {
-					t.Fatalf("suppressed semantic hook commands = %#v, want zero", commands)
-				}
-				if len(store.pushed) != 0 || len(store.ackedIDs) != 0 || desktopCalls != 0 {
-					t.Fatalf("suppressed writes queue=%#v ack=%#v desktop=%d", store.pushed, store.ackedIDs, desktopCalls)
-				}
-			})
+func TestNativeCodexHookAuthorityChangeAfterGuardCommitsZero(t *testing.T) {
+	store, identity := phase0RNativeCodexFixture(t)
+	beforeAgent, _ := store.registry.Agent(identity.AgentUID)
+	options := map[string]string{
+		tmuxopts.PaneUID:           identity.PaneUID,
+		aiPaneCodexAuthorityOption: codexAuthorityHook,
+		aiPaneCodexEpochOption:     "epoch-before",
+		aiPaneCodexReasonOption:    "native-fallback",
+	}
+	var optionsMu sync.Mutex
+	sinkAtAuthorityRead := make(chan struct{})
+	allowInvalidation := make(chan struct{})
+	var sinkReadOnce sync.Once
+	sinkRunner := phase0RTmuxRunner(func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name != "tmux" || len(args) < 1 {
+			return nil, fmt.Errorf("unexpected sink command %s %q", name, args)
 		}
+		switch args[0] {
+		case "show-options":
+			option := args[len(args)-1]
+			if option == aiPaneCodexAuthorityOption {
+				sinkReadOnce.Do(func() {
+					close(sinkAtAuthorityRead)
+					<-allowInvalidation
+				})
+			}
+			optionsMu.Lock()
+			defer optionsMu.Unlock()
+			return []byte(options[option] + "\n"), nil
+		case "set-option":
+			optionsMu.Lock()
+			defer optionsMu.Unlock()
+			option := args[len(args)-2]
+			if slices.Contains(args, "-u") {
+				delete(options, args[len(args)-1])
+			} else {
+				options[option] = args[len(args)-1]
+			}
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unexpected sink tmux command %q", args)
+		}
+	})
+
+	// The injected token has the same ownership semantics as the production
+	// flock while exposing a deterministic handoff point to the test.
+	token := make(chan struct{}, 1)
+	token <- struct{}{}
+	acquire := func(paneUID string) (func(), error) {
+		if paneUID != identity.PaneUID {
+			return nil, fmt.Errorf("authority fence Pane uid = %q, want %q", paneUID, identity.PaneUID)
+		}
+		<-token
+		var once sync.Once
+		return func() { once.Do(func() { token <- struct{}{} }) }, nil
+	}
+
+	home := t.TempDir()
+	sinkCommand := testAICommand(home)
+	sinkCommand.loadRegistry = store.store().load
+	sinkCommand.acquireCodexAuthority = acquire
+	sink := aiCodexLifecycleSink{command: sinkCommand, runner: sinkRunner}
+	sinkResult := make(chan error, 1)
+	go func() {
+		sinkResult <- sink.SetAuthority(identity, codexAuthorityInvalidating, "epoch-after", "disconnected")
+	}()
+	select {
+	case <-sinkAtAuthorityRead:
+	case <-time.After(time.Second):
+		t.Fatal("native invalidation did not acquire the authority fence")
+	}
+
+	queue := &stubNotifyStore{}
+	hookCommand := testAICommand(home)
+	hookCommand.loadRegistry = store.store().load
+	hookCommand.updateRegistry = store.store().update
+	hookCommand.acquireCodexAuthority = acquire
+	hookCommand.notifyStore = queue
+	hookCommand.producer = &storeAttentionNotifyProducer{store: queue, ttl: time.Minute}
+	hookCommand.stdin = bytes.NewBufferString(`{"hook_event_name":"Stop","thread_id":"thread-phase0r","turn_id":"turn-gap","cwd":"/repo/projmux"}`)
+	hookInitialGuard := make(chan struct{})
+	var hookReadOnce sync.Once
+	baseRead := codexHookIngestReadCommand(identity.RuntimeID)
+	hookCommand.readCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		switch {
+		case name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-t", identity.RuntimeID, "#{" + aiPaneCodexAuthorityOption + "}"}):
+			optionsMu.Lock()
+			value := options[aiPaneCodexAuthorityOption]
+			optionsMu.Unlock()
+			hookReadOnce.Do(func() { close(hookInitialGuard) })
+			return []byte(value + "\n"), nil
+		case name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-t", identity.RuntimeID, "#{" + tmuxopts.PaneUID + "}"}):
+			return []byte(identity.PaneUID + "\n"), nil
+		default:
+			return baseRead(ctx, name, args...)
+		}
+	}
+	desktopWrites := 0
+	baseLookup := hookCommand.lookupEnv
+	hookCommand.lookupEnv = func(name string) string {
+		switch name {
+		case internalActivationPaneUIDEnv:
+			return identity.PaneUID
+		case internalActivationGenerationEnv:
+			return identity.Generation
+		case "PROJMUX_NOTIFY_HOOK":
+			return "/tmp/projmux-phase0r-notify-recorder"
+		default:
+			return baseLookup(name)
+		}
+	}
+	hookCommand.runCommand = func(_ context.Context, name string, args ...string) error {
+		if name == "/tmp/projmux-phase0r-notify-recorder" {
+			desktopWrites++
+		}
+		cmdRecorder(hookCommand).commands = append(cmdRecorder(hookCommand).commands, recordedAICommand{name: name, args: append([]string(nil), args...)})
+		return nil
+	}
+	hookResult := make(chan error, 1)
+	go func() {
+		hookResult <- hookCommand.Run([]string{"ingest", "codex-hook"}, &bytes.Buffer{}, &bytes.Buffer{})
+	}()
+	select {
+	case <-hookInitialGuard:
+	case <-time.After(time.Second):
+		t.Fatal("Stop hook did not observe the initial provider-hook authority")
+	}
+	close(allowInvalidation)
+	select {
+	case err := <-sinkResult:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("native invalidation did not release the authority fence")
+	}
+	select {
+	case err := <-hookResult:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("suppressed Stop hook did not finish after invalidation")
+	}
+
+	optionsMu.Lock()
+	authorityTuple := strings.Join([]string{options[aiPaneCodexAuthorityOption], options[aiPaneCodexEpochOption], options[aiPaneCodexReasonOption]}, "|")
+	state, badge, attention := options[aiPaneStateOption], options[aiPaneBadgeKindOption], options[attentionStateOption]
+	optionsMu.Unlock()
+	agent, _ := store.registry.Agent(identity.AgentUID)
+	if authorityTuple != "invalidating|epoch-after|disconnected" || state != "" || badge != "" || attention != "" ||
+		store.writes != 0 || !reflect.DeepEqual(agent.Status.Interaction, beforeAgent.Status.Interaction) ||
+		len(queue.pushed) != 0 || len(queue.ackedIDs) != 0 || desktopWrites != 0 {
+		t.Fatalf("forced invalidation write ledger authority=%s state=%q badge=%q attention=%q Registry=%d interaction=%#v queue=%#v ack=%#v desktop=%d hook-commands=%#v",
+			authorityTuple, state, badge, attention, store.writes, agent.Status.Interaction, queue.pushed, queue.ackedIDs, desktopWrites, cmdRecorder(hookCommand).commands)
 	}
 }
 

--- a/internal/app/codex_authority_fence.go
+++ b/internal/app/codex_authority_fence.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+
+	localstate "github.com/crevissepartners/projmux/internal/state"
+)
+
+const codexAuthorityFenceDir = "codex-authority-fences"
+
+// acquireCodexAuthorityFence serializes the native authority transition with
+// the complete provider-hook semantic write set for one resource Pane. The
+// kernel owns the lock lifetime: normal returns unlock explicitly, while a
+// panic, signal, or process exit closes the descriptor and cannot strand a
+// reconnect behind a stale userspace token.
+func (c *aiCommand) acquireCodexAuthorityFence(paneUID string) (func(), error) {
+	if c == nil {
+		return nil, fmt.Errorf("Codex authority fence requires command")
+	}
+	if c != nil && c.acquireCodexAuthority != nil {
+		return c.acquireCodexAuthority(paneUID)
+	}
+	path, err := c.codexAuthorityFencePath(paneUID)
+	if err != nil {
+		return nil, err
+	}
+	// #nosec G304 -- codexAuthorityFencePath returns the private state
+	// directory plus a digest of the Registry-authenticated Pane uid.
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, localstate.PrivateFileMode)
+	if err != nil {
+		return nil, fmt.Errorf("open Codex authority fence: %w", err)
+	}
+	localstate.RepairPrivateFile(path)
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock Codex authority fence: %w", err)
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+			_ = file.Close()
+		})
+	}, nil
+}
+
+func (c *aiCommand) codexAuthorityFencePath(paneUID string) (string, error) {
+	paneUID = strings.TrimSpace(paneUID)
+	if paneUID == "" {
+		return "", fmt.Errorf("Codex authority fence requires Pane uid")
+	}
+	paths, err := configPaths(c.homeDir, c.lookupEnv)
+	if err != nil {
+		return "", fmt.Errorf("resolve Codex authority fence: %w", err)
+	}
+	dir := filepath.Join(paths.StateDir, codexAuthorityFenceDir)
+	if err := localstate.EnsurePrivateDir(dir); err != nil {
+		return "", fmt.Errorf("create Codex authority fence directory: %w", err)
+	}
+	digest := sha256.Sum256([]byte(paneUID))
+	return filepath.Join(dir, fmt.Sprintf("%x.lock", digest)), nil
+}

--- a/internal/app/codex_authority_fence.go
+++ b/internal/app/codex_authority_fence.go
@@ -21,7 +21,7 @@ const codexAuthorityFenceDir = "codex-authority-fences"
 // reconnect behind a stale userspace token.
 func (c *aiCommand) acquireCodexAuthorityFence(paneUID string) (func(), error) {
 	if c == nil {
-		return nil, fmt.Errorf("Codex authority fence requires command")
+		return nil, fmt.Errorf("codex authority fence requires command")
 	}
 	if c != nil && c.acquireCodexAuthority != nil {
 		return c.acquireCodexAuthority(paneUID)
@@ -53,7 +53,7 @@ func (c *aiCommand) acquireCodexAuthorityFence(paneUID string) (func(), error) {
 func (c *aiCommand) codexAuthorityFencePath(paneUID string) (string, error) {
 	paneUID = strings.TrimSpace(paneUID)
 	if paneUID == "" {
-		return "", fmt.Errorf("Codex authority fence requires Pane uid")
+		return "", fmt.Errorf("codex authority fence requires pane uid")
 	}
 	paths, err := configPaths(c.homeDir, c.lookupEnv)
 	if err != nil {

--- a/internal/app/codex_authority_fence_test.go
+++ b/internal/app/codex_authority_fence_test.go
@@ -1,0 +1,48 @@
+package app
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+
+	localstate "github.com/crevissepartners/projmux/internal/state"
+)
+
+func TestCodexAuthorityFenceSerializesOnlyTheExactPaneAndReleases(t *testing.T) {
+	command := testAICommand(t.TempDir())
+	releaseFirst, err := command.acquireCodexAuthorityFence("pane-phase0r-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path, err := command.codexAuthorityFencePath("pane-phase0r-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	contender, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, localstate.PrivateFileMode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer contender.Close()
+	if err := syscall.Flock(int(contender.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+		t.Fatalf("same-Pane authority contender lock error = %v, want busy", err)
+	}
+
+	releaseOther, err := command.acquireCodexAuthorityFence("pane-phase0r-b")
+	if err != nil {
+		t.Fatalf("independent Pane authority fence: %v", err)
+	}
+	releaseOther()
+	releaseFirst()
+	if err := syscall.Flock(int(contender.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("same-Pane authority fence after release: %v", err)
+	}
+	if err := syscall.Flock(int(contender.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatal(err)
+	}
+	releaseAgain, err := command.acquireCodexAuthorityFence("pane-phase0r-a")
+	if err != nil {
+		t.Fatalf("same-Pane authority fence reacquire: %v", err)
+	}
+	releaseAgain()
+}

--- a/test/e2e/codex-lifecycle.sh
+++ b/test/e2e/codex-lifecycle.sh
@@ -647,17 +647,28 @@ if [[ "$provider_writes_after" != "$provider_writes_before" ]]; then
 fi
 
 # Native reconnect remains authoritative during the gap. The same raw hook
-# event must therefore write no hook badge and must not move the exact
-# invalidating/unavailable projection.
+# event must therefore write no pane semantic, Registry interaction, queue, or
+# desktop delivery and must not move the exact invalidating projection.
+lifecycle_gap_before_hook="$(lifecycle_tmux display-message -p -t "$lifecycle_pane" \
+  '#{@projmux_codex_authority}|#{@projmux_codex_authority_reason}|#{@projmux_ai_state}|#{@projmux_ai_badge_kind}|#{@projmux_attention_state}')"
+lifecycle_gap_registry_before_hook="$(lifecycle_pmx describe agent "uid:$lifecycle_agent_uid" |
+  awk '$1 == "Interaction:" || $1 == "InteractionSource:" { values = values sep $2; sep = "|" } END { print values }')"
+lifecycle_gap_queue_before_hook="$(lifecycle_queue_count)"
+lifecycle_gap_desktop_before_hook="$(lifecycle_desktop_count)"
 printf '%s' '{"hook_event_name":"Stop","thread_id":"thread-phase3","turn_id":"turn-fallback","cwd":"'"$lifecycle_project"'"}' |
   lifecycle_pmx_hook internal agent-hook ingest codex-hook
 lifecycle_gap_after_hook="$(lifecycle_tmux display-message -p -t "$lifecycle_pane" \
-  '#{@projmux_codex_authority}|#{@projmux_codex_authority_reason}|#{@projmux_ai_state}|#{@projmux_ai_badge_kind}')"
+  '#{@projmux_codex_authority}|#{@projmux_codex_authority_reason}|#{@projmux_ai_state}|#{@projmux_ai_badge_kind}|#{@projmux_attention_state}')"
+lifecycle_gap_registry_after_hook="$(lifecycle_pmx describe agent "uid:$lifecycle_agent_uid" |
+  awk '$1 == "Interaction:" || $1 == "InteractionSource:" { values = values sep $2; sep = "|" } END { print values }')"
 lifecycle_gap_queue_after_hook="$(lifecycle_queue_count)"
 lifecycle_gap_desktop_after_hook="$(lifecycle_desktop_count)"
-if [[ "$lifecycle_gap_after_hook" != "invalidating|disconnected||" ]] ||
-  [[ "$lifecycle_gap_queue_after_hook" != "1" ]] || [[ "$lifecycle_gap_desktop_after_hook" != "2" ]]; then
-  echo "Codex reconnect gap admitted provider-hook projection: tuple=$lifecycle_gap_after_hook queue=$lifecycle_gap_queue_after_hook desktop=$lifecycle_gap_desktop_after_hook" >&2
+if [[ "$lifecycle_gap_before_hook" != "invalidating|disconnected|||" ]] ||
+  [[ "$lifecycle_gap_after_hook" != "$lifecycle_gap_before_hook" ]] ||
+  [[ "$lifecycle_gap_registry_after_hook" != "$lifecycle_gap_registry_before_hook" ]] ||
+  [[ "$lifecycle_gap_queue_before_hook" != "1" || "$lifecycle_gap_queue_after_hook" != "$lifecycle_gap_queue_before_hook" ]] ||
+  [[ "$lifecycle_gap_desktop_before_hook" != "2" || "$lifecycle_gap_desktop_after_hook" != "$lifecycle_gap_desktop_before_hook" ]]; then
+  echo "Codex reconnect gap admitted provider-hook projection: pane=$lifecycle_gap_before_hook->$lifecycle_gap_after_hook Registry=$lifecycle_gap_registry_before_hook->$lifecycle_gap_registry_after_hook queue=$lifecycle_gap_queue_before_hook->$lifecycle_gap_queue_after_hook desktop=$lifecycle_gap_desktop_before_hook->$lifecycle_gap_desktop_after_hook" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- classify the preserved #864 C01 failure as a cross-process hook guard/commit TOCTOU
- serialize native authority transitions with the full provider-hook semantic write set using a Pane-UID-scoped crash-safe flock
- fail closed for native-routed hooks unless the current fenced authority is exactly `provider-hook`
- extend C01 with pane, Registry interaction, queue, and desktop before/after write ledgers

## Root-cause receipt

`Stop` could observe `provider-hook`, then native reconnect invalidation could publish `invalidating|disconnected` and clear semantics before the stale hook committed `waiting|response_complete`. Queue and desktop remained `1`/`2`; pane state was the first visible divergence.

## Validation

- `go test ./internal/app -run 'TestNativeCodexHookAuthoritySemanticWriteSet|TestNativeCodexHookAuthorityChangeAfterGuardCommitsZero|TestCodexAuthorityFenceSerializesOnlyTheExactPaneAndReleases|TestBrokerCutoverPreservesTheHookFallbackVocabulary'`
- `PROJMUX_E2E_SUITE=codex-lifecycle make test-e2e` — attempt 1 PASS; target `2081-1→2081-2`, sibling `2478-1→2478-2`, steer `0→1`
- `make fmt`
- `make fix`
- `make test`

## Scope

PR #864 installed-qualification files, #860 six owned files, Backlog 14, Phase 1, and broad Phase 2/4 projection work are unchanged. `docs/agent-workflow.md` is intentionally excluded by the roadmap Phase contract.