### PR TITLE
test(codex): add lifecycle reducer reference model

### DIFF
--- a/internal/app/agent_interaction_codex_export_test.go
+++ b/internal/app/agent_interaction_codex_export_test.go
@@ -1,0 +1,109 @@
+package app
+
+import (
+	"sort"
+
+	"github.com/crevissepartners/projmux/internal/integrations/agents/codexappserver"
+)
+
+// CodexLifecycleTestHarness is a test-only adapter around the production
+// reducer. External property tests use this narrow seam so their reference
+// transition model cannot read or reuse production reducer state as its
+// expected oracle.
+type CodexLifecycleTestHarness struct {
+	reducer codexLifecycleReducer
+}
+
+type CodexLifecycleTestSnapshot struct {
+	Epoch       uint64
+	ThreadID    string
+	ThreadState string
+	TurnID      string
+	TurnState   string
+}
+
+type CodexLifecycleTestEvent struct {
+	Epoch        uint64
+	Kind         string
+	ThreadID     string
+	TurnID       string
+	ItemID       string
+	RequestID    string
+	ThreadState  string
+	TurnState    string
+	ApprovalKind string
+}
+
+type CodexLifecycleTestPending struct {
+	TurnID       string
+	ItemID       string
+	RequestID    string
+	ApprovalKind string
+	Notified     bool
+}
+
+type CodexLifecycleTestState struct {
+	Epoch       uint64
+	Active      bool
+	Interaction string
+	Pending     []CodexLifecycleTestPending
+}
+
+type CodexLifecycleTestResult struct {
+	Accepted    bool
+	Invalidated bool
+	State       CodexLifecycleTestState
+}
+
+func (h *CodexLifecycleTestHarness) Snapshot(snapshot CodexLifecycleTestSnapshot) CodexLifecycleTestResult {
+	projection := h.reducer.begin(snapshot.Epoch, testCodexLifecycleIdentity(), codexappserver.LifecycleSnapshot{
+		ThreadID:    snapshot.ThreadID,
+		ThreadState: codexappserver.ThreadState(snapshot.ThreadState),
+		TurnID:      snapshot.TurnID,
+		TurnState:   codexappserver.TurnState(snapshot.TurnState),
+	})
+	return h.result(projection)
+}
+
+func (h *CodexLifecycleTestHarness) Event(event CodexLifecycleTestEvent) CodexLifecycleTestResult {
+	projection := h.reducer.apply(event.Epoch, codexappserver.LifecycleEvent{
+		Kind:         codexappserver.LifecycleEventKind(event.Kind),
+		ThreadID:     event.ThreadID,
+		TurnID:       event.TurnID,
+		ItemID:       event.ItemID,
+		RequestID:    event.RequestID,
+		ThreadState:  codexappserver.ThreadState(event.ThreadState),
+		TurnState:    codexappserver.TurnState(event.TurnState),
+		ApprovalKind: codexappserver.ApprovalKind(event.ApprovalKind),
+	})
+	return h.result(projection)
+}
+
+func (h *CodexLifecycleTestHarness) Invalidate(epoch uint64) CodexLifecycleTestResult {
+	return h.result(h.reducer.invalidate(epoch))
+}
+
+func (h *CodexLifecycleTestHarness) State() CodexLifecycleTestState {
+	return h.state()
+}
+
+func (h *CodexLifecycleTestHarness) result(projection codexLifecycleProjection) CodexLifecycleTestResult {
+	return CodexLifecycleTestResult{
+		Accepted: projection.Accepted, Invalidated: projection.Invalidated, State: h.state(),
+	}
+}
+
+func (h *CodexLifecycleTestHarness) state() CodexLifecycleTestState {
+	pending := make([]CodexLifecycleTestPending, 0, len(h.reducer.pending))
+	for _, request := range h.reducer.pending {
+		pending = append(pending, CodexLifecycleTestPending{
+			TurnID: request.TurnID, ItemID: request.ItemID, RequestID: request.RequestID,
+			ApprovalKind: string(request.Kind), Notified: request.Notified,
+		})
+	}
+	sort.Slice(pending, func(i, j int) bool { return pending[i].RequestID < pending[j].RequestID })
+	return CodexLifecycleTestState{
+		Epoch: h.reducer.epoch, Active: h.reducer.active,
+		Interaction: string(h.reducer.interaction), Pending: pending,
+	}
+}

--- a/internal/app/agent_interaction_codex_property_test.go
+++ b/internal/app/agent_interaction_codex_property_test.go
@@ -1,0 +1,395 @@
+package app_test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	app "github.com/crevissepartners/projmux/internal/app"
+)
+
+type lifecyclePropertyRunner struct {
+	sut       app.CodexLifecycleTestHarness
+	model     lifecycleModelState
+	history   []lifecycleConcreteOperation
+	lastEvent *lifecycleConcreteOperation
+}
+
+func TestCodexLifecycleReferenceModelSeedCorpus(t *testing.T) {
+	// This corpus and the generated property own pure invalidation, not-loaded
+	// snapshot, and epoch fencing semantics. Their former example tests were
+	// removed; the remaining examples own notice side effects the model omits.
+	traces := [][]lifecycleOperation{
+		{
+			testSnapshot("active", "turn-1", "in-progress"),
+			testEvent(lifecycleCurrent, lifecycleModelEvent{kind: "thread-status", threadState: "waiting-on-approval"}),
+			testEvent(lifecycleCurrent, testPendingEvent("turn-1", "item-1", "request-1")),
+			{kind: lifecycleDuplicate},
+			{kind: lifecycleAllowedReorder, reorderKey: 7},
+			testEvent(lifecycleCurrent, lifecycleModelEvent{kind: "request-resolved", requestID: "request-1"}),
+			{kind: lifecycleInvalidation, authority: lifecycleCurrent},
+			testEvent(lifecycleCurrent, lifecycleModelEvent{kind: "turn-started", turnID: "turn-late"}),
+			{kind: lifecycleEpochReplace, snapshot: lifecycleModelSnapshot{threadID: "thread-1", threadState: "idle"}},
+		},
+		{
+			testSnapshot("waiting-on-user-input", "turn-1", "in-progress"),
+			testEvent(lifecycleForeign, lifecycleModelEvent{kind: "thread-status", threadState: "idle"}),
+			testEvent(lifecycleStale, lifecycleModelEvent{kind: "turn-started", turnID: "turn-stale"}),
+			testEvent(lifecycleFuture, lifecycleModelEvent{kind: "turn-started", turnID: "turn-future"}),
+			{kind: lifecycleAllowedReorder, reorderKey: 13},
+		},
+		{
+			testSnapshot("not-loaded", "turn-1", "completed"),
+			testEvent(lifecycleCurrent, lifecycleModelEvent{kind: "turn-started", turnID: "turn-late"}),
+			{kind: lifecycleEpochReplace, snapshot: lifecycleModelSnapshot{threadID: "thread-1", threadState: "active", turnID: "turn-2", turnState: "in-progress"}},
+		},
+	}
+	for index, trace := range traces {
+		t.Run(fmt.Sprintf("trace-%d", index), func(t *testing.T) {
+			runLifecyclePropertyTrace(t, trace)
+		})
+	}
+}
+
+func TestCodexLifecycleDuplicateStaleAndForeignOperationsAreNoOps(t *testing.T) {
+	runLifecyclePropertyTrace(t, []lifecycleOperation{
+		testSnapshot("idle", "turn-1", "in-progress"),
+		testEvent(lifecycleCurrent, lifecycleModelEvent{kind: "turn-started", turnID: "turn-2"}),
+		{kind: lifecycleDuplicate},
+		{kind: lifecycleEpochReplace, snapshot: lifecycleModelSnapshot{threadID: "thread-1", threadState: "active", turnID: "turn-2", turnState: "in-progress"}},
+		testEvent(lifecycleStale, testPendingEvent("turn-2", "item-stale", "request-stale")),
+		testEvent(lifecycleFuture, testPendingEvent("turn-2", "item-future", "request-future")),
+		testEvent(lifecycleForeign, testPendingEvent("turn-2", "item-foreign", "request-foreign")),
+		{kind: lifecycleInvalidation, authority: lifecycleStale},
+	})
+}
+
+func TestCodexLifecycleAllowedReorderReachesSameFixedPoint(t *testing.T) {
+	runLifecyclePropertyTrace(t, []lifecycleOperation{
+		testSnapshot("waiting-on-approval", "turn-1", "in-progress"),
+		{kind: lifecycleAllowedReorder, reorderKey: 42},
+	})
+}
+
+func TestCodexLifecycleMutationDiagnosticsIncludeMinimalOperationTrace(t *testing.T) {
+	t.Run("stale-acceptance", func(t *testing.T) {
+		trace := []lifecycleOperation{
+			testSnapshot("idle", "turn-1", "in-progress"),
+			testEvent(lifecycleStale, lifecycleModelEvent{kind: "turn-started", turnID: "turn-stale"}),
+		}
+		runner := runLifecyclePropertyTrace(t, trace)
+		mutant := runner.sut.State()
+		mutant.Interaction = "in_progress"
+		diagnostic := lifecycleStateDiff(1, trace, runner.model, mutant)
+		assertMinimalTraceDiagnostic(t, diagnostic, "field=interaction", "event[stale]")
+	})
+
+	t.Run("wrong-request-ownership", func(t *testing.T) {
+		trace := []lifecycleOperation{
+			testSnapshot("waiting-on-approval", "turn-1", "in-progress"),
+			testEvent(lifecycleCurrent, testPendingEvent("turn-1", "item-1", "request-1")),
+		}
+		runner := runLifecyclePropertyTrace(t, trace)
+		mutant := runner.sut.State()
+		mutant.Pending[0].TurnID = "turn-foreign"
+		diagnostic := lifecycleStateDiff(1, trace, runner.model, mutant)
+		assertMinimalTraceDiagnostic(t, diagnostic, "field=pending", "request=request-1")
+	})
+}
+
+func FuzzCodexLifecycleReferenceModel(f *testing.F) {
+	f.Add([]byte{0, 3, 0, 1, 21, 0, 1, 2, 0, 2, 0, 0, 3, 9, 0, 1, 3, 0, 4, 0, 0, 1, 5, 0})
+	f.Add([]byte{0, 25, 0, 1, 2, 3, 1, 2, 1, 1, 2, 2, 3, 17, 0, 5, 3, 0})
+	f.Add([]byte{0, 1, 0, 1, 64, 0, 2, 0, 0, 4, 0, 0, 5, 3, 0})
+	f.Fuzz(func(t *testing.T, encoded []byte) {
+		if len(encoded) > 384 {
+			encoded = encoded[:384]
+		}
+		runLifecyclePropertyTrace(t, decodeLifecycleOperations(encoded))
+	})
+}
+
+func runLifecyclePropertyTrace(t *testing.T, trace []lifecycleOperation) *lifecyclePropertyRunner {
+	t.Helper()
+	runner := &lifecyclePropertyRunner{}
+	for index, operation := range trace {
+		runner.apply(t, index, trace[:index+1], operation)
+	}
+	return runner
+}
+
+func (r *lifecyclePropertyRunner) apply(t *testing.T, index int, trace []lifecycleOperation, operation lifecycleOperation) {
+	t.Helper()
+	beforeModel := lifecycleContractStateFromModel(r.model)
+	beforeSUT := r.sut.State()
+	shouldBeNoOp := false
+
+	switch operation.kind {
+	case lifecycleSnapshot:
+		epoch := currentLifecycleEpoch(r.model.epoch)
+		concrete := lifecycleConcreteOperation{kind: lifecycleConcreteSnapshot, epoch: epoch, snapshot: operation.snapshot}
+		r.applyConcrete(t, index, 0, trace, concrete)
+		r.history = append(r.history, concrete)
+		r.lastEvent = nil
+		shouldBeNoOp = operation.snapshot.threadID != "thread-1"
+	case lifecycleProviderEvent:
+		concrete := lifecycleConcreteOperation{
+			kind: lifecycleConcreteEvent, epoch: lifecycleEpochFor(operation.authority, r.model.epoch), event: operation.event,
+		}
+		if operation.authority == lifecycleForeign {
+			concrete.event.threadID = "thread-foreign"
+		} else {
+			concrete.event.threadID = "thread-1"
+		}
+		r.applyConcrete(t, index, 0, trace, concrete)
+		r.history = append(r.history, concrete)
+		r.lastEvent = &r.history[len(r.history)-1]
+		shouldBeNoOp = operation.authority != lifecycleCurrent
+	case lifecycleDuplicate:
+		shouldBeNoOp = true
+		if r.lastEvent != nil {
+			concrete := *r.lastEvent
+			r.applyConcrete(t, index, 0, trace, concrete)
+			r.history = append(r.history, concrete)
+		}
+	case lifecycleAllowedReorder:
+		r.applyAllowedReorder(t, index, trace, operation)
+	case lifecycleInvalidation:
+		concrete := lifecycleConcreteOperation{
+			kind: lifecycleConcreteInvalidation, epoch: lifecycleInvalidationEpochFor(operation.authority, r.model.epoch),
+		}
+		r.applyConcrete(t, index, 0, trace, concrete)
+		r.history = append(r.history, concrete)
+		r.lastEvent = nil
+		shouldBeNoOp = operation.authority != lifecycleCurrent
+	case lifecycleEpochReplace:
+		concrete := lifecycleConcreteOperation{
+			kind: lifecycleConcreteSnapshot, epoch: nextLifecycleEpoch(r.model.epoch), snapshot: operation.snapshot,
+		}
+		r.applyConcrete(t, index, 0, trace, concrete)
+		r.history = append(r.history, concrete)
+		r.lastEvent = nil
+	default:
+		t.Fatalf("closed operation vocabulary escaped: operation=%d trace=%s", operation.kind, formatLifecycleTrace(trace))
+	}
+
+	if diagnostic := lifecycleStateDiff(index, trace, r.model, r.sut.State()); diagnostic != "" {
+		t.Fatal(diagnostic)
+	}
+	if shouldBeNoOp {
+		if diagnostic := lifecycleNoOpDiff(index, trace, beforeModel, lifecycleContractStateFromModel(r.model), beforeSUT, r.sut.State()); diagnostic != "" {
+			t.Fatal(diagnostic)
+		}
+	}
+}
+
+func (r *lifecyclePropertyRunner) applyAllowedReorder(t *testing.T, index int, trace []lifecycleOperation, operation lifecycleOperation) {
+	t.Helper()
+	prefix := append([]lifecycleConcreteOperation(nil), r.history...)
+	turnID := r.model.currentTurnID
+	requestPrefix := fmt.Sprintf("reorder-%d-%d", operation.reorderKey, index)
+	first := lifecycleConcreteOperation{kind: lifecycleConcreteEvent, epoch: currentLifecycleEpoch(r.model.epoch), event: lifecycleModelEvent{
+		kind: "approval-pending", threadID: "thread-1", turnID: turnID,
+		itemID: requestPrefix + "-item-a", requestID: requestPrefix + "-request-a", approvalKind: "command",
+	}}
+	second := lifecycleConcreteOperation{kind: lifecycleConcreteEvent, epoch: currentLifecycleEpoch(r.model.epoch), event: lifecycleModelEvent{
+		kind: "approval-pending", threadID: "thread-1", turnID: turnID,
+		itemID: requestPrefix + "-item-b", requestID: requestPrefix + "-request-b", approvalKind: "file-change",
+	}}
+
+	r.applyConcrete(t, index, 0, trace, first)
+	r.applyConcrete(t, index, 1, trace, second)
+	canonical := r.sut.State()
+	r.history = append(r.history, first, second)
+	r.lastEvent = &r.history[len(r.history)-1]
+
+	var alternate lifecyclePropertyRunner
+	for replayIndex, concrete := range prefix {
+		alternate.applyConcrete(t, index, replayIndex, trace, concrete)
+		alternate.history = append(alternate.history, concrete)
+	}
+	alternate.applyConcrete(t, index, len(prefix), trace, second)
+	alternate.applyConcrete(t, index, len(prefix)+1, trace, first)
+	if diagnostic := lifecycleFixedPointDiff(index, trace, canonical, alternate.sut.State()); diagnostic != "" {
+		t.Fatal(diagnostic)
+	}
+}
+
+func (r *lifecyclePropertyRunner) applyConcrete(t *testing.T, operationIndex, substep int, trace []lifecycleOperation, operation lifecycleConcreteOperation) {
+	t.Helper()
+	want := r.model.apply(operation)
+	got := applyLifecycleSUTOperation(&r.sut, operation)
+	if want.accepted != got.Accepted {
+		t.Fatalf("step=%d.%d field=accepted want=%t got=%t trace=%s", operationIndex, substep, want.accepted, got.Accepted, formatLifecycleTrace(trace))
+	}
+	if want.invalidated != got.Invalidated {
+		t.Fatalf("step=%d.%d field=invalidated want=%t got=%t trace=%s", operationIndex, substep, want.invalidated, got.Invalidated, formatLifecycleTrace(trace))
+	}
+	if diagnostic := lifecycleStateDiff(operationIndex, trace, r.model, got.State); diagnostic != "" {
+		t.Fatal(diagnostic)
+	}
+}
+
+func applyLifecycleSUTOperation(harness *app.CodexLifecycleTestHarness, operation lifecycleConcreteOperation) app.CodexLifecycleTestResult {
+	switch operation.kind {
+	case lifecycleConcreteSnapshot:
+		return harness.Snapshot(app.CodexLifecycleTestSnapshot{
+			Epoch: operation.epoch, ThreadID: operation.snapshot.threadID,
+			ThreadState: operation.snapshot.threadState, TurnID: operation.snapshot.turnID, TurnState: operation.snapshot.turnState,
+		})
+	case lifecycleConcreteEvent:
+		return harness.Event(app.CodexLifecycleTestEvent{
+			Epoch: operation.epoch, Kind: operation.event.kind, ThreadID: operation.event.threadID,
+			TurnID: operation.event.turnID, ItemID: operation.event.itemID, RequestID: operation.event.requestID,
+			ThreadState: operation.event.threadState, TurnState: operation.event.turnState, ApprovalKind: operation.event.approvalKind,
+		})
+	case lifecycleConcreteInvalidation:
+		return harness.Invalidate(operation.epoch)
+	default:
+		return app.CodexLifecycleTestResult{State: harness.State()}
+	}
+}
+
+func lifecycleStateDiff(step int, trace []lifecycleOperation, want lifecycleModelState, got app.CodexLifecycleTestState) string {
+	if want.epoch != got.Epoch {
+		return lifecycleDiagnostic(step, "epoch", want.epoch, got.Epoch, trace)
+	}
+	if want.active != got.Active {
+		return lifecycleDiagnostic(step, "active", want.active, got.Active, trace)
+	}
+	if want.interaction != got.Interaction {
+		return lifecycleDiagnostic(step, "interaction", want.interaction, got.Interaction, trace)
+	}
+	wantPending := want.sortedPending()
+	gotPending := make([]lifecycleModelPending, len(got.Pending))
+	for index, pending := range got.Pending {
+		gotPending[index] = lifecycleModelPending{
+			turnID: pending.TurnID, itemID: pending.ItemID, requestID: pending.RequestID,
+			approvalKind: pending.ApprovalKind, notified: pending.Notified,
+		}
+	}
+	if !reflect.DeepEqual(wantPending, gotPending) {
+		return lifecycleDiagnostic(step, "pending", wantPending, gotPending, trace)
+	}
+	return ""
+}
+
+type lifecycleContractState struct {
+	epoch       uint64
+	active      bool
+	interaction string
+	pending     []lifecycleModelPending
+}
+
+func lifecycleContractStateFromModel(state lifecycleModelState) lifecycleContractState {
+	return lifecycleContractState{epoch: state.epoch, active: state.active, interaction: state.interaction, pending: state.sortedPending()}
+}
+
+func lifecycleContractStateFromSUT(state app.CodexLifecycleTestState) lifecycleContractState {
+	pending := make([]lifecycleModelPending, len(state.Pending))
+	for index, request := range state.Pending {
+		pending[index] = lifecycleModelPending{
+			turnID: request.TurnID, itemID: request.ItemID, requestID: request.RequestID,
+			approvalKind: request.ApprovalKind, notified: request.Notified,
+		}
+	}
+	return lifecycleContractState{epoch: state.Epoch, active: state.Active, interaction: state.Interaction, pending: pending}
+}
+
+func lifecycleNoOpDiff(step int, trace []lifecycleOperation, beforeModel, afterModel lifecycleContractState, beforeSUT, afterSUT app.CodexLifecycleTestState) string {
+	if !reflect.DeepEqual(beforeModel, afterModel) {
+		return lifecycleDiagnostic(step, "model-no-op", beforeModel, afterModel, trace)
+	}
+	beforeActual := lifecycleContractStateFromSUT(beforeSUT)
+	afterActual := lifecycleContractStateFromSUT(afterSUT)
+	if !reflect.DeepEqual(beforeActual, afterActual) {
+		return lifecycleDiagnostic(step, "sut-no-op", beforeActual, afterActual, trace)
+	}
+	return ""
+}
+
+func lifecycleFixedPointDiff(step int, trace []lifecycleOperation, canonical, alternate app.CodexLifecycleTestState) string {
+	canonicalState := lifecycleContractStateFromSUT(canonical)
+	alternateState := lifecycleContractStateFromSUT(alternate)
+	if !reflect.DeepEqual(canonicalState, alternateState) {
+		return lifecycleDiagnostic(step, "reorder-fixed-point", canonicalState, alternateState, trace)
+	}
+	return ""
+}
+
+func lifecycleDiagnostic(step int, field string, want, got any, trace []lifecycleOperation) string {
+	return fmt.Sprintf("step=%d field=%s want=%#v got=%#v trace=%s", step, field, want, got, formatLifecycleTrace(trace))
+}
+
+func assertMinimalTraceDiagnostic(t *testing.T, diagnostic string, fragments ...string) {
+	t.Helper()
+	if diagnostic == "" {
+		t.Fatal("injected lifecycle mutant escaped the reference property")
+	}
+	for _, fragment := range append([]string{"step=1", "trace=["}, fragments...) {
+		if !strings.Contains(diagnostic, fragment) {
+			t.Fatalf("diagnostic %q does not contain %q", diagnostic, fragment)
+		}
+	}
+}
+
+func currentLifecycleEpoch(epoch uint64) uint64 {
+	if epoch == 0 {
+		return 1
+	}
+	return epoch
+}
+
+func nextLifecycleEpoch(epoch uint64) uint64 {
+	if epoch == 0 {
+		return 1
+	}
+	return epoch + 1
+}
+
+func lifecycleEpochFor(authority lifecycleAuthority, epoch uint64) uint64 {
+	current := currentLifecycleEpoch(epoch)
+	switch authority {
+	case lifecycleCurrent, lifecycleForeign:
+		return current
+	case lifecycleStale:
+		if current > 1 {
+			return current - 1
+		}
+		return current + 97
+	case lifecycleFuture:
+		return current + 1
+	default:
+		return current + 101
+	}
+}
+
+func lifecycleInvalidationEpochFor(authority lifecycleAuthority, epoch uint64) uint64 {
+	if authority == lifecycleForeign {
+		return currentLifecycleEpoch(epoch) + 1
+	}
+	return lifecycleEpochFor(authority, epoch)
+}
+
+func testSnapshot(threadState, turnID, turnState string) lifecycleOperation {
+	return lifecycleOperation{
+		kind: lifecycleSnapshot, authority: lifecycleCurrent,
+		snapshot: lifecycleModelSnapshot{threadID: "thread-1", threadState: threadState, turnID: turnID, turnState: turnState},
+	}
+}
+
+func testEvent(authority lifecycleAuthority, event lifecycleModelEvent) lifecycleOperation {
+	if authority == lifecycleForeign {
+		event.threadID = "thread-foreign"
+	} else {
+		event.threadID = "thread-1"
+	}
+	return lifecycleOperation{kind: lifecycleProviderEvent, authority: authority, event: event}
+}
+
+func testPendingEvent(turnID, itemID, requestID string) lifecycleModelEvent {
+	return lifecycleModelEvent{
+		kind: "approval-pending", turnID: turnID, itemID: itemID, requestID: requestID, approvalKind: "command",
+	}
+}

--- a/internal/app/agent_interaction_codex_reference_model_test.go
+++ b/internal/app/agent_interaction_codex_reference_model_test.go
@@ -1,0 +1,391 @@
+package app_test
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type lifecycleOperationKind uint8
+
+const (
+	lifecycleSnapshot lifecycleOperationKind = iota
+	lifecycleProviderEvent
+	lifecycleDuplicate
+	lifecycleAllowedReorder
+	lifecycleInvalidation
+	lifecycleEpochReplace
+)
+
+type lifecycleAuthority uint8
+
+const (
+	lifecycleCurrent lifecycleAuthority = iota
+	lifecycleStale
+	lifecycleFuture
+	lifecycleForeign
+)
+
+type lifecycleOperation struct {
+	kind       lifecycleOperationKind
+	authority  lifecycleAuthority
+	snapshot   lifecycleModelSnapshot
+	event      lifecycleModelEvent
+	reorderKey byte
+}
+
+type lifecycleModelSnapshot struct {
+	threadID    string
+	threadState string
+	turnID      string
+	turnState   string
+}
+
+type lifecycleModelEvent struct {
+	kind         string
+	threadID     string
+	turnID       string
+	itemID       string
+	requestID    string
+	threadState  string
+	turnState    string
+	approvalKind string
+}
+
+type lifecycleConcreteKind uint8
+
+const (
+	lifecycleConcreteSnapshot lifecycleConcreteKind = iota
+	lifecycleConcreteEvent
+	lifecycleConcreteInvalidation
+)
+
+type lifecycleConcreteOperation struct {
+	kind     lifecycleConcreteKind
+	epoch    uint64
+	snapshot lifecycleModelSnapshot
+	event    lifecycleModelEvent
+}
+
+type lifecycleModelPending struct {
+	turnID       string
+	itemID       string
+	requestID    string
+	approvalKind string
+	notified     bool
+}
+
+type lifecycleModelState struct {
+	epoch            uint64
+	active           bool
+	threadID         string
+	threadState      string
+	currentTurnID    string
+	currentTurnState string
+	interaction      string
+	pending          map[string]lifecycleModelPending
+	terminalTurns    map[string]string
+}
+
+type lifecycleModelResult struct {
+	accepted    bool
+	invalidated bool
+}
+
+var lifecycleThreadStates = [...]string{
+	"unknown", "not-loaded", "idle", "active", "waiting-on-approval", "waiting-on-user-input", "system-error",
+}
+
+var lifecycleTurnStates = [...]string{"unknown", "in-progress", "completed", "failed", "interrupted"}
+
+func decodeLifecycleOperations(data []byte) []lifecycleOperation {
+	operations := make([]lifecycleOperation, 0, (len(data)+2)/3)
+	for offset := 0; offset < len(data); offset += 3 {
+		opcode := data[offset]
+		var payload, authority byte
+		if offset+1 < len(data) {
+			payload = data[offset+1]
+		}
+		if offset+2 < len(data) {
+			authority = data[offset+2]
+		}
+		operations = append(operations, decodeLifecycleOperation(opcode, payload, authority))
+	}
+	return operations
+}
+
+func decodeLifecycleOperation(opcode, payload, authority byte) lifecycleOperation {
+	op := lifecycleOperation{
+		kind:       lifecycleOperationKind(opcode % 6),
+		authority:  lifecycleAuthority(authority % 4),
+		reorderKey: payload,
+	}
+	turnIDs := [...]string{"turn-1", "turn-2", ""}
+	requestIDs := [...]string{"request-1", "request-2", "request-missing"}
+	itemIDs := [...]string{"item-1", "item-2", ""}
+	op.snapshot = lifecycleModelSnapshot{
+		threadID:    "thread-1",
+		threadState: lifecycleThreadStates[payload%byte(len(lifecycleThreadStates))],
+		turnID:      turnIDs[(payload/7)%byte(len(turnIDs))],
+		turnState:   lifecycleTurnStates[(payload/21)%byte(len(lifecycleTurnStates))],
+	}
+	if op.authority == lifecycleForeign {
+		op.snapshot.threadID = "thread-foreign"
+	}
+	if op.kind == lifecycleSnapshot && op.authority != lifecycleForeign {
+		op.authority = lifecycleCurrent
+	}
+	if op.kind == lifecycleEpochReplace {
+		op.authority = lifecycleCurrent
+		op.snapshot.threadID = "thread-1"
+	}
+	variant := payload / 5
+	op.event = lifecycleModelEvent{
+		threadID:     "thread-1",
+		turnID:       turnIDs[variant%byte(len(turnIDs))],
+		itemID:       itemIDs[(variant/3)%byte(len(itemIDs))],
+		requestID:    requestIDs[(variant/9)%byte(len(requestIDs))],
+		threadState:  lifecycleThreadStates[variant%byte(len(lifecycleThreadStates))],
+		turnState:    lifecycleTurnStates[variant%byte(len(lifecycleTurnStates))],
+		approvalKind: [...]string{"command", "file-change", "permissions"}[(variant/5)%3],
+	}
+	if op.authority == lifecycleForeign {
+		op.event.threadID = "thread-foreign"
+	}
+	switch payload % 5 {
+	case 0:
+		op.event.kind = "turn-started"
+	case 1:
+		op.event.kind = "thread-status"
+	case 2:
+		op.event.kind = "approval-pending"
+	case 3:
+		op.event.kind = "request-resolved"
+	case 4:
+		op.event.kind = "turn-completed"
+	}
+	return op
+}
+
+func (m *lifecycleModelState) apply(operation lifecycleConcreteOperation) lifecycleModelResult {
+	switch operation.kind {
+	case lifecycleConcreteSnapshot:
+		return m.begin(operation.epoch, operation.snapshot)
+	case lifecycleConcreteEvent:
+		return m.applyEvent(operation.epoch, operation.event)
+	case lifecycleConcreteInvalidation:
+		return m.invalidate(operation.epoch)
+	default:
+		return lifecycleModelResult{}
+	}
+}
+
+func (m *lifecycleModelState) begin(epoch uint64, snapshot lifecycleModelSnapshot) lifecycleModelResult {
+	if epoch == 0 || strings.TrimSpace(snapshot.threadID) != "thread-1" {
+		return lifecycleModelResult{}
+	}
+	m.epoch = epoch
+	m.active = true
+	m.threadID = "thread-1"
+	m.threadState = snapshot.threadState
+	m.currentTurnID = strings.TrimSpace(snapshot.turnID)
+	m.currentTurnState = snapshot.turnState
+	m.pending = map[string]lifecycleModelPending{}
+	m.terminalTurns = map[string]string{}
+	if snapshot.threadState == "not-loaded" {
+		return m.invalidate(epoch)
+	}
+	if m.currentTurnID != "" && terminalTurnState(snapshot.turnState) {
+		m.terminalTurns[m.currentTurnID] = snapshot.turnState
+	}
+	m.interaction = m.snapshotInteraction()
+	return lifecycleModelResult{accepted: true}
+}
+
+func (m *lifecycleModelState) invalidate(epoch uint64) lifecycleModelResult {
+	if !m.active || epoch != m.epoch {
+		return lifecycleModelResult{}
+	}
+	m.active = false
+	m.pending = nil
+	m.currentTurnID = ""
+	m.currentTurnState = "unknown"
+	m.interaction = "unknown"
+	return lifecycleModelResult{accepted: true, invalidated: true}
+}
+
+func (m *lifecycleModelState) applyEvent(epoch uint64, event lifecycleModelEvent) lifecycleModelResult {
+	if !m.active || epoch != m.epoch || strings.TrimSpace(event.threadID) != strings.TrimSpace(m.threadID) {
+		return lifecycleModelResult{}
+	}
+	result := lifecycleModelResult{accepted: true}
+	switch event.kind {
+	case "turn-started":
+		if event.turnID == "" {
+			return lifecycleModelResult{}
+		}
+		m.pending = map[string]lifecycleModelPending{}
+		m.terminalTurns = map[string]string{}
+		m.currentTurnID = event.turnID
+		m.currentTurnState = "in-progress"
+		m.threadState = "active"
+		m.interaction = "in_progress"
+	case "thread-status":
+		if event.threadState == "not-loaded" {
+			return m.invalidate(epoch)
+		}
+		if m.threadState == "waiting-on-approval" && event.threadState != "waiting-on-approval" {
+			for requestID, pending := range m.pending {
+				pending.notified = false
+				m.pending[requestID] = pending
+			}
+		}
+		m.threadState = event.threadState
+		m.interaction = m.liveInteraction()
+		if m.interaction == "approval_required" {
+			m.markActionableApprovalsNotified()
+		}
+	case "approval-pending":
+		if event.turnID == "" || event.itemID == "" || event.requestID == "" || event.turnID != m.currentTurnID {
+			return lifecycleModelResult{}
+		}
+		if m.pending == nil {
+			m.pending = map[string]lifecycleModelPending{}
+		}
+		if existing, ok := m.pending[event.requestID]; ok {
+			if existing.turnID != event.turnID || existing.itemID != event.itemID {
+				return lifecycleModelResult{}
+			}
+		} else {
+			m.pending[event.requestID] = lifecycleModelPending{
+				turnID: event.turnID, itemID: event.itemID, requestID: event.requestID, approvalKind: event.approvalKind,
+			}
+		}
+		m.interaction = m.liveInteraction()
+		if m.interaction == "approval_required" {
+			m.markActionableApprovalsNotified()
+		}
+	case "request-resolved":
+		pending, ok := m.pending[event.requestID]
+		if !ok || pending.turnID != m.currentTurnID {
+			return lifecycleModelResult{}
+		}
+		delete(m.pending, event.requestID)
+		m.interaction = m.liveInteraction()
+	case "turn-completed":
+		if event.turnID == "" || event.turnID != m.currentTurnID {
+			return lifecycleModelResult{}
+		}
+		if _, duplicate := m.terminalTurns[event.turnID]; duplicate || !terminalTurnState(event.turnState) {
+			return lifecycleModelResult{}
+		}
+		m.pending = map[string]lifecycleModelPending{}
+		m.currentTurnState = event.turnState
+		m.terminalTurns[event.turnID] = event.turnState
+		if event.turnState == "completed" {
+			m.interaction = "response_complete"
+		} else {
+			m.interaction = "idle"
+		}
+	default:
+		return lifecycleModelResult{}
+	}
+	return result
+}
+
+func (m *lifecycleModelState) snapshotInteraction() string {
+	if m.currentTurnState == "completed" {
+		return "response_complete"
+	}
+	if m.currentTurnState == "failed" || m.currentTurnState == "interrupted" {
+		return "idle"
+	}
+	return m.liveInteraction()
+}
+
+func (m *lifecycleModelState) liveInteraction() string {
+	if m.currentTurnState == "completed" {
+		return "response_complete"
+	}
+	switch m.threadState {
+	case "idle", "system-error":
+		return "idle"
+	case "waiting-on-user-input":
+		return "input_required"
+	case "waiting-on-approval":
+		for _, pending := range m.pending {
+			if pending.turnID == m.currentTurnID && pending.itemID != "" && pending.requestID != "" {
+				return "approval_required"
+			}
+		}
+		return "in_progress"
+	case "active":
+		return "in_progress"
+	default:
+		return "unknown"
+	}
+}
+
+func (m *lifecycleModelState) markActionableApprovalsNotified() {
+	for requestID, pending := range m.pending {
+		if pending.turnID == m.currentTurnID && !pending.notified {
+			pending.notified = true
+			m.pending[requestID] = pending
+		}
+	}
+}
+
+func (m lifecycleModelState) sortedPending() []lifecycleModelPending {
+	pending := make([]lifecycleModelPending, 0, len(m.pending))
+	for _, request := range m.pending {
+		pending = append(pending, request)
+	}
+	sort.Slice(pending, func(i, j int) bool { return pending[i].requestID < pending[j].requestID })
+	return pending
+}
+
+func terminalTurnState(state string) bool {
+	return state == "completed" || state == "failed" || state == "interrupted"
+}
+
+func (o lifecycleOperation) String() string {
+	switch o.kind {
+	case lifecycleSnapshot:
+		return fmt.Sprintf("snapshot[%s](thread=%s,turn=%s/%s)", o.authority, o.snapshot.threadState, o.snapshot.turnID, o.snapshot.turnState)
+	case lifecycleProviderEvent:
+		return fmt.Sprintf("event[%s](%s,thread_id=%s,turn=%s,item=%s,request=%s,thread_state=%s,turn_state=%s)", o.authority, o.event.kind, o.event.threadID, o.event.turnID, o.event.itemID, o.event.requestID, o.event.threadState, o.event.turnState)
+	case lifecycleDuplicate:
+		return "duplicate(last-provider-event)"
+	case lifecycleAllowedReorder:
+		return fmt.Sprintf("allowed-reorder(pending-%d-a,pending-%d-b)", o.reorderKey, o.reorderKey)
+	case lifecycleInvalidation:
+		return fmt.Sprintf("invalidation[%s]", o.authority)
+	case lifecycleEpochReplace:
+		return fmt.Sprintf("epoch-replace(thread=%s,turn=%s/%s)", o.snapshot.threadState, o.snapshot.turnID, o.snapshot.turnState)
+	default:
+		return fmt.Sprintf("operation(%d)", o.kind)
+	}
+}
+
+func (a lifecycleAuthority) String() string {
+	switch a {
+	case lifecycleCurrent:
+		return "current"
+	case lifecycleStale:
+		return "stale"
+	case lifecycleFuture:
+		return "future"
+	case lifecycleForeign:
+		return "foreign"
+	default:
+		return fmt.Sprintf("authority(%d)", a)
+	}
+}
+
+func formatLifecycleTrace(operations []lifecycleOperation) string {
+	parts := make([]string, len(operations))
+	for index, operation := range operations {
+		parts[index] = operation.String()
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}

--- a/internal/app/agent_interaction_codex_test.go
+++ b/internal/app/agent_interaction_codex_test.go
@@ -14,6 +14,8 @@ func testCodexLifecycleIdentity() codexLifecycleIdentity {
 	}
 }
 
+// This readable example remains because it owns notice publish, clear, and
+// re-notify effects that the pure state reference model intentionally omits.
 func TestCodexLifecycleApprovalRequiresExactPendingAndWaitingPair(t *testing.T) {
 	r := &codexLifecycleReducer{}
 	identity := testCodexLifecycleIdentity()
@@ -79,6 +81,8 @@ func TestCodexLifecycleApprovalRequiresExactPendingAndWaitingPair(t *testing.T) 
 	}
 }
 
+// This example retains the unique no-notice projection boundary for a request
+// that resolves before the waiting status arrives.
 func TestCodexLifecycleAutoApprovedRequestNeverProjectsAttention(t *testing.T) {
 	r := &codexLifecycleReducer{}
 	r.begin(1, testCodexLifecycleIdentity(), codexappserver.LifecycleSnapshot{
@@ -98,6 +102,8 @@ func TestCodexLifecycleAutoApprovedRequestNeverProjectsAttention(t *testing.T) {
 	}
 }
 
+// This example owns exact notification identity and clear-ID behavior; the
+// reference model compares pending ownership but never predicts notice IDs.
 func TestCodexLifecycleResolvedRequestUsesStoredExactTuple(t *testing.T) {
 	r := &codexLifecycleReducer{}
 	r.begin(1, testCodexLifecycleIdentity(), codexappserver.LifecycleSnapshot{
@@ -144,6 +150,8 @@ func TestCodexLifecycleResolvedRequestUsesStoredExactTuple(t *testing.T) {
 	}
 }
 
+// This table remains the canonical notification-once example for terminal
+// outcomes. The reference property owns terminal reducer state only.
 func TestCodexLifecycleCompletionIsExactSuccessfulAndOnce(t *testing.T) {
 	for _, test := range []struct {
 		name        string
@@ -174,106 +182,4 @@ func TestCodexLifecycleCompletionIsExactSuccessfulAndOnce(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestCodexLifecycleInvalidationRejectsLateAndReplacementEvents(t *testing.T) {
-	r := &codexLifecycleReducer{}
-	r.begin(1, testCodexLifecycleIdentity(), codexappserver.LifecycleSnapshot{
-		ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive,
-		TurnID: "turn-1", TurnState: codexappserver.TurnStateInProgress,
-	})
-	if got := r.invalidate(1); !got.Invalidated || got.Interaction != coremetadata.InteractionUnknown {
-		t.Fatalf("invalidate = %#v", got)
-	}
-	late := r.apply(1, codexappserver.LifecycleEvent{
-		Kind: codexappserver.LifecycleTurnCompleted, ThreadID: "thread-1", TurnID: "turn-1", TurnState: codexappserver.TurnStateCompleted,
-	})
-	if late.Accepted || len(late.Notices) != 0 {
-		t.Fatalf("late event accepted: %#v", late)
-	}
-	r.begin(2, testCodexLifecycleIdentity(), codexappserver.LifecycleSnapshot{
-		ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle,
-	})
-	if stale := r.apply(1, codexappserver.LifecycleEvent{
-		Kind: codexappserver.LifecycleTurnStarted, ThreadID: "thread-1", TurnID: "turn-old",
-	}); stale.Accepted {
-		t.Fatalf("old epoch event accepted: %#v", stale)
-	}
-	if foreign := r.apply(2, codexappserver.LifecycleEvent{
-		Kind: codexappserver.LifecycleTurnStarted, ThreadID: "thread-foreign", TurnID: "turn-foreign",
-	}); foreign.Accepted {
-		t.Fatalf("foreign thread event accepted: %#v", foreign)
-	}
-}
-
-func TestCodexLifecycleNotLoadedSnapshotIsImmediateInvalidation(t *testing.T) {
-	r := &codexLifecycleReducer{}
-	projection := r.begin(3, testCodexLifecycleIdentity(), codexappserver.LifecycleSnapshot{
-		ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateNotLoaded,
-		TurnID: "turn-1", TurnState: codexappserver.TurnStateCompleted,
-	})
-	if !projection.Accepted || !projection.Invalidated || projection.Interaction != coremetadata.InteractionUnknown || len(projection.Notices) != 0 {
-		t.Fatalf("not-loaded snapshot = %#v", projection)
-	}
-	if late := r.apply(3, codexappserver.LifecycleEvent{
-		Kind: codexappserver.LifecycleTurnCompleted, ThreadID: "thread-1", TurnID: "turn-1", TurnState: codexappserver.TurnStateCompleted,
-	}); late.Accepted {
-		t.Fatalf("not-loaded epoch accepted late completion: %#v", late)
-	}
-}
-
-func FuzzCodexLifecycleEventSequence(f *testing.F) {
-	f.Add([]byte{0, 1, 2, 3, 4, 5})
-	f.Add([]byte{3, 2, 4, 2, 3, 5})
-	f.Fuzz(func(t *testing.T, sequence []byte) {
-		if len(sequence) > 128 {
-			sequence = sequence[:128]
-		}
-		r := &codexLifecycleReducer{}
-		r.begin(1, testCodexLifecycleIdentity(), codexappserver.LifecycleSnapshot{
-			ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive,
-			TurnID: "turn-1", TurnState: codexappserver.TurnStateInProgress,
-		})
-		for index, raw := range sequence {
-			epoch := uint64(1)
-			threadID := "thread-1"
-			if raw&0x40 != 0 {
-				epoch = 99
-			}
-			if raw&0x80 != 0 {
-				threadID = "foreign"
-			}
-			requestID := "request-1"
-			if index%2 == 1 {
-				requestID = "request-2"
-			}
-			var event codexappserver.LifecycleEvent
-			switch raw % 6 {
-			case 0:
-				event = codexappserver.LifecycleEvent{Kind: codexappserver.LifecycleTurnStarted, ThreadID: threadID, TurnID: "turn-1"}
-			case 1:
-				event = codexappserver.LifecycleEvent{Kind: codexappserver.LifecycleThreadStatus, ThreadID: threadID, ThreadState: codexappserver.ThreadStateWaitingOnApproval}
-			case 2:
-				event = codexappserver.LifecycleEvent{Kind: codexappserver.LifecycleApprovalPending, ThreadID: threadID, TurnID: "turn-1", ItemID: "item-1", RequestID: requestID, ApprovalKind: codexappserver.ApprovalCommand}
-			case 3:
-				event = codexappserver.LifecycleEvent{Kind: codexappserver.LifecycleRequestResolved, ThreadID: threadID, RequestID: requestID}
-			case 4:
-				event = codexappserver.LifecycleEvent{Kind: codexappserver.LifecycleTurnCompleted, ThreadID: threadID, TurnID: "turn-1", TurnState: codexappserver.TurnStateCompleted}
-			case 5:
-				event = codexappserver.LifecycleEvent{Kind: codexappserver.LifecycleTurnCompleted, ThreadID: threadID, TurnID: "turn-1", TurnState: codexappserver.TurnStateFailed}
-			}
-			projection := r.apply(epoch, event)
-			if projection.Accepted && !coremetadata.ValidAgentInteractionKind(projection.Interaction) {
-				t.Fatalf("open interaction %q after %#v", projection.Interaction, event)
-			}
-			for _, notice := range projection.Notices {
-				if notice.Category == "approval_required" && (notice.ThreadID != "thread-1" || notice.TurnID == "" || notice.ItemID == "" || notice.RequestID == "") {
-					t.Fatalf("inexact approval notice: %#v", notice)
-				}
-				if notice.Category == "response_complete" && event.TurnState != codexappserver.TurnStateCompleted {
-					t.Fatalf("non-success completion notice: event=%#v notice=%#v", event, notice)
-				}
-			}
-		}
-	})
 }


### PR DESCRIPTION
## Summary
- add a test-only, provider-independent lifecycle operation vocabulary and pure reference transition model
- compare the production reducer with the model after every generated step and verify duplicate/stale/foreign no-ops plus allowed reorder fixed points
- replace the weak lifecycle fuzz/invalidation examples while retaining notice-specific readable regressions

## Validation
- `make fmt`
- `make fix`
- `make test`
- `go test ./internal/app -run ^$ -fuzz ^FuzzCodexLifecycleReferenceModel$ -fuzztime=30s`

Phase 1 only; projection, runtime, tmux, installed Codex, and maintenance producers are unchanged.