### PR TITLE
feat(codex): model app-server generations and qualification

### DIFF
--- a/.deadcode-must-keep.txt
+++ b/.deadcode-must-keep.txt
@@ -7,18 +7,26 @@
 # they appear in deadcode output; unrelated new findings still fail the gate.
 
 AggregateTeardownEvents	Pure multi-event teardown authority is retained for lifecycle decision proofs and planned consumers.
+ApplyAuthorized	Phase 0 composite authority gate is retained before generation-aware runtime consumers are enabled.
+ApplySuccessorResume	Phase 0 old-stop semantic barrier is retained before journaled handover consumers are enabled.
 Binding.ControlAuthority	The snapshot-barrier control authority accessor is retained as the in-process mutation gate; the local IPC path fences inside Submit instead.
 Broker.WriteLedger	The mutation write ledger is retained as the observable no-replay evidence surface.
 CanonicalRoutes	The canonical route table accessor is retained for cross-package coverage and generated-reference consumers.
 CleanupLegacyArtifacts	Persisted usage-state cleanup must remain available across legacy state migrations.
+Create	Phase 0 immutable Codex release-bundle lease creator is retained for the later private generation host.
 CurrentProtocol	The build's local IPC version window accessor is retained as the negotiation input an explicit caller supplies.
+DecideAuthority	Phase 0 pure five-axis Codex authority decision is retained for the generation-aware projection phase.
+DecideSuccessorResume	Phase 0 pure same-thread old-stop decision is retained for the journaled handover phase.
 DecideTeardownEvent	The pure teardown decision API is retained for lifecycle authority proofs and planned consumers.
 DecodeCapabilityLedger	Test-only installed qualification API retained for strict checked-in capability-ledger validation.
+DecodeQualificationResult	Phase 0 strict content-free generation qualification receipt decoder is retained for later upgrade gates.
 DirectEndpoint.Close	Test-only installed qualification API retained for bounded direct endpoint cleanup proof.
 DirectEndpoint.Health	Test-only installed qualification API retained for canonical direct readiness evidence.
 DirectEndpoint.forceCleanup	Test-only installed qualification helper retained for injected direct startup-failure cleanup proof.
 DirectEndpoint.markClosed	Test-only installed qualification helper retained for single-consumer bounded direct exit finalization proof.
 Discover	The background-context discovery wrapper is retained as a test and compatibility seam.
+Error.Error	Phase 0 bundle refusal renderer is retained as the content-free immutable lease error contract.
+EvaluateQualification	Phase 0 exact-version-pair qualification reducer is retained for installed pool admission gates.
 EvaluateTurnFreeThreadLiveAttach	Test-only installed qualification API retained for method-independent semantic capability reduction.
 Fixture.ApplyEnv	Test-only installed qualification API retained for isolated environment containment proof.
 Fixture.Cleanup	Test-only installed qualification API retained for exact owned-artifact cleanup proof.
@@ -36,11 +44,14 @@ Fixture.readDaemonVersion	Test-only installed qualification helper retained for 
 Fixture.readManagedPID	Test-only installed qualification helper retained for contained public PID artifact proof.
 Fixture.readManagedStartResult	Test-only installed qualification helper retained for exact managed start PID proof.
 Fixture.retireAfterFailure	Test-only installed qualification helper retained for bounded exact managed failure cleanup proof.
+GateQualification	Phase 0 go/no-go gate is retained to keep unsafe Phase 2+ pool work closed.
 Host.RuntimeID	The runtime identity accessor is retained as the authority axis clients present alongside both epochs.
+Inspect	Phase 0 Codex release manifest inspector is retained for later private generation provisioning.
 IsolatedPane.Alive	Test-only installed qualification API retained for exact pane-dead and socket-identity observation.
 IsolatedPane.Close	Test-only installed qualification API retained for contained exact tmux server cleanup.
 IsolatedPane.ID	Test-only installed qualification API retained for content-free exact Pane evidence.
 IsolatedPane.run	Test-only installed qualification helper retained for inherited tmux identity stripping on every command.
+Lease.Paths	Phase 0 verified bundle role resolver is retained for generation-pinned server, TUI, and helper launch.
 Ledger.AmbientMutations	Test-only installed qualification API retained for typed ambient mutation counting proof.
 Ledger.AssertNoAmbientMutation	Test-only installed qualification API retained for zero ambient mutation proof.
 Ledger.AssertNoLifecycleMutation	Test-only installed qualification API retained for broker-smoke lifecycle non-mutation proof.
@@ -49,29 +60,53 @@ Ledger.DistinctOperations	Test-only installed qualification API retained for con
 Ledger.HasOperation	Test-only installed qualification API retained for canonical proxy observation proof.
 Ledger.record	Test-only installed qualification helper retained for owned lifecycle command evidence.
 LookupCanonicalRoute	Canonical spelling lookup is retained for route coverage and generated-reference consumers.
+Manifest.ContentID	Phase 0 canonical bundle identity is retained for generation lease persistence.
+Manifest.Validate	Phase 0 complete server, TUI, helper, hash, mode, and protocol manifest validation is retained.
 MigrateGlobalLegacyScripts	Global legacy hook migration must remain available while old installations can still be upgraded.
 MigrateProjectLegacyScripts	Project legacy hook migration must remain available while old repositories can still be upgraded.
 NewClean	Test-only installed qualification API retained for canonical clean-root topology proof.
 NewExisting	Test-only installed qualification API retained for unchanged model-dependent broker smoke containment.
 NewResult	Test-only installed qualification API retained for typed terminal result construction.
+Open	Phase 0 immutable bundle reopen verification is retained for source-removal relaunch and later recovery.
+OpenPrivateUnix	Test-only private Unix app-server dial is retained for fixed dual-version installed qualification only.
+PlanUpgrade	Phase 0 pure read-only upgrade plan is retained for the later upgrade command.
+Pool.Current	Phase 0 sole-current lookup is retained as part of the bounded read-only planning model.
+Pool.Validate	Phase 0 bounded current-one plus draining-one topology validator is retained for later coordinators.
+ProtocolRange.Supports	Phase 0 protocol range containment check is retained for pre-commit bundle refusal.
+ProtocolRange.Valid	Phase 0 protocol range validation is retained as part of immutable bundle manifests.
+QualificationResult.JSON	Phase 0 content-free generation qualification writer is retained for installed receipts.
+QualificationResult.Validate	Phase 0 strict generation qualification consistency check is retained for installed receipts.
 ReadRuntimeHealth	The typed no-write runtime-health seam is retained for diagnostics tests and the planned doctor consumer.
+Refusal.String	Phase 0 closed bundle refusal token renderer is retained for content-free diagnostics.
+RefusalOf	Phase 0 bundle refusal classifier is retained for pre-commit drift and protocol gates.
 Registry.snapshotPanesOf	Snapshot pane lookup remains part of the retained snapshot reconciliation implementation.
 Result.JSON	Test-only installed qualification API retained for terminal JSON evidence.
 Result.Validate	Test-only installed qualification API retained for closed class and nonblank tuple validation.
+RetainedQualificationFields	Phase 0 qualification privacy allowlist is retained for schema redaction audits.
 Routes	The public route table accessor is retained for cross-package coverage and generated-reference consumers.
 SmokeRoot	Test-only installed qualification API retained for canonical isolated root validation.
 Store.Migrate	Registry schema migration must remain available for persisted pre-current Registry files.
 Store.Path	The Registry path accessor is retained for migration and storage-boundary tests.
 Store.SetClock	The injected Registry clock is retained as a deterministic migration and transaction test seam.
 TeardownObservations	The closed teardown-observation catalog is retained for authority proofs and planned consumers.
+TopologyError.Error	Phase 0 topology refusal renderer is retained as the content-free bounded-pool error contract.
+TopologyRefusal.String	Phase 0 closed topology refusal token renderer is retained for exact plan blockers.
+UpgradePlan.JSON	Phase 0 exact JSON plan projection is retained for the later upgrade command.
+UpgradePlan.Text	Phase 0 exact text plan projection is retained for the later upgrade command.
 VersionTuple.normalized	Test-only installed qualification helper retained for explicit unknown version evidence.
 WithSocketName	The injected tmux socket option is retained as an exact routing compatibility and test seam.
 boundedBuffer.Bytes	Test-only installed qualification helper retained for bounded public status decoding.
 boundedBuffer.Write	Test-only installed qualification helper retained for bounded installed command capture.
+canonicalize	Phase 0 bundle manifest canonicalizer is retained to make content identity independent of discovery order.
 classifyCodexCommand	Test-only installed qualification helper retained for semantic mutation classification.
+cleanRelative	Phase 0 bundle relative-path validator is retained to keep lease artifacts contained.
+cloneManifest	Phase 0 manifest clone helper is retained to canonicalize without aliasing caller state.
+copyVerified	Phase 0 staged bundle copier is retained for hash, size, mode, and source-identity pre-commit verification.
 equalArgv	Test-only installed qualification helper retained for closed command-shape classification.
 formatLegacyPaneSummary	Legacy pane-summary rendering remains required while persisted legacy pane metadata is readable.
 genericTeardownRefusal	The generic refusal constructor is retained inside the pure teardown authority proof surface.
+inspectArtifact	Phase 0 source artifact inspector is retained for content-addressed upstream identity verification.
+inspectCommittedArtifact	Phase 0 committed artifact inspector is retained to refuse symlinks before launch.
 isolatedEnvironment	Test-only installed qualification helper retained for CODEX_HOME and tmux identity containment.
 legacyDesktopAppID	The retired desktop application identifier remains required to recognize and clean legacy integration state.
 legacyWindowAttentionRows	Legacy attention rows remain required while older persisted window attention state is readable.
@@ -80,15 +115,25 @@ newLedger	Test-only installed qualification helper retained for canonical semant
 observationRefusal	Observation-specific refusal mapping is retained inside the pure teardown authority proof surface.
 pathWithin	Test-only installed qualification helper retained for tmux socket containment proof.
 projectPreservedAssets	The preserved-assets outcome helper is retained for project teardown authority proofs.
+readCommittedRegularFile	Phase 0 committed bundle reader is retained to keep manifest and artifact authority inside the lease root.
 removeExactResidualSocket	Test-only installed qualification helper retained for ready-time socket identity cleanup proof.
 rootDefaults	Root teardown defaults are retained inside the pure teardown decision authority.
+safeRoot	Phase 0 lease root validator is retained to keep future bundle mutations off broad or relative targets.
+safeVersionToken	Phase 0 bundle version token validator is retained to keep manifests content-free.
 tmuxCapabilityEnvironment	Test-only installed qualification helper retained for per-command tmux and CODEX_HOME isolation.
 tmuxRetiredKeyUnbindLines	Retired key cleanup must remain available so old generated tmux bindings can be removed.
+validGenerationState	Phase 0 closed generation-state validator is retained for bounded-pool topology proofs.
+validIdentityToken	Phase 0 opaque identity validator is retained to keep plans and receipts content-free.
+validObligationState	Phase 0 closed Agent-obligation validator is retained for exact plan blockers.
 validOwnerChain	Owner-chain validation is retained inside the pure teardown decision authority.
+validOwnerClass	Phase 0 closed endpoint-owner validator is retained for attach-only unmanaged planning.
 validTeardownEventKind	The closed event-kind validator is retained inside the pure teardown decision authority.
 validTeardownObservation	The closed observation validator is retained inside the pure teardown decision authority.
+validVersionToken	Phase 0 qualification version validator is retained to keep persisted receipts content-free.
 validateInheritedEnvironment	Test-only installed qualification helper retained for inherited tmux refusal proof.
 validateManagedIdentity	Test-only installed qualification helper retained for foreign PID/socket cleanup refusal proof.
+valueOrNone	Phase 0 deterministic absent-identity rendering is retained for exact text plan goldens.
+verifyAt	Phase 0 committed bundle verifier is retained for source-removal relaunch and drift refusal.
 versionOrUnknown	Test-only installed qualification helper retained for nonblank version-tuple evidence.
 waitForProcessExit	Test-only installed qualification helper retained for independently bounded direct kill-wait proof.
 waitForRetirement	Test-only installed qualification helper retained for bounded PID/socket retirement proof.

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -600,6 +600,44 @@
   have non-zero status, stdout zero, bounded actionable stderr, and unchanged
   attention state.
 
+### Codex app-server generation Phase 0 tests
+
+- `TestCodexEndpointAndAuthorityRefsRoundTripExactlyAndIgnorePaneGeneration`,
+  `TestLegacyCodexRefsRemainGenerationUnavailableWithoutInference`,
+  `TestLegacyHookReobservationPreservesAnExactCodexEndpointRef`, and
+  `TestCodexEndpointIdentityRejectsNonCanonicalWhitespace` own the additive
+  Registry schema: refs reopen exactly, remain independent of Pane generation,
+  reject noncanonical identities, preserve future exact refs across legacy
+  hook observations, and never infer a current endpoint for legacy state.
+- `TestBoundedPoolRejectsEveryInvalidV1Topology`,
+  `TestBoundedPoolStateSpaceProperty`, and
+  `FuzzBoundedPoolNeverAcceptsMoreThanTwoLiveSlots` own the current-one plus
+  draining-one state model.
+- `TestCompositeAuthorityRejectsSameNumberCrossGenerationAndLegacyWithZeroWrites`
+  and `TestOldStopBarrierKeepsSuccessorResumeAtZeroUntilSafe` own the Phase 0
+  write-zero fences for equal numeric epochs, missing generation identity, and
+  same-thread successor resume before old-stop.
+- `TestReadOnlyUpgradePlanIsRepeatableContentFreeAndNamesExactBlockers` freezes
+  exact JSON/text blockers and all five zero mutation counters;
+  `TestReadOnlyUpgradePlanNeverRendersInvalidIdentitiesOrQualificationFields`
+  keeps hostile invalid input out of both projections.
+- `TestQualificationDecisionTableClosesPhase2OnEitherSharedStateFailure` and
+  `TestQualificationReceiptRetainsOnlyContentFreeAllowlistedFields` own the
+  persisted go/no-go and redaction schema.
+- `TestContentAddressedBundleSurvivesSourceRemovalForServerTUIAndHelpers`,
+  `TestBundleDriftAndProtocolMismatchRefuseBeforeFinalCommit`, and
+  `TestCommittedBundleTamperingIsRefusedBeforeLaunch`,
+  `TestCommittedBundleRefusesMatchingSymlinksBeforeLaunch`, and
+  `TestBundleRefusesNonCanonicalRootsAndVersions` own immutable complete
+  release-bundle retention and refusal, including manifest/artifact links and
+  noncanonical mutation roots.
+- Opt-in `TestInstalledIsolatedGenerationPoolQualification` is the fixed
+  0.152.0/0.152.1 shared-state conformance. It strips inherited tmux identity,
+  uses one unique private state root and two private sockets, records no
+  provider content or secrets, requires distinct-thread overlap plus the
+  old-stop same-thread barrier, and performs exact cleanup. See
+  [codex-generation-pool.md](codex-generation-pool.md).
+
 ## Review Checklist
 - The branch stays within its stated scope.
 - The change preserves boundaries between portable `projmux` behavior and local machine policy.

--- a/docs/codex-generation-pool.md
+++ b/docs/codex-generation-pool.md
@@ -1,0 +1,129 @@
+# Codex app-server generation pool — Phase 0 contract
+
+Phase 0 adds the identity, validation, qualification, immutable bundle, and
+read-only planning contracts needed by a future bounded app-server pool. It
+does not start or stop a product endpoint, change a current pointer, dial more
+than the existing broker endpoint, or change Agent create/resume behavior.
+
+## Identity and schema
+
+A native Codex Agent has two independent generation axes:
+
+- `Pane.status.activation.generation` identifies one Pane child
+  materialization. Existing lifecycle and termination guards keep this meaning.
+- `Agent.status.sessionRef.codex.endpoint` identifies the Codex state domain and
+  app-server generation that durably owns the thread.
+
+The additive endpoint shape is:
+
+```json
+{
+  "stateDomainID": "opaque-state-domain",
+  "endpointGenerationID": "opaque-endpoint-generation"
+}
+```
+
+The optional live activation authority is:
+
+```json
+{
+  "stateDomainID": "opaque-state-domain",
+  "endpointGenerationID": "opaque-endpoint-generation",
+  "brokerRuntimeID": "opaque-broker-runtime",
+  "connectionEpoch": 1,
+  "bindingEpoch": 1
+}
+```
+
+All five live authority dimensions must match. Connection and binding epochs
+remain broker-local counters; equal numbers from another endpoint generation or
+restarted broker are not authority. A registry written before these optional
+fields existed decodes and re-encodes with them absent. Absence is
+`legacy-generation-unavailable`, never an inference to the current endpoint.
+
+## Bounded model and read-only plan
+
+The v1 model permits at most two non-retired slots: one `current` and one
+draining obligation (`draining` or `handover-pending`). Preparing, recovering,
+and blocked candidates also consume a live slot. It rejects, among other
+invalid states:
+
+- two current generations;
+- two draining/handover-pending generations;
+- more than two non-retired generations;
+- a live Agent obligation without an admission-current generation;
+- obligations naming a missing or retired generation.
+
+`codexgeneration.PlanUpgrade` is a pure value reduction. It has no Registry
+writer, provider, tmux, process, or filesystem/current-pointer adapter. JSON and
+text output include the exact Agent UID and endpoint-generation ID for every
+blocker and an explicit zero counter for each mutation class. An exact-current
+unmanaged endpoint is attach-only: the plan can report it, but cannot stop,
+restart, kill, or adopt it.
+
+## Shared-state qualification gate
+
+The pool lane remains closed unless one exact old/new version pair passes all
+of the following in a single isolated state domain:
+
+1. different private sockets concurrently create and turn different threads;
+2. both endpoints read and list the exact threads without duplicates;
+3. both endpoints survive an observed crash/exit and restart barrier;
+4. a successor resume is not invoked while the old generation owns the same
+   thread;
+5. after the exact old process stops, only the completed persisted thread is
+   resumed and its exact completed-turn snapshot is observed;
+6. cross-thread writes, store corruption, and ambient mutations remain zero;
+7. copied `auth.json` and `config.toml` are shared only inside the private state
+   domain at mode `0600` and no values enter the receipt.
+
+The strict `codexgeneration.QualificationResult` persists only versions,
+booleans, counters, a closed verdict, and a closed reason. If distinct-thread
+concurrency or same-thread ownership is `no`—or any other required fact is
+missing—`GateQualification` keeps Phase 2+ closed and selects
+`single-endpoint-journaled-handover`. It never stores prompts, responses,
+credentials, paths, sockets, or rollout content.
+
+## Release bundle lease
+
+`codexbundle` retains the complete executable set a generation needs:
+
+- the `codex` binary in both server and TUI roles;
+- `codex-code-mode-host`, bundled `rg`, and bundled `bwrap` as helpers.
+
+The lease ID hashes the canonical manifest, which covers version, protocol
+range, role set, relative path, file mode, size, and SHA-256 for every artifact.
+Creation copies into a private staging directory, verifies it, and only then
+atomically commits the content-addressed directory. It never writes a current
+symlink. Missing roles, manifest/hash/size/mode drift, or an unsupported
+protocol range refuse before a usable lease is returned. `Open` repeats the
+verification before launch, so removing the mutable upstream release directory
+does not affect a valid lease.
+
+## Validation workflow
+
+The deterministic suite is part of `make test`. The real-Codex test is opt-in
+and requires exact 0.152.0 and 0.152.1 standalone executables plus a source
+Codex home containing `auth.json` and `config.toml`:
+
+```sh
+smoke_root="$(mktemp -d /tmp/projmux-codex-generation-XXXXXX)"
+bundle_root="$(mktemp -d /path/with/at-least-700MiB/projmux-codex-bundles-XXXXXX)"
+env -u TMUX -u TMUX_PANE \
+  PROJMUX_CODEX_GENERATION_SMOKE_ROOT="$smoke_root" \
+  PROJMUX_CODEX_GENERATION_BUNDLE_SMOKE_ROOT="$bundle_root" \
+  PROJMUX_CODEX_GENERATION_OLD="/absolute/path/to/0.152.0/bin/codex" \
+  PROJMUX_CODEX_GENERATION_NEW="/absolute/path/to/0.152.1/bin/codex" \
+  PROJMUX_CODEX_GENERATION_SOURCE_HOME="/absolute/path/to/source-codex-home" \
+  go test ./internal/testutil/codexinstalled \
+    -run '^TestInstalledIsolatedGenerationPoolQualification$' -count=1 -v
+```
+
+The root must be an empty child of the system temporary directory. The test
+uses two root-contained sockets, performs semantic readiness/completion/exit
+barriers rather than fixed sleeps, removes the leased source directories, and
+deletes only the exact owned root after both children and sockets are gone.
+
+The four existing empty-prompt canonical tests retain their current plain-CLI
+expectation. Their migration receipt belongs to Phase 3, not this additive
+model phase.

--- a/internal/core/codexgeneration/authority.go
+++ b/internal/core/codexgeneration/authority.go
@@ -1,0 +1,87 @@
+package codexgeneration
+
+import "github.com/crevissepartners/projmux/internal/core/metadata"
+
+type AuthorityDecision string
+
+const (
+	AuthorityAllowed               AuthorityDecision = "allowed"
+	AuthorityLegacyUnavailable     AuthorityDecision = "legacy-generation-unavailable"
+	AuthorityEndpointMismatch      AuthorityDecision = "endpoint-mismatch"
+	AuthorityBrokerRuntimeMismatch AuthorityDecision = "broker-runtime-mismatch"
+	AuthorityConnectionStale       AuthorityDecision = "connection-epoch-stale"
+	AuthorityBindingStale          AuthorityDecision = "binding-epoch-stale"
+)
+
+// DecideAuthority is the only Phase 0 comparison for a live Codex authority.
+// Legacy fields do not inherit the current endpoint. Ordering is deliberate so
+// diagnostics identify the first namespace that differs without exposing
+// provider content.
+func DecideAuthority(durable *metadata.CodexEndpointRef, stored, presented *metadata.CodexAuthorityRef) AuthorityDecision {
+	if durable == nil || stored == nil || presented == nil || !durable.Valid() || !stored.Valid() || !presented.Valid() {
+		return AuthorityLegacyUnavailable
+	}
+	if !durable.Same(stored.Endpoint()) || !durable.Same(presented.Endpoint()) {
+		return AuthorityEndpointMismatch
+	}
+	if stored.BrokerRuntimeID != presented.BrokerRuntimeID {
+		return AuthorityBrokerRuntimeMismatch
+	}
+	if stored.ConnectionEpoch != presented.ConnectionEpoch {
+		return AuthorityConnectionStale
+	}
+	if stored.BindingEpoch != presented.BindingEpoch {
+		return AuthorityBindingStale
+	}
+	return AuthorityAllowed
+}
+
+// ApplyAuthorized invokes write exactly once only for the complete exact
+// authority. Every legacy, same-number cross-generation, and stale row has a
+// provider/Registry/tmux write count of zero by construction.
+func ApplyAuthorized(durable *metadata.CodexEndpointRef, stored, presented *metadata.CodexAuthorityRef, write func()) AuthorityDecision {
+	decision := DecideAuthority(durable, stored, presented)
+	if decision == AuthorityAllowed && write != nil {
+		write()
+	}
+	return decision
+}
+
+type ResumeDecision string
+
+const (
+	ResumeAllowed            ResumeDecision = "allowed"
+	ResumeOwnerStillLive     ResumeDecision = "owner-still-live"
+	ResumeTargetMismatch     ResumeDecision = "target-mismatch"
+	ResumeNotDurable         ResumeDecision = "thread-not-durable"
+	ResumeAuthorityUncertain ResumeDecision = "authority-unavailable"
+)
+
+// DecideSuccessorResume is the content-free old-stop semantic barrier used by
+// qualification. It does not call the provider; the caller may do so only for
+// ResumeAllowed.
+func DecideSuccessorResume(owner, successor metadata.CodexEndpointRef, oldStopped, completedPersisted bool) ResumeDecision {
+	if !owner.Valid() || !successor.Valid() || owner.StateDomainID != successor.StateDomainID {
+		return ResumeAuthorityUncertain
+	}
+	if owner.Same(successor) {
+		return ResumeTargetMismatch
+	}
+	if !oldStopped {
+		return ResumeOwnerStillLive
+	}
+	if !completedPersisted {
+		return ResumeNotDurable
+	}
+	return ResumeAllowed
+}
+
+// ApplySuccessorResume runs resume only after the semantic old-stopped and
+// durable barriers are both closed.
+func ApplySuccessorResume(owner, successor metadata.CodexEndpointRef, oldStopped, completedPersisted bool, resume func()) ResumeDecision {
+	decision := DecideSuccessorResume(owner, successor, oldStopped, completedPersisted)
+	if decision == ResumeAllowed && resume != nil {
+		resume()
+	}
+	return decision
+}

--- a/internal/core/codexgeneration/model.go
+++ b/internal/core/codexgeneration/model.go
@@ -1,0 +1,214 @@
+// Package codexgeneration owns the pure, content-free model for a bounded
+// Codex app-server generation pool. It has no provider, process, filesystem,
+// Registry-writer, or tmux dependency; Phase 0 can therefore plan and qualify
+// topology without accidentally implementing lifecycle mutation.
+package codexgeneration
+
+import (
+	"errors"
+	"slices"
+	"strings"
+
+	"github.com/crevissepartners/projmux/internal/core/metadata"
+)
+
+const (
+	// ModelVersion identifies the first bounded-pool decision model.
+	ModelVersion = 1
+	// QualificationSchemaVersion is the strict, content-free receipt schema.
+	QualificationSchemaVersion = 1
+)
+
+type GenerationState string
+
+const (
+	StatePreparing       GenerationState = "preparing"
+	StateCurrent         GenerationState = "current"
+	StateDraining        GenerationState = "draining"
+	StateHandoverPending GenerationState = "handover-pending"
+	StateRetired         GenerationState = "retired"
+	StateRecovering      GenerationState = "recovering"
+	StateBlocked         GenerationState = "blocked"
+)
+
+func validGenerationState(state GenerationState) bool {
+	return slices.Contains([]GenerationState{
+		StatePreparing, StateCurrent, StateDraining, StateHandoverPending,
+		StateRetired, StateRecovering, StateBlocked,
+	}, state)
+}
+
+type OwnerClass string
+
+const (
+	OwnerProjmuxPrivate OwnerClass = "projmux-private"
+	OwnerUnmanaged      OwnerClass = "unmanaged"
+	OwnerUnknown        OwnerClass = "unknown"
+)
+
+func validOwnerClass(owner OwnerClass) bool {
+	return slices.Contains([]OwnerClass{OwnerProjmuxPrivate, OwnerUnmanaged, OwnerUnknown}, owner)
+}
+
+// Generation is the durable, path-free inventory of one pool slot.
+type Generation struct {
+	Endpoint metadata.CodexEndpointRef `json:"endpoint"`
+	State    GenerationState           `json:"state"`
+	Owner    OwnerClass                `json:"owner"`
+	BundleID string                    `json:"bundleID"`
+}
+
+type ObligationState string
+
+const (
+	ObligationActive             ObligationState = "active"
+	ObligationApprovalPending    ObligationState = "approval-pending"
+	ObligationNoTurn             ObligationState = "no-turn"
+	ObligationUnknown            ObligationState = "unknown"
+	ObligationCompletedPersisted ObligationState = "completed-persisted"
+	ObligationClosed             ObligationState = "closed"
+)
+
+func validObligationState(state ObligationState) bool {
+	return slices.Contains([]ObligationState{
+		ObligationActive, ObligationApprovalPending, ObligationNoTurn,
+		ObligationUnknown, ObligationCompletedPersisted, ObligationClosed,
+	}, state)
+}
+
+// AgentObligation is the minimum identity/state tuple an upgrade plan may
+// retain. It intentionally cannot carry prompt, message, transcript, socket,
+// or credential material.
+type AgentObligation struct {
+	AgentUID             string          `json:"agentUID"`
+	EndpointGenerationID string          `json:"endpointGenerationID"`
+	State                ObligationState `json:"state"`
+}
+
+// Pool is the complete input to the Phase 0 topology and plan model.
+type Pool struct {
+	StateDomainID string            `json:"stateDomainID"`
+	Generations   []Generation      `json:"generations"`
+	Obligations   []AgentObligation `json:"obligations,omitempty"`
+}
+
+type TopologyRefusal string
+
+const (
+	RefusalNone                        TopologyRefusal = "none"
+	RefusalStateDomainRequired         TopologyRefusal = "state-domain-required"
+	RefusalGenerationInvalid           TopologyRefusal = "generation-invalid"
+	RefusalGenerationDuplicate         TopologyRefusal = "generation-duplicate"
+	RefusalGenerationDomainMismatch    TopologyRefusal = "generation-domain-mismatch"
+	RefusalPoolCapacityExceeded        TopologyRefusal = "pool-capacity-exceeded"
+	RefusalMultipleCurrent             TopologyRefusal = "multiple-current"
+	RefusalMultipleDraining            TopologyRefusal = "multiple-draining"
+	RefusalCurrentMissingWithLiveWork  TopologyRefusal = "current-missing-with-live-obligations"
+	RefusalObligationInvalid           TopologyRefusal = "obligation-invalid"
+	RefusalObligationGenerationUnknown TopologyRefusal = "obligation-generation-unknown"
+)
+
+// TopologyError renders only one closed refusal token.
+type TopologyError struct{ Refusal TopologyRefusal }
+
+func (e *TopologyError) Error() string {
+	return "Codex generation topology refused: " + string(e.Refusal)
+}
+
+func RefusalOf(err error) TopologyRefusal {
+	var refusal *TopologyError
+	if errors.As(err, &refusal) {
+		return refusal.Refusal
+	}
+	return RefusalNone
+}
+
+// Validate enforces the v1 current-one plus draining-one topology. Preparing,
+// handover-pending, recovering, and blocked generations also occupy one of the
+// two live slots; retired receipt rows do not.
+func (p Pool) Validate() error {
+	if !validIdentityToken(p.StateDomainID) {
+		return &TopologyError{Refusal: RefusalStateDomainRequired}
+	}
+	seen := make(map[string]Generation, len(p.Generations))
+	current, draining, liveSlots := 0, 0, 0
+	for _, generation := range p.Generations {
+		id := strings.TrimSpace(generation.Endpoint.EndpointGenerationID)
+		if !generation.Endpoint.Valid() || !validGenerationState(generation.State) ||
+			!validOwnerClass(generation.Owner) || !validIdentityToken(generation.BundleID) {
+			return &TopologyError{Refusal: RefusalGenerationInvalid}
+		}
+		if generation.Endpoint.StateDomainID != p.StateDomainID {
+			return &TopologyError{Refusal: RefusalGenerationDomainMismatch}
+		}
+		if _, exists := seen[id]; exists {
+			return &TopologyError{Refusal: RefusalGenerationDuplicate}
+		}
+		seen[id] = generation
+		if generation.State != StateRetired {
+			liveSlots++
+		}
+		if generation.State == StateCurrent {
+			current++
+		}
+		if generation.State == StateDraining || generation.State == StateHandoverPending {
+			draining++
+		}
+	}
+	if current > 1 {
+		return &TopologyError{Refusal: RefusalMultipleCurrent}
+	}
+	if draining > 1 {
+		return &TopologyError{Refusal: RefusalMultipleDraining}
+	}
+	if liveSlots > 2 {
+		return &TopologyError{Refusal: RefusalPoolCapacityExceeded}
+	}
+	liveObligations := 0
+	for _, obligation := range p.Obligations {
+		if !validIdentityToken(obligation.AgentUID) ||
+			!validIdentityToken(obligation.EndpointGenerationID) ||
+			!validObligationState(obligation.State) {
+			return &TopologyError{Refusal: RefusalObligationInvalid}
+		}
+		generation, ok := seen[obligation.EndpointGenerationID]
+		if !ok || generation.State == StateRetired {
+			return &TopologyError{Refusal: RefusalObligationGenerationUnknown}
+		}
+		if obligation.State != ObligationClosed {
+			liveObligations++
+		}
+	}
+	if liveObligations != 0 && current == 0 {
+		return &TopologyError{Refusal: RefusalCurrentMissingWithLiveWork}
+	}
+	return nil
+}
+
+// Current returns the sole admission-current generation after validation.
+func (p Pool) Current() (Generation, bool) {
+	for _, generation := range p.Generations {
+		if generation.State == StateCurrent {
+			return generation, true
+		}
+	}
+	return Generation{}, false
+}
+
+// String keeps TopologyError values from gaining contextual or sensitive
+// material through fmt wrapping in tests and diagnostics.
+func (r TopologyRefusal) String() string { return string(r) }
+
+func validIdentityToken(value string) bool {
+	if value == "" || value != strings.TrimSpace(value) || len(value) > 128 {
+		return false
+	}
+	for _, char := range value {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') || char == '-' || char == '_' || char == '.' || char == ':' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/core/codexgeneration/model_test.go
+++ b/internal/core/codexgeneration/model_test.go
@@ -1,0 +1,369 @@
+package codexgeneration
+
+import (
+	"encoding/json"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/core/metadata"
+)
+
+func TestPhase0ModelImportsNoMutationAdapter(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const allowed = "github.com/crevissepartners/projmux/internal/core/metadata"
+	fileSet := token.NewFileSet()
+	inspected := 0
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fileSet, entry.Name(), nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatal(err)
+		}
+		inspected++
+		for _, imported := range file.Imports {
+			path, err := strconv.Unquote(imported.Path.Value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(strings.SplitN(path, "/", 2)[0], ".") && path != allowed {
+				t.Fatalf("%s imports mutation-capable dependency %q", entry.Name(), path)
+			}
+		}
+	}
+	if inspected != 4 {
+		t.Fatalf("inspected %d pure model files, want 4", inspected)
+	}
+}
+
+func generation(id string, state GenerationState) Generation {
+	return Generation{
+		Endpoint: metadata.CodexEndpointRef{StateDomainID: "state-domain", EndpointGenerationID: id},
+		State:    state, Owner: OwnerProjmuxPrivate, BundleID: "sha256:bundle-" + id,
+	}
+}
+
+func qualified() QualificationResult {
+	return EvaluateQualification(VersionPair{Old: "0.152.0", New: "0.152.1"}, QualificationEvidence{
+		SharedStateDomain: true, DistinctPrivateEndpoints: true,
+		DistinctThreadCreateTurn: true, DistinctThreadReadList: true, CrashRestart: true,
+		OldStoppedBeforeResume: true, PersistedResumeSnapshot: true,
+		SharedAuthConfigPrivate: true, BundleSourceRemovalLaunch: true,
+		BundleDriftRefused: true, ProtocolMismatchRefused: true,
+	})
+}
+
+func TestBoundedPoolRejectsEveryInvalidV1Topology(t *testing.T) {
+	tests := []struct {
+		name string
+		pool Pool
+		want TopologyRefusal
+	}{
+		{name: "two current", pool: Pool{StateDomainID: "state-domain", Generations: []Generation{generation("g1", StateCurrent), generation("g2", StateCurrent)}}, want: RefusalMultipleCurrent},
+		{name: "two draining", pool: Pool{StateDomainID: "state-domain", Generations: []Generation{generation("g1", StateDraining), generation("g2", StateHandoverPending)}}, want: RefusalMultipleDraining},
+		{name: "no current with live obligation", pool: Pool{StateDomainID: "state-domain", Generations: []Generation{generation("g1", StateDraining)}, Obligations: []AgentObligation{{AgentUID: "agent-1", EndpointGenerationID: "g1", State: ObligationCompletedPersisted}}}, want: RefusalCurrentMissingWithLiveWork},
+		{name: "three live slots", pool: Pool{StateDomainID: "state-domain", Generations: []Generation{generation("g1", StateCurrent), generation("g2", StatePreparing), generation("g3", StateRecovering)}}, want: RefusalPoolCapacityExceeded},
+		{name: "duplicate generation", pool: Pool{StateDomainID: "state-domain", Generations: []Generation{generation("g1", StateCurrent), generation("g1", StateDraining)}}, want: RefusalGenerationDuplicate},
+		{name: "different domain", pool: Pool{StateDomainID: "state-domain", Generations: []Generation{{Endpoint: metadata.CodexEndpointRef{StateDomainID: "other", EndpointGenerationID: "g1"}, State: StateCurrent, Owner: OwnerProjmuxPrivate, BundleID: "bundle"}}}, want: RefusalGenerationDomainMismatch},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := RefusalOf(test.pool.Validate()); got != test.want {
+				t.Fatalf("refusal=%s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestBoundedPoolStateSpaceProperty(t *testing.T) {
+	states := []GenerationState{StatePreparing, StateCurrent, StateDraining, StateHandoverPending, StateRetired, StateRecovering, StateBlocked}
+	for _, a := range states {
+		for _, b := range states {
+			for _, c := range states {
+				pool := Pool{StateDomainID: "state-domain", Generations: []Generation{
+					generation("g1", a), generation("g2", b), generation("g3", c),
+				}}
+				err := pool.Validate()
+				live, current, draining := 0, 0, 0
+				for _, state := range []GenerationState{a, b, c} {
+					if state != StateRetired {
+						live++
+					}
+					if state == StateCurrent {
+						current++
+					}
+					if state == StateDraining || state == StateHandoverPending {
+						draining++
+					}
+				}
+				valid := live <= 2 && current <= 1 && draining <= 1
+				if (err == nil) != valid {
+					t.Fatalf("states=(%s,%s,%s) err=%v valid=%t", a, b, c, err, valid)
+				}
+			}
+		}
+	}
+}
+
+func FuzzBoundedPoolNeverAcceptsMoreThanTwoLiveSlots(f *testing.F) {
+	f.Add(uint8(0), uint8(1), uint8(4))
+	f.Add(uint8(1), uint8(1), uint8(1))
+	states := []GenerationState{StatePreparing, StateCurrent, StateDraining, StateHandoverPending, StateRetired, StateRecovering, StateBlocked}
+	f.Fuzz(func(t *testing.T, x, y, z uint8) {
+		selected := []GenerationState{states[int(x)%len(states)], states[int(y)%len(states)], states[int(z)%len(states)]}
+		pool := Pool{StateDomainID: "state-domain"}
+		for i, state := range selected {
+			pool.Generations = append(pool.Generations, generation(string(rune('a'+i)), state))
+		}
+		if pool.Validate() == nil {
+			live := 0
+			for _, state := range selected {
+				if state != StateRetired {
+					live++
+				}
+			}
+			if live > 2 {
+				t.Fatalf("accepted %d live slots", live)
+			}
+		}
+	})
+}
+
+func TestIdentityAndVersionTokensRejectNonCanonicalWhitespace(t *testing.T) {
+	for _, token := range []string{" generation", "generation ", "generation\n"} {
+		if validIdentityToken(token) {
+			t.Fatalf("identity token %q validated", token)
+		}
+	}
+	for _, version := range []string{" 0.152.0", "0.152.0 ", "0.152.0\n"} {
+		if validVersionToken(version) {
+			t.Fatalf("version token %q validated", version)
+		}
+		result := qualified()
+		result.Versions.Old = version
+		if _, err := result.JSON(); err == nil {
+			t.Fatalf("qualification receipt normalized version %q", version)
+		}
+	}
+}
+
+func TestCompositeAuthorityRejectsSameNumberCrossGenerationAndLegacyWithZeroWrites(t *testing.T) {
+	durable := &metadata.CodexEndpointRef{StateDomainID: "domain", EndpointGenerationID: "old"}
+	stored := &metadata.CodexAuthorityRef{StateDomainID: "domain", EndpointGenerationID: "old", BrokerRuntimeID: "runtime-old", ConnectionEpoch: 1, BindingEpoch: 1}
+	tests := []struct {
+		name       string
+		ref        *metadata.CodexAuthorityRef
+		endpoint   *metadata.CodexEndpointRef
+		want       AuthorityDecision
+		wantWrites int
+	}{
+		{name: "exact", ref: stored, endpoint: durable, want: AuthorityAllowed, wantWrites: 1},
+		{name: "same epochs other generation", ref: &metadata.CodexAuthorityRef{StateDomainID: "domain", EndpointGenerationID: "new", BrokerRuntimeID: "runtime-new", ConnectionEpoch: 1, BindingEpoch: 1}, endpoint: durable, want: AuthorityEndpointMismatch},
+		{name: "same generation restarted broker", ref: &metadata.CodexAuthorityRef{StateDomainID: "domain", EndpointGenerationID: "old", BrokerRuntimeID: "runtime-new", ConnectionEpoch: 1, BindingEpoch: 1}, endpoint: durable, want: AuthorityBrokerRuntimeMismatch},
+		{name: "legacy activation", ref: nil, endpoint: durable, want: AuthorityLegacyUnavailable},
+		{name: "legacy durable ref", ref: stored, endpoint: nil, want: AuthorityLegacyUnavailable},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			writes := struct{ Provider, Registry, Tmux int }{}
+			got := ApplyAuthorized(test.endpoint, stored, test.ref, func() {
+				writes.Provider++
+				writes.Registry++
+				writes.Tmux++
+			})
+			if got != test.want || writes.Provider != test.wantWrites || writes.Registry != test.wantWrites || writes.Tmux != test.wantWrites {
+				t.Fatalf("decision=%s writes=%+v, want %s/%d for each mutation surface", got, writes, test.want, test.wantWrites)
+			}
+		})
+	}
+}
+
+func TestOldStopBarrierKeepsSuccessorResumeAtZeroUntilSafe(t *testing.T) {
+	old := metadata.CodexEndpointRef{StateDomainID: "domain", EndpointGenerationID: "old"}
+	newEndpoint := metadata.CodexEndpointRef{StateDomainID: "domain", EndpointGenerationID: "new"}
+	writes := 0
+	if got := ApplySuccessorResume(old, newEndpoint, false, true, func() { writes++ }); got != ResumeOwnerStillLive || writes != 0 {
+		t.Fatalf("live-old decision=%s writes=%d", got, writes)
+	}
+	if got := ApplySuccessorResume(old, newEndpoint, true, true, func() { writes++ }); got != ResumeAllowed || writes != 1 {
+		t.Fatalf("stopped-old decision=%s writes=%d", got, writes)
+	}
+}
+
+func TestReadOnlyUpgradePlanIsRepeatableContentFreeAndNamesExactBlockers(t *testing.T) {
+	pool := Pool{StateDomainID: "state-domain", Generations: []Generation{
+		generation("old", StateDraining),
+		{Endpoint: metadata.CodexEndpointRef{StateDomainID: "state-domain", EndpointGenerationID: "current"}, State: StateCurrent, Owner: OwnerUnmanaged, BundleID: "sha256:current"},
+	}, Obligations: []AgentObligation{{AgentUID: "agent-exact", EndpointGenerationID: "old", State: ObligationNoTurn}}}
+	q := qualified()
+	first := PlanUpgrade(pool, "target", &q)
+	second := PlanUpgrade(pool, "target", &q)
+	if got := pool.Generations[0].State; got != StateDraining {
+		t.Fatalf("plan mutated its input generation to %s", got)
+	}
+	if !reflect.DeepEqual(first, second) || first.Decision != PlanBlocked || first.Mutations != (MutationCount{}) {
+		t.Fatalf("repeated plan drift/mutation: first=%+v second=%+v", first, second)
+	}
+	encoded, err := first.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := first.Text()
+	wantJSON := `{
+  "modelVersion": 1,
+  "stateDomainID": "state-domain",
+  "currentGeneration": "current",
+  "targetGeneration": "target",
+  "decision": "blocked",
+  "blockers": [
+    {
+      "code": "agent-obligation",
+      "agentUID": "agent-exact",
+      "endpointGenerationID": "old",
+      "reason": "no-turn"
+    },
+    {
+      "code": "pool-full",
+      "endpointGenerationID": "old",
+      "reason": "bounded current-plus-draining pool has no free slot"
+    },
+    {
+      "code": "unmanaged-lifecycle",
+      "endpointGenerationID": "current",
+      "reason": "exact-current unmanaged endpoint is attach-only; operator-owned stop is required"
+    }
+  ],
+  "mutations": {
+    "registry": 0,
+    "provider": 0,
+    "tmux": 0,
+    "process": 0,
+    "currentPointer": 0
+  }
+}`
+	wantText := `codex app-server upgrade plan: blocked
+state-domain: state-domain
+current-generation: current
+target-generation: target
+blocker: code=agent-obligation agent=agent-exact generation=old reason=no-turn
+blocker: code=pool-full agent=none generation=old reason=bounded current-plus-draining pool has no free slot
+blocker: code=unmanaged-lifecycle agent=none generation=current reason=exact-current unmanaged endpoint is attach-only; operator-owned stop is required
+mutations: registry=0 provider=0 tmux=0 process=0 current-pointer=0`
+	if string(encoded) != wantJSON {
+		t.Fatalf("plan JSON golden drift:\n--- got ---\n%s\n--- want ---\n%s", encoded, wantJSON)
+	}
+	if text != wantText {
+		t.Fatalf("plan text golden drift:\n--- got ---\n%s\n--- want ---\n%s", text, wantText)
+	}
+	for _, exact := range []string{"agent-exact", "old", "current"} {
+		if strings.Count(string(encoded), exact) == 0 || strings.Count(text, exact) == 0 {
+			t.Fatalf("plan output misses exact blocker identity %q", exact)
+		}
+	}
+	for _, secret := range []string{"prompt body", "secret-token", "/tmp/private.sock"} {
+		if strings.Contains(string(encoded)+text, secret) {
+			t.Fatalf("plan leaked %q", secret)
+		}
+	}
+}
+
+func TestReadOnlyUpgradePlanNeverRendersInvalidIdentitiesOrQualificationFields(t *testing.T) {
+	q := qualified()
+	hostile := "provider-content/private/path\nsecret"
+	pool := Pool{StateDomainID: hostile, Generations: []Generation{{
+		Endpoint: metadata.CodexEndpointRef{StateDomainID: hostile, EndpointGenerationID: hostile},
+		State:    StateCurrent, Owner: OwnerUnmanaged, BundleID: hostile,
+	}}, Obligations: []AgentObligation{{AgentUID: hostile, EndpointGenerationID: hostile, State: ObligationNoTurn}}}
+	plan := PlanUpgrade(pool, hostile, &q)
+	raw, err := plan.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.StateDomainID != "" || plan.CurrentGeneration != "" || plan.TargetGeneration != "" ||
+		strings.Contains(string(raw), hostile) || strings.Contains(plan.Text(), hostile) {
+		t.Fatalf("invalid identity reached plan output: json=%s text=%s", raw, plan.Text())
+	}
+
+	validPool := Pool{StateDomainID: "state-domain", Generations: []Generation{generation("current", StateCurrent)}}
+	q.Reason = QualificationReason(hostile)
+	plan = PlanUpgrade(validPool, "target", &q)
+	raw, err = plan.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), hostile) || strings.Contains(plan.Text(), hostile) ||
+		len(plan.Blockers) != 1 || plan.Blockers[0].Reason != "qualification-invalid" {
+		t.Fatalf("invalid qualification reached plan output: json=%s text=%s", raw, plan.Text())
+	}
+}
+
+func TestQualificationDecisionTableClosesPhase2OnEitherSharedStateFailure(t *testing.T) {
+	base := qualified()
+	if gate := GateQualification(base); !gate.Phase2Ready || gate.Lane != FollowupGenerationPool {
+		t.Fatalf("qualified gate=%+v", gate)
+	}
+	tests := []struct {
+		name   string
+		mutate func(*QualificationEvidence)
+		reason QualificationReason
+	}{
+		{name: "distinct threads no", mutate: func(e *QualificationEvidence) { e.DistinctThreadCreateTurn = false }, reason: ReasonDistinctThreadFailed},
+		{name: "same thread no", mutate: func(e *QualificationEvidence) { e.PersistedResumeSnapshot = false }, reason: ReasonSameThreadOwnershipFailed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			evidence := base.Evidence
+			test.mutate(&evidence)
+			result := EvaluateQualification(base.Versions, evidence)
+			gate := GateQualification(result)
+			if result.Verdict != VerdictNo || result.Reason != test.reason || gate.Phase2Ready || gate.Lane != FollowupSingleEndpointJournaledHandover || gate.Blocker == "" {
+				t.Fatalf("result=%+v gate=%+v", result, gate)
+			}
+			raw, err := result.JSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			decoded, err := DecodeQualificationResult(raw)
+			if err != nil || !reflect.DeepEqual(decoded, result) {
+				t.Fatalf("receipt round trip=%+v err=%v", decoded, err)
+			}
+		})
+	}
+}
+
+func TestQualificationReceiptRetainsOnlyContentFreeAllowlistedFields(t *testing.T) {
+	resultType := reflect.TypeFor[QualificationResult]()
+	var fields []string
+	for i := range resultType.NumField() {
+		fields = append(fields, resultType.Field(i).Name)
+	}
+	if want := RetainedQualificationFields(); !reflect.DeepEqual(fields, want) {
+		t.Fatalf("QualificationResult fields=%v want=%v", fields, want)
+	}
+	evidenceType := reflect.TypeFor[QualificationEvidence]()
+	for i := range evidenceType.NumField() {
+		name := strings.ToLower(evidenceType.Field(i).Name)
+		for _, forbidden := range []string{"prompt", "message", "content", "secret", "token", "path", "socket", "transcript", "output"} {
+			if strings.Contains(name, forbidden) {
+				t.Fatalf("QualificationEvidence.%s can retain content", evidenceType.Field(i).Name)
+			}
+		}
+	}
+	raw, err := json.Marshal(qualified())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "private") {
+		t.Fatalf("receipt unexpectedly retained a secret-like value: %s", raw)
+	}
+}

--- a/internal/core/codexgeneration/plan.go
+++ b/internal/core/codexgeneration/plan.go
@@ -1,0 +1,139 @@
+package codexgeneration
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+type PlanDecision string
+
+const (
+	PlanReady   PlanDecision = "ready"
+	PlanBlocked PlanDecision = "blocked"
+)
+
+type BlockerCode string
+
+const (
+	BlockerInvalidTopology      BlockerCode = "invalid-topology"
+	BlockerQualificationMissing BlockerCode = "qualification-missing"
+	BlockerQualificationFailed  BlockerCode = "qualification-failed"
+	BlockerPoolFull             BlockerCode = "pool-full"
+	BlockerAgentObligation      BlockerCode = "agent-obligation"
+	BlockerUnmanagedLifecycle   BlockerCode = "unmanaged-lifecycle"
+	BlockerUnknownLifecycle     BlockerCode = "unknown-lifecycle"
+)
+
+type Blocker struct {
+	Code                 BlockerCode `json:"code"`
+	AgentUID             string      `json:"agentUID,omitempty"`
+	EndpointGenerationID string      `json:"endpointGenerationID,omitempty"`
+	Reason               string      `json:"reason"`
+}
+
+// MutationCount is present in every plan so repeated/read-only behavior is
+// machine-verifiable rather than an implementation comment.
+type MutationCount struct {
+	Registry       int `json:"registry"`
+	Provider       int `json:"provider"`
+	Tmux           int `json:"tmux"`
+	Process        int `json:"process"`
+	CurrentPointer int `json:"currentPointer"`
+}
+
+type UpgradePlan struct {
+	ModelVersion      int           `json:"modelVersion"`
+	StateDomainID     string        `json:"stateDomainID"`
+	CurrentGeneration string        `json:"currentGeneration,omitempty"`
+	TargetGeneration  string        `json:"targetGeneration"`
+	Decision          PlanDecision  `json:"decision"`
+	Blockers          []Blocker     `json:"blockers,omitempty"`
+	Mutations         MutationCount `json:"mutations"`
+}
+
+// PlanUpgrade is a pure reduction over values. It neither accepts nor returns
+// a callback or adapter, making process/provider/Registry/tmux mutation
+// unreachable from the Phase 0 product path.
+func PlanUpgrade(pool Pool, targetGenerationID string, qualification *QualificationResult) UpgradePlan {
+	plan := UpgradePlan{ModelVersion: ModelVersion, Decision: PlanReady}
+	poolValid := true
+	if err := pool.Validate(); err != nil {
+		poolValid = false
+		plan.Blockers = append(plan.Blockers, Blocker{Code: BlockerInvalidTopology, Reason: RefusalOf(err).String()})
+	}
+	if !validIdentityToken(targetGenerationID) {
+		plan.Blockers = append(plan.Blockers, Blocker{Code: BlockerInvalidTopology, Reason: "target-generation-required"})
+	} else {
+		plan.TargetGeneration = targetGenerationID
+	}
+	if qualification == nil {
+		plan.Blockers = append(plan.Blockers, Blocker{Code: BlockerQualificationMissing, Reason: "fixed-version-pair qualification is required"})
+	} else if err := qualification.Validate(); err != nil {
+		plan.Blockers = append(plan.Blockers, Blocker{Code: BlockerQualificationFailed, Reason: "qualification-invalid"})
+	} else if gate := GateQualification(*qualification); !gate.Phase2Ready {
+		plan.Blockers = append(plan.Blockers, Blocker{Code: BlockerQualificationFailed, Reason: string(qualification.Reason)})
+	}
+	if poolValid {
+		plan.StateDomainID = pool.StateDomainID
+		if current, ok := pool.Current(); ok {
+			plan.CurrentGeneration = current.Endpoint.EndpointGenerationID
+			switch current.Owner {
+			case OwnerUnmanaged:
+				plan.Blockers = append(plan.Blockers, Blocker{Code: BlockerUnmanagedLifecycle,
+					EndpointGenerationID: current.Endpoint.EndpointGenerationID,
+					Reason:               "exact-current unmanaged endpoint is attach-only; operator-owned stop is required"})
+			case OwnerUnknown:
+				plan.Blockers = append(plan.Blockers, Blocker{Code: BlockerUnknownLifecycle,
+					EndpointGenerationID: current.Endpoint.EndpointGenerationID,
+					Reason:               "endpoint lifecycle owner is unknown"})
+			}
+		}
+		for _, generation := range pool.Generations {
+			if generation.State != StateRetired && generation.State != StateCurrent {
+				plan.Blockers = append(plan.Blockers, Blocker{Code: BlockerPoolFull,
+					EndpointGenerationID: generation.Endpoint.EndpointGenerationID,
+					Reason:               "bounded current-plus-draining pool has no free slot"})
+			}
+		}
+		for _, obligation := range pool.Obligations {
+			if obligation.State == ObligationClosed {
+				continue
+			}
+			plan.Blockers = append(plan.Blockers, Blocker{Code: BlockerAgentObligation,
+				AgentUID: obligation.AgentUID, EndpointGenerationID: obligation.EndpointGenerationID,
+				Reason: string(obligation.State)})
+		}
+	}
+	slices.SortFunc(plan.Blockers, func(a, b Blocker) int {
+		return strings.Compare(string(a.Code)+"\x00"+a.EndpointGenerationID+"\x00"+a.AgentUID+"\x00"+a.Reason,
+			string(b.Code)+"\x00"+b.EndpointGenerationID+"\x00"+b.AgentUID+"\x00"+b.Reason)
+	})
+	if len(plan.Blockers) != 0 {
+		plan.Decision = PlanBlocked
+	}
+	return plan
+}
+
+func (p UpgradePlan) JSON() ([]byte, error) { return json.MarshalIndent(p, "", "  ") }
+
+func (p UpgradePlan) Text() string {
+	var out strings.Builder
+	fmt.Fprintf(&out, "codex app-server upgrade plan: %s\nstate-domain: %s\ncurrent-generation: %s\ntarget-generation: %s",
+		p.Decision, valueOrNone(p.StateDomainID), valueOrNone(p.CurrentGeneration), valueOrNone(p.TargetGeneration))
+	for _, blocker := range p.Blockers {
+		fmt.Fprintf(&out, "\nblocker: code=%s agent=%s generation=%s reason=%s", blocker.Code,
+			valueOrNone(blocker.AgentUID), valueOrNone(blocker.EndpointGenerationID), blocker.Reason)
+	}
+	fmt.Fprintf(&out, "\nmutations: registry=%d provider=%d tmux=%d process=%d current-pointer=%d",
+		p.Mutations.Registry, p.Mutations.Provider, p.Mutations.Tmux, p.Mutations.Process, p.Mutations.CurrentPointer)
+	return out.String()
+}
+
+func valueOrNone(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "none"
+	}
+	return value
+}

--- a/internal/core/codexgeneration/qualification.go
+++ b/internal/core/codexgeneration/qualification.go
@@ -1,0 +1,165 @@
+package codexgeneration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+)
+
+type QualificationVerdict string
+
+const (
+	VerdictYes QualificationVerdict = "yes"
+	VerdictNo  QualificationVerdict = "no"
+)
+
+type QualificationReason string
+
+const (
+	ReasonQualified                 QualificationReason = "qualified"
+	ReasonDistinctThreadFailed      QualificationReason = "distinct-thread-concurrency-failed"
+	ReasonSameThreadOwnershipFailed QualificationReason = "same-thread-single-owner-failed"
+	ReasonBundleLeaseFailed         QualificationReason = "bundle-lease-failed"
+	ReasonAuthConfigIsolationFailed QualificationReason = "auth-config-isolation-failed"
+	ReasonProtocolMismatch          QualificationReason = "protocol-mismatch"
+	ReasonEvidenceIncomplete        QualificationReason = "evidence-incomplete"
+)
+
+type VersionPair struct {
+	Old string `json:"old"`
+	New string `json:"new"`
+}
+
+// QualificationEvidence is intentionally boolean/counter-only. It is safe to
+// persist because it cannot represent a prompt, response, credential, socket,
+// filesystem path, or provider payload.
+type QualificationEvidence struct {
+	SharedStateDomain         bool `json:"sharedStateDomain"`
+	DistinctPrivateEndpoints  bool `json:"distinctPrivateEndpoints"`
+	DistinctThreadCreateTurn  bool `json:"distinctThreadCreateTurn"`
+	DistinctThreadReadList    bool `json:"distinctThreadReadList"`
+	CrashRestart              bool `json:"crashRestart"`
+	CrossThreadWrites         int  `json:"crossThreadWrites"`
+	StoreCorruptions          int  `json:"storeCorruptions"`
+	LiveOwnerResumeWrites     int  `json:"liveOwnerResumeWrites"`
+	OldStoppedBeforeResume    bool `json:"oldStoppedBeforeResume"`
+	PersistedResumeSnapshot   bool `json:"persistedResumeSnapshot"`
+	SharedAuthConfigPrivate   bool `json:"sharedAuthConfigPrivate"`
+	BundleSourceRemovalLaunch bool `json:"bundleSourceRemovalLaunch"`
+	BundleDriftRefused        bool `json:"bundleDriftRefused"`
+	ProtocolMismatchRefused   bool `json:"protocolMismatchRefused"`
+	AmbientMutations          int  `json:"ambientMutations"`
+}
+
+type QualificationResult struct {
+	SchemaVersion int                   `json:"schemaVersion"`
+	Versions      VersionPair           `json:"versions"`
+	Verdict       QualificationVerdict  `json:"verdict"`
+	Reason        QualificationReason   `json:"reason"`
+	Evidence      QualificationEvidence `json:"evidence"`
+}
+
+func EvaluateQualification(versions VersionPair, evidence QualificationEvidence) QualificationResult {
+	result := QualificationResult{SchemaVersion: QualificationSchemaVersion, Versions: versions, Evidence: evidence}
+	switch {
+	case !evidence.SharedStateDomain || !evidence.DistinctPrivateEndpoints ||
+		!evidence.DistinctThreadCreateTurn || !evidence.DistinctThreadReadList || !evidence.CrashRestart ||
+		evidence.CrossThreadWrites != 0 || evidence.StoreCorruptions != 0 || evidence.AmbientMutations != 0:
+		result.Verdict, result.Reason = VerdictNo, ReasonDistinctThreadFailed
+	case evidence.LiveOwnerResumeWrites != 0 || !evidence.OldStoppedBeforeResume || !evidence.PersistedResumeSnapshot:
+		result.Verdict, result.Reason = VerdictNo, ReasonSameThreadOwnershipFailed
+	case !evidence.SharedAuthConfigPrivate:
+		result.Verdict, result.Reason = VerdictNo, ReasonAuthConfigIsolationFailed
+	case !evidence.BundleSourceRemovalLaunch || !evidence.BundleDriftRefused:
+		result.Verdict, result.Reason = VerdictNo, ReasonBundleLeaseFailed
+	case !evidence.ProtocolMismatchRefused:
+		result.Verdict, result.Reason = VerdictNo, ReasonProtocolMismatch
+	default:
+		result.Verdict, result.Reason = VerdictYes, ReasonQualified
+	}
+	return result
+}
+
+func (r QualificationResult) Validate() error {
+	if r.SchemaVersion != QualificationSchemaVersion || !validVersionToken(r.Versions.Old) || !validVersionToken(r.Versions.New) {
+		return fmt.Errorf("Codex generation qualification receipt is incomplete")
+	}
+	want := EvaluateQualification(r.Versions, r.Evidence)
+	if r.Verdict != want.Verdict || r.Reason != want.Reason {
+		return fmt.Errorf("Codex generation qualification verdict is inconsistent")
+	}
+	return nil
+}
+
+func validVersionToken(value string) bool {
+	if value == "" || value != strings.TrimSpace(value) || len(value) > 64 {
+		return false
+	}
+	for _, char := range value {
+		if (char >= '0' && char <= '9') || char == '.' || char == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func (r QualificationResult) JSON() ([]byte, error) {
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(r, "", "  ")
+}
+
+func DecodeQualificationResult(encoded []byte) (QualificationResult, error) {
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.DisallowUnknownFields()
+	var result QualificationResult
+	if err := decoder.Decode(&result); err != nil {
+		return QualificationResult{}, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err == nil {
+		return QualificationResult{}, fmt.Errorf("Codex generation qualification receipt contains trailing JSON")
+	} else if err != io.EOF {
+		return QualificationResult{}, err
+	}
+	if err := result.Validate(); err != nil {
+		return QualificationResult{}, err
+	}
+	return result, nil
+}
+
+type FollowupLane string
+
+const (
+	FollowupGenerationPool                  FollowupLane = "generation-pool"
+	FollowupSingleEndpointJournaledHandover FollowupLane = "single-endpoint-journaled-handover"
+)
+
+// QualificationGate is the only Phase 0 gate to later pool work. Any NO,
+// especially either shared-state acceptance row, closes Phase 2+.
+type QualificationGate struct {
+	Phase2Ready bool         `json:"phase2Ready"`
+	Lane        FollowupLane `json:"lane"`
+	Blocker     string       `json:"blocker,omitempty"`
+}
+
+func GateQualification(result QualificationResult) QualificationGate {
+	if result.Validate() == nil && result.Verdict == VerdictYes {
+		return QualificationGate{Phase2Ready: true, Lane: FollowupGenerationPool}
+	}
+	return QualificationGate{
+		Lane:    FollowupSingleEndpointJournaledHandover,
+		Blocker: "shared-state qualification is not fully yes; keep the unsafe pool and Phase 2+ closed",
+	}
+}
+
+// retainedQualificationFields is kept next to the model as a reviewable
+// allowlist for privacy tests.
+var retainedQualificationFields = []string{"SchemaVersion", "Versions", "Verdict", "Reason", "Evidence"}
+
+func RetainedQualificationFields() []string { return slices.Clone(retainedQualificationFields) }

--- a/internal/core/codexgeneration/qualification.go
+++ b/internal/core/codexgeneration/qualification.go
@@ -85,11 +85,11 @@ func EvaluateQualification(versions VersionPair, evidence QualificationEvidence)
 
 func (r QualificationResult) Validate() error {
 	if r.SchemaVersion != QualificationSchemaVersion || !validVersionToken(r.Versions.Old) || !validVersionToken(r.Versions.New) {
-		return fmt.Errorf("Codex generation qualification receipt is incomplete")
+		return fmt.Errorf("codex generation qualification receipt is incomplete")
 	}
 	want := EvaluateQualification(r.Versions, r.Evidence)
 	if r.Verdict != want.Verdict || r.Reason != want.Reason {
-		return fmt.Errorf("Codex generation qualification verdict is inconsistent")
+		return fmt.Errorf("codex generation qualification verdict is inconsistent")
 	}
 	return nil
 }
@@ -123,7 +123,7 @@ func DecodeQualificationResult(encoded []byte) (QualificationResult, error) {
 	}
 	var trailing any
 	if err := decoder.Decode(&trailing); err == nil {
-		return QualificationResult{}, fmt.Errorf("Codex generation qualification receipt contains trailing JSON")
+		return QualificationResult{}, fmt.Errorf("codex generation qualification receipt contains trailing JSON")
 	} else if err != io.EOF {
 		return QualificationResult{}, err
 	}

--- a/internal/core/metadata/agentsession.go
+++ b/internal/core/metadata/agentsession.go
@@ -63,8 +63,48 @@ type ClaudeSessionRef struct {
 // not point at the conversation. Storing it would give the Agent a durable
 // field that is stale the moment it is written.
 type CodexSessionRef struct {
-	ThreadID  string `json:"threadId,omitempty"`
-	SessionID string `json:"sessionId,omitempty"`
+	ThreadID  string            `json:"threadId,omitempty"`
+	SessionID string            `json:"sessionId,omitempty"`
+	Endpoint  *CodexEndpointRef `json:"endpoint,omitempty"`
+}
+
+// CodexEndpointRef is the durable endpoint identity of one Codex thread.
+//
+// It is deliberately independent of PaneActivation.Generation. A Pane
+// generation identifies one materialized child process, while this reference
+// survives that process and pins the provider thread to the state domain and
+// app-server generation that currently owns it. Both fields are opaque,
+// content-free identifiers; neither is a path, socket, version, or credential.
+// A nil pointer is the only legacy spelling and is never inferred as current.
+type CodexEndpointRef struct {
+	StateDomainID        string `json:"stateDomainID"`
+	EndpointGenerationID string `json:"endpointGenerationID"`
+}
+
+// Valid reports whether both dimensions of an endpoint identity are present.
+func (r CodexEndpointRef) Valid() bool {
+	return validCodexIdentityToken(r.StateDomainID) && validCodexIdentityToken(r.EndpointGenerationID)
+}
+
+// Same reports exact endpoint identity. Empty or partial references never
+// compare equal as authority.
+func (r CodexEndpointRef) Same(other CodexEndpointRef) bool {
+	return r.Valid() && other.Valid() &&
+		r.StateDomainID == other.StateDomainID && r.EndpointGenerationID == other.EndpointGenerationID
+}
+
+func validCodexIdentityToken(value string) bool {
+	if value == "" || value != strings.TrimSpace(value) || len(value) > 128 {
+		return false
+	}
+	for _, char := range value {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') || char == '-' || char == '_' || char == '.' || char == ':' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // AntigravitySessionRef is Antigravity's conversation identity as its hook
@@ -84,6 +124,7 @@ type AgentSessionObservation struct {
 	SessionID      string
 	ThreadID       string
 	TranscriptPath string
+	Endpoint       *CodexEndpointRef
 }
 
 // NewAgentSessionRef folds one hook observation onto the provider member that
@@ -112,6 +153,13 @@ func NewAgentSessionRef(obs AgentSessionObservation, observedAt time.Time) (*Age
 			return nil, false
 		}
 		ref.Codex = &CodexSessionRef{ThreadID: threadID, SessionID: sessionID}
+		if obs.Endpoint != nil {
+			endpoint := *obs.Endpoint
+			if !endpoint.Valid() {
+				return nil, false
+			}
+			ref.Codex.Endpoint = &endpoint
+		}
 	case aiprovider.Antigravity:
 		conversationID := threadID
 		if conversationID == "" {
@@ -140,6 +188,10 @@ func (r *AgentSessionRef) Clone() *AgentSessionRef {
 	}
 	if r.Codex != nil {
 		codex := *r.Codex
+		if r.Codex.Endpoint != nil {
+			endpoint := *r.Codex.Endpoint
+			codex.Endpoint = &endpoint
+		}
 		out.Codex = &codex
 	}
 	if r.Antigravity != nil {
@@ -169,12 +221,25 @@ func (r *AgentSessionRef) SameConversation(other *AgentSessionRef) bool {
 	case r.Claude != nil || other.Claude != nil:
 		return r.Claude != nil && other.Claude != nil && *r.Claude == *other.Claude
 	case r.Codex != nil || other.Codex != nil:
-		return r.Codex != nil && other.Codex != nil && *r.Codex == *other.Codex
+		return sameCodexSessionRef(r.Codex, other.Codex)
 	case r.Antigravity != nil || other.Antigravity != nil:
 		return r.Antigravity != nil && other.Antigravity != nil && *r.Antigravity == *other.Antigravity
 	default:
 		return true
 	}
+}
+
+func sameCodexSessionRef(a, b *CodexSessionRef) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	if a.ThreadID != b.ThreadID || a.SessionID != b.SessionID {
+		return false
+	}
+	if a.Endpoint == nil || b.Endpoint == nil {
+		return a.Endpoint == nil && b.Endpoint == nil
+	}
+	return *a.Endpoint == *b.Endpoint
 }
 
 // ConversationID returns the identifier that names the conversation for the
@@ -227,6 +292,10 @@ func (r *AgentSessionRef) Fields() [][2]string {
 	case r.Codex != nil:
 		add("ThreadID", r.Codex.ThreadID)
 		add("SessionID", r.Codex.SessionID)
+		if r.Codex.Endpoint != nil {
+			add("StateDomainID", r.Codex.Endpoint.StateDomainID)
+			add("EndpointGenerationID", r.Codex.Endpoint.EndpointGenerationID)
+		}
 	case r.Antigravity != nil:
 		add("ConversationID", r.Antigravity.ConversationID)
 		add("TranscriptPath", r.Antigravity.TranscriptPath)
@@ -269,12 +338,35 @@ func (m Mutator) RecordAgentSessionRef(reg *Registry, agentUID string, obs Agent
 		return Agent{}, false, inputErr(op, ErrInvalidRegistry, "agent %s is a %s Agent; refusing to record a %s conversation",
 			agent.Metadata.Name, agent.Spec.Provider, ref.Provider)
 	}
+	// Provider hooks in the legacy/default lane know the thread but not the
+	// generation endpoint. A re-observation of the same exact conversation
+	// must not erase a ref written by a generation-aware producer, and it must
+	// not guess a ref when there is none.
+	if ref.Codex != nil && ref.Codex.Endpoint == nil && agent.Status.SessionRef != nil &&
+		sameCodexThreadObservation(agent.Status.SessionRef.Codex, ref.Codex) &&
+		agent.Status.SessionRef.Codex.Endpoint != nil {
+		previous := agent.Status.SessionRef.Codex
+		endpoint := *previous.Endpoint
+		ref.Codex.Endpoint = &endpoint
+		// SessionID is optional hook metadata. Its omission must not turn an
+		// otherwise exact thread re-observation into a destructive rewrite.
+		if ref.Codex.SessionID == "" {
+			ref.Codex.SessionID = previous.SessionID
+		}
+	}
 	if agent.Status.SessionRef.SameConversation(ref) {
 		return agent.Clone(), false, nil
 	}
 	agent.Status.SessionRef = ref
 	reg.UpdatedAt = m.clock()().UTC()
 	return agent.Clone(), true, nil
+}
+
+func sameCodexThreadObservation(previous, observed *CodexSessionRef) bool {
+	if previous == nil || observed == nil || previous.ThreadID == "" || previous.ThreadID != observed.ThreadID {
+		return false
+	}
+	return previous.SessionID == "" || observed.SessionID == "" || previous.SessionID == observed.SessionID
 }
 
 // validateSessionRef checks the union invariants of one Agent session ref.
@@ -317,6 +409,9 @@ func validateSessionRef(op string, agent Agent) error {
 	}
 	if ref.ConversationID() == "" {
 		return stateErr(op, ErrInvalidRegistry, "agent %q sessionRef carries no conversation id", agent.Metadata.Name)
+	}
+	if ref.Codex != nil && ref.Codex.Endpoint != nil && !ref.Codex.Endpoint.Valid() {
+		return stateErr(op, ErrInvalidRegistry, "agent %q Codex sessionRef has an incomplete endpoint identity", agent.Metadata.Name)
 	}
 	// spec.provider is only cross-checked when the Agent actually declares one.
 	// An Agent created from an unrecognized provider spelling normalizes to "",

--- a/internal/core/metadata/codexgeneration_test.go
+++ b/internal/core/metadata/codexgeneration_test.go
@@ -1,0 +1,146 @@
+package metadata
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCodexEndpointAndAuthorityRefsRoundTripExactlyAndIgnorePaneGeneration(t *testing.T) {
+	reg := lifecycleFixture(t)
+	agent, _ := reg.Agent(lifecycleAgentUID)
+	pane, _ := reg.Pane(lifecyclePaneUID)
+	endpoint := &CodexEndpointRef{StateDomainID: "state-domain-a", EndpointGenerationID: "endpoint-generation-7"}
+	agent.Status.SessionRef = &AgentSessionRef{
+		Provider: "codex", ObservedAt: lifecycleClock,
+		Codex: &CodexSessionRef{ThreadID: "thread-exact", Endpoint: endpoint},
+	}
+	pane.Status.Activation.Generation = "pane-materialization-unrelated"
+	pane.Status.Activation.Codex = &CodexActivationBinding{
+		ThreadID: "thread-exact", TurnID: "turn-exact",
+		Authority: &CodexAuthorityRef{
+			StateDomainID: "state-domain-a", EndpointGenerationID: "endpoint-generation-7",
+			BrokerRuntimeID: "broker-runtime-2", ConnectionEpoch: 1, BindingEpoch: 1,
+		},
+	}
+	if err := reg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, exact := range []string{
+		`"endpoint":{"stateDomainID":"state-domain-a","endpointGenerationID":"endpoint-generation-7"}`,
+		`"authority":{"stateDomainID":"state-domain-a","endpointGenerationID":"endpoint-generation-7","brokerRuntimeID":"broker-runtime-2","connectionEpoch":1,"bindingEpoch":1}`,
+		`"generation":"pane-materialization-unrelated"`,
+	} {
+		if !strings.Contains(string(raw), exact) {
+			t.Fatalf("encoded Registry misses exact ref %s: %s", exact, raw)
+		}
+	}
+	var reopened Registry
+	if err := json.Unmarshal(raw, &reopened); err != nil {
+		t.Fatal(err)
+	}
+	if err := reopened.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	gotAgent, _ := reopened.Agent(lifecycleAgentUID)
+	gotPane, _ := reopened.Pane(lifecyclePaneUID)
+	if !reflect.DeepEqual(gotAgent.Status.SessionRef.Codex.Endpoint, endpoint) ||
+		gotPane.Status.Activation.Codex.Authority.EndpointGenerationID != "endpoint-generation-7" ||
+		gotPane.Status.Activation.Generation == gotPane.Status.Activation.Codex.Authority.EndpointGenerationID {
+		t.Fatal("endpoint/authority identity did not survive independently of PaneActivation.Generation")
+	}
+	if again, err := json.Marshal(&reopened); err != nil || string(again) != string(raw) {
+		t.Fatalf("reopened Registry bytes drifted: err=%v", err)
+	}
+}
+
+func TestLegacyCodexRefsRemainGenerationUnavailableWithoutInference(t *testing.T) {
+	reg := lifecycleFixture(t)
+	agent, _ := reg.Agent(lifecycleAgentUID)
+	pane, _ := reg.Pane(lifecyclePaneUID)
+	agent.Status.SessionRef = &AgentSessionRef{Provider: "codex", ObservedAt: lifecycleClock, Codex: &CodexSessionRef{ThreadID: "legacy-thread"}}
+	pane.Status.Activation.Codex = &CodexActivationBinding{ThreadID: "legacy-thread"}
+	raw, err := json.Marshal(reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "stateDomainID") || strings.Contains(string(raw), "endpointGenerationID") || strings.Contains(string(raw), "brokerRuntimeID") {
+		t.Fatalf("legacy encoding inferred endpoint authority: %s", raw)
+	}
+	var reopened Registry
+	if err := json.Unmarshal(raw, &reopened); err != nil {
+		t.Fatal(err)
+	}
+	if err := reopened.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	gotAgent, _ := reopened.Agent(lifecycleAgentUID)
+	gotPane, _ := reopened.Pane(lifecyclePaneUID)
+	if gotAgent.Status.SessionRef.Codex.Endpoint != nil || gotPane.Status.Activation.Codex.Authority != nil {
+		t.Fatal("legacy decode invented a generation or authority")
+	}
+	if again, err := json.Marshal(&reopened); err != nil || string(again) != string(raw) {
+		t.Fatal("legacy generation-unavailable state did not round-trip exactly")
+	}
+}
+
+func TestCodexEndpointAndAuthorityValidationRejectsPartialRefs(t *testing.T) {
+	reg := lifecycleFixture(t)
+	agent, _ := reg.Agent(lifecycleAgentUID)
+	pane, _ := reg.Pane(lifecyclePaneUID)
+	agent.Status.SessionRef = &AgentSessionRef{Provider: "codex", ObservedAt: lifecycleClock, Codex: &CodexSessionRef{
+		ThreadID: "thread", Endpoint: &CodexEndpointRef{StateDomainID: "domain"},
+	}}
+	if err := reg.Validate(); err == nil {
+		t.Fatal("partial durable endpoint ref validated")
+	}
+	agent.Status.SessionRef.Codex.Endpoint = nil
+	pane.Status.Activation.Codex = &CodexActivationBinding{ThreadID: "thread", Authority: &CodexAuthorityRef{
+		StateDomainID: "domain", EndpointGenerationID: "generation", BrokerRuntimeID: "runtime", ConnectionEpoch: 1,
+	}}
+	if err := reg.Validate(); err == nil {
+		t.Fatal("partial live authority ref validated")
+	}
+}
+
+func TestCodexEndpointIdentityRejectsNonCanonicalWhitespace(t *testing.T) {
+	for _, endpoint := range []CodexEndpointRef{
+		{StateDomainID: " domain", EndpointGenerationID: "generation"},
+		{StateDomainID: "domain", EndpointGenerationID: "generation\n"},
+	} {
+		if endpoint.Valid() {
+			t.Fatalf("non-canonical endpoint validated: %#v", endpoint)
+		}
+		if _, ok := NewAgentSessionRef(AgentSessionObservation{Provider: "codex", ThreadID: "thread", Endpoint: &endpoint}, lifecycleClock); ok {
+			t.Fatalf("ingest normalized non-canonical endpoint: %#v", endpoint)
+		}
+	}
+}
+
+func TestLegacyHookReobservationPreservesAnExactCodexEndpointRef(t *testing.T) {
+	reg := lifecycleFixture(t)
+	agent, _ := reg.Agent(lifecycleAgentUID)
+	agent.Status.SessionRef = &AgentSessionRef{
+		Provider: "codex", ObservedAt: lifecycleClock,
+		Codex: &CodexSessionRef{ThreadID: "thread", SessionID: "optional-session", Endpoint: &CodexEndpointRef{
+			StateDomainID: "domain", EndpointGenerationID: "generation",
+		}},
+	}
+	mut := Mutator{Now: func() time.Time { return lifecycleClock.Add(time.Minute) }}
+	if _, changed, err := mut.RecordAgentSessionRef(reg, lifecycleAgentUID, AgentSessionObservation{Provider: "codex", ThreadID: "thread"}); err != nil || changed {
+		t.Fatalf("legacy reobservation = changed:%t err:%v", changed, err)
+	}
+	got, _ := reg.Agent(lifecycleAgentUID)
+	if got.Status.SessionRef.Codex.Endpoint == nil || got.Status.SessionRef.Codex.Endpoint.EndpointGenerationID != "generation" {
+		t.Fatal("legacy hook erased exact endpoint identity")
+	}
+	if got.Status.SessionRef.Codex.SessionID != "optional-session" {
+		t.Fatal("legacy hook erased an omitted optional session identifier")
+	}
+}

--- a/internal/core/metadata/termination.go
+++ b/internal/core/metadata/termination.go
@@ -212,8 +212,41 @@ type PaneActivation struct {
 // local app-server. TurnID is optional for an interactive create/resume that
 // has not started a turn yet.
 type CodexActivationBinding struct {
-	ThreadID string `json:"threadId"`
-	TurnID   string `json:"turnId,omitempty"`
+	ThreadID  string             `json:"threadId"`
+	TurnID    string             `json:"turnId,omitempty"`
+	Authority *CodexAuthorityRef `json:"authority,omitempty"`
+}
+
+// CodexAuthorityRef is the live authority namespace for one exact native
+// binding. Epochs are local counters: StateDomainID, EndpointGenerationID and
+// BrokerRuntimeID make equal numbers from another endpoint or restarted broker
+// unambiguously foreign. A missing authority is legacy state, never authority
+// for a current endpoint.
+type CodexAuthorityRef struct {
+	StateDomainID        string `json:"stateDomainID"`
+	EndpointGenerationID string `json:"endpointGenerationID"`
+	BrokerRuntimeID      string `json:"brokerRuntimeID"`
+	ConnectionEpoch      uint64 `json:"connectionEpoch"`
+	BindingEpoch         uint64 `json:"bindingEpoch"`
+}
+
+// Valid reports whether the complete composite authority is available.
+func (r CodexAuthorityRef) Valid() bool {
+	return validCodexIdentityToken(r.StateDomainID) &&
+		validCodexIdentityToken(r.EndpointGenerationID) &&
+		validCodexIdentityToken(r.BrokerRuntimeID) &&
+		r.ConnectionEpoch != 0 && r.BindingEpoch != 0
+}
+
+// Endpoint returns the durable endpoint portion of this live authority.
+func (r CodexAuthorityRef) Endpoint() CodexEndpointRef {
+	return CodexEndpointRef{StateDomainID: r.StateDomainID, EndpointGenerationID: r.EndpointGenerationID}
+}
+
+// Authorizes requires an exact five-dimensional match. A partial or legacy
+// value returns false even when the numeric epochs happen to be equal.
+func (r CodexAuthorityRef) Authorizes(presented CodexAuthorityRef) bool {
+	return r.Valid() && presented.Valid() && r == presented
 }
 
 // IsZero lets registry documents written before activation generations existed
@@ -229,6 +262,10 @@ func (a PaneActivation) Clone() PaneActivation {
 	out := a
 	if a.Codex != nil {
 		binding := *a.Codex
+		if a.Codex.Authority != nil {
+			authority := *a.Codex.Authority
+			binding.Authority = &authority
+		}
 		out.Codex = &binding
 	}
 	return out

--- a/internal/core/metadata/validate.go
+++ b/internal/core/metadata/validate.go
@@ -134,6 +134,9 @@ func (r Registry) Validate() error {
 			if pane.Spec.Role != PaneRoleAgent || strings.TrimSpace(pane.Status.Activation.AgentUID) == "" || strings.TrimSpace(binding.ThreadID) == "" {
 				return stateErr(op, ErrInvalidRegistry, "pane %q has an invalid native Codex activation binding", pane.Metadata.Name)
 			}
+			if binding.Authority != nil && !binding.Authority.Valid() {
+				return stateErr(op, ErrInvalidRegistry, "pane %q has an incomplete native Codex authority", pane.Metadata.Name)
+			}
 		}
 		if err := validateTermination(op, "pane "+pane.Metadata.Name, pane.Status.LastTermination); err != nil {
 			return err

--- a/internal/integrations/agents/codexappserver/private_unix.go
+++ b/internal/integrations/agents/codexappserver/private_unix.go
@@ -1,0 +1,40 @@
+package codexappserver
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// OpenPrivateUnix opens and initializes an explicitly named private listener.
+// It performs no discovery or lifecycle action and accepts only an absolute
+// socket path. Generation hosting and ownership remain outside this adapter;
+// Phase 0 uses it only for isolated fixed-version conformance.
+func OpenPrivateUnix(ctx context.Context, socketPath string, timeout time.Duration, projmuxVersion string, experimental bool) (*Client, error) {
+	socketPath = filepath.Clean(strings.TrimSpace(socketPath))
+	if !filepath.IsAbs(socketPath) {
+		return nil, ErrDisconnected
+	}
+	if timeout <= 0 {
+		timeout = DefaultProbeTimeout
+	}
+	setupCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	connection, err := (&net.Dialer{}).DialContext(setupCtx, "unix", socketPath)
+	if err != nil {
+		return nil, classifyProxyOpenError(setupCtx, err)
+	}
+	websocket, err := upgradeProxyWebSocket(setupCtx, connection)
+	if err != nil {
+		_ = connection.Close()
+		return nil, classifyProxyOpenError(setupCtx, err)
+	}
+	client := NewClient(websocket)
+	if _, err := client.initialize(setupCtx, projmuxVersion, experimental); err != nil {
+		_ = client.Close()
+		return nil, classifyProxyOpenError(setupCtx, err)
+	}
+	return client, nil
+}

--- a/internal/integrations/agents/codexbundle/bundle.go
+++ b/internal/integrations/agents/codexbundle/bundle.go
@@ -1,0 +1,465 @@
+// Package codexbundle owns immutable, content-addressed Codex release bundle
+// leases. It does not own generation lifecycle or a mutable current pointer.
+package codexbundle
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const ManifestSchemaVersion = 1
+
+type Role string
+
+const (
+	RoleServer Role = "server"
+	RoleTUI    Role = "tui"
+	RoleHelper Role = "helper"
+)
+
+type ProtocolRange struct {
+	Min uint32 `json:"min"`
+	Max uint32 `json:"max"`
+}
+
+func (r ProtocolRange) Valid() bool { return r.Min > 0 && r.Max >= r.Min }
+
+func (r ProtocolRange) Supports(required ProtocolRange) bool {
+	return r.Valid() && required.Valid() && r.Min <= required.Min && r.Max >= required.Max
+}
+
+type ArtifactSpec struct {
+	Path  string `json:"path"`
+	Roles []Role `json:"roles"`
+}
+
+type Artifact struct {
+	Path   string `json:"path"`
+	Roles  []Role `json:"roles"`
+	SHA256 string `json:"sha256"`
+	Mode   uint32 `json:"mode"`
+	Size   int64  `json:"size"`
+}
+
+type Manifest struct {
+	SchemaVersion int           `json:"schemaVersion"`
+	Version       string        `json:"version"`
+	Protocol      ProtocolRange `json:"protocol"`
+	Artifacts     []Artifact    `json:"artifacts"`
+}
+
+type Refusal string
+
+const (
+	RefusalNone              Refusal = "none"
+	RefusalManifestInvalid   Refusal = "manifest-invalid"
+	RefusalBundleIncomplete  Refusal = "bundle-incomplete"
+	RefusalProtocolMismatch  Refusal = "protocol-mismatch"
+	RefusalSourceUnavailable Refusal = "source-unavailable"
+	RefusalArtifactHashDrift Refusal = "artifact-hash-drift"
+	RefusalArtifactModeDrift Refusal = "artifact-mode-drift"
+	RefusalArtifactSizeDrift Refusal = "artifact-size-drift"
+	RefusalLeaseDrift        Refusal = "lease-drift"
+	RefusalCommitCollision   Refusal = "commit-collision"
+)
+
+type Error struct{ Refusal Refusal }
+
+func (e *Error) Error() string { return "Codex bundle lease refused: " + string(e.Refusal) }
+
+func RefusalOf(err error) Refusal {
+	var bundleErr *Error
+	if errors.As(err, &bundleErr) {
+		return bundleErr.Refusal
+	}
+	return RefusalNone
+}
+
+type Lease struct {
+	ID       string
+	Root     string
+	Manifest Manifest
+}
+
+// Inspect builds a canonical source manifest without persisting it.
+func Inspect(sourceRoot, version string, protocol ProtocolRange, specs []ArtifactSpec) (Manifest, error) {
+	if !safeRoot(sourceRoot) {
+		return Manifest{}, &Error{Refusal: RefusalManifestInvalid}
+	}
+	manifest := Manifest{SchemaVersion: ManifestSchemaVersion, Version: version, Protocol: protocol}
+	for _, spec := range specs {
+		path, ok := cleanRelative(spec.Path)
+		if !ok || len(spec.Roles) == 0 {
+			return Manifest{}, &Error{Refusal: RefusalManifestInvalid}
+		}
+		artifact, err := inspectArtifact(filepath.Join(sourceRoot, filepath.FromSlash(path)), path, spec.Roles)
+		if err != nil {
+			return Manifest{}, err
+		}
+		manifest.Artifacts = append(manifest.Artifacts, artifact)
+	}
+	canonicalize(&manifest)
+	if err := manifest.Validate(); err != nil {
+		return Manifest{}, err
+	}
+	return manifest, nil
+}
+
+func inspectArtifact(source, path string, roles []Role) (Artifact, error) {
+	// Source layouts commonly expose a mutable `current` symlink. Following a
+	// source link is safe here because identity is the bytes/mode/size copied
+	// into the lease, and copyVerified requires the resolved file identity to
+	// remain the same for the whole copy. The committed lease contains no link.
+	info, err := os.Stat(source)
+	if err != nil || !info.Mode().IsRegular() {
+		return Artifact{}, &Error{Refusal: RefusalSourceUnavailable}
+	}
+	file, err := os.Open(source) // #nosec G304 -- source is an explicit manifest path under the supplied root.
+	if err != nil {
+		return Artifact{}, &Error{Refusal: RefusalSourceUnavailable}
+	}
+	digest := sha256.New()
+	_, copyErr := io.Copy(digest, file)
+	closeErr := file.Close()
+	if copyErr != nil || closeErr != nil {
+		return Artifact{}, &Error{Refusal: RefusalSourceUnavailable}
+	}
+	return Artifact{
+		Path: path, Roles: append([]Role(nil), roles...), SHA256: hex.EncodeToString(digest.Sum(nil)),
+		Mode: uint32(info.Mode().Perm()), Size: info.Size(),
+	}, nil
+}
+
+func (m Manifest) Validate() error {
+	if m.SchemaVersion != ManifestSchemaVersion || !safeVersionToken(m.Version) || !m.Protocol.Valid() || len(m.Artifacts) == 0 {
+		return &Error{Refusal: RefusalManifestInvalid}
+	}
+	seen := make(map[string]bool, len(m.Artifacts))
+	roleCount := map[Role]int{}
+	for _, artifact := range m.Artifacts {
+		path, ok := cleanRelative(artifact.Path)
+		if !ok || path != artifact.Path || seen[path] || artifact.Size <= 0 ||
+			artifact.Mode == 0 || artifact.Mode&^0o777 != 0 || len(artifact.Roles) == 0 {
+			return &Error{Refusal: RefusalManifestInvalid}
+		}
+		seen[path] = true
+		if len(artifact.SHA256) != sha256.Size*2 {
+			return &Error{Refusal: RefusalManifestInvalid}
+		}
+		if _, err := hex.DecodeString(artifact.SHA256); err != nil {
+			return &Error{Refusal: RefusalManifestInvalid}
+		}
+		for _, role := range artifact.Roles {
+			if role != RoleServer && role != RoleTUI && role != RoleHelper {
+				return &Error{Refusal: RefusalManifestInvalid}
+			}
+			roleCount[role]++
+			if artifact.Mode&0o111 == 0 {
+				return &Error{Refusal: RefusalManifestInvalid}
+			}
+		}
+	}
+	if roleCount[RoleServer] != 1 || roleCount[RoleTUI] != 1 || roleCount[RoleHelper] == 0 {
+		return &Error{Refusal: RefusalBundleIncomplete}
+	}
+	return nil
+}
+
+// ContentID hashes the canonical manifest, so identity covers every retained
+// executable's role, bytes, mode and size plus the protocol range.
+func (m Manifest) ContentID() (string, error) {
+	canonical := cloneManifest(m)
+	canonicalize(&canonical)
+	if err := canonical.Validate(); err != nil {
+		return "", err
+	}
+	raw, err := json.Marshal(canonical)
+	if err != nil {
+		return "", &Error{Refusal: RefusalManifestInvalid}
+	}
+	digest := sha256.Sum256(raw)
+	return "sha256-" + hex.EncodeToString(digest[:]), nil
+}
+
+// Create verifies all source bytes and modes while copying into a private
+// staging directory, verifies the complete staging tree again, and only then
+// atomically commits the immutable content-addressed directory. It never
+// creates or mutates a current symlink.
+func Create(storeRoot, sourceRoot string, manifest Manifest, required ProtocolRange) (Lease, error) {
+	if !safeRoot(storeRoot) || !safeRoot(sourceRoot) {
+		return Lease{}, &Error{Refusal: RefusalManifestInvalid}
+	}
+	canonicalize(&manifest)
+	if err := manifest.Validate(); err != nil {
+		return Lease{}, err
+	}
+	if !manifest.Protocol.Supports(required) {
+		return Lease{}, &Error{Refusal: RefusalProtocolMismatch}
+	}
+	id, err := manifest.ContentID()
+	if err != nil {
+		return Lease{}, err
+	}
+	finalRoot := filepath.Join(storeRoot, id)
+	if info, err := os.Lstat(finalRoot); err == nil {
+		if !info.IsDir() {
+			return Lease{}, &Error{Refusal: RefusalCommitCollision}
+		}
+		return Open(finalRoot, required)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return Lease{}, &Error{Refusal: RefusalCommitCollision}
+	}
+	if err := os.MkdirAll(storeRoot, 0o700); err != nil {
+		return Lease{}, &Error{Refusal: RefusalSourceUnavailable}
+	}
+	stage, err := os.MkdirTemp(storeRoot, ".lease-stage-")
+	if err != nil {
+		return Lease{}, &Error{Refusal: RefusalSourceUnavailable}
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.RemoveAll(stage)
+		}
+	}()
+	for _, artifact := range manifest.Artifacts {
+		source := filepath.Join(sourceRoot, filepath.FromSlash(artifact.Path))
+		if err := copyVerified(source, filepath.Join(stage, filepath.FromSlash(artifact.Path)), artifact); err != nil {
+			return Lease{}, err
+		}
+	}
+	rawManifest, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil || os.WriteFile(filepath.Join(stage, "manifest.json"), rawManifest, 0o600) != nil {
+		return Lease{}, &Error{Refusal: RefusalSourceUnavailable}
+	}
+	if _, err := verifyAt(stage, manifest, required); err != nil {
+		return Lease{}, err
+	}
+	if err := os.Rename(stage, finalRoot); err != nil {
+		if _, statErr := os.Lstat(finalRoot); statErr == nil {
+			return Lease{}, &Error{Refusal: RefusalCommitCollision}
+		}
+		return Lease{}, &Error{Refusal: RefusalSourceUnavailable}
+	}
+	committed = true
+	return Lease{ID: id, Root: finalRoot, Manifest: manifest}, nil
+}
+
+func copyVerified(source, target string, want Artifact) error {
+	before, err := os.Stat(source)
+	if err != nil || !before.Mode().IsRegular() {
+		return &Error{Refusal: RefusalSourceUnavailable}
+	}
+	if uint32(before.Mode().Perm()) != want.Mode {
+		return &Error{Refusal: RefusalArtifactModeDrift}
+	}
+	if before.Size() != want.Size {
+		return &Error{Refusal: RefusalArtifactSizeDrift}
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		return &Error{Refusal: RefusalSourceUnavailable}
+	}
+	in, err := os.Open(source) // #nosec G304 -- exact manifest source.
+	if err != nil {
+		return &Error{Refusal: RefusalSourceUnavailable}
+	}
+	out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, fs.FileMode(want.Mode)) // #nosec G304 -- exact private staging target.
+	if err != nil {
+		_ = in.Close()
+		return &Error{Refusal: RefusalSourceUnavailable}
+	}
+	digest := sha256.New()
+	_, copyErr := io.Copy(io.MultiWriter(out, digest), in)
+	closeInErr, closeOutErr := in.Close(), out.Close()
+	if copyErr != nil || closeInErr != nil || closeOutErr != nil {
+		return &Error{Refusal: RefusalSourceUnavailable}
+	}
+	after, err := os.Stat(source)
+	if err != nil || !os.SameFile(before, after) || uint32(after.Mode().Perm()) != want.Mode || after.Size() != want.Size {
+		return &Error{Refusal: RefusalArtifactModeDrift}
+	}
+	if hex.EncodeToString(digest.Sum(nil)) != want.SHA256 {
+		return &Error{Refusal: RefusalArtifactHashDrift}
+	}
+	return nil
+}
+
+// Open re-verifies a committed lease and refuses any manifest, hash, size,
+// mode, completeness, or protocol drift before a caller can launch from it.
+func Open(root string, required ProtocolRange) (Lease, error) {
+	if !safeRoot(root) {
+		return Lease{}, &Error{Refusal: RefusalManifestInvalid}
+	}
+	raw, mode, err := readCommittedRegularFile(root, "manifest.json")
+	if err != nil {
+		return Lease{}, &Error{Refusal: RefusalLeaseDrift}
+	}
+	if mode != 0o600 {
+		return Lease{}, &Error{Refusal: RefusalLeaseDrift}
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.DisallowUnknownFields()
+	var manifest Manifest
+	if decoder.Decode(&manifest) != nil {
+		return Lease{}, &Error{Refusal: RefusalLeaseDrift}
+	}
+	var trailing any
+	if trailingErr := decoder.Decode(&trailing); trailingErr != io.EOF {
+		return Lease{}, &Error{Refusal: RefusalLeaseDrift}
+	}
+	canonicalize(&manifest)
+	if _, err := verifyAt(root, manifest, required); err != nil {
+		return Lease{}, err
+	}
+	id, err := manifest.ContentID()
+	if err != nil || filepath.Base(filepath.Clean(root)) != id {
+		return Lease{}, &Error{Refusal: RefusalLeaseDrift}
+	}
+	return Lease{ID: id, Root: filepath.Clean(root), Manifest: manifest}, nil
+}
+
+func verifyAt(root string, manifest Manifest, required ProtocolRange) (Manifest, error) {
+	if err := manifest.Validate(); err != nil {
+		return Manifest{}, err
+	}
+	if !manifest.Protocol.Supports(required) {
+		return Manifest{}, &Error{Refusal: RefusalProtocolMismatch}
+	}
+	for _, artifact := range manifest.Artifacts {
+		got, err := inspectCommittedArtifact(root, artifact)
+		if err != nil {
+			return Manifest{}, &Error{Refusal: RefusalLeaseDrift}
+		}
+		switch {
+		case got.Mode != artifact.Mode:
+			return Manifest{}, &Error{Refusal: RefusalArtifactModeDrift}
+		case got.Size != artifact.Size:
+			return Manifest{}, &Error{Refusal: RefusalArtifactSizeDrift}
+		case got.SHA256 != artifact.SHA256:
+			return Manifest{}, &Error{Refusal: RefusalArtifactHashDrift}
+		}
+	}
+	return manifest, nil
+}
+
+// inspectCommittedArtifact rejects links in the committed tree. Source
+// inspection intentionally follows a mutable upstream `current` symlink, but
+// a lease is launch authority only for regular files physically retained under
+// its own immutable root.
+func inspectCommittedArtifact(root string, want Artifact) (Artifact, error) {
+	raw, mode, err := readCommittedRegularFile(root, want.Path)
+	if err != nil {
+		return Artifact{}, err
+	}
+	digest := sha256.Sum256(raw)
+	return Artifact{
+		Path: want.Path, Roles: append([]Role(nil), want.Roles...), SHA256: hex.EncodeToString(digest[:]),
+		Mode: uint32(mode), Size: int64(len(raw)),
+	}, nil
+}
+
+func readCommittedRegularFile(root, relative string) ([]byte, fs.FileMode, error) {
+	path, ok := cleanRelative(relative)
+	if !ok || path != relative {
+		return nil, 0, &Error{Refusal: RefusalLeaseDrift}
+	}
+	rootInfo, err := os.Lstat(root)
+	if err != nil || !rootInfo.IsDir() || rootInfo.Mode()&os.ModeSymlink != 0 {
+		return nil, 0, &Error{Refusal: RefusalLeaseDrift}
+	}
+	parts := strings.Split(filepath.ToSlash(path), "/")
+	parent := root
+	for _, part := range parts[:len(parts)-1] {
+		parent = filepath.Join(parent, filepath.FromSlash(part))
+		info, err := os.Lstat(parent)
+		if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return nil, 0, &Error{Refusal: RefusalLeaseDrift}
+		}
+	}
+	target := filepath.Join(root, filepath.FromSlash(path))
+	before, err := os.Lstat(target)
+	if err != nil || !before.Mode().IsRegular() || before.Mode()&os.ModeSymlink != 0 {
+		return nil, 0, &Error{Refusal: RefusalLeaseDrift}
+	}
+	file, err := os.Open(target) // #nosec G304 -- canonical path below an exact lease root.
+	if err != nil {
+		return nil, 0, &Error{Refusal: RefusalLeaseDrift}
+	}
+	opened, statErr := file.Stat()
+	if statErr != nil || !os.SameFile(before, opened) {
+		_ = file.Close()
+		return nil, 0, &Error{Refusal: RefusalLeaseDrift}
+	}
+	raw, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+	after, afterErr := os.Lstat(target)
+	if readErr != nil || closeErr != nil || afterErr != nil || !after.Mode().IsRegular() ||
+		after.Mode()&os.ModeSymlink != 0 || !os.SameFile(opened, after) {
+		return nil, 0, &Error{Refusal: RefusalLeaseDrift}
+	}
+	return raw, opened.Mode().Perm(), nil
+}
+
+func (l Lease) Paths(role Role) []string {
+	var paths []string
+	for _, artifact := range l.Manifest.Artifacts {
+		if slices.Contains(artifact.Roles, role) {
+			paths = append(paths, filepath.Join(l.Root, filepath.FromSlash(artifact.Path)))
+		}
+	}
+	return paths
+}
+
+func canonicalize(manifest *Manifest) {
+	for index := range manifest.Artifacts {
+		manifest.Artifacts[index].Path = filepath.ToSlash(filepath.Clean(manifest.Artifacts[index].Path))
+		slices.Sort(manifest.Artifacts[index].Roles)
+	}
+	slices.SortFunc(manifest.Artifacts, func(a, b Artifact) int { return strings.Compare(a.Path, b.Path) })
+}
+
+func cloneManifest(manifest Manifest) Manifest {
+	out := manifest
+	out.Artifacts = make([]Artifact, len(manifest.Artifacts))
+	for index, artifact := range manifest.Artifacts {
+		out.Artifacts[index] = artifact
+		out.Artifacts[index].Roles = append([]Role(nil), artifact.Roles...)
+	}
+	return out
+}
+
+func cleanRelative(path string) (string, bool) {
+	path = filepath.ToSlash(filepath.Clean(strings.TrimSpace(path)))
+	return path, path != "" && path != "." && !strings.HasPrefix(path, "../") && !filepath.IsAbs(path) && !strings.Contains(path, "\\")
+}
+
+func safeRoot(path string) bool {
+	if path == "" || path != strings.TrimSpace(path) {
+		return false
+	}
+	clean := filepath.Clean(path)
+	return path == clean && filepath.IsAbs(path) && path != filepath.Clean(string(filepath.Separator))
+}
+
+func safeVersionToken(value string) bool {
+	if value == "" || value != strings.TrimSpace(value) || len(value) > 64 {
+		return false
+	}
+	for _, char := range value {
+		if (char >= '0' && char <= '9') || char == '.' || char == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func (r Refusal) String() string { return string(r) }

--- a/internal/integrations/agents/codexbundle/bundle_test.go
+++ b/internal/integrations/agents/codexbundle/bundle_test.go
@@ -1,0 +1,220 @@
+package codexbundle
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func writeBundleSource(t *testing.T, root string) []ArtifactSpec {
+	t.Helper()
+	files := map[string]string{
+		"bin/codex":                "#!/bin/sh\nprintf 'codex-ok\\n'\n",
+		"bin/codex-code-mode-host": "#!/bin/sh\nprintf 'host-ok\\n'\n",
+		"codex-path/rg":            "#!/bin/sh\nprintf 'rg-ok\\n'\n",
+		"codex-resources/bwrap":    "#!/bin/sh\nprintf 'bwrap-ok\\n'\n",
+	}
+	for path, body := range files {
+		target := filepath.Join(root, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(target, []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return []ArtifactSpec{
+		{Path: "bin/codex", Roles: []Role{RoleServer, RoleTUI}},
+		{Path: "bin/codex-code-mode-host", Roles: []Role{RoleHelper}},
+		{Path: "codex-path/rg", Roles: []Role{RoleHelper}},
+		{Path: "codex-resources/bwrap", Roles: []Role{RoleHelper}},
+	}
+}
+
+func TestContentAddressedBundleSurvivesSourceRemovalForServerTUIAndHelpers(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "upstream-current")
+	store := filepath.Join(root, "leases")
+	specs := writeBundleSource(t, source)
+	manifest, err := Inspect(source, "0.152.0", ProtocolRange{Min: 2, Max: 2}, specs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := Create(store, source, manifest, ProtocolRange{Min: 2, Max: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(source); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(source); !os.IsNotExist(err) {
+		t.Fatalf("upstream source still exists: %v", err)
+	}
+	reopened, err := Open(lease.Root, ProtocolRange{Min: 2, Max: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reopened.ID != lease.ID {
+		t.Fatalf("reopened lease id=%s want=%s", reopened.ID, lease.ID)
+	}
+	for _, role := range []Role{RoleServer, RoleTUI, RoleHelper} {
+		paths := reopened.Paths(role)
+		if len(paths) == 0 {
+			t.Fatalf("leased role %s has no executable", role)
+		}
+		for _, path := range paths {
+			output, err := exec.Command(path).CombinedOutput() // #nosec G204 -- exact verified lease path.
+			if err != nil || !strings.HasSuffix(strings.TrimSpace(string(output)), "-ok") {
+				t.Fatalf("launch %s role=%s output=%q err=%v", filepath.Base(path), role, output, err)
+			}
+		}
+	}
+}
+
+func TestBundleDriftAndProtocolMismatchRefuseBeforeFinalCommit(t *testing.T) {
+	tests := []struct {
+		name     string
+		mutate   func(t *testing.T, source string, manifest *Manifest)
+		required ProtocolRange
+		want     Refusal
+	}{
+		{name: "hash drift", mutate: func(t *testing.T, source string, _ *Manifest) {
+			if err := os.WriteFile(filepath.Join(source, "bin/codex"), []byte("#!/bin/sh\nprintf changed\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}, required: ProtocolRange{Min: 2, Max: 2}, want: RefusalArtifactSizeDrift},
+		{name: "same-size hash drift", mutate: func(t *testing.T, source string, manifest *Manifest) {
+			path := filepath.Join(source, "bin/codex")
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			raw[len(raw)-2] ^= 1
+			if err := os.WriteFile(path, raw, os.FileMode(manifest.Artifacts[0].Mode)); err != nil {
+				t.Fatal(err)
+			}
+		}, required: ProtocolRange{Min: 2, Max: 2}, want: RefusalArtifactHashDrift},
+		{name: "mode drift", mutate: func(t *testing.T, source string, _ *Manifest) {
+			if err := os.Chmod(filepath.Join(source, "bin/codex"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+		}, required: ProtocolRange{Min: 2, Max: 2}, want: RefusalArtifactModeDrift},
+		{name: "protocol mismatch", mutate: func(_ *testing.T, _ string, _ *Manifest) {}, required: ProtocolRange{Min: 3, Max: 3}, want: RefusalProtocolMismatch},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			source, store := filepath.Join(root, "source"), filepath.Join(root, "store")
+			manifest, err := Inspect(source, "0.152.0", ProtocolRange{Min: 2, Max: 2}, writeBundleSource(t, source))
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.mutate(t, source, &manifest)
+			_, err = Create(store, source, manifest, test.required)
+			if got := RefusalOf(err); got != test.want {
+				t.Fatalf("refusal=%s want=%s err=%v", got, test.want, err)
+			}
+			id, idErr := manifest.ContentID()
+			if idErr != nil {
+				t.Fatal(idErr)
+			}
+			if _, statErr := os.Lstat(filepath.Join(store, id)); !os.IsNotExist(statErr) {
+				t.Fatalf("refused lease committed final directory: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestBundleRefusesNonCanonicalRootsAndVersions(t *testing.T) {
+	root := t.TempDir()
+	source, store := filepath.Join(root, "source"), filepath.Join(root, "store")
+	specs := writeBundleSource(t, source)
+	for _, padded := range []string{" " + source, source + " ", source + string(os.PathSeparator)} {
+		if _, err := Inspect(padded, "0.152.0", ProtocolRange{Min: 2, Max: 2}, specs); RefusalOf(err) != RefusalManifestInvalid {
+			t.Fatalf("Inspect root %q refusal=%s err=%v", padded, RefusalOf(err), err)
+		}
+	}
+	if _, err := Inspect(source, " 0.152.0", ProtocolRange{Min: 2, Max: 2}, specs); RefusalOf(err) != RefusalManifestInvalid {
+		t.Fatalf("padded version refusal=%s err=%v", RefusalOf(err), err)
+	}
+	manifest, err := Inspect(source, "0.152.0", ProtocolRange{Min: 2, Max: 2}, specs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Create(" "+store, source, manifest, ProtocolRange{Min: 2, Max: 2}); RefusalOf(err) != RefusalManifestInvalid {
+		t.Fatalf("padded store refusal=%s err=%v", RefusalOf(err), err)
+	}
+}
+
+func TestCommittedBundleTamperingIsRefusedBeforeLaunch(t *testing.T) {
+	root := t.TempDir()
+	source, store := filepath.Join(root, "source"), filepath.Join(root, "store")
+	manifest, err := Inspect(source, "0.152.0", ProtocolRange{Min: 2, Max: 2}, writeBundleSource(t, source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := Create(store, source, manifest, ProtocolRange{Min: 2, Max: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filepath.Join(lease.Root, "bin/codex"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Open(lease.Root, ProtocolRange{Min: 2, Max: 2}); RefusalOf(err) != RefusalArtifactModeDrift {
+		t.Fatalf("tampered lease refusal=%s err=%v", RefusalOf(err), err)
+	}
+}
+
+func TestCommittedBundleRefusesMatchingSymlinksBeforeLaunch(t *testing.T) {
+	for _, relative := range []string{"bin/codex", "manifest.json"} {
+		t.Run(relative, func(t *testing.T) {
+			root := t.TempDir()
+			source, store := filepath.Join(root, "source"), filepath.Join(root, "store")
+			manifest, err := Inspect(source, "0.152.0", ProtocolRange{Min: 2, Max: 2}, writeBundleSource(t, source))
+			if err != nil {
+				t.Fatal(err)
+			}
+			lease, err := Create(store, source, manifest, ProtocolRange{Min: 2, Max: 2})
+			if err != nil {
+				t.Fatal(err)
+			}
+			leasedPath := filepath.Join(lease.Root, filepath.FromSlash(relative))
+			outside := filepath.Join(root, "outside-"+filepath.Base(relative))
+			if err := os.Rename(leasedPath, outside); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(outside, leasedPath); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Open(lease.Root, ProtocolRange{Min: 2, Max: 2}); RefusalOf(err) != RefusalLeaseDrift {
+				t.Fatalf("matching symlink refusal=%s err=%v", RefusalOf(err), err)
+			}
+		})
+	}
+}
+
+func TestManifestCanonicalizationMakesRoleAndArtifactOrderIrrelevant(t *testing.T) {
+	root := t.TempDir()
+	specs := writeBundleSource(t, root)
+	a, err := Inspect(root, "0.152.0", ProtocolRange{Min: 2, Max: 2}, specs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reversed := append([]ArtifactSpec(nil), specs...)
+	for left, right := 0, len(reversed)-1; left < right; left, right = left+1, right-1 {
+		reversed[left], reversed[right] = reversed[right], reversed[left]
+	}
+	reversed[len(reversed)-1].Roles = []Role{RoleTUI, RoleServer}
+	b, err := Inspect(root, "0.152.0", ProtocolRange{Min: 2, Max: 2}, reversed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idA, _ := a.ContentID()
+	idB, _ := b.ContentID()
+	if idA != idB || !reflect.DeepEqual(a, b) {
+		t.Fatalf("canonical manifests differ: %s %s", idA, idB)
+	}
+}

--- a/internal/testutil/codexinstalled/generation_conformance_installed_test.go
+++ b/internal/testutil/codexinstalled/generation_conformance_installed_test.go
@@ -1,0 +1,778 @@
+package codexinstalled
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/codexgeneration"
+	"github.com/crevissepartners/projmux/internal/core/metadata"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/codexappserver"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/codexbundle"
+)
+
+const (
+	generationSmokeRootEnv  = "PROJMUX_CODEX_GENERATION_SMOKE_ROOT"
+	generationOldEnv        = "PROJMUX_CODEX_GENERATION_OLD"
+	generationNewEnv        = "PROJMUX_CODEX_GENERATION_NEW"
+	generationStateEnv      = "PROJMUX_CODEX_GENERATION_SOURCE_HOME"
+	generationBundleRootEnv = "PROJMUX_CODEX_GENERATION_BUNDLE_SMOKE_ROOT"
+)
+
+// TestInstalledIsolatedGenerationPoolQualification is the fixed 0.152.0 /
+// 0.152.1 Phase 0 conformance gate. It is opt-in because it uses the installed
+// Codex service and performs two bounded, minimal canary turns. The fixture
+// owns only its explicit /tmp root, private sockets, child processes, and copied
+// state. It neither discovers nor mutates the ambient/default daemon or tmux.
+func TestInstalledIsolatedGenerationPoolQualification(t *testing.T) {
+	root, enabled, err := SmokeRoot(generationSmokeRootEnv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !enabled {
+		t.Skipf("set %s for the fixed dual-version generation qualification", generationSmokeRootEnv)
+	}
+	if err := validateInheritedEnvironment(); err != nil {
+		t.Fatal(err)
+	}
+	oldBinary := exactGenerationBinary(t, generationOldEnv, "0.152.0")
+	newBinary := exactGenerationBinary(t, generationNewEnv, "0.152.1")
+	stateSource := filepath.Clean(strings.TrimSpace(os.Getenv(generationStateEnv)))
+	if !filepath.IsAbs(stateSource) {
+		t.Fatalf("%s must be absolute", generationStateEnv)
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("generation smoke root must start empty: entries=%d err=%v", len(entries), err)
+	}
+	rootRemoved := false
+	bundleRoot := filepath.Clean(strings.TrimSpace(os.Getenv(generationBundleRootEnv)))
+	if !filepath.IsAbs(bundleRoot) || bundleRoot == filepath.Clean(string(filepath.Separator)) {
+		t.Fatalf("%s must be an absolute dedicated directory", generationBundleRootEnv)
+	}
+	if err := os.MkdirAll(bundleRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	bundleEntries, err := os.ReadDir(bundleRoot)
+	if err != nil || len(bundleEntries) != 0 {
+		t.Fatalf("generation bundle root must start empty: entries=%d err=%v", len(bundleEntries), err)
+	}
+	bundleRootRemoved := false
+	t.Cleanup(func() {
+		if !rootRemoved {
+			if err := os.RemoveAll(root); err != nil {
+				t.Errorf("remove exact generation smoke root: %v", err)
+			}
+		}
+		if !bundleRootRemoved {
+			if err := os.RemoveAll(bundleRoot); err != nil {
+				t.Errorf("remove exact generation bundle root: %v", err)
+			}
+		}
+	})
+
+	stateDomain := filepath.Join(root, "shared-state-domain")
+	workspace := filepath.Join(root, "workspace")
+	if err := os.MkdirAll(stateDomain, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(workspace, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	copySharedCodexConfig(t, stateSource, stateDomain)
+	ledger := &generationConformanceLedger{}
+	ledger.recordFilesystem(pathWithin(root, stateDomain), "shared-auth-config")
+
+	protocol := codexbundle.ProtocolRange{Min: 2, Max: 2}
+	oldLease := leaseInstalledBundle(t, filepath.Join(bundleRoot, "bundle-store"), oldBinary, "0.152.0", protocol)
+	newLease := leaseInstalledBundle(t, filepath.Join(bundleRoot, "bundle-store"), newBinary, "0.152.1", protocol)
+	ledger.recordFilesystem(pathWithin(bundleRoot, oldLease.Root) && pathWithin(bundleRoot, newLease.Root), "bundle-leases")
+	bundleDriftRefused, protocolMismatchRefused := true, true
+	for _, lease := range []codexbundle.Lease{oldLease, newLease} {
+		if _, err := codexbundle.Open(lease.Root, protocol); err != nil {
+			t.Fatalf("reopen leased bundle: %v", err)
+		}
+		mismatchStore := filepath.Join(bundleRoot, "protocol-mismatch", lease.ID)
+		if _, err := codexbundle.Create(mismatchStore, lease.Root, lease.Manifest, codexbundle.ProtocolRange{Min: 3, Max: 3}); codexbundle.RefusalOf(err) != codexbundle.RefusalProtocolMismatch {
+			protocolMismatchRefused = false
+		}
+		drifted := lease.Manifest
+		drifted.Artifacts = append([]codexbundle.Artifact(nil), lease.Manifest.Artifacts...)
+		drifted.Artifacts[0].Mode = 0o700
+		driftStore := filepath.Join(bundleRoot, "manifest-drift", lease.ID)
+		_, driftErr := codexbundle.Create(driftStore, lease.Root, drifted, protocol)
+		driftID, idErr := drifted.ContentID()
+		_, finalErr := os.Lstat(filepath.Join(driftStore, driftID))
+		if codexbundle.RefusalOf(driftErr) != codexbundle.RefusalArtifactModeDrift || idErr != nil || !errors.Is(finalErr, fs.ErrNotExist) {
+			bundleDriftRefused = false
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Minute)
+	defer cancel()
+	oldSocket, newSocket := filepath.Join(root, "old.sock"), filepath.Join(root, "new.sock")
+	oldEndpoint := startPrivateGeneration(t, ctx, oldLease.Paths(codexbundle.RoleServer)[0], stateDomain, oldSocket, ledger, "old")
+	newEndpoint := startPrivateGeneration(t, ctx, newLease.Paths(codexbundle.RoleServer)[0], stateDomain, newSocket, ledger, "new")
+	t.Cleanup(func() { oldEndpoint.cleanup(t); newEndpoint.cleanup(t) })
+
+	oldClient := openPrivateGeneration(t, ctx, oldSocket, "old", ledger)
+	newClient := openPrivateGeneration(t, ctx, newSocket, "new", ledger)
+	oldThread, newThread := createConcurrentGenerationThreads(t, ctx, oldClient, newClient, workspace)
+	if oldThread.ThreadID == newThread.ThreadID {
+		t.Fatal("old/new endpoints returned the same new thread")
+	}
+	oldTurn, newTurn := turnConcurrentGenerationThreads(t, ctx, oldClient, newClient, oldThread.ThreadID, newThread.ThreadID)
+	oldSnapshot := waitForGenerationTurn(t, ctx, oldClient.Client, oldThread.ThreadID, oldTurn)
+	newSnapshot := waitForGenerationTurn(t, ctx, newClient.Client, newThread.ThreadID, newTurn)
+	assertGenerationReadList(t, ctx, oldClient, oldThread.ThreadID, newThread.ThreadID)
+	assertGenerationReadList(t, ctx, newClient, newThread.ThreadID, oldThread.ThreadID)
+	_ = oldClient.Close()
+	_ = newClient.Close()
+
+	// Kill rather than gracefully retire both isolated children, then wait for
+	// exact process/socket absence before restarting. The barrier observes state;
+	// no fixed sleep is completion evidence.
+	oldEndpoint.crash(t, ctx)
+	newEndpoint.crash(t, ctx)
+	oldEndpoint = startPrivateGeneration(t, ctx, oldLease.Paths(codexbundle.RoleServer)[0], stateDomain, oldSocket, ledger, "old")
+	newEndpoint = startPrivateGeneration(t, ctx, newLease.Paths(codexbundle.RoleServer)[0], stateDomain, newSocket, ledger, "new")
+	oldClient = openPrivateGeneration(t, ctx, oldSocket, "old", ledger)
+	newClient = openPrivateGeneration(t, ctx, newSocket, "new", ledger)
+	if _, err := oldClient.ResumeThread(ctx, oldThread.ThreadID, workspace, nil); err != nil {
+		t.Fatalf("old exact-thread restart resume: %v", err)
+	}
+	if _, err := newClient.ResumeThread(ctx, newThread.ThreadID, workspace, nil); err != nil {
+		t.Fatalf("new exact-thread restart resume: %v", err)
+	}
+	assertGenerationReadList(t, ctx, oldClient, oldThread.ThreadID, newThread.ThreadID)
+	assertGenerationReadList(t, ctx, newClient, newThread.ThreadID, oldThread.ThreadID)
+	oldRestartSnapshot, err := oldClient.ReadLifecycleSnapshot(ctx, oldThread.ThreadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newRestartSnapshot, err := newClient.ReadLifecycleSnapshot(ctx, newThread.ThreadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldRef := metadata.CodexEndpointRef{StateDomainID: "state-domain-qualification", EndpointGenerationID: "g-0.152.0"}
+	newRef := metadata.CodexEndpointRef{StateDomainID: "state-domain-qualification", EndpointGenerationID: "g-0.152.1"}
+	if decision := codexgeneration.ApplySuccessorResume(oldRef, newRef, false, true, func() {
+		_, _ = newClient.ResumeThread(ctx, oldThread.ThreadID, workspace, nil)
+	}); decision != codexgeneration.ResumeOwnerStillLive {
+		t.Fatalf("live-owner barrier decision=%s", decision)
+	}
+	liveOwnerResumeWrites := ledger.liveOwnerResumeWrites(oldThread.ThreadID)
+	if liveOwnerResumeWrites != 0 {
+		t.Fatalf("live-owner successor provider writes=%d", liveOwnerResumeWrites)
+	}
+	_ = oldClient.Close()
+	oldEndpoint.stop(t, ctx)
+	ledger.markOldStopped()
+	resumed := false
+	if decision := codexgeneration.ApplySuccessorResume(oldRef, newRef, true, true, func() {
+		binding, resumeErr := newClient.ResumeThread(ctx, oldThread.ThreadID, workspace, nil)
+		if resumeErr != nil || binding.ThreadID != oldThread.ThreadID {
+			t.Fatalf("successor exact-thread resume binding=%+v err=%v", binding, resumeErr)
+		}
+		resumed = true
+	}); decision != codexgeneration.ResumeAllowed || !resumed {
+		t.Fatalf("post-stop successor decision=%s resumed=%t", decision, resumed)
+	}
+	snapshot, err := newClient.ReadLifecycleSnapshot(ctx, oldThread.ThreadID)
+	if err != nil || snapshot.ThreadID != oldThread.ThreadID || snapshot.TurnID != oldTurn || snapshot.TurnState != codexappserver.TurnStateCompleted {
+		t.Fatalf("successor snapshot does not preserve completed exact turn: snapshot=%+v err=%v", snapshot, err)
+	}
+	_ = newClient.Close()
+	newEndpoint.stop(t, ctx)
+
+	crossThreadWrites := ledger.crossThreadWrites(oldThread.ThreadID, newThread.ThreadID)
+	storeCorruptions := generationStoreCorruptions(stateDomain,
+		[]generationThreadSnapshot{
+			{ThreadID: oldSnapshot.ThreadID, TurnID: oldSnapshot.TurnID},
+			{ThreadID: newSnapshot.ThreadID, TurnID: newSnapshot.TurnID},
+			{ThreadID: oldRestartSnapshot.ThreadID, TurnID: oldRestartSnapshot.TurnID},
+			{ThreadID: newRestartSnapshot.ThreadID, TurnID: newRestartSnapshot.TurnID},
+		}, oldThread.ThreadID, oldTurn, newThread.ThreadID, newTurn)
+	ambientMutations := ledger.ambientMutations()
+	bundleVersionTuple, bundleLaunches := bundleVersions(t, ctx, ledger, oldLease, newLease)
+	evidence := codexgeneration.QualificationEvidence{
+		SharedStateDomain: true, DistinctPrivateEndpoints: oldSocket != newSocket,
+		DistinctThreadCreateTurn: true, DistinctThreadReadList: true, CrashRestart: true,
+		CrossThreadWrites: crossThreadWrites, StoreCorruptions: storeCorruptions, LiveOwnerResumeWrites: liveOwnerResumeWrites,
+		OldStoppedBeforeResume: true, PersistedResumeSnapshot: true,
+		SharedAuthConfigPrivate:   sharedConfigPrivate(t, stateDomain),
+		BundleSourceRemovalLaunch: bundleLaunches && bundleVersionTuple == "0.152.0/0.152.1",
+		BundleDriftRefused:        bundleDriftRefused, ProtocolMismatchRefused: protocolMismatchRefused, AmbientMutations: ambientMutations,
+	}
+	result := codexgeneration.EvaluateQualification(codexgeneration.VersionPair{Old: "0.152.0", New: "0.152.1"}, evidence)
+	if result.Verdict != codexgeneration.VerdictYes {
+		t.Fatalf("generation qualification: %+v", result)
+	}
+	raw, err := result.JSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := codexgeneration.DecodeQualificationResult(raw)
+	if err != nil || reopened != result {
+		t.Fatalf("content-free receipt reopen=%+v err=%v", reopened, err)
+	}
+	t.Logf("generation-qualification=%s", raw)
+
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatal(err)
+	}
+	rootRemoved = true
+	if _, err := os.Lstat(root); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("exact cleanup incomplete: %v", err)
+	}
+	if err := os.RemoveAll(bundleRoot); err != nil {
+		t.Fatal(err)
+	}
+	bundleRootRemoved = true
+	if _, err := os.Lstat(bundleRoot); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("exact bundle cleanup incomplete: %v", err)
+	}
+}
+
+type generationProcessRecord struct {
+	Isolated   bool
+	Operation  string
+	Generation string
+}
+
+type generationProviderRecord struct {
+	Generation string
+	Operation  string
+	ThreadID   string
+	OldStopped bool
+}
+
+type generationConformanceLedger struct {
+	mu         sync.Mutex
+	process    []generationProcessRecord
+	provider   []generationProviderRecord
+	oldStopped bool
+}
+
+func (ledger *generationConformanceLedger) recordProcess(isolated bool, operation, generation string) {
+	ledger.mu.Lock()
+	defer ledger.mu.Unlock()
+	ledger.process = append(ledger.process, generationProcessRecord{Isolated: isolated, Operation: operation, Generation: generation})
+}
+
+func (ledger *generationConformanceLedger) recordFilesystem(isolated bool, operation string) {
+	ledger.recordProcess(isolated, operation, "filesystem")
+}
+
+func (ledger *generationConformanceLedger) recordProvider(generation, operation, threadID string) {
+	ledger.mu.Lock()
+	defer ledger.mu.Unlock()
+	ledger.provider = append(ledger.provider, generationProviderRecord{
+		Generation: generation, Operation: operation, ThreadID: threadID, OldStopped: ledger.oldStopped,
+	})
+}
+
+func (ledger *generationConformanceLedger) markOldStopped() {
+	ledger.mu.Lock()
+	defer ledger.mu.Unlock()
+	ledger.oldStopped = true
+}
+
+func (ledger *generationConformanceLedger) ambientMutations() int {
+	ledger.mu.Lock()
+	defer ledger.mu.Unlock()
+	count := 0
+	for _, record := range ledger.process {
+		if !record.Isolated {
+			count++
+		}
+	}
+	return count
+}
+
+func (ledger *generationConformanceLedger) liveOwnerResumeWrites(oldThread string) int {
+	ledger.mu.Lock()
+	defer ledger.mu.Unlock()
+	count := 0
+	for _, record := range ledger.provider {
+		if record.Generation == "new" && record.Operation == "thread-resume" && record.ThreadID == oldThread && !record.OldStopped {
+			count++
+		}
+	}
+	return count
+}
+
+func (ledger *generationConformanceLedger) crossThreadWrites(oldThread, newThread string) int {
+	ledger.mu.Lock()
+	defer ledger.mu.Unlock()
+	count := 0
+	expected := map[string]int{
+		"old/thread-start/" + oldThread:             1,
+		"new/thread-start/" + newThread:             1,
+		"old/turn-start/" + oldThread:               1,
+		"new/turn-start/" + newThread:               1,
+		"old/thread-resume/" + oldThread:            1,
+		"new/thread-resume/" + newThread:            1,
+		"new/thread-resume-after-stop/" + oldThread: 1,
+	}
+	got := make(map[string]int)
+	for _, record := range ledger.provider {
+		operation := record.Operation
+		if operation == "thread-resume" && record.OldStopped {
+			operation += "-after-stop"
+		}
+		key := record.Generation + "/" + operation + "/" + record.ThreadID
+		got[key]++
+		if _, ok := expected[key]; !ok {
+			count++
+		}
+	}
+	for key, want := range expected {
+		if got[key] != want {
+			if got[key] > want {
+				count += got[key] - want
+			} else {
+				count += want - got[key]
+			}
+		}
+	}
+	return count
+}
+
+type generationThreadSnapshot struct {
+	ThreadID string
+	TurnID   string
+}
+
+func generationStoreCorruptions(stateDomain string, snapshots []generationThreadSnapshot, oldThread, oldTurn, newThread, newTurn string) int {
+	corruptions := 0
+	want := []generationThreadSnapshot{
+		{ThreadID: oldThread, TurnID: oldTurn}, {ThreadID: newThread, TurnID: newTurn},
+		{ThreadID: oldThread, TurnID: oldTurn}, {ThreadID: newThread, TurnID: newTurn},
+	}
+	if len(snapshots) != len(want) {
+		corruptions++
+	} else {
+		for index := range want {
+			if snapshots[index] != want[index] {
+				corruptions++
+			}
+		}
+	}
+	rolloutCounts := map[string]int{oldThread: 0, newThread: 0}
+	err := filepath.WalkDir(filepath.Join(stateDomain, "sessions"), func(_ string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.Type().IsRegular() || !strings.HasPrefix(entry.Name(), "rollout-") || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			return nil
+		}
+		for threadID := range rolloutCounts {
+			if strings.Contains(entry.Name(), threadID) {
+				rolloutCounts[threadID]++
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		corruptions++
+	}
+	for _, count := range rolloutCounts {
+		if count != 1 {
+			corruptions++
+		}
+	}
+	return corruptions
+}
+
+type privateGeneration struct {
+	command    *exec.Cmd
+	exited     chan error
+	socket     string
+	closed     bool
+	readyInfo  fs.FileInfo
+	ledger     *generationConformanceLedger
+	generation string
+}
+
+func startPrivateGeneration(t *testing.T, ctx context.Context, binary, stateDomain, socket string, ledger *generationConformanceLedger, generation string) *privateGeneration {
+	t.Helper()
+	command := exec.CommandContext(ctx, binary, "app-server", "--listen", "unix://"+socket) // #nosec G204 -- exact verified lease binary and private socket.
+	command.Env = isolatedEnvironment(os.Environ(), stateDomain)
+	command.Stdout, command.Stderr = &boundedBuffer{}, &boundedBuffer{}
+	if err := command.Start(); err != nil {
+		t.Fatalf("start private generation: %v", err)
+	}
+	ledger.recordProcess(pathWithin(filepath.Dir(stateDomain), socket), "endpoint-start", generation)
+	endpoint := &privateGeneration{command: command, exited: make(chan error, 1), socket: socket, ledger: ledger, generation: generation}
+	go func() { endpoint.exited <- command.Wait() }()
+	waitForGenerationSocket(t, ctx, endpoint)
+	return endpoint
+}
+
+func waitForGenerationSocket(t *testing.T, ctx context.Context, endpoint *privateGeneration) {
+	t.Helper()
+	barrierCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	for {
+		select {
+		case err := <-endpoint.exited:
+			endpoint.closed = true
+			t.Fatalf("private generation exited before ready: %v", err)
+		default:
+		}
+		if info, err := os.Lstat(endpoint.socket); err == nil && info.Mode()&os.ModeSocket != 0 {
+			client, openErr := codexappserver.OpenPrivateUnix(barrierCtx, endpoint.socket, time.Second, "generation-qualification", true)
+			if openErr == nil {
+				endpoint.readyInfo = info
+				_ = client.Close()
+				return
+			}
+		}
+		select {
+		case <-barrierCtx.Done():
+			t.Fatal("private generation readiness barrier timed out")
+		default:
+			runtime.Gosched()
+		}
+	}
+}
+
+func (endpoint *privateGeneration) crash(t *testing.T, ctx context.Context) {
+	t.Helper()
+	if endpoint.closed {
+		return
+	}
+	endpoint.ledger.recordProcess(true, "endpoint-crash", endpoint.generation)
+	if err := endpoint.command.Process.Kill(); err != nil {
+		t.Fatalf("crash exact private generation: %v", err)
+	}
+	endpoint.waitGone(t, ctx)
+}
+
+func (endpoint *privateGeneration) stop(t *testing.T, ctx context.Context) {
+	t.Helper()
+	if endpoint.closed {
+		return
+	}
+	endpoint.ledger.recordProcess(true, "endpoint-stop", endpoint.generation)
+	if err := endpoint.command.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("stop exact private generation: %v", err)
+	}
+	endpoint.waitGone(t, ctx)
+}
+
+func (endpoint *privateGeneration) waitGone(t *testing.T, ctx context.Context) {
+	t.Helper()
+	barrierCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	select {
+	case <-endpoint.exited:
+		endpoint.closed = true
+	case <-barrierCtx.Done():
+		t.Fatal("private generation process exit barrier timed out")
+	}
+	info, err := os.Lstat(endpoint.socket)
+	if errors.Is(err, fs.ErrNotExist) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("observe private generation socket: %v", err)
+	}
+	if !endpoint.closed || endpoint.readyInfo == nil || !os.SameFile(endpoint.readyInfo, info) {
+		t.Fatal("refusing to remove a replacement private generation socket")
+	}
+	if err := os.Remove(endpoint.socket); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("remove exact stopped private socket: %v", err)
+	}
+	if _, err := os.Lstat(endpoint.socket); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("exact stopped private socket remains: %v", err)
+	}
+}
+
+func (endpoint *privateGeneration) cleanup(t *testing.T) {
+	t.Helper()
+	if endpoint == nil || endpoint.closed {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	endpoint.stop(t, ctx)
+}
+
+type observedGenerationClient struct {
+	*codexappserver.Client
+	generation string
+	ledger     *generationConformanceLedger
+}
+
+func openPrivateGeneration(t *testing.T, ctx context.Context, socket, generation string, ledger *generationConformanceLedger) *observedGenerationClient {
+	t.Helper()
+	client, err := codexappserver.OpenPrivateUnix(ctx, socket, 10*time.Second, "generation-qualification", true)
+	if err != nil {
+		t.Fatalf("open private generation: %v", err)
+	}
+	return &observedGenerationClient{Client: client, generation: generation, ledger: ledger}
+}
+
+func (client *observedGenerationClient) StartThread(ctx context.Context, workspace string, roots []string) (codexappserver.ThreadBinding, error) {
+	binding, err := client.Client.StartThread(ctx, workspace, roots)
+	client.ledger.recordProvider(client.generation, "thread-start", binding.ThreadID)
+	return binding, err
+}
+
+func (client *observedGenerationClient) StartTurn(ctx context.Context, threadID, prompt, requestKey string) (string, error) {
+	client.ledger.recordProvider(client.generation, "turn-start", threadID)
+	return client.Client.StartTurn(ctx, threadID, prompt, requestKey)
+}
+
+func (client *observedGenerationClient) ResumeThread(ctx context.Context, threadID, workspace string, roots []string) (codexappserver.ThreadBinding, error) {
+	client.ledger.recordProvider(client.generation, "thread-resume", threadID)
+	return client.Client.ResumeThread(ctx, threadID, workspace, roots)
+}
+
+func createConcurrentGenerationThreads(t *testing.T, ctx context.Context, oldClient, newClient *observedGenerationClient, workspace string) (codexappserver.ThreadBinding, codexappserver.ThreadBinding) {
+	t.Helper()
+	var oldThread, newThread codexappserver.ThreadBinding
+	var oldErr, newErr error
+	var group sync.WaitGroup
+	group.Add(2)
+	go func() { defer group.Done(); oldThread, oldErr = oldClient.StartThread(ctx, workspace, nil) }()
+	go func() { defer group.Done(); newThread, newErr = newClient.StartThread(ctx, workspace, nil) }()
+	group.Wait()
+	if oldErr != nil || newErr != nil {
+		t.Fatalf("concurrent thread/start old=%v new=%v", oldErr, newErr)
+	}
+	return oldThread, newThread
+}
+
+func turnConcurrentGenerationThreads(t *testing.T, ctx context.Context, oldClient, newClient *observedGenerationClient, oldThread, newThread string) (string, string) {
+	t.Helper()
+	var oldTurn, newTurn string
+	var oldErr, newErr error
+	var group sync.WaitGroup
+	group.Add(2)
+	go func() {
+		defer group.Done()
+		oldTurn, oldErr = oldClient.StartTurn(ctx, oldThread, "Reply with exactly OLD_OK. Do not use tools.", "generation-old-canary")
+	}()
+	go func() {
+		defer group.Done()
+		newTurn, newErr = newClient.StartTurn(ctx, newThread, "Reply with exactly NEW_OK. Do not use tools.", "generation-new-canary")
+	}()
+	group.Wait()
+	if oldErr != nil || newErr != nil {
+		t.Fatalf("concurrent turn/start old=%v new=%v", oldErr, newErr)
+	}
+	return oldTurn, newTurn
+}
+
+func waitForGenerationTurn(t *testing.T, ctx context.Context, client *codexappserver.Client, threadID, turnID string) codexappserver.LifecycleSnapshot {
+	t.Helper()
+	barrierCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+	for {
+		select {
+		case <-barrierCtx.Done():
+			t.Fatal("generation turn completion barrier timed out")
+		case notification, ok := <-client.Notifications():
+			if !ok {
+				t.Fatal("generation notification stream closed before turn completion")
+			}
+			event, recognized, err := codexappserver.DecodeLifecycleEvent(notification)
+			if err != nil {
+				t.Fatalf("decode generation lifecycle event: %v", err)
+			}
+			if !recognized || event.ThreadID != threadID || event.TurnID != turnID {
+				continue
+			}
+			if event.Kind == codexappserver.LifecycleApprovalPending {
+				_, _ = client.InterruptExactTurn(barrierCtx, threadID, turnID)
+				t.Fatal("qualification turn requested approval")
+			}
+			if event.Kind != codexappserver.LifecycleTurnCompleted {
+				continue
+			}
+			switch event.TurnState {
+			case codexappserver.TurnStateCompleted:
+				return codexappserver.LifecycleSnapshot{ThreadID: threadID, TurnID: turnID, TurnState: event.TurnState}
+			case codexappserver.TurnStateFailed, codexappserver.TurnStateInterrupted:
+				t.Fatalf("qualification turn ended %s", event.TurnState)
+			default:
+				t.Fatalf("qualification turn ended with unknown state %s", event.TurnState)
+			}
+		}
+	}
+}
+
+func assertGenerationReadList(t *testing.T, ctx context.Context, client *observedGenerationClient, ownThread, siblingThread string) {
+	t.Helper()
+	thread, err := client.ReadCatalogThread(ctx, ownThread)
+	if err != nil || thread.ID != ownThread {
+		t.Fatalf("read own thread=%q err=%v", thread.ID, err)
+	}
+	page, err := client.ListCatalogThreads(ctx, codexappserver.CatalogQuery{})
+	if err != nil {
+		t.Fatalf("list shared state catalog: %v", err)
+	}
+	for _, exact := range []string{ownThread, siblingThread} {
+		count := 0
+		for _, got := range page.Threads {
+			if got.ID == exact {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Fatalf("shared catalog exact thread count=%d want=1", count)
+		}
+	}
+}
+
+func exactGenerationBinary(t *testing.T, envName, wantVersion string) string {
+	t.Helper()
+	path := filepath.Clean(strings.TrimSpace(os.Getenv(envName)))
+	if !filepath.IsAbs(path) {
+		t.Fatalf("%s must be absolute", envName)
+	}
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&0o111 == 0 {
+		t.Fatalf("%s must name an executable regular file", envName)
+	}
+	command := exec.Command(path, "--version") // #nosec G204 -- explicit installed candidate.
+	command.Env = isolatedEnvironment(os.Environ(), filepath.Join(t.TempDir(), "version-home"))
+	output, err := command.Output()
+	if err != nil || !strings.HasSuffix(strings.TrimSpace(string(output)), wantVersion) {
+		t.Fatalf("%s is not exact Codex %s", envName, wantVersion)
+	}
+	return path
+}
+
+func copySharedCodexConfig(t *testing.T, source, target string) {
+	t.Helper()
+	for _, name := range []string{"auth.json", "config.toml"} {
+		input := filepath.Join(source, name)
+		info, err := os.Stat(input)
+		if err != nil || !info.Mode().IsRegular() || info.Size() <= 0 {
+			t.Fatalf("shared Codex %s source is unavailable", name)
+		}
+		in, err := os.Open(input) // #nosec G304 -- explicit operator source and closed filenames.
+		if err != nil {
+			t.Fatalf("open shared Codex %s", name)
+		}
+		out, err := os.OpenFile(filepath.Join(target, name), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- exact private fixture target.
+		if err != nil {
+			_ = in.Close()
+			t.Fatalf("create private shared Codex %s", name)
+		}
+		_, copyErr := io.Copy(out, in)
+		inErr, outErr := in.Close(), out.Close()
+		if copyErr != nil || inErr != nil || outErr != nil {
+			t.Fatalf("copy shared Codex %s failed", name)
+		}
+	}
+}
+
+func sharedConfigPrivate(t *testing.T, target string) bool {
+	t.Helper()
+	for _, name := range []string{"auth.json", "config.toml"} {
+		info, err := os.Stat(filepath.Join(target, name))
+		if err != nil || info.Mode().Perm() != 0o600 || info.Size() <= 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func leaseInstalledBundle(t *testing.T, store, binary, version string, protocol codexbundle.ProtocolRange) codexbundle.Lease {
+	t.Helper()
+	real, err := filepath.EvalSymlinks(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseRoot := filepath.Dir(filepath.Dir(real))
+	specs := []codexbundle.ArtifactSpec{
+		{Path: "bin/codex", Roles: []codexbundle.Role{codexbundle.RoleServer, codexbundle.RoleTUI}},
+		{Path: "bin/codex-code-mode-host", Roles: []codexbundle.Role{codexbundle.RoleHelper}},
+		{Path: "codex-path/rg", Roles: []codexbundle.Role{codexbundle.RoleHelper}},
+		{Path: "codex-resources/bwrap", Roles: []codexbundle.Role{codexbundle.RoleHelper}},
+	}
+	source := filepath.Join(filepath.Dir(store), "source-"+version)
+	for _, spec := range specs {
+		from, to := filepath.Join(releaseRoot, filepath.FromSlash(spec.Path)), filepath.Join(source, filepath.FromSlash(spec.Path))
+		if err := os.MkdirAll(filepath.Dir(to), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(from, to); err != nil {
+			t.Fatalf("stage installed bundle source link: %v", err)
+		}
+	}
+	manifest, err := codexbundle.Inspect(source, version, protocol, specs)
+	if err != nil {
+		t.Fatalf("inspect installed bundle: %v", err)
+	}
+	lease, err := codexbundle.Create(store, source, manifest, protocol)
+	if err != nil {
+		t.Fatalf("lease installed bundle: %v", err)
+	}
+	if err := os.RemoveAll(source); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(source); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("bundle source removal failed: %v", err)
+	}
+	return lease
+}
+
+func bundleVersions(t *testing.T, ctx context.Context, ledger *generationConformanceLedger, oldLease, newLease codexbundle.Lease) (string, bool) {
+	t.Helper()
+	versions := make([]string, 0, 2)
+	for _, lease := range []codexbundle.Lease{oldLease, newLease} {
+		paths := lease.Paths(codexbundle.RoleTUI)
+		if len(paths) != 1 {
+			t.Fatal("bundle has no exact TUI")
+		}
+		command := exec.Command(paths[0], "--version") // #nosec G204 -- exact verified leased path.
+		ledger.recordProcess(pathWithin(lease.Root, paths[0]), "leased-tui-version", lease.Manifest.Version)
+		output, err := command.Output()
+		if err != nil {
+			return "", false
+		}
+		fields := strings.Fields(string(output))
+		if len(fields) == 0 {
+			return "", false
+		}
+		versions = append(versions, fields[len(fields)-1])
+		helpers := lease.Paths(codexbundle.RoleHelper)
+		if len(helpers) != 3 || !slices.ContainsFunc(helpers, func(path string) bool { return filepath.Base(path) == "codex-code-mode-host" }) {
+			return "", false
+		}
+		for _, helper := range helpers {
+			flag := "--version"
+			if filepath.Base(helper) == "codex-code-mode-host" {
+				flag = "--help"
+			}
+			helperCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			ledger.recordProcess(pathWithin(lease.Root, helper), "leased-helper-launch", lease.Manifest.Version)
+			err := exec.CommandContext(helperCtx, helper, flag).Run() // #nosec G204 -- exact verified leased helper path.
+			cancel()
+			if err != nil {
+				return "", false
+			}
+		}
+	}
+	return strings.Join(versions, "/"), true
+}


### PR DESCRIPTION
## Summary

- add exact durable `stateDomainID + endpointGenerationID` refs and live `brokerRuntimeID + connectionEpoch + bindingEpoch` authority, independent of Pane activation generation
- add a bounded two-slot generation model, mutation-free upgrade plan, strict content-free qualification receipt, and fail-closed Phase 2+ gate
- add content-addressed server/TUI/helper bundle leases plus fixed 0.152.0/0.152.1 isolated shared-state conformance

## Acceptance

| # | Result | Evidence |
| --- | --- | --- |
| 1 | PASS | Endpoint and authority refs round-trip byte-exactly; Pane activation generation remains independent; legacy refs infer zero generation fields. |
| 2 | PASS | Exhaustive state-space test and fuzz property reject multiple-current, multiple-draining, over-capacity, domain/obligation, and other invalid topologies. |
| 3 | PASS | Equal-number cross-generation epochs and legacy activation/durable refs authorize zero provider/Registry/tmux writes. |
| 4 | PASS | Repeated plans are identical, report exact ordered blockers, and retain explicit zero Registry/provider/tmux/process/current-pointer mutation counters. |
| 5 | PASS | Shared auth/config are copied only into the isolated state domain at mode 0600; receipts retain closed booleans/counters/version/verdict/reason fields only. |
| 6 | YES | Exact old/new private endpoints concurrently create/turn/read/list distinct threads, survive restart, and report `crossThreadWrites=0`, `storeCorruptions=0`. |
| 7 | YES | Successor same-thread resume writes remain zero while old owns the thread; after observed old stop, completed persisted resume and exact snapshot succeed. |
| 8 | PASS | Content-addressed server/TUI/helper bundles launch after source removal; drift and protocol mismatch refuse before final commit. |
| 9 | NOT TRIGGERED | Both shared-state rows are YES. Decision-table tests prove any NO emits a content-free receipt, selects `single-endpoint-journaled-handover`, and keeps the unsafe pool and Phase 2+ closed. |

Fixed qualification tuple: Codex 0.152.0 / 0.152.1. Ambient mutations: 0. The test removes inherited `TMUX`/`TMUX_PANE`, uses one owned state root, two private sockets, bounded semantic barriers, and exact cleanup.

## Validation

- [x] `make fmt`
- [x] `make fix`
- [x] `TMPDIR=/var/tmp GOTMPDIR=/var/tmp make test`
- [x] targeted metadata/model/app-server/bundle/app invariant suite
- [x] fixed 0.152.0/0.152.1 installed isolated generation qualification
- [x] `make test-integration`
- [x] `make test-e2e`
- [x] required CI jobs and aggregate `Test`

## Scope audit

Included only additive schema/model/PBT, read-only planning, qualification fixture/receipt, immutable bundle lease, a test-only explicit private Unix dial, and workflow documentation. Existing Codex invariant tests and empty-prompt expectations remain unchanged.

Excluded: endpoint lifecycle/current-pointer mutation, multi-endpoint broker dial, Agent create/resume behavior changes, store copy/merge/import, Phase 1+ implementation, and unrelated cleanup. Exact-current unmanaged endpoints remain attach-only; no stop/restart/kill/adopt path was added.

## Roadmap / contract trace

- Roadmap: `Codex app-server generation pool and managed Agent continuity` — Phase 0, `Generation model, state-domain qualification, read-only plan`
- C-1: generation-pinned routing identity and composite authority
- C-2: bounded current/draining topology and retirement obligations
- C-4: qualification gate and single-endpoint journaled-handover fallback

## Globalization

- [x] No localized UI/CLI surface was added; new strings are internal schema/refusal tokens, test diagnostics, and English engineering documentation.

