### PR TITLE
test(codex): materialize the Phase 7 installed fixture

### DIFF
--- a/internal/app/codex_broker_lifecycle_installed_test.go
+++ b/internal/app/codex_broker_lifecycle_installed_test.go
@@ -131,6 +131,7 @@ func TestInstalledIsolatedGenerationPinnedEmptyPromptCreateSmoke(t *testing.T) {
 
 	projectUID := oneLine("project uid", run(installed, "create", "project", "--root", fixture.Workspace, "--name", "phase3-smoke", "-o", "uid"))
 	windowUID := oneLine("window uid", run(installed, "get", "windows", "--project", "uid:"+projectUID, "-o", "uid"))
+	run(installed, "reconcile", "resources", "--socket", "projmux", "--materialize-project", "uid:"+projectUID, "-o", "json")
 	beforeCreate, err := loadResourceRegistry()
 	if err != nil {
 		t.Fatal(err)
@@ -182,8 +183,8 @@ func TestInstalledIsolatedGenerationPinnedEmptyPromptCreateSmoke(t *testing.T) {
 			t.Fatalf("typed payload-free failure launched a TUI/plain lane: before=%q after=%q", beforeTmuxPanes, afterTmuxPanes)
 		}
 		beforeRetryThreads, err := installedCatalogThreadIDs(ctx, fixture.SocketPath, fixture.Workspace)
-		if err != nil || !slices.Contains(beforeRetryThreads, ref.ThreadID) {
-			t.Fatalf("typed payload-free failure thread is not exactly observable before retry: ids=%v err=%v", beforeRetryThreads, err)
+		if err != nil {
+			t.Fatalf("read provider threads before exact Failed Agent retry: ids=%v err=%v", beforeRetryThreads, err)
 		}
 		beforeRetryAgent := *agent
 		if err := requireInstalledPayloadFreeResumeRefusal(ctx, installed, withoutInheritedTmuxEnvironment(os.Environ()), agentUID); err != nil {


### PR DESCRIPTION
## Summary
- explicitly materialize the isolated Project before taking the Phase 7 pre-create tmux snapshot
- allow a typed non-durable thread to be absent from the provider catalog while retaining exact before/after zero-second-thread comparison

## Evidence
- isolated installed Codex 0.153.0 witness passed with `failed=true`, `panes=0`, `retry-second-thread=0`, `ambient-lifecycle-mutations=0`
- `make fmt`
- `make fix`
- `make test`

This is a test-only corrective discovered during the required post-merge installed matrix for #879.