### PR TITLE
feat(codex): record why the app-server observer loses its epoch

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -771,6 +771,43 @@
   historical names are not persisted or reconstructed after cascade. Existing
   title suppression/precedence, provider settlement/status, exact routing,
   and first-frame bound suites remain the authority for those unchanged paths.
+### Codex observer disconnect-reason Phase 0 tests
+
+- `TestCodexObserverEventLoopExitsCarryTheirOwnReasonToken` owns the exit-path
+  table: every way out of the observer event loop publishes the vocabulary
+  token for that path, and the authority writes it pins prove the recovery
+  strategy did not move when the tokens became precise. A cancelled observer,
+  a closed notification stream, and a real endpoint disconnect no longer share
+  a word.
+- `TestCodexObserverExitPathsAreOneToOneWithTokens` owns the converse
+  property: the exit tokens are distinct, neither the `unrecorded` nor the
+  retired `disconnected` bucket is reachable from an exit, and `hold` is a
+  stored decision rather than a comparison against the published reason.
+- `TestCodexObserverReasonVocabularyIsClosed` owns the single vocabulary.
+  `codexNativeReason`'s four open-failure tokens are members of it, every
+  token round-trips through `safeCodexAuthorityReason`, and anything outside
+  it renders as `bounded reason unavailable`.
+- `TestCodexBrokerEpochRecordsWhyItsStreamClosed` owns the close cause at the
+  layer that knows it. All five calls that end a broker epoch record a
+  different token, which is what separates an upstream connection that went
+  away from a rotated barrier, a revoked binding, a backlog overflow, and an
+  observer that closed its own connection.
+- `TestCodexObserverJournalRecordsConnectDisconnectReconnectInOrder` owns the
+  durable history the pane option cannot hold: connect, disconnect, and
+  reconnect records in time order, each carrying the epoch label, and no
+  fallback record behind a held disconnect.
+- `TestCodexObserverJournalRecordFieldsAreWhitelisted` is the negative audit.
+  It names every column an observer record may carry and refuses an
+  out-of-vocabulary reason and an unnamed transition.
+- `TestCodexObserverJournalCoalescesRepeatedTransitions` owns the write-rate
+  boundary on the shared `ai-ingest.log` sink: one record per
+  (transition, reason) pair per window, with the suppressed count riding the
+  next record so the flap rate stays readable.
+- `TestManagedCodexAuthorityDoctorSeparatesFlappingFrozenAndStopped` owns the
+  operator surface. The census carries a count-only reason distribution and
+  `doctor` renders it, which is what tells flapping, frozen, and stopped
+  apart; `TestManagedCodexAuthorityCensusSeparatesDeclaredFromUnexplainedFallback`
+  keeps that distribution pinned alongside the source counts.
 
 ## Review Checklist
 - The branch stays within its stated scope.

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -803,6 +803,17 @@
   boundary on the shared `ai-ingest.log` sink: one record per
   (transition, reason) pair per window, with the suppressed count riding the
   next record so the flap rate stays readable.
+- `test/e2e/codex-lifecycle.sh` (C01) pins the exact disconnect token at its
+  disconnect projection barrier and at the reconnect-gap hook comparison. It
+  waited on the literal `disconnected` before, which was the bucket published
+  when the observer recorded no reason at all; killing the exact E1 proxy takes
+  the upstream connection away, so the projection now reads
+  `endpoint-suspended`. The barrier is still an exact string match, so a path
+  that stops capturing its reason lands on a different token and fails it. That
+  barrier also now gates on `@projmux_attention_state`: the projection writes
+  its three pane options as three separate `set-option` calls, so releasing on
+  the first two let the five-field assertion 46 lines later read a torn
+  projection under load. The assertion is unchanged and still owns the verdict.
 - `TestManagedCodexAuthorityDoctorSeparatesFlappingFrozenAndStopped` owns the
   operator surface. The census carries a count-only reason distribution and
   `doctor` renders it, which is what tells flapping, frozen, and stopped

--- a/internal/app/ai_ingest.go
+++ b/internal/app/ai_ingest.go
@@ -75,6 +75,14 @@ type aiIngestLogEntry struct {
 	ThreadID  string `json:"thread_id,omitempty"`
 	SessionID string `json:"session_id,omitempty"`
 	TurnID    string `json:"turn_id,omitempty"`
+	// Epoch is the observer epoch label a lifecycle transition belongs to. It
+	// is what makes two adjacent records comparable: the same label twice is
+	// one epoch reporting twice, a new label is a new connection.
+	Epoch string `json:"epoch,omitempty"`
+	// Repeat counts identical transitions coalesced into this record by the
+	// observer journal's rate window. Zero, and therefore omitted, means this
+	// record stands for exactly one transition.
+	Repeat int `json:"repeat,omitempty"`
 }
 
 func (c *aiCommand) runIngest(args []string, stdout, stderr io.Writer) error {

--- a/internal/app/ai_ingest_codex_native.go
+++ b/internal/app/ai_ingest_codex_native.go
@@ -89,6 +89,167 @@ const (
 	codexNativeLifecycleIngestRoute = "codex-broker-watch"
 )
 
+// codexObserverReason is the closed vocabulary for every reason a managed
+// Codex observer publishes: the value of the @projmux_codex_authority_reason
+// pane option, and the reason column of the observer transition records this
+// process appends to ai-ingest.log.
+//
+// It is deliberately one vocabulary. Before this type existed the event loop
+// carried a literal default that meant "nothing recorded why this epoch
+// ended", and a separate four-token set derived from open errors lived beside
+// it, so a Pane could publish a bucket name as though it were an observation.
+// Every producer now names a token from this list and codexObserverReasonFor
+// is the only door a foreign string comes through.
+type codexObserverReason string
+
+const (
+	// Steady-state tokens.
+	codexObserverReasonReady      codexObserverReason = "ready"
+	codexObserverReasonConnecting codexObserverReason = "connecting"
+
+	// Open, snapshot, control, and sink failures. The first four are what
+	// codexNativeReason maps one transport error onto.
+	codexObserverReasonUnsupported           codexObserverReason = "unsupported"
+	codexObserverReasonProtocolError         codexObserverReason = "protocol-error"
+	codexObserverReasonTimeout               codexObserverReason = "timeout"
+	codexObserverReasonUnavailable           codexObserverReason = "unavailable"
+	codexObserverReasonSinkError             codexObserverReason = "sink-error"
+	codexObserverReasonControlUnavailable    codexObserverReason = "control-unavailable"
+	codexObserverReasonGenerationUnavailable codexObserverReason = codexNativeReasonGenerationUnavailable
+	codexObserverReasonThreadUnloaded        codexObserverReason = "thread-unloaded"
+
+	// Event-loop exits. Each token names exactly one way out of the loop, and
+	// the three the observer used to collapse into one bucket are separated
+	// here: a cancelled observer, a notification stream that closed for a
+	// cause the broker epoch recorded, and a stream that closed with no cause
+	// recorded at all.
+	codexObserverReasonCancelled    codexObserverReason = "observer-cancelled"
+	codexObserverReasonStreamClosed codexObserverReason = "stream-closed"
+
+	// Notification-stream close causes. These come from the broker epoch, not
+	// from a guess made above it, and they are what separates "the upstream
+	// connection went away" from "the broker replaced this epoch" from "the
+	// binding was revoked". Which one appears is the answer to who closed the
+	// stream.
+	codexObserverReasonEndpointSuspended codexObserverReason = "endpoint-suspended"
+	codexObserverReasonEpochRotated      codexObserverReason = "epoch-rotated"
+	codexObserverReasonBindingRevoked    codexObserverReason = "binding-revoked"
+	codexObserverReasonBacklogOverflow   codexObserverReason = "backlog-overflow"
+	codexObserverReasonEpochClosed       codexObserverReason = "epoch-closed"
+
+	// Supervisor-side tokens. The parent process writes these when the child
+	// observer never reached its own authority write.
+	codexObserverReasonObserverTimeout     codexObserverReason = "observer-timeout"
+	codexObserverReasonObserverStartFailed codexObserverReason = "observer-start-failed"
+	codexObserverReasonObserverExited      codexObserverReason = "observer-exited"
+	codexObserverReasonObserverUnavailable codexObserverReason = "observer-unavailable"
+	codexObserverReasonNoActiveEpoch       codexObserverReason = "no active native epoch"
+
+	// codexObserverReasonUnrecorded is the explicit "nothing recorded why"
+	// bucket. It exists so that state is nameable and countable instead of
+	// being disguised as an endpoint disconnect. No exit path may map to it;
+	// codexObserverExitReasons pins that, and seeing it in the field means a
+	// producer was added without a token.
+	codexObserverReasonUnrecorded codexObserverReason = "unrecorded"
+
+	// codexObserverReasonRetired is the pre-instrumentation literal default.
+	// It is retained for reading only: pane options written by an older binary
+	// still carry it, and reading them truthfully is better than rendering
+	// them as out-of-vocabulary. Nothing in this package emits it.
+	codexObserverReasonRetired codexObserverReason = "disconnected"
+)
+
+// codexObserverReasons is the whole vocabulary. safeCodexAuthorityReason and
+// every record writer validate against exactly this list.
+var codexObserverReasons = []codexObserverReason{
+	codexObserverReasonReady,
+	codexObserverReasonConnecting,
+	codexObserverReasonUnsupported,
+	codexObserverReasonProtocolError,
+	codexObserverReasonTimeout,
+	codexObserverReasonUnavailable,
+	codexObserverReasonSinkError,
+	codexObserverReasonControlUnavailable,
+	codexObserverReasonGenerationUnavailable,
+	codexObserverReasonThreadUnloaded,
+	codexObserverReasonCancelled,
+	codexObserverReasonStreamClosed,
+	codexObserverReasonEndpointSuspended,
+	codexObserverReasonEpochRotated,
+	codexObserverReasonBindingRevoked,
+	codexObserverReasonBacklogOverflow,
+	codexObserverReasonEpochClosed,
+	codexObserverReasonObserverTimeout,
+	codexObserverReasonObserverStartFailed,
+	codexObserverReasonObserverExited,
+	codexObserverReasonObserverUnavailable,
+	codexObserverReasonNoActiveEpoch,
+	codexObserverReasonUnrecorded,
+	codexObserverReasonRetired,
+}
+
+// codexObserverReasonFor admits one foreign string into the vocabulary. It
+// returns the empty reason for anything outside it, so a caller must decide
+// what an unknown value means rather than letting it through.
+func codexObserverReasonFor(value string) codexObserverReason {
+	candidate := codexObserverReason(strings.TrimSpace(value))
+	if slices.Contains(codexObserverReasons, candidate) {
+		return candidate
+	}
+	return ""
+}
+
+// codexObserverExit is one way out of the observer event loop: the vocabulary
+// token that names that path, whether the observer itself is stopping, and
+// which recovery transition the path takes.
+//
+// hold is a stored decision rather than a comparison against the reason. The
+// diagnosis and the strategy used to be the same value, so making the
+// diagnosis more precise would have silently moved the strategy; they are now
+// decided together at each exit and kept apart afterwards.
+type codexObserverExit struct {
+	reason codexObserverReason
+	// hold suppresses provider-hook fallback and keeps the one unavailable
+	// projection published while the durable broker binding reconnects
+	// underneath this loop.
+	hold bool
+	// stopping means the observer process is going away, so no recovery
+	// attempt follows the transition.
+	stopping bool
+}
+
+var (
+	// codexObserverExitCancelled is the ctx cancellation exit. It is not an
+	// endpoint disconnect and no longer shares a token with one.
+	codexObserverExitCancelled = codexObserverExit{reason: codexObserverReasonCancelled, stopping: true}
+	// codexObserverExitProtocolError is every exit taken because a delivered
+	// frame could not be decoded or applied.
+	codexObserverExitProtocolError = codexObserverExit{reason: codexObserverReasonProtocolError}
+	// codexObserverExitThreadUnloaded is the exit taken when the reduced
+	// projection says the bound thread is gone.
+	codexObserverExitThreadUnloaded = codexObserverExit{reason: codexObserverReasonThreadUnloaded}
+)
+
+// codexObserverStreamExit is the exit for a closed notification stream.
+//
+// hold is true for every cause because the binding beneath a closed stream is
+// still reconnecting on the broker's own backoff, which is exactly the
+// strategy this path took before its cause was observable. The cause only
+// changes what is reported, never what is done.
+func codexObserverStreamExit(reason codexObserverReason) codexObserverExit {
+	if reason == "" {
+		reason = codexObserverReasonStreamClosed
+	}
+	return codexObserverExit{reason: reason, hold: true}
+}
+
+// codexLifecycleStreamCause is implemented by a connection that records why
+// its notification stream closed. Without it the observer can only report that
+// the stream ended; with it the report names who ended it.
+type codexLifecycleStreamCause interface {
+	NotificationsClosedCause() codexObserverReason
+}
+
 type codexLifecycleConnection interface {
 	Notifications() <-chan codexappserver.Notification
 	LifecycleEventsAvailable() bool
@@ -168,6 +329,19 @@ type codexNativeObserver struct {
 	reportStartup   func(codexObserverStartupResult)
 	progress        agentprogress.Reducer
 	now             func() time.Time
+	// transitions is the durable history sink. The pane option holds one
+	// current value, so without this an observer's connect/disconnect
+	// sequence is unobservable between two samples.
+	transitions codexObserverJournal
+}
+
+// journal appends one lifecycle transition to the durable sink, if one is
+// configured. A missing sink never blocks a transition.
+func (o *codexNativeObserver) journal(kind codexObserverTransition, epochLabel string, reason codexObserverReason) {
+	if o.transitions == nil {
+		return
+	}
+	o.transitions.RecordObserverTransition(o.identity, kind, epochLabel, reason)
 }
 
 func (o *codexNativeObserver) Run(ctx context.Context) error {
@@ -189,14 +363,14 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 			if ctx.Err() == nil {
 				// SetAuthority repeats the exact binding predicate. A still-current
 				// startup may fall back; a replaced runtime writes nothing.
-				o.setStartupFallback("observer-timeout")
+				o.setStartupFallback(codexObserverReasonObserverTimeout)
 			} else {
 				o.reportStartupResult(codexObserverStartupResult{Status: codexObserverStartupStale})
 			}
 			return nil
 		}
 		if err := o.clearProgress(); err != nil {
-			o.setStartupFallback("sink-error")
+			o.setStartupFallback(codexObserverReasonSinkError)
 			return err
 		}
 		openTimeout := o.openTimeout
@@ -234,7 +408,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 				}
 				continue
 			}
-			o.setStartupFallback("unsupported")
+			o.setStartupFallback(codexObserverReasonUnsupported)
 			if !waitCodexObserver(ctx, delay) {
 				return nil
 			}
@@ -281,7 +455,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 				}
 				continue
 			}
-			o.setStartupFallback("protocol-error")
+			o.setStartupFallback(codexObserverReasonProtocolError)
 			return errors.New("codex native lifecycle snapshot did not match exact binding")
 		}
 		if projection.Invalidated {
@@ -300,7 +474,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 				}
 				continue
 			}
-			transitionErr := o.applyInvalidationAndFallback(epochLabel, "thread-unloaded", projection)
+			transitionErr := o.applyInvalidationAndFallback(epochLabel, codexObserverReasonThreadUnloaded, projection)
 			_ = client.Close()
 			if transitionErr != nil {
 				return transitionErr
@@ -324,7 +498,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 			if authorityErr != nil || !authority.Valid() || !authority.Endpoint().Same(o.endpoint) || !ok || !lifecycleOK ||
 				generationSink.SetGenerationAuthority(o.identity, o.endpoint, lifecycle.State, authority) != nil {
 				_ = client.Close()
-				o.setStartupFallback(codexNativeReasonGenerationUnavailable)
+				o.setStartupFallback(codexObserverReasonGenerationUnavailable)
 				return nil
 			}
 			o.authority = &authority
@@ -355,7 +529,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 				}
 				continue
 			}
-			cleanupErr := o.invalidateAndFallback(epoch, epochLabel, "control-unavailable")
+			cleanupErr := o.invalidateAndFallback(epoch, epochLabel, codexObserverReasonControlUnavailable)
 			_ = client.Close()
 			if cleanupErr != nil {
 				return cleanupErr
@@ -382,15 +556,15 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 			if control != nil {
 				_ = control.Close()
 			}
-			cleanupErr := o.invalidateAndFallback(epoch, epochLabel, "sink-error")
+			cleanupErr := o.invalidateAndFallback(epoch, epochLabel, codexObserverReasonSinkError)
 			_ = client.Close()
 			return errors.Join(err, cleanupErr)
 		}
-		if err := o.sink.SetAuthority(o.identity, codexAuthorityControlPlane, epochLabel, "ready"); err != nil {
+		if err := o.sink.SetAuthority(o.identity, codexAuthorityControlPlane, epochLabel, string(codexObserverReasonReady)); err != nil {
 			if control != nil {
 				_ = control.Close()
 			}
-			cleanupErr := o.invalidateAndFallback(epoch, epochLabel, "sink-error")
+			cleanupErr := o.invalidateAndFallback(epoch, epochLabel, codexObserverReasonSinkError)
 			_ = client.Close()
 			return errors.Join(err, cleanupErr)
 		}
@@ -399,17 +573,20 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 				_ = control.Close()
 				control = nil
 			}
-			cleanupErr := o.invalidateAndFallback(epoch, epochLabel, "sink-error")
+			cleanupErr := o.invalidateAndFallback(epoch, epochLabel, codexObserverReasonSinkError)
 			_ = client.Close()
 			return errors.Join(err, cleanupErr)
 		}
+		o.journal(codexObserverTransitionConnected, epochLabel, codexObserverReasonReady)
 		o.reportStartupResult(codexObserverStartupResult{Status: codexObserverStartupReady, Epoch: epochLabel})
 		recovering = false
 		recoveryAttempts = 0
 
-		reconnectReason := "disconnected"
+		// The zero exit is the unrecorded bucket on purpose: if a new break
+		// were added without naming its path, the record and the pane option
+		// would both say "unrecorded" instead of impersonating a disconnect.
+		exit := codexObserverExit{reason: codexObserverReasonUnrecorded}
 		invalidated := false
-		stopAfterTransition := false
 		bindingTicker := time.NewTicker(codexObserverBindingDelay)
 		progressTicker := time.NewTicker(25 * time.Millisecond)
 		notifications := client.Notifications()
@@ -417,7 +594,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 		for {
 			select {
 			case <-ctx.Done():
-				stopAfterTransition = true
+				exit = codexObserverExitCancelled
 				break eventLoop
 			case <-bindingTicker.C:
 				if !o.sink.BindingCurrent(o.identity) {
@@ -434,7 +611,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 						_ = control.Close()
 						control = nil
 					}
-					cleanupErr := o.invalidateAndFallback(epoch, epochLabel, "sink-error")
+					cleanupErr := o.invalidateAndFallback(epoch, epochLabel, codexObserverReasonSinkError)
 					bindingTicker.Stop()
 					progressTicker.Stop()
 					_ = client.Close()
@@ -442,23 +619,24 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 				}
 			case notification, open := <-notifications:
 				if !open {
+					exit = o.streamCloseExit(client)
 					break eventLoop
 				}
 				if control != nil {
 					if controlErr := control.epoch.ApplyNotification(notification); controlErr != nil {
-						reconnectReason = "protocol-error"
+						exit = codexObserverExitProtocolError
 						break eventLoop
 					}
 				}
 				event, recognized, decodeErr := codexappserver.DecodeLifecycleEvent(notification)
 				if decodeErr != nil {
-					reconnectReason = "protocol-error"
+					exit = codexObserverExitProtocolError
 					break eventLoop
 				}
 				if !recognized {
 					progressEvent, progressRecognized, progressErr := codexappserver.DecodeProgressEvent(notification, o.currentTime())
 					if progressErr != nil {
-						reconnectReason = "protocol-error"
+						exit = codexObserverExitProtocolError
 						break eventLoop
 					}
 					if !progressRecognized {
@@ -472,7 +650,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 							_ = control.Close()
 							control = nil
 						}
-						cleanupErr := o.invalidateAndFallback(epoch, epochLabel, "sink-error")
+						cleanupErr := o.invalidateAndFallback(epoch, epochLabel, codexObserverReasonSinkError)
 						bindingTicker.Stop()
 						progressTicker.Stop()
 						_ = client.Close()
@@ -490,12 +668,12 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 				}
 				markCodexApprovalAvailability(&projection, responderAvailable)
 				if projection.Invalidated {
-					reconnectReason = "thread-unloaded"
+					exit = codexObserverExitThreadUnloaded
 					if control != nil {
 						_ = control.Close()
 						control = nil
 					}
-					if err := o.applyInvalidationAndFallback(epochLabel, reconnectReason, projection); err != nil {
+					if err := o.applyInvalidationAndFallback(epochLabel, exit.reason, projection); err != nil {
 						bindingTicker.Stop()
 						_ = client.Close()
 						return err
@@ -508,13 +686,13 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 						_ = control.Close()
 						control = nil
 					}
-					cleanupErr := o.invalidateAndFallback(epoch, epochLabel, "sink-error")
+					cleanupErr := o.invalidateAndFallback(epoch, epochLabel, codexObserverReasonSinkError)
 					bindingTicker.Stop()
 					_ = client.Close()
 					return errors.Join(err, cleanupErr)
 				}
 				if progressEvent, progressRecognized, progressErr := codexappserver.DecodeProgressEvent(notification, o.currentTime()); progressErr != nil {
-					reconnectReason = "protocol-error"
+					exit = codexObserverExitProtocolError
 					break eventLoop
 				} else if progressRecognized {
 					if !o.observeProgress(progressEvent) {
@@ -527,7 +705,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 								_ = control.Close()
 								control = nil
 							}
-							cleanupErr := o.invalidateAndFallback(epoch, epochLabel, "sink-error")
+							cleanupErr := o.invalidateAndFallback(epoch, epochLabel, codexObserverReasonSinkError)
 							bindingTicker.Stop()
 							progressTicker.Stop()
 							_ = client.Close()
@@ -538,7 +716,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 							_ = control.Close()
 							control = nil
 						}
-						cleanupErr := o.invalidateAndFallback(epoch, epochLabel, "sink-error")
+						cleanupErr := o.invalidateAndFallback(epoch, epochLabel, codexObserverReasonSinkError)
 						bindingTicker.Stop()
 						progressTicker.Stop()
 						_ = client.Close()
@@ -553,24 +731,28 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 			_ = control.Close()
 		}
 		_ = client.Close()
+		o.journal(codexObserverTransitionDisconnected, epochLabel, exit.reason)
 		if !invalidated {
+			// The broker binding survives a transient endpoint disconnect and
+			// owns the reconnect, so a closed stream keeps one deterministic
+			// unavailable projection until its replacement barrier and control
+			// endpoint are both ready; provider-hook is not reconnect
+			// authority. Every other exit falls back. The exit carries that
+			// decision, so refining a reason token cannot move it.
 			transition := o.invalidateAndFallback
-			if !stopAfterTransition && reconnectReason == "disconnected" {
-				// The broker binding survives a transient endpoint disconnect and
-				// owns the reconnect. Keep one deterministic unavailable
-				// projection until its replacement barrier and control endpoint
-				// are both ready; provider-hook is not reconnect authority.
+			if exit.hold {
 				transition = o.invalidateAndHold
 			}
-			if err := transition(epoch, epochLabel, reconnectReason); err != nil {
+			if err := transition(epoch, epochLabel, exit.reason); err != nil {
 				return err
 			}
 		}
-		if stopAfterTransition {
+		if exit.stopping {
 			return nil
 		}
 		recovering = true
 		recoveryAttempts = 0
+		o.journal(codexObserverTransitionReconnecting, epochLabel, exit.reason)
 		if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts); recoveryErr != nil {
 			return recoveryErr
 		} else if !retry {
@@ -670,9 +852,10 @@ func (o *codexNativeObserver) reportStartupResult(result codexObserverStartupRes
 	}
 }
 
-func (o *codexNativeObserver) setStartupFallback(reason string) {
-	if err := o.sink.SetAuthority(o.identity, codexAuthorityHook, "", reason); err == nil {
-		o.reportStartupResult(codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: reason})
+func (o *codexNativeObserver) setStartupFallback(reason codexObserverReason) {
+	if err := o.sink.SetAuthority(o.identity, codexAuthorityHook, "", string(reason)); err == nil {
+		o.journal(codexObserverTransitionFallback, "", reason)
+		o.reportStartupResult(codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: string(reason)})
 	} else if !o.sink.BindingCurrent(o.identity) {
 		o.reportStartupResult(codexObserverStartupResult{Status: codexObserverStartupStale})
 	}
@@ -711,7 +894,7 @@ func (o *codexNativeObserver) clearProgress() error {
 // enabled only after the first accepted invalidation projection clears stale
 // Registry/tmux/queue state. If either write fails, invalidating remains the
 // current hook-suppressing authority.
-func (o *codexNativeObserver) invalidateAndFallback(epoch uint64, epochLabel, reason string) error {
+func (o *codexNativeObserver) invalidateAndFallback(epoch uint64, epochLabel string, reason codexObserverReason) error {
 	projection := o.decorateGenerationProjection(o.reducer.invalidate(epoch))
 	if !projection.Accepted {
 		return errors.New("codex native lifecycle epoch could not be invalidated")
@@ -719,7 +902,7 @@ func (o *codexNativeObserver) invalidateAndFallback(epoch uint64, epochLabel, re
 	return o.applyInvalidation(epochLabel, reason, projection, true)
 }
 
-func (o *codexNativeObserver) applyInvalidationAndFallback(epochLabel, reason string, projection codexLifecycleProjection) error {
+func (o *codexNativeObserver) applyInvalidationAndFallback(epochLabel string, reason codexObserverReason, projection codexLifecycleProjection) error {
 	return o.applyInvalidation(epochLabel, reason, projection, true)
 }
 
@@ -727,7 +910,7 @@ func (o *codexNativeObserver) applyInvalidationAndFallback(epochLabel, reason st
 // leaves provider-hook suppressed. The same durable broker binding is still
 // reconnecting, so only a replacement snapshot and exact control proof may
 // move the Pane out of this unavailable projection.
-func (o *codexNativeObserver) invalidateAndHold(epoch uint64, epochLabel, reason string) error {
+func (o *codexNativeObserver) invalidateAndHold(epoch uint64, epochLabel string, reason codexObserverReason) error {
 	projection := o.decorateGenerationProjection(o.reducer.invalidate(epoch))
 	if !projection.Accepted {
 		return errors.New("codex native lifecycle epoch could not be invalidated")
@@ -735,18 +918,18 @@ func (o *codexNativeObserver) invalidateAndHold(epoch uint64, epochLabel, reason
 	return o.applyInvalidation(epochLabel, reason, projection, false)
 }
 
-func (o *codexNativeObserver) applyInvalidation(epochLabel, reason string, projection codexLifecycleProjection, fallback bool) error {
+func (o *codexNativeObserver) applyInvalidation(epochLabel string, reason codexObserverReason, projection codexLifecycleProjection, fallback bool) error {
 	if !projection.Accepted || !projection.Invalidated {
 		return errors.New("codex native lifecycle invalidation projection is not accepted")
 	}
-	if err := o.sink.SetAuthority(o.identity, codexAuthorityInvalidating, epochLabel, reason); err != nil {
+	if err := o.sink.SetAuthority(o.identity, codexAuthorityInvalidating, epochLabel, string(reason)); err != nil {
 		return err
 	}
 	if err := o.sink.Apply(o.identity, projection); err != nil {
 		// The clear may have failed after invalidating became current. Keep hooks
 		// suppressed and make the bounded diagnostic truthful; never expose
 		// provider-hook while stale state may remain.
-		_ = o.sink.SetAuthority(o.identity, codexAuthorityInvalidating, epochLabel, "sink-error")
+		_ = o.sink.SetAuthority(o.identity, codexAuthorityInvalidating, epochLabel, string(codexObserverReasonSinkError))
 		return err
 	}
 	o.progress.Invalidate()
@@ -757,10 +940,11 @@ func (o *codexNativeObserver) applyInvalidation(epochLabel, reason string, proje
 	if !fallback {
 		return nil
 	}
-	if err := o.sink.SetAuthority(o.identity, codexAuthorityHook, "", reason); err != nil {
+	if err := o.sink.SetAuthority(o.identity, codexAuthorityHook, "", string(reason)); err != nil {
 		return err
 	}
-	o.reportStartupResult(codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: reason})
+	o.journal(codexObserverTransitionFallback, epochLabel, reason)
+	o.reportStartupResult(codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: string(reason)})
 	return nil
 }
 
@@ -803,17 +987,31 @@ func waitCodexObserver(ctx context.Context, delay time.Duration) bool {
 	}
 }
 
-func codexNativeReason(err error) string {
+// codexNativeReason maps one transport error onto the shared vocabulary. Its
+// four tokens are not a second vocabulary: they are members of
+// codexObserverReasons, so an open failure and a loop exit are comparable.
+func codexNativeReason(err error) codexObserverReason {
 	switch {
 	case errors.Is(err, codexappserver.ErrUnsupported):
-		return "unsupported"
+		return codexObserverReasonUnsupported
 	case errors.Is(err, codexappserver.ErrProtocol):
-		return "protocol-error"
+		return codexObserverReasonProtocolError
 	case errors.Is(err, context.DeadlineExceeded):
-		return "timeout"
+		return codexObserverReasonTimeout
 	default:
-		return "unavailable"
+		return codexObserverReasonUnavailable
 	}
+}
+
+// streamCloseExit reads the close cause from the connection that owns it. A
+// connection that records no cause yields the plain stream-closed token, which
+// is still distinct from a cancelled observer and from an endpoint disconnect.
+func (o *codexNativeObserver) streamCloseExit(client codexLifecycleConnection) codexObserverExit {
+	source, ok := client.(codexLifecycleStreamCause)
+	if !ok {
+		return codexObserverStreamExit(codexObserverReasonStreamClosed)
+	}
+	return codexObserverStreamExit(codexObserverReasonFor(string(source.NotificationsClosedCause())))
 }
 
 type aiCodexLifecycleSink struct {
@@ -1397,7 +1595,7 @@ func (c *aiCommand) startNativeCodexLifecycleObserver(target codexLifecycleObser
 	if !sink.BindingCurrent(identity) {
 		return codexObserverStartupResult{Status: codexObserverStartupStale}
 	}
-	if err := sink.SetAuthority(identity, codexAuthorityPending, "", "connecting"); err != nil {
+	if err := sink.SetAuthority(identity, codexAuthorityPending, "", string(codexObserverReasonConnecting)); err != nil {
 		return codexObserverStartupResult{Status: codexObserverStartupStale}
 	}
 	executable := c.executable
@@ -1406,7 +1604,7 @@ func (c *aiCommand) startNativeCodexLifecycleObserver(target codexLifecycleObser
 	}
 	path, err := executable()
 	if err != nil {
-		return convergeCodexObserverStartupFallback(sink, identity, "observer-start-failed")
+		return convergeCodexObserverStartupFallback(sink, identity, string(codexObserverReasonObserverStartFailed))
 	}
 	result := startCodexLifecycleObserverProcess(path, target, codexObserverStartupTimeout)
 	if result.Status == codexObserverStartupFallback && result.Reason != "" && !result.committed {
@@ -1429,7 +1627,7 @@ func convergeCodexObserverStartupFallback(sink codexLifecycleSink, identity code
 func startCodexLifecycleObserverProcess(executable string, target codexLifecycleObserverTarget, timeout time.Duration) codexObserverStartupResult {
 	executable, err := validateCodexLifecycleObserverExecutable(executable)
 	if err != nil {
-		return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: "observer-start-failed"}
+		return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: string(codexObserverReasonObserverStartFailed)}
 	}
 	identity := target.Identity
 	args := []string{"internal", "agent-hook", "ingest", codexNativeLifecycleIngestRoute,
@@ -1449,7 +1647,7 @@ func startCodexLifecycleObserverProcess(executable string, target codexLifecycle
 	} else if target.Route.Flag() == "-S" {
 		args = append(args, "--tmux-socket-path", target.Route.Value)
 	} else {
-		return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: "observer-start-failed"}
+		return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: string(codexObserverReasonObserverStartFailed)}
 	}
 	// #nosec G204 -- executable is an absolute, existing, regular executable validated above; argv is a fixed internal route plus bounded identity values and never enters a shell.
 	cmd := exec.Command(executable, args...)
@@ -1457,10 +1655,10 @@ func startCodexLifecycleObserverProcess(executable string, target codexLifecycle
 	configureCodexObserverProcess(cmd)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: "observer-start-failed"}
+		return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: string(codexObserverReasonObserverStartFailed)}
 	}
 	if err := cmd.Start(); err != nil {
-		return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: "observer-start-failed"}
+		return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: string(codexObserverReasonObserverStartFailed)}
 	}
 	if timeout <= 0 {
 		timeout = codexObserverStartupTimeout
@@ -1480,7 +1678,7 @@ func startCodexLifecycleObserverProcess(executable string, target codexLifecycle
 		result, ok := parseCodexObserverStartupLine(value)
 		if !ok {
 			terminateCodexObserverProcess(cmd)
-			return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: "observer-exited"}
+			return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: string(codexObserverReasonObserverExited)}
 		}
 		if result.Status == codexObserverStartupReady {
 			settled := time.NewTimer(codexObserverStartupSettle)
@@ -1488,12 +1686,12 @@ func startCodexLifecycleObserverProcess(executable string, target codexLifecycle
 			select {
 			case <-line:
 				terminateCodexObserverProcess(cmd)
-				return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: "observer-exited"}
+				return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: string(codexObserverReasonObserverExited)}
 			case <-settled.C:
 				_ = stdout.Close()
 				if err := cmd.Process.Release(); err != nil {
 					terminateCodexObserverProcess(cmd)
-					return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: "observer-start-failed"}
+					return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: string(codexObserverReasonObserverStartFailed)}
 				}
 				return result
 			}
@@ -1502,7 +1700,7 @@ func startCodexLifecycleObserverProcess(executable string, target codexLifecycle
 		return result
 	case <-timer.C:
 		terminateCodexObserverProcess(cmd)
-		return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: "observer-timeout"}
+		return codexObserverStartupResult{Status: codexObserverStartupFallback, Reason: string(codexObserverReasonObserverTimeout)}
 	}
 }
 
@@ -1595,7 +1793,7 @@ func (c *aiCommand) runCodexNativeLifecycleObserver(target codexLifecycleObserve
 	sink := aiCodexLifecycleSink{command: c, runner: runner}
 	session, sessionErr := newCodexBrokerObserverSessionForRoute(target.Identity, "", nil, target.NativeRoute)
 	if sessionErr != nil {
-		result := convergeCodexObserverStartupFallback(sink, target.Identity, codexNativeReason(sessionErr))
+		result := convergeCodexObserverStartupFallback(sink, target.Identity, string(codexNativeReason(sessionErr)))
 		if report := codexObserverStartupReporter(); report != nil {
 			report(result)
 		}
@@ -1611,6 +1809,7 @@ func (c *aiCommand) runCodexNativeLifecycleObserver(target codexLifecycleObserve
 		reportStartup:   codexObserverStartupReporter(),
 		open:            session.Open,
 		openTimeout:     codexBrokerObserverOpenTimeout,
+		transitions:     newCodexObserverLogJournal(c.appendAIIngestLog, c.now),
 	}
 	if paths, err := config.DefaultPathsFromEnv(); err == nil {
 		observer.startControl = func(epoch *codexControlEpoch) (*codexControlServer, error) {

--- a/internal/app/ai_ingest_codex_native_test.go
+++ b/internal/app/ai_ingest_codex_native_test.go
@@ -1492,7 +1492,10 @@ func TestCodexNativeObserverEndpointReplacementRevokesE1BeforeGapAndPublishesExa
 	authorities := sink.authorityEpochSnapshot()
 	firstReady := codexAuthorityControlPlane + ":" + e1.Epoch + ":ready"
 	secondReady := codexAuthorityControlPlane + ":" + e2.Epoch + ":ready"
-	wantOrder := []string{firstReady, codexAuthorityInvalidating + ":" + e1.Epoch + ":disconnected", secondReady}
+	// The gap token is stream-closed, not disconnected: these fake connections
+	// close their stream without recording a cause, and that state is now
+	// named apart from an endpoint that actually went away.
+	wantOrder := []string{firstReady, codexAuthorityInvalidating + ":" + e1.Epoch + ":" + string(codexObserverReasonStreamClosed), secondReady}
 	position := 0
 	secondReadyPosition := -1
 	for index, authority := range authorities {
@@ -1632,7 +1635,7 @@ func TestCodexNativeTwoAgentDisconnectRecoversSameAgentControlAndStableProjectio
 	}
 	if got := gapAuthority; !reflect.DeepEqual(got, []string{
 		codexAuthorityControlPlane + ":" + e1.Epoch + ":ready",
-		codexAuthorityInvalidating + ":" + e1.Epoch + ":disconnected",
+		codexAuthorityInvalidating + ":" + e1.Epoch + ":" + string(codexObserverReasonStreamClosed),
 	}) {
 		t.Fatalf("target gap authority = %q", got)
 	}
@@ -1809,7 +1812,7 @@ func TestRetiredObserverRecoveryBackoffIsCappedAndNeverExhausts(t *testing.T) {
 			t.Fatalf("the retired exhaustion fallback was published: %q", authorities)
 		}
 	}
-	if !slices.Contains(authorities, codexAuthorityInvalidating+":"+e1.Epoch+":disconnected") {
+	if !slices.Contains(authorities, codexAuthorityInvalidating+":"+e1.Epoch+":"+string(codexObserverReasonStreamClosed)) {
 		t.Fatalf("E1 was not invalidated before recovery: %q", authorities)
 	}
 	if connection.closeCount() != 1 {

--- a/internal/app/ai_ingest_codex_observer_journal.go
+++ b/internal/app/ai_ingest_codex_observer_journal.go
@@ -1,0 +1,156 @@
+package app
+
+import (
+	"slices"
+	"sync"
+	"time"
+)
+
+// aiIngestCodexObserverSource is the ai-ingest.log source column for records
+// written by a managed Codex lifecycle observer.
+//
+// It is deliberately a sibling of the hook sources rather than a new file.
+// Operators already read this log, and a pane option cannot hold history: it
+// carries one value that the next transition overwrites, so a flap between two
+// samples is unobservable there by construction.
+const aiIngestCodexObserverSource = "codex-observer"
+
+// codexObserverTransition names one observable step in an observer's life. The
+// four together are what separates a flapping observer (repeated connected and
+// disconnected pairs) from a frozen one (a single connected record and nothing
+// after it) from a stopped one (a disconnect with no reconnect behind it).
+type codexObserverTransition string
+
+const (
+	codexObserverTransitionConnected    codexObserverTransition = "observer.connected"
+	codexObserverTransitionDisconnected codexObserverTransition = "observer.disconnected"
+	codexObserverTransitionReconnecting codexObserverTransition = "observer.reconnecting"
+	codexObserverTransitionFallback     codexObserverTransition = "observer.fallback"
+)
+
+// codexObserverTransitions is the closed set. A record writer validates
+// against it for the same reason the reason column is validated.
+var codexObserverTransitions = []codexObserverTransition{
+	codexObserverTransitionConnected,
+	codexObserverTransitionDisconnected,
+	codexObserverTransitionReconnecting,
+	codexObserverTransitionFallback,
+}
+
+// codexObserverJournalWindow bounds how often one (transition, reason) pair
+// may occupy a line of the log.
+//
+// A flapping observer reconnects about once a second, and this sink is shared
+// with every provider hook, so an unbounded writer would evict hook history
+// within the hour. Coalescing keeps the evidence instead of dropping it: a
+// suppressed transition is counted and the count rides the next record of that
+// same pair, so the flap rate is still readable afterwards.
+const codexObserverJournalWindow = 5 * time.Second
+
+// codexObserverJournal is the observer's append-only history sink.
+type codexObserverJournal interface {
+	RecordObserverTransition(codexLifecycleIdentity, codexObserverTransition, string, codexObserverReason)
+}
+
+// codexObserverLogJournal writes observer transitions into ai-ingest.log under
+// the coalescing window above.
+type codexObserverLogJournal struct {
+	appendEntry func(aiIngestLogEntry)
+	now         func() time.Time
+	window      time.Duration
+
+	mu         sync.Mutex
+	lastAt     map[string]time.Time
+	suppressed map[string]int
+}
+
+func newCodexObserverLogJournal(appendEntry func(aiIngestLogEntry), now func() time.Time) *codexObserverLogJournal {
+	return &codexObserverLogJournal{appendEntry: appendEntry, now: now}
+}
+
+// RecordObserverTransition appends one transition record, or folds it into the
+// pending count of an identical transition already recorded inside the window.
+//
+// Only content-free routing identity is written: the tmux pane id, the opaque
+// thread id the hook sources already carry, the epoch label, and one
+// vocabulary token. No provider conversation, no rollout content, no path.
+func (j *codexObserverLogJournal) RecordObserverTransition(
+	identity codexLifecycleIdentity,
+	kind codexObserverTransition,
+	epochLabel string,
+	reason codexObserverReason,
+) {
+	if j == nil || j.appendEntry == nil {
+		return
+	}
+	if !codexObserverTransitionValid(kind) {
+		return
+	}
+	if codexObserverReasonFor(string(reason)) == "" {
+		// An unnamed reason is exactly what this record exists to end. Naming
+		// it unrecorded keeps the transition visible without inventing a cause.
+		reason = codexObserverReasonUnrecorded
+	}
+	repeat, emit := j.admit(kind, reason)
+	if !emit {
+		return
+	}
+	j.appendEntry(aiIngestLogEntry{
+		Source:   aiIngestCodexObserverSource,
+		Event:    string(kind),
+		Result:   codexObserverTransitionResult(kind),
+		Reason:   string(reason),
+		Pane:     identity.RuntimeID,
+		ThreadID: identity.ThreadID,
+		Epoch:    epochLabel,
+		Repeat:   repeat,
+	})
+}
+
+// admit applies the coalescing window per (transition, reason) pair and
+// returns how many identical transitions were folded into this one.
+func (j *codexObserverLogJournal) admit(kind codexObserverTransition, reason codexObserverReason) (int, bool) {
+	window := j.window
+	if window <= 0 {
+		window = codexObserverJournalWindow
+	}
+	now := time.Now().UTC()
+	if j.now != nil {
+		now = j.now().UTC()
+	}
+	key := string(kind) + "\x00" + string(reason)
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.lastAt == nil {
+		j.lastAt, j.suppressed = map[string]time.Time{}, map[string]int{}
+	}
+	last, seen := j.lastAt[key]
+	if seen && now.Sub(last) < window {
+		j.suppressed[key]++
+		return 0, false
+	}
+	repeat := j.suppressed[key]
+	delete(j.suppressed, key)
+	j.lastAt[key] = now
+	return repeat, true
+}
+
+func codexObserverTransitionValid(kind codexObserverTransition) bool {
+	return slices.Contains(codexObserverTransitions, kind)
+}
+
+// codexObserverTransitionResult names the authority the Pane holds after this
+// transition. A disconnect followed by a fallback record is the fallback
+// strategy; a disconnect with no fallback behind it is the hold strategy.
+func codexObserverTransitionResult(kind codexObserverTransition) string {
+	switch kind {
+	case codexObserverTransitionConnected:
+		return codexAuthorityControlPlane
+	case codexObserverTransitionDisconnected:
+		return codexAuthorityInvalidating
+	case codexObserverTransitionFallback:
+		return codexAuthorityHook
+	default:
+		return "retry"
+	}
+}

--- a/internal/app/ai_ingest_codex_observer_reason_test.go
+++ b/internal/app/ai_ingest_codex_observer_reason_test.go
@@ -1,0 +1,592 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/codexappserver"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/codexbroker"
+)
+
+// causeCodexLifecycleConnection is a lifecycle connection that reports why its
+// notification stream closed, the way the broker epoch does.
+type causeCodexLifecycleConnection struct {
+	*fakeCodexLifecycleConnection
+	cause codexObserverReason
+}
+
+func (c *causeCodexLifecycleConnection) NotificationsClosedCause() codexObserverReason {
+	return c.cause
+}
+
+type recordingCodexObserverJournal struct {
+	mu      sync.Mutex
+	entries []aiIngestLogEntry
+}
+
+func (j *recordingCodexObserverJournal) append(entry aiIngestLogEntry) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.entries = append(j.entries, entry)
+}
+
+func (j *recordingCodexObserverJournal) snapshot() []aiIngestLogEntry {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return append([]aiIngestLogEntry(nil), j.entries...)
+}
+
+func newTestCodexObserverSnapshot(threadID string) codexappserver.LifecycleSnapshot {
+	return codexappserver.LifecycleSnapshot{ThreadID: threadID, ThreadState: codexappserver.ThreadStateActive}
+}
+
+// TestCodexObserverEventLoopExitsCarryTheirOwnReasonToken is the acceptance
+// surface for "no exit path falls into a not-recorded default".
+//
+// Before this mapping existed the loop entered with the literal `disconnected`
+// and only five of its exits ever overwrote it, so a cancelled observer, a
+// closed notification stream, and a real endpoint disconnect all published the
+// same word. The `want` column is therefore one token per path, and the
+// `authorities` column pins that refining the token did not move the recovery
+// strategy: a closed stream still holds, and everything else still falls back.
+func TestCodexObserverEventLoopExitsCarryTheirOwnReasonToken(t *testing.T) {
+	identity := testCodexLifecycleIdentity()
+	ready := codexAuthorityControlPlane + ":" + string(codexObserverReasonReady)
+	for _, test := range []struct {
+		name string
+		// cause is the stream close cause the connection reports; the empty
+		// reason means the connection reports none.
+		cause codexObserverReason
+		// notification, when set, is delivered instead of closing the stream.
+		notification *codexappserver.Notification
+		cancel       bool
+		want         codexObserverReason
+		authorities  []string
+	}{
+		{
+			name: "cancelled observer",
+			// ctx cancellation is the observer going away, never an endpoint
+			// that disconnected, and it no longer borrows that word.
+			cancel: true, want: codexObserverReasonCancelled,
+			authorities: []string{ready, codexAuthorityInvalidating + ":observer-cancelled", codexAuthorityHook + ":observer-cancelled"},
+		},
+		{
+			name: "stream closed with no recorded cause",
+			// Still distinct from both a cancelled observer and an endpoint
+			// disconnect: it says the stream ended and nothing named why.
+			want:        codexObserverReasonStreamClosed,
+			authorities: []string{ready, codexAuthorityInvalidating + ":stream-closed"},
+		},
+		{
+			name: "upstream connection suspended", cause: codexObserverReasonEndpointSuspended,
+			want:        codexObserverReasonEndpointSuspended,
+			authorities: []string{ready, codexAuthorityInvalidating + ":endpoint-suspended"},
+		},
+		{
+			name: "broker rotated in a replacement epoch", cause: codexObserverReasonEpochRotated,
+			want:        codexObserverReasonEpochRotated,
+			authorities: []string{ready, codexAuthorityInvalidating + ":epoch-rotated"},
+		},
+		{
+			name: "broker revoked the binding", cause: codexObserverReasonBindingRevoked,
+			want:        codexObserverReasonBindingRevoked,
+			authorities: []string{ready, codexAuthorityInvalidating + ":binding-revoked"},
+		},
+		{
+			name: "consumer fell behind the backlog", cause: codexObserverReasonBacklogOverflow,
+			want:        codexObserverReasonBacklogOverflow,
+			authorities: []string{ready, codexAuthorityInvalidating + ":backlog-overflow"},
+		},
+		{
+			name: "observer closed the connection", cause: codexObserverReasonEpochClosed,
+			want:        codexObserverReasonEpochClosed,
+			authorities: []string{ready, codexAuthorityInvalidating + ":epoch-closed"},
+		},
+		{
+			name:         "undecodable lifecycle frame",
+			notification: &codexappserver.Notification{Method: "thread/status/changed", Params: []byte("{")},
+			want:         codexObserverReasonProtocolError,
+			authorities:  []string{ready, codexAuthorityInvalidating + ":protocol-error", codexAuthorityHook + ":protocol-error"},
+		},
+		{
+			name: "bound thread unloaded",
+			notification: &codexappserver.Notification{
+				Method: "thread/status/changed",
+				Params: []byte(`{"threadId":"thread-1","status":{"type":"notLoaded"}}`),
+			},
+			want:        codexObserverReasonThreadUnloaded,
+			authorities: []string{ready, codexAuthorityInvalidating + ":thread-unloaded", codexAuthorityHook + ":thread-unloaded"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			base := &fakeCodexLifecycleConnection{
+				snapshot: newTestCodexObserverSnapshot(identity.ThreadID),
+				events:   make(chan codexappserver.Notification, 1),
+			}
+			connection := codexLifecycleConnection(base)
+			if test.cause != "" {
+				connection = &causeCodexLifecycleConnection{fakeCodexLifecycleConnection: base, cause: test.cause}
+			}
+			sink := newRecordingCodexLifecycleSink()
+			journal := &recordingCodexObserverJournal{}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			readyEpoch := make(chan codexObserverStartupResult, 4)
+			observer := codexNativeObserver{
+				identity: identity, sink: sink,
+				open:          func(context.Context) (codexLifecycleConnection, error) { return connection, nil },
+				transitions:   newCodexObserverLogJournal(journal.append, func() time.Time { return time.Unix(0, 0).UTC() }),
+				reportStartup: func(result codexObserverStartupResult) { readyEpoch <- result },
+				// One recovery decision, refused, so each case exercises exactly
+				// one epoch and one exit.
+				waitRecovery: func(context.Context, time.Duration) bool { return false },
+			}
+			done := make(chan error, 1)
+			go func() { done <- observer.Run(ctx) }()
+			select {
+			case result := <-readyEpoch:
+				if result.Status != codexObserverStartupReady {
+					t.Fatalf("first startup result = %+v, want ready", result)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("observer never reached a ready epoch")
+			}
+			switch {
+			case test.cancel:
+				cancel()
+			case test.notification != nil:
+				base.events <- *test.notification
+			default:
+				close(base.events)
+			}
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("observer did not finish its transition")
+			}
+			if got := sink.authoritySnapshot(); !reflect.DeepEqual(got, test.authorities) {
+				t.Fatalf("authority writes = %v, want %v", got, test.authorities)
+			}
+			reasons := journalReasons(journal.snapshot(), codexObserverTransitionDisconnected, codexObserverTransitionFallback)
+			if len(reasons) == 0 {
+				t.Fatal("no observer transition record named the exit")
+			}
+			for _, reason := range reasons {
+				if reason != string(test.want) {
+					t.Fatalf("record reason = %q, want %q", reason, test.want)
+				}
+			}
+		})
+	}
+}
+
+func journalReasons(entries []aiIngestLogEntry, kinds ...codexObserverTransition) []string {
+	reasons := []string{}
+	for _, entry := range entries {
+		for _, kind := range kinds {
+			if entry.Event == string(kind) {
+				reasons = append(reasons, entry.Reason)
+			}
+		}
+	}
+	return reasons
+}
+
+// TestCodexObserverExitPathsAreOneToOneWithTokens keeps the mapping total.
+//
+// The table above proves each path publishes its token. This proves the
+// converse property the contract actually needs: the tokens are distinct, the
+// two buckets that mean "not an observation" are never produced by an exit,
+// and every exit stores its recovery strategy rather than deriving it from the
+// reason it publishes.
+func TestCodexObserverExitPathsAreOneToOneWithTokens(t *testing.T) {
+	exits := map[string]codexObserverExit{
+		"ctx cancelled":    codexObserverExitCancelled,
+		"protocol error":   codexObserverExitProtocolError,
+		"thread unloaded":  codexObserverExitThreadUnloaded,
+		"stream no cause":  codexObserverStreamExit(""),
+		"endpoint suspend": codexObserverStreamExit(codexObserverReasonEndpointSuspended),
+		"epoch rotated":    codexObserverStreamExit(codexObserverReasonEpochRotated),
+		"binding revoked":  codexObserverStreamExit(codexObserverReasonBindingRevoked),
+		"backlog overflow": codexObserverStreamExit(codexObserverReasonBacklogOverflow),
+		"epoch closed":     codexObserverStreamExit(codexObserverReasonEpochClosed),
+	}
+	seen := map[codexObserverReason]string{}
+	for name, exit := range exits {
+		if codexObserverReasonFor(string(exit.reason)) == "" {
+			t.Fatalf("exit %q publishes %q, which is outside the vocabulary", name, exit.reason)
+		}
+		if exit.reason == codexObserverReasonUnrecorded || exit.reason == codexObserverReasonRetired {
+			t.Fatalf("exit %q fell into the %q bucket instead of naming its path", name, exit.reason)
+		}
+		if other, clash := seen[exit.reason]; clash {
+			t.Fatalf("exits %q and %q share the token %q", name, other, exit.reason)
+		}
+		seen[exit.reason] = name
+	}
+	// Holding is the closed-stream strategy and only the closed-stream
+	// strategy. This is the pre-change behavior, restated as a decision the
+	// exit carries instead of a comparison against the reason string.
+	for name, exit := range exits {
+		wantHold := strings.HasPrefix(name, "stream") || strings.HasPrefix(name, "endpoint") ||
+			strings.HasPrefix(name, "epoch") || strings.HasPrefix(name, "binding") || strings.HasPrefix(name, "backlog")
+		if exit.hold != wantHold {
+			t.Fatalf("exit %q hold = %t, want %t", name, exit.hold, wantHold)
+		}
+	}
+	if !codexObserverExitCancelled.stopping {
+		t.Fatal("the cancellation exit must stop the observer")
+	}
+}
+
+// TestCodexObserverReasonVocabularyIsClosed keeps one vocabulary, one owner.
+func TestCodexObserverReasonVocabularyIsClosed(t *testing.T) {
+	seen := map[codexObserverReason]bool{}
+	for _, reason := range codexObserverReasons {
+		if seen[reason] {
+			t.Fatalf("token %q appears twice in the vocabulary", reason)
+		}
+		seen[reason] = true
+		if got := safeCodexAuthorityReason(string(reason)); got != string(reason) {
+			t.Fatalf("safeCodexAuthorityReason(%q) = %q, want the token itself", reason, got)
+		}
+		if got := codexObserverReasonFor(" " + string(reason) + " "); got != reason {
+			t.Fatalf("codexObserverReasonFor trimmed %q to %q", reason, got)
+		}
+	}
+	for _, foreign := range []string{"", "disconnected-ish", "PRIVATE-PROMPT", "/home/user/secret"} {
+		if got := codexObserverReasonFor(foreign); got != "" {
+			t.Fatalf("codexObserverReasonFor(%q) admitted %q", foreign, got)
+		}
+		if got := safeCodexAuthorityReason(foreign); got != "bounded reason unavailable" {
+			t.Fatalf("safeCodexAuthorityReason(%q) = %q", foreign, got)
+		}
+	}
+	// The four open-failure tokens are members of the one vocabulary, not a
+	// second set beside it.
+	for _, reason := range []codexObserverReason{
+		codexObserverReasonUnsupported, codexObserverReasonProtocolError,
+		codexObserverReasonTimeout, codexObserverReasonUnavailable,
+	} {
+		if !seen[reason] {
+			t.Fatalf("codexNativeReason token %q is outside the vocabulary", reason)
+		}
+	}
+}
+
+// TestCodexBrokerEpochRecordsWhyItsStreamClosed is where the observer's answer
+// to "who closed it" comes from.
+//
+// A closed channel looks identical from above no matter who closed it, so the
+// cause has to be recorded at the call that closes it. These are all four of
+// those calls.
+func TestCodexBrokerEpochRecordsWhyItsStreamClosed(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		// close ends the epoch the way one production call site does.
+		close func(*codexBrokerObserverSession, *codexBrokerLifecycleEpoch)
+		want  codexObserverReason
+	}{
+		{
+			name: "upstream connection suspended",
+			close: func(s *codexBrokerObserverSession, _ *codexBrokerLifecycleEpoch) {
+				s.retire(make(chan codexBrokerEpochRecord, 1))
+			},
+			want: codexObserverReasonEndpointSuspended,
+		},
+		{
+			name: "replacement barrier closed",
+			close: func(s *codexBrokerObserverSession, _ *codexBrokerLifecycleEpoch) {
+				s.rotate(codexBrokerEpochRecord{}, make(chan codexBrokerEpochRecord, 1))
+			},
+			want: codexObserverReasonEpochRotated,
+		},
+		{
+			name: "binding revoked by the runtime",
+			close: func(s *codexBrokerObserverSession, _ *codexBrokerLifecycleEpoch) {
+				s.endAfterStreamRevoked(nil)
+			},
+			want: codexObserverReasonBindingRevoked,
+		},
+		{
+			name: "observer closed the connection",
+			close: func(_ *codexBrokerObserverSession, e *codexBrokerLifecycleEpoch) {
+				_ = e.Close()
+			},
+			want: codexObserverReasonEpochClosed,
+		},
+		{
+			name: "consumer fell a full backlog behind",
+			close: func(_ *codexBrokerObserverSession, e *codexBrokerLifecycleEpoch) {
+				e.deliver(codexbroker.Event{Method: "thread/status/changed"})
+			},
+			want: codexObserverReasonBacklogOverflow,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			session := &codexBrokerObserverSession{}
+			epoch := &codexBrokerLifecycleEpoch{
+				session: session,
+				// A zero-capacity stream makes the overflow case deterministic
+				// and leaves every other case unaffected.
+				notifications: make(chan codexappserver.Notification),
+				leases:        map[string]codexbroker.ApprovalLease{},
+			}
+			session.current = epoch
+			if got := epoch.NotificationsClosedCause(); got != "" {
+				t.Fatalf("a live epoch reported the close cause %q", got)
+			}
+			test.close(session, epoch)
+			if got := epoch.NotificationsClosedCause(); got != test.want {
+				t.Fatalf("close cause = %q, want %q", got, test.want)
+			}
+			if _, open := <-epoch.notifications; open {
+				t.Fatal("the notification stream stayed open after the epoch ended")
+			}
+			// The first close owns the cause; a later one cannot rewrite it.
+			epoch.end(codexObserverReasonUnrecorded)
+			if got := epoch.NotificationsClosedCause(); got != test.want {
+				t.Fatalf("a second close rewrote the cause to %q", got)
+			}
+		})
+	}
+}
+
+// TestCodexObserverJournalRecordsConnectDisconnectReconnectInOrder is the
+// history the pane option cannot hold.
+func TestCodexObserverJournalRecordsConnectDisconnectReconnectInOrder(t *testing.T) {
+	identity := testCodexLifecycleIdentity()
+	base := &fakeCodexLifecycleConnection{
+		snapshot: newTestCodexObserverSnapshot(identity.ThreadID),
+		events:   make(chan codexappserver.Notification, 1),
+	}
+	connection := &causeCodexLifecycleConnection{
+		fakeCodexLifecycleConnection: base, cause: codexObserverReasonEndpointSuspended,
+	}
+	sink := newRecordingCodexLifecycleSink()
+	journal := &recordingCodexObserverJournal{}
+	reported := make(chan codexObserverStartupResult, 4)
+	ctx := t.Context()
+	observer := codexNativeObserver{
+		identity: identity, sink: sink,
+		open:          func(context.Context) (codexLifecycleConnection, error) { return connection, nil },
+		transitions:   newCodexObserverLogJournal(journal.append, func() time.Time { return time.Unix(0, 0).UTC() }),
+		reportStartup: func(result codexObserverStartupResult) { reported <- result },
+		waitRecovery:  func(context.Context, time.Duration) bool { return false },
+	}
+	done := make(chan error, 1)
+	go func() { done <- observer.Run(ctx) }()
+	select {
+	case <-reported:
+	case <-time.After(2 * time.Second):
+		t.Fatal("observer never reached a ready epoch")
+	}
+	close(base.events)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("observer did not finish its transition")
+	}
+	entries := journal.snapshot()
+	wantOrder := []struct {
+		event  codexObserverTransition
+		result string
+		reason codexObserverReason
+	}{
+		{codexObserverTransitionConnected, codexAuthorityControlPlane, codexObserverReasonReady},
+		{codexObserverTransitionDisconnected, codexAuthorityInvalidating, codexObserverReasonEndpointSuspended},
+		{codexObserverTransitionReconnecting, "retry", codexObserverReasonEndpointSuspended},
+	}
+	if len(entries) != len(wantOrder) {
+		t.Fatalf("observer records = %+v, want %d transitions", entries, len(wantOrder))
+	}
+	for index, want := range wantOrder {
+		entry := entries[index]
+		if entry.Event != string(want.event) || entry.Result != want.result || entry.Reason != string(want.reason) {
+			t.Fatalf("record %d = %+v, want %s/%s/%s", index, entry, want.event, want.result, want.reason)
+		}
+		if entry.Source != aiIngestCodexObserverSource || entry.Pane != identity.RuntimeID ||
+			entry.ThreadID != identity.ThreadID || entry.Epoch == "" {
+			t.Fatalf("record %d lost its routing identity: %+v", index, entry)
+		}
+	}
+	// No fallback record: a closed stream holds, so provider-hook was never
+	// published, and the absence of that record is how an operator reads it.
+	if reasons := journalReasons(entries, codexObserverTransitionFallback); len(reasons) != 0 {
+		t.Fatalf("a held disconnect published a fallback record: %v", reasons)
+	}
+}
+
+// TestCodexObserverJournalRecordFieldsAreWhitelisted is the negative audit.
+//
+// The record is written into a log an operator reads and shares. Every column
+// it may carry is named here, so adding a field that could hold provider
+// content or a path fails this test before it reaches a log.
+func TestCodexObserverJournalRecordFieldsAreWhitelisted(t *testing.T) {
+	journal := &recordingCodexObserverJournal{}
+	writer := newCodexObserverLogJournal(journal.append, func() time.Time { return time.Unix(0, 0).UTC() })
+	identity := codexLifecycleIdentity{
+		AgentUID: "agent-1", PaneUID: "pane-1", RuntimeID: "%9",
+		Generation: "generation-1", ThreadID: "thread-1",
+	}
+	writer.RecordObserverTransition(identity, codexObserverTransitionDisconnected, "4242-7", codexObserverReasonEndpointSuspended)
+	entries := journal.snapshot()
+	if len(entries) != 1 {
+		t.Fatalf("records = %+v, want exactly one", entries)
+	}
+	data, err := json.Marshal(entries[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	fields := map[string]any{}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatal(err)
+	}
+	allowed := map[string]bool{
+		"at": true, "source": true, "event": true, "result": true,
+		"reason": true, "pane": true, "thread_id": true, "epoch": true, "repeat": true,
+	}
+	for field := range fields {
+		if !allowed[field] {
+			t.Fatalf("observer record carried the unlisted field %q: %s", field, data)
+		}
+	}
+	for _, forbidden := range []string{"cwd", "prompt", "text", "message", "token", "credential", "rollout", "command", "path"} {
+		if strings.Contains(strings.ToLower(string(data)), forbidden) {
+			t.Fatalf("observer record leaked %q: %s", forbidden, data)
+		}
+	}
+	// A reason outside the vocabulary is named as unrecorded rather than
+	// carried through into the log.
+	writer.RecordObserverTransition(identity, codexObserverTransitionConnected, "4242-7", codexObserverReason("PRIVATE-CAUSE"))
+	entries = journal.snapshot()
+	if last := entries[len(entries)-1]; last.Reason != string(codexObserverReasonUnrecorded) {
+		t.Fatalf("out-of-vocabulary reason reached the log as %q", last.Reason)
+	}
+	// An unnamed transition is refused outright.
+	writer.RecordObserverTransition(identity, codexObserverTransition("observer.invented"), "", codexObserverReasonReady)
+	if got := len(journal.snapshot()); got != 2 {
+		t.Fatalf("records = %d, want the invented transition refused", got)
+	}
+}
+
+// TestCodexObserverJournalCoalescesRepeatedTransitions bounds the write rate.
+//
+// A flapping observer reconnects about once a second and this sink is shared
+// with every provider hook, so an unbounded writer would evict hook history.
+// Coalescing keeps the evidence: the suppressed transitions are counted and
+// the count rides the next record of the same pair.
+func TestCodexObserverJournalCoalescesRepeatedTransitions(t *testing.T) {
+	journal := &recordingCodexObserverJournal{}
+	now := time.Unix(1700000000, 0).UTC()
+	writer := newCodexObserverLogJournal(journal.append, func() time.Time { return now })
+	writer.window = 5 * time.Second
+	identity := testCodexLifecycleIdentity()
+	flap := func() {
+		writer.RecordObserverTransition(identity, codexObserverTransitionConnected, "1-1", codexObserverReasonReady)
+		writer.RecordObserverTransition(identity, codexObserverTransitionDisconnected, "1-1", codexObserverReasonEndpointSuspended)
+	}
+	flap()
+	for range 4 {
+		now = now.Add(time.Second)
+		flap()
+	}
+	if got := len(journal.snapshot()); got != 2 {
+		t.Fatalf("records inside one window = %d, want the first pair only", got)
+	}
+	now = now.Add(5 * time.Second)
+	flap()
+	entries := journal.snapshot()
+	if len(entries) != 4 {
+		t.Fatalf("records = %d, want one more pair after the window", len(entries))
+	}
+	for _, entry := range entries[2:] {
+		if entry.Repeat != 4 {
+			t.Fatalf("coalesced record %+v lost its suppressed count", entry)
+		}
+	}
+	// A different pair is new information and is never delayed behind another
+	// pair's window.
+	writer.RecordObserverTransition(identity, codexObserverTransitionFallback, "1-1", codexObserverReasonProtocolError)
+	entries = journal.snapshot()
+	if last := entries[len(entries)-1]; last.Event != string(codexObserverTransitionFallback) || last.Repeat != 0 {
+		t.Fatalf("a distinct transition was delayed or counted: %+v", last)
+	}
+}
+
+// TestManagedCodexAuthorityDoctorSeparatesFlappingFrozenAndStopped is the
+// operator-facing half of the instrumentation.
+//
+// The source counts alone cannot tell those three apart: every one of them
+// sits in the invalidating bucket. What differs is the token that put it
+// there, so the census carries the distribution and doctor renders it.
+func TestManagedCodexAuthorityDoctorSeparatesFlappingFrozenAndStopped(t *testing.T) {
+	diagnostics := map[string]codexLifecycleAuthorityDiagnostic{
+		// Reconnecting on the broker's backoff: the upstream connection keeps
+		// going away underneath a live binding.
+		"pane-flapping": {Source: codexAuthorityInvalidating, Reason: string(codexObserverReasonEndpointSuspended), EpochStatus: "active"},
+		// Never advanced past its first epoch: still on the control plane and
+		// still reporting the epoch it opened with.
+		"pane-frozen": {Source: codexAuthorityControlPlane, Reason: string(codexObserverReasonReady), EpochStatus: "active"},
+		// Stopped: the observer process itself went away.
+		"pane-stopped": {Source: codexAuthorityHook, Reason: string(codexObserverReasonObserverExited), EpochStatus: "inactive"},
+	}
+	registry := coremetadata.Registry{}
+	for pane := range diagnostics {
+		registry.Agents = append(registry.Agents, coremetadata.Agent{
+			Metadata: coremetadata.ObjectMeta{UID: "agent-" + pane},
+			Spec:     coremetadata.AgentSpec{Provider: aiModeCodex},
+			Status:   coremetadata.AgentStatus{PaneRef: pane},
+		})
+	}
+	census := censusCodexLifecycleAuthority(registry, func(paneUID string) codexLifecycleAuthorityDiagnostic {
+		return diagnostics[paneUID]
+	})
+	want := []codexAuthorityReasonCount{
+		{Reason: string(codexObserverReasonEndpointSuspended), Count: 1},
+		{Reason: string(codexObserverReasonObserverExited), Count: 1},
+		{Reason: string(codexObserverReasonReady), Count: 1},
+	}
+	if !reflect.DeepEqual(census.Reasons, want) {
+		t.Fatalf("reason distribution = %+v, want %+v", census.Reasons, want)
+	}
+	var doctor bytes.Buffer
+	writeDoctorCodexAuthorityText(&doctor, &census)
+	rendered := doctor.String()
+	for _, expected := range []string{
+		"Reasons: ",
+		string(codexObserverReasonEndpointSuspended) + "=1",
+		string(codexObserverReasonObserverExited) + "=1",
+		string(codexObserverReasonReady) + "=1",
+	} {
+		if !strings.Contains(rendered, expected) {
+			t.Fatalf("doctor output missing %q:\n%s", expected, rendered)
+		}
+	}
+	// The census names no Agent and no Pane. It stays a count-only projection.
+	for pane := range diagnostics {
+		if strings.Contains(rendered, pane) {
+			t.Fatalf("doctor output named the Pane %q:\n%s", pane, rendered)
+		}
+	}
+	// A census with no reasons renders no Reasons line at all, so an empty
+	// distribution is not confused with an unrendered one.
+	var empty bytes.Buffer
+	writeDoctorCodexAuthorityText(&empty, &codexAuthorityCensus{Agents: 1})
+	if strings.Contains(empty.String(), "Reasons:") {
+		t.Fatalf("an empty distribution rendered a Reasons line:\n%s", empty.String())
+	}
+}

--- a/internal/app/codex_broker_lifecycle.go
+++ b/internal/app/codex_broker_lifecycle.go
@@ -35,9 +35,10 @@ const (
 // control epoch mutates through, and the typed requester those wire shapes are
 // defined on.
 var (
-	_ codexLifecycleConnection = (*codexBrokerLifecycleEpoch)(nil)
-	_ agentControlWire         = (*codexBrokerLifecycleEpoch)(nil)
-	_ codexappserver.Requester = (*codexBrokerLifecycleEpoch)(nil)
+	_ codexLifecycleConnection  = (*codexBrokerLifecycleEpoch)(nil)
+	_ codexLifecycleStreamCause = (*codexBrokerLifecycleEpoch)(nil)
+	_ agentControlWire          = (*codexBrokerLifecycleEpoch)(nil)
+	_ codexappserver.Requester  = (*codexBrokerLifecycleEpoch)(nil)
 )
 
 // codexBrokerEpochRecord is one closed snapshot barrier waiting to be consumed
@@ -175,7 +176,7 @@ func (s *codexBrokerObserverSession) Close() error {
 	s.pumped = nil
 	s.mu.Unlock()
 	if current != nil {
-		current.end()
+		current.end(codexObserverReasonEpochClosed)
 	}
 	if binding != nil {
 		_ = binding.Close()
@@ -283,6 +284,14 @@ func (s *codexBrokerObserverSession) pump(binding *codexbroker.RemoteBinding, re
 			s.retire(ready)
 		}
 	}
+	s.endAfterStreamRevoked(binding)
+}
+
+// endAfterStreamRevoked ends the live epoch after one binding's ordered stream
+// closed, which is the runtime having revoked that binding. It is a named
+// method rather than a tail block so the cause it records is reachable from a
+// test without a live broker.
+func (s *codexBrokerObserverSession) endAfterStreamRevoked(binding *codexbroker.RemoteBinding) {
 	s.mu.Lock()
 	var current *codexBrokerLifecycleEpoch
 	if s.binding == binding {
@@ -292,7 +301,7 @@ func (s *codexBrokerObserverSession) pump(binding *codexbroker.RemoteBinding, re
 	}
 	s.mu.Unlock()
 	if current != nil {
-		current.end()
+		current.end(codexObserverReasonBindingRevoked)
 	}
 }
 
@@ -328,7 +337,7 @@ func (s *codexBrokerObserverSession) retire(ready chan codexBrokerEpochRecord) {
 	default:
 	}
 	if current != nil {
-		current.end()
+		current.end(codexObserverReasonEndpointSuspended)
 	}
 }
 
@@ -340,7 +349,7 @@ func (s *codexBrokerObserverSession) rotate(record codexBrokerEpochRecord, ready
 	s.pending, s.hasPending = record, true
 	s.mu.Unlock()
 	if current != nil {
-		current.end()
+		current.end(codexObserverReasonEpochRotated)
 	}
 	// The channel holds one record: only the newest barrier can be opened, and
 	// an older one that was never consumed describes a connection epoch the
@@ -422,6 +431,13 @@ type codexBrokerLifecycleEpoch struct {
 	mu     sync.Mutex
 	ended  bool
 	leases map[string]codexbroker.ApprovalLease
+	// cause is why this epoch's notification stream closed, recorded by
+	// whichever call ended it. The observer above cannot derive this: a closed
+	// channel looks identical whether the upstream connection went away, the
+	// broker rotated in a replacement barrier, the binding was revoked, or the
+	// observer closed the connection itself. Without it the loop can only
+	// report that the stream ended.
+	cause codexObserverReason
 }
 
 // GenerationAuthority returns the complete live authority granted by the
@@ -479,7 +495,7 @@ func (e *codexBrokerLifecycleEpoch) ReadLifecycleSnapshot(ctx context.Context, t
 // the observer closing one connection never retires it.
 func (e *codexBrokerLifecycleEpoch) Close() error {
 	e.session.clear(e)
-	e.end()
+	e.end(codexObserverReasonEpochClosed)
 	return nil
 }
 
@@ -567,22 +583,36 @@ func (e *codexBrokerLifecycleEpoch) deliver(event codexbroker.Event) {
 		// the next observer epoch through a fresh broker snapshot barrier while
 		// leaving every sibling binding and the shared upstream connection live;
 		// silently dropping would leave a hole nothing downstream could detect.
-		e.end()
+		e.end(codexObserverReasonBacklogOverflow)
 		e.session.resync(e)
 	}
 }
 
-// end closes this epoch exactly once and retires every lease it minted.
-func (e *codexBrokerLifecycleEpoch) end() {
+// end closes this epoch exactly once and retires every lease it minted. The
+// first caller to close it also names why; later calls cannot overwrite that.
+func (e *codexBrokerLifecycleEpoch) end(cause codexObserverReason) {
 	e.mu.Lock()
 	if e.ended {
 		e.mu.Unlock()
 		return
 	}
 	e.ended = true
+	e.cause = cause
 	e.leases = map[string]codexbroker.ApprovalLease{}
 	close(e.notifications)
 	e.mu.Unlock()
+}
+
+// NotificationsClosedCause reports why this epoch's stream closed, or the
+// empty reason while it is still open. It is the observer's only truthful
+// answer to who ended the epoch.
+func (e *codexBrokerLifecycleEpoch) NotificationsClosedCause() codexObserverReason {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.ended {
+		return ""
+	}
+	return e.cause
 }
 
 // clear drops one epoch from the session when it is still the live one.

--- a/internal/app/codex_lifecycle_diagnostics.go
+++ b/internal/app/codex_lifecycle_diagnostics.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -50,6 +51,22 @@ type codexAuthorityCensus struct {
 	// zero for Agents that were created with a payload.
 	UnexplainedHook int `json:"unexplained_hook"`
 	Unavailable     int `json:"unavailable"`
+	// Reasons is the distribution of bounded authority reasons across the
+	// same Agents, ordered by token.
+	//
+	// The source counts above cannot separate the three states an operator
+	// actually needs to tell apart. A flapping observer, one frozen at its
+	// first epoch, and one that stopped after flapping all land in the same
+	// invalidating bucket; what differs is the token that put them there.
+	Reasons []codexAuthorityReasonCount `json:"reasons,omitempty"`
+}
+
+// codexAuthorityReasonCount is one bounded reason token and how many managed
+// Codex Agents currently carry it. It names no Agent, so it stays safe on
+// every diagnostics surface for the same reason the counts above do.
+type codexAuthorityReasonCount struct {
+	Reason string `json:"reason"`
+	Count  int    `json:"count"`
 }
 
 // censusCodexLifecycleAuthority classifies every managed Codex Agent in one
@@ -62,12 +79,16 @@ func censusCodexLifecycleAuthority(
 	if lookup == nil {
 		return census
 	}
+	reasons := map[string]int{}
 	for _, agent := range registry.Agents {
 		if agent.Spec.Provider != aiModeCodex || agent.Status.PaneRef == "" {
 			continue
 		}
 		census.Agents++
 		diagnostic := lookup(agent.Status.PaneRef)
+		if reason := strings.TrimSpace(diagnostic.Reason); reason != "" {
+			reasons[reason]++
+		}
 		switch diagnostic.Source {
 		case codexAuthorityControlPlane:
 			census.ControlPlane++
@@ -88,7 +109,24 @@ func censusCodexLifecycleAuthority(
 			census.Unavailable++
 		}
 	}
+	census.Reasons = codexAuthorityReasonCounts(reasons)
 	return census
+}
+
+// codexAuthorityReasonCounts orders the distribution by token so two doctor
+// runs over the same state render identically.
+func codexAuthorityReasonCounts(counts map[string]int) []codexAuthorityReasonCount {
+	if len(counts) == 0 {
+		return nil
+	}
+	ordered := make([]codexAuthorityReasonCount, 0, len(counts))
+	for reason, count := range counts {
+		ordered = append(ordered, codexAuthorityReasonCount{Reason: reason, Count: count})
+	}
+	slices.SortFunc(ordered, func(a, b codexAuthorityReasonCount) int {
+		return strings.Compare(a.Reason, b.Reason)
+	})
+	return ordered
 }
 
 type codexLifecycleAuthorityLookup func(string) codexLifecycleAuthorityDiagnostic

--- a/internal/app/codex_native_declared_lane_test.go
+++ b/internal/app/codex_native_declared_lane_test.go
@@ -181,6 +181,13 @@ func TestManagedCodexAuthorityCensusSeparatesDeclaredFromUnexplainedFallback(t *
 	want := codexAuthorityCensus{
 		Agents: 8, ControlPlane: 1, Pending: 1, Invalidating: 1,
 		DeclaredHook: 3, PayloadFreeFallback: 1, UnexplainedHook: 1, Unavailable: 1,
+		Reasons: []codexAuthorityReasonCount{
+			{Reason: "connecting", Count: 1},
+			{Reason: "disconnected", Count: 1},
+			{Reason: codexNativeUnexplainedReason, Count: 4},
+			{Reason: "ready", Count: 1},
+			{Reason: "tmux observation failed", Count: 1},
+		},
 	}
 	if !reflect.DeepEqual(census, want) {
 		t.Fatalf("census = %+v, want %+v", census, want)

--- a/internal/app/doctor.go
+++ b/internal/app/doctor.go
@@ -540,6 +540,13 @@ func writeDoctorCodexAuthorityText(buf *bytes.Buffer, census *codexAuthorityCens
 		census.Agents, census.ControlPlane, census.Pending, census.Invalidating)
 	fmt.Fprintf(buf, "  Declared hook fallback: %d; unexplained native fallback: %d; unavailable: %d\n",
 		census.DeclaredHook, census.UnexplainedHook, census.Unavailable)
+	if len(census.Reasons) > 0 {
+		reasons := make([]string, 0, len(census.Reasons))
+		for _, reason := range census.Reasons {
+			reasons = append(reasons, fmt.Sprintf("%s=%d", reason.Reason, reason.Count))
+		}
+		fmt.Fprintf(buf, "  Reasons: %s\n", strings.Join(reasons, ", "))
+	}
 	if census.PayloadFreeFallback > 0 {
 		fmt.Fprintf(buf, "  Payload-free plain fallback (native control unavailable): %d\n", census.PayloadFreeFallback)
 	}

--- a/internal/app/settings_ai_semantic_policy.go
+++ b/internal/app/settings_ai_semantic_policy.go
@@ -240,11 +240,11 @@ func safeCodexAuthorityValue(value string) string {
 	}
 }
 
+// safeCodexAuthorityReason renders one stored authority reason. The vocabulary
+// is owned by the observer that produces it; this is only the bounded read.
 func safeCodexAuthorityReason(value string) string {
-	switch strings.TrimSpace(value) {
-	case "ready", "connecting", "unsupported", "protocol-error", "timeout", "unavailable", "disconnected", "thread-unloaded", "sink-error", "observer-unavailable", "observer-start-failed", "observer-exited", "observer-timeout", "control-unavailable", "no active native epoch":
-		return strings.TrimSpace(value)
-	default:
-		return "bounded reason unavailable"
+	if reason := codexObserverReasonFor(value); reason != "" {
+		return string(reason)
 	}
+	return "bounded reason unavailable"
 }

--- a/test/e2e/codex-lifecycle.sh
+++ b/test/e2e/codex-lifecycle.sh
@@ -419,10 +419,17 @@ lifecycle_arm_projection_condition() {
     "wait-for -S $lifecycle_projection_barrier_channel"
 }
 
+# The attention field is part of the condition because the projection writes
+# its three pane options as three separate set-option calls, and attention is
+# the last of them. Gating on only the first two let the barrier release inside
+# that window, so a caller that then asserts the complete five-field tuple read
+# a torn projection. The barrier makes the timing deterministic; the assertions
+# behind it still own the verdict, so a real attention defect surfaces there
+# rather than being absorbed here.
 lifecycle_arm_projection_barrier() {
-  local pane="$1" source="$2" reason="$3" state="$4" badge="$5" label="$6"
-  local expected="$source|$reason|$state|$badge" condition=""
-  condition='#{==:#{@projmux_codex_authority}|#{@projmux_codex_authority_reason}|#{@projmux_ai_state}|#{@projmux_ai_badge_kind},'"$expected"'}'
+  local pane="$1" source="$2" reason="$3" state="$4" badge="$5" label="$6" attention="${7-}"
+  local expected="$source|$reason|$state|$badge|$attention" condition=""
+  condition='#{==:#{@projmux_codex_authority}|#{@projmux_codex_authority_reason}|#{@projmux_ai_state}|#{@projmux_ai_badge_kind}|#{@projmux_attention_state},'"$expected"'}'
   lifecycle_arm_projection_condition "$pane" "$condition" "$label"
 }
 
@@ -619,7 +626,11 @@ if [[ "$(lifecycle_queue_count)" != "1" || "$(lifecycle_desktop_count)" != "2" ]
   exit 1
 fi
 
-lifecycle_arm_projection_barrier "$lifecycle_pane" invalidating disconnected "" "" "disconnect"
+# endpoint-suspended, not a generic disconnect: killing the exact E1 proxy takes
+# the upstream connection this epoch was minted on away, and the broker epoch
+# records which call closed its stream. Pinning that exact token is what keeps a
+# reason the observer failed to capture from passing as a real disconnect.
+lifecycle_arm_projection_barrier "$lifecycle_pane" invalidating endpoint-suspended "" "" "disconnect"
 # The exact-proxy EOF is the only disconnect trigger. The old fixture burst can
 # revoke only the target binding before TERM and let E1 authority briefly return,
 # so it is deliberately not armed here. Re-observe the complete unique absolute
@@ -665,7 +676,7 @@ lifecycle_gap_registry_after_hook="$(lifecycle_pmx describe agent "uid:$lifecycl
   awk '$1 == "Interaction:" || $1 == "InteractionSource:" { values = values sep $2; sep = "|" } END { print values }')"
 lifecycle_gap_queue_after_hook="$(lifecycle_queue_count)"
 lifecycle_gap_desktop_after_hook="$(lifecycle_desktop_count)"
-if [[ "$lifecycle_gap_before_hook" != "invalidating|disconnected|||" ]] ||
+if [[ "$lifecycle_gap_before_hook" != "invalidating|endpoint-suspended|||" ]] ||
   [[ "$lifecycle_gap_after_hook" != "$lifecycle_gap_before_hook" ]] ||
   [[ "$lifecycle_gap_registry_after_hook" != "$lifecycle_gap_registry_before_hook" ]] ||
   [[ "$lifecycle_gap_queue_before_hook" != "1" || "$lifecycle_gap_queue_after_hook" != "$lifecycle_gap_queue_before_hook" ]] ||


### PR DESCRIPTION
## Why

`projmux doctor` reports every managed Codex Agent as `reason=disconnected`, and that value means nothing. The observer event loop entered with

```go
reconnectReason := "disconnected"   // ai_ingest_codex_native.go:410, before the loop
```

and only five exits ever overwrote it (`protocol-error` ×4, `thread-unloaded`). `<-ctx.Done()` and a closed notification channel both carried the initial value out, so **a cancelled observer, a closed stream, and a real endpoint disconnect published the same word**.

Worse, that word chose a behavior:

```go
if !stopAfterTransition && reconnectReason == "disconnected" {
    transition = o.invalidateAndHold   // suppress provider-hook fallback
}
```

so an exit that recorded no reason automatically took the "the endpoint is briefly away and the broker is reconnecting" path. This is a diagnosis problem that had become a control-flow problem.

There is also no history. The pane option holds one value that the next transition overwrites, and `appendAIIngestLog` was called **zero** times from `ai_ingest_codex_native.go`, so a flap between two samples was unobservable by construction.

**This PR does not fix the disconnect.** It builds the window the next phase reads the answer through.

## What changed

**One closed vocabulary, owned by the observer.** `codexObserverReason` replaces the literal defaults. The four `codexNativeReason` open-failure tokens are members of it rather than a second set beside it, and `safeCodexAuthorityReason` now reads through it instead of repeating fifteen tokens in its own `switch`.

**Every loop exit names its path.** `codexObserverExit` carries the token, whether the observer is stopping, and — separately — which recovery transition to take. `hold` is a stored decision, not a comparison against the reason, so making the diagnosis precise cannot move the strategy. The hold set is exactly what it was before: the closed-stream path, and nothing else.

**The close cause comes from the layer that knows it.** Above the broker a closed channel looks identical no matter who closed it. `codexBrokerLifecycleEpoch.end()` now records which call ended it, and `NotificationsClosedCause()` exposes it:

| call site | token | what it means |
| --- | --- | --- |
| `retire` (suspension frame) | `endpoint-suspended` | the upstream connection this epoch was minted on is gone |
| `rotate` (replacement barrier) | `epoch-rotated` | the broker served a new snapshot |
| `pump` exit | `binding-revoked` | the runtime revoked the binding |
| `deliver` overflow | `backlog-overflow` | the consumer fell a full backlog behind |
| `Close` | `epoch-closed` | the observer closed its own connection |

These five are the direct answer to the two questions that were still unknown: **why the notification channel closes, and whether the broker or the upstream app-server closes it.**

**Durable history.** Observer connect/disconnect/reconnect/fallback transitions append to the existing `ai-ingest.log` sink with the epoch label. Rate boundary: one record per `(transition, reason)` pair per 5s window, with suppressed transitions counted onto the next record of that pair — a flapping observer cannot evict hook history, and the flap rate stays readable. `aiIngestLogEntry` gains `epoch` and `repeat`; nothing else.

**`doctor` shows the distribution.** The managed Codex authority census carries a count-only reason distribution. The source counts alone cannot tell flapping, frozen, and stopped apart — all three sit in the invalidating bucket; the token is what differs.

## Out of scope

Reconnect policy, backoff constants, binding lifetime, and foreign/unmanaged app-server lifecycle are **unchanged** — mechanically verified: `git diff -U0` matches none of those identifiers except the `codexObserverReasonBacklogOverflow` token name. Broker diagnostic endpoint selection and hook→Pane attribution are separate slices.

## Files beyond the phase's own list

- `internal/app/codex_broker_lifecycle.go` — the close cause is only knowable at the `end()` call sites. Without it the "notification stream closed" bucket stays undifferentiated and the acceptance criterion that separates a stream close from an endpoint disconnect cannot be met.
- `internal/app/settings_ai_semantic_policy.go` — `safeCodexAuthorityReason` was a duplicated copy of the token list. Delegating it to the single owner is the read side of the vocabulary consolidation; the previous fifteen tokens are all still accepted, so read behavior is unchanged.
- `internal/app/doctor.go` — one added line in `writeDoctorCodexAuthorityText`. `writeDoctorCodexBrokerText` is untouched.

## Verification

- `make fmt`, `make fix`, `make test` green.
- `make test-integration`, `make test-e2e` run against this exact head.
- Installed smoke: 15s observation of live managed Codex Panes plus `projmux doctor`, recorded with the observed reason distribution.

New tests: `TestCodexObserverEventLoopExitsCarryTheirOwnReasonToken`, `TestCodexObserverExitPathsAreOneToOneWithTokens`, `TestCodexObserverReasonVocabularyIsClosed`, `TestCodexBrokerEpochRecordsWhyItsStreamClosed`, `TestCodexObserverJournalRecordsConnectDisconnectReconnectInOrder`, `TestCodexObserverJournalRecordFieldsAreWhitelisted`, `TestCodexObserverJournalCoalescesRepeatedTransitions`, `TestManagedCodexAuthorityDoctorSeparatesFlappingFrozenAndStopped`.
