### PR TITLE
feat(agent): bind Claude coordination endpoints

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -772,6 +772,33 @@
   title suppression/precedence, provider settlement/status, exact routing,
   and first-frame bound suites remain the authority for those unchanged paths.
 
+### Claude coordination endpoint Phase 1 tests
+
+- `TestAgentRouteClaudeIdentityTransitions`, `TestClaudeRegistrationAdmissionAndCleanupCAS`,
+  and the `TestAgentRoute` / `TestClaudeRegistration` model tests own the sealed
+  provider authority union, existing Codex composite fence, exact Claude process
+  and registration claims, same-UID rename preservation, and stale registration
+  admission/cleanup replay. The property model retains historical routes and
+  requires stale replay to leave current state unchanged.
+- `TestClaudeEndpoint` unit tests own private lease probes, kernel peer identity,
+  socket owner/mode/inode checks, nested producer refusal, creator-selected
+  activation context, read-only capability observation, and token/locator
+  residue scans. Private readiness probes never connect to a provider inbox.
+- `test/integration/claude-endpoint-binding.sh`, included in
+  `make test-integration`, builds the product and runs
+  `TestClaudeEndpointProcessIntegration` through supervisor, activation gate,
+  public SessionStart hook, and detached helper. It covers registration
+  replacement, actual helper death while the provider remains alive, automatic
+  lease cleanup, nested/forged entrypoint refusal, provider exit, zero provider
+  connections, and zero token/locator residue in output and live lease files.
+- `TestClaudeEndpointInstalledSourceGate` is opt-in evidence from a disposable
+  installed Claude one-shot. It checks public SessionStart identity, exact
+  readiness, exit invalidation, empty tools/MCP/plugins, and zero tool-use.
+  Raw provider streams remain in memory. This is the Phase 1 registration source
+  gate without safe mode; it does not satisfy or relax the later mandatory
+  safe-mode delivery gate. Setup and limits are in
+  [claude-coordination-endpoints.md](claude-coordination-endpoints.md).
+
 ## Review Checklist
 - The branch stays within its stated scope.
 - The change preserves boundaries between portable `projmux` behavior and local machine policy.

--- a/docs/claude-coordination-endpoints.md
+++ b/docs/claude-coordination-endpoints.md
@@ -1,0 +1,75 @@
+# Claude coordination endpoint registration
+
+Phase 1 binds a Claude-created endpoint to a managed Agent activation. It does
+not implement message delivery, a provider message schema, a message/wait parser,
+or a new public provider command. `agent capabilities` reports the exact Agent's
+`runtimeEligibility.coordination` readiness and evidence. Static provider queries
+remain static, and existing action cells stay unchanged.
+
+`AgentRouteRef` shares stable Agent UID, Pane UID, and activation generation.
+Its sealed provider authority union consumes the existing Codex thread and
+`CodexAuthorityRef` composite unchanged. Claude authority instead consists of the
+actual public SessionStart session ID, kernel process birth identity, a fresh
+registration generation, and the kernel identity of the helper retaining its
+registration lease. No Claude connection/binding epochs are synthesized.
+
+Managed Agent/Pane names and Claude session titles are not route authority.
+Renaming an unchanged UID/activation preserves its registration. Phase 1 does
+not discover unmanaged provider names or observe live Claude `/rename` events.
+Competing session/process/helper claims for an exact activation are refused;
+the exact child's next SessionStart atomically claims a new registration
+generation before launching its helper. Delayed admission and cleanup from an
+older generation cannot overwrite or clear that newer registration.
+
+The activation gate records the actual child PID and kernel birth identity
+before replacing itself with Claude. The separate managed SessionStart hook
+uses `exec`, making the registered provider its direct parent. The helper
+verifies the complete helper → hook → provider process chain while the hook
+waits for a bounded startup acknowledgement. A nested unmanaged Claude cannot
+register its own endpoint through inherited activation environment variables.
+The creator-selected Registry path travels only in private Claude activation
+context, independent of a tmux server's older XDG environment.
+
+The hook obtains the socket and credential solely from Claude's documented
+`CLAUDE_CODE_MESSAGING_SOCKET` and `CLAUDE_CODE_MESSAGING_TOKEN` environment.
+These values pass to the helper over an anonymous pipe and remain in process
+memory. They are absent from Registry, helper argv, helper environment, public
+capabilities, diagnostic messages, and the content-free cleanup receipt.
+Projmux does not predict, issue, read a vendor registration file for, connect
+to, or write to the Claude inbox.
+
+Readiness validates exact Registry ownership/generation, provider and helper
+kernel birth identity, socket type/owner/mode and unchanged inode. The read-only
+capability query probes only a short, private Projmux readiness socket and
+authenticates its kernel peer PID and birth. Linux birth identity includes boot
+ID and start ticks; Darwin uses kernel process start time. The private socket
+path fits both supported Unix socket limits and does not depend on TMPDIR.
+
+The helper invalidates on provider exit, socket replacement, or loss of exact
+Registry authority. The supervisor independently detects helper death while
+the provider remains alive, clears only that exact lease, and removes orphaned
+helper files. Provider exit keeps the existing lock-free termination journal
+boundary; it never waits for the cleanup watcher's Registry transaction.
+Provider sockets are never removed by Projmux. Generation replacement and
+termination convergence discard old registration observations.
+
+The required deterministic process integration is
+`test/integration/claude-endpoint-binding.sh`. It is included in
+`make test-integration`. The opt-in `TestClaudeEndpointInstalledSourceGate`
+requires `PMX_TEST_CLAUDE_ENDPOINT_BIN`, `PMX_TEST_REAL_CLAUDE_BIN`, and a prepared
+disposable authenticated `PMX_TEST_REAL_CLAUDE_CONFIG_DIR`. The harness creates
+its own provider config with an authentication symlink; it never reads or copies
+the caller's credentials. Its one-shot uses
+strict empty MCP, empty tools, empty setting sources, and no session persistence;
+it checks public init tools/MCP/plugins and tool-use are all zero. Raw public
+stream and messaging credentials stay in memory; only allowlisted receipts
+are reported. The token scan covers all owned files, including provider source
+state. Upstream may store its own public locator; the test observes only a
+boolean and removes the entire owned provider config before reporting cleanup.
+Projmux Registry, helper files, diagnostics, and evidence contain neither value.
+Inbound cross-session messaging is explicitly refused during the one-shot.
+This is a Phase 1 registration source gate without `--safe-mode`.
+It does not establish or relax the later mandatory safe-mode delivery gate.
+
+Provider sources: [SessionStart hooks](https://code.claude.com/docs/en/hooks)
+and [cross-session messaging](https://code.claude.com/docs/en/cross-session-messaging).

--- a/internal/app/activation_exec.go
+++ b/internal/app/activation_exec.go
@@ -17,14 +17,15 @@ import (
 // provider. Keeping the gate inside the child means the supervisor can always
 // reap an external HUP, even while create still owns the commit boundary.
 type activationExecCommand struct {
-	store     *resourceStore
-	lookupEnv func(string) (string, bool)
-	exec      func(argv []string, argv0 string, spec superviseSpec) error
-	failure   io.Writer
+	store         *resourceStore
+	lookupEnv     func(string) (string, bool)
+	exec          func(argv []string, argv0 string, spec superviseSpec) error
+	failure       io.Writer
+	prepareClaude func(superviseSpec) (bool, error)
 }
 
 func newActivationExecCommand() *activationExecCommand {
-	return &activationExecCommand{lookupEnv: os.LookupEnv, exec: execCommittedActivation}
+	return &activationExecCommand{lookupEnv: os.LookupEnv, exec: execCommittedActivation, prepareClaude: prepareClaudeActivationProcess}
 }
 
 func (c *activationExecCommand) Run(args []string, stdout, stderr io.Writer) (runErr error) {
@@ -82,6 +83,13 @@ func (c *activationExecCommand) Run(args []string, stdout, stderr io.Writer) (ru
 		return fmt.Errorf("internal activation-exec: activation admission: %w", err)
 	}
 	spec.RuntimeID = runtimeID
+	if c.prepareClaude != nil {
+		claudeRegistration, err := c.prepareClaude(spec)
+		if err != nil {
+			return errors.New("internal activation-exec: Claude process admission failed")
+		}
+		spec.ClaudeRegistration = claudeRegistration
+	}
 	execProvider := c.exec
 	if execProvider == nil {
 		execProvider = execCommittedActivation
@@ -175,6 +183,9 @@ func activationEnvironment(spec superviseSpec) []string {
 	}
 	if runtimeID := exactTmuxHandle(strings.TrimSpace(spec.RuntimeID), "%"); runtimeID != "" {
 		environment = append(environment, runtimeMutationAnchorPaneEnv+"="+runtimeID)
+	}
+	if spec.ClaudeRegistration {
+		environment = append(environment, internalClaudeRegistryPathEnv+"="+spec.RegistryPath)
 	}
 	return environment
 }

--- a/internal/app/activation_exec_unix.go
+++ b/internal/app/activation_exec_unix.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 )
 
@@ -26,5 +27,27 @@ func execCommittedActivation(argv []string, argv0 string, spec superviseSpec) er
 	// #nosec G204 -- this dynamic executable is the existing managed Pane/provider
 	// contract input, resolved by exec.LookPath above and passed with its exact
 	// argv directly to Exec without a shell.
-	return syscall.Exec(path, execArgv, append(os.Environ(), activationEnvironment(spec)...))
+	return syscall.Exec(path, execArgv, committedActivationEnvironment(os.Environ(), spec))
+}
+
+func committedActivationEnvironment(inherited []string, spec superviseSpec) []string {
+	if !spec.ClaudeRegistration {
+		return append(inherited, activationEnvironment(spec)...)
+	}
+	// Exec accepts duplicate environment keys, while provider and Go readers
+	// disagree about which wins. A managed parent may already carry its own
+	// private activation envelope; it cannot remain authority for this child.
+	keys := map[string]bool{}
+	for _, value := range activationEnvironment(spec) {
+		key, _, _ := strings.Cut(value, "=")
+		keys[key] = true
+	}
+	var env []string
+	for _, value := range inherited {
+		key, _, _ := strings.Cut(value, "=")
+		if !keys[key] {
+			env = append(env, value)
+		}
+	}
+	return append(env, activationEnvironment(spec)...)
 }

--- a/internal/app/agent_capabilities.go
+++ b/internal/app/agent_capabilities.go
@@ -10,8 +10,10 @@ import (
 	"strings"
 
 	"github.com/crevissepartners/projmux/internal/aiprovider"
+	"github.com/crevissepartners/projmux/internal/config"
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
 	"github.com/crevissepartners/projmux/internal/core/selector"
+	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
 )
 
 type agentCapabilityProjection struct {
@@ -28,18 +30,25 @@ type agentCapabilityAgent struct {
 }
 
 type agentCapabilityRuntime struct {
-	Ready                bool   `json:"registryReady"`
-	Evidence             string `json:"evidence"`
-	LiveVerified         bool   `json:"liveVerified"`
-	Reason               string `json:"reason"`
-	PaneUID              string `json:"paneUID,omitempty"`
-	PaneRuntimeID        string `json:"paneRuntimeID,omitempty"`
-	ActivationGeneration string `json:"activationGeneration,omitempty"`
-	StateDomainID        string `json:"stateDomainID,omitempty"`
-	EndpointGenerationID string `json:"endpointGenerationID,omitempty"`
-	BrokerRuntimeID      string `json:"brokerRuntimeID,omitempty"`
-	ConnectionEpoch      uint64 `json:"connectionEpoch,omitempty"`
-	BindingEpoch         uint64 `json:"bindingEpoch,omitempty"`
+	Ready                bool                         `json:"registryReady"`
+	Evidence             string                       `json:"evidence"`
+	LiveVerified         bool                         `json:"liveVerified"`
+	Reason               string                       `json:"reason"`
+	PaneUID              string                       `json:"paneUID,omitempty"`
+	PaneRuntimeID        string                       `json:"paneRuntimeID,omitempty"`
+	ActivationGeneration string                       `json:"activationGeneration,omitempty"`
+	StateDomainID        string                       `json:"stateDomainID,omitempty"`
+	EndpointGenerationID string                       `json:"endpointGenerationID,omitempty"`
+	BrokerRuntimeID      string                       `json:"brokerRuntimeID,omitempty"`
+	ConnectionEpoch      uint64                       `json:"connectionEpoch,omitempty"`
+	BindingEpoch         uint64                       `json:"bindingEpoch,omitempty"`
+	Coordination         *agentCapabilityCoordination `json:"coordination,omitempty"`
+}
+
+type agentCapabilityCoordination struct {
+	Eligible bool   `json:"eligible"`
+	Evidence string `json:"evidence"`
+	Reason   string `json:"reason"`
 }
 
 type agentCapabilityProjectionEntry struct {
@@ -101,8 +110,28 @@ func (c *agentCommand) runCapabilities(args []string, stdout, stderr io.Writer) 
 			return fmt.Errorf("%s: agent/%s has unsupported provider %q", spelling, agent.Metadata.Name, agent.Spec.Provider)
 		}
 		projection = projectExactAgentCapabilities(registry, agent, metadata.ID)
+		if metadata.ID == aiprovider.Claude {
+			projection.Runtime.Coordination = projectClaudeCoordinationEligibility(registry, agent)
+		}
 	}
 	return writeAgentCapabilityProjection(stdout, projection, jsonOutput)
+}
+
+func projectClaudeCoordinationEligibility(registry coremetadata.Registry, agent coremetadata.Agent) *agentCapabilityCoordination {
+	projection := &agentCapabilityCoordination{Evidence: "local-registration-lease"}
+	route, reason := coremetadata.ResolveAgentRoute(registry, agent.Metadata.UID)
+	if reason != "" {
+		projection.Reason = reason
+		return projection
+	}
+	paths, err := config.DefaultPathsFromEnv()
+	if err != nil || !probeClaudeRegistrationLease(intmetadata.PathFor(paths.StateDir), route) {
+		projection.Reason = "Claude registration lease is stale or unavailable"
+		return projection
+	}
+	projection.Eligible = true
+	projection.Reason = "exact local registration lease is ready; message delivery is unavailable"
+	return projection
 }
 
 func projectStaticAgentCapabilities(provider aiprovider.ID) agentCapabilityProjection {
@@ -256,6 +285,11 @@ func writeAgentCapabilityProjection(stdout io.Writer, projection agentCapability
 		projection.Agent.Name, projection.Agent.UID, projection.Provider, projection.Agent.Phase, projection.Runtime.Ready,
 		projection.Runtime.LiveVerified, projection.Runtime.ActivationGeneration, projection.Runtime.ConnectionEpoch, projection.Runtime.BindingEpoch); err != nil {
 		return err
+	}
+	if coordination := projection.Runtime.Coordination; coordination != nil {
+		if _, err := fmt.Fprintf(stdout, "coordination eligible=%t evidence=%s reason=%s\n", coordination.Eligible, coordination.Evidence, coordination.Reason); err != nil {
+			return err
+		}
 	}
 	if _, err := fmt.Fprintln(stdout, "ACTION\tMODE\tCOMPLETION\tAVAILABLE\tEVIDENCE\tREASON"); err != nil {
 		return err

--- a/internal/app/ai_integrate.go
+++ b/internal/app/ai_integrate.go
@@ -392,7 +392,13 @@ func (c *aiCommand) planClaudeHookIntegration(remove bool) (claudeHookPlan, erro
 		return claudeHookPlan{}, err
 	}
 	for _, event := range hookEvents {
-		hooks[event] = append(claudeHookEntrySlice(hooks[event]), claudeHookManagedEntry())
+		entry := claudeHookManagedEntry()
+		if event == "SessionStart" {
+			entry["hooks"] = append(entry["hooks"].([]any), map[string]any{
+				"type": "command", "command": claudeRegistrationHookCommand, "timeout": 5,
+			})
+		}
+		hooks[event] = append(claudeHookEntrySlice(hooks[event]), entry)
 	}
 	next, err := encodeClaudeSettings(settings)
 	if err != nil {

--- a/internal/app/claude_endpoint.go
+++ b/internal/app/claude_endpoint.go
@@ -57,7 +57,7 @@ func prepareClaudeActivationProcess(spec superviseSpec) (bool, error) {
 		claudeRegistration = true
 		process, _, err := claudeadapter.Process(os.Getpid())
 		if err != nil {
-			return errors.New("Claude process identity unavailable")
+			return errors.New("claude process identity unavailable")
 		}
 		return intmetadata.DefaultMutator().RecordClaudeProcess(reg, spec.PaneUID, spec.AgentUID, spec.Generation, process)
 	})
@@ -118,7 +118,7 @@ func claudeRegistrationBootstrap(reg coremetadata.Registry, registryPath string,
 	}
 	process := pane.Status.Activation.Claude.Process
 	actual, _, err := claudeadapter.Process(parentPID)
-	if err != nil || actual != process || actual.OwnerUID != uint32(os.Getuid()) {
+	if err != nil || actual != process || int64(actual.OwnerUID) != int64(os.Getuid()) {
 		return claudeEndpointBootstrap{}, false
 	}
 	socket, token := env("CLAUDE_CODE_MESSAGING_SOCKET"), env("CLAUDE_CODE_MESSAGING_TOKEN")
@@ -157,17 +157,19 @@ func claudeRegistrationBootstrap(reg coremetadata.Registry, registryPath string,
 func startClaudeEndpointHelper(bootstrap claudeEndpointBootstrap) error {
 	binary, err := os.Executable()
 	if err != nil {
-		return errors.New("Claude helper unavailable")
+		return errors.New("claude helper unavailable")
 	}
 	input, err := json.Marshal(bootstrap)
 	if err != nil {
-		return errors.New("Claude helper bootstrap unavailable")
+		return errors.New("claude helper bootstrap unavailable")
 	}
 	readAck, writeAck, err := os.Pipe()
 	if err != nil {
-		return errors.New("Claude helper acknowledgement unavailable")
+		return errors.New("claude helper acknowledgement unavailable")
 	}
 	defer readAck.Close()
+	// #nosec G204 -- os.Executable above identifies this running Projmux binary;
+	// the hidden route and argv are fixed, and bootstrap secrets use only stdin.
 	cmd := exec.Command(binary, "internal", "claude-endpoint-helper")
 	cmd.Stdin = strings.NewReader(string(input))
 	cmd.Stdout, cmd.Stderr = io.Discard, io.Discard
@@ -182,7 +184,7 @@ func startClaudeEndpointHelper(bootstrap claudeEndpointBootstrap) error {
 	}
 	if err := cmd.Start(); err != nil {
 		_ = writeAck.Close()
-		return errors.New("Claude helper start failed")
+		return errors.New("claude helper start failed")
 	}
 	_ = writeAck.Close()
 	_ = readAck.SetReadDeadline(time.Now().Add(3 * time.Second))
@@ -191,7 +193,7 @@ func startClaudeEndpointHelper(bootstrap claudeEndpointBootstrap) error {
 	if err != nil || ack[0] != 1 {
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
-		return errors.New("Claude helper admission failed")
+		return errors.New("claude helper admission failed")
 	}
 	return cmd.Process.Release()
 }
@@ -237,7 +239,7 @@ type claudeSocketIdentity struct {
 }
 
 func inspectClaudeSocket(path string) (claudeSocketIdentity, error) {
-	refused := errors.New("Claude socket is unavailable")
+	refused := errors.New("claude socket is unavailable")
 	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path {
 		return claudeSocketIdentity{}, refused
 	}
@@ -249,7 +251,7 @@ func inspectClaudeSocket(path string) (claudeSocketIdentity, error) {
 		}
 		if current == path {
 			stat, ok := info.Sys().(*syscall.Stat_t)
-			if !ok || info.Mode()&os.ModeSocket == 0 || info.Mode().Perm() != 0o600 || stat.Uid != uint32(os.Getuid()) {
+			if !ok || info.Mode()&os.ModeSocket == 0 || info.Mode().Perm() != 0o600 || int64(stat.Uid) != int64(os.Getuid()) {
 				return claudeSocketIdentity{}, refused
 			}
 			first = claudeSocketIdentity{device: uint64(stat.Dev), inode: stat.Ino, owner: stat.Uid, mode: info.Mode()}
@@ -263,7 +265,7 @@ func inspectClaudeSocket(path string) (claudeSocketIdentity, error) {
 		return claudeSocketIdentity{}, refused
 	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok || info.Mode()&os.ModeSocket == 0 || info.Mode().Perm() != 0o600 || stat.Uid != uint32(os.Getuid()) {
+	if !ok || info.Mode()&os.ModeSocket == 0 || info.Mode().Perm() != 0o600 || int64(stat.Uid) != int64(os.Getuid()) {
 		return claudeSocketIdentity{}, refused
 	}
 	last := claudeSocketIdentity{device: uint64(stat.Dev), inode: stat.Ino, owner: stat.Uid, mode: info.Mode()}
@@ -303,7 +305,7 @@ func privateClaudeLeaseDir(path string) bool {
 		return false
 	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
-	return ok && stat.Uid == uint32(os.Getuid())
+	return ok && int64(stat.Uid) == int64(os.Getuid())
 }
 
 // The supervisor knows the exact activation, so after reaping its child it can
@@ -348,15 +350,15 @@ func cleanupClaudeActivationLeases(spec superviseSpec) {
 
 func serveClaudeEndpoint(ctx context.Context, bootstrap claudeEndpointBootstrap, ack io.Writer) error {
 	if exactActivationRegistryPath(bootstrap.RegistryPath) != nil || bootstrap.Token == "" {
-		return errors.New("Claude helper admission failed")
+		return errors.New("claude helper admission failed")
 	}
 	process, _, err := claudeadapter.Process(os.Getpid())
 	if err != nil {
-		return errors.New("Claude helper identity unavailable")
+		return errors.New("claude helper identity unavailable")
 	}
 	bootstrap.Registration.Authority.LeaseProcess = process
 	if !bootstrap.Registration.Authority.Valid() {
-		return errors.New("Claude registration identity unavailable")
+		return errors.New("claude registration identity unavailable")
 	}
 	socketIdentity, err := inspectClaudeSocket(bootstrap.Socket)
 	if err != nil {
@@ -364,15 +366,15 @@ func serveClaudeEndpoint(ctx context.Context, bootstrap claudeEndpointBootstrap,
 	}
 	leasePath := claudeLeaseSocket(bootstrap.RegistryPath, bootstrap.PaneUID, bootstrap.Generation, bootstrap.Registration.Authority.RegistrationGeneration)
 	if err := os.Mkdir(filepath.Dir(leasePath), 0o700); err != nil && !errors.Is(err, os.ErrExist) {
-		return errors.New("Claude helper lease unavailable")
+		return errors.New("claude helper lease unavailable")
 	}
 	if !privateClaudeLeaseDir(filepath.Dir(leasePath)) {
-		return errors.New("Claude helper lease unavailable")
+		return errors.New("claude helper lease unavailable")
 	}
 	defer os.Remove(filepath.Dir(leasePath))
 	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: leasePath, Net: "unix"})
 	if err != nil {
-		return errors.New("Claude helper lease unavailable")
+		return errors.New("claude helper lease unavailable")
 	}
 	defer listener.Close()
 	listener.SetUnlinkOnClose(false)
@@ -383,26 +385,26 @@ func serveClaudeEndpoint(ctx context.Context, bootstrap claudeEndpointBootstrap,
 		}
 	}()
 	if os.Chmod(leasePath, 0o600) != nil {
-		return errors.New("Claude helper lease unavailable")
+		return errors.New("claude helper lease unavailable")
 	}
 	leaseIdentity, err := inspectClaudeSocket(leasePath)
 	if err != nil {
-		return errors.New("Claude helper lease unavailable")
+		return errors.New("claude helper lease unavailable")
 	}
 	if writeClaudeLeaseOwner(leasePath+".json", bootstrap) != nil {
-		return errors.New("Claude helper ownership unavailable")
+		return errors.New("claude helper ownership unavailable")
 	}
 	defer os.Remove(leasePath + ".json")
 	store := intmetadata.NewStore(bootstrap.RegistryPath)
 	mutator := intmetadata.DefaultMutator()
 	_, _, err = store.UpdateConvergent(func(reg *coremetadata.Registry) error {
 		if actual, _, err := claudeadapter.Process(bootstrap.Registration.Authority.Process.PID); err != nil || actual != bootstrap.Registration.Authority.Process {
-			return errors.New("Claude provider process is unavailable")
+			return errors.New("claude provider process is unavailable")
 		}
 		return mutator.RecordClaudeRegistration(reg, bootstrap.PaneUID, bootstrap.AgentUID, bootstrap.Generation, bootstrap.Registration)
 	})
 	if err != nil {
-		return errors.New("Claude registration admission failed")
+		return errors.New("claude registration admission failed")
 	}
 	defer func() {
 		_, _, _ = store.UpdateConvergent(func(reg *coremetadata.Registry) error {
@@ -412,11 +414,11 @@ func serveClaudeEndpoint(ctx context.Context, bootstrap claudeEndpointBootstrap,
 	}()
 	initial, err := store.LoadDegradedReadOnly()
 	if err != nil {
-		return errors.New("Claude registration is unavailable")
+		return errors.New("claude registration is unavailable")
 	}
 	expectedRoute, reason := coremetadata.ResolveAgentRoute(initial, bootstrap.AgentUID)
 	if reason != "" {
-		return errors.New("Claude registration is unavailable")
+		return errors.New("claude registration is unavailable")
 	}
 	current := func() bool {
 		if observed, err := inspectClaudeSocket(leasePath); err != nil || observed != leaseIdentity {
@@ -439,10 +441,10 @@ func serveClaudeEndpoint(ctx context.Context, bootstrap claudeEndpointBootstrap,
 		return reason == "" && ok && route.Same(expectedRoute) && route.PaneUID == bootstrap.PaneUID && route.Generation == bootstrap.Generation && authority == bootstrap.Registration.Authority
 	}
 	if !current() {
-		return errors.New("Claude registration is stale")
+		return errors.New("claude registration is stale")
 	}
 	if _, err := ack.Write([]byte{1}); err != nil {
-		return errors.New("Claude helper acknowledgement failed")
+		return errors.New("claude helper acknowledgement failed")
 	}
 	for {
 		if ctx.Err() != nil || !current() {

--- a/internal/app/claude_endpoint.go
+++ b/internal/app/claude_endpoint.go
@@ -1,0 +1,501 @@
+package app
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	claudeadapter "github.com/crevissepartners/projmux/internal/integrations/agents/claude"
+	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
+)
+
+// Exec replaces the hook shell: the registration process's direct parent must
+// be the exact activation-exec process after it exec'd Claude. An unmanaged
+// nested Claude may inherit the private activation environment, but cannot pass
+// this producer check for its own SessionStart.
+const claudeRegistrationHookCommand = "exec projmux internal claude-endpoint-register >/dev/null 2>&1 # " + claudeHookManagedMarker
+
+const claudeEndpointPollInterval = 100 * time.Millisecond
+
+// claudeEndpointBootstrap travels only over an anonymous pipe from the exact
+// SessionStart hook to its detached helper. Never log or persist this value.
+type claudeEndpointBootstrap struct {
+	RegistryPath string
+	AgentUID     string
+	PaneUID      string
+	Generation   string
+	Registration coremetadata.ClaudeRegistration
+	HookProcess  coremetadata.ProcessIdentity
+	Socket       string
+	Token        string
+}
+
+func (claudeEndpointBootstrap) String() string   { return "[private Claude registration]" }
+func (claudeEndpointBootstrap) GoString() string { return "[private Claude registration]" }
+
+func prepareClaudeActivationProcess(spec superviseSpec) (bool, error) {
+	store := resourceStoreAtPath(spec.RegistryPath)
+	claudeRegistration := false
+	_, _, err := store.updateConvergent(func(reg *coremetadata.Registry) error {
+		agent, ok := reg.Agent(spec.AgentUID)
+		if !ok || agent.Spec.Provider != aiModeClaude {
+			return nil
+		}
+		claudeRegistration = true
+		process, _, err := claudeadapter.Process(os.Getpid())
+		if err != nil {
+			return errors.New("Claude process identity unavailable")
+		}
+		return intmetadata.DefaultMutator().RecordClaudeProcess(reg, spec.PaneUID, spec.AgentUID, spec.Generation, process)
+	})
+	return claudeRegistration, err
+}
+
+// Only the separate SessionStart registration hook calls this route. Existing
+// status hooks and their parser/projection remain unchanged. Every failure is
+// quiet and fail-closed; no raw upstream input or credential reaches errors.
+func runClaudeEndpointRegistration(args []string) error {
+	if len(args) != 0 {
+		return nil
+	}
+	registryPath := os.Getenv(internalClaudeRegistryPathEnv)
+	if exactActivationRegistryPath(registryPath) != nil {
+		return nil
+	}
+	store := intmetadata.NewStore(registryPath)
+	reg, err := store.LoadDegradedReadOnly()
+	if err != nil {
+		return nil
+	}
+	data, err := io.ReadAll(io.LimitReader(os.Stdin, 64*1024+1))
+	if err != nil || len(data) > 64*1024 {
+		return nil
+	}
+	bootstrap, ok := claudeRegistrationBootstrap(reg, registryPath, data, os.Getenv, os.Getppid())
+	if !ok {
+		return nil
+	}
+	_, _, err = store.UpdateConvergent(func(current *coremetadata.Registry) error {
+		return intmetadata.DefaultMutator().BeginClaudeRegistration(current, bootstrap.PaneUID, bootstrap.AgentUID, bootstrap.Generation, bootstrap.Registration.Authority)
+	})
+	if err != nil {
+		return nil
+	}
+	_ = startClaudeEndpointHelper(bootstrap)
+	return nil
+}
+
+func claudeRegistrationBootstrap(reg coremetadata.Registry, registryPath string, data []byte, env func(string) string, parentPID int) (claudeEndpointBootstrap, bool) {
+	var payload struct {
+		Event     string `json:"hook_event_name"`
+		SessionID string `json:"session_id"`
+	}
+	if json.Unmarshal(data, &payload) != nil || payload.Event != "SessionStart" {
+		return claudeEndpointBootstrap{}, false
+	}
+	paneUID, generation := env(internalActivationPaneUIDEnv), env(internalActivationGenerationEnv)
+	pane, ok := reg.Pane(paneUID)
+	if !ok || pane.Status.Activation.Generation != generation || generation == "" || pane.Status.Activation.Claude == nil {
+		return claudeEndpointBootstrap{}, false
+	}
+	agent, ok := reg.Agent(pane.Status.Activation.AgentUID)
+	if !ok || agent.Spec.Provider != aiModeClaude || agent.Status.Phase != coremetadata.PhaseRunning ||
+		agent.Status.PaneRef != paneUID || pane.Metadata.OwnerRef == nil || pane.Metadata.OwnerRef.Kind != coremetadata.KindAgent || pane.Metadata.OwnerUID() != agent.Metadata.UID || pane.Spec.Role != coremetadata.PaneRoleAgent {
+		return claudeEndpointBootstrap{}, false
+	}
+	process := pane.Status.Activation.Claude.Process
+	actual, _, err := claudeadapter.Process(parentPID)
+	if err != nil || actual != process || actual.OwnerUID != uint32(os.Getuid()) {
+		return claudeEndpointBootstrap{}, false
+	}
+	socket, token := env("CLAUDE_CODE_MESSAGING_SOCKET"), env("CLAUDE_CODE_MESSAGING_TOKEN")
+	if socket == "" || token == "" || len(token) > 4096 || strings.ContainsAny(token, "\r\n\x00") {
+		return claudeEndpointBootstrap{}, false
+	}
+	// Hook identities are untrusted data too. Refuse a credential or locator
+	// embedded in any field destined for Registry, even when syntactically valid.
+	for _, value := range []string{payload.SessionID} {
+		if strings.Contains(value, token) || strings.Contains(value, socket) {
+			return claudeEndpointBootstrap{}, false
+		}
+	}
+	if _, err := inspectClaudeSocket(socket); err != nil {
+		return claudeEndpointBootstrap{}, false
+	}
+	nonce := make([]byte, 24)
+	if _, err := rand.Read(nonce); err != nil {
+		return claudeEndpointBootstrap{}, false
+	}
+	authority := coremetadata.ClaudeAuthorityRef{SessionID: payload.SessionID, Process: process,
+		RegistrationGeneration: hex.EncodeToString(nonce), LeaseProcess: process}
+	if !authority.Valid() {
+		return claudeEndpointBootstrap{}, false
+	}
+	hookProcess, _, err := claudeadapter.Process(os.Getpid())
+	if err != nil {
+		return claudeEndpointBootstrap{}, false
+	}
+	return claudeEndpointBootstrap{RegistryPath: registryPath, AgentUID: agent.Metadata.UID, PaneUID: paneUID, Generation: generation,
+		Registration: coremetadata.ClaudeRegistration{Authority: authority},
+		HookProcess:  hookProcess,
+		Socket:       socket, Token: token}, true
+}
+
+func startClaudeEndpointHelper(bootstrap claudeEndpointBootstrap) error {
+	binary, err := os.Executable()
+	if err != nil {
+		return errors.New("Claude helper unavailable")
+	}
+	input, err := json.Marshal(bootstrap)
+	if err != nil {
+		return errors.New("Claude helper bootstrap unavailable")
+	}
+	readAck, writeAck, err := os.Pipe()
+	if err != nil {
+		return errors.New("Claude helper acknowledgement unavailable")
+	}
+	defer readAck.Close()
+	cmd := exec.Command(binary, "internal", "claude-endpoint-helper")
+	cmd.Stdin = strings.NewReader(string(input))
+	cmd.Stdout, cmd.Stderr = io.Discard, io.Discard
+	cmd.ExtraFiles = []*os.File{writeAck}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	// The official secret is transferred only in the private pipe, never in
+	// helper argv or its inherited environment.
+	for _, value := range os.Environ() {
+		if !strings.HasPrefix(value, "CLAUDE_CODE_MESSAGING_SOCKET=") && !strings.HasPrefix(value, "CLAUDE_CODE_MESSAGING_TOKEN=") {
+			cmd.Env = append(cmd.Env, value)
+		}
+	}
+	if err := cmd.Start(); err != nil {
+		_ = writeAck.Close()
+		return errors.New("Claude helper start failed")
+	}
+	_ = writeAck.Close()
+	_ = readAck.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var ack [1]byte
+	_, err = io.ReadFull(readAck, ack[:])
+	if err != nil || ack[0] != 1 {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return errors.New("Claude helper admission failed")
+	}
+	return cmd.Process.Release()
+}
+
+func runClaudeEndpointHelper(args []string) error {
+	if len(args) != 0 {
+		return nil
+	}
+	ack := os.NewFile(3, "claude-endpoint-ack")
+	if ack == nil {
+		return nil
+	}
+	defer ack.Close()
+	if info, err := ack.Stat(); err != nil || info.Mode()&os.ModeNamedPipe == 0 {
+		return nil
+	}
+	var bootstrap claudeEndpointBootstrap
+	data, err := io.ReadAll(io.LimitReader(os.Stdin, 64*1024+1))
+	if err != nil || len(data) > 64*1024 || json.Unmarshal(data, &bootstrap) != nil {
+		return nil
+	}
+	if !claudeHelperProducerMatches(bootstrap, os.Getppid()) {
+		return nil
+	}
+	_ = serveClaudeEndpoint(context.Background(), bootstrap, ack)
+	return nil
+}
+
+func claudeHelperProducerMatches(bootstrap claudeEndpointBootstrap, parentPID int) bool {
+	hook, providerPID, err := claudeadapter.Process(parentPID)
+	if err != nil || hook != bootstrap.HookProcess || providerPID != bootstrap.Registration.Authority.Process.PID {
+		return false
+	}
+	provider, _, err := claudeadapter.Process(providerPID)
+	return err == nil && provider == bootstrap.Registration.Authority.Process
+}
+
+type claudeSocketIdentity struct {
+	device uint64
+	inode  uint64
+	owner  uint32
+	mode   os.FileMode
+}
+
+func inspectClaudeSocket(path string) (claudeSocketIdentity, error) {
+	refused := errors.New("Claude socket is unavailable")
+	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return claudeSocketIdentity{}, refused
+	}
+	var first claudeSocketIdentity
+	for current := path; ; current = filepath.Dir(current) {
+		info, err := os.Lstat(current)
+		if err != nil || (info.Mode()&os.ModeSymlink != 0 && !trustedDarwinTempAlias(current)) {
+			return claudeSocketIdentity{}, refused
+		}
+		if current == path {
+			stat, ok := info.Sys().(*syscall.Stat_t)
+			if !ok || info.Mode()&os.ModeSocket == 0 || info.Mode().Perm() != 0o600 || stat.Uid != uint32(os.Getuid()) {
+				return claudeSocketIdentity{}, refused
+			}
+			first = claudeSocketIdentity{device: uint64(stat.Dev), inode: stat.Ino, owner: stat.Uid, mode: info.Mode()}
+		}
+		if current == filepath.Dir(current) {
+			break
+		}
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return claudeSocketIdentity{}, refused
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || info.Mode()&os.ModeSocket == 0 || info.Mode().Perm() != 0o600 || stat.Uid != uint32(os.Getuid()) {
+		return claudeSocketIdentity{}, refused
+	}
+	last := claudeSocketIdentity{device: uint64(stat.Dev), inode: stat.Ino, owner: stat.Uid, mode: info.Mode()}
+	if last != first {
+		return claudeSocketIdentity{}, refused
+	}
+	return last, nil
+}
+
+func trustedDarwinTempAlias(path string) bool {
+	if runtime.GOOS != "darwin" || (path != "/tmp" && path != "/var") {
+		return false
+	}
+	target, err := os.Readlink(path)
+	return err == nil && (target == "/private"+path || target == "private"+path)
+}
+
+// This is Projmux's own private readiness socket, never the provider address.
+// It can be derived from nonsecret exact registration identity without storing
+// either socket path in Registry or printing it in a capability projection.
+func claudeActivationLeaseDir(registryPath, paneUID, generation string) string {
+	digest := sha256.Sum256([]byte(registryPath + "\x00" + paneUID + "\x00" + generation))
+	// Both supported operating systems provide /tmp. A fixed short root avoids
+	// Darwin's long per-user TMPDIR exceeding sun_path and makes the creator,
+	// hook, supervisor, and read-only client independent of inherited TMPDIR.
+	return filepath.Join("/tmp", "pmx-ce-"+hex.EncodeToString(digest[:16]))
+}
+
+func claudeLeaseSocket(registryPath, paneUID, generation, registrationGeneration string) string {
+	digest := sha256.Sum256([]byte(registrationGeneration))
+	return filepath.Join(claudeActivationLeaseDir(registryPath, paneUID, generation), hex.EncodeToString(digest[:16])+".sock")
+}
+
+func privateClaudeLeaseDir(path string) bool {
+	info, err := os.Lstat(path)
+	if err != nil || !info.IsDir() || info.Mode().Perm() != 0o700 {
+		return false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && stat.Uid == uint32(os.Getuid())
+}
+
+// The supervisor knows the exact activation, so after reaping its child it can
+// remove orphaned helper sockets even if a helper was killed without defers.
+// This never reads or waits on Registry, touches a provider socket, or changes
+// the termination journal contract. Normal Registry convergence clears the
+// nonsecret registration when it consumes that exact supervisor receipt.
+func cleanupClaudeActivationLeases(spec superviseSpec) {
+	if spec.AgentUID == "" || spec.Generation == "" || exactActivationRegistryPath(spec.RegistryPath) != nil {
+		return
+	}
+	dir := claudeActivationLeaseDir(spec.RegistryPath, spec.PaneUID, spec.Generation)
+	if !privateClaudeLeaseDir(dir) {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasSuffix(name, ".sock.json") {
+			path := filepath.Join(dir, name)
+			if receipt, ok := readClaudeLeaseOwner(path, spec); ok && path == claudeLeaseSocket(spec.RegistryPath, spec.PaneUID, spec.Generation, receipt.Authority.RegistrationGeneration)+".json" {
+				_ = os.Remove(path)
+			}
+			continue
+		}
+		if len(name) != 37 || !strings.HasSuffix(name, ".sock") {
+			continue
+		}
+		if _, err := hex.DecodeString(strings.TrimSuffix(name, ".sock")); err != nil {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		if _, err := inspectClaudeSocket(path); err == nil {
+			_ = os.Remove(path)
+		}
+	}
+	_ = os.Remove(dir)
+}
+
+func serveClaudeEndpoint(ctx context.Context, bootstrap claudeEndpointBootstrap, ack io.Writer) error {
+	if exactActivationRegistryPath(bootstrap.RegistryPath) != nil || bootstrap.Token == "" {
+		return errors.New("Claude helper admission failed")
+	}
+	process, _, err := claudeadapter.Process(os.Getpid())
+	if err != nil {
+		return errors.New("Claude helper identity unavailable")
+	}
+	bootstrap.Registration.Authority.LeaseProcess = process
+	if !bootstrap.Registration.Authority.Valid() {
+		return errors.New("Claude registration identity unavailable")
+	}
+	socketIdentity, err := inspectClaudeSocket(bootstrap.Socket)
+	if err != nil {
+		return err
+	}
+	leasePath := claudeLeaseSocket(bootstrap.RegistryPath, bootstrap.PaneUID, bootstrap.Generation, bootstrap.Registration.Authority.RegistrationGeneration)
+	if err := os.Mkdir(filepath.Dir(leasePath), 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+		return errors.New("Claude helper lease unavailable")
+	}
+	if !privateClaudeLeaseDir(filepath.Dir(leasePath)) {
+		return errors.New("Claude helper lease unavailable")
+	}
+	defer os.Remove(filepath.Dir(leasePath))
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: leasePath, Net: "unix"})
+	if err != nil {
+		return errors.New("Claude helper lease unavailable")
+	}
+	defer listener.Close()
+	listener.SetUnlinkOnClose(false)
+	ownedLease, _ := os.Lstat(leasePath)
+	defer func() {
+		if current, err := os.Lstat(leasePath); err == nil && ownedLease != nil && os.SameFile(ownedLease, current) {
+			_ = os.Remove(leasePath)
+		}
+	}()
+	if os.Chmod(leasePath, 0o600) != nil {
+		return errors.New("Claude helper lease unavailable")
+	}
+	leaseIdentity, err := inspectClaudeSocket(leasePath)
+	if err != nil {
+		return errors.New("Claude helper lease unavailable")
+	}
+	if writeClaudeLeaseOwner(leasePath+".json", bootstrap) != nil {
+		return errors.New("Claude helper ownership unavailable")
+	}
+	defer os.Remove(leasePath + ".json")
+	store := intmetadata.NewStore(bootstrap.RegistryPath)
+	mutator := intmetadata.DefaultMutator()
+	_, _, err = store.UpdateConvergent(func(reg *coremetadata.Registry) error {
+		if actual, _, err := claudeadapter.Process(bootstrap.Registration.Authority.Process.PID); err != nil || actual != bootstrap.Registration.Authority.Process {
+			return errors.New("Claude provider process is unavailable")
+		}
+		return mutator.RecordClaudeRegistration(reg, bootstrap.PaneUID, bootstrap.AgentUID, bootstrap.Generation, bootstrap.Registration)
+	})
+	if err != nil {
+		return errors.New("Claude registration admission failed")
+	}
+	defer func() {
+		_, _, _ = store.UpdateConvergent(func(reg *coremetadata.Registry) error {
+			mutator.ClearClaudeRegistration(reg, bootstrap.PaneUID, bootstrap.AgentUID, bootstrap.Generation, bootstrap.Registration.Authority)
+			return nil
+		})
+	}()
+	initial, err := store.LoadDegradedReadOnly()
+	if err != nil {
+		return errors.New("Claude registration is unavailable")
+	}
+	expectedRoute, reason := coremetadata.ResolveAgentRoute(initial, bootstrap.AgentUID)
+	if reason != "" {
+		return errors.New("Claude registration is unavailable")
+	}
+	current := func() bool {
+		if observed, err := inspectClaudeSocket(leasePath); err != nil || observed != leaseIdentity {
+			return false
+		}
+		actual, _, err := claudeadapter.Process(bootstrap.Registration.Authority.Process.PID)
+		if err != nil || actual != bootstrap.Registration.Authority.Process {
+			return false
+		}
+		observed, err := inspectClaudeSocket(bootstrap.Socket)
+		if err != nil || observed != socketIdentity {
+			return false
+		}
+		reg, err := store.LoadDegradedReadOnly()
+		if err != nil {
+			return false
+		}
+		route, reason := coremetadata.ResolveAgentRoute(reg, bootstrap.AgentUID)
+		authority, ok := route.Authority().(coremetadata.ClaudeAuthorityRef)
+		return reason == "" && ok && route.Same(expectedRoute) && route.PaneUID == bootstrap.PaneUID && route.Generation == bootstrap.Generation && authority == bootstrap.Registration.Authority
+	}
+	if !current() {
+		return errors.New("Claude registration is stale")
+	}
+	if _, err := ack.Write([]byte{1}); err != nil {
+		return errors.New("Claude helper acknowledgement failed")
+	}
+	for {
+		if ctx.Err() != nil || !current() {
+			return nil
+		}
+		_ = listener.SetDeadline(time.Now().Add(claudeEndpointPollInterval))
+		connection, err := listener.AcceptUnix()
+		if err != nil {
+			if timeout, ok := err.(net.Error); ok && timeout.Timeout() {
+				continue
+			}
+			return nil
+		}
+		_ = connection.SetDeadline(time.Now().Add(claudeEndpointPollInterval))
+		if current() {
+			_, _ = connection.Write([]byte{1})
+		}
+		_ = connection.Close()
+	}
+}
+
+func probeClaudeRegistrationLease(registryPath string, route coremetadata.AgentRouteRef) bool {
+	authority, ok := route.Authority().(coremetadata.ClaudeAuthorityRef)
+	if !ok || !authority.Valid() {
+		return false
+	}
+	for _, expected := range []coremetadata.ProcessIdentity{authority.Process, authority.LeaseProcess} {
+		actual, _, err := claudeadapter.Process(expected.PID)
+		if err != nil || actual != expected {
+			return false
+		}
+	}
+	path := claudeLeaseSocket(registryPath, route.PaneUID, route.Generation, authority.RegistrationGeneration)
+	if _, err := inspectClaudeSocket(path); err != nil {
+		return false
+	}
+	// Dial only Projmux's readiness helper. Never connect to the provider inbox;
+	// its secret path exists only in serveClaudeEndpoint's private memory.
+	connection, err := net.DialTimeout("unix", path, 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	defer connection.Close()
+	unixConnection, ok := connection.(*net.UnixConn)
+	if !ok {
+		return false
+	}
+	peer, err := claudeadapter.PeerProcess(unixConnection)
+	if err != nil || peer != authority.LeaseProcess {
+		return false
+	}
+	_ = connection.SetDeadline(time.Now().Add(200 * time.Millisecond))
+	var ready [1]byte
+	_, err = io.ReadFull(connection, ready[:])
+	return err == nil && ready[0] == 1
+}

--- a/internal/app/claude_endpoint_installed_test.go
+++ b/internal/app/claude_endpoint_installed_test.go
@@ -1,0 +1,307 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	claudeadapter "github.com/crevissepartners/projmux/internal/integrations/agents/claude"
+	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
+)
+
+// TestClaudeEndpointInstalledSourceGate is opt-in account-backed evidence for
+// Phase 1 registration only. The caller supplies an already prepared disposable
+// Claude auth directory; the harness never reads or copies credentials. Raw
+// provider stream and exported messaging credentials remain only in memory.
+// This deliberately does NOT establish the later mandatory safe-mode delivery
+// gate: no message is sent and no provider transport is opened by Projmux.
+func TestClaudeEndpointInstalledSourceGate(t *testing.T) {
+	binary, claude, claudeConfig := os.Getenv("PMX_TEST_CLAUDE_ENDPOINT_BIN"), os.Getenv("PMX_TEST_REAL_CLAUDE_BIN"), os.Getenv("PMX_TEST_REAL_CLAUDE_CONFIG_DIR")
+	if binary == "" || claude == "" || claudeConfig == "" {
+		t.Skip("requires built binary, installed Claude, and disposable authenticated Claude config directory")
+	}
+	if !filepath.IsAbs(binary) || !filepath.IsAbs(claude) || !filepath.IsAbs(claudeConfig) {
+		t.Fatal("installed source gate paths must be absolute")
+	}
+	root, err := os.MkdirTemp("", "pce-real-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+	// Provider source state belongs to a separate disposable directory. The
+	// caller's authentication path is linked, never read, copied, or removed.
+	providerConfig, err := os.MkdirTemp("", "pce-provider-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(providerConfig)
+	if err := os.Symlink(filepath.Join(claudeConfig, ".credentials.json"), filepath.Join(providerConfig, ".credentials.json")); err != nil {
+		t.Fatal("disposable provider authentication link unavailable")
+	}
+	work := filepath.Join(root, "work")
+	if err := os.Mkdir(work, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	h := newSessionRefHarness(t, "claude")
+	registryPath := intmetadata.PathFor(filepath.Join(root, "state", "projmux"))
+	store := intmetadata.NewStore(registryPath)
+	if _, err := store.Update(func(reg *coremetadata.Registry) error { *reg = h.registry.Clone(); return nil }); err != nil {
+		t.Fatal(err)
+	}
+	capturePath := filepath.Join(root, "capture.sock")
+	capture, err := net.ListenUnix("unix", &net.UnixAddr{Name: capturePath, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer capture.Close()
+	if err := os.Chmod(capturePath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapper := filepath.Join(root, "session-start.py")
+	// Capture the documented hook environment through an owned in-memory
+	// channel, restore the public stdin payload, then exec the actual product
+	// registration hook without adding an ancestor between it and Claude.
+	script := `#!` + python + `
+import json, os, socket, sys
+payload = sys.stdin.buffer.read()
+data = json.loads(payload)
+capture = socket.socket(socket.AF_UNIX)
+capture.connect(os.environ['PMX_TEST_CAPTURE'])
+capture.sendall(json.dumps({'session_id':data.get('session_id'),'socket':os.environ.get('CLAUDE_CODE_MESSAGING_SOCKET'),'token':os.environ.get('CLAUDE_CODE_MESSAGING_TOKEN')}).encode() + b'\n')
+capture.close()
+read_fd, write_fd = os.pipe()
+os.write(write_fd,payload)
+os.close(write_fd)
+os.dup2(read_fd,0)
+os.close(read_fd)
+binary = os.environ['PMX_TEST_BIN']
+os.execv(binary,[binary,'internal','claude-endpoint-register'])
+`
+	if err := os.WriteFile(wrapper, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	settings := map[string]any{"crossSessionInbound": "refuse", "hooks": map[string]any{"SessionStart": []any{map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "exec " + shellQuote(wrapper), "timeout": 10}}}}}}
+	settingsData, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(root, "settings.json")
+	if err := os.WriteFile(settingsPath, settingsData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mcpPath := filepath.Join(root, "empty-mcp.json")
+	if err := os.WriteFile(mcpPath, []byte(`{"mcpServers":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"internal", "supervise", "--pane-uid", h.paneUID, "--agent-uid", h.agentUID, "--generation", h.envGeneration, "--operation-id", "op-3", "--registry-path", registryPath, "--", claude,
+		"--print", "--verbose", "--output-format", "stream-json", "--strict-mcp-config", "--mcp-config", mcpPath, "--setting-sources", "", "--tools", "", "--no-session-persistence", "--settings", settingsPath, "--", "Reply exactly PHASE1_OK. Do not use tools or other agents."}
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = work
+	cmd.Env = append(claudeEndpointProcessEnv(root, binary), "CLAUDE_CONFIG_DIR="+providerConfig, "PMX_TEST_CAPTURE="+capturePath, "CLAUDE_CODE_DEBUG_LOGS_DIR="+filepath.Join(root, "diagnostics"))
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait(); close(done) }()
+	spec := superviseSpec{RegistryPath: registryPath, PaneUID: h.paneUID, AgentUID: h.agentUID, Generation: h.envGeneration}
+	defer func() {
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			_ = cmd.Process.Kill()
+		}
+		cleanupClaudeEndpointTestActivation(store, spec)
+	}()
+	_ = capture.SetDeadline(time.Now().Add(30 * time.Second))
+	connection, err := capture.AcceptUnix()
+	if err != nil {
+		t.Fatal("installed Claude did not emit public SessionStart registration")
+	}
+	_ = connection.SetDeadline(time.Now().Add(3 * time.Second))
+	var private struct {
+		SessionID string `json:"session_id"`
+		Socket    string `json:"socket"`
+		Token     string `json:"token"`
+	}
+	err = json.NewDecoder(connection).Decode(&private)
+	_ = connection.Close()
+	if err != nil || private.SessionID == "" || private.Socket == "" || private.Token == "" {
+		t.Fatal("installed SessionStart metadata incomplete")
+	}
+	deadline := time.Now().Add(15 * time.Second)
+	var ready coremetadata.AgentRouteRef
+	for {
+		reg, err := store.LoadDegradedReadOnly()
+		if err != nil {
+			t.Fatal(err)
+		}
+		route, reason := coremetadata.ResolveAgentRoute(reg, h.agentUID)
+		if reason == "" && probeClaudeRegistrationLease(registryPath, route) {
+			ready = route
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("installed registration never became ready")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	authority := ready.Authority().(coremetadata.ClaudeAuthorityRef)
+	if authority.SessionID != private.SessionID {
+		t.Fatal("public SessionStart identity did not match exact activation registration")
+	}
+	assertNoClaudeSecretResidue(t, root, []string{private.Token, private.Socket})
+	assertNoClaudeSecretResidue(t, claudeActivationLeaseDir(registryPath, h.paneUID, h.envGeneration), []string{private.Token, private.Socket})
+	upstreamLocatorObserved := assertClaudeConfigMessagingResidue(t, providerConfig, []string{private.Token, private.Socket})
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal("installed one-shot failed")
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("installed one-shot deadline")
+	}
+	initSeen, resultSeen, toolUses := false, false, 0
+	for line := range bytes.SplitSeq(stdout.Bytes(), []byte{'\n'}) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var event map[string]any
+		if json.Unmarshal(line, &event) != nil {
+			t.Fatal("installed public stream was not JSON")
+		}
+		if event["type"] == "system" && event["subtype"] == "init" {
+			initSeen = true
+			for _, field := range []string{"tools", "mcp_servers", "plugins"} {
+				items, ok := event[field].([]any)
+				if !ok || len(items) != 0 {
+					t.Fatal("installed init isolation gate failed")
+				}
+			}
+		}
+		if event["type"] == "result" {
+			resultSeen = true
+			if failed, _ := event["is_error"].(bool); failed {
+				t.Fatal("installed result reported failure")
+			}
+			if result, _ := event["result"].(string); strings.TrimSpace(result) != "PHASE1_OK" {
+				t.Fatal("installed one-shot marker mismatch")
+			}
+		}
+		toolUses += countClaudeToolUse(event)
+	}
+	if !initSeen || !resultSeen || toolUses != 0 {
+		t.Fatal("installed tools/MCP/plugins/tool-use gate incomplete")
+	}
+	// The upstream public init may contain its nonsecret socket locator. It is
+	// inspected only in this in-memory buffer and never emitted as evidence.
+	if bytes.Contains(stdout.Bytes(), []byte(private.Token)) || bytes.Contains(stderr.Bytes(), []byte(private.Token)) {
+		t.Fatal("installed stream contained messaging credential")
+	}
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		reg, err := store.LoadDegradedReadOnly()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, reason := coremetadata.ResolveAgentRoute(reg, h.agentUID)
+		_, statErr := os.Lstat(claudeActivationLeaseDir(registryPath, h.paneUID, h.envGeneration))
+		if reason != "" && os.IsNotExist(statErr) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("installed activation cleanup incomplete")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if probeClaudeRegistrationLease(registryPath, ready) {
+		t.Fatal("exited installed registration remained eligible")
+	}
+	if actual, _, err := claudeadapter.Process(authority.LeaseProcess.PID); err == nil && actual == authority.LeaseProcess {
+		t.Fatal("installed helper survived provider")
+	}
+	if _, err := os.Lstat(private.Socket); !os.IsNotExist(err) {
+		t.Fatal("installed provider inbox survived exit")
+	}
+	assertNoClaudeSecretResidue(t, root, []string{private.Token, private.Socket})
+	upstreamLocatorObserved = assertClaudeConfigMessagingResidue(t, providerConfig, []string{private.Token, private.Socket}) || upstreamLocatorObserved
+	if err := os.RemoveAll(providerConfig); err != nil {
+		t.Fatal("disposable provider source state cleanup failed")
+	}
+	if _, err := os.Lstat(providerConfig); !os.IsNotExist(err) {
+		t.Fatal("disposable provider source state survived cleanup")
+	}
+	t.Logf("public SessionStart→exact ready→exit→invalidated; tools=0 MCP=0 plugins=0 tool-use=0; messaging-token residue=0; helper/process/socket cleanup=0; upstream-public-locator-observed=%t; disposable-provider-state cleanup=0; Phase1 registration source gate only", upstreamLocatorObserved)
+}
+
+func assertClaudeConfigMessagingResidue(t *testing.T, root string, private []string) bool {
+	t.Helper()
+	tokenFound, socketFound := false, false
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		// Account auth is caller-owned and never read or copied by this test.
+		if entry.Name() == ".credentials.json" || !entry.Type().IsRegular() {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		tokenFound = tokenFound || (len(private) > 0 && private[0] != "" && bytes.Contains(data, []byte(private[0])))
+		socketFound = socketFound || (len(private) > 1 && private[1] != "" && bytes.Contains(data, []byte(private[1])))
+		return nil
+	})
+	if err != nil {
+		t.Fatal("disposable provider diagnostics scan failed")
+	}
+	if tokenFound {
+		t.Fatal("messaging credential residue in disposable provider state")
+	}
+	// Native source state may store its own public locator, just as the public
+	// init event does. It is never interpreted as authority or emitted, and the
+	// entire task-owned directory is removed before reporting final evidence.
+	return socketFound
+}
+
+func countClaudeToolUse(value any) int {
+	count := 0
+	switch value := value.(type) {
+	case map[string]any:
+		if kind, _ := value["type"].(string); kind == "tool_use" {
+			count++
+		}
+		for _, child := range value {
+			count += countClaudeToolUse(child)
+		}
+	case []any:
+		for _, child := range value {
+			count += countClaudeToolUse(child)
+		}
+	}
+	return count
+}
+
+func TestClaudeEndpointLeasePathFitsSupportedUnixSockets(t *testing.T) {
+	t.Setenv("TMPDIR", "/var/folders/"+strings.Repeat("long", 30)+"/T")
+	path := claudeLeaseSocket("/very/long/creator/metadata/registry.json", "pane", "generation", "registration")
+	if len(path) >= 104 {
+		t.Fatal("helper locator exceeds supported Darwin sun_path")
+	}
+}

--- a/internal/app/claude_endpoint_process_test.go
+++ b/internal/app/claude_endpoint_process_test.go
@@ -1,0 +1,341 @@
+package app
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	claudeadapter "github.com/crevissepartners/projmux/internal/integrations/agents/claude"
+	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
+)
+
+// The disposable synthetic provider owns its own actual socket and credential,
+// then emits the public SessionStart input. A private capture socket carries
+// receipts to test memory, never stdout/stderr or a test artifact. This is required
+// by make test-integration; it does not require a model, account, or network.
+const claudeEndpointSyntheticProvider = `
+import json, os, secrets, socket, subprocess, sys
+path = os.path.join(os.environ['PMX_TEST_ROOT'], 'provider-' + secrets.token_hex(8) + '.sock')
+os.umask(0o077)
+inbox = socket.socket(socket.AF_UNIX)
+inbox.bind(path)
+os.chmod(path,0o600)
+inbox.listen()
+inbox.settimeout(0.01)
+token = secrets.token_hex(24)
+os.environ['CLAUDE_CODE_MESSAGING_SOCKET'] = path
+os.environ['CLAUDE_CODE_MESSAGING_TOKEN'] = token
+capture = socket.socket(socket.AF_UNIX)
+capture.connect(os.environ['PMX_TEST_CAPTURE'])
+receipt = capture.makefile('w', buffering=1)
+receipt.write(json.dumps({'socket': path, 'token': token, 'pid':os.getpid(), 'pane_env':os.environ.get('PMX_INTERNAL_ACTIVATION_PANE_UID'), 'generation_env':os.environ.get('PMX_INTERNAL_ACTIVATION_GENERATION'), 'registry_env':os.environ.get('PMX_INTERNAL_CLAUDE_REGISTRY_PATH')}) + '\n'); receipt.flush()
+def hook(session):
+    result = subprocess.run([os.environ['PMX_TEST_BIN'], 'internal', 'claude-endpoint-register'], input=json.dumps({'hook_event_name':'SessionStart','session_id':session}).encode(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert result.returncode == 0 and not result.stdout and not result.stderr
+hook('synthetic-session-1')
+receipt.write('hook-returned\n'); receipt.flush()
+for line in sys.stdin:
+    if line.strip() == 'repeat':
+        hook('synthetic-session-2')
+        receipt.write('hook-returned\n'); receipt.flush()
+    elif line.strip() == 'nested':
+        child = "import json,os,subprocess; subprocess.run([os.environ['PMX_TEST_BIN'],'internal','claude-endpoint-register'],input=json.dumps({'hook_event_name':'SessionStart','session_id':'nested-foreign-session'}).encode(),check=True)"
+        result = subprocess.run([sys.executable,'-c',child],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+        assert result.returncode == 0 and not result.stdout and not result.stderr
+        receipt.write('nested-returned\n'); receipt.flush()
+    elif line.strip() == 'exit':
+        break
+try:
+    connection, _ = inbox.accept()
+    connection.close()
+    raise AssertionError('provider transport was opened')
+except socket.timeout:
+    pass
+inbox.close()
+os.unlink(path)
+receipt.write('provider-connections=0\n'); receipt.flush()
+`
+
+func TestClaudeEndpointProcessIntegration(t *testing.T) {
+	binary := os.Getenv("PMX_TEST_CLAUDE_ENDPOINT_BIN")
+	if binary == "" {
+		t.Skip("run test/integration/claude-endpoint-binding.sh for built-binary process integration")
+	}
+	if !filepath.IsAbs(binary) {
+		t.Fatal("process test requires an absolute built binary")
+	}
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.MkdirTemp("", "pce-process-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+	h := newSessionRefHarness(t, "claude")
+	registryPath := intmetadata.PathFor(filepath.Join(root, "state", "projmux"))
+	store := intmetadata.NewStore(registryPath)
+	if _, err := store.Update(func(reg *coremetadata.Registry) error { *reg = h.registry.Clone(); return nil }); err != nil {
+		t.Fatal(err)
+	}
+	capturePath := filepath.Join(root, "capture.sock")
+	capture, err := net.ListenUnix("unix", &net.UnixAddr{Name: capturePath, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer capture.Close()
+	readControl, writeControl, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writeControl.Close()
+	args := []string{"internal", "supervise", "--pane-uid", h.paneUID, "--agent-uid", h.agentUID, "--generation", h.envGeneration, "--operation-id", "op-3", "--registry-path", registryPath, "--", python, "-c", claudeEndpointSyntheticProvider}
+	cmd := exec.Command(binary, args...)
+	cmd.Stdin = readControl
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = claudeEndpointProcessEnv(root, binary)
+	cmd.Env = append(cmd.Env, "PMX_TEST_CAPTURE="+capturePath)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	_ = readControl.Close()
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait(); close(done) }()
+	defer func() {
+		_ = writeControl.Close()
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			_ = cmd.Process.Kill()
+			t.Error("provider process did not stop")
+		}
+		cleanupClaudeEndpointTestActivation(store, superviseSpec{RegistryPath: registryPath, PaneUID: h.paneUID, AgentUID: h.agentUID, Generation: h.envGeneration})
+	}()
+	_ = capture.SetDeadline(time.Now().Add(8 * time.Second))
+	readReceipt, err := capture.AcceptUnix()
+	if err != nil {
+		t.Fatal("provider capture startup failed")
+	}
+	defer readReceipt.Close()
+	_ = readReceipt.SetReadDeadline(time.Now().Add(8 * time.Second))
+	reader := bufio.NewReader(readReceipt)
+	line, err := reader.ReadBytes('\n')
+	if err != nil {
+		t.Fatal("provider did not produce private registration receipt")
+	}
+	var private struct {
+		Socket        string
+		Token         string
+		PID           int
+		PaneEnv       string `json:"pane_env"`
+		GenerationEnv string `json:"generation_env"`
+		RegistryEnv   string `json:"registry_env"`
+	}
+	if json.Unmarshal(line, &private) != nil || private.Token == "" || private.Socket == "" {
+		t.Fatal("private registration receipt invalid")
+	}
+	if private.PaneEnv != h.paneUID || private.GenerationEnv != h.envGeneration || private.RegistryEnv != registryPath {
+		t.Fatalf("private activation context mismatch: pane=%t generation=%t registry=%t", private.PaneEnv == h.paneUID, private.GenerationEnv == h.envGeneration, private.RegistryEnv == registryPath)
+	}
+	waitHook := func() {
+		t.Helper()
+		line, err := reader.ReadString('\n')
+		if err != nil || line != "hook-returned\n" {
+			t.Fatal("SessionStart helper bootstrap failed")
+		}
+	}
+	waitHook()
+	getRoute := func() coremetadata.AgentRouteRef {
+		t.Helper()
+		reg, err := store.LoadDegradedReadOnly()
+		if err != nil {
+			t.Fatal(err)
+		}
+		route, reason := coremetadata.ResolveAgentRoute(reg, h.agentUID)
+		if reason != "" || !probeClaudeRegistrationLease(registryPath, route) {
+			pane, _ := reg.Pane(h.paneUID)
+			if pane != nil && pane.Status.Activation.Claude != nil {
+				binding := pane.Status.Activation.Claude
+				t.Logf("process_bound=%t claim_present=%t registration_present=%t registry_reason=%s", binding.Process.Valid(), binding.RegistrationGeneration != "", binding.Registration != nil, reason)
+				actual, _, processErr := claudeadapter.Process(private.PID)
+				_, socketErr := inspectClaudeSocket(private.Socket)
+				t.Logf("exact_provider_birth=%t socket_admitted=%t", processErr == nil && actual == binding.Process, socketErr == nil)
+			}
+			t.Fatal("exact process registration was not ready")
+		}
+		return route
+	}
+	first := getRoute()
+	assertNoClaudeSecretResidue(t, claudeActivationLeaseDir(registryPath, h.paneUID, h.envGeneration), []string{private.Token, private.Socket})
+	// Exercise actual entrypoints with malformed, oversized, and foreign
+	// bootstrap input. The output/diagnostic scanner must never echo stdin.
+	beforeNegative, _ := os.ReadFile(registryPath)
+	hookIdentity, _, err := claudeadapter.Process(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	forged, _ := json.Marshal(claudeEndpointBootstrap{RegistryPath: registryPath, PaneUID: h.paneUID, AgentUID: h.agentUID, Generation: h.envGeneration,
+		Registration: coremetadata.ClaudeRegistration{Authority: first.Authority().(coremetadata.ClaudeAuthorityRef)}, HookProcess: hookIdentity, Socket: private.Socket, Token: private.Token})
+	for _, input := range [][]byte{[]byte("{" + private.Token), []byte(strings.Repeat(private.Token, 2000)), forged} {
+		for _, route := range []string{"claude-endpoint-register", "claude-endpoint-helper"} {
+			readAck, writeAck, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			negative := exec.Command(binary, "internal", route)
+			negative.Stdin = bytes.NewReader(input)
+			negative.ExtraFiles = []*os.File{writeAck}
+			negative.Env = append(claudeEndpointProcessEnv(root, binary), internalClaudeRegistryPathEnv+"="+registryPath, internalActivationPaneUIDEnv+"="+h.paneUID, internalActivationGenerationEnv+"="+h.envGeneration)
+			output, runErr := negative.CombinedOutput()
+			_ = readAck.Close()
+			_ = writeAck.Close()
+			if runErr != nil || len(output) != 0 {
+				t.Fatal("private invalid entrypoint emitted output or failed noisily")
+			}
+			assertNoClaudeSecretResidue(t, root, []string{private.Token, private.Socket}, output)
+		}
+	}
+	afterNegative, _ := os.ReadFile(registryPath)
+	if !bytes.Equal(beforeNegative, afterNegative) || !first.Same(getRoute()) {
+		t.Fatal("invalid private entrypoint changed current registration")
+	}
+	providerIdentity := first.Authority().(coremetadata.ClaudeAuthorityRef).Process
+	if _, parent, err := claudeadapter.Process(providerIdentity.PID); err != nil || parent != cmd.Process.Pid {
+		t.Fatal("provider did not match supervisor's exact child")
+	}
+	_, _ = io.WriteString(writeControl, "nested\n")
+	line, err = reader.ReadBytes('\n')
+	if err != nil || string(line) != "nested-returned\n" {
+		t.Fatal("nested isolation fixture failed")
+	}
+	if !first.Same(getRoute()) {
+		t.Fatal("nested unmanaged process replaced managed activation")
+	}
+	_, _ = io.WriteString(writeControl, "repeat\n")
+	waitHook()
+	second := getRoute()
+	if first.Same(second) || probeClaudeRegistrationLease(registryPath, first) {
+		t.Fatal("repeated SessionStart reused old lease")
+	}
+	// Kill the actual helper while its provider remains alive. The production
+	// supervisor watcher must revoke and clean it without a capability write.
+	helperPID := second.Authority().(coremetadata.ClaudeAuthorityRef).LeaseProcess.PID
+	if current, _, err := claudeadapter.Process(helperPID); err != nil || current != second.Authority().(coremetadata.ClaudeAuthorityRef).LeaseProcess {
+		t.Fatal("helper birth changed before controlled kill")
+	}
+	helperProcess, err := os.FindProcess(helperPID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := helperProcess.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	crashDeadline := time.Now().Add(5 * time.Second)
+	for {
+		reg, err := store.LoadDegradedReadOnly()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, reason := coremetadata.ResolveAgentRoute(reg, h.agentUID)
+		_, statErr := os.Lstat(claudeActivationLeaseDir(registryPath, h.paneUID, h.envGeneration))
+		if reason != "" && os.IsNotExist(statErr) {
+			break
+		}
+		if time.Now().After(crashDeadline) {
+			t.Fatal("supervisor did not invalidate and clean killed helper")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if actual, _, err := claudeadapter.Process(providerIdentity.PID); err != nil || actual != providerIdentity {
+		t.Fatal("provider stopped when helper was killed")
+	}
+	_, _ = io.WriteString(writeControl, "repeat\n")
+	waitHook()
+	third := getRoute()
+	_, _ = io.WriteString(writeControl, "exit\n")
+	line, err = reader.ReadBytes('\n')
+	if err != nil || string(line) != "provider-connections=0\n" {
+		t.Fatal("provider transport isolation failed")
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal("provider process failed")
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("provider exit deadline")
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		reg, err := store.LoadDegradedReadOnly()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, reason := coremetadata.ResolveAgentRoute(reg, h.agentUID)
+		_, statErr := os.Lstat(claudeActivationLeaseDir(registryPath, h.paneUID, h.envGeneration))
+		if reason != "" && os.IsNotExist(statErr) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("registration or helper files survived provider exit")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	for _, route := range []coremetadata.AgentRouteRef{first, second, third} {
+		helper := route.Authority().(coremetadata.ClaudeAuthorityRef).LeaseProcess
+		if observed, _, err := claudeadapter.Process(helper.PID); err == nil && observed == helper {
+			t.Fatal("helper process survived activation")
+		}
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatal("registration process wrote stdout or stderr")
+	}
+	assertNoClaudeSecretResidue(t, root, []string{private.Token, private.Socket}, stdout.Bytes(), stderr.Bytes())
+	t.Log("SessionStart→ready→replacement→exit→invalidated; nested registration refused; provider connections=0; secret residue=0; helper/process/socket cleanup=0")
+}
+
+func cleanupClaudeEndpointTestActivation(store *intmetadata.Store, spec superviseSpec) {
+	if reg, err := store.LoadDegradedReadOnly(); err == nil {
+		if pane, ok := reg.Pane(spec.PaneUID); ok && pane.Status.Activation.Generation == spec.Generation && pane.Status.Activation.Claude != nil {
+			binding := pane.Status.Activation.Claude
+			processes := []coremetadata.ProcessIdentity{binding.Process}
+			if binding.Registration != nil {
+				processes = append(processes, binding.Registration.Authority.LeaseProcess)
+			}
+			for _, expected := range processes {
+				if actual, _, err := claudeadapter.Process(expected.PID); err == nil && actual == expected {
+					if process, err := os.FindProcess(expected.PID); err == nil {
+						_ = process.Kill()
+					}
+				}
+			}
+		}
+	}
+	cleanupClaudeActivationLeases(spec)
+}
+
+func claudeEndpointProcessEnv(root, binary string) []string {
+	drop := map[string]bool{"TMUX": true, "TMUX_PANE": true, "XDG_CONFIG_HOME": true, "XDG_STATE_HOME": true, "XDG_RUNTIME_DIR": true, "TMPDIR": true, "PMX_TEST_ROOT": true, "PMX_TEST_BIN": true}
+	var env []string
+	for _, value := range os.Environ() {
+		key, _, _ := strings.Cut(value, "=")
+		if !drop[key] {
+			env = append(env, value)
+		}
+	}
+	return append(env, "TMUX_PANE=%7", "XDG_CONFIG_HOME="+filepath.Join(root, "config"), "XDG_STATE_HOME="+filepath.Join(root, "state"), "XDG_RUNTIME_DIR="+filepath.Join(root, "runtime"), "TMPDIR="+root, "PMX_TEST_ROOT="+root, "PMX_TEST_BIN="+binary)
+}

--- a/internal/app/claude_endpoint_test.go
+++ b/internal/app/claude_endpoint_test.go
@@ -1,0 +1,541 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	claudeadapter "github.com/crevissepartners/projmux/internal/integrations/agents/claude"
+	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
+)
+
+type claudeEndpointTestFixture struct {
+	bootstrap claudeEndpointBootstrap
+	store     *intmetadata.Store
+	provider  *exec.Cmd
+	inbox     *net.UnixListener
+	root      string
+}
+
+func TestClaudeEndpointHookMigrationPreservesStatusAndUserHooks(t *testing.T) {
+	root := t.TempDir()
+	command := testAICommand(root)
+	command.readFile = os.ReadFile
+	path := filepath.Join(root, claudeSettingsRelativePath)
+	settings := map[string]any{"hooks": map[string]any{"SessionStart": []any{
+		claudeHookManagedEntry(),
+		map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "echo user-session-start"}}},
+	}}}
+	data, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeCodexTestFile(t, path, string(data))
+	if err := command.Run([]string{"integrate", "claude", "--dry-run"}, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(path); err != nil || !bytes.Equal(got, data) {
+		t.Fatal("dry-run changed existing hook settings")
+	}
+	if err := command.Run([]string{"integrate", "claude"}, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	installed := readClaudeSettingsTestFile(t, path)
+	hooks := installed["hooks"].(map[string]any)["SessionStart"].([]any)
+	status, registration, user := 0, 0, 0
+	for _, entry := range hooks {
+		for _, raw := range entry.(map[string]any)["hooks"].([]any) {
+			hook := raw.(map[string]any)
+			switch hook["command"] {
+			case claudeHookCommand:
+				status++
+			case claudeRegistrationHookCommand:
+				registration++
+				if hook["timeout"] != float64(5) {
+					t.Fatal("registration bootstrap timeout is not bounded")
+				}
+			case "echo user-session-start":
+				user++
+			}
+		}
+	}
+	if status != 1 || registration != 1 || user != 1 {
+		t.Fatal("migration changed status/user hooks or duplicated registration")
+	}
+	first, _ := os.ReadFile(path)
+	if err := command.Run([]string{"integrate", "claude"}, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if second, err := os.ReadFile(path); err != nil || !bytes.Equal(first, second) {
+		t.Fatal("hook migration is not idempotent")
+	}
+	if err := command.Run([]string{"integrate", "claude", "--remove"}, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	removed, _ := os.ReadFile(path)
+	if bytes.Contains(removed, []byte(claudeHookManagedMarker)) || !bytes.Contains(removed, []byte("echo user-session-start")) {
+		t.Fatal("removal retained managed hook or removed user hook")
+	}
+}
+
+func newClaudeEndpointTestFixture(t *testing.T) *claudeEndpointTestFixture {
+	t.Helper()
+	root, err := os.MkdirTemp("", "pce-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	provider := exec.Command("sleep", "60")
+	if err := provider.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = provider.Process.Kill(); _ = provider.Wait() })
+	process, _, err := claudeadapter.Process(provider.Process.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := newSessionRefHarness(t, "claude")
+	if err := intmetadata.DefaultMutator().RecordClaudeProcess(h.registry, h.paneUID, h.agentUID, h.envGeneration, process); err != nil {
+		t.Fatal(err)
+	}
+	path := intmetadata.PathFor(filepath.Join(root, "state"))
+	store := intmetadata.NewStore(path)
+	if _, err := store.Update(func(reg *coremetadata.Registry) error { *reg = h.registry.Clone(); return nil }); err != nil {
+		t.Fatal(err)
+	}
+	inbox, err := net.ListenUnix("unix", &net.UnixAddr{Name: filepath.Join(root, "provider.sock"), Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inbox.SetUnlinkOnClose(false)
+	t.Cleanup(func() { _ = inbox.Close() })
+	if err := os.Chmod(inbox.Addr().String(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bootstrap, ok := claudeRegistrationBootstrap(*h.registry, path, []byte(`{"hook_event_name":"SessionStart","session_id":"actual-session"}`), func(key string) string {
+		switch key {
+		case internalActivationPaneUIDEnv:
+			return h.paneUID
+		case internalActivationGenerationEnv:
+			return h.envGeneration
+		case "CLAUDE_CODE_MESSAGING_SOCKET":
+			return inbox.Addr().String()
+		case "CLAUDE_CODE_MESSAGING_TOKEN":
+			return "synthetic-private-credential-for-residue-scan"
+		}
+		return ""
+	}, provider.Process.Pid)
+	if !ok {
+		t.Fatal("valid SessionStart refused")
+	}
+	if _, _, err := store.UpdateConvergent(func(reg *coremetadata.Registry) error {
+		return intmetadata.DefaultMutator().BeginClaudeRegistration(reg, bootstrap.PaneUID, bootstrap.AgentUID, bootstrap.Generation, bootstrap.Registration.Authority)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return &claudeEndpointTestFixture{bootstrap: bootstrap, store: store, provider: provider, inbox: inbox, root: root}
+}
+
+func (f *claudeEndpointTestFixture) route(t *testing.T) (coremetadata.AgentRouteRef, string) {
+	t.Helper()
+	reg, err := f.store.LoadDegradedReadOnly()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return coremetadata.ResolveAgentRoute(reg, f.bootstrap.AgentUID)
+}
+
+func (f *claudeEndpointTestFixture) start(t *testing.T) (context.CancelFunc, <-chan error) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	readAck, writeAck := io.Pipe()
+	done := make(chan error, 1)
+	go func() { done <- serveClaudeEndpoint(ctx, f.bootstrap, writeAck); close(done); _ = writeAck.Close() }()
+	ackDone := make(chan bool, 1)
+	go func() {
+		var ack [1]byte
+		_, err := io.ReadFull(readAck, ack[:])
+		ackDone <- err == nil && ack[0] == 1
+		_ = readAck.Close()
+	}()
+	select {
+	case ok := <-ackDone:
+		if !ok {
+			t.Fatal("helper failed before readiness")
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("helper readiness deadline")
+	}
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(4 * time.Second):
+			t.Error("helper did not exit")
+		}
+	})
+	return cancel, done
+}
+
+func assertNoClaudeSecretResidue(t *testing.T, root string, private []string, outputs ...[]byte) {
+	t.Helper()
+	check := func(data []byte) {
+		for _, value := range private {
+			if value != "" && bytes.Contains(data, []byte(value)) {
+				t.Fatal("private Claude registration residue detected")
+			}
+		}
+	}
+	for _, output := range outputs {
+		check(output)
+	}
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.Type().IsRegular() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			check(data)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal("residue scan failed")
+	}
+}
+
+func TestClaudeEndpointReadyExitInvalidated(t *testing.T) {
+	t.Parallel()
+	f := newClaudeEndpointTestFixture(t)
+	if _, reason := f.route(t); reason == "" {
+		t.Fatal("pending registration became ready")
+	}
+	_, done := f.start(t)
+	route, reason := f.route(t)
+	if reason != "" || !probeClaudeRegistrationLease(f.bootstrap.RegistryPath, route) {
+		t.Fatal("exact registration not ready")
+	}
+	assertNoClaudeSecretResidue(t, claudeActivationLeaseDir(f.bootstrap.RegistryPath, route.PaneUID, route.Generation), []string{f.bootstrap.Token, f.bootstrap.Socket})
+	before, _ := os.ReadFile(f.bootstrap.RegistryPath)
+	for range 3 {
+		if !probeClaudeRegistrationLease(f.bootstrap.RegistryPath, route) {
+			t.Fatal("read-only lease probe failed")
+		}
+	}
+	after, _ := os.ReadFile(f.bootstrap.RegistryPath)
+	if !bytes.Equal(before, after) {
+		t.Fatal("readiness probe mutated Registry")
+	}
+	if err := f.provider.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.provider.Wait()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal("helper exit failed")
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("helper outlived provider")
+	}
+	if _, reason := f.route(t); reason == "" || probeClaudeRegistrationLease(f.bootstrap.RegistryPath, route) {
+		t.Fatal("exited activation remained eligible")
+	}
+	leasePath := claudeLeaseSocket(f.bootstrap.RegistryPath, route.PaneUID, route.Generation, f.bootstrap.Registration.Authority.RegistrationGeneration)
+	if _, err := os.Lstat(filepath.Dir(leasePath)); !os.IsNotExist(err) {
+		t.Fatal("helper files survived exit")
+	}
+	_ = f.inbox.SetDeadline(time.Now().Add(20 * time.Millisecond))
+	if conn, err := f.inbox.Accept(); err == nil {
+		_ = conn.Close()
+		t.Fatal("provider transport connection occurred")
+	}
+	assertNoClaudeSecretResidue(t, f.root, []string{f.bootstrap.Token, f.bootstrap.Socket}, before, after, fmt.Appendf(nil, "%v %#v", f.bootstrap, f.bootstrap))
+}
+
+func TestClaudeEndpointRenamePreservesAndSocketReplacementInvalidates(t *testing.T) {
+	t.Parallel()
+	f := newClaudeEndpointTestFixture(t)
+	_, done := f.start(t)
+	before, reason := f.route(t)
+	if reason != "" {
+		t.Fatal(reason)
+	}
+	_, _, err := f.store.UpdateConvergent(func(reg *coremetadata.Registry) error {
+		m := intmetadata.DefaultMutator()
+		if _, err := m.RenameAgent(reg, f.bootstrap.AgentUID, "renamed-agent"); err != nil {
+			return err
+		}
+		_, err := m.RenamePane(reg, f.bootstrap.PaneUID, "renamed-pane")
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, reason := f.route(t)
+	if reason != "" || !before.Same(after) || !probeClaudeRegistrationLease(f.bootstrap.RegistryPath, after) {
+		t.Fatal("same-UID rename invalidated endpoint")
+	}
+	if err := os.Remove(f.bootstrap.Socket); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := net.ListenUnix("unix", &net.UnixAddr{Name: f.bootstrap.Socket, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement.SetUnlinkOnClose(false)
+	defer replacement.Close()
+	if err := os.Chmod(f.bootstrap.Socket, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if probeClaudeRegistrationLease(f.bootstrap.RegistryPath, before) {
+		t.Fatal("provider socket replacement remained eligible")
+	}
+	select {
+	case <-done:
+	case <-time.After(4 * time.Second):
+		t.Fatal("socket replacement did not stop helper")
+	}
+	if _, err := os.Lstat(f.bootstrap.Socket); err != nil {
+		t.Fatal("helper removed replacement provider socket")
+	}
+}
+
+func TestClaudeEndpointBootstrapRejectsForeignAndSecretClaims(t *testing.T) {
+	t.Parallel()
+	f := newClaudeEndpointTestFixture(t)
+	reg, err := f.store.LoadDegradedReadOnly()
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseEnv := map[string]string{internalActivationPaneUIDEnv: f.bootstrap.PaneUID, internalActivationGenerationEnv: f.bootstrap.Generation,
+		"CLAUDE_CODE_MESSAGING_SOCKET": f.bootstrap.Socket, "CLAUDE_CODE_MESSAGING_TOKEN": f.bootstrap.Token}
+	for _, test := range []struct {
+		name    string
+		parent  int
+		session string
+		change  func(*coremetadata.Registry, map[string]string)
+	}{
+		{"unmanaged nested producer", os.Getpid(), "actual-session", nil},
+		{"secret session identity", f.provider.Process.Pid, f.bootstrap.Token, nil},
+		{"stale generation", f.provider.Process.Pid, "actual-session", func(_ *coremetadata.Registry, env map[string]string) { env[internalActivationGenerationEnv] = "old" }},
+		{"absent socket", f.provider.Process.Pid, "actual-session", func(_ *coremetadata.Registry, env map[string]string) {
+			env["CLAUDE_CODE_MESSAGING_SOCKET"] = filepath.Join(f.root, "absent.sock")
+		}},
+		{"wrong owner kind", f.provider.Process.Pid, "actual-session", func(reg *coremetadata.Registry, _ map[string]string) {
+			pane, _ := reg.Pane(f.bootstrap.PaneUID)
+			pane.Metadata.OwnerRef.Kind = coremetadata.KindWindow
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			current := reg.Clone()
+			env := map[string]string{}
+			maps.Copy(env, baseEnv)
+			if test.change != nil {
+				test.change(&current, env)
+			}
+			payload, _ := json.Marshal(map[string]string{"hook_event_name": "SessionStart", "session_id": test.session})
+			before := current.Clone()
+			if _, ok := claudeRegistrationBootstrap(current, f.bootstrap.RegistryPath, payload, func(key string) string { return env[key] }, test.parent); ok {
+				t.Fatal("foreign bootstrap accepted")
+			}
+			if !reflect.DeepEqual(current, before) {
+				t.Fatal("refused bootstrap changed Registry")
+			}
+		})
+	}
+	if claudeHelperProducerMatches(f.bootstrap, os.Getppid()) {
+		t.Fatal("unrelated helper invocation accepted")
+	}
+}
+
+func TestClaudeEndpointSocketGuardsAndPrivatePeer(t *testing.T) {
+	t.Parallel()
+	f := newClaudeEndpointTestFixture(t)
+	link := filepath.Join(f.root, "link.sock")
+	if err := os.Symlink(f.bootstrap.Socket, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := inspectClaudeSocket(link); err == nil {
+		t.Fatal("symlink socket accepted")
+	}
+	if err := os.Chmod(f.bootstrap.Socket, 0o666); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := inspectClaudeSocket(f.bootstrap.Socket); err == nil {
+		t.Fatal("open socket mode accepted")
+	}
+	if err := os.Chmod(f.bootstrap.Socket, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A replacement helper socket cannot borrow a different live process's
+	// Registry lease merely by returning the right readiness byte.
+	r := f.bootstrap.Registration
+	r.Ready = true
+	_, _, err := f.store.UpdateConvergent(func(reg *coremetadata.Registry) error {
+		return intmetadata.DefaultMutator().RecordClaudeRegistration(reg, f.bootstrap.PaneUID, f.bootstrap.AgentUID, f.bootstrap.Generation, r)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	route, reason := f.route(t)
+	if reason != "" {
+		t.Fatal(reason)
+	}
+	lease := claudeLeaseSocket(f.bootstrap.RegistryPath, route.PaneUID, route.Generation, r.Authority.RegistrationGeneration)
+	if err := os.Mkdir(filepath.Dir(lease), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(lease)) })
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: lease, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	if err := os.Chmod(lease, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			_, _ = conn.Write([]byte{1})
+			_ = conn.Close()
+		}
+	}()
+	if probeClaudeRegistrationLease(f.bootstrap.RegistryPath, route) {
+		t.Fatal("replacement helper borrowed foreign process lease")
+	}
+}
+
+func TestClaudeEndpointDeadLeaseWatcherInvalidatesWhileProviderLives(t *testing.T) {
+	t.Parallel()
+	f := newClaudeEndpointTestFixture(t)
+	helper := exec.Command("sleep", "60")
+	if err := helper.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = helper.Process.Kill(); _ = helper.Wait() })
+	helperIdentity, _, err := claudeadapter.Process(helper.Process.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.bootstrap.Registration.Authority.LeaseProcess = helperIdentity
+	_, _, err = f.store.UpdateConvergent(func(reg *coremetadata.Registry) error {
+		return intmetadata.DefaultMutator().RecordClaudeRegistration(reg, f.bootstrap.PaneUID, f.bootstrap.AgentUID, f.bootstrap.Generation, f.bootstrap.Registration)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease := claudeLeaseSocket(f.bootstrap.RegistryPath, f.bootstrap.PaneUID, f.bootstrap.Generation, f.bootstrap.Registration.Authority.RegistrationGeneration)
+	if err := os.Mkdir(filepath.Dir(lease), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(lease)) })
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: lease, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	if err := os.Chmod(lease, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeClaudeLeaseOwner(lease+".json", f.bootstrap); err != nil {
+		t.Fatal(err)
+	}
+	if err := helper.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	_ = helper.Wait()
+	spec := superviseSpec{RegistryPath: f.bootstrap.RegistryPath, PaneUID: f.bootstrap.PaneUID, AgentUID: f.bootstrap.AgentUID, Generation: f.bootstrap.Generation}
+	ctx := t.Context()
+	go watchClaudeActivationLeases(ctx, spec)
+	deadline := time.Now().Add(4 * time.Second)
+	for {
+		if _, reason := f.route(t); reason != "" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("dead helper registration was not reaped")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, _, err := claudeadapter.Process(f.provider.Process.Pid); err != nil {
+		t.Fatal("provider did not remain alive")
+	}
+	for {
+		if _, err := os.Lstat(filepath.Dir(lease)); os.IsNotExist(err) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("dead helper files survived")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	assertNoClaudeSecretResidue(t, f.root, []string{f.bootstrap.Token, f.bootstrap.Socket})
+}
+
+func TestClaudeEndpointCreatorRegistryContextIsPrivateAndExact(t *testing.T) {
+	t.Parallel()
+	path := testActivationRegistryPath(t)
+	spec := superviseSpec{RegistryPath: path, PaneUID: "pane", Generation: "generation", ClaudeRegistration: true}
+	joined := strings.Join(activationEnvironment(spec), "\n")
+	if !strings.Contains(joined, internalClaudeRegistryPathEnv+"="+path) || strings.Contains(joined, "PROJMUX_") {
+		t.Fatal("private creator Registry context missing or public")
+	}
+	spec.ClaudeRegistration = false
+	if strings.Contains(strings.Join(activationEnvironment(spec), "\n"), path) {
+		t.Fatal("non-Claude process inherited new private context")
+	}
+	spec.ClaudeRegistration = true
+	spec.RuntimeID = "%7"
+	stale := []string{internalActivationPaneUIDEnv + "=old-pane", internalActivationGenerationEnv + "=old-generation", internalClaudeRegistryPathEnv + "=/old/metadata/registry.json", runtimeMutationAnchorPaneEnv + "=%999"}
+	actual := committedActivationEnvironment(stale, spec)
+	for _, key := range []string{internalActivationPaneUIDEnv, internalActivationGenerationEnv, internalClaudeRegistryPathEnv, runtimeMutationAnchorPaneEnv} {
+		count := 0
+		for _, value := range actual {
+			if strings.HasPrefix(value, key+"=") {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Fatal("private activation envelope retained duplicate authority")
+		}
+	}
+	if strings.Contains(strings.Join(actual, "\n"), "old-") || strings.Contains(strings.Join(actual, "\n"), "%999") {
+		t.Fatal("inherited activation authority survived")
+	}
+}
+
+func TestClaudeEndpointOwnerReceiptFIFORefusesPromptly(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "receipt.sock.json")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan bool, 1)
+	go func() { _, ok := readClaudeLeaseOwner(path, superviseSpec{}); done <- ok }()
+	select {
+	case ok := <-done:
+		if ok {
+			t.Fatal("FIFO admitted as lease ownership")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("FIFO blocked ownership reader")
+	}
+}

--- a/internal/app/claude_endpoint_watch.go
+++ b/internal/app/claude_endpoint_watch.go
@@ -1,0 +1,120 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	claudeadapter "github.com/crevissepartners/projmux/internal/integrations/agents/claude"
+	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
+)
+
+// claudeLeaseOwnerReceipt is crash-cleanup evidence, not a provider locator.
+// Its file contains only identities already safe for Registry persistence.
+type claudeLeaseOwnerReceipt struct {
+	AgentUID   string                          `json:"agentUID"`
+	PaneUID    string                          `json:"paneUID"`
+	Generation string                          `json:"generation"`
+	Authority  coremetadata.ClaudeAuthorityRef `json:"authority"`
+}
+
+func writeClaudeLeaseOwner(path string, bootstrap claudeEndpointBootstrap) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return json.NewEncoder(file).Encode(claudeLeaseOwnerReceipt{AgentUID: bootstrap.AgentUID, PaneUID: bootstrap.PaneUID,
+		Generation: bootstrap.Generation, Authority: bootstrap.Registration.Authority})
+}
+
+func readClaudeLeaseOwner(path string, spec superviseSpec) (claudeLeaseOwnerReceipt, bool) {
+	var receipt claudeLeaseOwnerReceipt
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return receipt, false
+	}
+	file := os.NewFile(uintptr(fd), "Claude lease owner")
+	if file == nil {
+		_ = syscall.Close(fd)
+		return receipt, false
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 || info.Size() > 8192 {
+		return receipt, false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat.Uid != uint32(os.Getuid()) {
+		return receipt, false
+	}
+	if json.NewDecoder(io.LimitReader(file, 8192)).Decode(&receipt) != nil || !receipt.Authority.Valid() ||
+		receipt.AgentUID != spec.AgentUID || receipt.PaneUID != spec.PaneUID || receipt.Generation != spec.Generation {
+		return receipt, false
+	}
+	return receipt, true
+}
+
+func watchClaudeActivationLeases(ctx context.Context, spec superviseSpec) {
+	if spec.AgentUID == "" || exactActivationRegistryPath(spec.RegistryPath) != nil {
+		return
+	}
+	ticker := time.NewTicker(2 * claudeEndpointPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			reapDeadClaudeLeases(spec)
+		}
+	}
+}
+
+func reapDeadClaudeLeases(spec superviseSpec) {
+	dir := claudeActivationLeaseDir(spec.RegistryPath, spec.PaneUID, spec.Generation)
+	if !privateClaudeLeaseDir(dir) {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".sock.json") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		receipt, ok := readClaudeLeaseOwner(path, spec)
+		if !ok {
+			continue
+		}
+		socket := claudeLeaseSocket(spec.RegistryPath, spec.PaneUID, spec.Generation, receipt.Authority.RegistrationGeneration)
+		if path != socket+".json" {
+			continue
+		}
+		expected := receipt.Authority.LeaseProcess
+		if actual, _, err := claudeadapter.Process(expected.PID); err == nil && actual == expected {
+			continue
+		}
+		store := intmetadata.NewStore(spec.RegistryPath)
+		_, _, err := store.UpdateConvergent(func(reg *coremetadata.Registry) error {
+			intmetadata.DefaultMutator().ClearClaudeRegistration(reg, spec.PaneUID, spec.AgentUID, spec.Generation, receipt.Authority)
+			return nil
+		})
+		if err != nil {
+			continue
+		}
+		if _, err := inspectClaudeSocket(socket); err == nil {
+			_ = os.Remove(socket)
+		}
+		_ = os.Remove(path)
+	}
+	_ = os.Remove(dir)
+}

--- a/internal/app/claude_endpoint_watch.go
+++ b/internal/app/claude_endpoint_watch.go
@@ -25,6 +25,9 @@ type claudeLeaseOwnerReceipt struct {
 }
 
 func writeClaudeLeaseOwner(path string, bootstrap claudeEndpointBootstrap) error {
+	// #nosec G304 -- the caller derives this receipt from hashed exact activation
+	// and registration identities under an owned 0700 lease directory. Exclusive
+	// creation refuses an existing path or symlink; no provider locator is used.
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
@@ -51,7 +54,7 @@ func readClaudeLeaseOwner(path string, spec superviseSpec) (claudeLeaseOwnerRece
 		return receipt, false
 	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok || stat.Uid != uint32(os.Getuid()) {
+	if !ok || int64(stat.Uid) != int64(os.Getuid()) {
 		return receipt, false
 	}
 	if json.NewDecoder(io.LimitReader(file, 8192)).Decode(&receipt) != nil || !receipt.Authority.Valid() ||

--- a/internal/app/internal_routes.go
+++ b/internal/app/internal_routes.go
@@ -107,6 +107,10 @@ func (c *internalCommand) Run(args []string, stdout, stderr io.Writer) error {
 		return forwardRawArgv(c.supervise, "internal supervise", "supervise", nil, rest, stdout, stderr)
 	case "activation-exec":
 		return forwardRawArgv(c.activationExec, "internal activation-exec", "activation-exec", nil, rest, stdout, stderr)
+	case "claude-endpoint-register":
+		return runClaudeEndpointRegistration(rest)
+	case "claude-endpoint-helper":
+		return runClaudeEndpointHelper(rest)
 	case "codex-broker":
 		return forwardRawArgv(c.codexBroker, "internal codex-broker", "codex-broker", nil, rest, stdout, stderr)
 	case "codex-generation-launch":

--- a/internal/app/supervise.go
+++ b/internal/app/supervise.go
@@ -20,6 +20,7 @@ import (
 const (
 	internalActivationPaneUIDEnv    = "PMX_INTERNAL_ACTIVATION_PANE_UID"
 	internalActivationGenerationEnv = "PMX_INTERNAL_ACTIVATION_GENERATION"
+	internalClaudeRegistryPathEnv   = "PMX_INTERNAL_CLAUDE_REGISTRY_PATH"
 )
 
 // superviseSpec is the identity one supervised launch quotes back when its
@@ -41,9 +42,14 @@ type superviseSpec struct {
 	// with its inherited TMUX_PANE.
 	RuntimeID string
 	// RegistryPath is the creator-resolved private authority for Agent
-	// admission. It is carried only between internal routes and is never
-	// exported to providers or public PROJMUX_* hooks.
+	// admission. Internal routes carry it explicitly; the admitted Claude
+	// child also passes it to its hook in private PMX_INTERNAL context. It is
+	// never part of the public PROJMUX_* hook contract.
 	RegistryPath string
+	// ClaudeRegistration is set only after exact gate admission identifies a
+	// Claude child. Its registration hook inherits the creator-selected path
+	// through private PMX_INTERNAL context, never the public PROJMUX hook API.
+	ClaudeRegistration bool
 }
 
 // valid reports whether the spec can identify a receipt at all.

--- a/internal/app/supervise_child_unix.go
+++ b/internal/app/supervise_child_unix.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -56,7 +57,13 @@ func runSupervisedChildWithActivation(argv []string, argv0 string, spec supervis
 	if err != nil {
 		return processOutcome{}, fmt.Errorf("resolve activation gate executable: %w", err)
 	}
-	return runSupervisedActivationGate(activationExecArgv(binary, spec, argv0, 3, argv))
+	watchContext, cancelWatch := context.WithCancel(context.Background())
+	defer cancelWatch()
+	go watchClaudeActivationLeases(watchContext, spec)
+	outcome, runErr := runSupervisedActivationGate(activationExecArgv(binary, spec, argv0, 3, argv))
+	cancelWatch()
+	cleanupClaudeActivationLeases(spec)
+	return outcome, runErr
 }
 
 // runSupervisedChildWithSignalSource is the test seam for signals delivered to

--- a/internal/core/metadata/agent.go
+++ b/internal/core/metadata/agent.go
@@ -269,6 +269,8 @@ func (m Mutator) TransitionAgent(reg *Registry, agentUID string, phase AgentPhas
 	agent.Status.Reason = strings.TrimSpace(reason)
 	agent.Status.LastTransitionAt = now
 	if phase != PhaseRunning {
+		pane, _ := reg.Pane(agent.Status.PaneRef)
+		clearClaudeRegistration(pane)
 		agent.Status.PaneRef = ""
 		agent.Status.Interaction = AgentInteraction{Kind: InteractionUnknown, ObservedAt: now, Source: "lifecycle"}
 		agent.Status.Progress = AgentProgress{}

--- a/internal/core/metadata/agentroute.go
+++ b/internal/core/metadata/agentroute.go
@@ -1,0 +1,119 @@
+package metadata
+
+import "strings"
+
+// ProviderAuthorityRef is a sealed union. Each adapter owns its authority
+// namespace; no common epoch or nullable bag of provider fields exists.
+type ProviderAuthorityRef interface {
+	Provider() string
+	providerAuthority()
+	sameAuthority(ProviderAuthorityRef) bool
+}
+
+// AgentRouteRef addresses one stable Agent activation. It contains identity
+// only, never a provider address or credential. Construct it from Registry
+// evidence, then let the adapter revalidate its live authority before use.
+type AgentRouteRef struct {
+	AgentUID   string
+	PaneUID    string
+	Generation string
+	authority  ProviderAuthorityRef
+}
+
+func (r AgentRouteRef) Authority() ProviderAuthorityRef { return r.authority }
+
+func (r AgentRouteRef) Same(other AgentRouteRef) bool {
+	return r.AgentUID != "" && r.PaneUID != "" && r.Generation != "" && r.authority != nil &&
+		r.AgentUID == other.AgentUID && r.PaneUID == other.PaneUID && r.Generation == other.Generation &&
+		r.authority.sameAuthority(other.authority)
+}
+
+// CodexRouteAuthority consumes the existing composite authority unchanged.
+// It has no ownership of app-server lifecycle, upgrades, or epoch allocation.
+type CodexRouteAuthority struct {
+	ThreadID  string
+	Authority CodexAuthorityRef
+}
+
+func (CodexRouteAuthority) Provider() string   { return "codex" }
+func (CodexRouteAuthority) providerAuthority() {}
+func (a CodexRouteAuthority) sameAuthority(other ProviderAuthorityRef) bool {
+	b, ok := other.(CodexRouteAuthority)
+	return ok && a.ThreadID != "" && a.ThreadID == b.ThreadID && a.Authority.Authorizes(b.Authority)
+}
+
+// ProcessIdentity uses the kernel's process birth identity, not a PID alone.
+// Start is OS-qualified and includes the boot identity where birth is relative.
+type ProcessIdentity struct {
+	PID      int    `json:"pid"`
+	OwnerUID uint32 `json:"ownerUID"`
+	Start    string `json:"start"`
+}
+
+func (p ProcessIdentity) Valid() bool {
+	return p.PID > 0 && p.Start != "" && len(p.Start) <= 160 && !strings.ContainsAny(p.Start, "\r\n\x00")
+}
+
+// ClaudeAuthorityRef has a session/process/registration lease namespace, not
+// Codex connection or binding epochs. LeaseProcess is the private helper which
+// retains the actual endpoint and credential only in its memory.
+type ClaudeAuthorityRef struct {
+	SessionID              string          `json:"sessionId"`
+	Process                ProcessIdentity `json:"process"`
+	RegistrationGeneration string          `json:"registrationGeneration"`
+	LeaseProcess           ProcessIdentity `json:"leaseProcess"`
+}
+
+func (ClaudeAuthorityRef) Provider() string   { return "claude" }
+func (ClaudeAuthorityRef) providerAuthority() {}
+func (a ClaudeAuthorityRef) Valid() bool {
+	return validCodexIdentityToken(a.SessionID) && a.Process.Valid() &&
+		validCodexIdentityToken(a.RegistrationGeneration) && a.LeaseProcess.Valid()
+}
+func (a ClaudeAuthorityRef) sameAuthority(other ProviderAuthorityRef) bool {
+	b, ok := other.(ClaudeAuthorityRef)
+	return ok && a.Valid() && b.Valid() && a == b
+}
+
+// ResolveAgentRoute uses only exact managed ownership. Runtime liveness remains
+// adapter evidence; a Registry snapshot alone never proves a live endpoint.
+func ResolveAgentRoute(reg Registry, agentUID string) (AgentRouteRef, string) {
+	agent, ok := reg.Agent(agentUID)
+	if !ok || agent.Status.Phase != PhaseRunning || agent.Status.PaneRef == "" {
+		return AgentRouteRef{}, "no current Running Agent activation"
+	}
+	pane, ok := reg.Pane(agent.Status.PaneRef)
+	if !ok || pane.Spec.Role != PaneRoleAgent || pane.Metadata.OwnerRef == nil ||
+		pane.Metadata.OwnerRef.Kind != KindAgent || pane.Metadata.OwnerRef.UID != agentUID ||
+		pane.Status.Activation.AgentUID != agentUID {
+		return AgentRouteRef{}, "managed activation ownership mismatch"
+	}
+	activation := pane.Status.Activation
+	if activation.Generation == "" || activation.RuntimeID == "" {
+		return AgentRouteRef{}, "managed activation identity is incomplete"
+	}
+	ref := AgentRouteRef{AgentUID: agentUID, PaneUID: pane.Metadata.UID, Generation: activation.Generation}
+	switch agent.Spec.Provider {
+	case "codex":
+		binding := activation.Codex
+		durable := agent.Status.SessionRef
+		if binding == nil || binding.Authority == nil || !binding.Authority.Valid() || binding.ThreadID == "" ||
+			durable == nil || durable.Provider != "codex" || durable.Codex == nil || durable.Codex.ThreadID != binding.ThreadID ||
+			durable.Codex.Endpoint == nil || !durable.Codex.Endpoint.Same(binding.Authority.Endpoint()) {
+			return AgentRouteRef{}, "Codex composite authority is unavailable"
+		}
+		ref.authority = CodexRouteAuthority{ThreadID: binding.ThreadID, Authority: *binding.Authority}
+	case "claude":
+		binding := activation.Claude
+		if binding == nil || binding.Registration == nil || !binding.Registration.Authority.Valid() ||
+			binding.RegistrationGeneration != binding.Registration.Authority.RegistrationGeneration ||
+			binding.RegistrationSessionID != binding.Registration.Authority.SessionID ||
+			binding.Process != binding.Registration.Authority.Process || !binding.Registration.Ready {
+			return AgentRouteRef{}, "Claude registration lease is unavailable"
+		}
+		ref.authority = binding.Registration.Authority
+	default:
+		return AgentRouteRef{}, "provider has no endpoint adapter"
+	}
+	return ref, ""
+}

--- a/internal/core/metadata/agentroute_test.go
+++ b/internal/core/metadata/agentroute_test.go
@@ -1,0 +1,257 @@
+package metadata
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"testing/quick"
+)
+
+func claudeRouteFixture(t *testing.T) (Registry, Mutator, string, string, ClaudeRegistration) {
+	t.Helper()
+	m := testMutator(dirSet{"/src/projmux": true})
+	reg := NewRegistry()
+	project, err := registerFixture(m, &reg, "/src/projmux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	agent, err := m.CreateAgent(&reg, project.Windows[0].Metadata.UID, CreateAgentOptions{Name: "claude-one", Provider: "claude", OperationID: "create"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pane, err := m.AttachAgentPane(&reg, agent.Metadata.UID, BootstrapPane{Name: "claude-pane", Command: "claude", CWD: "/src/projmux"}, "create")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = m.RecordPaneActivation(&reg, pane.Metadata.UID, PaneActivationOptions{Generation: "activation-1", RuntimeID: "%7", AgentUID: agent.Metadata.UID, OperationID: "create"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	process := ProcessIdentity{PID: 100, OwnerUID: 1000, Start: "test:provider-birth"}
+	if err := m.RecordClaudeProcess(&reg, pane.Metadata.UID, agent.Metadata.UID, "activation-1", process); err != nil {
+		t.Fatal(err)
+	}
+	registration := ClaudeRegistration{Authority: ClaudeAuthorityRef{SessionID: "actual-session", Process: process, RegistrationGeneration: "registration-1",
+		LeaseProcess: ProcessIdentity{PID: 101, OwnerUID: 1000, Start: "test:helper-birth"}}, Ready: true}
+	if err := m.BeginClaudeRegistration(&reg, pane.Metadata.UID, agent.Metadata.UID, "activation-1", registration.Authority); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.RecordClaudeRegistration(&reg, pane.Metadata.UID, agent.Metadata.UID, "activation-1", registration); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	return reg, m, agent.Metadata.UID, pane.Metadata.UID, registration
+}
+
+func TestAgentRouteClaudeIdentityTransitions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		change func(*Registry, Mutator, string, string, ClaudeRegistration)
+	}{
+		{"generation", func(reg *Registry, m Mutator, a, p string, _ ClaudeRegistration) {
+			_, _ = m.RecordPaneActivation(reg, p, PaneActivationOptions{Generation: "activation-2", AgentUID: a, RuntimeID: "%7"})
+		}},
+		{"runtime absent", func(reg *Registry, _ Mutator, _, p string, _ ClaudeRegistration) {
+			pane, _ := reg.Pane(p)
+			pane.Status.Activation.RuntimeID = ""
+		}},
+		{"wrong owner kind", func(reg *Registry, _ Mutator, _, p string, _ ClaudeRegistration) {
+			pane, _ := reg.Pane(p)
+			pane.Metadata.OwnerRef.Kind = KindWindow
+		}},
+		{"owner mismatch", func(reg *Registry, _ Mutator, _, p string, _ ClaudeRegistration) {
+			pane, _ := reg.Pane(p)
+			pane.Metadata.OwnerRef.UID = "foreign"
+		}},
+		{"process restart same PID", func(reg *Registry, _ Mutator, _, p string, _ ClaudeRegistration) {
+			pane, _ := reg.Pane(p)
+			pane.Status.Activation.Claude.Process.Start = "test:new-birth"
+		}},
+		{"stop", func(reg *Registry, m Mutator, a, _ string, _ ClaudeRegistration) {
+			_, _ = m.TransitionAgent(reg, a, PhaseOffline, "exit")
+		}},
+		{"termination", func(reg *Registry, m Mutator, a, p string, _ ClaudeRegistration) {
+			code := 0
+			_, _ = m.RecordTermination(reg, TerminationEvidence{Source: TerminationSourceSupervisor, Classification: TerminationNormal, PaneUID: p, AgentUID: a, Generation: "activation-1", ExitCode: &code})
+		}},
+		{"new SessionStart pending", func(reg *Registry, m Mutator, a, p string, r ClaudeRegistration) {
+			r.Authority.RegistrationGeneration = "registration-2"
+			_ = m.BeginClaudeRegistration(reg, p, a, "activation-1", r.Authority)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reg, m, a, p, r := claudeRouteFixture(t)
+			before, reason := ResolveAgentRoute(reg, a)
+			if reason != "" {
+				t.Fatal(reason)
+			}
+			test.change(&reg, m, a, p, r)
+			after, reason := ResolveAgentRoute(reg, a)
+			if reason == "" || before.Same(after) {
+				t.Fatal("stale route remained eligible")
+			}
+		})
+	}
+}
+
+func TestClaudeRegistrationAdmissionAndCleanupCAS(t *testing.T) {
+	t.Parallel()
+	reg, m, a, p, old := claudeRouteFixture(t)
+	newer := old
+	newer.Authority.RegistrationGeneration = "registration-2"
+	newer.Authority.LeaseProcess.Start = "test:new-helper"
+	if err := m.BeginClaudeRegistration(&reg, p, a, "activation-1", newer.Authority); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.RecordClaudeRegistration(&reg, p, a, "activation-1", old); err == nil {
+		t.Fatal("delayed old helper overwrote newer SessionStart claim")
+	}
+	if err := m.RecordClaudeRegistration(&reg, p, a, "activation-1", newer); err != nil {
+		t.Fatal(err)
+	}
+	before := reg.Clone()
+	if m.ClearClaudeRegistration(&reg, p, a, "activation-1", old.Authority) || !reflect.DeepEqual(before, reg) {
+		t.Fatal("old helper cleared new lease")
+	}
+	for _, change := range []func(*Registry){
+		func(r *Registry) { pane, _ := r.Pane(p); pane.Metadata.OwnerRef.Kind = KindWindow },
+		func(r *Registry) { agent, _ := r.Agent(a); agent.Status.PaneRef = "foreign-pane" },
+		func(r *Registry) { pane, _ := r.Pane(p); pane.Spec.Role = PaneRoleShell },
+		func(r *Registry) {
+			pane, _ := r.Pane(p)
+			pane.Status.Activation.Claude.RegistrationGeneration = "newer-claim"
+		},
+	} {
+		foreign := reg.Clone()
+		change(&foreign)
+		before = foreign.Clone()
+		if m.ClearClaudeRegistration(&foreign, p, a, "activation-1", newer.Authority) || !reflect.DeepEqual(before, foreign) {
+			t.Fatal("foreign owner or claim cleanup wrote Registry")
+		}
+	}
+}
+
+func TestAgentRouteNamesAreNotAuthority(t *testing.T) {
+	t.Parallel()
+	reg, m, a, p, _ := claudeRouteFixture(t)
+	before, reason := ResolveAgentRoute(reg, a)
+	if reason != "" {
+		t.Fatal(reason)
+	}
+	if _, err := m.RenameAgent(&reg, a, "renamed-agent"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.RenamePane(&reg, p, "renamed-pane"); err != nil {
+		t.Fatal(err)
+	}
+	after, reason := ResolveAgentRoute(reg, a)
+	if reason != "" || !before.Same(after) {
+		t.Fatal("same-UID rename changed endpoint authority")
+	}
+}
+
+func TestClaudeRegistrationRejectsCompetingClaims(t *testing.T) {
+	t.Parallel()
+	for _, change := range []func(*ClaudeRegistration){
+		func(r *ClaudeRegistration) { r.Authority.SessionID = "competing-session" },
+		func(r *ClaudeRegistration) { r.Authority.Process.Start = "foreign-process" },
+		func(r *ClaudeRegistration) { r.Authority.LeaseProcess.Start = "competing-helper" },
+	} {
+		reg, m, a, p, r := claudeRouteFixture(t)
+		before := reg.Clone()
+		change(&r)
+		if m.RecordClaudeRegistration(&reg, p, a, "activation-1", r) == nil || !reflect.DeepEqual(before, reg) {
+			t.Fatal("competing claim changed Registry")
+		}
+	}
+}
+
+func TestAgentRouteProviderAuthoritiesNeverCrossCompare(t *testing.T) {
+	t.Parallel()
+	reg, _, a, p, r := claudeRouteFixture(t)
+	claude, reason := ResolveAgentRoute(reg, a)
+	if reason != "" {
+		t.Fatal(reason)
+	}
+	codex := claude
+	codex.authority = CodexRouteAuthority{ThreadID: r.Authority.SessionID, Authority: CodexAuthorityRef{StateDomainID: "domain", EndpointGenerationID: "endpoint", BrokerRuntimeID: "broker", ConnectionEpoch: 1, BindingEpoch: 1}}
+	if claude.Same(codex) || codex.Same(claude) {
+		t.Fatal("cross-provider authority compared equal")
+	}
+	agent, _ := reg.Agent(a)
+	agent.Spec.Provider = "codex"
+	pane, _ := reg.Pane(p)
+	pane.Status.Activation.Claude = nil
+	authority := codex.authority.(CodexRouteAuthority)
+	pane.Status.Activation.Codex = &CodexActivationBinding{ThreadID: authority.ThreadID, Authority: &authority.Authority}
+	endpoint := authority.Authority.Endpoint()
+	agent.Status.SessionRef = &AgentSessionRef{Provider: "codex", Codex: &CodexSessionRef{ThreadID: authority.ThreadID, Endpoint: &endpoint}}
+	current, reason := ResolveAgentRoute(reg, a)
+	if reason != "" || !current.Same(codex) {
+		t.Fatal("existing Codex composite was not consumed exactly")
+	}
+	pane.Status.Activation.Codex.Authority.BrokerRuntimeID = "restarted"
+	changed, _ := ResolveAgentRoute(reg, a)
+	if current.Same(changed) {
+		t.Fatal("foreign Codex broker numeric epochs matched")
+	}
+}
+
+func TestAgentRouteStaleReferenceModel(t *testing.T) {
+	t.Parallel()
+	// Model: every observed SessionStart replaces the current registration;
+	// every activation replacement destroys it. A historical reference never
+	// authorizes the current route, even when names, PID, and runtime are reused.
+	property := func(events []uint8) bool {
+		reg, m, a, p, registration := claudeRouteFixture(t)
+		generation := "activation-1"
+		var history []AgentRouteRef
+		type oldLease struct {
+			generation   string
+			registration ClaudeRegistration
+		}
+		var leases []oldLease
+		for step, event := range events {
+			current, reason := ResolveAgentRoute(reg, a)
+			if reason == "" {
+				history = append(history, current)
+				leases = append(leases, oldLease{generation, registration})
+			}
+			if event%2 == 0 {
+				generation = fmt.Sprintf("activation-%d", step+2)
+				_, _ = m.RecordPaneActivation(&reg, p, PaneActivationOptions{Generation: generation, AgentUID: a, RuntimeID: "%7"})
+				if m.RecordClaudeProcess(&reg, p, a, generation, registration.Authority.Process) != nil {
+					return false
+				}
+			}
+			registration.Authority.RegistrationGeneration = fmt.Sprintf("registration-step-%d", step)
+			if m.BeginClaudeRegistration(&reg, p, a, generation, registration.Authority) != nil || m.RecordClaudeRegistration(&reg, p, a, generation, registration) != nil {
+				return false
+			}
+			now, reason := ResolveAgentRoute(reg, a)
+			if reason != "" {
+				return false
+			}
+			for _, old := range history {
+				if old.Same(now) {
+					return false
+				}
+			}
+			for _, old := range leases {
+				before := reg.Clone()
+				if m.RecordClaudeRegistration(&reg, p, a, old.generation, old.registration) == nil ||
+					m.ClearClaudeRegistration(&reg, p, a, old.generation, old.registration.Authority) || !reflect.DeepEqual(before, reg) {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	if err := quick.Check(property, &quick.Config{MaxCount: 200}); err != nil {
+		t.Fatal("stale-reference model failed")
+	}
+}

--- a/internal/core/metadata/claudebinding.go
+++ b/internal/core/metadata/claudebinding.go
@@ -1,0 +1,105 @@
+package metadata
+
+// ClaudeActivationBinding is an observation of the exact child launched by the
+// activation gate. It is replaced with the Pane generation, never resumed from
+// the durable AgentSessionRef. Only a public SessionStart can add Registration.
+type ClaudeActivationBinding struct {
+	Process                ProcessIdentity     `json:"process"`
+	RegistrationSessionID  string              `json:"registrationSessionId,omitempty"`
+	RegistrationGeneration string              `json:"registrationGeneration,omitempty"`
+	Registration           *ClaudeRegistration `json:"registration,omitempty"`
+}
+
+// ClaudeRegistration is entirely non-secret. Names and optional public titles
+// are not part of the route, authority, or registration.
+type ClaudeRegistration struct {
+	Authority ClaudeAuthorityRef `json:"authority"`
+	Ready     bool               `json:"ready"`
+}
+
+func (m Mutator) RecordClaudeProcess(reg *Registry, paneUID, agentUID, generation string, process ProcessIdentity) error {
+	const op = "record Claude process"
+	pane, ok := reg.Pane(paneUID)
+	agent, found := reg.Agent(agentUID)
+	if !ok || !found || agent.Spec.Provider != "claude" || agent.Status.Phase != PhaseRunning ||
+		agent.Status.PaneRef != paneUID || pane.Metadata.OwnerRef == nil || pane.Metadata.OwnerRef.Kind != KindAgent || pane.Metadata.OwnerUID() != agentUID || pane.Spec.Role != PaneRoleAgent ||
+		pane.Status.Activation.AgentUID != agentUID || pane.Status.Activation.Generation != generation || generation == "" || !process.Valid() {
+		return stateErr(op, ErrInvalidRegistry, "exact managed Claude activation is unavailable")
+	}
+	if pane.Status.Activation.Claude != nil {
+		return stateErr(op, ErrInvalidRegistry, "Claude process has already been bound")
+	}
+	pane.Status.Activation.Claude = &ClaudeActivationBinding{Process: process}
+	reg.UpdatedAt = m.clock()().UTC()
+	return nil
+}
+
+// BeginClaudeRegistration is the SessionStart hook's admission claim. A newer
+// claim fences out an older helper still starting, before either can be Ready.
+func (m Mutator) BeginClaudeRegistration(reg *Registry, paneUID, agentUID, generation string, authority ClaudeAuthorityRef) error {
+	const op = "begin Claude registration"
+	pane, ok := reg.Pane(paneUID)
+	agent, found := reg.Agent(agentUID)
+	if !ok || !found || agent.Spec.Provider != "claude" || agent.Status.Phase != PhaseRunning || agent.Status.PaneRef != paneUID ||
+		pane.Spec.Role != PaneRoleAgent || pane.Metadata.OwnerRef == nil || pane.Metadata.OwnerRef.Kind != KindAgent || pane.Metadata.OwnerUID() != agentUID ||
+		pane.Status.Activation.AgentUID != agentUID || pane.Status.Activation.Generation != generation || generation == "" ||
+		pane.Status.Activation.Claude == nil || pane.Status.Activation.Claude.Process != authority.Process || !authority.Valid() {
+		return stateErr(op, ErrInvalidRegistry, "exact managed Claude activation is unavailable")
+	}
+	pane.Status.Activation.Claude.RegistrationSessionID = authority.SessionID
+	pane.Status.Activation.Claude.RegistrationGeneration = authority.RegistrationGeneration
+	pane.Status.Activation.Claude.Registration = nil
+	reg.UpdatedAt = m.clock()().UTC()
+	return nil
+}
+
+func (m Mutator) RecordClaudeRegistration(reg *Registry, paneUID, agentUID, generation string, registration ClaudeRegistration) error {
+	const op = "record Claude registration"
+	pane, ok := reg.Pane(paneUID)
+	agent, found := reg.Agent(agentUID)
+	if !ok || !found || agent.Spec.Provider != "claude" || agent.Status.Phase != PhaseRunning ||
+		agent.Status.PaneRef != paneUID || pane.Metadata.OwnerRef == nil || pane.Metadata.OwnerRef.Kind != KindAgent || pane.Metadata.OwnerUID() != agentUID || pane.Spec.Role != PaneRoleAgent ||
+		pane.Status.Activation.AgentUID != agentUID || pane.Status.Activation.Generation != generation || generation == "" ||
+		pane.Status.Activation.Claude == nil || pane.Status.Activation.Claude.Process != registration.Authority.Process ||
+		pane.Status.Activation.Claude.RegistrationGeneration != registration.Authority.RegistrationGeneration ||
+		pane.Status.Activation.Claude.RegistrationSessionID != registration.Authority.SessionID || !registration.Authority.Valid() {
+		return stateErr(op, ErrInvalidRegistry, "exact managed Claude registration is unavailable")
+	}
+	if current := pane.Status.Activation.Claude.Registration; current != nil {
+		if current.Authority == registration.Authority {
+			return nil
+		}
+		return stateErr(op, ErrInvalidRegistry, "competing Claude registration lease")
+	}
+	registration.Ready = true
+	pane.Status.Activation.Claude.Registration = &registration
+	reg.UpdatedAt = m.clock()().UTC()
+	return nil
+}
+
+// ClearClaudeRegistration is a CAS: an old helper cannot clear the new lease.
+func (m Mutator) ClearClaudeRegistration(reg *Registry, paneUID, agentUID, generation string, authority ClaudeAuthorityRef) bool {
+	pane, ok := reg.Pane(paneUID)
+	agent, found := reg.Agent(agentUID)
+	if !ok || pane.Status.Activation.Generation != generation || pane.Status.Activation.Claude == nil ||
+		!found || agent.Spec.Provider != "claude" || agent.Status.PaneRef != paneUID || pane.Spec.Role != PaneRoleAgent || pane.Metadata.OwnerRef == nil || pane.Metadata.OwnerRef.Kind != KindAgent ||
+		pane.Metadata.OwnerUID() != agentUID || pane.Status.Activation.AgentUID != agentUID ||
+		pane.Status.Activation.Claude.Process != authority.Process ||
+		pane.Status.Activation.Claude.RegistrationSessionID != authority.SessionID ||
+		pane.Status.Activation.Claude.RegistrationGeneration != authority.RegistrationGeneration ||
+		pane.Status.Activation.Claude.Registration == nil ||
+		pane.Status.Activation.Claude.Registration.Authority != authority {
+		return false
+	}
+	pane.Status.Activation.Claude.Registration = nil
+	reg.UpdatedAt = m.clock()().UTC()
+	return true
+}
+
+func clearClaudeRegistration(pane *Pane) {
+	if pane != nil && pane.Status.Activation.Claude != nil {
+		pane.Status.Activation.Claude.Registration = nil
+		pane.Status.Activation.Claude.RegistrationGeneration = ""
+		pane.Status.Activation.Claude.RegistrationSessionID = ""
+	}
+}

--- a/internal/core/metadata/termination.go
+++ b/internal/core/metadata/termination.go
@@ -205,7 +205,8 @@ type PaneActivation struct {
 	// Codex is the provider-native conversation/turn observed for exactly this
 	// materialization. The durable conversation pointer remains on the Agent;
 	// this refinement is nested under the generation so replacement clears it.
-	Codex *CodexActivationBinding `json:"codex,omitempty"`
+	Codex  *CodexActivationBinding  `json:"codex,omitempty"`
+	Claude *ClaudeActivationBinding `json:"claude,omitempty"`
 }
 
 // CodexActivationBinding is the content-free native identity returned by the
@@ -253,13 +254,21 @@ func (r CodexAuthorityRef) Authorizes(presented CodexAuthorityRef) bool {
 // re-encode without the additive block.
 func (a PaneActivation) IsZero() bool {
 	return a.Generation == "" && a.RuntimeID == "" && a.AgentUID == "" &&
-		a.OperationID == "" && a.StartedAt.IsZero() && a.Codex == nil
+		a.OperationID == "" && a.StartedAt.IsZero() && a.Codex == nil && a.Claude == nil
 }
 
 // Clone returns an activation record whose provider binding cannot alias the
 // source Registry snapshot.
 func (a PaneActivation) Clone() PaneActivation {
 	out := a
+	if a.Claude != nil {
+		binding := *a.Claude
+		if binding.Registration != nil {
+			registration := *binding.Registration
+			binding.Registration = &registration
+		}
+		out.Claude = &binding
+	}
 	if a.Codex != nil {
 		binding := *a.Codex
 		if a.Codex.Authority != nil {
@@ -542,6 +551,7 @@ func (m Mutator) RecordTermination(reg *Registry, receipt TerminationEvidence) (
 		receipt.ObservedAt = receipt.ObservedAt.UTC()
 	}
 	pane.Status.LastTermination = receipt.Clone()
+	clearClaudeRegistration(pane)
 	if agent != nil {
 		agent.Status.LastTermination = receipt.Clone()
 	}

--- a/internal/core/metadata/validate.go
+++ b/internal/core/metadata/validate.go
@@ -150,6 +150,17 @@ func (r Registry) Validate() error {
 				return stateErr(op, ErrInvalidRegistry, "pane %q has an incomplete native Codex authority", pane.Metadata.Name)
 			}
 		}
+		if binding := pane.Status.Activation.Claude; binding != nil {
+			agent, ok := r.Agent(pane.Metadata.OwnerUID())
+			if !ok || agent.Spec.Provider != "claude" || pane.Spec.Role != PaneRoleAgent ||
+				pane.Status.Activation.AgentUID != agent.Metadata.UID || pane.Status.Activation.Codex != nil || !binding.Process.Valid() {
+				return stateErr(op, ErrInvalidRegistry, "invalid Claude process binding")
+			}
+			if registration := binding.Registration; registration != nil &&
+				(!registration.Authority.Valid() || registration.Authority.Process != binding.Process) {
+				return stateErr(op, ErrInvalidRegistry, "invalid Claude registration identity")
+			}
+		}
 		if err := validateTermination(op, "pane "+pane.Metadata.Name, pane.Status.LastTermination); err != nil {
 			return err
 		}

--- a/internal/integrations/agents/claude/peer_darwin.go
+++ b/internal/integrations/agents/claude/peer_darwin.go
@@ -1,0 +1,27 @@
+package claude
+
+import (
+	"errors"
+	"net"
+
+	"github.com/crevissepartners/projmux/internal/core/metadata"
+	"golang.org/x/sys/unix"
+)
+
+func PeerProcess(conn *net.UnixConn) (metadata.ProcessIdentity, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return metadata.ProcessIdentity{}, errors.New("helper peer unavailable")
+	}
+	var pid int
+	var peerErr error
+	err = raw.Control(func(fd uintptr) { pid, peerErr = unix.GetsockoptInt(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERPID) })
+	if err != nil || peerErr != nil {
+		return metadata.ProcessIdentity{}, errors.New("helper peer unavailable")
+	}
+	identity, _, err := Process(pid)
+	if err != nil {
+		return metadata.ProcessIdentity{}, errors.New("helper peer unavailable")
+	}
+	return identity, nil
+}

--- a/internal/integrations/agents/claude/peer_linux.go
+++ b/internal/integrations/agents/claude/peer_linux.go
@@ -1,0 +1,29 @@
+package claude
+
+import (
+	"errors"
+	"net"
+
+	"github.com/crevissepartners/projmux/internal/core/metadata"
+	"golang.org/x/sys/unix"
+)
+
+// PeerProcess authenticates Projmux's private readiness helper, not a Claude
+// transport peer. No provider socket is opened by this adapter.
+func PeerProcess(conn *net.UnixConn) (metadata.ProcessIdentity, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return metadata.ProcessIdentity{}, errors.New("helper peer unavailable")
+	}
+	var peer *unix.Ucred
+	var peerErr error
+	err = raw.Control(func(fd uintptr) { peer, peerErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED) })
+	if err != nil || peerErr != nil || peer == nil {
+		return metadata.ProcessIdentity{}, errors.New("helper peer unavailable")
+	}
+	identity, _, err := Process(int(peer.Pid))
+	if err != nil || identity.OwnerUID != peer.Uid {
+		return metadata.ProcessIdentity{}, errors.New("helper peer unavailable")
+	}
+	return identity, nil
+}

--- a/internal/integrations/agents/claude/process_darwin.go
+++ b/internal/integrations/agents/claude/process_darwin.go
@@ -1,0 +1,23 @@
+package claude
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/crevissepartners/projmux/internal/core/metadata"
+	"golang.org/x/sys/unix"
+)
+
+// Process uses the kernel's absolute process birth time on both Darwin targets.
+func Process(pid int) (metadata.ProcessIdentity, int, error) {
+	if pid <= 0 {
+		return metadata.ProcessIdentity{}, 0, errors.New("process unavailable")
+	}
+	info, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil || info == nil || int(info.Proc.P_pid) != pid || info.Proc.P_stat == 5 {
+		return metadata.ProcessIdentity{}, 0, errors.New("process unavailable")
+	}
+	start := info.Proc.P_starttime
+	return metadata.ProcessIdentity{PID: pid, OwnerUID: info.Eproc.Ucred.Uid,
+		Start: "darwin:" + strconv.FormatInt(start.Sec, 10) + ":" + strconv.FormatInt(int64(start.Usec), 10)}, int(info.Eproc.Ppid), nil
+}

--- a/internal/integrations/agents/claude/process_linux.go
+++ b/internal/integrations/agents/claude/process_linux.go
@@ -1,0 +1,52 @@
+package claude
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/crevissepartners/projmux/internal/core/metadata"
+)
+
+// Process reads kernel birth identity. No command line, environment, transcript,
+// or provider registration store is inspected.
+func Process(pid int) (metadata.ProcessIdentity, int, error) {
+	if pid <= 0 {
+		return metadata.ProcessIdentity{}, 0, errors.New("process unavailable")
+	}
+	path := "/proc/" + strconv.Itoa(pid) + "/stat"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return metadata.ProcessIdentity{}, 0, errors.New("process unavailable")
+	}
+	end := strings.LastIndexByte(string(data), ')')
+	if end < 0 {
+		return metadata.ProcessIdentity{}, 0, errors.New("process identity unavailable")
+	}
+	fields := strings.Fields(string(data[end+1:]))
+	if len(fields) < 20 || fields[0] == "Z" || fields[0] == "X" {
+		return metadata.ProcessIdentity{}, 0, errors.New("process unavailable")
+	}
+	parent, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return metadata.ProcessIdentity{}, 0, errors.New("process identity unavailable")
+	}
+	if _, err = strconv.ParseUint(fields[19], 10, 64); err != nil {
+		return metadata.ProcessIdentity{}, 0, errors.New("process identity unavailable")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return metadata.ProcessIdentity{}, 0, errors.New("process unavailable")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return metadata.ProcessIdentity{}, 0, errors.New("process owner unavailable")
+	}
+	boot, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return metadata.ProcessIdentity{}, 0, errors.New("process boot identity unavailable")
+	}
+	return metadata.ProcessIdentity{PID: pid, OwnerUID: stat.Uid, Start: "linux:" + strings.TrimSpace(string(boot)) + ":" + fields[19]}, parent, nil
+}

--- a/internal/integrations/agents/claude/process_linux.go
+++ b/internal/integrations/agents/claude/process_linux.go
@@ -17,6 +17,8 @@ func Process(pid int) (metadata.ProcessIdentity, int, error) {
 		return metadata.ProcessIdentity{}, 0, errors.New("process unavailable")
 	}
 	path := "/proc/" + strconv.Itoa(pid) + "/stat"
+	// #nosec G304 -- pid is a checked positive integer rendered in decimal;
+	// the fixed procfs stat path cannot contain caller-supplied traversal.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return metadata.ProcessIdentity{}, 0, errors.New("process unavailable")

--- a/scripts/test-integration-docker.sh
+++ b/scripts/test-integration-docker.sh
@@ -4,4 +4,5 @@ set -euo pipefail
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 "$root/scripts/test-docker-run.sh" test/integration/linux-smoke.sh "$@"
 "$root/scripts/test-docker-run.sh" test/integration/agent-control-binding-frame.sh "$@"
+"$root/scripts/test-docker-run.sh" test/integration/claude-endpoint-binding.sh "$@"
 exec "$root/scripts/test-docker-run.sh" test/integration/codex-appserver-topology.sh "$@"

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
     make \
     ncurses-bin \
     procps \
+    python3 \
     tmux \
     util-linux \
     zsh \

--- a/test/integration/claude-endpoint-binding.sh
+++ b/test/integration/claude-endpoint-binding.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Disposable own-child SessionStart registration. No tmux, provider account,
+# model, external tools, MCP, or provider transport is used by this fixture.
+unset TMUX TMUX_PANE
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+build_root="$(mktemp -d "${TMPDIR:-/tmp}/projmux-claude-endpoint-build.XXXXXX")"
+trap 'rm -rf -- "$build_root"' EXIT
+cd "$root"
+go build -o "$build_root/projmux" ./cmd/projmux
+PMX_TEST_CLAUDE_ENDPOINT_BIN="$build_root/projmux" go test ./internal/app -run '^TestClaudeEndpointProcessIntegration$' -count=1 -v


### PR DESCRIPTION
## Summary
- Bind each managed Claude activation to its own public SessionStart registration and kernel process identity. Keep the endpoint and credential inside a private helper; expose only non-secret eligibility through `agent capabilities`.
- Share stable Agent and activation fences through typed provider authority, consuming the existing Codex composite authority unchanged. Resource names remain independent of the route.
- Invalidate stale registrations and clean helper leases on process exit, replacement, or generation changes. Reject competing claims before provider transport; actual message delivery remains unavailable.

## Test plan
- [x] `make fmt`
- [x] `make fix`
- [x] `make test`
- [x] `make security-go` and `make security-static` (existing baselines unchanged)
- [x] `make test-integration`
- [x] `E2E_WAIT_SCALE=2 make test-e2e` — full 21 scenarios, same measured wait policy as CI
- [x] Disposable Claude SessionStart → ready → exit → invalidated; strict empty MCP, tools/plugins/tool-use zero, messaging-token residue and helper/process/socket/disposable-provider-state cleanup zero
- [x] Full application builds: Linux amd64/arm64 and Darwin amd64/arm64

## Globalization
- [ ] No user-facing string changes.
- [ ] User-facing strings are behind `internal/i18n` catalog keys with tests.
- [x] Non-translated strings are classified as literal/data/debug-only: capability evidence/reason fields and internal registration diagnostics.

Phase 1 covers registration and eligibility only. The one-shot registration test omits `--safe-mode` because the measured Claude version suppresses SessionStart hooks in that mode; it does not qualify a safe-mode delivery harness. Message/wait execution, provider-name routing, control-plane changes, and later dialogue phases remain outside this change.

Deterministic subprocess integration passed through the actual supervisor and activation gate, including nested and forged registration refusal, repeated SessionStart, helper SIGKILL while its provider remains alive, and automatic lease cleanup. The account-backed canary passed with Claude 2.1.261. Upstream public locator bytes were observed only inside disposable native provider state, which the harness removed before reporting success.

The complete local E2E run passed with the CI wait setting on the validated head. Earlier local runs encountered unreproduced L11/L12 and C01 timeouts; their replay evidence is retained. C01's fixed 30-second barrier was unchanged. No scenarios, assertions, or product code were changed to obtain the final pass.
