### PR TITLE
fix(agent): read a settled codex authority before admitting a turn

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -965,6 +965,46 @@ conversation the Registry already records.
   whole route rather than the matcher alone: a payload arriving with an empty
   `--pane` produces a record naming its own Pane, and an unclaimed conversation
   produces a record naming why it has none.
+### Settled Codex authority admission tests
+
+`aiCodexLifecycleSink.SetAuthority` publishes one native authority transition as
+three separate tmux writes — `@projmux_codex_authority`, then
+`@projmux_codex_authority_epoch`, then `@projmux_codex_authority_reason` — under
+a per-Pane kernel fence. That fence serializes writers against each other only.
+Turn and approval admission reads the same three options with one
+`display-message`, so a read that lands between two of those writes can see an
+authority that is already `provider-control-plane` paired with the epoch or
+reason of the transition being replaced, and refuse the turn for an unavailable
+epoch while the native connection is alive.
+
+Admission now takes that same fence for the live read, so the triple it judges
+is one completed transition:
+
+- `TestSettledCodexAuthorityAdmissionIgnoresTornAuthorityWrites` owns the
+  mid-write-to-verdict mapping. Each row injects the triple that exists while
+  the writer still holds the fence, records whether judging that triple directly
+  would have refused a live connection, and then asserts the verdict reached
+  from the settled triple. A control plane that is genuinely lost — the provider
+  hook, a pending connection, an invalidation with no epoch — still refuses, and
+  the refusal still names the observer's reason.
+- `TestCodexAuthorityAdmissionTakesTheExactWriterFence` owns the fence identity.
+  The reader derives the same lock file as the writer, waits while a transition
+  is in flight, holds it exclusively while it samples, and gives the wait up at
+  the control deadline rather than stalling `projmux agent turn` behind a wedged
+  transition.
+- `TestConcurrentCodexAuthorityTransitionsNeverExposeATornAdmissionSnapshot`
+  owns the race. A transition writer and the real admission path run
+  concurrently, and every snapshot admission read must be one of the complete
+  triples the writer published; a control-plane authority with no epoch is the
+  false refusal this closes.
+
+The fence covers the live read only, not the judgment that follows it. A
+transition that lands after admission returns is not prevented: the control
+epoch still owns provider-side fencing, and `revalidateControlConsumerFence`
+still re-checks the Registry half immediately before the transport call.
+Admission also does not reduce how often the native connection drops, and it
+says nothing about the `@projmux_ai_state` / `@projmux_ai_badge_kind` /
+`@projmux_attention_state` triple, which has no fence of its own.
 
 ## Review Checklist
 - The branch stays within its stated scope.

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -965,6 +965,7 @@ conversation the Registry already records.
   whole route rather than the matcher alone: a payload arriving with an empty
   `--pane` produces a record naming its own Pane, and an unclaimed conversation
   produces a record naming why it has none.
+
 ### Settled Codex authority admission tests
 
 `aiCodexLifecycleSink.SetAuthority` publishes one native authority transition as

--- a/internal/app/agent_control.go
+++ b/internal/app/agent_control.go
@@ -208,6 +208,13 @@ func acquireCodexAuthorityReadFenceIn(ctx context.Context, stateDir, paneUID str
 // does not guarantee. Holding a cross-process kernel lock across Registry
 // projection would only stall the observer that owns the next transition.
 func readSettledAgentControlBinding(ctx context.Context, lookup agentControlBindingLookup, acquire codexAuthorityFenceAcquirer, paneUID string) (agentControlLive, bool, error) {
+	if strings.TrimSpace(paneUID) == "" {
+		// An Agent with no current Pane has nothing to fence and no live
+		// binding to sample. Leaving the read unfenced here keeps the refusal
+		// with the Registry judgment that owns it, instead of replacing it
+		// with a fence-path error.
+		return lookup.Live(ctx, paneUID)
+	}
 	release, err := acquire(ctx, paneUID)
 	if err != nil {
 		return agentControlLive{}, false, err

--- a/internal/app/agent_control.go
+++ b/internal/app/agent_control.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
+	"syscall"
 	"time"
 
 	"github.com/crevissepartners/projmux/internal/config"
@@ -19,6 +21,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/i18n"
 	"github.com/crevissepartners/projmux/internal/integrations/agents/codexappserver"
 	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
+	localstate "github.com/crevissepartners/projmux/internal/state"
 	intpicker "github.com/crevissepartners/projmux/internal/ui/picker"
 	intpickercompat "github.com/crevissepartners/projmux/internal/ui/pickercompat"
 )
@@ -127,6 +130,90 @@ func (l *tmuxAgentControlBindingLookup) Live(ctx context.Context, paneUID string
 		return agentControlLive{}, false, err
 	}
 	return live, true, nil
+}
+
+// codexAuthorityFenceReadPoll is the retry step used while an admission read
+// waits for an in-flight authority transition to complete. It only bounds how
+// often the wait re-tests the kernel lock; the wait itself ends at the caller's
+// control deadline.
+const codexAuthorityFenceReadPoll = 2 * time.Millisecond
+
+// codexAuthorityFenceAcquirer takes the exact per-Pane authority fence and
+// returns its release. It is the seam that lets admission tests drive one exact
+// writer/reader interleaving instead of racing for it.
+type codexAuthorityFenceAcquirer func(context.Context, string) (func(), error)
+
+// acquireCodexAuthorityReadFenceIn takes the same kernel fence that
+// aiCodexLifecycleSink.SetAuthority holds while it publishes
+// @projmux_codex_authority, @projmux_codex_authority_epoch and
+// @projmux_codex_authority_reason as three separate tmux set-option calls.
+// That fence serializes writers against each other only, so a reader that
+// skips it can sample the Pane between two of those three writes and see an
+// authority that is already provider-control-plane paired with the epoch or
+// reason of the transition being replaced.
+//
+// Unlike the writer, this acquisition is bounded by ctx. The writer owns the
+// transition and must be allowed to finish it, while an admission read that
+// cannot reach a settled snapshot inside the control budget refuses with a
+// reason instead of stalling `projmux agent turn` behind a wedged transition.
+func acquireCodexAuthorityReadFenceIn(ctx context.Context, stateDir, paneUID string) (func(), error) {
+	path, err := codexAuthorityFencePathIn(stateDir, paneUID)
+	if err != nil {
+		return nil, err
+	}
+	// #nosec G304 -- codexAuthorityFencePathIn returns the private state
+	// directory plus a digest of the Registry-authenticated Pane uid.
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, localstate.PrivateFileMode)
+	if err != nil {
+		return nil, fmt.Errorf("open Codex authority fence: %w", err)
+	}
+	localstate.RepairPrivateFile(path)
+	for {
+		lockErr := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if lockErr == nil {
+			var once sync.Once
+			return func() {
+				once.Do(func() {
+					_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+					_ = file.Close()
+				})
+			}, nil
+		}
+		if !errors.Is(lockErr, syscall.EWOULDBLOCK) && !errors.Is(lockErr, syscall.EAGAIN) {
+			_ = file.Close()
+			return nil, fmt.Errorf("lock Codex authority fence: %w", lockErr)
+		}
+		timer := time.NewTimer(codexAuthorityFenceReadPoll)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			_ = file.Close()
+			return nil, fmt.Errorf("wait for a settled Codex authority transition: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+// readSettledAgentControlBinding samples the live tmux binding under the
+// writer's per-Pane authority fence, so the (authority, epoch, reason) triple
+// handed to admission is one completed transition rather than a torn mid-write
+// snapshot. Without it a turn can be refused for an unavailable epoch while the
+// native connection is alive, purely because the read landed between the
+// authority write and the epoch write of the transition that established it.
+//
+// The fence deliberately covers the read only, not the admission judgment that
+// follows. Widening it would buy nothing this contract does not already
+// exclude: the Registry half of the judgment is snapshotted before this read,
+// and any change after the fence is released is TOCTOU, which C-5 explicitly
+// does not guarantee. Holding a cross-process kernel lock across Registry
+// projection would only stall the observer that owns the next transition.
+func readSettledAgentControlBinding(ctx context.Context, lookup agentControlBindingLookup, acquire codexAuthorityFenceAcquirer, paneUID string) (agentControlLive, bool, error) {
+	release, err := acquire(ctx, paneUID)
+	if err != nil {
+		return agentControlLive{}, false, err
+	}
+	defer release()
+	return lookup.Live(ctx, paneUID)
 }
 
 type exactAgentControlBinding struct {
@@ -242,13 +329,18 @@ func (c *agentCommand) resolveControlBinding(spelling, ref string) (exactAgentCo
 		routed := explicitTmuxRunner{runner: c.controlRunner, target: route.target}
 		lookup = &tmuxAgentControlBindingLookup{lookup: intmetadata.NewMirror(routed), runner: routed}
 	}
-	live, observed, err := lookup.Live(ctx, agent.Status.PaneRef)
-	if err != nil {
-		return exactAgentControlBinding{}, fmt.Errorf("exact Agent native control unavailable: read live binding: %w", err)
-	}
 	paths, err := c.controlPaths()
 	if err != nil {
 		return exactAgentControlBinding{}, fmt.Errorf("exact Agent native control unavailable: resolve private control path: %w", err)
+	}
+	// The private control path is resolved before the live read because the
+	// same state directory holds the authority fence the read must take.
+	acquire := func(ctx context.Context, paneUID string) (func(), error) {
+		return acquireCodexAuthorityReadFenceIn(ctx, paths.StateDir, paneUID)
+	}
+	live, observed, err := readSettledAgentControlBinding(ctx, lookup, acquire, agent.Status.PaneRef)
+	if err != nil {
+		return exactAgentControlBinding{}, fmt.Errorf("exact Agent native control unavailable: read live binding: %w", err)
 	}
 	binding, err := resolveExactAgentControlBinding(registry, agent, live, observed, paths.StateDir)
 	if err != nil {

--- a/internal/app/agent_control_settled_authority_test.go
+++ b/internal/app/agent_control_settled_authority_test.go
@@ -209,6 +209,27 @@ func TestSettledCodexAuthorityAdmissionIgnoresTornAuthorityWrites(t *testing.T) 
 	}
 }
 
+// TestSettledCodexAuthorityReadKeepsTheRegistryRefusalForAPanelessAgent pins
+// the one case that must stay unfenced: an Agent with no current Pane has no
+// fence to take, and the refusal must remain the Registry judgment that owns it
+// rather than a fence-path error.
+func TestSettledCodexAuthorityReadKeepsTheRegistryRefusalForAPanelessAgent(t *testing.T) {
+	t.Parallel()
+	state := &codexAuthorityPaneState{}
+	lookup := &codexAuthorityPaneLookup{state: state}
+	acquired := false
+	acquire := func(context.Context, string) (func(), error) {
+		acquired = true
+		return nil, errors.New("fence must not be taken for a Pane-less Agent")
+	}
+	if _, _, err := readSettledAgentControlBinding(context.Background(), lookup, acquire, "  "); err != nil {
+		t.Fatalf("Pane-less read = %v, want the lookup answer", err)
+	}
+	if acquired {
+		t.Fatal("Pane-less read reached for an authority fence")
+	}
+}
+
 // TestCodexAuthorityAdmissionTakesTheExactWriterFence pins the reader to the
 // writer's kernel lock rather than a second, independent one. A separate fence
 // would serialize nothing and reintroduce the torn read.

--- a/internal/app/agent_control_settled_authority_test.go
+++ b/internal/app/agent_control_settled_authority_test.go
@@ -1,0 +1,351 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/config"
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	localstate "github.com/crevissepartners/projmux/internal/state"
+)
+
+// codexAuthorityPaneState models the three Pane options
+// aiCodexLifecycleSink.SetAuthority publishes with three separate tmux
+// set-option calls. Each option is individually atomic exactly as tmux makes
+// it, and the triple is not: a reader can land on any prefix of a transition.
+type codexAuthorityPaneState struct {
+	mu        sync.Mutex
+	authority string
+	epoch     string
+	reason    string
+}
+
+func (s *codexAuthorityPaneState) set(authority, epoch, reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.authority, s.epoch, s.reason = authority, epoch, reason
+}
+
+func (s *codexAuthorityPaneState) setAuthority(value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.authority = value
+}
+
+func (s *codexAuthorityPaneState) setEpoch(value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.epoch = value
+}
+
+func (s *codexAuthorityPaneState) setReason(value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reason = value
+}
+
+func (s *codexAuthorityPaneState) read() (string, string, string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.authority, s.epoch, s.reason
+}
+
+// publish replays one complete SetAuthority transition in the exact order the
+// sink writes it: authority, then epoch, then reason.
+func (s *codexAuthorityPaneState) publish(authority, epoch, reason string) {
+	s.setAuthority(authority)
+	time.Sleep(200 * time.Microsecond)
+	s.setEpoch(epoch)
+	time.Sleep(200 * time.Microsecond)
+	s.setReason(reason)
+}
+
+// codexAuthorityPaneLookup is the live tmux binding read, sourced from the
+// unsynchronized Pane triple above. It records every snapshot it handed to
+// admission so a test can assert no torn triple ever reached the judgment.
+type codexAuthorityPaneLookup struct {
+	state    *codexAuthorityPaneState
+	observed []agentControlLive
+}
+
+func (l *codexAuthorityPaneLookup) Live(_ context.Context, paneUID string) (agentControlLive, bool, error) {
+	authority, epoch, reason := l.state.read()
+	live := agentControlLive{
+		RuntimeID: "%7", PaneUID: paneUID, ThreadID: "thread-1",
+		Authority: authority, Epoch: epoch, Reason: reason,
+	}
+	l.observed = append(l.observed, live)
+	return live, true, nil
+}
+
+func settledAuthorityFixture(t *testing.T) (coremetadata.Registry, coremetadata.Agent) {
+	t.Helper()
+	_, store, _ := exactControlCLICommand(t)
+	agent, ok := store.registry.Agent("agt-alpha-codex")
+	if !ok {
+		t.Fatal("control fixture is missing its Codex Agent")
+	}
+	return store.registry, *agent
+}
+
+// TestSettledCodexAuthorityAdmissionIgnoresTornAuthorityWrites is the C-5
+// Guarantee row. The writer publishes (authority, epoch, reason) as three
+// sequential tmux writes under its own fence; admission must judge only a
+// completed transition. Each torn row below is injected as the Pane state that
+// exists while the writer still holds the fence, and the settled row is what
+// the writer leaves behind once it releases it.
+func TestSettledCodexAuthorityAdmissionIgnoresTornAuthorityWrites(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		// midWrite is the triple visible while the transition is in flight.
+		midWrite [3]string
+		// settled is the triple the completed transition leaves behind.
+		settled [3]string
+		// tornWouldRefuse records whether judging the mid-write triple would
+		// have refused a turn on a connection that is in fact alive.
+		tornWouldRefuse bool
+		wantEpoch       string
+		wantRefusal     string
+	}{
+		{
+			name:            "authority written epoch and reason still pending",
+			midWrite:        [3]string{codexAuthorityControlPlane, "", "disconnected"},
+			settled:         [3]string{codexAuthorityControlPlane, "752812-41", "ready"},
+			tornWouldRefuse: true,
+			wantEpoch:       "752812-41",
+		},
+		{
+			name:      "authority and epoch written reason still pending",
+			midWrite:  [3]string{codexAuthorityControlPlane, "752812-40", "disconnected"},
+			settled:   [3]string{codexAuthorityControlPlane, "752812-41", "ready"},
+			wantEpoch: "752812-41",
+		},
+		{
+			name:      "already settled control plane",
+			midWrite:  [3]string{codexAuthorityControlPlane, "752812-41", "ready"},
+			settled:   [3]string{codexAuthorityControlPlane, "752812-41", "ready"},
+			wantEpoch: "752812-41",
+		},
+		{
+			name:            "settled loss to the provider hook",
+			midWrite:        [3]string{codexAuthorityHook, "", "disconnected"},
+			settled:         [3]string{codexAuthorityHook, "", "disconnected"},
+			tornWouldRefuse: true,
+			wantRefusal:     "the native connection epoch is unavailable (disconnected)",
+		},
+		{
+			name:            "settled pending connection",
+			midWrite:        [3]string{codexAuthorityPending, "", "connecting"},
+			settled:         [3]string{codexAuthorityPending, "", "connecting"},
+			tornWouldRefuse: true,
+			wantRefusal:     "the native connection epoch is unavailable (connecting)",
+		},
+		{
+			name:            "settled invalidation without an epoch",
+			midWrite:        [3]string{codexAuthorityInvalidating, "", ""},
+			settled:         [3]string{codexAuthorityInvalidating, "", ""},
+			tornWouldRefuse: true,
+			wantRefusal:     "the native connection epoch is unavailable (not-ready)",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			registry, agent := settledAuthorityFixture(t)
+			state := &codexAuthorityPaneState{}
+			state.set(test.midWrite[0], test.midWrite[1], test.midWrite[2])
+			lookup := &codexAuthorityPaneLookup{state: state}
+
+			// The unfenced control: judging the in-flight triple directly is
+			// exactly the defect, so assert whether that snapshot refuses.
+			torn, _, err := lookup.Live(context.Background(), "pan-alpha-codex")
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, tornErr := resolveExactAgentControlBinding(registry, agent, torn, true, "/tmp/projmux-settled")
+			tornRefused := tornErr != nil && strings.Contains(tornErr.Error(), "the native connection epoch is unavailable")
+			if tornRefused != test.tornWouldRefuse {
+				t.Fatalf("unfenced judgment of %v refused=%t (%v), want refused=%t", test.midWrite, tornRefused, tornErr, test.tornWouldRefuse)
+			}
+
+			// The fence is what forces the writer to finish first: a reader can
+			// only enter once the remaining writes have landed.
+			acquire := func(context.Context, string) (func(), error) {
+				state.set(test.settled[0], test.settled[1], test.settled[2])
+				return func() {}, nil
+			}
+			live, observed, err := readSettledAgentControlBinding(context.Background(), lookup, acquire, "pan-alpha-codex")
+			if err != nil || !observed {
+				t.Fatalf("settled read observed=%t err=%v", observed, err)
+			}
+			if live.Authority != test.settled[0] || live.Epoch != test.settled[1] || live.Reason != test.settled[2] {
+				t.Fatalf("settled snapshot = %+v, want %v", live, test.settled)
+			}
+
+			binding, err := resolveExactAgentControlBinding(registry, agent, live, observed, "/tmp/projmux-settled")
+			if test.wantRefusal != "" {
+				var bindingErr *exactAgentControlBindingError
+				if err == nil || !errors.As(err, &bindingErr) || bindingErr.Reason != test.wantRefusal+"; Open Codex" {
+					t.Fatalf("refusal = %v, want %q", err, test.wantRefusal)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("settled admission refused a live connection: %v", err)
+			}
+			if binding.Epoch != test.wantEpoch {
+				t.Fatalf("admitted epoch = %q, want %q", binding.Epoch, test.wantEpoch)
+			}
+		})
+	}
+}
+
+// TestCodexAuthorityAdmissionTakesTheExactWriterFence pins the reader to the
+// writer's kernel lock rather than a second, independent one. A separate fence
+// would serialize nothing and reintroduce the torn read.
+func TestCodexAuthorityAdmissionTakesTheExactWriterFence(t *testing.T) {
+	home := t.TempDir()
+	writer := testAICommand(home)
+	paths, err := configPaths(func() (string, error) { return home, nil }, func(string) string { return "" })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writerPath, err := writer.codexAuthorityFencePath("pan-alpha-codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	readerPath, err := codexAuthorityFencePathIn(paths.StateDir, "pan-alpha-codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if writerPath != readerPath {
+		t.Fatalf("reader fence %q is not the writer fence %q", readerPath, writerPath)
+	}
+
+	release, err := writer.acquireCodexAuthorityFence("pan-alpha-codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// While the writer holds the transition the admission read must wait, and
+	// it must give the wait up at the control deadline instead of hanging.
+	bounded, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	if _, err := acquireCodexAuthorityReadFenceIn(bounded, paths.StateDir, "pan-alpha-codex"); err == nil {
+		t.Fatal("admission read entered the fence while a transition was in flight")
+	} else if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("bounded fence wait error = %v, want the control deadline", err)
+	}
+	if waited := time.Since(start); waited < 20*time.Millisecond {
+		t.Fatalf("admission read waited %s, want a real wait on the writer fence", waited)
+	}
+
+	release()
+	readRelease, err := acquireCodexAuthorityReadFenceIn(context.Background(), paths.StateDir, "pan-alpha-codex")
+	if err != nil {
+		t.Fatalf("admission read after the transition completed: %v", err)
+	}
+	// The reader's own hold is exclusive too, so a concurrent transition cannot
+	// start publishing underneath an admission snapshot.
+	// #nosec G304 -- test-owned fence path under t.TempDir().
+	contender, err := os.OpenFile(readerPath, os.O_CREATE|os.O_RDWR, localstate.PrivateFileMode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer contender.Close()
+	if err := syscall.Flock(int(contender.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+		t.Fatalf("writer contention during an admission read = %v, want busy", err)
+	}
+	readRelease()
+	if err := syscall.Flock(int(contender.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("fence after the admission read released: %v", err)
+	}
+	if err := syscall.Flock(int(contender.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestConcurrentCodexAuthorityTransitionsNeverExposeATornAdmissionSnapshot runs
+// the real fence between a transition writer and the real
+// `agent turn`/`agent approval` admission path. Every snapshot admission reads
+// must be one of the two complete triples the writer publishes; observing any
+// other triple is a torn read, and observing a control-plane authority with no
+// epoch is the false refusal this Phase closes.
+func TestConcurrentCodexAuthorityTransitionsNeverExposeATornAdmissionSnapshot(t *testing.T) {
+	home := t.TempDir()
+	writer := testAICommand(home)
+	paths, err := configPaths(func() (string, error) { return home, nil }, func(string) string { return "" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd, _, _ := exactControlCLICommand(t)
+	cmd.controlPaths = func() (config.Paths, error) { return paths, nil }
+	state := &codexAuthorityPaneState{}
+	state.set(codexAuthorityHook, "", "disconnected")
+	lookup := &codexAuthorityPaneLookup{state: state}
+	cmd.controlBinding = lookup
+
+	const transitions = 120
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range transitions {
+			release, err := writer.acquireCodexAuthorityFence("pan-alpha-codex")
+			if err != nil {
+				return
+			}
+			state.publish(codexAuthorityControlPlane, fmt.Sprintf("752812-%d", i), "ready")
+			release()
+			runtime.Gosched()
+			release, err = writer.acquireCodexAuthorityFence("pan-alpha-codex")
+			if err != nil {
+				return
+			}
+			state.publish(codexAuthorityHook, "", "disconnected")
+			release()
+			runtime.Gosched()
+		}
+	}()
+
+	admitted, refused := 0, 0
+	for {
+		select {
+		case <-done:
+			if len(lookup.observed) == 0 {
+				t.Fatal("admission performed no live reads")
+			}
+			for _, live := range lookup.observed {
+				settledLive := live.Authority == codexAuthorityControlPlane && live.Epoch != "" && live.Reason == "ready"
+				settledLost := live.Authority == codexAuthorityHook && live.Epoch == "" && live.Reason == "disconnected"
+				if !settledLive && !settledLost {
+					t.Fatalf("admission read a torn authority triple: %+v", live)
+				}
+			}
+			t.Logf("admission reads=%d admitted=%d refused=%d", len(lookup.observed), admitted, refused)
+			return
+		default:
+		}
+		binding, err := cmd.resolveControlBinding("agent turn interrupt", "uid:agt-alpha-codex")
+		switch {
+		case err == nil:
+			if binding.Epoch == "" {
+				t.Fatalf("admitted a turn with no control epoch: %+v", binding)
+			}
+			admitted++
+		case strings.Contains(err.Error(), "the native connection epoch is unavailable (disconnected)"):
+			refused++
+		default:
+			t.Fatalf("unexpected admission error: %v", err)
+		}
+	}
+}

--- a/internal/app/codex_authority_fence.go
+++ b/internal/app/codex_authority_fence.go
@@ -51,15 +51,27 @@ func (c *aiCommand) acquireCodexAuthorityFence(paneUID string) (func(), error) {
 }
 
 func (c *aiCommand) codexAuthorityFencePath(paneUID string) (string, error) {
-	paneUID = strings.TrimSpace(paneUID)
-	if paneUID == "" {
+	if strings.TrimSpace(paneUID) == "" {
 		return "", fmt.Errorf("codex authority fence requires pane uid")
 	}
 	paths, err := configPaths(c.homeDir, c.lookupEnv)
 	if err != nil {
 		return "", fmt.Errorf("resolve Codex authority fence: %w", err)
 	}
-	dir := filepath.Join(paths.StateDir, codexAuthorityFenceDir)
+	return codexAuthorityFencePathIn(paths.StateDir, paneUID)
+}
+
+// codexAuthorityFencePathIn derives the exact fence file for one Pane inside a
+// private state directory. The derivation lives here once because the writer
+// and every reader that must observe a settled authority transition have to
+// contend on the same kernel lock; restating the digest or the directory on
+// either side would silently split them into two independent fences.
+func codexAuthorityFencePathIn(stateDir, paneUID string) (string, error) {
+	paneUID = strings.TrimSpace(paneUID)
+	if paneUID == "" {
+		return "", fmt.Errorf("codex authority fence requires pane uid")
+	}
+	dir := filepath.Join(stateDir, codexAuthorityFenceDir)
 	if err := localstate.EnsurePrivateDir(dir); err != nil {
 		return "", fmt.Errorf("create Codex authority fence directory: %w", err)
 	}


### PR DESCRIPTION
## Defect

`aiCodexLifecycleSink.SetAuthority` publishes one native authority transition as three separate `tmux set-option` calls — `@projmux_codex_authority`, then `@projmux_codex_authority_epoch`, then `@projmux_codex_authority_reason` — while holding the per-Pane authority fence. That fence serializes writers against each other only.

Turn and approval admission (`resolveControlBinding` → `tmuxAgentControlBindingLookup.Live` → `resolveExactAgentControlBinding`) reads the same three options with one `display-message` and took no fence. A read landing between two of those three writes sees an authority that is already `provider-control-plane` paired with the epoch or reason of the transition being replaced, and admission refuses:

```
the native connection epoch is unavailable (<stale reason>); Open Codex
```

while the native connection is alive. The window was directly observed as `auth=provider-control-plane epoch=752812-40 reason=disconnected` — the first two writes landed, the third had not.

This is the mechanism, not a claim about every refusal ever observed.

## Change

The admission read now takes the writer's own kernel fence, so the `(authority, epoch, reason)` triple it judges is one completed transition.

- `codexAuthorityFencePathIn` factors the fence-file derivation out of `(*aiCommand).codexAuthorityFencePath` so writer and reader contend on the same lock instead of restating the digest on either side. The lock semantics are unchanged.
- `acquireCodexAuthorityReadFenceIn` takes that lock for the reader. Unlike the writer it is bounded by the control deadline: the writer owns the transition and must be allowed to finish, while an admission read that cannot reach a settled snapshot inside the budget refuses with a reason rather than stalling `projmux agent turn` behind a wedged transition.
- `readSettledAgentControlBinding` wraps the live read in that fence. It is called from `resolveControlBinding`, so `agent turn start|steer|interrupt` and `agent approval review` are all covered by the one change.

### Fence window

The fence covers the live read only, not the judgment that follows it. Widening it buys nothing this contract does not already exclude: the Registry half of the judgment is snapshotted before the read, and any change after the fence is released is TOCTOU, which C-5 explicitly does not guarantee. Holding a cross-process kernel lock across Registry projection would only stall the observer that owns the next transition.

## Tests

- `TestSettledCodexAuthorityAdmissionIgnoresTornAuthorityWrites` — mid-write triple × verdict table. Each row injects the triple visible while the writer still holds the fence, records whether judging it directly would have refused a live connection, and asserts the verdict reached from the settled triple. Provider hook, pending connection, and epoch-less invalidation still refuse and still name the observer's reason.
- `TestCodexAuthorityAdmissionTakesTheExactWriterFence` — the reader derives the same lock file as the writer, waits while a transition is in flight, holds it exclusively while it samples, and gives the wait up at the control deadline.
- `TestConcurrentCodexAuthorityTransitionsNeverExposeATornAdmissionSnapshot` — a transition writer and the real admission path run concurrently; every snapshot admission read must be one of the complete triples the writer published. Removing the fence fails this test deterministically with the false refusal.

## Out of scope

Disconnect frequency and reconnect policy, backoff constants, binding lifetime, generation pool admission/qualification, and the unfenced `@projmux_ai_state` / `@projmux_ai_badge_kind` / `@projmux_attention_state` triple are untouched — diff 0.
