### PR TITLE
fix(hooks): attribute codex hooks through the registry

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -923,11 +923,47 @@
   live Pane.
 - `TestAttributionFailureReasonsAreDistinctAndClosed` owns the failure
   vocabulary: an unreachable Pane inventory, a genuine no-match, an unreachable
-  Registry, and an unregistered Pane each name themselves, and every token stays
-  a bounded phrase.
+  Registry, an unregistered Pane, a conversation no Pane holds, and a
+  conversation two Panes hold each name themselves, and every token stays a
+  bounded phrase.
 - `TestHookIngestRoutesAcceptTheExplicitPaneArgument` owns the route contract:
   `--pane` is optional, an empty value is a valid answer, and a positional
   payload argument is still refused.
+
+### Shared-host hook attribution tests
+
+A provider host shared by several Panes has no Pane to hand over and no tmux
+environment to inherit, so both the explicit argument and the three-step ladder
+above come up empty for it. These tests own the one further step that reads the
+conversation the Registry already records.
+
+- `TestMatchAIPaneAttributesASharedHostHookThroughTheRegistry` owns the normal
+  path: with nothing handed over and no readable Pane inventory, the thread or
+  session the payload carries resolves to the live runtime handle of the Pane
+  that holds that conversation.
+- `TestMatchAIPaneRefusesAConversationNoPaneHolds` and
+  `TestMatchAIPaneRefusesAConversationTwoPanesHold` own the refusals: an
+  unclaimed conversation and an ambiguous one both fail by name rather than
+  landing on a neighbouring Pane that merely shares a working directory.
+- `TestRegistryAttributionRequiresAnIntactBinding` owns the round trip. A Pane
+  that is no longer materialized, one whose Agent no longer points back at it,
+  and one whose Agent is gone are all torn state, never attribution targets.
+- `TestRegistryAttributionIsProviderNeutral` owns the shape of the lookup: it
+  reads the resource model, so every provider whose conversation the Registry
+  records resolves through the same code and none is named in it.
+- `TestMatchAIPaneKeepsTheRegistryStepBehindTheEstablishedLadder` and
+  `TestMatchAIPaneLeavesTheLadderReasonWhenThereIsNoConversation` own the order.
+  A handed identity, inherited `TMUX_PANE`, and the Pane inventory each still
+  answer first, and a payload carrying no conversation keeps the ladder's own
+  failure reason instead of being relabelled.
+- `TestRegistryAttributionReportsAnUnreachableRegistry` and
+  `TestRegistryAttributionDefinesNoBinding` own the boundary: the step reads the
+  Registry exactly once, writes nothing, defines no binding, and reports an
+  unreachable Registry as its own failure.
+- `TestCodexHookIngestAttributesASharedHostEventThroughTheRegistry` owns the
+  whole route rather than the matcher alone: a payload arriving with an empty
+  `--pane` produces a record naming its own Pane, and an unclaimed conversation
+  produces a record naming why it has none.
 
 ## Review Checklist
 - The branch stays within its stated scope.

--- a/internal/app/ai_hook_pane_identity_test.go
+++ b/internal/app/ai_hook_pane_identity_test.go
@@ -353,6 +353,20 @@ func TestAttributionFailureReasonsAreDistinctAndClosed(t *testing.T) {
 	_, reason = gone.matchAIPane(aiPaneMatchInput{ExplicitPane: "pane-handed"})
 	record(t, "unregistered pane", reason)
 
+	// Nothing handed over, no inventory, and a conversation the Registry does
+	// not place. This is the shared provider host, and it is a different
+	// failure from every one above it.
+	unclaimed := sharedHostCommand(t, coremetadata.Registry{})
+	_, reason = unclaimed.matchAIPane(aiPaneMatchInput{ThreadID: "thread-nobody-holds"})
+	record(t, "unclaimed conversation", reason)
+
+	twoPanes := conversationRegistry("pane-one", "%1", &coremetadata.CodexActivationBinding{ThreadID: "thread-shared"}, nil)
+	alsoClaimed := conversationRegistry("pane-two", "%2", &coremetadata.CodexActivationBinding{ThreadID: "thread-shared"}, nil)
+	twoPanes.Agents = append(twoPanes.Agents, alsoClaimed.Agents...)
+	twoPanes.Panes = append(twoPanes.Panes, alsoClaimed.Panes...)
+	_, reason = sharedHostCommand(t, twoPanes).matchAIPane(aiPaneMatchInput{ThreadID: "thread-shared"})
+	record(t, "conversation held by two panes", reason)
+
 	// Every token stays a bounded phrase: no path, payload, or provider text.
 	for token := range seen {
 		if strings.ContainsAny(token, "/\\\"") || len(token) > 64 {

--- a/internal/app/ai_hook_registry_attribution_test.go
+++ b/internal/app/ai_hook_registry_attribution_test.go
@@ -1,0 +1,386 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+)
+
+// sharedHostCommand is the exact shape of the process this step exists for: a
+// provider host several Panes share. It inherited no activation envelope, so
+// nothing was handed to `--pane`, and no tmux environment, so the Pane
+// inventory the established ladder reads is unreachable.
+func sharedHostCommand(t *testing.T, registry coremetadata.Registry) *aiCommand {
+	t.Helper()
+	cmd := testAICommand(t.TempDir())
+	cmd.lookupEnv = func(string) string { return "" }
+	cmd.readCommand = func(context.Context, string, ...string) ([]byte, error) { return nil, os.ErrNotExist }
+	cmd.loadRegistry = func() (coremetadata.Registry, error) { return registry, nil }
+	cmd.updateRegistry = func(func(*coremetadata.Registry) error) (coremetadata.Registry, error) {
+		t.Fatal("resolving a conversation wrote to the registry; this step is a lookup only")
+		return coremetadata.Registry{}, nil
+	}
+	return cmd
+}
+
+// conversationRegistry builds one intact Agent->Pane binding carrying both
+// conversation records the Registry keeps: the activation refinement pinned to
+// this materialization and the Agent's durable session pointer.
+func conversationRegistry(paneUID, runtimeID string, activation *coremetadata.CodexActivationBinding, session *coremetadata.AgentSessionRef) coremetadata.Registry {
+	agentUID := "agent-for-" + paneUID
+	return coremetadata.Registry{
+		Agents: []coremetadata.Agent{{
+			Metadata: coremetadata.ObjectMeta{UID: agentUID, Name: "conversation-agent"},
+			Status:   coremetadata.AgentStatus{PaneRef: paneUID, SessionRef: session},
+		}},
+		Panes: []coremetadata.Pane{{
+			Metadata: coremetadata.ObjectMeta{UID: paneUID, Name: "conversation-pane"},
+			Status: coremetadata.PaneStatus{Activation: coremetadata.PaneActivation{
+				RuntimeID: runtimeID,
+				AgentUID:  agentUID,
+				Codex:     activation,
+			}},
+		}},
+	}
+}
+
+// Acceptance 1: the hook a shared provider host fired reaches its own Pane. The
+// conversation identifier the payload carries is the only thing it has, and the
+// Registry already records which Pane owns that conversation.
+func TestMatchAIPaneAttributesASharedHostHookThroughTheRegistry(t *testing.T) {
+	t.Parallel()
+
+	registry := conversationRegistry("pane-native", "%78",
+		&coremetadata.CodexActivationBinding{ThreadID: "thread-native"}, nil)
+
+	for _, tc := range []struct {
+		name string
+		in   aiPaneMatchInput
+	}{
+		{name: "thread", in: aiPaneMatchInput{ThreadID: "thread-native"}},
+		{name: "session", in: aiPaneMatchInput{SessionID: "thread-native"}},
+		{
+			name: "cwd that matches nothing",
+			in:   aiPaneMatchInput{CWD: "/repo/projmux", ThreadID: "thread-native"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := sharedHostCommand(t, registry)
+			paneID, reason := cmd.matchAIPane(tc.in)
+			if paneID != "%78" || reason != "" {
+				t.Fatalf("matchAIPane() = %q, reason %q, want %%78", paneID, reason)
+			}
+		})
+	}
+}
+
+// Acceptance 2: a conversation no Pane holds fails by name. The neighbouring
+// Pane below shares the working directory and is live, which is exactly the
+// Pane a guess would land on.
+func TestMatchAIPaneRefusesAConversationNoPaneHolds(t *testing.T) {
+	t.Parallel()
+
+	registry := conversationRegistry("pane-native", "%78",
+		&coremetadata.CodexActivationBinding{ThreadID: "thread-native"}, nil)
+	cmd := sharedHostCommand(t, registry)
+
+	paneID, reason := cmd.matchAIPane(aiPaneMatchInput{
+		CWD:      "/repo/projmux",
+		ThreadID: "thread-somebody-else",
+	})
+	if paneID != "" {
+		t.Fatalf("matchAIPane() attributed an unregistered conversation to %q", paneID)
+	}
+	if reason != aiPaneMatchReasonConversationUnknown {
+		t.Fatalf("reason = %q, want %q", reason, aiPaneMatchReasonConversationUnknown)
+	}
+}
+
+// Two Panes recording the same conversation is a Registry the matcher cannot
+// disambiguate. Picking either one is a coin flip that silently lands half its
+// events on the wrong Pane, so both are refused.
+func TestMatchAIPaneRefusesAConversationTwoPanesHold(t *testing.T) {
+	t.Parallel()
+
+	shared := conversationRegistry("pane-one", "%1",
+		&coremetadata.CodexActivationBinding{ThreadID: "thread-shared"}, nil)
+	second := conversationRegistry("pane-two", "%2",
+		&coremetadata.CodexActivationBinding{ThreadID: "thread-shared"}, nil)
+	shared.Agents = append(shared.Agents, second.Agents...)
+	shared.Panes = append(shared.Panes, second.Panes...)
+
+	cmd := sharedHostCommand(t, shared)
+	paneID, reason := cmd.matchAIPane(aiPaneMatchInput{ThreadID: "thread-shared"})
+	if paneID != "" {
+		t.Fatalf("matchAIPane() picked %q out of an ambiguous conversation", paneID)
+	}
+	if reason != aiPaneMatchReasonConversationShared {
+		t.Fatalf("reason = %q, want %q", reason, aiPaneMatchReasonConversationShared)
+	}
+}
+
+// The lookup demands the same round trip the explicit path demands. A Pane that
+// records a conversation but is no longer materialized, or whose Agent no
+// longer points back at it, is torn state and never an attribution target.
+func TestRegistryAttributionRequiresAnIntactBinding(t *testing.T) {
+	t.Parallel()
+
+	activation := &coremetadata.CodexActivationBinding{ThreadID: "thread-native"}
+
+	noRuntime := conversationRegistry("pane-native", "", activation, nil)
+	torn := conversationRegistry("pane-native", "%78", activation, nil)
+	torn.Agents[0].Status.PaneRef = "pane-somewhere-else"
+	orphan := conversationRegistry("pane-native", "%78", activation, nil)
+	orphan.Agents = nil
+
+	for _, tc := range []struct {
+		name     string
+		registry coremetadata.Registry
+	}{
+		{name: "pane is not materialized", registry: noRuntime},
+		{name: "agent no longer points back", registry: torn},
+		{name: "owning agent is gone", registry: orphan},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := sharedHostCommand(t, tc.registry)
+			paneID, reason := cmd.matchAIPane(aiPaneMatchInput{ThreadID: "thread-native"})
+			if paneID != "" {
+				t.Fatalf("matchAIPane() attributed a torn binding to %q", paneID)
+			}
+			if reason != aiPaneMatchReasonConversationUnknown {
+				t.Fatalf("reason = %q, want %q", reason, aiPaneMatchReasonConversationUnknown)
+			}
+		})
+	}
+}
+
+// The step reads the resource model, not a provider name. Every provider whose
+// conversation the Registry records resolves through the same code, and a
+// provider that records none simply contributes nothing.
+func TestRegistryAttributionIsProviderNeutral(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		session *coremetadata.AgentSessionRef
+		in      aiPaneMatchInput
+	}{
+		{
+			name:    "claude",
+			session: &coremetadata.AgentSessionRef{Provider: "claude", Claude: &coremetadata.ClaudeSessionRef{SessionID: "session-claude"}},
+			in:      aiPaneMatchInput{SessionID: "session-claude"},
+		},
+		{
+			name:    "codex",
+			session: &coremetadata.AgentSessionRef{Provider: "codex", Codex: &coremetadata.CodexSessionRef{ThreadID: "thread-codex"}},
+			in:      aiPaneMatchInput{ThreadID: "thread-codex"},
+		},
+		{
+			name:    "antigravity",
+			session: &coremetadata.AgentSessionRef{Provider: "antigravity", Antigravity: &coremetadata.AntigravitySessionRef{ConversationID: "conversation-antigravity"}},
+			in:      aiPaneMatchInput{ThreadID: "conversation-antigravity"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := sharedHostCommand(t, conversationRegistry("pane-native", "%78", nil, tc.session))
+			paneID, reason := cmd.matchAIPane(tc.in)
+			if paneID != "%78" || reason != "" {
+				t.Fatalf("matchAIPane() = %q, reason %q, want %%78", paneID, reason)
+			}
+		})
+	}
+}
+
+// The order is the contract. The Registry step is the last resort, so anything
+// the established path can answer still answers it and this change cannot move
+// an event that already had a home.
+func TestMatchAIPaneKeepsTheRegistryStepBehindTheEstablishedLadder(t *testing.T) {
+	t.Parallel()
+
+	registry := conversationRegistry("pane-native", "%registry",
+		&coremetadata.CodexActivationBinding{ThreadID: "thread-native"}, nil)
+	in := aiPaneMatchInput{CWD: "/repo/projmux", ThreadID: "thread-native"}
+
+	withLadder := func(t *testing.T, env string) *aiCommand {
+		t.Helper()
+		cmd := sharedHostCommand(t, registry)
+		cmd.lookupEnv = func(name string) string {
+			if name == "TMUX_PANE" {
+				return env
+			}
+			return ""
+		}
+		cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if name == "tmux" && len(args) > 0 && args[0] == "list-panes" {
+				return []byte("%cwd\x1f/repo/projmux\x1fthread-native\x1f\n"), nil
+			}
+			return nil, os.ErrNotExist
+		}
+		return cmd
+	}
+
+	explicit := withLadder(t, "%inherited")
+	explicit.loadRegistry = func() (coremetadata.Registry, error) {
+		return hookIdentityRegistry("pane-handed", "%handed"), nil
+	}
+	handed := in
+	handed.ExplicitPane = "pane-handed"
+	if paneID, _ := explicit.matchAIPane(handed); paneID != "%handed" {
+		t.Fatalf("handed identity = %q, want %%handed", paneID)
+	}
+	if paneID, _ := withLadder(t, "%inherited").matchAIPane(in); paneID != "%inherited" {
+		t.Fatalf("inherited environment = %q, want %%inherited", paneID)
+	}
+	if paneID, _ := withLadder(t, "").matchAIPane(in); paneID != "%cwd" {
+		t.Fatalf("pane inventory = %q, want %%cwd", paneID)
+	}
+	if paneID, _ := sharedHostCommand(t, registry).matchAIPane(in); paneID != "%registry" {
+		t.Fatalf("registry step = %q, want %%registry", paneID)
+	}
+}
+
+// A conversation the payload never carried leaves the established ladder's own
+// answer in place. The Registry cannot be asked a question with no subject, and
+// inventing one would relabel two failures that mean different things.
+func TestMatchAIPaneLeavesTheLadderReasonWhenThereIsNoConversation(t *testing.T) {
+	t.Parallel()
+
+	registry := conversationRegistry("pane-native", "%78",
+		&coremetadata.CodexActivationBinding{ThreadID: "thread-native"}, nil)
+
+	unreachable := sharedHostCommand(t, registry)
+	if _, reason := unreachable.matchAIPane(aiPaneMatchInput{CWD: "/repo/projmux"}); reason != aiPaneMatchReasonNoInventory {
+		t.Fatalf("reason = %q, want %q", reason, aiPaneMatchReasonNoInventory)
+	}
+
+	readable := sharedHostCommand(t, registry)
+	readable.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "tmux" && len(args) > 0 && args[0] == "list-panes" {
+			return []byte("%other\x1f/repo/other\x1f\x1f\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+	if _, reason := readable.matchAIPane(aiPaneMatchInput{CWD: "/repo/projmux"}); reason != aiPaneMatchReasonNoMatch {
+		t.Fatalf("reason = %q, want %q", reason, aiPaneMatchReasonNoMatch)
+	}
+}
+
+// The registry itself being unreachable is its own answer. It is not the same
+// failure as a conversation nobody claims, and an operator reading the log has
+// to be able to tell them apart.
+func TestRegistryAttributionReportsAnUnreachableRegistry(t *testing.T) {
+	t.Parallel()
+
+	cmd := testAICommand(t.TempDir())
+	cmd.lookupEnv = func(string) string { return "" }
+	cmd.readCommand = func(context.Context, string, ...string) ([]byte, error) { return nil, os.ErrNotExist }
+	cmd.loadRegistry = func() (coremetadata.Registry, error) { return coremetadata.Registry{}, os.ErrPermission }
+
+	paneID, reason := cmd.matchAIPane(aiPaneMatchInput{ThreadID: "thread-native"})
+	if paneID != "" {
+		t.Fatalf("matchAIPane() = %q, want no attribution", paneID)
+	}
+	if reason != aiPaneMatchReasonRegistryUnavailable {
+		t.Fatalf("reason = %q, want %q", reason, aiPaneMatchReasonRegistryUnavailable)
+	}
+}
+
+// Negative audit: this step defines no binding. It reads the Registry, writes
+// nothing, and touches no conversation authority — that authority is owned
+// elsewhere and stays there.
+func TestRegistryAttributionDefinesNoBinding(t *testing.T) {
+	t.Parallel()
+
+	registry := conversationRegistry("pane-native", "%78",
+		&coremetadata.CodexActivationBinding{ThreadID: "thread-native"}, nil)
+	loads := 0
+	cmd := sharedHostCommand(t, registry)
+	cmd.loadRegistry = func() (coremetadata.Registry, error) {
+		loads++
+		return registry, nil
+	}
+	cmd.runCommand = func(_ context.Context, name string, args ...string) error {
+		t.Fatalf("the lookup issued a command: %s %s", name, strings.Join(args, " "))
+		return nil
+	}
+
+	if paneID, _ := cmd.matchAIPane(aiPaneMatchInput{ThreadID: "thread-native"}); paneID != "%78" {
+		t.Fatalf("matchAIPane() = %q, want %%78", paneID)
+	}
+	if loads != 1 {
+		t.Fatalf("registry reads = %d, want exactly one", loads)
+	}
+	if len(registry.Panes) != 1 || registry.Panes[0].Status.Activation.Codex.ThreadID != "thread-native" ||
+		registry.Agents[0].Status.PaneRef != "pane-native" {
+		t.Fatal("the lookup mutated the registry snapshot it was handed")
+	}
+}
+
+// The whole route, not just the matcher: a codex hook payload arriving from a
+// shared provider host with an empty `--pane` lands on its own Pane and says so
+// in the record an operator reads.
+func TestCodexHookIngestAttributesASharedHostEventThroughTheRegistry(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	registry := conversationRegistry("pane-native", "%78",
+		&coremetadata.CodexActivationBinding{ThreadID: "thread-native"}, nil)
+	cmd := sharedHostCommand(t, registry)
+	cmd.homeDir = func() (string, error) { return home, nil }
+	cmd.stdin = strings.NewReader(`{"hook_event_name":"PreToolUse","thread_id":"thread-native","turn_id":"turn-1","cwd":"/repo/projmux"}`)
+
+	if err := cmd.runIngest([]string{"codex-hook", "--pane="}, io.Discard, io.Discard); err != nil {
+		t.Fatalf("runIngest() error = %v", err)
+	}
+
+	entry := lastAIIngestLogEntry(t, cmd)
+	if entry.Pane != "%78" {
+		t.Fatalf("record pane = %q, want %%78 (record: %+v)", entry.Pane, entry)
+	}
+	if entry.Result == "ignored" || entry.Reason == aiPaneMatchReasonNoInventory {
+		t.Fatalf("the event was still dropped: %+v", entry)
+	}
+
+	// The same route, a conversation nothing holds: no Pane, and the reason
+	// names the step that could not answer.
+	unclaimedHome := t.TempDir()
+	unclaimed := sharedHostCommand(t, registry)
+	unclaimed.homeDir = func() (string, error) { return unclaimedHome, nil }
+	unclaimed.stdin = strings.NewReader(`{"hook_event_name":"PreToolUse","thread_id":"thread-nobody-holds","cwd":"/repo/projmux"}`)
+	if err := unclaimed.runIngest([]string{"codex-hook", "--pane="}, io.Discard, io.Discard); err != nil {
+		t.Fatalf("runIngest() error = %v", err)
+	}
+	entry = lastAIIngestLogEntry(t, unclaimed)
+	if entry.Pane != "" || entry.Result != "ignored" || entry.Reason != aiPaneMatchReasonConversationUnknown {
+		t.Fatalf("unclaimed conversation record = %+v", entry)
+	}
+}
+
+func lastAIIngestLogEntry(t *testing.T, cmd *aiCommand) aiIngestLogEntry {
+	t.Helper()
+	path, err := cmd.aiIngestLogPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := nonEmptyLines(string(data))
+	if len(lines) == 0 {
+		t.Fatal("the route wrote no record at all")
+	}
+	var entry aiIngestLogEntry
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &entry); err != nil {
+		t.Fatal(err)
+	}
+	return entry
+}

--- a/internal/app/ai_ingest.go
+++ b/internal/app/ai_ingest.go
@@ -74,6 +74,8 @@ const (
 	aiPaneMatchReasonExplicitUnknown     = "explicit pane is not registered"
 	aiPaneMatchReasonExplicitNoRuntime   = "explicit pane has no live runtime"
 	aiPaneMatchReasonExplicitStale       = "explicit pane binding is stale"
+	aiPaneMatchReasonConversationUnknown = "conversation is not registered to a pane"
+	aiPaneMatchReasonConversationShared  = "conversation is registered to several panes"
 )
 
 type aiPaneMatchRow struct {
@@ -614,6 +616,15 @@ func (c *aiCommand) writeAIHookResumeMetadata(paneID, resumeID string) {
 // event to whichever other live Pane happens to share a working directory. The
 // established three-step ladder is unchanged and remains the answer whenever no
 // explicit identity arrived.
+//
+// Behind that ladder sits one further step for the hook nobody can hand an
+// identity to. A provider host shared by several Panes inherits neither the
+// activation envelope nor a tmux environment, so the explicit argument arrives
+// empty and the ladder cannot even read a Pane inventory. What that hook does
+// carry is the conversation its event belongs to, and the Registry already
+// records which Pane owns which conversation. Reading that record is a lookup,
+// not a binding: nothing here decides what a conversation is bound to, and a
+// conversation no Pane claims fails by name rather than landing on a neighbour.
 func (c *aiCommand) matchAIPane(in aiPaneMatchInput) (string, string) {
 	if explicit := strings.TrimSpace(in.ExplicitPane); explicit != "" {
 		return c.resolveExplicitAIPane(explicit)
@@ -621,6 +632,21 @@ func (c *aiCommand) matchAIPane(in aiPaneMatchInput) (string, string) {
 	if envPane := strings.TrimSpace(c.env("TMUX_PANE")); envPane != "" {
 		return envPane, ""
 	}
+	paneID, reason := c.matchAIPaneFromInventory(in)
+	if paneID != "" {
+		return paneID, reason
+	}
+	if strings.TrimSpace(in.ThreadID) == "" && strings.TrimSpace(in.SessionID) == "" {
+		return "", reason
+	}
+	return c.resolveRegisteredConversationPane(in.ThreadID, in.SessionID)
+}
+
+// matchAIPaneFromInventory is the established three-step ladder over the live
+// tmux Pane inventory: working directory first, then the conversation options
+// the panes themselves carry. It is unchanged; it only reports its own failure
+// to a caller that now has one more step to try.
+func (c *aiCommand) matchAIPaneFromInventory(in aiPaneMatchInput) (string, string) {
 	rows, listed := c.listAIPaneMatchRows()
 	if !listed {
 		return "", aiPaneMatchReasonNoInventory
@@ -646,6 +672,79 @@ func (c *aiCommand) matchAIPane(in aiPaneMatchInput) (string, string) {
 		}
 	}
 	return "", aiPaneMatchReasonNoMatch
+}
+
+// resolveRegisteredConversationPane answers from the Registry alone, so it works
+// for a hook whose process reaches no tmux server at all. It refuses rather than
+// guesses: an identifier no Pane records, and an identifier two Panes record,
+// both end as a named failure, because a hook that lands on the wrong Pane is
+// worse than one that lands nowhere.
+func (c *aiCommand) resolveRegisteredConversationPane(threadID, sessionID string) (string, string) {
+	if c.loadRegistry == nil {
+		return "", aiPaneMatchReasonRegistryUnavailable
+	}
+	registry, err := c.loadRegistry()
+	if err != nil {
+		return "", aiPaneMatchReasonRegistryUnavailable
+	}
+	panes := registeredConversationPanes(registry)
+	for _, id := range []string{threadID, sessionID} {
+		runtimeID, ok := panes[strings.TrimSpace(id)]
+		if !ok || strings.TrimSpace(id) == "" {
+			continue
+		}
+		if runtimeID == "" {
+			return "", aiPaneMatchReasonConversationShared
+		}
+		return runtimeID, ""
+	}
+	return "", aiPaneMatchReasonConversationUnknown
+}
+
+// registeredConversationPanes indexes every conversation identifier the Registry
+// currently records against the live runtime handle of the Pane that holds it.
+//
+// The index is built from the resource model, never from a provider name: a
+// Pane contributes the conversation its current activation refinement recorded
+// and the one its Agent's durable session pointer names, and a provider that
+// records neither simply contributes nothing. The same round trip
+// resolveExplicitAIPane demands is required here — activation handle, owning
+// Agent, and that Agent pointing back at this Pane — so a half-torn binding
+// never becomes an attribution target.
+//
+// A conversation claimed by two Panes maps to the empty handle. That is the
+// ambiguity marker, not an absent entry: the caller has to be able to tell "no
+// Pane holds this" from "more than one does", and neither may resolve.
+func registeredConversationPanes(registry coremetadata.Registry) map[string]string {
+	panes := make(map[string]string, len(registry.Panes))
+	claim := func(conversationID, runtimeID string) {
+		conversationID = strings.TrimSpace(conversationID)
+		if conversationID == "" {
+			return
+		}
+		if held, ok := panes[conversationID]; ok && held != runtimeID {
+			panes[conversationID] = ""
+			return
+		}
+		panes[conversationID] = runtimeID
+	}
+	for i := range registry.Panes {
+		pane := &registry.Panes[i]
+		runtimeID := strings.TrimSpace(pane.Status.Activation.RuntimeID)
+		agentUID := strings.TrimSpace(pane.Status.Activation.AgentUID)
+		if runtimeID == "" || agentUID == "" {
+			continue
+		}
+		agent, ok := registry.Agent(agentUID)
+		if !ok || agent.Status.PaneRef != pane.Metadata.UID {
+			continue
+		}
+		if codex := pane.Status.Activation.Codex; codex != nil {
+			claim(codex.ThreadID, runtimeID)
+		}
+		claim(agent.Status.SessionRef.ConversationID(), runtimeID)
+	}
+	return panes
 }
 
 // resolveExplicitAIPane turns the identity a hook was handed into the exact


### PR DESCRIPTION
## What

A provider host shared by several Panes — the Codex app-server every managed
Codex Pane resumes into — has no Pane to hand over and no tmux environment to
inherit. Its hooks reached neither the explicit `--pane` path nor the Pane
inventory the established three-step ladder reads, so every codex hook it fired
was dropped as `pane inventory unavailable`.

That reason was accurate, not wrong: the step could not run. What the payload
does carry is the conversation the event belongs to, and the Registry already
records which Pane holds which conversation.

This adds one further step behind the established ladder that reads exactly
that.

## How

- `matchAIPane` keeps its order. A handed identity, inherited `TMUX_PANE`, and
  the Pane inventory each still answer first and are untouched; the new step
  runs only when all of them came up empty **and** the payload carried a
  conversation identifier.
- `resolveRegisteredConversationPane` answers from the Registry alone, so it
  works with no tmux server reachable at all.
- `registeredConversationPanes` indexes the conversations the Registry records —
  a Pane's activation refinement and its Agent's durable session pointer —
  against the live runtime handle of the Pane that holds them. It demands the
  same round trip the explicit path demands: activation handle, owning Agent,
  and that Agent pointing back at this Pane.
- A conversation no Pane holds and a conversation two Panes hold each end as a
  named failure. Landing on a neighbour that merely shares a working directory
  is the failure this step exists to avoid, so neither resolves.

## Boundaries

- **Lookup only.** The step reads the Registry once, writes nothing, and defines
  no binding. Conversation binding authority stays where it is.
- **Provider-neutral.** It reads the resource model, not a provider name; every
  provider whose conversation the Registry records resolves through the same
  code.
- The explicit `--pane` path and the three-step fallback are unchanged, and the
  ten existing attribution tests still hold them.

## Verification

- `make fmt`, `make fix`, `make test` green on this head.
- `make test-integration`, `make test-e2e` running alongside CI.
- New tests: shared-host attribution, unclaimed and ambiguous conversation
  refusals, torn-binding refusal, provider neutrality, ladder ordering, ladder
  reason preservation, unreachable Registry, a no-write negative audit, and the
  codex-hook route end to end.
- `TestAttributionFailureReasonsAreDistinctAndClosed` extends to the two new
  reason tokens; both stay bounded phrases carrying no path or payload.

Roadmap: Codex control-plane observability and reconnect truth / Phase 6
Contract: C-2 Guarantee
