### PR TITLE
test(codex): gate the control-plane surfaces against silent regression

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1141,7 +1141,7 @@ The gate has three parts.
   every contract in the map names a surface the diagnosis renders.
 
 `projmux doctor` gained the operator half under **Codex control-plane
-surfaces**. Five verdicts, one per surface, each with the counters it was
+surfaces**. Seven verdicts, one per surface, each with the counters it was
 reached on:
 
 - `TestCodexBrokerDiagnosticsSurfaceNamesThePublishedButUnreachableRuntime`
@@ -1164,6 +1164,26 @@ reached on:
   own fence, so a torn pairing is a producer fact rather than a transition
   caught in flight. A Pane with no fence file is reported `unfenced`, separately
   from torn: its writer predates the fence, which is a deployment answer.
+
+- `TestHookDeliverySurfaceTreatsAnOpaqueFailureAsBroken` owns the layer after
+  attribution. A hook that found its Pane has not yet changed it, and the write
+  that follows can fail on its own. A failure naming its cause is a fault an
+  operator acts on; one reporting only `exit status 1` says a process ended and
+  nothing else. `TestOpaqueDeliveryReasonsNeverReachTheDiagnosis` pins both
+  halves of that: the raw string is counted rather than repeated, and a reason
+  carrying a path is opaque for the second reason that it is a leak.
+- `TestPaneOwnershipSurfaceReportsAForeignAttributionAsBroken` owns the failure
+  that looks like success from every other angle — the event was attributed, the
+  write landed, and the Pane it moved belongs to another provider.
+  `TestOwnershipHealthCallsOnlyAPositivelyForeignPaneForeign` pins the predicate
+  as one-sided and provider-neutral: an attribution is foreign only when the
+  Registry positively records a *different* provider, so a Pane recording none
+  is not a finding, and the judgment is a table rather than a branch.
+
+The attribution verdict is reached per source rather than over the total. The
+defect it detects was one provider's, and a busy neighbour attributing
+everything would carry the aggregate and render the dead provider as a few stale
+panes — which is the reading that let it live for eight phases.
 
 The section leads with a deployment-vintage line, and
 `TestControlPlaneVintage*` owns it. `make install` replaces the executable on

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1219,10 +1219,13 @@ one today: two cosmetic (a pane title, a one-shot message on the operator's own
 screen) and one global cleanup marker whose failure simply causes a retry. None
 of the three can make a surface report a state a Pane does not hold.
 
-Two things about the scan itself. It covers the whole package rather than a
+Three things about the scan itself. It covers the whole package rather than a
 named list of files, so a discarded write appearing somewhere new is caught
-rather than skipped for being somewhere nobody thought to look. And it reads
-the syntax tree, not the text: a textual version counted the pattern inside the
+rather than skipped for being somewhere nobody thought to look. It counts a
+bare call statement as well as an assignment to blank identifiers — that second
+form appears nowhere in the tree today and is covered as prevention, so that
+deleting the assignment rather than checking the error does not quiet the gate.
+And it reads the syntax tree, not the text: a textual version counted the pattern inside the
 comment explaining why a checked helper replaced it, so the sentence describing
 the fix registered as the defect.
 `TestDiscardedWriteScanNeverCountsProseAboutCode` pins that, because a gate

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1207,13 +1207,26 @@ the log itself reports success and every diagnosis built on it inherits the lie.
 It is the strongest form of the failure this whole section exists to catch:
 `disconnected` and `no matching pane` were at least wrong out loud.
 
-The gate is zero and carries no baseline. Recording the current count as an
-allowance was considered and rejected: pinning today's state as the passing
-condition is the exact shape of the E2E assertion that made a silent control
-plane the condition for green, and building that trap inside the gate written
-to stop it is not a tradeoff worth making. The scan covers the whole package
-rather than a named list of files, so a discarded write appearing somewhere new
-is caught rather than skipped for being somewhere nobody thought to look.
+The gate is zero within the hook reflection path, and it carries no baseline.
+Recording the current count as an allowance was considered and rejected:
+pinning today's state as the passing condition is the exact shape of the E2E
+assertion that made a silent control plane the condition for green, and
+building that trap inside the gate written to stop it is not a tradeoff worth
+making. An exception is admitted by a stated `best-effort-write: <reason>`
+comment, never by a count — the difference being that a reason is a judgment a
+reviewer can dispute, while a number just defers on volume. Three writes carry
+one today: two cosmetic (a pane title, a one-shot message on the operator's own
+screen) and one global cleanup marker whose failure simply causes a retry. None
+of the three can make a surface report a state a Pane does not hold.
+
+Two things about the scan itself. It covers the whole package rather than a
+named list of files, so a discarded write appearing somewhere new is caught
+rather than skipped for being somewhere nobody thought to look. And it reads
+the syntax tree, not the text: a textual version counted the pattern inside the
+comment explaining why a checked helper replaced it, so the sentence describing
+the fix registered as the defect.
+`TestDiscardedWriteScanNeverCountsProseAboutCode` pins that, because a gate
+which cannot tell code from prose about code is one people route around.
 
 The `pane-ownership` foreign count is broken down by direction for a related
 reason. A hook landing on the Pane that launched its host is the identity leak

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1205,11 +1205,22 @@ log-derived verdicts can. A reflection path that runs a tmux write and throws
 the error away records `result:"state"` for an event whose Pane never moved, so
 the log itself reports success and every diagnosis built on it inherits the lie.
 It is the strongest form of the failure this whole section exists to catch:
-`disconnected` and `no matching pane` were at least wrong out loud. The test
-holds `aiHookDiscardedWriteInventory`, an exact per-file count of the discarded
-writes in the tree, as a ratchet — a new one fails the gate, and a fixed one
-must be recorded downward. The inventory is unfixed debt, not justification;
-repairing it belongs to the phase that owns those paths.
+`disconnected` and `no matching pane` were at least wrong out loud.
+
+The gate is zero and carries no baseline. Recording the current count as an
+allowance was considered and rejected: pinning today's state as the passing
+condition is the exact shape of the E2E assertion that made a silent control
+plane the condition for green, and building that trap inside the gate written
+to stop it is not a tradeoff worth making. The scan covers the whole package
+rather than a named list of files, so a discarded write appearing somewhere new
+is caught rather than skipped for being somewhere nobody thought to look.
+
+The `pane-ownership` foreign count is broken down by direction for a related
+reason. A hook landing on the Pane that launched its host is the identity leak
+the contract closes; a provider's events arriving under another provider's
+source were misrouted before attribution ever ran, which a stale hook config on
+the machine can produce and no code change here would fix. One number would let
+either be mistaken for the other.
 
 The section leads with a deployment-vintage line, and
 `TestControlPlaneVintage*` owns it. `make install` replaces the executable on

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1212,6 +1212,19 @@ mechanism not answering: an unreadable inventory or Registry, or the ladder
 running over readable data and finding nothing, which is the shape a re-broken
 hook identity would take.
 
+`TestEverySurfaceDeclaresWhatItsNumbersAreOver` and
+`TestEverySurfaceRendersTheScopeItDeclares` fold four separate corrections into
+one rule. Each of the four was the same mistake wearing a different face: a
+refusal the contract never promised counted among the failures it did; a judged
+count standing without its population; a lane that writes nothing sitting in a
+write rate's denominator; records from two binaries counted in one window. Every
+number was arithmetically right and none said what it ranged over, so a reader
+supplied the wrong range — and all four were found by a person, none by a test.
+A surface must now declare the phrase its rendering carries to answer "over
+what", and adding one without that answer fails the completeness check. The
+rule cannot judge whether a scope is *correct*; it makes stating one
+unavoidable, which is what none of the four had to do.
+
 `TestHookReflectionWritesNeverDiscardTheirErrorSilently` covers what none of the
 log-derived verdicts can. A reflection path that runs a tmux write and throws
 the error away records `result:"state"` for an event whose Pane never moved, so

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1182,6 +1182,18 @@ reached on:
 
 Two things the attribution verdict counts, and one it does not.
 
+The section carries the record span its hook rows were counted over. Every
+hook-layer number is cumulative across the whole reading window, and a
+deployment inside that window leaves records from both binaries in the same
+counts — so a repair that lands mid-window moves nothing until its predecessors
+age out, and a reader without the span reads the delay as the repair having
+failed and the eventual drop as time having healed it. Splitting the counts at
+a deployment boundary would need something this reader does not have: the hook
+layer is a short-lived process re-resolved from PATH on every firing, so the
+binary vintage of a long-running process says nothing about which image wrote a
+given record. That is also why the vintage line above qualifies the broker and
+observer rows and not these three.
+
 It is reached **per source** rather than over the total. The defect it detects
 was one provider's, and a busy neighbour attributing everything would carry the
 aggregate and render the dead provider as a few stale panes — which is the

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1180,10 +1180,36 @@ reached on:
   Registry positively records a *different* provider, so a Pane recording none
   is not a finding, and the judgment is a table rather than a branch.
 
-The attribution verdict is reached per source rather than over the total. The
-defect it detects was one provider's, and a busy neighbour attributing
-everything would carry the aggregate and render the dead provider as a few stale
-panes — which is the reading that let it live for eight phases.
+Two things the attribution verdict counts, and one it does not.
+
+It is reached **per source** rather than over the total. The defect it detects
+was one provider's, and a busy neighbour attributing everything would carry the
+aggregate and render the dead provider as a few stale panes — which is the
+reading that let it live for eight phases.
+
+It counts only events the contract owed a Pane. `aiPaneMatchRefusals` names the
+answers that decline something the contract never promised — a conversation or
+an explicit Pane that no longer exists — and those are reported beside the
+failure count, never inside it.
+`TestAttributionHealthSeparatesAContractualRefusalFromAFailure` pins the split.
+A retired conversation whose thread keeps firing hooks is the mechanism working;
+reporting it as breakage made `doctor` call a machine behaving to spec broken,
+and a gate that cries wolf gets switched off — which is how the defects this
+section exists to catch survived next door. What stays a failure is the
+mechanism not answering: an unreadable inventory or Registry, or the ladder
+running over readable data and finding nothing, which is the shape a re-broken
+hook identity would take.
+
+`TestHookReflectionWritesNeverDiscardTheirErrorSilently` covers what none of the
+log-derived verdicts can. A reflection path that runs a tmux write and throws
+the error away records `result:"state"` for an event whose Pane never moved, so
+the log itself reports success and every diagnosis built on it inherits the lie.
+It is the strongest form of the failure this whole section exists to catch:
+`disconnected` and `no matching pane` were at least wrong out loud. The test
+holds `aiHookDiscardedWriteInventory`, an exact per-file count of the discarded
+writes in the tree, as a ratchet — a new one fails the gate, and a fixed one
+must be recorded downward. The inventory is unfixed debt, not justification;
+repairing it belongs to the phase that owns those paths.
 
 The section leads with a deployment-vintage line, and
 `TestControlPlaneVintage*` owns it. `make install` replaces the executable on

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1112,6 +1112,71 @@ fall-through resolves — to the answer, never inside the shared ladder.
   the shared ladder is untouched: with no explicit value there is no refused
   envelope and therefore no coherence question, and the cwd and thread steps
   resolve exactly as before for every provider.
+### Codex control-plane regression-detection gate tests
+
+Three control-plane defects lived through a neighbouring eight-phase track
+closing green from end to end. Nothing reached those surfaces, and the one test
+that did — `test/e2e/codex-lifecycle.sh` — asserted the literal `disconnected`
+for a managed Codex Pane's authority reason. `disconnected` is the bucket that
+means no reason was captured, so capturing a real one would have turned the job
+red. Shipping the fixes without this gate would leave the same blind spot under
+new code.
+
+The gate has three parts.
+
+- `TestControlPlaneTestsNeverExpectAnUncapturedReason` sweeps every
+  `internal/**/*_test.go` and `test/e2e/*.sh` for values that mean "nothing was
+  recorded" — `unrecorded`, the pre-instrumentation `disconnected` literal, the
+  `bounded reason unavailable` read fallback, and the `target-unmatched`
+  operations bucket — and fails on any that is an expectation rather than an
+  input. A survivor is admitted only by an `uncaptured-default: <reason>`
+  comment on its line or in the comment block above it; every current survivor
+  is a different vocabulary that happens to spell a token the same way.
+- `TestControlPlaneContractCellsNameLiveTests` resolves every test named in
+  `codexControlPlaneContractEnforcement` against the declarations in the tree.
+  Squash merges erase the branch that tied a fix to the test holding it, so a
+  contract cell naming a renamed test reads as enforced while enforcing nothing.
+- `TestControlPlaneContractEnforcementCoversEverySurface` holds the two
+  directions of that map closed: every rendered surface names a contract, and
+  every contract in the map names a surface the diagnosis renders.
+
+`projmux doctor` gained the operator half under **Codex control-plane
+surfaces**. Five verdicts, one per surface, each with the counters it was
+reached on:
+
+- `TestCodexBrokerDiagnosticsSurfaceNamesThePublishedButUnreachableRuntime`
+  separates a domain that published nothing — the ordinary resting state — from
+  one whose published endpoint answered nothing, which used to render as
+  `absent` and was read as "no broker is running".
+- `TestHookAttributionSurfaceSeparatesTotalFailureFromPartial` keeps "no hook
+  reached its Pane" apart from "a few did not". `TestAttributionHealth*` own the
+  bounded tail read of `ai-ingest.log` behind it, including that an unreadable
+  log is reported as unobserved rather than as zero failures.
+- `TestObserverReasonSurfaceRefusesToCallAnUncapturedReasonHealthy` is the
+  product-side half of the sweep: a reason distribution made entirely of
+  uncaptured tokens is never a healthy row.
+- `TestConnectionContinuitySurfaceReportsCumulativeReconnects` reports the count
+  as the total it is and derives no rate from a single sample.
+- `TestTurnAdmissionSurfaceReportsATornAuthoritySnapshotAsBroken`, with
+  `TestSettledAuthorityObservationNamesATornTripleOnlyUnderTheFence` and
+  `TestAuthorityFenceObservation*`, owns the C-5 read. Doctor samples each
+  Pane's authority triple under a **shared, non-creating** hold of the writer's
+  own fence, so a torn pairing is a producer fact rather than a transition
+  caught in flight. A Pane with no fence file is reported `unfenced`, separately
+  from torn: its writer predates the fence, which is a deployment answer.
+
+The section leads with a deployment-vintage line, and
+`TestControlPlaneVintage*` owns it. `make install` replaces the executable on
+disk and never replaces the image of a running process, so a green surface read
+from a replaced-image process describes code that process never loaded. This
+track lost two acceptance criteria to that twice. On Linux the diagnosis
+resolves `/proc/<pid>/exe` for the broker runtime and the lifecycle observers
+and reports how many run a replaced image; on a platform with no such table it
+reports the answer as unknown rather than claiming currency.
+
+The gate does not change `projmux doctor`'s exit code. A broken surface is a
+readable verdict, not a failed command, and the CI half of the detection is the
+regression tests themselves.
 
 ### Attributed Codex hook delivery route tests
 

--- a/internal/app/agent_control_cli_test.go
+++ b/internal/app/agent_control_cli_test.go
@@ -342,10 +342,10 @@ func TestAgentControlCLIReconnectGapAndIdentityDriftRefuseEveryPublicWrite(t *te
 		wantTransport int
 	}{
 		{name: "disconnect invalidating", mutate: func(_ *fakeResourceStore, binding *staticAgentControlBinding) {
-			binding.live.Authority, binding.live.Epoch, binding.live.Reason = codexAuthorityInvalidating, "epoch-1", "disconnected"
+			binding.live.Authority, binding.live.Epoch, binding.live.Reason = codexAuthorityInvalidating, "epoch-1", "endpoint-suspended"
 		}},
 		{name: "reconnect hook gap", mutate: func(_ *fakeResourceStore, binding *staticAgentControlBinding) {
-			binding.live.Authority, binding.live.Epoch, binding.live.Reason = codexAuthorityHook, "", "disconnected"
+			binding.live.Authority, binding.live.Epoch, binding.live.Reason = codexAuthorityHook, "", "endpoint-suspended"
 		}},
 		{name: "broker unavailable", mutate: func(_ *fakeResourceStore, binding *staticAgentControlBinding) {
 			binding.live.Authority, binding.live.Epoch, binding.live.Reason = codexAuthorityHook, "", "unsupported-platform"

--- a/internal/app/agent_control_settled_authority_test.go
+++ b/internal/app/agent_control_settled_authority_test.go
@@ -119,14 +119,14 @@ func TestSettledCodexAuthorityAdmissionIgnoresTornAuthorityWrites(t *testing.T) 
 	}{
 		{
 			name:            "authority written epoch and reason still pending",
-			midWrite:        [3]string{codexAuthorityControlPlane, "", "disconnected"},
+			midWrite:        [3]string{codexAuthorityControlPlane, "", "endpoint-suspended"},
 			settled:         [3]string{codexAuthorityControlPlane, "752812-41", "ready"},
 			tornWouldRefuse: true,
 			wantEpoch:       "752812-41",
 		},
 		{
 			name:      "authority and epoch written reason still pending",
-			midWrite:  [3]string{codexAuthorityControlPlane, "752812-40", "disconnected"},
+			midWrite:  [3]string{codexAuthorityControlPlane, "752812-40", "endpoint-suspended"},
 			settled:   [3]string{codexAuthorityControlPlane, "752812-41", "ready"},
 			wantEpoch: "752812-41",
 		},
@@ -138,10 +138,10 @@ func TestSettledCodexAuthorityAdmissionIgnoresTornAuthorityWrites(t *testing.T) 
 		},
 		{
 			name:            "settled loss to the provider hook",
-			midWrite:        [3]string{codexAuthorityHook, "", "disconnected"},
-			settled:         [3]string{codexAuthorityHook, "", "disconnected"},
+			midWrite:        [3]string{codexAuthorityHook, "", "endpoint-suspended"},
+			settled:         [3]string{codexAuthorityHook, "", "endpoint-suspended"},
 			tornWouldRefuse: true,
-			wantRefusal:     "the native connection epoch is unavailable (disconnected)",
+			wantRefusal:     "the native connection epoch is unavailable (endpoint-suspended)",
 		},
 		{
 			name:            "settled pending connection",
@@ -312,7 +312,7 @@ func TestConcurrentCodexAuthorityTransitionsNeverExposeATornAdmissionSnapshot(t 
 	cmd, _, _ := exactControlCLICommand(t)
 	cmd.controlPaths = func() (config.Paths, error) { return paths, nil }
 	state := &codexAuthorityPaneState{}
-	state.set(codexAuthorityHook, "", "disconnected")
+	state.set(codexAuthorityHook, "", "endpoint-suspended")
 	lookup := &codexAuthorityPaneLookup{state: state}
 	cmd.controlBinding = lookup
 
@@ -332,7 +332,7 @@ func TestConcurrentCodexAuthorityTransitionsNeverExposeATornAdmissionSnapshot(t 
 			if err != nil {
 				return
 			}
-			state.publish(codexAuthorityHook, "", "disconnected")
+			state.publish(codexAuthorityHook, "", "endpoint-suspended")
 			release()
 			runtime.Gosched()
 		}
@@ -347,7 +347,7 @@ func TestConcurrentCodexAuthorityTransitionsNeverExposeATornAdmissionSnapshot(t 
 			}
 			for _, live := range lookup.observed {
 				settledLive := live.Authority == codexAuthorityControlPlane && live.Epoch != "" && live.Reason == "ready"
-				settledLost := live.Authority == codexAuthorityHook && live.Epoch == "" && live.Reason == "disconnected"
+				settledLost := live.Authority == codexAuthorityHook && live.Epoch == "" && live.Reason == "endpoint-suspended"
 				if !settledLive && !settledLost {
 					t.Fatalf("admission read a torn authority triple: %+v", live)
 				}
@@ -363,7 +363,7 @@ func TestConcurrentCodexAuthorityTransitionsNeverExposeATornAdmissionSnapshot(t 
 				t.Fatalf("admitted a turn with no control epoch: %+v", binding)
 			}
 			admitted++
-		case strings.Contains(err.Error(), "the native connection epoch is unavailable (disconnected)"):
+		case strings.Contains(err.Error(), "the native connection epoch is unavailable (endpoint-suspended)"):
 			refused++
 		default:
 			t.Fatalf("unexpected admission error: %v", err)

--- a/internal/app/ai_hook_write_evidence_test.go
+++ b/internal/app/ai_hook_write_evidence_test.go
@@ -93,9 +93,12 @@ func TestHookReflectionWritesNeverDiscardTheirErrorSilently(t *testing.T) {
 // discardedTmuxWrites finds every tmux invocation in one file whose error the
 // call site throws away.
 //
-// Both spellings count. An assignment to blank identifiers discards the error
-// explicitly; a bare call statement discards it without even naming it, which
-// is quieter still.
+// Both spellings count, and the second is prevention rather than discovery.
+// Every discarded write in the tree today is an assignment to blank
+// identifiers; a bare call statement, which discards the error without even
+// naming it, currently appears nowhere. It is covered so that the obvious way
+// to quiet this gate -- deleting the assignment rather than checking the error
+// -- does not work.
 func discardedTmuxWrites(fileSet *token.FileSet, file *ast.File) []token.Position {
 	var found []token.Position
 	ast.Inspect(file, func(node ast.Node) bool {

--- a/internal/app/ai_hook_write_evidence_test.go
+++ b/internal/app/ai_hook_write_evidence_test.go
@@ -36,11 +36,16 @@ import (
 // made and a reviewer can dispute. New writes with no reason stay red.
 const aiBestEffortWriteMarker = "best-effort-write:"
 
-// TestHookReflectionWritesNeverDiscardTheirErrorSilently holds the gate.
+// TestHookReflectionWritesNeverDiscardTheirErrorSilently holds the gate, and it
+// owns the whole package.
 //
-// The scan is over the whole package rather than a named list of files, so a
+// The scan reads every file in the package rather than a named list, so a
 // discarded write appearing somewhere new is caught rather than skipped for
-// being somewhere nobody thought to look.
+// being somewhere nobody thought to look. That breadth is the point, and it is
+// worth stating because a narrower audit lives alongside it: the phase that
+// repaired the reflection writes checks only the files it touched. Its green is
+// evidence about those files, never about the package. This test is where the
+// package-wide claim is made.
 //
 // It reads the syntax tree rather than the text. A textual scan counts the
 // pattern wherever it appears, including inside the comment that explains why a

--- a/internal/app/ai_hook_write_evidence_test.go
+++ b/internal/app/ai_hook_write_evidence_test.go
@@ -1,0 +1,79 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// A discarded write error is the strongest form of a surface lying.
+//
+// Everything else this track chased at least reported something. `disconnected`
+// meant nothing was recorded, `no matching pane` named the wrong step — both
+// wrong, both visible. A hook reflection path that runs a tmux write and throws
+// the error away reports **success**: the ingest log records `result:"state"`
+// for an event whose Pane never moved, and no diagnosis built on that log can
+// see it, because the log is the thing that is lying.
+//
+// It is why one hook event appeared to work and another appeared to fail. They
+// failed alike; only one of them said so.
+
+// aiHookDiscardedWritePattern matches a tmux invocation whose error is thrown
+// away at the call site.
+var aiHookDiscardedWritePattern = regexp.MustCompile(`_,? ?_? ?= c\.run\("tmux"`)
+
+// The gate is zero, and it carries no baseline.
+//
+// Recording the current count as an allowance was considered and rejected.
+// Pinning today's state as the passing condition is the exact shape of the E2E
+// assertion that made a silent control plane the condition for green, and
+// building that trap a second time inside the gate written to stop it is not a
+// tradeoff worth making. The count stays a failure until the writes check their
+// errors.
+
+// TestHookReflectionWritesNeverDiscardTheirErrorSilently holds the ratchet.
+//
+// The scan is over the whole package rather than a named list of files, so a
+// discarded write appearing somewhere new is caught rather than skipped for
+// being somewhere nobody thought to look.
+func TestHookReflectionWritesNeverDiscardTheirErrorSilently(t *testing.T) {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read package directory: %v", err)
+	}
+	found := map[string]int{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		payload, readErr := os.ReadFile(filepath.Join(dir, name)) // #nosec G304 -- package source under test.
+		if readErr != nil {
+			t.Fatalf("read %s: %v", name, readErr)
+		}
+		if count := len(aiHookDiscardedWritePattern.FindAllIndex(payload, -1)); count > 0 {
+			found[name] = count
+		}
+	}
+	var discarded []string
+	total := 0
+	for name, count := range found {
+		discarded = append(discarded, name+": "+strconv.Itoa(count))
+		total += count
+	}
+	sort.Strings(discarded)
+	if total > 0 {
+		t.Fatalf("%d tmux write(s) throw their error away:\n  %s\n\n"+
+			"Each one lets the ingest log record success for an event whose Pane never moved, so no diagnosis "+
+			"built on that log can detect it. Check the error and report a bounded reason instead.",
+			total, strings.Join(discarded, "\n  "))
+	}
+}

--- a/internal/app/ai_hook_write_evidence_test.go
+++ b/internal/app/ai_hook_write_evidence_test.go
@@ -1,9 +1,11 @@
 package app
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -14,32 +16,37 @@ import (
 //
 // Everything else this track chased at least reported something. `disconnected`
 // meant nothing was recorded, `no matching pane` named the wrong step — both
-// wrong, both visible. A hook reflection path that runs a tmux write and throws
-// the error away reports **success**: the ingest log records `result:"state"`
-// for an event whose Pane never moved, and no diagnosis built on that log can
-// see it, because the log is the thing that is lying.
+// wrong, both visible. A reflection path that runs a tmux write and throws the
+// error away reports **success**: the ingest log records `result:"state"` for an
+// event whose Pane never moved, and no diagnosis built on that log can see it,
+// because the log is the thing that is lying.
 //
 // It is why one hook event appeared to work and another appeared to fail. They
 // failed alike; only one of them said so.
 
-// aiHookDiscardedWritePattern matches a tmux invocation whose error is thrown
-// away at the call site.
-var aiHookDiscardedWritePattern = regexp.MustCompile(`_,? ?_? ?= c\.run\("tmux"`)
-
-// The gate is zero, and it carries no baseline.
+// aiBestEffortWriteMarker admits one discarded write.
 //
-// Recording the current count as an allowance was considered and rejected.
-// Pinning today's state as the passing condition is the exact shape of the E2E
-// assertion that made a silent control plane the condition for green, and
-// building that trap a second time inside the gate written to stop it is not a
-// tradeoff worth making. The count stays a failure until the writes check their
-// errors.
+// It carries the same rule as the uncaptured-reason sweep: an exception is
+// admitted by a stated reason, never by a count. That distinction is the whole
+// difference between this gate and a baseline. A baseline says "there are N
+// today, so N passes", which defers on volume and re-freezes the current state
+// as the passing condition — the exact shape of the E2E assertion that made a
+// silent control plane the condition for green. A marker says "this one write
+// is a different kind of thing, and here is why", which is a judgment someone
+// made and a reviewer can dispute. New writes with no reason stay red.
+const aiBestEffortWriteMarker = "best-effort-write:"
 
-// TestHookReflectionWritesNeverDiscardTheirErrorSilently holds the ratchet.
+// TestHookReflectionWritesNeverDiscardTheirErrorSilently holds the gate.
 //
 // The scan is over the whole package rather than a named list of files, so a
 // discarded write appearing somewhere new is caught rather than skipped for
 // being somewhere nobody thought to look.
+//
+// It reads the syntax tree rather than the text. A textual scan counts the
+// pattern wherever it appears, including inside the comment that explains why a
+// helper replaced it — so the gate would redden on the very sentence describing
+// its own fix. A gate that cannot tell code from prose about code is a gate
+// people route around.
 func TestHookReflectionWritesNeverDiscardTheirErrorSilently(t *testing.T) {
 	dir, err := os.Getwd()
 	if err != nil {
@@ -49,31 +56,160 @@ func TestHookReflectionWritesNeverDiscardTheirErrorSilently(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read package directory: %v", err)
 	}
-	found := map[string]int{}
+	var unjustified []string
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 			continue
 		}
-		payload, readErr := os.ReadFile(filepath.Join(dir, name)) // #nosec G304 -- package source under test.
+		path := filepath.Join(dir, name)
+		payload, readErr := os.ReadFile(path) // #nosec G304 -- package source under test.
 		if readErr != nil {
 			t.Fatalf("read %s: %v", name, readErr)
 		}
-		if count := len(aiHookDiscardedWritePattern.FindAllIndex(payload, -1)); count > 0 {
-			found[name] = count
+		lines := strings.Split(string(payload), "\n")
+		fileSet := token.NewFileSet()
+		parsed, parseErr := parser.ParseFile(fileSet, path, payload, 0)
+		if parseErr != nil {
+			t.Fatalf("parse %s: %v", name, parseErr)
+		}
+		for _, position := range discardedTmuxWrites(fileSet, parsed) {
+			if bestEffortWriteJustified(lines, position.Line-1) {
+				continue
+			}
+			unjustified = append(unjustified, name+":"+strconv.Itoa(position.Line))
 		}
 	}
-	var discarded []string
-	total := 0
-	for name, count := range found {
-		discarded = append(discarded, name+": "+strconv.Itoa(count))
-		total += count
+	sort.Strings(unjustified)
+	if len(unjustified) > 0 {
+		t.Fatalf("%d tmux write(s) throw their error away with no reason given:\n  %s\n\n"+
+			"Each one lets a reflection path report success for a write that never landed, which no diagnosis "+
+			"built on the ingest log can detect. Check the error and report a bounded reason, or state on the "+
+			"line above why this write is best-effort with a `%s <reason>` comment.",
+			len(unjustified), strings.Join(unjustified, "\n  "), aiBestEffortWriteMarker)
 	}
-	sort.Strings(discarded)
-	if total > 0 {
-		t.Fatalf("%d tmux write(s) throw their error away:\n  %s\n\n"+
-			"Each one lets the ingest log record success for an event whose Pane never moved, so no diagnosis "+
-			"built on that log can detect it. Check the error and report a bounded reason instead.",
-			total, strings.Join(discarded, "\n  "))
+}
+
+// discardedTmuxWrites finds every tmux invocation in one file whose error the
+// call site throws away.
+//
+// Both spellings count. An assignment to blank identifiers discards the error
+// explicitly; a bare call statement discards it without even naming it, which
+// is quieter still.
+func discardedTmuxWrites(fileSet *token.FileSet, file *ast.File) []token.Position {
+	var found []token.Position
+	ast.Inspect(file, func(node ast.Node) bool {
+		var call *ast.CallExpr
+		switch statement := node.(type) {
+		case *ast.AssignStmt:
+			if statement.Tok != token.ASSIGN || len(statement.Rhs) != 1 {
+				return true
+			}
+			for _, target := range statement.Lhs {
+				ident, ok := target.(*ast.Ident)
+				if !ok || ident.Name != "_" {
+					return true
+				}
+			}
+			candidate, ok := statement.Rhs[0].(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			call = candidate
+		case *ast.ExprStmt:
+			candidate, ok := statement.X.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			call = candidate
+		default:
+			return true
+		}
+		if isTmuxRunCall(call) {
+			found = append(found, fileSet.Position(call.Pos()))
+		}
+		return true
+	})
+	return found
+}
+
+// isTmuxRunCall reports whether one call runs tmux through the command runner.
+func isTmuxRunCall(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != "run" || len(call.Args) == 0 {
+		return false
+	}
+	literal, ok := call.Args[0].(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return false
+	}
+	value, err := strconv.Unquote(literal.Value)
+	return err == nil && value == "tmux"
+}
+
+// bestEffortWriteJustified reports whether a discarded write carries its reason
+// on its own line or in the comment block directly above it.
+func bestEffortWriteJustified(lines []string, index int) bool {
+	if index < 0 || index >= len(lines) {
+		return false
+	}
+	if markerCarriesBestEffortReason(lines[index]) {
+		return true
+	}
+	for above := index - 1; above >= 0 && strings.HasPrefix(strings.TrimSpace(lines[above]), "//"); above-- {
+		if markerCarriesBestEffortReason(lines[above]) {
+			return true
+		}
+	}
+	return false
+}
+
+// markerCarriesBestEffortReason reports whether one line states a reason after
+// the marker. An empty marker admits nothing.
+func markerCarriesBestEffortReason(line string) bool {
+	_, after, ok := strings.Cut(line, aiBestEffortWriteMarker)
+	if !ok {
+		return false
+	}
+	return strings.TrimSpace(after) != ""
+}
+
+// TestDiscardedWriteScanNeverCountsProseAboutCode is the gate checking itself.
+//
+// The first version of this scan matched text, and it reddened on the comment
+// that explains why a checked helper replaced the discarded call — the sentence
+// describing the fix counted as the defect. A gate that cannot tell code from
+// prose about code gets routed around, and being routed around is how the
+// defects this whole section exists to catch survived in the first place.
+func TestDiscardedWriteScanNeverCountsProseAboutCode(t *testing.T) {
+	const source = `package app
+
+// recordAIPaneOption is the honest spelling of what ` + "`_ = c.run(\"tmux\", ...)`" + ` used
+// to be: the failure is kept instead of dropped.
+func sample(c *thing) {
+	documentation := "_ = c.run(\"tmux\", \"set-option\")"
+	_ = documentation
+	_, _ = c.run("tmux", "select-pane")
+	c.run("tmux", "display-message")
+	if err := c.run("tmux", "set-option"); err != nil {
+		return
+	}
+}
+`
+	fileSet := token.NewFileSet()
+	parsed, err := parser.ParseFile(fileSet, "sample.go", source, 0)
+	if err != nil {
+		t.Fatalf("parse sample: %v", err)
+	}
+	found := discardedTmuxWrites(fileSet, parsed)
+	if len(found) != 2 {
+		t.Fatalf("found %d discarded write(s), want exactly the assignment and the bare call\n%+v", len(found), found)
+	}
+	// A checked call is not a discarded one, and neither the comment nor the
+	// string literal quoting the pattern may enter the count.
+	for _, position := range found {
+		if position.Line < 8 || position.Line > 9 {
+			t.Fatalf("counted something at line %d that is not one of the two discarded calls", position.Line)
+		}
 	}
 }

--- a/internal/app/ai_ingest_attribution_health.go
+++ b/internal/app/ai_ingest_attribution_health.go
@@ -143,6 +143,36 @@ func (h aiIngestAttributionHealth) Unattributed() int {
 	return total
 }
 
+// aiIngestWindowSpan reports the first and last record timestamps in a window.
+//
+// Every hook-layer count in this diagnosis is cumulative over the whole window,
+// and the window spans whatever happened during it -- including a deployment.
+// A repair therefore cannot move these numbers until the records that predate
+// it age out, and a reader who does not know the span reads the delay as the
+// repair having failed, then reads the eventual drop as time having healed it.
+//
+// Naming the span is the cheap half of the fix. Splitting the counts at a
+// deployment boundary would be the expensive half, and it needs something this
+// reader does not have: the hook layer is a short-lived process re-resolved on
+// every firing, so the binary vintage of a long-running process says nothing
+// about which image wrote a given record.
+func aiIngestWindowSpan(entries []aiIngestLogEntry) (string, string) {
+	first, last := "", ""
+	for _, entry := range entries {
+		at := strings.TrimSpace(entry.At)
+		if at == "" {
+			continue
+		}
+		if first == "" || at < first {
+			first = at
+		}
+		if last == "" || at > last {
+			last = at
+		}
+	}
+	return first, last
+}
+
 // readAIIngestLogTail reads the last window of a JSON-lines log.
 //
 // The first line of the window is dropped whenever the window did not start at

--- a/internal/app/ai_ingest_attribution_health.go
+++ b/internal/app/ai_ingest_attribution_health.go
@@ -223,7 +223,11 @@ func projectAIIngestAttributionHealth(entries []aiIngestLogEntry) aiIngestAttrib
 			attributed[source]++
 			continue
 		}
-		reason := strings.TrimSpace(entry.Reason)
+		// The conversion is explicit because this record's reason column becomes a
+		// named vocabulary type once the closed-vocabulary work lands, and an
+		// explicit conversion compiles against both spellings. It is not
+		// redundant; removing it breaks the build a version from now.
+		reason := strings.TrimSpace(string(entry.Reason))
 		if !slices.Contains(aiPaneMatchReasons, reason) {
 			continue
 		}

--- a/internal/app/ai_ingest_attribution_health.go
+++ b/internal/app/ai_ingest_attribution_health.go
@@ -24,6 +24,23 @@ const aiIngestAttributionWindow = 256 << 10
 // so a log of very short lines cannot turn this into an unbounded parse.
 const aiIngestAttributionRecords = 4096
 
+// The window must stay inside what a trim keeps.
+//
+// `trimAIIngestLogFile` discards the front of the log once it passes
+// aiIngestLogMaxSize, keeping the last aiIngestLogRetain bytes. As long as the
+// window is no larger than what is retained, every record the window covers is
+// a record that survived the trim, and a shrinking log costs history the window
+// never claimed to hold. Lower aiIngestLogRetain below aiIngestAttributionWindow
+// and that stops being true silently: the window would span a discarded prefix,
+// the counts would fall, and the diagnosis would read the deletion as an
+// improvement -- a check failing to check its own premise, which is the same
+// shape as every defect this file exists to detect.
+//
+// The subtraction is unsigned, so violating the invariant is a build failure
+// rather than a diagnosis that quietly starts lying. Both constant names appear
+// here on purpose: whoever next edits aiIngestLogRetain finds this by grep.
+const _ = uint(aiIngestLogRetain - aiIngestAttributionWindow)
+
 // aiIngestAttributionSources are the provider hook sources whose attribution
 // this projection answers for. tmux-bell is deliberately absent: it is not a
 // provider hook and carries its own pane through a different route, so folding

--- a/internal/app/ai_ingest_attribution_health.go
+++ b/internal/app/ai_ingest_attribution_health.go
@@ -1,0 +1,221 @@
+package app
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// aiIngestAttributionWindow bounds how much of ai-ingest.log one diagnostics
+// read looks at.
+//
+// The log is trimmed to a size bound rather than to a record count, so a window
+// expressed in bytes is the one that behaves the same before and after a trim.
+// It is a tail read: attribution health is a statement about what hooks are
+// doing now, and a window that reached back to the file's first line would keep
+// reporting an install-day failure long after it was fixed.
+const aiIngestAttributionWindow = 256 << 10
+
+// aiIngestAttributionRecords bounds how many parsed records the window yields,
+// so a log of very short lines cannot turn this into an unbounded parse.
+const aiIngestAttributionRecords = 4096
+
+// aiIngestAttributionSources are the provider hook sources whose attribution
+// this projection answers for. tmux-bell is deliberately absent: it is not a
+// provider hook and carries its own pane through a different route, so folding
+// it in would move the number this section exists to show.
+var aiIngestAttributionSources = []string{"codex-hook", "claude-hook", "antigravity-hook"}
+
+// aiPaneMatchReasons is the closed set of answers a failed attribution gives.
+// A record whose reason is outside this set is not an attribution outcome, and
+// counting it as one would put payload and transport failures into the number
+// that measures whether hooks find their Pane.
+var aiPaneMatchReasons = []string{
+	aiPaneMatchReasonNoMatch,
+	aiPaneMatchReasonNoInventory,
+	aiPaneMatchReasonRegistryUnavailable,
+	aiPaneMatchReasonExplicitUnknown,
+	aiPaneMatchReasonExplicitNoRuntime,
+	aiPaneMatchReasonExplicitStale,
+	aiPaneMatchReasonConversationUnknown,
+	aiPaneMatchReasonConversationShared,
+}
+
+// aiIngestAttributionReason is one closed attribution failure and its count.
+type aiIngestAttributionReason struct {
+	Reason string `json:"reason"`
+	Count  int    `json:"count"`
+}
+
+// aiIngestAttributionSource is one provider hook source's attribution outcome
+// over the window.
+type aiIngestAttributionSource struct {
+	Source       string                      `json:"source"`
+	Attributed   int                         `json:"attributed"`
+	Unattributed int                         `json:"unattributed"`
+	Reasons      []aiIngestAttributionReason `json:"reasons,omitempty"`
+}
+
+// aiIngestAttributionHealth is the content-free projection of whether provider
+// hook events are reaching the Pane that owns them.
+//
+// Every field is a count or a closed token. No pane content, payload, path, or
+// provider text crosses into it.
+type aiIngestAttributionHealth struct {
+	// Observed reports whether a log was readable at all. False is not
+	// "healthy": it is "this question was not answered", and the difference is
+	// the one an operator has to see.
+	Observed bool                        `json:"observed"`
+	Records  int                         `json:"records"`
+	Sources  []aiIngestAttributionSource `json:"sources,omitempty"`
+}
+
+// Unattributed is how many hook events over the window never reached a Pane.
+func (h aiIngestAttributionHealth) Unattributed() int {
+	total := 0
+	for _, source := range h.Sources {
+		total += source.Unattributed
+	}
+	return total
+}
+
+// Attributed is how many hook events over the window reached one.
+func (h aiIngestAttributionHealth) Attributed() int {
+	total := 0
+	for _, source := range h.Sources {
+		total += source.Attributed
+	}
+	return total
+}
+
+// readAIIngestAttributionHealth reads the tail of ai-ingest.log and projects
+// attribution health from it.
+//
+// It opens the log read-only and creates nothing. An absent log is reported as
+// unobserved rather than as an empty healthy result: a machine that has never
+// run a hook and one whose log this reader cannot open give the same counts,
+// and only the first is good news.
+func readAIIngestAttributionHealth(path string) aiIngestAttributionHealth {
+	entries, ok := readAIIngestLogTail(path, aiIngestAttributionWindow, aiIngestAttributionRecords)
+	if !ok {
+		return aiIngestAttributionHealth{}
+	}
+	return projectAIIngestAttributionHealth(entries)
+}
+
+// readAIIngestLogTail reads the last window of a JSON-lines log.
+//
+// The first line of the window is dropped whenever the window did not start at
+// the file's beginning, because a byte-aligned tail almost always lands inside
+// a record and a half-parsed line is not a record this projection may count.
+func readAIIngestLogTail(path string, window int64, limit int) ([]aiIngestLogEntry, bool) {
+	if strings.TrimSpace(path) == "" {
+		return nil, false
+	}
+	// #nosec G304 -- path is the caller's resolved private state file.
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, false
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return nil, false
+	}
+	offset := info.Size() - window
+	partial := offset > 0
+	if partial {
+		if _, err := file.Seek(offset, io.SeekStart); err != nil {
+			return nil, false
+		}
+	}
+	reader := bufio.NewReader(io.LimitReader(file, window))
+	if partial {
+		if _, err := reader.ReadString('\n'); err != nil {
+			return nil, true
+		}
+	}
+	entries := make([]aiIngestLogEntry, 0, 64)
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64<<10), 64<<10)
+	for scanner.Scan() {
+		if len(entries) >= limit {
+			break
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var entry aiIngestLogEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries, true
+}
+
+// projectAIIngestAttributionHealth classifies one window of records.
+//
+// A record with a Pane is an attribution that succeeded. A record with no Pane
+// and one of the closed match failures is an attribution that did not. Every
+// other record — a payload error, a quiet event, a lifecycle transition — is
+// neither, and is left out rather than folded into a bucket, which is the same
+// discipline the match vocabulary itself was written under.
+func projectAIIngestAttributionHealth(entries []aiIngestLogEntry) aiIngestAttributionHealth {
+	health := aiIngestAttributionHealth{Observed: true}
+	attributed := map[string]int{}
+	unattributed := map[string]int{}
+	reasons := map[string]map[string]int{}
+	for _, entry := range entries {
+		source := strings.TrimSpace(entry.Source)
+		if !slices.Contains(aiIngestAttributionSources, source) {
+			continue
+		}
+		if strings.TrimSpace(entry.Pane) != "" {
+			health.Records++
+			attributed[source]++
+			continue
+		}
+		reason := strings.TrimSpace(entry.Reason)
+		if !slices.Contains(aiPaneMatchReasons, reason) {
+			continue
+		}
+		health.Records++
+		unattributed[source]++
+		if reasons[source] == nil {
+			reasons[source] = map[string]int{}
+		}
+		reasons[source][reason]++
+	}
+	for _, source := range aiIngestAttributionSources {
+		if attributed[source] == 0 && unattributed[source] == 0 {
+			continue
+		}
+		health.Sources = append(health.Sources, aiIngestAttributionSource{
+			Source:       source,
+			Attributed:   attributed[source],
+			Unattributed: unattributed[source],
+			Reasons:      aiIngestAttributionReasons(reasons[source]),
+		})
+	}
+	return health
+}
+
+// aiIngestAttributionReasons orders one source's failures by token so two reads
+// of the same window render identically.
+func aiIngestAttributionReasons(counts map[string]int) []aiIngestAttributionReason {
+	if len(counts) == 0 {
+		return nil
+	}
+	ordered := make([]aiIngestAttributionReason, 0, len(counts))
+	for reason, count := range counts {
+		ordered = append(ordered, aiIngestAttributionReason{Reason: reason, Count: count})
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Reason < ordered[j].Reason })
+	return ordered
+}

--- a/internal/app/ai_ingest_attribution_health.go
+++ b/internal/app/ai_ingest_attribution_health.go
@@ -60,6 +60,8 @@ var aiPaneMatchReasons = []string{
 	aiPaneMatchReasonExplicitStale,
 	aiPaneMatchReasonConversationUnknown,
 	aiPaneMatchReasonConversationShared,
+	aiPaneMatchReasonExplicitForeign,
+	aiPaneMatchReasonExplicitForeignOnly,
 }
 
 // aiPaneMatchRefusals are the answers that name something the attribution
@@ -84,6 +86,14 @@ var aiPaneMatchRefusals = []string{
 	aiPaneMatchReasonExplicitStale,
 	aiPaneMatchReasonConversationUnknown,
 }
+
+// The two foreign-identity answers stay failures rather than refusals.
+//
+// A refusal names a Pane that no longer exists. These name a Pane that exists
+// and is not this hook's, after which the event went looking and still found
+// nobody. The conversation behind it may well have a live Pane, so the event
+// was owed one; that is a failure to attribute, not a promise the contract
+// never made.
 
 // aiIngestAttributionReason is one closed attribution failure and its count.
 type aiIngestAttributionReason struct {

--- a/internal/app/ai_ingest_attribution_health.go
+++ b/internal/app/ai_ingest_attribution_health.go
@@ -83,30 +83,6 @@ func (h aiIngestAttributionHealth) Unattributed() int {
 	return total
 }
 
-// Attributed is how many hook events over the window reached one.
-func (h aiIngestAttributionHealth) Attributed() int {
-	total := 0
-	for _, source := range h.Sources {
-		total += source.Attributed
-	}
-	return total
-}
-
-// readAIIngestAttributionHealth reads the tail of ai-ingest.log and projects
-// attribution health from it.
-//
-// It opens the log read-only and creates nothing. An absent log is reported as
-// unobserved rather than as an empty healthy result: a machine that has never
-// run a hook and one whose log this reader cannot open give the same counts,
-// and only the first is good news.
-func readAIIngestAttributionHealth(path string) aiIngestAttributionHealth {
-	entries, ok := readAIIngestLogTail(path, aiIngestAttributionWindow, aiIngestAttributionRecords)
-	if !ok {
-		return aiIngestAttributionHealth{}
-	}
-	return projectAIIngestAttributionHealth(entries)
-}
-
 // readAIIngestLogTail reads the last window of a JSON-lines log.
 //
 // The first line of the window is dropped whenever the window did not start at

--- a/internal/app/ai_ingest_attribution_health.go
+++ b/internal/app/ai_ingest_attribution_health.go
@@ -45,6 +45,29 @@ var aiPaneMatchReasons = []string{
 	aiPaneMatchReasonConversationShared,
 }
 
+// aiPaneMatchRefusals are the answers that name something the attribution
+// contract never promised, rather than a promise it failed to keep.
+//
+// The contract's scope excludes a Pane that is already gone, and an event whose
+// conversation no Pane owns is exactly that case: a hook still firing from a
+// thread whose Agent and Pane were retired. Refusing it is the mechanism
+// working, and the specific token exists so the refusal can be told apart from
+// a failure.
+//
+// Keeping them out of the failure count is not a courtesy. A gate that reports
+// contractual refusals as breakage cries wolf, and an ignored signal is exactly
+// how the defects this whole track chased survived a neighbouring track's eight
+// phases. The tokens that stay failures are the ones where the mechanism itself
+// could not answer -- an unreadable inventory or Registry -- plus the ladder
+// exhausting with readable data, which is the shape a re-broken hook identity
+// would take.
+var aiPaneMatchRefusals = []string{
+	aiPaneMatchReasonExplicitUnknown,
+	aiPaneMatchReasonExplicitNoRuntime,
+	aiPaneMatchReasonExplicitStale,
+	aiPaneMatchReasonConversationUnknown,
+}
+
 // aiIngestAttributionReason is one closed attribution failure and its count.
 type aiIngestAttributionReason struct {
 	Reason string `json:"reason"`
@@ -54,10 +77,19 @@ type aiIngestAttributionReason struct {
 // aiIngestAttributionSource is one provider hook source's attribution outcome
 // over the window.
 type aiIngestAttributionSource struct {
-	Source       string                      `json:"source"`
-	Attributed   int                         `json:"attributed"`
-	Unattributed int                         `json:"unattributed"`
-	Reasons      []aiIngestAttributionReason `json:"reasons,omitempty"`
+	Source     string `json:"source"`
+	Attributed int    `json:"attributed"`
+	// Unattributed counts events the mechanism owed a Pane and did not deliver
+	// one for. This is the number the contract requires to stay at zero.
+	Unattributed int `json:"unattributed"`
+	// Refused counts events the contract never promised to attribute, because
+	// the Pane they name is gone. It is reported beside the failure count and
+	// never inside it.
+	Refused int                         `json:"refused"`
+	Reasons []aiIngestAttributionReason `json:"reasons,omitempty"`
+	// RefusalReasons breaks Refused down, so a reader can see that a large
+	// number is a retired conversation rather than a hidden fault.
+	RefusalReasons []aiIngestAttributionReason `json:"refusal_reasons,omitempty"`
 }
 
 // aiIngestAttributionHealth is the content-free projection of whether provider
@@ -74,7 +106,8 @@ type aiIngestAttributionHealth struct {
 	Sources  []aiIngestAttributionSource `json:"sources,omitempty"`
 }
 
-// Unattributed is how many hook events over the window never reached a Pane.
+// Unattributed is how many hook events over the window were owed a Pane and
+// did not get one.
 func (h aiIngestAttributionHealth) Unattributed() int {
 	total := 0
 	for _, source := range h.Sources {
@@ -145,8 +178,14 @@ func readAIIngestLogTail(path string, window int64, limit int) ([]aiIngestLogEnt
 func projectAIIngestAttributionHealth(entries []aiIngestLogEntry) aiIngestAttributionHealth {
 	health := aiIngestAttributionHealth{Observed: true}
 	attributed := map[string]int{}
-	unattributed := map[string]int{}
-	reasons := map[string]map[string]int{}
+	unattributed, refused := map[string]int{}, map[string]int{}
+	reasons, refusalReasons := map[string]map[string]int{}, map[string]map[string]int{}
+	tally := func(into map[string]map[string]int, source, reason string) {
+		if into[source] == nil {
+			into[source] = map[string]int{}
+		}
+		into[source][reason]++
+	}
 	for _, entry := range entries {
 		source := strings.TrimSpace(entry.Source)
 		if !slices.Contains(aiIngestAttributionSources, source) {
@@ -162,21 +201,25 @@ func projectAIIngestAttributionHealth(entries []aiIngestLogEntry) aiIngestAttrib
 			continue
 		}
 		health.Records++
-		unattributed[source]++
-		if reasons[source] == nil {
-			reasons[source] = map[string]int{}
+		if slices.Contains(aiPaneMatchRefusals, reason) {
+			refused[source]++
+			tally(refusalReasons, source, reason)
+			continue
 		}
-		reasons[source][reason]++
+		unattributed[source]++
+		tally(reasons, source, reason)
 	}
 	for _, source := range aiIngestAttributionSources {
-		if attributed[source] == 0 && unattributed[source] == 0 {
+		if attributed[source] == 0 && unattributed[source] == 0 && refused[source] == 0 {
 			continue
 		}
 		health.Sources = append(health.Sources, aiIngestAttributionSource{
-			Source:       source,
-			Attributed:   attributed[source],
-			Unattributed: unattributed[source],
-			Reasons:      aiIngestAttributionReasons(reasons[source]),
+			Source:         source,
+			Attributed:     attributed[source],
+			Unattributed:   unattributed[source],
+			Refused:        refused[source],
+			Reasons:        aiIngestAttributionReasons(reasons[source]),
+			RefusalReasons: aiIngestAttributionReasons(refusalReasons[source]),
 		})
 	}
 	return health

--- a/internal/app/ai_ingest_attribution_health_test.go
+++ b/internal/app/ai_ingest_attribution_health_test.go
@@ -140,3 +140,29 @@ func TestAttributionHealthIgnoresAReasonOutsideTheClosedMatchVocabulary(t *testi
 		}
 	}
 }
+
+// Attributed is how many hook events over the window reached a Pane. The
+// verdict is reached per source rather than over this total, so the aggregate
+// is only ever a test's summary of a fixture.
+func (h aiIngestAttributionHealth) Attributed() int {
+	total := 0
+	for _, source := range h.Sources {
+		total += source.Attributed
+	}
+	return total
+}
+
+// readAIIngestAttributionHealth reads the tail of ai-ingest.log and projects
+// attribution health from it in one call.
+//
+// Doctor takes the tail once and derives all three hook projections from it, so
+// this single-projection path exists for the tests that drive the reader end to
+// end against a real file: an absent log must report itself unobserved rather
+// than as an empty healthy result.
+func readAIIngestAttributionHealth(path string) aiIngestAttributionHealth {
+	entries, ok := readAIIngestLogTail(path, aiIngestAttributionWindow, aiIngestAttributionRecords)
+	if !ok {
+		return aiIngestAttributionHealth{}
+	}
+	return projectAIIngestAttributionHealth(entries)
+}

--- a/internal/app/ai_ingest_attribution_health_test.go
+++ b/internal/app/ai_ingest_attribution_health_test.go
@@ -43,8 +43,8 @@ func TestAttributionHealthCountsOnlyAttributionOutcomes(t *testing.T) {
 		{Source: "codex-hook", Event: "Stop", Result: "state", Pane: "%1"},
 		{Source: "codex-hook", Event: "Stop", Result: "ignored", Reason: aiPaneMatchReasonNoInventory},
 		{Source: "claude-hook", Event: "Stop", Result: "state", Pane: "%2"},
-		{Source: "claude-hook", Event: "Stop", Result: "ignored", Reason: aiPaneMatchReasonExplicitStale},
-		{Source: "claude-hook", Event: "Stop", Result: "ignored", Reason: aiPaneMatchReasonExplicitStale},
+		{Source: "claude-hook", Event: "Stop", Result: "ignored", Reason: aiPaneMatchReasonNoMatch},
+		{Source: "claude-hook", Event: "Stop", Result: "ignored", Reason: aiPaneMatchReasonNoMatch},
 		// Neither of these is an attribution outcome.
 		{Source: "codex-hook", Result: "error", Reason: "payload decode failed"},
 		{Source: "codex-observer", Event: "observer.disconnected", Result: "invalidating", Reason: "endpoint-suspended", Pane: "%1"},
@@ -59,7 +59,7 @@ func TestAttributionHealthCountsOnlyAttributionOutcomes(t *testing.T) {
 				{Reason: aiPaneMatchReasonNoInventory, Count: 1},
 			}},
 			{Source: "claude-hook", Attributed: 1, Unattributed: 2, Reasons: []aiIngestAttributionReason{
-				{Reason: aiPaneMatchReasonExplicitStale, Count: 2},
+				{Reason: aiPaneMatchReasonNoMatch, Count: 2},
 			}},
 		},
 	}
@@ -141,6 +141,17 @@ func TestAttributionHealthIgnoresAReasonOutsideTheClosedMatchVocabulary(t *testi
 	}
 }
 
+// Refused is how many hook events were declined for naming a Pane that no
+// longer exists. Like Attributed, the verdict works per source and this
+// aggregate is only ever a test's summary of a fixture.
+func (h aiIngestAttributionHealth) Refused() int {
+	total := 0
+	for _, source := range h.Sources {
+		total += source.Refused
+	}
+	return total
+}
+
 // Attributed is how many hook events over the window reached a Pane. The
 // verdict is reached per source rather than over this total, so the aggregate
 // is only ever a test's summary of a fixture.
@@ -165,4 +176,52 @@ func readAIIngestAttributionHealth(path string) aiIngestAttributionHealth {
 		return aiIngestAttributionHealth{}
 	}
 	return projectAIIngestAttributionHealth(entries)
+}
+
+// TestAttributionHealthSeparatesAContractualRefusalFromAFailure is the
+// correction that keeps this gate honest.
+//
+// The contract's scope excludes a Pane that is already gone, and a hook still
+// firing from a retired conversation is exactly that: its Agent and Pane were
+// cleaned up and the thread kept talking. Refusing it is the mechanism working.
+// Counting it as a failure made `doctor` report a machine behaving to spec as
+// broken, and a gate that cries wolf gets switched off — which is how the
+// defects this whole section exists to catch survived eight phases next door.
+//
+// What stays a failure is the mechanism itself not answering: an inventory or
+// Registry it could not read, or the ladder running over readable data and
+// finding nothing, which is the shape a re-broken hook identity would take.
+func TestAttributionHealthSeparatesAContractualRefusalFromAFailure(t *testing.T) {
+	health := projectAIIngestAttributionHealth([]aiIngestLogEntry{
+		// Out of contract: the Pane these name is gone.
+		{Source: "codex-hook", Result: "ignored", Reason: aiPaneMatchReasonConversationUnknown},
+		{Source: "codex-hook", Result: "ignored", Reason: aiPaneMatchReasonExplicitUnknown},
+		{Source: "codex-hook", Result: "ignored", Reason: aiPaneMatchReasonExplicitNoRuntime},
+		{Source: "codex-hook", Result: "ignored", Reason: aiPaneMatchReasonExplicitStale},
+		// Failures: the mechanism owed an answer and had none.
+		{Source: "claude-hook", Result: "ignored", Reason: aiPaneMatchReasonNoInventory},
+		{Source: "claude-hook", Result: "ignored", Reason: aiPaneMatchReasonRegistryUnavailable},
+		{Source: "claude-hook", Result: "ignored", Reason: aiPaneMatchReasonNoMatch},
+		{Source: "claude-hook", Result: "ignored", Reason: aiPaneMatchReasonConversationShared},
+	})
+	if health.Refused() != 4 || health.Unattributed() != 4 {
+		t.Fatalf("refused = %d, unattributed = %d, want 4 and 4", health.Refused(), health.Unattributed())
+	}
+	for _, source := range health.Sources {
+		if source.Source == "codex-hook" && source.Unattributed != 0 {
+			t.Fatalf("a contractual refusal was counted as a failure: %+v", source)
+		}
+		if source.Source == "claude-hook" && source.Refused != 0 {
+			t.Fatalf("a mechanism failure was excused as a refusal: %+v", source)
+		}
+	}
+	// A source that only ever refused is not a source that failed.
+	refusedOnly := projectAIIngestAttributionHealth([]aiIngestLogEntry{
+		{Source: "codex-hook", Result: "ignored", Reason: aiPaneMatchReasonConversationUnknown},
+	})
+	if surface := codexHookAttributionSurface(refusedOnly); surface.Status != codexSurfaceStatusOK {
+		t.Fatalf("surface = %q (detail %q), want %q for a retired conversation", surface.Status, surface.Detail, codexSurfaceStatusOK)
+	} else if !strings.Contains(surface.Detail, "out of contract") {
+		t.Fatalf("detail = %q, want the refusal reported rather than hidden", surface.Detail)
+	}
 }

--- a/internal/app/ai_ingest_attribution_health_test.go
+++ b/internal/app/ai_ingest_attribution_health_test.go
@@ -1,0 +1,142 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func writeAttributionLog(t *testing.T, entries []aiIngestLogEntry, padding int) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ai-ingest.log")
+	var builder strings.Builder
+	for range padding {
+		builder.WriteString(strings.Repeat("x", 512) + "\n")
+	}
+	for _, entry := range entries {
+		payload, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("marshal entry: %v", err)
+		}
+		builder.Write(payload)
+		builder.WriteString("\n")
+	}
+	if err := os.WriteFile(path, []byte(builder.String()), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	return path
+}
+
+// TestAttributionHealthCountsOnlyAttributionOutcomes pins what the number
+// means.
+//
+// A payload error, a quiet event, and an observer transition are not failed
+// attributions, and folding them in would move the number that answers whether
+// hooks find their Pane. That is the same discipline that separated `no
+// matching pane` from `pane inventory unavailable`: a bucket wide enough to
+// hold everything answers nothing.
+func TestAttributionHealthCountsOnlyAttributionOutcomes(t *testing.T) {
+	health := projectAIIngestAttributionHealth([]aiIngestLogEntry{
+		{Source: "codex-hook", Event: "Stop", Result: "state", Pane: "%1"},
+		{Source: "codex-hook", Event: "Stop", Result: "ignored", Reason: aiPaneMatchReasonNoInventory},
+		{Source: "claude-hook", Event: "Stop", Result: "state", Pane: "%2"},
+		{Source: "claude-hook", Event: "Stop", Result: "ignored", Reason: aiPaneMatchReasonExplicitStale},
+		{Source: "claude-hook", Event: "Stop", Result: "ignored", Reason: aiPaneMatchReasonExplicitStale},
+		// Neither of these is an attribution outcome.
+		{Source: "codex-hook", Result: "error", Reason: "payload decode failed"},
+		{Source: "codex-observer", Event: "observer.disconnected", Result: "invalidating", Reason: "endpoint-suspended", Pane: "%1"},
+		// A sibling source that carries its pane through another route.
+		{Source: "tmux-bell", Result: "ignored", Reason: aiPaneMatchReasonNoMatch},
+	})
+	want := aiIngestAttributionHealth{
+		Observed: true,
+		Records:  5,
+		Sources: []aiIngestAttributionSource{
+			{Source: "codex-hook", Attributed: 1, Unattributed: 1, Reasons: []aiIngestAttributionReason{
+				{Reason: aiPaneMatchReasonNoInventory, Count: 1},
+			}},
+			{Source: "claude-hook", Attributed: 1, Unattributed: 2, Reasons: []aiIngestAttributionReason{
+				{Reason: aiPaneMatchReasonExplicitStale, Count: 2},
+			}},
+		},
+	}
+	if !reflect.DeepEqual(health, want) {
+		t.Fatalf("health = %+v, want %+v", health, want)
+	}
+	if health.Attributed() != 2 || health.Unattributed() != 3 {
+		t.Fatalf("attributed = %d, unattributed = %d, want 2 and 3", health.Attributed(), health.Unattributed())
+	}
+}
+
+// TestAttributionHealthSeparatesAnUnreadableLogFromAQuietOne pins that an
+// absent log is not a healthy one.
+//
+// A machine that never ran a hook and a machine whose log this reader cannot
+// open produce the same counts, and only the first is good news. Reporting
+// both as zero failures is the shape of silence this section replaced.
+func TestAttributionHealthSeparatesAnUnreadableLogFromAQuietOne(t *testing.T) {
+	missing := readAIIngestAttributionHealth(filepath.Join(t.TempDir(), "absent.log"))
+	if missing.Observed {
+		t.Fatalf("health = %+v, want an unreadable log reported as unobserved", missing)
+	}
+	quiet := readAIIngestAttributionHealth(writeAttributionLog(t, nil, 0))
+	if !quiet.Observed || quiet.Records != 0 {
+		t.Fatalf("health = %+v, want an empty log observed with no records", quiet)
+	}
+	if surface := codexHookAttributionSurface(missing); surface.Status != codexSurfaceStatusUnobserved {
+		t.Fatalf("surface = %q, want %q for an unreadable log", surface.Status, codexSurfaceStatusUnobserved)
+	}
+}
+
+// TestAttributionHealthReadsTheTailAndDropsThePartialRecord pins the window.
+//
+// The read is a tail because attribution health is a statement about what hooks
+// are doing now; a window reaching the file's first line would keep reporting an
+// install-day failure long after it was fixed. A byte-aligned tail almost always
+// lands inside a record, and half a record is not one this projection may count.
+func TestAttributionHealthReadsTheTailAndDropsThePartialRecord(t *testing.T) {
+	entries := make([]aiIngestLogEntry, 0, 64)
+	for range 64 {
+		entries = append(entries, aiIngestLogEntry{Source: "codex-hook", Event: "Stop", Result: "state", Pane: "%1"})
+	}
+	path := writeAttributionLog(t, entries, 64)
+	all, ok := readAIIngestLogTail(path, 1<<20, 4096)
+	if !ok || len(all) != 64 {
+		t.Fatalf("full read = %d records (ok=%v), want 64", len(all), ok)
+	}
+	windowed, ok := readAIIngestLogTail(path, 2<<10, 4096)
+	if !ok {
+		t.Fatal("windowed read failed")
+	}
+	if len(windowed) == 0 || len(windowed) >= 64 {
+		t.Fatalf("windowed read = %d records, want a strict tail of the 64", len(windowed))
+	}
+	for _, entry := range windowed {
+		if entry.Source != "codex-hook" || entry.Pane != "%1" {
+			t.Fatalf("windowed read produced a partial record: %+v", entry)
+		}
+	}
+}
+
+// TestAttributionHealthIgnoresAReasonOutsideTheClosedMatchVocabulary pins that
+// the failure tally is bounded by the vocabulary the matcher actually speaks,
+// so a free-text reason cannot enter the diagnosis through this reader.
+func TestAttributionHealthIgnoresAReasonOutsideTheClosedMatchVocabulary(t *testing.T) {
+	health := projectAIIngestAttributionHealth([]aiIngestLogEntry{
+		{Source: "codex-hook", Result: "ignored", Reason: "/home/user/secret/rollout.jsonl"},
+		{Source: "codex-hook", Result: "ignored", Reason: aiPaneMatchReasonRegistryUnavailable},
+	})
+	if health.Unattributed() != 1 {
+		t.Fatalf("unattributed = %d, want only the closed-vocabulary failure counted", health.Unattributed())
+	}
+	for _, source := range health.Sources {
+		for _, reason := range source.Reasons {
+			if reason.Reason != aiPaneMatchReasonRegistryUnavailable {
+				t.Fatalf("reason %q reached the diagnosis from outside the closed vocabulary", reason.Reason)
+			}
+		}
+	}
+}

--- a/internal/app/ai_ingest_attribution_health_test.go
+++ b/internal/app/ai_ingest_attribution_health_test.go
@@ -2,9 +2,15 @@ package app
 
 import (
 	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -223,5 +229,71 @@ func TestAttributionHealthSeparatesAContractualRefusalFromAFailure(t *testing.T)
 		t.Fatalf("surface = %q (detail %q), want %q for a retired conversation", surface.Status, surface.Detail, codexSurfaceStatusOK)
 	} else if !strings.Contains(surface.Detail, "out of contract") {
 		t.Fatalf("detail = %q, want the refusal reported rather than hidden", surface.Detail)
+	}
+}
+
+// TestAttributionVocabularyCoversEveryDeclaredMatchReason keeps this reader
+// from going deaf as the matcher learns new answers.
+//
+// The reader classifies a record by comparing its reason against a list
+// restated here, and a token the list does not know is not counted as anything
+// — not a failure, not a refusal. So a new answer added to the matcher would
+// quietly shrink both numbers, and the surface would report improvement. That
+// is this track's recurring shape once more: a check that does not check its
+// own premise. The declarations are read out of the source, so the list cannot
+// fall behind them without this failing.
+func TestAttributionVocabularyCoversEveryDeclaredMatchReason(t *testing.T) {
+	root := repoRootForGate(t)
+	path := filepath.Join(root, "internal", "app", "ai_ingest.go")
+	payload, err := os.ReadFile(path) // #nosec G304 -- repository source under test.
+	if err != nil {
+		t.Fatalf("read matcher source: %v", err)
+	}
+	fileSet := token.NewFileSet()
+	parsed, err := parser.ParseFile(fileSet, path, payload, 0)
+	if err != nil {
+		t.Fatalf("parse matcher source: %v", err)
+	}
+	declared := map[string]bool{}
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		spec, ok := node.(*ast.ValueSpec)
+		if !ok {
+			return true
+		}
+		for index, name := range spec.Names {
+			if !strings.HasPrefix(name.Name, "aiPaneMatchReason") || index >= len(spec.Values) {
+				continue
+			}
+			literal, ok := spec.Values[index].(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				continue
+			}
+			value, unquoteErr := strconv.Unquote(literal.Value)
+			if unquoteErr == nil {
+				declared[value] = true
+			}
+		}
+		return true
+	})
+	if len(declared) == 0 {
+		t.Fatal("no attribution reason declarations found; the scan is looking in the wrong place")
+	}
+	var missing []string
+	for value := range declared {
+		if !slices.Contains(aiPaneMatchReasons, value) {
+			missing = append(missing, value)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("%d declared attribution reason(s) this reader would silently ignore:\n  %q\n\n"+
+			"Add each to aiPaneMatchReasons, and decide whether it is a contractual refusal "+
+			"(the Pane it names is gone) or an attribution failure (the mechanism owed an answer).",
+			len(missing), missing)
+	}
+	for _, known := range aiPaneMatchReasons {
+		if !declared[known] {
+			t.Fatalf("aiPaneMatchReasons carries %q, which the matcher no longer declares", known)
+		}
 	}
 }

--- a/internal/app/ai_ingest_codex_native_test.go
+++ b/internal/app/ai_ingest_codex_native_test.go
@@ -280,7 +280,7 @@ func TestNativeCodexHookAuthorityChangeAfterGuardCommitsZero(t *testing.T) {
 	sink := aiCodexLifecycleSink{command: sinkCommand, runner: sinkRunner}
 	sinkResult := make(chan error, 1)
 	go func() {
-		sinkResult <- sink.SetAuthority(identity, codexAuthorityInvalidating, "epoch-after", "disconnected")
+		sinkResult <- sink.SetAuthority(identity, codexAuthorityInvalidating, "epoch-after", "endpoint-suspended")
 	}()
 	select {
 	case <-sinkAtAuthorityRead:
@@ -366,7 +366,7 @@ func TestNativeCodexHookAuthorityChangeAfterGuardCommitsZero(t *testing.T) {
 	state, badge, attention := options[aiPaneStateOption], options[aiPaneBadgeKindOption], options[attentionStateOption]
 	optionsMu.Unlock()
 	agent, _ := store.registry.Agent(identity.AgentUID)
-	if authorityTuple != "invalidating|epoch-after|disconnected" || state != "" || badge != "" || attention != "" ||
+	if authorityTuple != "invalidating|epoch-after|endpoint-suspended" || state != "" || badge != "" || attention != "" ||
 		store.writes != 0 || !reflect.DeepEqual(agent.Status.Interaction, beforeAgent.Status.Interaction) ||
 		len(queue.pushed) != 0 || len(queue.ackedIDs) != 0 || desktopWrites != 0 {
 		t.Fatalf("forced invalidation write ledger authority=%s state=%q badge=%q attention=%q Registry=%d interaction=%#v queue=%#v ack=%#v desktop=%d hook-commands=%#v",
@@ -466,7 +466,7 @@ func TestNativeSemanticApplyAndInvalidationShareExactPaneFence(t *testing.T) {
 
 	invalidationResult := make(chan error, 1)
 	go func() {
-		if err := sink.SetAuthority(identity, codexAuthorityInvalidating, "epoch-after", "disconnected"); err != nil {
+		if err := sink.SetAuthority(identity, codexAuthorityInvalidating, "epoch-after", "endpoint-suspended"); err != nil {
 			invalidationResult <- err
 			return
 		}
@@ -496,7 +496,7 @@ func TestNativeSemanticApplyAndInvalidationShareExactPaneFence(t *testing.T) {
 	state, badge, attention := options[aiPaneStateOption], options[aiPaneBadgeKindOption], options[attentionStateOption]
 	optionsMu.Unlock()
 	agent, _ = store.registry.Agent(identity.AgentUID)
-	if authorityTuple != "invalidating|epoch-after|disconnected" || state != "" || badge != "" || attention != "" ||
+	if authorityTuple != "invalidating|epoch-after|endpoint-suspended" || state != "" || badge != "" || attention != "" ||
 		agent.Status.Interaction.Kind != coremetadata.InteractionUnknown {
 		t.Fatalf("invalidation was not final: authority=%s state=%q badge=%q attention=%q interaction=%#v",
 			authorityTuple, state, badge, attention, agent.Status.Interaction)
@@ -2659,7 +2659,7 @@ func TestCodexSemanticSettingsMatrixAndMixedAuthorityDiagnostics(t *testing.T) {
 		name, source, epoch, reason, want string
 	}{
 		{name: "native authority", source: codexAuthorityControlPlane, epoch: "epoch-native", reason: "ready", want: "inactive on 1 live Codex pane(s)"},
-		{name: "hook authority", source: codexAuthorityHook, reason: "disconnected", want: "active on 1 live Codex pane(s); inactive on 0"},
+		{name: "hook authority", source: codexAuthorityHook, reason: "endpoint-suspended", want: "active on 1 live Codex pane(s); inactive on 0"},
 	} {
 		t.Run(test.name+" raw override activity", func(t *testing.T) {
 			cmd.tmuxRunner = phase3StaticTmuxRunner{output: strings.Join([]string{"codex", test.source, test.epoch, test.reason}, "\x1f")}
@@ -2786,10 +2786,13 @@ func TestCodexLifecycleSettingsLocalizationParity(t *testing.T) {
 		wantHook    string
 	}{
 		{
-			locale:      i18n.FallbackLocale,
-			wantTitle:   "Agent event behavior - Codex - Approval required",
-			wantPrompt:  "Settings > Notifications > Agent event behavior > Codex > Approval required > ",
-			wantResult:  "Codex native semantic policy: Response complete = State only\n",
+			locale:     i18n.FallbackLocale,
+			wantTitle:  "Agent event behavior - Codex - Approval required",
+			wantPrompt: "Settings > Notifications > Agent event behavior > Codex > Approval required > ",
+			wantResult: "Codex native semantic policy: Response complete = State only\n",
+			// uncaptured-default: the bounded read renders this for a pane option
+			// outside the vocabulary, so it is the correct answer to a malformed
+			// value rather than a reason any transition produced.
 			wantSummary: []string{"mixed (provider-control-plane 1, provider-hook 1)", "bounded reason unavailable", "epochs active 1, pending 0, inactive 1"},
 			wantHook:    "active on 1 live Codex pane(s); inactive on 1",
 		},
@@ -2873,6 +2876,8 @@ func TestDescribeCodexAgentShowsContentFreeLifecycleAuthority(t *testing.T) {
 
 func TestCodexLifecycleAuthorityRejectsUnboundedRuntimeReason(t *testing.T) {
 	diagnostic := observeCodexLifecycleAuthority(context.Background(), phase3StaticTmuxRunner{output: "pan-alpha-codex\x1fprovider-control-plane\x1fepoch-1\x1fprompt=private"}, "pan-alpha-codex")
+	// uncaptured-default: the fixture publishes an out-of-vocabulary reason on
+	// purpose; the bounded fallback is what a truthful read of it must say.
 	if diagnostic.Source != codexAuthorityControlPlane || diagnostic.EpochStatus != "active" || diagnostic.Reason != "bounded reason unavailable" {
 		t.Fatalf("sanitized diagnostic = %#v", diagnostic)
 	}

--- a/internal/app/ai_ingest_codex_observer_reason_test.go
+++ b/internal/app/ai_ingest_codex_observer_reason_test.go
@@ -268,6 +268,8 @@ func TestCodexObserverReasonVocabularyIsClosed(t *testing.T) {
 		if got := codexObserverReasonFor(foreign); got != "" {
 			t.Fatalf("codexObserverReasonFor(%q) admitted %q", foreign, got)
 		}
+		// uncaptured-default: the input is a foreign string, and rendering it as
+		// the bounded fallback rather than as itself is the property under test.
 		if got := safeCodexAuthorityReason(foreign); got != "bounded reason unavailable" {
 			t.Fatalf("safeCodexAuthorityReason(%q) = %q", foreign, got)
 		}

--- a/internal/app/ai_ingest_delivery_health.go
+++ b/internal/app/ai_ingest_delivery_health.go
@@ -1,0 +1,160 @@
+package app
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Attribution and delivery are two layers, and this file owns the second.
+//
+// A hook that found its Pane has not yet done anything to it. The write that
+// follows can fail on its own, and when it does the failure is the operator's
+// only evidence that the event went nowhere. Reporting attribution alone would
+// say the hook succeeded when the Pane never moved.
+
+// aiIngestOpaqueReasonShapes are the raw failure strings that carry no answer.
+//
+// `exit status 1` names a process that ended and nothing else: not which write
+// failed, not why, not what an operator could do about it. A signal string is
+// the same fact from the kernel's side. Neither is a reason; both are the
+// absence of one, wearing an error's clothes.
+var aiIngestOpaqueReasonShapes = []*regexp.Regexp{
+	regexp.MustCompile(`^exit status \d+$`),
+	regexp.MustCompile(`^signal: `),
+}
+
+// aiIngestDeliverySource is one provider hook source's delivery outcome.
+type aiIngestDeliverySource struct {
+	Source string `json:"source"`
+	// Delivered counts events that reached their Pane and changed it.
+	Delivered int `json:"delivered"`
+	// Failed counts events that reached their Pane and could not change it.
+	Failed int `json:"failed"`
+	// Opaque is the subset of Failed whose reason answers nothing.
+	Opaque  int                         `json:"opaque"`
+	Reasons []aiIngestAttributionReason `json:"reasons,omitempty"`
+}
+
+// aiIngestDeliveryHealth is the content-free projection of whether attributed
+// hook events actually land on the Pane that owns them.
+type aiIngestDeliveryHealth struct {
+	Observed bool                     `json:"observed"`
+	Records  int                      `json:"records"`
+	Sources  []aiIngestDeliverySource `json:"sources,omitempty"`
+}
+
+// Failed is how many attributed events could not change their Pane.
+func (h aiIngestDeliveryHealth) Failed() int {
+	total := 0
+	for _, source := range h.Sources {
+		total += source.Failed
+	}
+	return total
+}
+
+// Opaque is how many of those failures answer nothing.
+func (h aiIngestDeliveryHealth) Opaque() int {
+	total := 0
+	for _, source := range h.Sources {
+		total += source.Opaque
+	}
+	return total
+}
+
+// projectAIIngestDeliveryHealth classifies one window of records.
+//
+// Only records that already carry a Pane are counted. A hook that never found
+// its Pane failed at attribution, and folding it in here would report one
+// defect as two.
+func projectAIIngestDeliveryHealth(entries []aiIngestLogEntry) aiIngestDeliveryHealth {
+	health := aiIngestDeliveryHealth{Observed: true}
+	delivered, failed, opaque := map[string]int{}, map[string]int{}, map[string]int{}
+	reasons := map[string]map[string]int{}
+	for _, entry := range entries {
+		source := strings.TrimSpace(entry.Source)
+		if !isAIIngestHookSource(source) || strings.TrimSpace(entry.Pane) == "" {
+			continue
+		}
+		health.Records++
+		if strings.TrimSpace(entry.Result) != "error" {
+			delivered[source]++
+			continue
+		}
+		failed[source]++
+		reason := strings.TrimSpace(entry.Reason)
+		if aiIngestReasonIsOpaque(reason) {
+			opaque[source]++
+			// An opaque reason is not recorded verbatim. It is the shape that
+			// carries a path or a raw process detail onto a diagnostics
+			// surface, and the count is the whole answer an operator needs.
+			reason = aiIngestOpaqueDeliveryReason
+		}
+		if reasons[source] == nil {
+			reasons[source] = map[string]int{}
+		}
+		reasons[source][reason]++
+	}
+	for _, source := range aiIngestAttributionSources {
+		if delivered[source] == 0 && failed[source] == 0 {
+			continue
+		}
+		health.Sources = append(health.Sources, aiIngestDeliverySource{
+			Source:    source,
+			Delivered: delivered[source],
+			Failed:    failed[source],
+			Opaque:    opaque[source],
+			Reasons:   aiIngestDeliveryReasons(reasons[source]),
+		})
+	}
+	return health
+}
+
+// aiIngestOpaqueDeliveryReason is what an opaque failure is counted as. The
+// original string is never rendered: it is the one that carries a path or a raw
+// process detail, which is exactly what a diagnostics surface must not repeat.
+const aiIngestOpaqueDeliveryReason = "opaque delivery failure"
+
+// aiIngestReasonIsOpaque reports whether a delivery failure reason answers
+// nothing.
+//
+// An empty reason is the plainest case. A raw process-exit or signal string is
+// the shape observed in the field. A reason carrying a path is opaque for a
+// second reason as well: this track's change boundary keeps paths out of the
+// records entirely, so one appearing here is a leak as much as a non-answer.
+func aiIngestReasonIsOpaque(reason string) bool {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return true
+	}
+	if strings.Contains(reason, "/") {
+		return true
+	}
+	for _, shape := range aiIngestOpaqueReasonShapes {
+		if shape.MatchString(reason) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAIIngestHookSource(source string) bool {
+	for _, known := range aiIngestAttributionSources {
+		if known == source {
+			return true
+		}
+	}
+	return false
+}
+
+func aiIngestDeliveryReasons(counts map[string]int) []aiIngestAttributionReason {
+	if len(counts) == 0 {
+		return nil
+	}
+	ordered := make([]aiIngestAttributionReason, 0, len(counts))
+	for reason, count := range counts {
+		ordered = append(ordered, aiIngestAttributionReason{Reason: reason, Count: count})
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Reason < ordered[j].Reason })
+	return ordered
+}

--- a/internal/app/ai_ingest_delivery_health.go
+++ b/internal/app/ai_ingest_delivery_health.go
@@ -25,13 +25,29 @@ var aiIngestOpaqueReasonShapes = []*regexp.Regexp{
 	regexp.MustCompile(`^signal: `),
 }
 
+// aiIngestDeliveryResults are the outcomes that mean a reflection write was
+// attempted.
+//
+// The quiet lane is deliberately not among them. A quiet event reached its Pane
+// and deliberately wrote nothing, so it can neither succeed nor fail at
+// delivery, and it is by far the most common outcome: on a live machine it was
+// 989 of 1028 attributed records. Counting it as delivered turned one failure
+// out of three real write attempts into one out of twenty-nine, which reads as
+// a healthy path with an incident rather than a path that fails a third of the
+// time. Diluting a rate by widening its denominator is a shape this diagnosis
+// has met before.
+var aiIngestDeliveryResults = []string{"state", "notify"}
+
 // aiIngestDeliverySource is one provider hook source's delivery outcome.
 type aiIngestDeliverySource struct {
 	Source string `json:"source"`
-	// Delivered counts events that reached their Pane and changed it.
+	// Delivered counts events that attempted a write and changed their Pane.
 	Delivered int `json:"delivered"`
-	// Failed counts events that reached their Pane and could not change it.
+	// Failed counts events that attempted a write and could not.
 	Failed int `json:"failed"`
+	// Quiet counts events that reached their Pane and attempted no write. They
+	// are reported beside the two counts above and never inside them.
+	Quiet int `json:"quiet"`
 	// Opaque is the subset of Failed whose reason answers nothing.
 	Opaque int `json:"opaque"`
 	// PathBearing is the subset whose explanatory detail carries a filesystem
@@ -78,23 +94,31 @@ func (h aiIngestDeliveryHealth) Opaque() int {
 func projectAIIngestDeliveryHealth(entries []aiIngestLogEntry) aiIngestDeliveryHealth {
 	health := aiIngestDeliveryHealth{Observed: true}
 	delivered, failed, opaque := map[string]int{}, map[string]int{}, map[string]int{}
-	pathBearing := map[string]int{}
+	quiet, pathBearing := map[string]int{}, map[string]int{}
 	reasons := map[string]map[string]int{}
 	for _, entry := range entries {
 		source := strings.TrimSpace(entry.Source)
 		if !isAIIngestHookSource(source) || strings.TrimSpace(entry.Pane) == "" {
 			continue
 		}
+		// The path check covers every attributed record, not only the failures.
+		// A path can ride a quiet event's reason as easily as a failure's, and
+		// on this machine that is where one live inflow sits.
+		if aiIngestDetailCarriesAPath(entry.Reason) {
+			pathBearing[source]++
+		}
+		result := strings.TrimSpace(entry.Result)
+		if !slices.Contains(aiIngestDeliveryResults, result) && result != "error" {
+			quiet[source]++
+			continue
+		}
 		health.Records++
-		if strings.TrimSpace(entry.Result) != "error" {
+		if result != "error" {
 			delivered[source]++
 			continue
 		}
 		failed[source]++
 		reason := aiIngestReasonToken(entry.Reason)
-		if aiIngestDetailCarriesAPath(entry.Reason) {
-			pathBearing[source]++
-		}
 		if aiIngestReasonIsOpaque(reason) {
 			opaque[source]++
 			// An opaque reason is not recorded verbatim. It is the shape that
@@ -108,13 +132,14 @@ func projectAIIngestDeliveryHealth(entries []aiIngestLogEntry) aiIngestDeliveryH
 		reasons[source][reason]++
 	}
 	for _, source := range aiIngestAttributionSources {
-		if delivered[source] == 0 && failed[source] == 0 {
+		if delivered[source] == 0 && failed[source] == 0 && quiet[source] == 0 {
 			continue
 		}
 		health.Sources = append(health.Sources, aiIngestDeliverySource{
 			Source:      source,
 			Delivered:   delivered[source],
 			Failed:      failed[source],
+			Quiet:       quiet[source],
 			Opaque:      opaque[source],
 			PathBearing: pathBearing[source],
 			Reasons:     aiIngestDeliveryReasons(reasons[source]),

--- a/internal/app/ai_ingest_delivery_health.go
+++ b/internal/app/ai_ingest_delivery_health.go
@@ -33,8 +33,15 @@ type aiIngestDeliverySource struct {
 	// Failed counts events that reached their Pane and could not change it.
 	Failed int `json:"failed"`
 	// Opaque is the subset of Failed whose reason answers nothing.
-	Opaque  int                         `json:"opaque"`
-	Reasons []aiIngestAttributionReason `json:"reasons,omitempty"`
+	Opaque int `json:"opaque"`
+	// PathBearing is the subset whose explanatory detail carries a filesystem
+	// path. It is counted and reported, and it deliberately does not move the
+	// verdict: a reason can name its cause precisely and still carry a path,
+	// and those are two different properties about two different halves of the
+	// string. Folding them into one number is the mistake that made a
+	// contractual refusal read as an attribution failure.
+	PathBearing int                         `json:"path_bearing"`
+	Reasons     []aiIngestAttributionReason `json:"reasons,omitempty"`
 }
 
 // aiIngestDeliveryHealth is the content-free projection of whether attributed
@@ -71,6 +78,7 @@ func (h aiIngestDeliveryHealth) Opaque() int {
 func projectAIIngestDeliveryHealth(entries []aiIngestLogEntry) aiIngestDeliveryHealth {
 	health := aiIngestDeliveryHealth{Observed: true}
 	delivered, failed, opaque := map[string]int{}, map[string]int{}, map[string]int{}
+	pathBearing := map[string]int{}
 	reasons := map[string]map[string]int{}
 	for _, entry := range entries {
 		source := strings.TrimSpace(entry.Source)
@@ -83,12 +91,15 @@ func projectAIIngestDeliveryHealth(entries []aiIngestLogEntry) aiIngestDeliveryH
 			continue
 		}
 		failed[source]++
-		reason := strings.TrimSpace(entry.Reason)
+		reason := aiIngestReasonToken(entry.Reason)
+		if aiIngestDetailCarriesAPath(entry.Reason) {
+			pathBearing[source]++
+		}
 		if aiIngestReasonIsOpaque(reason) {
 			opaque[source]++
 			// An opaque reason is not recorded verbatim. It is the shape that
-			// carries a path or a raw process detail onto a diagnostics
-			// surface, and the count is the whole answer an operator needs.
+			// carries a raw process detail onto a diagnostics surface, and the
+			// count is the whole answer an operator needs.
 			reason = aiIngestOpaqueDeliveryReason
 		}
 		if reasons[source] == nil {
@@ -101,11 +112,12 @@ func projectAIIngestDeliveryHealth(entries []aiIngestLogEntry) aiIngestDeliveryH
 			continue
 		}
 		health.Sources = append(health.Sources, aiIngestDeliverySource{
-			Source:    source,
-			Delivered: delivered[source],
-			Failed:    failed[source],
-			Opaque:    opaque[source],
-			Reasons:   aiIngestDeliveryReasons(reasons[source]),
+			Source:      source,
+			Delivered:   delivered[source],
+			Failed:      failed[source],
+			Opaque:      opaque[source],
+			PathBearing: pathBearing[source],
+			Reasons:     aiIngestDeliveryReasons(reasons[source]),
 		})
 	}
 	return health
@@ -116,27 +128,55 @@ func projectAIIngestDeliveryHealth(entries []aiIngestLogEntry) aiIngestDeliveryH
 // process detail, which is exactly what a diagnostics surface must not repeat.
 const aiIngestOpaqueDeliveryReason = "opaque delivery failure"
 
-// aiIngestReasonIsOpaque reports whether a delivery failure reason answers
+// aiIngestReasonToken takes the naming half of a delivery failure reason.
+//
+// A reflection refusal is written as a bounded token, optionally followed by
+// ": " and an explanation. The token is the part that has to answer the
+// question; the explanation exists to help an operator and may say anything a
+// tmux message says. Judging opacity on the whole string would call a reason
+// that names its cause precisely opaque the moment the explanation behind it
+// mentioned a socket, which is the opposite of what this verdict measures.
+func aiIngestReasonToken(reason string) string {
+	token, _, found := strings.Cut(strings.TrimSpace(reason), ": ")
+	if !found {
+		return strings.TrimSpace(reason)
+	}
+	return strings.TrimSpace(token)
+}
+
+// aiIngestReasonIsOpaque reports whether a delivery failure token answers
 // nothing.
 //
-// An empty reason is the plainest case. A raw process-exit or signal string is
-// the shape observed in the field. A reason carrying a path is opaque for a
-// second reason as well: this track's change boundary keeps paths out of the
-// records entirely, so one appearing here is a leak as much as a non-answer.
-func aiIngestReasonIsOpaque(reason string) bool {
-	reason = strings.TrimSpace(reason)
-	if reason == "" {
+// An empty token is the plainest case. A raw process-exit or signal string is
+// the shape observed in the field. A path where a token belongs is a third:
+// a bounded vocabulary token never contains one, so a path in that position
+// means no token was written at all.
+func aiIngestReasonIsOpaque(token string) bool {
+	token = strings.TrimSpace(token)
+	if token == "" {
 		return true
 	}
-	if strings.Contains(reason, "/") {
+	if strings.Contains(token, "/") {
 		return true
 	}
 	for _, shape := range aiIngestOpaqueReasonShapes {
-		if shape.MatchString(reason) {
+		if shape.MatchString(token) {
 			return true
 		}
 	}
 	return false
+}
+
+// aiIngestDetailCarriesAPath reports whether the explanation behind a bounded
+// token names a filesystem path.
+//
+// It is a separate observation from opacity and never moves the verdict. This
+// track's change boundary keeps paths out of the records, so the count belongs
+// on the surface where an operator and an owner can see it; deciding whether a
+// given path may be there is not a reading this diagnosis gets to make.
+func aiIngestDetailCarriesAPath(reason string) bool {
+	_, detail, found := strings.Cut(strings.TrimSpace(reason), ": ")
+	return found && strings.Contains(detail, "/")
 }
 
 func isAIIngestHookSource(source string) bool {

--- a/internal/app/ai_ingest_delivery_health.go
+++ b/internal/app/ai_ingest_delivery_health.go
@@ -104,7 +104,11 @@ func projectAIIngestDeliveryHealth(entries []aiIngestLogEntry) aiIngestDeliveryH
 		// The path check covers every attributed record, not only the failures.
 		// A path can ride a quiet event's reason as easily as a failure's, and
 		// on this machine that is where one live inflow sits.
-		if aiIngestDetailCarriesAPath(entry.Reason) {
+		// The conversion is explicit because this record's reason column becomes a
+		// named vocabulary type once the closed-vocabulary work lands, and an
+		// explicit conversion compiles against both spellings. It is not
+		// redundant; removing it breaks the build a version from now.
+		if aiIngestDetailCarriesAPath(string(entry.Reason)) {
 			pathBearing[source]++
 		}
 		result := strings.TrimSpace(entry.Result)
@@ -118,7 +122,7 @@ func projectAIIngestDeliveryHealth(entries []aiIngestLogEntry) aiIngestDeliveryH
 			continue
 		}
 		failed[source]++
-		reason := aiIngestReasonToken(entry.Reason)
+		reason := aiIngestReasonToken(string(entry.Reason))
 		if aiIngestReasonIsOpaque(reason) {
 			opaque[source]++
 			// An opaque reason is not recorded verbatim. It is the shape that

--- a/internal/app/ai_ingest_delivery_health.go
+++ b/internal/app/ai_ingest_delivery_health.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -139,12 +140,7 @@ func aiIngestReasonIsOpaque(reason string) bool {
 }
 
 func isAIIngestHookSource(source string) bool {
-	for _, known := range aiIngestAttributionSources {
-		if known == source {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(aiIngestAttributionSources, source)
 }
 
 func aiIngestDeliveryReasons(counts map[string]int) []aiIngestAttributionReason {

--- a/internal/app/ai_ingest_diagnostics_test.go
+++ b/internal/app/ai_ingest_diagnostics_test.go
@@ -218,6 +218,9 @@ func TestAIIngestActualClaudeNormalUnknownAndUnmatched(t *testing.T) {
 			t.Fatal(err)
 		}
 		events := readAIOperationalEvents(t, store)
+		// uncaptured-default: `target-unmatched` here is the operations journal's
+		// own AI failure vocabulary, not a Codex authority reason; this pins the
+		// legacy projection that maps an ignored hook onto it.
 		if len(events) != 1 || events[0].Provider != "claude" || events[0].AIKind != "stop" || events[0].Failure != "target-unmatched" {
 			t.Fatalf("unmatched Claude events = %#v", events)
 		}
@@ -319,6 +322,8 @@ func TestAIIngestActualBellValidInvalidUnmatchedAndRouteFailure(t *testing.T) {
 		if err := cmd.Run([]string{"ingest", "bell", "--pane", "%404"}, io.Discard, io.Discard); err != nil {
 			t.Fatal(err)
 		}
+		// uncaptured-default: same operations journal vocabulary as above; a bell
+		// event with no matching target really is target-unmatched.
 		assertSingleAIBellOutcome(t, store, "ignored", "target-unmatched")
 		if !lifecycle.RecordedOutcome() {
 			t.Fatal("pane-not-found bell did not claim terminal ownership")

--- a/internal/app/ai_ingest_hook_layer_health_test.go
+++ b/internal/app/ai_ingest_hook_layer_health_test.go
@@ -176,6 +176,16 @@ func TestOwnershipHealthCallsOnlyAPositivelyForeignPaneForeign(t *testing.T) {
 	if ownership.Unresolved != 1 {
 		t.Fatalf("unresolved = %d, want the attribution to a Pane the Registry lost", ownership.Unresolved)
 	}
+	// The two directions have different causes and must stay separable: one is
+	// a hook landing on the Pane that launched its host, the other an event
+	// that arrived under the wrong source before attribution ran.
+	directions := map[string]int{}
+	for _, direction := range ownership.Directions {
+		directions[direction.Reason] = direction.Count
+	}
+	if directions["codex-hook onto claude"] != 1 || directions["claude-hook onto codex"] != 1 {
+		t.Fatalf("directions = %+v, want each mismatch reported by which way it runs", ownership.Directions)
+	}
 	unread := projectAIIngestOwnershipHealth(nil, coremetadata.Registry{}, false)
 	if unread.Observed {
 		t.Fatal("an unreadable log and Registry pair reported itself as observed")

--- a/internal/app/ai_ingest_hook_layer_health_test.go
+++ b/internal/app/ai_ingest_hook_layer_health_test.go
@@ -186,6 +186,16 @@ func TestOwnershipHealthCallsOnlyAPositivelyForeignPaneForeign(t *testing.T) {
 	if ownership.Unresolved != 1 {
 		t.Fatalf("unresolved = %d, want the attribution to a Pane the Registry lost", ownership.Unresolved)
 	}
+	// The verdict may not certify past what it can judge. A Pane the Registry
+	// holds without a provider resolves the old way, so an attribution landing
+	// there is neither proven right nor proven wrong, and a zero foreign count
+	// beside a hidden pile of these would read as a guarantee nobody gave.
+	if ownership.Unrecorded != 1 {
+		t.Fatalf("unrecorded = %d, want the attribution onto a Pane recording no provider counted apart", ownership.Unrecorded)
+	}
+	if surface := codexPaneOwnershipSurface(ownership); !strings.Contains(surface.Detail, "provider unrecorded 1") {
+		t.Fatalf("detail = %q, want the unjudgeable attribution visible beside the verdict", surface.Detail)
+	}
 	// The two directions have different causes and must stay separable: one is
 	// a hook landing on the Pane that launched its host, the other an event
 	// that arrived under the wrong source before attribution ran.

--- a/internal/app/ai_ingest_hook_layer_health_test.go
+++ b/internal/app/ai_ingest_hook_layer_health_test.go
@@ -1,0 +1,230 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+)
+
+// TestDeliveryHealthCountsOnlyAttributedEvents keeps the two hook layers apart.
+//
+// An event that never found its Pane failed at attribution and cannot also have
+// failed to change one. Folding the two together would report one defect twice
+// and make the delivery number move whenever attribution did.
+func TestDeliveryHealthCountsOnlyAttributedEvents(t *testing.T) {
+	delivery := projectAIIngestDeliveryHealth([]aiIngestLogEntry{
+		{Source: "codex-hook", Event: "Stop", Result: "state", Pane: "%1"},
+		{Source: "codex-hook", Event: "Stop", Result: "error", Reason: "exit status 1", Pane: "%1"},
+		{Source: "codex-hook", Event: "Stop", Result: "error", Reason: "pane option write refused", Pane: "%1"},
+		// Attribution failures belong to the other layer.
+		{Source: "codex-hook", Event: "Stop", Result: "ignored", Reason: aiPaneMatchReasonNoInventory},
+		// A payload error that never reached a Pane is neither layer.
+		{Source: "codex-hook", Result: "error", Reason: "payload decode failed"},
+		// An observer transition is not a hook event.
+		{Source: "codex-observer", Result: "invalidating", Reason: "endpoint-suspended", Pane: "%1"},
+	})
+	if delivery.Records != 3 {
+		t.Fatalf("records = %d, want the 3 attributed hook events", delivery.Records)
+	}
+	if delivery.Failed() != 2 || delivery.Opaque() != 1 {
+		t.Fatalf("failed = %d, opaque = %d, want 2 and 1", delivery.Failed(), delivery.Opaque())
+	}
+}
+
+// TestOpaqueDeliveryReasonsNeverReachTheDiagnosis pins both halves of what
+// "opaque" buys.
+//
+// A raw process-exit string names a process that ended and nothing else, so it
+// is counted rather than repeated. A reason carrying a path is opaque for a
+// second reason as well: this track's change boundary keeps paths out of these
+// records, so one appearing here is a leak as much as a non-answer, and
+// rendering it would carry the leak onto a diagnostics surface.
+func TestOpaqueDeliveryReasonsNeverReachTheDiagnosis(t *testing.T) {
+	for _, test := range []struct {
+		reason string
+		opaque bool
+	}{
+		{reason: "exit status 1", opaque: true},
+		{reason: "exit status 127", opaque: true},
+		{reason: "signal: killed", opaque: true},
+		{reason: "", opaque: true},
+		{reason: "open /home/user/.codex/config.toml: no such file", opaque: true},
+		{reason: "pane option write refused"},
+		{reason: "tmux-socket-unavailable"},
+	} {
+		if got := aiIngestReasonIsOpaque(test.reason); got != test.opaque {
+			t.Fatalf("aiIngestReasonIsOpaque(%q) = %v, want %v", test.reason, got, test.opaque)
+		}
+	}
+	delivery := projectAIIngestDeliveryHealth([]aiIngestLogEntry{
+		{Source: "codex-hook", Result: "error", Reason: "exit status 1", Pane: "%1"},
+		{Source: "codex-hook", Result: "error", Reason: "open /home/user/secret/rollout.jsonl: denied", Pane: "%1"},
+	})
+	for _, source := range delivery.Sources {
+		for _, reason := range source.Reasons {
+			if reason.Reason != aiIngestOpaqueDeliveryReason {
+				t.Fatalf("reason %q reached the diagnosis verbatim", reason.Reason)
+			}
+		}
+	}
+	if delivery.Opaque() != 2 {
+		t.Fatalf("opaque = %d, want both counted", delivery.Opaque())
+	}
+}
+
+// TestHookDeliverySurfaceTreatsAnOpaqueFailureAsBroken is the ⑥ verdict.
+//
+// This is the property the reflection layer owes regardless of which tokens its
+// vocabulary ends up carrying: a write that cannot happen leaves an answer. A
+// failure with a bounded reason is a fault an operator acts on; one reporting
+// only that a process exited is the state this surface was opened on.
+func TestHookDeliverySurfaceTreatsAnOpaqueFailureAsBroken(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		delivery   aiIngestDeliveryHealth
+		wantStatus string
+	}{
+		{
+			name:       "no readable log is unobserved, not healthy",
+			delivery:   aiIngestDeliveryHealth{},
+			wantStatus: codexSurfaceStatusUnobserved,
+		},
+		{
+			name:       "no attributed event answers nothing",
+			delivery:   aiIngestDeliveryHealth{Observed: true},
+			wantStatus: codexSurfaceStatusUnobserved,
+		},
+		{
+			name: "a failure that answers nothing is broken",
+			delivery: aiIngestDeliveryHealth{Observed: true, Records: 60, Sources: []aiIngestDeliverySource{
+				{Source: "codex-hook", Delivered: 52, Failed: 8, Opaque: 8, Reasons: []aiIngestAttributionReason{
+					{Reason: aiIngestOpaqueDeliveryReason, Count: 8},
+				}},
+			}},
+			wantStatus: codexSurfaceStatusBroken,
+		},
+		{
+			name: "a failure that names its cause is a degradation",
+			delivery: aiIngestDeliveryHealth{Observed: true, Records: 60, Sources: []aiIngestDeliverySource{
+				{Source: "codex-hook", Delivered: 52, Failed: 8, Reasons: []aiIngestAttributionReason{
+					{Reason: "pane option write refused", Count: 8},
+				}},
+			}},
+			wantStatus: codexSurfaceStatusDegraded,
+		},
+		{
+			name: "every attributed event landing is healthy",
+			delivery: aiIngestDeliveryHealth{Observed: true, Records: 23, Sources: []aiIngestDeliverySource{
+				{Source: "codex-hook", Delivered: 23},
+			}},
+			wantStatus: codexSurfaceStatusOK,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			surface := codexHookDeliverySurface(test.delivery)
+			if surface.Surface != codexSurfaceHookDelivery {
+				t.Fatalf("surface = %q, want %q", surface.Surface, codexSurfaceHookDelivery)
+			}
+			if surface.Status != test.wantStatus {
+				t.Fatalf("status = %q, want %q (detail %q)", surface.Status, test.wantStatus, surface.Detail)
+			}
+		})
+	}
+}
+
+func paneWithActivation(runtimeID string, activation coremetadata.PaneActivation) coremetadata.Pane {
+	activation.RuntimeID = runtimeID
+	return coremetadata.Pane{Status: coremetadata.PaneStatus{Activation: activation}}
+}
+
+// TestOwnershipHealthCallsOnlyAPositivelyForeignPaneForeign pins the predicate.
+//
+// The judgment is one-sided on purpose. An attribution is foreign only when the
+// Registry positively records a different provider for that Pane; a Pane that
+// records no provider is not a contradiction. Calling it one would turn every
+// ordinary shell Pane into a finding and bury the case that matters, and it
+// would break the neutrality the attribution contract is written under — which
+// is also why the predicate is a table rather than a branch on one provider.
+func TestOwnershipHealthCallsOnlyAPositivelyForeignPaneForeign(t *testing.T) {
+	registry := coremetadata.Registry{Panes: []coremetadata.Pane{
+		paneWithActivation("%1", coremetadata.PaneActivation{Codex: &coremetadata.CodexActivationBinding{ThreadID: "t"}}),
+		paneWithActivation("%2", coremetadata.PaneActivation{Claude: &coremetadata.ClaudeActivationBinding{}}),
+		paneWithActivation("%3", coremetadata.PaneActivation{}),
+	}}
+	ownership := projectAIIngestOwnershipHealth([]aiIngestLogEntry{
+		{Source: "codex-hook", Result: "state", Pane: "%1"},
+		{Source: "claude-hook", Result: "state", Pane: "%2"},
+		// The latent leak: a Codex hook landing on a Pane the Registry records
+		// as Claude's.
+		{Source: "codex-hook", Result: "state", Pane: "%2"},
+		// And the mirror, so the judgment cannot be one provider's special case.
+		{Source: "claude-hook", Result: "state", Pane: "%1"},
+		// A Pane recording no provider is not another provider.
+		{Source: "codex-hook", Result: "state", Pane: "%3"},
+		// A Pane the Registry no longer holds is outside the contract.
+		{Source: "codex-hook", Result: "state", Pane: "%99"},
+		// A source with no provider binding cannot be judged either way.
+		{Source: "antigravity-hook", Result: "state", Pane: "%2"},
+	}, registry, true)
+	if ownership.Foreign != 2 {
+		t.Fatalf("foreign = %d, want both directions of the mismatch counted", ownership.Foreign)
+	}
+	if ownership.Classified != 4 {
+		t.Fatalf("classified = %d, want the four judgeable attributions", ownership.Classified)
+	}
+	if ownership.Unresolved != 1 {
+		t.Fatalf("unresolved = %d, want the attribution to a Pane the Registry lost", ownership.Unresolved)
+	}
+	unread := projectAIIngestOwnershipHealth(nil, coremetadata.Registry{}, false)
+	if unread.Observed {
+		t.Fatal("an unreadable log and Registry pair reported itself as observed")
+	}
+}
+
+// TestPaneOwnershipSurfaceReportsAForeignAttributionAsBroken is the ⑦ verdict.
+//
+// A foreign attribution looks like success from every other angle: the event
+// was attributed, the write landed, and the Pane it moved belongs to someone
+// else. No other surface in this diagnosis can see it.
+func TestPaneOwnershipSurfaceReportsAForeignAttributionAsBroken(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		ownership  aiIngestOwnershipHealth
+		wantStatus string
+	}{
+		{
+			name:       "no log and Registry pair is unobserved, not healthy",
+			ownership:  aiIngestOwnershipHealth{},
+			wantStatus: codexSurfaceStatusUnobserved,
+		},
+		{
+			name:       "nothing judgeable answers nothing",
+			ownership:  aiIngestOwnershipHealth{Observed: true, Unresolved: 4},
+			wantStatus: codexSurfaceStatusUnobserved,
+		},
+		{
+			name:       "one foreign attribution is broken",
+			ownership:  aiIngestOwnershipHealth{Observed: true, Classified: 23, Foreign: 1},
+			wantStatus: codexSurfaceStatusBroken,
+		},
+		{
+			name:       "every attribution on its own provider is healthy",
+			ownership:  aiIngestOwnershipHealth{Observed: true, Classified: 23},
+			wantStatus: codexSurfaceStatusOK,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			surface := codexPaneOwnershipSurface(test.ownership)
+			if surface.Surface != codexSurfacePaneOwnership {
+				t.Fatalf("surface = %q, want %q", surface.Surface, codexSurfacePaneOwnership)
+			}
+			if surface.Status != test.wantStatus {
+				t.Fatalf("status = %q, want %q (detail %q)", surface.Status, test.wantStatus, surface.Detail)
+			}
+			if strings.TrimSpace(surface.Detail) == "" {
+				t.Fatal("a verdict with no evidence behind it")
+			}
+		})
+	}
+}

--- a/internal/app/ai_ingest_hook_layer_health_test.go
+++ b/internal/app/ai_ingest_hook_layer_health_test.go
@@ -52,6 +52,16 @@ func TestOpaqueDeliveryReasonsNeverReachTheDiagnosis(t *testing.T) {
 		{reason: "open /home/user/.codex/config.toml: no such file", opaque: true},
 		{reason: "pane option write refused"},
 		{reason: "tmux-socket-unavailable"},
+		// The three shapes the reflection layer's own vocabulary takes. They
+		// are listed as shapes, not as a binding: the gate that requires a
+		// failure reason to be one of those tokens has to reference the
+		// declared constants, or a rename walks past it. What is pinned here
+		// is only that a bounded kebab-or-prose token of this shape is not
+		// mistaken for a raw process detail, so the layer's own vocabulary
+		// cannot trip the opaque verdict the moment it arrives.
+		{reason: "pane runtime route unavailable"},
+		{reason: "pane runtime route does not hold this pane"},
+		{reason: "pane option write rejected"},
 	} {
 		if got := aiIngestReasonIsOpaque(test.reason); got != test.opaque {
 			t.Fatalf("aiIngestReasonIsOpaque(%q) = %v, want %v", test.reason, got, test.opaque)

--- a/internal/app/ai_ingest_hook_layer_health_test.go
+++ b/internal/app/ai_ingest_hook_layer_health_test.go
@@ -468,9 +468,31 @@ func TestOwnershipHealthCountsAConversationCarriedByTheWrongSource(t *testing.T)
 	if ownership.Foreign != 2 {
 		t.Fatalf("foreign = %d, want only the two that actually landed on a Pane", ownership.Foreign)
 	}
+	if ownership.OwnedConversations != 2 {
+		t.Fatalf("owned conversations = %d, want the two the window can see an owner for", ownership.OwnedConversations)
+	}
 	surface := codexPaneOwnershipSurface(ownership)
-	if !strings.Contains(surface.Detail, "3 record(s) misrouted") {
-		t.Fatalf("detail = %q, want the misroute count visible", surface.Detail)
+	if !strings.Contains(surface.Detail, "3 record(s) misrouted across 2 conversation(s) with a known owner") {
+		t.Fatalf("detail = %q, want the misroute count carried with what it is over", surface.Detail)
+	}
+
+	// The detector is a join, so it needs the owning source's records in the
+	// same window. The log is trimmed by size, and when the owner ages out
+	// first the misrouted records revert to looking like ordinary unregistered
+	// conversations — the exact blind spot this counter closed. It was seen
+	// happening: 98 fell to 2 across one trim with nothing repaired. A zero
+	// therefore has to be readable against how much the window could check.
+	blinded := projectAIIngestOwnershipHealth([]aiIngestLogEntry{
+		{Source: "claude-hook", Event: "Stop", Result: "ignored", Reason: aiPaneMatchReasonConversationUnknown, SessionID: conversation},
+	}, registry, true)
+	if blinded.Misrouted != 0 {
+		t.Fatalf("misrouted = %d with the owner outside the window, want the join to find nothing", blinded.Misrouted)
+	}
+	if blinded.OwnedConversations != 0 {
+		t.Fatalf("owned conversations = %d, want zero so the zero above reads as unchecked", blinded.OwnedConversations)
+	}
+	if detail := codexPaneOwnershipSurface(blinded).Detail; !strings.Contains(detail, "0 record(s) misrouted across 0 conversation(s)") {
+		t.Fatalf("detail = %q, want a zero that shows nothing could be checked", detail)
 	}
 	// A window with no cross-provider carriage counts none, so the number
 	// cannot become background noise.
@@ -478,8 +500,9 @@ func TestOwnershipHealthCountsAConversationCarriedByTheWrongSource(t *testing.T)
 		{Source: "codex-hook", Result: "state", Pane: "%122", ThreadID: conversation},
 		{Source: "claude-hook", Result: "state", Pane: "%123", ThreadID: "claude-own"},
 	}, registry, true)
-	if clean.Misrouted != 0 {
-		t.Fatalf("misrouted = %d on a clean window, want none", clean.Misrouted)
+	if clean.Misrouted != 0 || clean.OwnedConversations != 2 {
+		t.Fatalf("clean window misrouted=%d owned=%d, want none over the two it could check",
+			clean.Misrouted, clean.OwnedConversations)
 	}
 	// Misrouting alone is a degradation, not a break: the routing that produced
 	// it lives outside this application, so there is nothing here to repair.

--- a/internal/app/ai_ingest_hook_layer_health_test.go
+++ b/internal/app/ai_ingest_hook_layer_health_test.go
@@ -193,8 +193,15 @@ func TestOwnershipHealthCallsOnlyAPositivelyForeignPaneForeign(t *testing.T) {
 	if ownership.Unrecorded != 1 {
 		t.Fatalf("unrecorded = %d, want the attribution onto a Pane recording no provider counted apart", ownership.Unrecorded)
 	}
-	if surface := codexPaneOwnershipSurface(ownership); !strings.Contains(surface.Detail, "provider unrecorded 1") {
+	surface := codexPaneOwnershipSurface(ownership)
+	if !strings.Contains(surface.Detail, "provider unrecorded 1") {
 		t.Fatalf("detail = %q, want the unjudgeable attribution visible beside the verdict", surface.Detail)
+	}
+	// The denominator has to lead. A judged count standing alone reads as the
+	// whole population, and on a live machine more than a third of the window
+	// has fallen outside it.
+	if !strings.Contains(surface.Detail, "judged 4 of 6 attributions") {
+		t.Fatalf("detail = %q, want the judged count carried against the whole window", surface.Detail)
 	}
 	// The two directions have different causes and must stay separable: one is
 	// a hook landing on the Pane that launched its host, the other an event
@@ -257,4 +264,15 @@ func TestPaneOwnershipSurfaceReportsAForeignAttributionAsBroken(t *testing.T) {
 			}
 		})
 	}
+}
+
+// PathBearing is how many delivery failures carry a filesystem path in their
+// explanation. The surface renders the count per source, so this aggregate is
+// only ever a test's summary of a fixture.
+func (h aiIngestDeliveryHealth) PathBearing() int {
+	total := 0
+	for _, source := range h.Sources {
+		total += source.PathBearing
+	}
+	return total
 }

--- a/internal/app/ai_ingest_hook_layer_health_test.go
+++ b/internal/app/ai_ingest_hook_layer_health_test.go
@@ -55,16 +55,6 @@ func TestOpaqueDeliveryReasonsNeverReachTheDiagnosis(t *testing.T) {
 		{reason: "open /home/user/.codex/config.toml: no such file", opaque: true},
 		{reason: "pane option write refused"},
 		{reason: "tmux-socket-unavailable"},
-		// The three shapes the reflection layer's own vocabulary takes. They
-		// are listed as shapes, not as a binding: the gate that requires a
-		// failure reason to be one of those tokens has to reference the
-		// declared constants, or a rename walks past it. What is pinned here
-		// is only that a bounded kebab-or-prose token of this shape is not
-		// mistaken for a raw process detail, so the layer's own vocabulary
-		// cannot trip the opaque verdict the moment it arrives.
-		{reason: "pane runtime route unavailable"},
-		{reason: "pane runtime route does not hold this pane"},
-		{reason: "pane option write rejected"},
 	} {
 		if got := aiIngestReasonIsOpaque(test.reason); got != test.opaque {
 			t.Fatalf("aiIngestReasonIsOpaque(%q) = %v, want %v", test.reason, got, test.opaque)
@@ -353,5 +343,38 @@ func TestPaneOwnershipVerdictIgnoresForeignLifecycleChurn(t *testing.T) {
 	foreign.Foreign = 1
 	if got := codexPaneOwnershipSurface(foreign); got.Status != codexSurfaceStatusBroken {
 		t.Fatalf("status = %q, want %q once an attribution is provably foreign", got.Status, codexSurfaceStatusBroken)
+	}
+}
+
+// TestReflectionRefusalVocabularyIsNeverOpaque binds the delivery verdict to
+// the reflection layer's own declarations.
+//
+// Until that layer existed this could only be pinned as shapes -- string
+// literals spelling what its tokens would look like -- and a literal is exactly
+// what a rename walks past. Now the constants are here, so a token renamed or
+// replaced by something the opaque test would refuse fails at this line rather
+// than turning the delivery row red in the field for a reason nobody expected.
+//
+// The check stays provider-neutral. It does not require a failure reason to be
+// one of these three; it requires these three to be the kind of answer the
+// verdict accepts. Requiring membership would tie one provider's vocabulary
+// into a surface all three providers report on.
+func TestReflectionRefusalVocabularyIsNeverOpaque(t *testing.T) {
+	for _, declared := range []string{
+		codexHookRouteUnavailableReason,
+		codexHookRouteForeignPaneReason,
+		codexHookWriteRejectedReason,
+	} {
+		if aiIngestReasonIsOpaque(aiIngestReasonToken(declared)) {
+			t.Fatalf("declared refusal %q reads as opaque; the delivery row would redden on a bounded answer", declared)
+		}
+		if declared == "" {
+			t.Fatal("a declared refusal is empty, which is the plainest opaque value there is")
+		}
+	}
+	// And the failure it replaced still reads as opaque, or the verdict has
+	// stopped distinguishing the two.
+	if !aiIngestReasonIsOpaque(aiIngestReasonToken("exit status 1")) {
+		t.Fatal("a raw process exit no longer reads as opaque")
 	}
 }

--- a/internal/app/ai_ingest_hook_layer_health_test.go
+++ b/internal/app/ai_ingest_hook_layer_health_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -376,5 +377,49 @@ func TestReflectionRefusalVocabularyIsNeverOpaque(t *testing.T) {
 	// stopped distinguishing the two.
 	if !aiIngestReasonIsOpaque(aiIngestReasonToken("exit status 1")) {
 		t.Fatal("a raw process exit no longer reads as opaque")
+	}
+}
+
+// TestHookWindowSpanIsCarriedOntoTheSection pins that the hook counts say what
+// span they are over.
+//
+// Every hook-layer number here is cumulative across the whole reading window,
+// and a deployment inside that window leaves records from both images in the
+// same counts. A repair that lands mid-window therefore moves nothing until its
+// predecessors age out — and a reader without the span reads the delay as the
+// repair having failed, then reads the eventual drop as time having healed it.
+// That misreading already happened once on this track, in both directions,
+// within ten minutes.
+func TestHookWindowSpanIsCarriedOntoTheSection(t *testing.T) {
+	entries := []aiIngestLogEntry{
+		{At: "2026-09-05T09:48:09Z", Source: "codex-hook", Result: "notify", Pane: "%1"},
+		{At: "2026-09-05T08:44:30Z", Source: "codex-hook", Result: "error", Reason: "exit status 1", Pane: "%1"},
+		{At: "2026-09-05T09:12:00Z", Source: "claude-hook", Result: "state", Pane: "%2"},
+		// A record with no timestamp must not become the boundary.
+		{Source: "claude-hook", Result: "quiet", Pane: "%2"},
+	}
+	from, to := aiIngestWindowSpan(entries)
+	if from != "2026-09-05T08:44:30Z" || to != "2026-09-05T09:48:09Z" {
+		t.Fatalf("span = %q..%q, want the earliest and latest timestamped records", from, to)
+	}
+	report := projectCodexControlPlaneSurfaces(nil, nil, codexHookHealth{
+		Attribution: projectAIIngestAttributionHealth(entries),
+		Delivery:    projectAIIngestDeliveryHealth(entries),
+		From:        from,
+		To:          to,
+	}, codexControlPlaneVintage{})
+	if report.HookWindow != from+" to "+to {
+		t.Fatalf("hook window = %q, want the span carried onto the section", report.HookWindow)
+	}
+	var buf bytes.Buffer
+	writeDoctorCodexControlPlaneText(&buf, &report)
+	if !strings.Contains(buf.String(), "Hook reading window: "+from+" to "+to) {
+		t.Fatalf("rendered:\n%s\nwant the span above the rows it qualifies", buf.String())
+	}
+	// An unreadable log has no span, and an empty range must not be rendered as
+	// one.
+	empty := projectCodexControlPlaneSurfaces(nil, nil, codexHookHealth{}, codexControlPlaneVintage{})
+	if empty.HookWindow != "" {
+		t.Fatalf("hook window = %q with nothing read, want none", empty.HookWindow)
 	}
 }

--- a/internal/app/ai_ingest_hook_layer_health_test.go
+++ b/internal/app/ai_ingest_hook_layer_health_test.go
@@ -27,6 +27,9 @@ func TestDeliveryHealthCountsOnlyAttributedEvents(t *testing.T) {
 	if delivery.Records != 3 {
 		t.Fatalf("records = %d, want the 3 attributed hook events", delivery.Records)
 	}
+	if delivery.Sources[0].Quiet != 0 {
+		t.Fatalf("quiet = %d, want none in this fixture", delivery.Sources[0].Quiet)
+	}
 	if delivery.Failed() != 2 || delivery.Opaque() != 1 {
 		t.Fatalf("failed = %d, opaque = %d, want 2 and 1", delivery.Failed(), delivery.Opaque())
 	}
@@ -275,4 +278,47 @@ func (h aiIngestDeliveryHealth) PathBearing() int {
 		total += source.PathBearing
 	}
 	return total
+}
+
+// TestDeliveryHealthKeepsTheQuietLaneOutOfTheRate is the denominator gate.
+//
+// A quiet event reached its Pane and deliberately wrote nothing, so it can
+// neither succeed nor fail at delivery. On a live machine that lane was 989 of
+// 1028 attributed records, and counting it as delivered turned one failure out
+// of three real write attempts into one out of twenty-nine — a path that fails
+// a third of the time reading as a healthy path with an incident. Widening a
+// denominator until the rate disappears is a shape this diagnosis has met more
+// than once, and the fix each time was to name what the number is over.
+func TestDeliveryHealthKeepsTheQuietLaneOutOfTheRate(t *testing.T) {
+	entries := []aiIngestLogEntry{
+		{Source: "codex-hook", Event: "Stop", Result: "error", Reason: "exit status 1", Pane: "%1"},
+		{Source: "codex-hook", Event: "SessionStart", Result: "state", Pane: "%1"},
+		{Source: "codex-hook", Event: "PreCompact", Result: "notify", Pane: "%1"},
+	}
+	for range 82 {
+		entries = append(entries, aiIngestLogEntry{Source: "codex-hook", Event: "PreToolUse", Result: "quiet", Pane: "%1"})
+	}
+	delivery := projectAIIngestDeliveryHealth(entries)
+	source := delivery.Sources[0]
+	if source.Delivered != 2 || source.Failed != 1 || source.Quiet != 82 {
+		t.Fatalf("delivered=%d failed=%d quiet=%d, want 2/1/82", source.Delivered, source.Failed, source.Quiet)
+	}
+	if delivery.Records != 3 {
+		t.Fatalf("records = %d, want only the write attempts", delivery.Records)
+	}
+	surface := codexHookDeliverySurface(delivery)
+	if !strings.Contains(surface.Detail, "82 made no write") {
+		t.Fatalf("detail = %q, want the quiet lane reported beside the rate", surface.Detail)
+	}
+	if strings.Contains(surface.Detail, "84 delivered") {
+		t.Fatalf("detail = %q, want the quiet lane out of the delivered count", surface.Detail)
+	}
+	// A window in which nothing attempted a write answers nothing about
+	// delivery, and must not answer well.
+	onlyQuiet := projectAIIngestDeliveryHealth([]aiIngestLogEntry{
+		{Source: "codex-hook", Result: "quiet", Pane: "%1"},
+	})
+	if got := codexHookDeliverySurface(onlyQuiet); got.Status != codexSurfaceStatusUnobserved {
+		t.Fatalf("status = %q (detail %q), want %q when no write was attempted", got.Status, got.Detail, codexSurfaceStatusUnobserved)
+	}
 }

--- a/internal/app/ai_ingest_hook_layer_health_test.go
+++ b/internal/app/ai_ingest_hook_layer_health_test.go
@@ -322,3 +322,36 @@ func TestDeliveryHealthKeepsTheQuietLaneOutOfTheRate(t *testing.T) {
 		t.Fatalf("status = %q (detail %q), want %q when no write was attempted", got.Status, got.Detail, codexSurfaceStatusUnobserved)
 	}
 }
+
+// TestPaneOwnershipVerdictIgnoresForeignLifecycleChurn pins that neither
+// unjudgeable count can move the verdict on its own.
+//
+// Both counts change for reasons this track does not cause. A Pane recording
+// no provider is an ordinary Pane; a Pane the Registry no longer holds is one
+// somebody else retired — on this machine a neighbouring track reclaimed a
+// worker and a single Pane carrying 134 records in the window went absent
+// between two readings of unchanged code, taking the unresolved count from
+// zero to two hundred odd. A row that reddens and greens on a neighbour's
+// housekeeping is a signal nobody can act on, and this diagnosis has already
+// had to learn once what an unactionable red costs.
+func TestPaneOwnershipVerdictIgnoresForeignLifecycleChurn(t *testing.T) {
+	settled := aiIngestOwnershipHealth{Observed: true, Classified: 805}
+	churned := aiIngestOwnershipHealth{Observed: true, Classified: 559, Unresolved: 234, Unrecorded: 235}
+	if before, after := codexPaneOwnershipSurface(settled), codexPaneOwnershipSurface(churned); before.Status != after.Status {
+		t.Fatalf("verdict moved from %q to %q on churn alone (%q → %q)",
+			before.Status, after.Status, before.Detail, after.Detail)
+	}
+	// It must still be visible, or the verdict silently narrows.
+	detail := codexPaneOwnershipSurface(churned).Detail
+	for _, want := range []string{"judged 559 of 1028", "unresolved 234", "provider unrecorded 235"} {
+		if !strings.Contains(detail, want) {
+			t.Fatalf("detail = %q, want it to carry %q", detail, want)
+		}
+	}
+	// A foreign attribution is the one thing that does move it.
+	foreign := churned
+	foreign.Foreign = 1
+	if got := codexPaneOwnershipSurface(foreign); got.Status != codexSurfaceStatusBroken {
+		t.Fatalf("status = %q, want %q once an attribution is provably foreign", got.Status, codexSurfaceStatusBroken)
+	}
+}

--- a/internal/app/ai_ingest_hook_layer_health_test.go
+++ b/internal/app/ai_ingest_hook_layer_health_test.go
@@ -423,3 +423,71 @@ func TestHookWindowSpanIsCarriedOntoTheSection(t *testing.T) {
 		t.Fatalf("hook window = %q with nothing read, want none", empty.HookWindow)
 	}
 }
+
+// TestOwnershipHealthCountsAConversationCarriedByTheWrongSource pins the
+// detector for records that were routed by something that should not have been
+// routing them.
+//
+// It is built from the shape actually observed: a provider host still serving a
+// hook route its configuration no longer carried kept emitting records for
+// another provider's conversations, and 98 of them reached the log over 95
+// minutes. Only two ever attributed — those two the ownership verdict caught.
+// The other 96 failed to attribute and landed in the contractual refusal
+// bucket, which is the right place for them and also where they became
+// indistinguishable from an ordinary retired conversation. Nothing counted
+// them.
+//
+// Ownership is decided by the log's own account of itself rather than by any
+// knowledge of what a provider's identifiers look like: a conversation belongs
+// to the source that names it in its own thread field, so a record from a
+// different source carrying that conversation is misrouted. No version
+// heuristic, no provider table, nothing to rot when an identifier format
+// changes.
+func TestOwnershipHealthCountsAConversationCarriedByTheWrongSource(t *testing.T) {
+	const conversation = "01a0705a-d4dd-71c2-8c65-f0c3b1506715"
+	registry := coremetadata.Registry{Panes: []coremetadata.Pane{
+		paneWithActivation("%122", coremetadata.PaneActivation{Codex: &coremetadata.CodexActivationBinding{ThreadID: conversation}}),
+	}}
+	entries := []aiIngestLogEntry{
+		// The owning source names the conversation in its own thread field.
+		{Source: "codex-hook", Event: "UserPromptSubmit", Result: "state", Pane: "%122", ThreadID: conversation, SessionID: conversation},
+		{Source: "codex-hook", Event: "Stop", Result: "notify", Pane: "%122", ThreadID: conversation, SessionID: conversation},
+		// The same conversation carried by another provider's source: the two
+		// that attributed, and one of the many that did not.
+		{Source: "claude-hook", Event: "UserPromptSubmit", Result: "state", Pane: "%122", SessionID: conversation},
+		{Source: "claude-hook", Event: "Stop", Result: "notify", Pane: "%122", SessionID: conversation},
+		{Source: "claude-hook", Event: "Stop", Result: "ignored", Reason: aiPaneMatchReasonConversationUnknown, SessionID: conversation},
+		// An ordinary record of the other provider's own conversation.
+		{Source: "claude-hook", Event: "Stop", Result: "state", Pane: "%123", ThreadID: "claude-own", SessionID: "claude-own"},
+	}
+	ownership := projectAIIngestOwnershipHealth(entries, registry, true)
+	if ownership.Misrouted != 3 {
+		t.Fatalf("misrouted = %d, want all three records carrying another source's conversation "+
+			"— including the one that never reached a Pane", ownership.Misrouted)
+	}
+	if ownership.Foreign != 2 {
+		t.Fatalf("foreign = %d, want only the two that actually landed on a Pane", ownership.Foreign)
+	}
+	surface := codexPaneOwnershipSurface(ownership)
+	if !strings.Contains(surface.Detail, "3 record(s) misrouted") {
+		t.Fatalf("detail = %q, want the misroute count visible", surface.Detail)
+	}
+	// A window with no cross-provider carriage counts none, so the number
+	// cannot become background noise.
+	clean := projectAIIngestOwnershipHealth([]aiIngestLogEntry{
+		{Source: "codex-hook", Result: "state", Pane: "%122", ThreadID: conversation},
+		{Source: "claude-hook", Result: "state", Pane: "%123", ThreadID: "claude-own"},
+	}, registry, true)
+	if clean.Misrouted != 0 {
+		t.Fatalf("misrouted = %d on a clean window, want none", clean.Misrouted)
+	}
+	// Misrouting alone is a degradation, not a break: the routing that produced
+	// it lives outside this application, so there is nothing here to repair.
+	if got := codexPaneOwnershipSurface(clean); got.Status != codexSurfaceStatusOK {
+		t.Fatalf("clean window = %q, want %q", got.Status, codexSurfaceStatusOK)
+	}
+	degraded := aiIngestOwnershipHealth{Observed: true, Classified: 10, Misrouted: 96}
+	if got := codexPaneOwnershipSurface(degraded); got.Status != codexSurfaceStatusDegraded {
+		t.Fatalf("misrouted-only window = %q, want %q", got.Status, codexSurfaceStatusDegraded)
+	}
+}

--- a/internal/app/ai_ingest_ownership_health.go
+++ b/internal/app/ai_ingest_ownership_health.go
@@ -31,6 +31,17 @@ type aiIngestOwnershipHealth struct {
 	// Foreign counts attributions to a Pane the Registry records under another
 	// provider. This is the number the contract requires to be zero.
 	Foreign int `json:"foreign"`
+	// Directions breaks Foreign down by which way the mismatch runs.
+	//
+	// The two directions have different causes and must not be read as one
+	// number. A hook attributing onto the Pane that launched its host is the
+	// identity leak the contract closes. The opposite direction — a provider's
+	// events arriving under another provider's source — means the event was
+	// misrouted before attribution ever ran, which a stale hook config on the
+	// machine can produce and no code change here would fix. Reporting a single
+	// count would let one be mistaken for the other, and this machine has
+	// carried both.
+	Directions []aiIngestAttributionReason `json:"directions,omitempty"`
 }
 
 // codexHookProviderBinding answers, for one hook source, whether a Pane records
@@ -56,6 +67,7 @@ func projectAIIngestOwnershipHealth(entries []aiIngestLogEntry, registry coremet
 	if !observed {
 		return health
 	}
+	directions := map[string]int{}
 	byRuntime := make(map[string]coremetadata.PaneActivation, len(registry.Panes))
 	for _, pane := range registry.Panes {
 		if runtime := strings.TrimSpace(pane.Status.Activation.RuntimeID); runtime != "" {
@@ -88,8 +100,19 @@ func projectAIIngestOwnershipHealth(entries []aiIngestLogEntry, registry coremet
 		}
 		health.Classified++
 		health.Foreign++
+		directions[source+" onto "+paneRecordedProvider(activation)]++
 	}
+	health.Directions = aiIngestAttributionReasons(directions)
 	return health
+}
+
+// paneRecordedProvider names the provider the Registry records for one Pane.
+// It is only ever called for a Pane that records one.
+func paneRecordedProvider(activation coremetadata.PaneActivation) string {
+	if activation.Codex != nil {
+		return "codex"
+	}
+	return "claude"
 }
 
 // paneRecordsAnyProvider reports whether the Registry positively records a

--- a/internal/app/ai_ingest_ownership_health.go
+++ b/internal/app/ai_ingest_ownership_health.go
@@ -31,6 +31,18 @@ type aiIngestOwnershipHealth struct {
 	// Foreign counts attributions to a Pane the Registry records under another
 	// provider. This is the number the contract requires to be zero.
 	Foreign int `json:"foreign"`
+	// Unrecorded counts attributions to a Pane the Registry holds but records
+	// no provider for.
+	//
+	// These are the ones this verdict cannot judge, and the count exists so
+	// that a zero above it cannot be read as "nothing was misattributed". The
+	// ownership guarantee closed the case where a Pane positively records
+	// another provider; a Pane recording none resolves the old way, so an
+	// attribution landing there is neither proven right nor proven wrong.
+	// Rendering only the foreign count would let this diagnosis certify past
+	// the guarantee it is reporting on -- a check overstating what it checked,
+	// which is the failure this whole section was built to end.
+	Unrecorded int `json:"unrecorded"`
 	// Directions breaks Foreign down by which way the mismatch runs.
 	//
 	// The two directions have different causes and must not be read as one
@@ -94,8 +106,10 @@ func projectAIIngestOwnershipHealth(entries []aiIngestLogEntry, registry coremet
 			continue
 		}
 		if !paneRecordsAnyProvider(activation) {
-			// No provider recorded is not another provider. Leaving it
-			// unclassified keeps the foreign count meaning exactly one thing.
+			// No provider recorded is not another provider. Counting it apart
+			// keeps the foreign number meaning exactly one thing while still
+			// showing how much of the window that number does not cover.
+			health.Unrecorded++
 			continue
 		}
 		health.Classified++

--- a/internal/app/ai_ingest_ownership_health.go
+++ b/internal/app/ai_ingest_ownership_health.go
@@ -31,6 +31,21 @@ type aiIngestOwnershipHealth struct {
 	// Foreign counts attributions to a Pane the Registry records under another
 	// provider. This is the number the contract requires to be zero.
 	Foreign int `json:"foreign"`
+	// Misrouted counts records whose conversation belongs to another provider's
+	// source, whether or not they ever reached a Pane.
+	//
+	// It is found without asking what a provider's identifiers look like: a
+	// conversation claimed by one source and carried by another is misrouted by
+	// the log's own account of itself, and no version heuristic or provider
+	// table is involved.
+	//
+	// The count matters because the rest of this projection cannot see it. A
+	// misrouted record that fails to attribute lands in the contractual refusal
+	// bucket, which is the correct place for it -- the conversation genuinely
+	// belongs to no Pane the matcher can reach -- and there it is
+	// indistinguishable from an ordinary retired conversation. On this machine
+	// that hid 96 of 98 such records behind a number that reads as routine.
+	Misrouted int `json:"misrouted"`
 	// Unrecorded counts attributions to a Pane the Registry holds but records
 	// no provider for.
 	//
@@ -86,6 +101,7 @@ func projectAIIngestOwnershipHealth(entries []aiIngestLogEntry, registry coremet
 			byRuntime[runtime] = pane.Status.Activation
 		}
 	}
+	health.Misrouted = countMisroutedConversations(entries)
 	for _, entry := range entries {
 		source := strings.TrimSpace(entry.Source)
 		binds, known := codexHookProviderBinding[source]
@@ -133,4 +149,53 @@ func paneRecordedProvider(activation coremetadata.PaneActivation) string {
 // provider for this Pane.
 func paneRecordsAnyProvider(activation coremetadata.PaneActivation) bool {
 	return activation.Codex != nil || activation.Claude != nil
+}
+
+// aiIngestConversationID takes the conversation a record belongs to.
+//
+// A hook records its conversation under whichever field its provider uses, and
+// this reader does not care which: it needs an identifier stable enough to say
+// that two records describe the same conversation.
+func aiIngestConversationID(entry aiIngestLogEntry) string {
+	if thread := strings.TrimSpace(entry.ThreadID); thread != "" {
+		return thread
+	}
+	return strings.TrimSpace(entry.SessionID)
+}
+
+// countMisroutedConversations counts records carried by a source that does not
+// own their conversation.
+//
+// Ownership is decided by the log rather than by any knowledge of provider
+// identifier formats: a conversation is owned by the source that names it in
+// its own thread field, and a record from a different source carrying that
+// same conversation was routed by something that should not have been routing
+// it. Two sources legitimately sharing one conversation would defeat this, and
+// nothing in the hook contract does that.
+func countMisroutedConversations(entries []aiIngestLogEntry) int {
+	owner := map[string]string{}
+	for _, entry := range entries {
+		source := strings.TrimSpace(entry.Source)
+		if _, known := codexHookProviderBinding[source]; !known {
+			continue
+		}
+		if thread := strings.TrimSpace(entry.ThreadID); thread != "" {
+			owner[thread] = source
+		}
+	}
+	misrouted := 0
+	for _, entry := range entries {
+		source := strings.TrimSpace(entry.Source)
+		if _, known := codexHookProviderBinding[source]; !known {
+			continue
+		}
+		conversation := aiIngestConversationID(entry)
+		if conversation == "" {
+			continue
+		}
+		if claimant, found := owner[conversation]; found && claimant != source {
+			misrouted++
+		}
+	}
+	return misrouted
 }

--- a/internal/app/ai_ingest_ownership_health.go
+++ b/internal/app/ai_ingest_ownership_health.go
@@ -46,6 +46,18 @@ type aiIngestOwnershipHealth struct {
 	// indistinguishable from an ordinary retired conversation. On this machine
 	// that hid 96 of 98 such records behind a number that reads as routine.
 	Misrouted int `json:"misrouted"`
+	// OwnedConversations is how many distinct conversations in the window had
+	// their owning source observed.
+	//
+	// It is the denominator Misrouted is over, and it has to be rendered
+	// because the detector is a join: a record is only known to be misrouted
+	// while the conversation's owner is also in the window. The log is trimmed
+	// by size, so the owner's records can age out while the misrouted ones
+	// remain, and the count silently returns to zero. That is not a repair --
+	// it is the detector going blind, and it was observed doing so: 98 fell to
+	// 2 across one trim with nothing changed. A zero over a small denominator
+	// means "little was visible"; over a large one it means "little happened".
+	OwnedConversations int `json:"owned_conversations"`
 	// Unrecorded counts attributions to a Pane the Registry holds but records
 	// no provider for.
 	//
@@ -101,7 +113,7 @@ func projectAIIngestOwnershipHealth(entries []aiIngestLogEntry, registry coremet
 			byRuntime[runtime] = pane.Status.Activation
 		}
 	}
-	health.Misrouted = countMisroutedConversations(entries)
+	health.Misrouted, health.OwnedConversations = countMisroutedConversations(entries)
 	for _, entry := range entries {
 		source := strings.TrimSpace(entry.Source)
 		binds, known := codexHookProviderBinding[source]
@@ -172,7 +184,7 @@ func aiIngestConversationID(entry aiIngestLogEntry) string {
 // same conversation was routed by something that should not have been routing
 // it. Two sources legitimately sharing one conversation would defeat this, and
 // nothing in the hook contract does that.
-func countMisroutedConversations(entries []aiIngestLogEntry) int {
+func countMisroutedConversations(entries []aiIngestLogEntry) (int, int) {
 	owner := map[string]string{}
 	for _, entry := range entries {
 		source := strings.TrimSpace(entry.Source)
@@ -197,5 +209,5 @@ func countMisroutedConversations(entries []aiIngestLogEntry) int {
 			misrouted++
 		}
 	}
-	return misrouted
+	return misrouted, len(owner)
 }

--- a/internal/app/ai_ingest_ownership_health.go
+++ b/internal/app/ai_ingest_ownership_health.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"strings"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+)
+
+// Attribution can succeed and still be wrong.
+//
+// A hook is handed a Pane identity explicitly, and the process that runs it may
+// have inherited that identity from whatever Pane happened to launch it rather
+// than from the Pane that owns the conversation. The event then lands on a real
+// Pane, is recorded as attributed, and belongs to somebody else. Counting it as
+// a success is the failure this surface exists to make visible.
+
+// aiIngestOwnershipHealth is the content-free projection of whether attributed
+// hook events landed on a Pane of their own provider.
+type aiIngestOwnershipHealth struct {
+	// Observed reports whether both a log and a Registry were readable. One
+	// without the other answers nothing, and answering nothing must not read
+	// as answering well.
+	Observed bool `json:"observed"`
+	// Classified counts attributions this reader could judge: the Pane was
+	// found in the Registry and records a provider.
+	Classified int `json:"classified"`
+	// Unresolved counts attributions to a Pane the Registry no longer holds.
+	// A Pane that is gone is outside the attribution contract, so this is
+	// reported beside the verdict rather than inside it.
+	Unresolved int `json:"unresolved"`
+	// Foreign counts attributions to a Pane the Registry records under another
+	// provider. This is the number the contract requires to be zero.
+	Foreign int `json:"foreign"`
+}
+
+// codexHookProviderBinding answers, for one hook source, whether a Pane records
+// that provider.
+//
+// It is a table rather than a branch on purpose. The attribution contract is
+// provider-neutral, and a reader that special-cased one provider would reopen
+// the asymmetry the hook identity work closed.
+var codexHookProviderBinding = map[string]func(coremetadata.PaneActivation) bool{
+	"codex-hook":  func(activation coremetadata.PaneActivation) bool { return activation.Codex != nil },
+	"claude-hook": func(activation coremetadata.PaneActivation) bool { return activation.Claude != nil },
+}
+
+// projectAIIngestOwnershipHealth judges each attributed hook event against the
+// Registry's record of the Pane it landed on.
+//
+// The predicate is deliberately one-sided: an attribution is foreign only when
+// the Pane positively records a different provider. A Pane that records no
+// provider at all is not a contradiction, and calling it one would turn every
+// ordinary shell Pane into a finding and bury the case that matters.
+func projectAIIngestOwnershipHealth(entries []aiIngestLogEntry, registry coremetadata.Registry, observed bool) aiIngestOwnershipHealth {
+	health := aiIngestOwnershipHealth{Observed: observed}
+	if !observed {
+		return health
+	}
+	byRuntime := make(map[string]coremetadata.PaneActivation, len(registry.Panes))
+	for _, pane := range registry.Panes {
+		if runtime := strings.TrimSpace(pane.Status.Activation.RuntimeID); runtime != "" {
+			byRuntime[runtime] = pane.Status.Activation
+		}
+	}
+	for _, entry := range entries {
+		source := strings.TrimSpace(entry.Source)
+		binds, known := codexHookProviderBinding[source]
+		if !known {
+			continue
+		}
+		runtime := strings.TrimSpace(entry.Pane)
+		if runtime == "" {
+			continue
+		}
+		activation, found := byRuntime[runtime]
+		if !found {
+			health.Unresolved++
+			continue
+		}
+		if binds(activation) {
+			health.Classified++
+			continue
+		}
+		if !paneRecordsAnyProvider(activation) {
+			// No provider recorded is not another provider. Leaving it
+			// unclassified keeps the foreign count meaning exactly one thing.
+			continue
+		}
+		health.Classified++
+		health.Foreign++
+	}
+	return health
+}
+
+// paneRecordsAnyProvider reports whether the Registry positively records a
+// provider for this Pane.
+func paneRecordsAnyProvider(activation coremetadata.PaneActivation) bool {
+	return activation.Codex != nil || activation.Claude != nil
+}

--- a/internal/app/ai_ingest_reason_vocabulary_test.go
+++ b/internal/app/ai_ingest_reason_vocabulary_test.go
@@ -6,6 +6,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -408,5 +409,73 @@ func sample(c *aiCommand, err error) {
 	}
 	if found[0].Position.Line != 10 {
 		t.Fatalf("counted line %d, want the log entry on line 10", found[0].Position.Line)
+	}
+}
+
+// aiIngestReasonAssertion matches a test asserting the content of the ingest
+// log's reason field.
+var aiIngestReasonAssertion = regexp.MustCompile(`"reason":"([^"]*)"`)
+
+// TestNoTestExpectsALeakedReason is the narrow half of the leak rule.
+//
+// A test that fixes a leaked value as its expected output is why the leak
+// survives: repairing it turns the suite red, so nobody repairs it. Two such
+// tests were found on this track, and they had pinned a provider's own text
+// into the reason column.
+//
+// The rule reaches only what it can see, and the scoping was measured rather
+// than guessed. Matching these shapes anywhere in a quoted string across the
+// test corpus hits 1598 lines -- socket fixtures, executable paths, transport
+// tables, nearly all legitimate -- and a gate that reddens on those is one
+// people switch off. Matching them inside an asserted reason field hits none
+// today and catches the shape tomorrow.
+//
+// What it cannot see is the pair that prompted it. `unknown termination
+// reason: FUTURE_SAFE_REASON` carries no forbidden shape; what made it a leak
+// is that the tail came from the provider's payload, and provenance is a
+// runtime fact no syntax check reaches. The runtime half -- drive a failure,
+// assert the log does not contain the input -- belongs with the vocabulary
+// owner. This rule makes the detectable half unavoidable and claims nothing
+// about the rest.
+func TestNoTestExpectsALeakedReason(t *testing.T) {
+	root := repoRootForGate(t)
+	var leaked []string
+	for _, scope := range []struct {
+		dir   string
+		match func(string) bool
+	}{
+		{dir: "internal", match: func(name string) bool { return strings.HasSuffix(name, "_test.go") }},
+		{dir: filepath.Join("test", "e2e"), match: func(name string) bool { return strings.HasSuffix(name, ".sh") }},
+	} {
+		err := filepath.WalkDir(filepath.Join(root, scope.dir), func(path string, entry os.DirEntry, err error) error {
+			if err != nil || entry.IsDir() || !scope.match(entry.Name()) {
+				return err
+			}
+			payload, readErr := os.ReadFile(path) // #nosec G304 -- repository source under test.
+			if readErr != nil {
+				return readErr
+			}
+			relative, _ := filepath.Rel(root, path)
+			for index, line := range strings.Split(string(payload), "\n") {
+				for _, match := range aiIngestReasonAssertion.FindAllStringSubmatch(line, -1) {
+					for _, forbidden := range aiIngestReasonForbiddenText {
+						if strings.Contains(match[1], forbidden) {
+							leaked = append(leaked, relative+":"+strconv.Itoa(index+1)+": expects "+strconv.Quote(match[1]))
+						}
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", scope.dir, err)
+		}
+	}
+	sort.Strings(leaked)
+	if len(leaked) > 0 {
+		t.Fatalf("%d test(s) expect a reason carrying a value the column may not hold:\n  %s\n\n"+
+			"Fixing a leak as the expected output is why leaks survive: repairing one turns the suite red. "+
+			"Expect the bounded token the column should hold instead.",
+			len(leaked), strings.Join(leaked, "\n  "))
 	}
 }

--- a/internal/app/ai_ingest_reason_vocabulary_test.go
+++ b/internal/app/ai_ingest_reason_vocabulary_test.go
@@ -295,6 +295,10 @@ func sample(c *aiCommand, err error, reason string) {
 	c.appendAIIngestLog(aiIngestLogEntry{Reason: aiPaneMatchReasonNoMatch})
 	c.appendAIIngestLog(aiIngestLogEntry{Reason: string(codexObserverReasonReady)})
 	c.appendAIIngestLog(aiIngestLogEntry{Reason: "pane inventory unavailable"})
+	// A different struct that happens to spell the same field name. Its value
+	// never reaches the log, and counting it would make this gate refuse code
+	// it has no claim over.
+	_ = otherHealth{Reason: err.Error()}
 }
 `
 	fileSet := token.NewFileSet()
@@ -359,5 +363,50 @@ func sample(c *aiCommand, err error) {
 	}
 	if !strings.Contains(found[0].Shape, "via hookLogEntry()") {
 		t.Fatalf("shape = %q, want the sink named so the caller can be found", found[0].Shape)
+	}
+}
+
+// TestIngestReasonAuditIgnoresAForeignStructNamedReason pins the filter that
+// keeps this gate inside its own claim.
+//
+// `Reason` is an ordinary field name. Several structs in this package carry one
+// and never reach the ingest log -- a session-state health projection and a
+// pane blocker among them -- and each writes an error's text into it quite
+// legitimately. A scan that matched the field name alone would refuse code it
+// has no claim over, which is the same failure as counting a contractual
+// refusal among the breakages: a gate declaring something broken that is
+// working exactly as specified.
+//
+// The filter has to hold on both paths. The literal scan checks the composite
+// type directly; the sink scan reaches call sites, and only functions whose own
+// log-entry literal binds a parameter are ever promoted, so a foreign struct
+// cannot introduce one.
+func TestIngestReasonAuditIgnoresAForeignStructNamedReason(t *testing.T) {
+	const source = `package app
+
+type otherHealth struct{ Reason string }
+
+func otherEntry(reason string) otherHealth { return otherHealth{Reason: reason} }
+
+func sample(c *aiCommand, err error) {
+	_ = otherHealth{Reason: err.Error()}
+	_ = otherEntry(err.Error())
+	c.appendAIIngestLog(aiIngestLogEntry{Reason: err.Error()})
+}
+`
+	fileSet := token.NewFileSet()
+	parsed, err := parser.ParseFile(fileSet, "sample.go", source, 0)
+	if err != nil {
+		t.Fatalf("parse sample: %v", err)
+	}
+	if sinks := aiIngestReasonSinks(parsed); len(sinks) != 0 {
+		t.Fatalf("promoted %+v as a reason sink; only a log-entry literal may promote one", sinks)
+	}
+	found := aiIngestReasonWrites(fileSet, parsed)
+	if len(found) != 1 {
+		t.Fatalf("counted %d write(s), want only the log entry", len(found))
+	}
+	if found[0].Position.Line != 10 {
+		t.Fatalf("counted line %d, want the log entry on line 10", found[0].Position.Line)
 	}
 }

--- a/internal/app/ai_ingest_reason_vocabulary_test.go
+++ b/internal/app/ai_ingest_reason_vocabulary_test.go
@@ -122,6 +122,107 @@ type reasonWrite struct {
 	Shape    string
 }
 
+// reasonSink is a function that builds a log entry whose reason comes from one
+// of its own parameters.
+//
+// A sink is a second doorway into the column, and it is invisible to a scan
+// that only reads entry literals: the literal inside the sink names an
+// identifier, which is bounded as far as that file can tell, while every caller
+// hands it whatever it likes. This is not hypothetical. One provider's path
+// routes six raw errors through a sink today, and reading only the literals
+// counted that provider as one violation instead of seven.
+type reasonSink struct {
+	Name  string
+	Param int
+}
+
+// aiIngestReasonSinks finds the functions that pass a parameter into the reason
+// column.
+//
+// One level of indirection is followed, not an arbitrary chain. A sink calling
+// another sink would escape this, and closing that needs the value's type
+// rather than its syntax -- which is the other half of this guarantee and
+// belongs with whoever owns the vocabulary. What this closes is the doorway
+// that is standing open.
+func aiIngestReasonSinks(file *ast.File) []reasonSink {
+	var sinks []reasonSink
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Type.Params == nil {
+			continue
+		}
+		params := map[string]int{}
+		index := 0
+		for _, field := range function.Type.Params.List {
+			for _, name := range field.Names {
+				params[name.Name] = index
+				index++
+			}
+		}
+		ast.Inspect(function, func(node ast.Node) bool {
+			literal, ok := node.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			name, ok := literal.Type.(*ast.Ident)
+			if !ok || name.Name != "aiIngestLogEntry" {
+				return true
+			}
+			for _, element := range literal.Elts {
+				field, ok := element.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				key, ok := field.Key.(*ast.Ident)
+				if !ok || key.Name != "Reason" {
+					continue
+				}
+				value, ok := field.Value.(*ast.Ident)
+				if !ok {
+					continue
+				}
+				if position, bound := params[value.Name]; bound {
+					sinks = append(sinks, reasonSink{Name: function.Name.Name, Param: position})
+				}
+			}
+			return true
+		})
+	}
+	return sinks
+}
+
+// aiIngestReasonSinkCalls classifies the argument each call hands to a sink.
+func aiIngestReasonSinkCalls(fileSet *token.FileSet, file *ast.File, sinks map[string]int) []reasonWrite {
+	var found []reasonWrite
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		var name string
+		switch fun := call.Fun.(type) {
+		case *ast.Ident:
+			name = fun.Name
+		case *ast.SelectorExpr:
+			name = fun.Sel.Name
+		default:
+			return true
+		}
+		param, known := sinks[name]
+		if !known || param >= len(call.Args) {
+			return true
+		}
+		if raw := aiIngestReasonRawValue(call.Args[param]); raw != "" {
+			found = append(found, reasonWrite{
+				Position: fileSet.Position(call.Args[param].Pos()),
+				Shape:    raw + " via " + name + "()",
+			})
+		}
+		return true
+	})
+	return found
+}
+
 // TestIngestReasonColumnCarriesOnlyBoundedValues is the static half.
 func TestIngestReasonColumnCarriesOnlyBoundedValues(t *testing.T) {
 	dir, err := os.Getwd()
@@ -132,7 +233,13 @@ func TestIngestReasonColumnCarriesOnlyBoundedValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read package directory: %v", err)
 	}
-	var raw []string
+	type parsedFile struct {
+		name    string
+		fileSet *token.FileSet
+		file    *ast.File
+	}
+	var sources []parsedFile
+	sinks := map[string]int{}
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
@@ -148,8 +255,17 @@ func TestIngestReasonColumnCarriesOnlyBoundedValues(t *testing.T) {
 		if parseErr != nil {
 			t.Fatalf("parse %s: %v", name, parseErr)
 		}
-		for _, write := range aiIngestReasonWrites(fileSet, parsed) {
-			raw = append(raw, name+":"+strconv.Itoa(write.Position.Line)+": "+write.Shape)
+		sources = append(sources, parsedFile{name: name, fileSet: fileSet, file: parsed})
+		for _, sink := range aiIngestReasonSinks(parsed) {
+			sinks[sink.Name] = sink.Param
+		}
+	}
+	var raw []string
+	for _, source := range sources {
+		writes := aiIngestReasonWrites(source.fileSet, source.file)
+		writes = append(writes, aiIngestReasonSinkCalls(source.fileSet, source.file, sinks)...)
+		for _, write := range writes {
+			raw = append(raw, source.name+":"+strconv.Itoa(write.Position.Line)+": "+write.Shape)
 		}
 	}
 	sort.Strings(raw)
@@ -199,5 +315,49 @@ func sample(c *aiCommand, err error, reason string) {
 		if write.Position.Line < 4 || write.Position.Line > 7 {
 			t.Fatalf("line %d was classified raw; the bounded writes start at line 8", write.Position.Line)
 		}
+	}
+}
+
+// TestIngestReasonAuditFollowsAReasonThroughItsSink is the second half of the
+// gate checking itself.
+//
+// A scan that reads only entry literals sees a sink's inner literal name an
+// identifier and calls it bounded, while every caller hands that identifier
+// whatever it likes. One provider routes six raw errors that way today, and
+// reading only the literals counted that provider as one violation instead of
+// seven -- so the gate under-reported the very number it was asked to be the
+// judgment of record for.
+func TestIngestReasonAuditFollowsAReasonThroughItsSink(t *testing.T) {
+	const source = `package app
+
+func hookLogEntry(paneID string, result, reason string) aiIngestLogEntry {
+	return aiIngestLogEntry{Pane: paneID, Result: result, Reason: reason}
+}
+
+func sample(c *aiCommand, err error) {
+	c.appendAIIngestLog(hookLogEntry("%1", "error", err.Error()))
+	c.appendAIIngestLog(hookLogEntry("%1", "ignored", aiPaneMatchReasonNoMatch))
+}
+`
+	fileSet := token.NewFileSet()
+	parsed, err := parser.ParseFile(fileSet, "sample.go", source, 0)
+	if err != nil {
+		t.Fatalf("parse sample: %v", err)
+	}
+	sinks := aiIngestReasonSinks(parsed)
+	if len(sinks) != 1 || sinks[0].Name != "hookLogEntry" || sinks[0].Param != 2 {
+		t.Fatalf("sinks = %+v, want the reason parameter of hookLogEntry at index 2", sinks)
+	}
+	// The literal inside the sink names a parameter, so the literal scan alone
+	// must find nothing. That is exactly why the sink scan has to exist.
+	if direct := aiIngestReasonWrites(fileSet, parsed); len(direct) != 0 {
+		t.Fatalf("literal scan found %+v, want the sink to be invisible to it", direct)
+	}
+	found := aiIngestReasonSinkCalls(fileSet, parsed, map[string]int{"hookLogEntry": 2})
+	if len(found) != 1 {
+		t.Fatalf("sink scan found %d call(s), want only the one handing over a raw error", len(found))
+	}
+	if !strings.Contains(found[0].Shape, "via hookLogEntry()") {
+		t.Fatalf("shape = %q, want the sink named so the caller can be found", found[0].Shape)
 	}
 }

--- a/internal/app/ai_ingest_reason_vocabulary_test.go
+++ b/internal/app/ai_ingest_reason_vocabulary_test.go
@@ -1,0 +1,203 @@
+package app
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The reason column of ai-ingest.log is a closed vocabulary, and this is the
+// gate that keeps it one.
+//
+// Every other surface in this diagnosis reads that column. A bounded token
+// there is what lets a reader count, compare and classify; a subprocess message
+// there is a sentence nobody can aggregate, and it carries whatever the
+// subprocess felt like printing -- a socket path, a home directory, an exit
+// status. This track's change boundary excludes exactly that.
+//
+// The static half matters more than the dynamic half. Injecting a failure and
+// asserting the log stays clean only covers the paths a fixture actually
+// drives; the sites that write a raw error are many, and hitting one of them
+// leaves the rest open behind a green run. Reading the writes themselves
+// covers all of them at once.
+
+// aiIngestReasonForbiddenText are shapes that must never reach the column.
+//
+// They are the spellings observed in the field rather than a general secret
+// scan: an absolute path, the transport label's own rendering, and the
+// subprocess phrases that appear when a raw error is passed through.
+var aiIngestReasonForbiddenText = []string{
+	"/tmp/", "/home/", "-S/", "-L/",
+	"exit status", "no server running", "error connecting to",
+}
+
+// aiIngestReasonRawValue reports whether one expression assigned to the reason
+// column carries an unbounded value.
+//
+// Two shapes are refused. A call to Error() hands the column whatever an error
+// chose to say, and a concatenation builds a sentence rather than naming a
+// token. Everything else -- an identifier, a constant, a conversion of a
+// vocabulary type -- is left alone: this gate cannot prove an identifier holds
+// a bounded token, and pretending otherwise would make it noise.
+func aiIngestReasonRawValue(expression ast.Expr) string {
+	switch value := expression.(type) {
+	case *ast.CallExpr:
+		if selector, ok := value.Fun.(*ast.SelectorExpr); ok && selector.Sel.Name == "Error" {
+			return "err.Error()"
+		}
+		if selector, ok := value.Fun.(*ast.SelectorExpr); ok {
+			if pkg, ok := selector.X.(*ast.Ident); ok && pkg.Name == "fmt" {
+				return "fmt." + selector.Sel.Name
+			}
+		}
+		return ""
+	case *ast.BinaryExpr:
+		if value.Op != token.ADD {
+			return ""
+		}
+		if raw := aiIngestReasonRawValue(value.X); raw != "" {
+			return raw + " (concatenated)"
+		}
+		if raw := aiIngestReasonRawValue(value.Y); raw != "" {
+			return raw + " (concatenated)"
+		}
+		return ""
+	case *ast.BasicLit:
+		if value.Kind != token.STRING {
+			return ""
+		}
+		text, err := strconv.Unquote(value.Value)
+		if err != nil {
+			return ""
+		}
+		for _, forbidden := range aiIngestReasonForbiddenText {
+			if strings.Contains(text, forbidden) {
+				return "literal containing " + strconv.Quote(forbidden)
+			}
+		}
+		return ""
+	default:
+		return ""
+	}
+}
+
+// aiIngestReasonWrites finds every reason value one file writes into the log.
+func aiIngestReasonWrites(fileSet *token.FileSet, file *ast.File) []reasonWrite {
+	var found []reasonWrite
+	ast.Inspect(file, func(node ast.Node) bool {
+		literal, ok := node.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		name, ok := literal.Type.(*ast.Ident)
+		if !ok || name.Name != "aiIngestLogEntry" {
+			return true
+		}
+		for _, element := range literal.Elts {
+			field, ok := element.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := field.Key.(*ast.Ident)
+			if !ok || key.Name != "Reason" {
+				continue
+			}
+			if raw := aiIngestReasonRawValue(field.Value); raw != "" {
+				found = append(found, reasonWrite{Position: fileSet.Position(field.Pos()), Shape: raw})
+			}
+		}
+		return true
+	})
+	return found
+}
+
+type reasonWrite struct {
+	Position token.Position
+	Shape    string
+}
+
+// TestIngestReasonColumnCarriesOnlyBoundedValues is the static half.
+func TestIngestReasonColumnCarriesOnlyBoundedValues(t *testing.T) {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read package directory: %v", err)
+	}
+	var raw []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		payload, readErr := os.ReadFile(path) // #nosec G304 -- package source under test.
+		if readErr != nil {
+			t.Fatalf("read %s: %v", name, readErr)
+		}
+		fileSet := token.NewFileSet()
+		parsed, parseErr := parser.ParseFile(fileSet, path, payload, 0)
+		if parseErr != nil {
+			t.Fatalf("parse %s: %v", name, parseErr)
+		}
+		for _, write := range aiIngestReasonWrites(fileSet, parsed) {
+			raw = append(raw, name+":"+strconv.Itoa(write.Position.Line)+": "+write.Shape)
+		}
+	}
+	sort.Strings(raw)
+	if len(raw) > 0 {
+		t.Fatalf("%d reason write(s) carry an unbounded value:\n  %s\n\n"+
+			"The reason column is a closed vocabulary every diagnosis surface reads. A subprocess message "+
+			"there cannot be counted or compared, and it carries whatever that subprocess printed -- a socket "+
+			"path, a home directory, an exit status. Name a bounded token instead.",
+			len(raw), strings.Join(raw, "\n  "))
+	}
+}
+
+// TestIngestReasonAuditRejectsARawValueItIsShown is the gate checking itself.
+//
+// A rule written down is not a rule that holds. This drives the classifier over
+// each shape it is meant to refuse and each it is meant to leave alone, so the
+// audit cannot quietly stop recognising the thing it exists to find.
+func TestIngestReasonAuditRejectsARawValueItIsShown(t *testing.T) {
+	const source = `package app
+
+func sample(c *aiCommand, err error, reason string) {
+	c.appendAIIngestLog(aiIngestLogEntry{Reason: err.Error()})
+	c.appendAIIngestLog(aiIngestLogEntry{Reason: "route: " + err.Error()})
+	c.appendAIIngestLog(aiIngestLogEntry{Reason: fmt.Sprintf("failed on %s", path)})
+	c.appendAIIngestLog(aiIngestLogEntry{Reason: "no server running on the socket"})
+	c.appendAIIngestLog(aiIngestLogEntry{Reason: reason})
+	c.appendAIIngestLog(aiIngestLogEntry{Reason: aiPaneMatchReasonNoMatch})
+	c.appendAIIngestLog(aiIngestLogEntry{Reason: string(codexObserverReasonReady)})
+	c.appendAIIngestLog(aiIngestLogEntry{Reason: "pane inventory unavailable"})
+}
+`
+	fileSet := token.NewFileSet()
+	parsed, err := parser.ParseFile(fileSet, "sample.go", source, 0)
+	if err != nil {
+		t.Fatalf("parse sample: %v", err)
+	}
+	found := aiIngestReasonWrites(fileSet, parsed)
+	if len(found) != 4 {
+		shapes := make([]string, 0, len(found))
+		for _, write := range found {
+			shapes = append(shapes, strconv.Itoa(write.Position.Line)+":"+write.Shape)
+		}
+		t.Fatalf("classified %d write(s) as raw, want the error, the concatenation, the Sprintf and the "+
+			"subprocess literal — and none of the bounded four\n%v", len(found), shapes)
+	}
+	for _, write := range found {
+		if write.Position.Line < 4 || write.Position.Line > 7 {
+			t.Fatalf("line %d was classified raw; the bounded writes start at line 8", write.Position.Line)
+		}
+	}
+}

--- a/internal/app/attention.go
+++ b/internal/app/attention.go
@@ -657,10 +657,16 @@ func (c *attentionCommand) unsetPaneOption(paneID, option string) {
 }
 
 func (c *attentionCommand) selectPaneTitle(paneID, title string) {
+	// best-effort-write: a pane title is decoration. Nothing reads it back and
+	// no record claims it was set, so a failure here cannot make a surface
+	// report a state the Pane does not hold.
 	_, _ = c.run("tmux", "select-pane", "-T", title, "-t", paneID)
 }
 
 func (c *attentionCommand) displayPaneMessage(paneID, message string) {
+	// best-effort-write: a one-shot message to the operator's own screen. Its
+	// failure mode is the operator not seeing a line they were already looking
+	// at, which is not a lie told to a later reader.
 	_, _ = c.run("tmux", "display-message", "-t", paneID, message)
 }
 

--- a/internal/app/codex_appserver_health_test.go
+++ b/internal/app/codex_appserver_health_test.go
@@ -113,9 +113,12 @@ func TestDoctorCodexAppServerJSONSchemaV2IsAdditive(t *testing.T) {
 		"probe_reason":       "daemon-not-running",
 		"install_capability": "external-cli-only",
 		"endpoint_kind":      "stdio-proxy",
-		"connection_state":   "disconnected",
-		"lifecycle_outcome":  "not-attempted",
-		"lifecycle_reason":   "read-only",
+		// uncaptured-default: `connection_state` is the app-server transport
+		// vocabulary, where disconnected is an observed state rather than a
+		// missing observation.
+		"connection_state":  "disconnected",
+		"lifecycle_outcome": "not-attempted",
+		"lifecycle_reason":  "read-only",
 	}
 	for field, value := range want {
 		if fields[field] != value {

--- a/internal/app/codex_authority_fence.go
+++ b/internal/app/codex_authority_fence.go
@@ -67,14 +67,28 @@ func (c *aiCommand) codexAuthorityFencePath(paneUID string) (string, error) {
 // contend on the same kernel lock; restating the digest or the directory on
 // either side would silently split them into two independent fences.
 func codexAuthorityFencePathIn(stateDir, paneUID string) (string, error) {
+	path, err := codexAuthorityFenceFileIn(stateDir, paneUID)
+	if err != nil {
+		return "", err
+	}
+	if err := localstate.EnsurePrivateDir(filepath.Dir(path)); err != nil {
+		return "", fmt.Errorf("create Codex authority fence directory: %w", err)
+	}
+	return path, nil
+}
+
+// codexAuthorityFenceFileIn derives the fence file without creating anything.
+//
+// It is split out for the one caller that must not create: a diagnostics read
+// establishes whether a Pane's transitions are published under a fence at all,
+// and a reader that created the directory on the way to asking would answer its
+// own question. Every other caller goes through codexAuthorityFencePathIn, so
+// the digest and the directory name are still stated once.
+func codexAuthorityFenceFileIn(stateDir, paneUID string) (string, error) {
 	paneUID = strings.TrimSpace(paneUID)
 	if paneUID == "" {
 		return "", fmt.Errorf("codex authority fence requires pane uid")
 	}
-	dir := filepath.Join(stateDir, codexAuthorityFenceDir)
-	if err := localstate.EnsurePrivateDir(dir); err != nil {
-		return "", fmt.Errorf("create Codex authority fence directory: %w", err)
-	}
 	digest := sha256.Sum256([]byte(paneUID))
-	return filepath.Join(dir, fmt.Sprintf("%x.lock", digest)), nil
+	return filepath.Join(stateDir, codexAuthorityFenceDir, fmt.Sprintf("%x.lock", digest)), nil
 }

--- a/internal/app/codex_authority_settled_observation.go
+++ b/internal/app/codex_authority_settled_observation.go
@@ -1,0 +1,175 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
+)
+
+// How one authority observation stood with respect to the per-Pane fence the
+// writer holds while it publishes (authority, epoch, reason) as three separate
+// tmux set-option calls.
+//
+// The three are not degrees of health. They say which question the observation
+// is allowed to answer: only a settled read may be judged for coherence, a
+// contended read caught a transition in progress and says nothing, and an
+// unfenced Pane has never had a transition published under a fence at all —
+// which on a machine that installed the fenced build means the process writing
+// that Pane predates it.
+const (
+	codexAuthorityFenceSettled   = "settled"
+	codexAuthorityFenceContended = "contended"
+	codexAuthorityFenceUnfenced  = "unfenced"
+	// codexAuthorityFenceUnavailable is a fence this reader could not evaluate,
+	// such as an unresolvable state directory. It is distinct from unfenced so
+	// that a reader failure is never reported as a producer fact.
+	codexAuthorityFenceUnavailable = "unavailable"
+)
+
+// codexAuthorityObservationBudget bounds how long one diagnostics observation
+// waits for a transition in flight to complete.
+//
+// It is short because a diagnostics read must not stall behind a wedged writer,
+// and it does not need to be long: the writer holds the fence across three tmux
+// calls, so a transition that has not settled inside this budget is not a
+// transition this snapshot was going to describe anyway.
+const codexAuthorityObservationBudget = 250 * time.Millisecond
+
+// codexAuthorityObservationPoll is how often the shared acquisition retries
+// inside that budget.
+const codexAuthorityObservationPoll = 10 * time.Millisecond
+
+// codexAuthorityFenceObserver reports how a Pane's fence stood and releases it.
+// It is the seam a test drives to produce one exact interleaving instead of
+// racing for it.
+type codexAuthorityFenceObserver func(context.Context, string) (string, func())
+
+// defaultSettledCodexLifecycleAuthorityLookup reads each Pane's authority
+// triple under the writer's own fence.
+//
+// Doctor's earlier reader took the triple with a plain tmux read. That is the
+// same unfenced sample C-5 removed from the admission path: with a control
+// plane cycling once a second it will eventually land between two of the three
+// writes and render a pairing that no completed transition produced. Reporting
+// that as a fault would train an operator to ignore the row, and reporting it
+// as health would hide a producer that really did stop fencing. Taking the
+// fence is what makes the difference decidable.
+func defaultSettledCodexLifecycleAuthorityLookup(stateDir string) codexLifecycleAuthorityLookup {
+	runner := inttmux.ExecRunner{}
+	observe := defaultCodexAuthorityFenceObserver(stateDir)
+	return func(paneUID string) codexLifecycleAuthorityDiagnostic {
+		ctx, cancel := context.WithTimeout(context.Background(), codexAuthorityObservationBudget)
+		defer cancel()
+		return observeSettledCodexLifecycleAuthority(ctx, runner, observe, paneUID)
+	}
+}
+
+// observeSettledCodexLifecycleAuthority samples one Pane and classifies the
+// sample.
+func observeSettledCodexLifecycleAuthority(
+	ctx context.Context,
+	runner tmuxRunner,
+	observe codexAuthorityFenceObserver,
+	paneUID string,
+) codexLifecycleAuthorityDiagnostic {
+	fence := codexAuthorityFenceUnavailable
+	var release func()
+	if observe != nil {
+		fence, release = observe(ctx, paneUID)
+	}
+	if release != nil {
+		defer release()
+	}
+	diagnostic := observeCodexLifecycleAuthority(ctx, runner, paneUID)
+	diagnostic.Fence = fence
+	if fence == codexAuthorityFenceSettled {
+		diagnostic.Torn = codexAuthorityTripleTorn(diagnostic.Source, diagnostic.Epoch)
+	}
+	return diagnostic
+}
+
+// codexAuthorityTripleTorn reports whether an authority and epoch pairing is
+// one no completed transition produces.
+//
+// A control-plane or invalidating authority names a live native epoch, so an
+// empty epoch beside it is the state between the authority write and the epoch
+// write. A hook authority is published with the epoch cleared, so an epoch
+// beside it is the same interval seen from the other direction. Both are the
+// exact shape that refused a live Pane its turn before C-5 fenced the read.
+func codexAuthorityTripleTorn(source, epoch string) bool {
+	epoch = strings.TrimSpace(epoch)
+	switch source {
+	case codexAuthorityControlPlane, codexAuthorityInvalidating:
+		return epoch == ""
+	case codexAuthorityHook:
+		return epoch != ""
+	default:
+		return false
+	}
+}
+
+// defaultCodexAuthorityFenceObserver takes the writer's fence in shared mode
+// without creating it.
+//
+// Two properties are deliberate. It never creates the file or its directory, so
+// asking whether a Pane's transitions are fenced cannot manufacture the answer;
+// and it takes a shared lock rather than the writer's exclusive one, so two
+// concurrent diagnostics reads do not serialize behind each other while both
+// still exclude a writer mid-transition.
+func defaultCodexAuthorityFenceObserver(stateDir string) codexAuthorityFenceObserver {
+	return func(ctx context.Context, paneUID string) (string, func()) {
+		if strings.TrimSpace(stateDir) == "" {
+			return codexAuthorityFenceUnavailable, nil
+		}
+		path, err := codexAuthorityFenceFileIn(stateDir, paneUID)
+		if err != nil {
+			return codexAuthorityFenceUnavailable, nil
+		}
+		// #nosec G304 -- codexAuthorityFenceFileIn returns the private state
+		// directory plus a digest of the Registry-authenticated Pane uid.
+		file, err := os.Open(path)
+		if errors.Is(err, os.ErrNotExist) {
+			return codexAuthorityFenceUnfenced, nil
+		}
+		if err != nil {
+			return codexAuthorityFenceUnavailable, nil
+		}
+		if !acquireSharedFence(ctx, file) {
+			_ = file.Close()
+			return codexAuthorityFenceContended, nil
+		}
+		var once sync.Once
+		return codexAuthorityFenceSettled, func() {
+			once.Do(func() {
+				_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+				_ = file.Close()
+			})
+		}
+	}
+}
+
+// acquireSharedFence polls for the shared lock inside the caller's deadline.
+func acquireSharedFence(ctx context.Context, file *os.File) bool {
+	for {
+		err := syscall.Flock(int(file.Fd()), syscall.LOCK_SH|syscall.LOCK_NB)
+		if err == nil {
+			return true
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			return false
+		}
+		timer := time.NewTimer(codexAuthorityObservationPoll)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return false
+		case <-timer.C:
+		}
+	}
+}

--- a/internal/app/codex_authority_settled_observation_test.go
+++ b/internal/app/codex_authority_settled_observation_test.go
@@ -1,0 +1,178 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+)
+
+type settledObservationRunner struct{ output string }
+
+func (r settledObservationRunner) Run(context.Context, string, ...string) ([]byte, error) {
+	return []byte(r.output), nil
+}
+
+func paneObservationLine(paneUID, authority, epoch, reason string) string {
+	return strings.Join([]string{paneUID, authority, epoch, reason, "0", "0", "0", ""}, "\x1f")
+}
+
+// TestSettledAuthorityObservationNamesATornTripleOnlyUnderTheFence is the
+// diagnostic half of C-5.
+//
+// The triple is published as three separate tmux writes, so a plain read lands
+// between two of them often enough that reporting every inconsistent pairing as
+// a fault would make the row noise. Under the fence the pairing cannot be an
+// artefact of timing, which is what makes the verdict decidable: a torn triple
+// there means a writer stopped fencing, and that is the defect that refused
+// live Panes their turn.
+func TestSettledAuthorityObservationNamesATornTripleOnlyUnderTheFence(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		authority string
+		epoch     string
+		fence     string
+		wantTorn  bool
+	}{
+		{name: "control plane with no epoch", authority: codexAuthorityControlPlane, fence: codexAuthorityFenceSettled, wantTorn: true},
+		{name: "invalidating with no epoch", authority: codexAuthorityInvalidating, fence: codexAuthorityFenceSettled, wantTorn: true},
+		{name: "hook carrying an epoch", authority: codexAuthorityHook, epoch: "752812-40", fence: codexAuthorityFenceSettled, wantTorn: true},
+		{name: "control plane with its epoch", authority: codexAuthorityControlPlane, epoch: "752812-40", fence: codexAuthorityFenceSettled},
+		{name: "hook with the epoch cleared", authority: codexAuthorityHook, fence: codexAuthorityFenceSettled},
+		{
+			name:      "the same inconsistent pairing caught in flight is not a verdict",
+			authority: codexAuthorityControlPlane,
+			fence:     codexAuthorityFenceContended,
+		},
+		{
+			name:      "nor is it one on a pane whose writer never fenced",
+			authority: codexAuthorityControlPlane,
+			fence:     codexAuthorityFenceUnfenced,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runner := settledObservationRunner{output: paneObservationLine("pane-1", test.authority, test.epoch, string(codexObserverReasonEndpointSuspended))}
+			observe := func(context.Context, string) (string, func()) { return test.fence, nil }
+			diagnostic := observeSettledCodexLifecycleAuthority(context.Background(), runner, observe, "pane-1")
+			if diagnostic.Fence != test.fence {
+				t.Fatalf("fence = %q, want %q", diagnostic.Fence, test.fence)
+			}
+			if diagnostic.Torn != test.wantTorn {
+				t.Fatalf("torn = %v, want %v for %s/%q under %s", diagnostic.Torn, test.wantTorn, test.authority, test.epoch, test.fence)
+			}
+		})
+	}
+}
+
+// TestAuthorityFenceObservationNeverCreatesTheFenceItAsksAbout pins the
+// read-only property that makes the unfenced verdict mean anything.
+//
+// A reader that created the fence file on the way to asking whether the Pane is
+// fenced would answer its own question, and every subsequent read would report
+// a fenced Pane whose writer still never takes one.
+func TestAuthorityFenceObservationNeverCreatesTheFenceItAsksAbout(t *testing.T) {
+	stateDir := t.TempDir()
+	observe := defaultCodexAuthorityFenceObserver(stateDir)
+	fence, release := observe(context.Background(), "pane-never-fenced")
+	if release != nil {
+		release()
+	}
+	if fence != codexAuthorityFenceUnfenced {
+		t.Fatalf("fence = %q, want %q", fence, codexAuthorityFenceUnfenced)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, codexAuthorityFenceDir)); !os.IsNotExist(err) {
+		t.Fatalf("the observation created the fence directory it asked about (stat err = %v)", err)
+	}
+}
+
+// TestAuthorityFenceObservationYieldsToAWriterMidTransition pins that the
+// observer excludes a writer rather than racing it, and that it gives up inside
+// its budget instead of stalling the whole diagnosis behind a wedged writer.
+func TestAuthorityFenceObservationYieldsToAWriterMidTransition(t *testing.T) {
+	stateDir := t.TempDir()
+	path, err := codexAuthorityFencePathIn(stateDir, "pane-live")
+	if err != nil {
+		t.Fatalf("derive fence: %v", err)
+	}
+	writer, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open fence: %v", err)
+	}
+	defer writer.Close()
+	observe := defaultCodexAuthorityFenceObserver(stateDir)
+
+	free, release := observe(context.Background(), "pane-live")
+	if free != codexAuthorityFenceSettled {
+		t.Fatalf("fence with no writer = %q, want %q", free, codexAuthorityFenceSettled)
+	}
+	release()
+
+	if err := syscall.Flock(int(writer.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatalf("hold writer fence: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	held, heldRelease := observe(ctx, "pane-live")
+	if heldRelease != nil {
+		heldRelease()
+	}
+	if held != codexAuthorityFenceContended {
+		t.Fatalf("fence under a writer = %q, want %q", held, codexAuthorityFenceContended)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("observation waited %s on a held fence, want it bounded by the caller deadline", elapsed)
+	}
+	if err := syscall.Flock(int(writer.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatalf("release writer fence: %v", err)
+	}
+	after, afterRelease := observe(context.Background(), "pane-live")
+	if afterRelease != nil {
+		afterRelease()
+	}
+	if after != codexAuthorityFenceSettled {
+		t.Fatalf("fence after the writer finished = %q, want %q", after, codexAuthorityFenceSettled)
+	}
+}
+
+// TestAuthorityCensusCountsHowEachSnapshotWasTaken pins that the census keeps
+// the four sampling outcomes apart.
+//
+// Folding an unfenced Pane into the torn count would report a deployment fact
+// as a correctness fault, and folding a contended read into either would report
+// a transition in progress as a defect.
+func TestAuthorityCensusCountsHowEachSnapshotWasTaken(t *testing.T) {
+	diagnostics := map[string]codexLifecycleAuthorityDiagnostic{
+		"pane-settled":   {Source: codexAuthorityControlPlane, Epoch: "1-1", Fence: codexAuthorityFenceSettled},
+		"pane-torn":      {Source: codexAuthorityControlPlane, Fence: codexAuthorityFenceSettled, Torn: true},
+		"pane-contended": {Source: codexAuthorityControlPlane, Fence: codexAuthorityFenceContended},
+		"pane-unfenced":  {Source: codexAuthorityHook, Fence: codexAuthorityFenceUnfenced},
+	}
+	registry := registryWithCodexPanes(t, "pane-settled", "pane-torn", "pane-contended", "pane-unfenced")
+	census := censusCodexLifecycleAuthority(registry, func(paneUID string) codexLifecycleAuthorityDiagnostic {
+		return diagnostics[paneUID]
+	})
+	if census.Settled != 2 || census.Torn != 1 || census.Contended != 1 || census.Unfenced != 1 {
+		t.Fatalf("census settled=%d torn=%d contended=%d unfenced=%d, want 2/1/1/1",
+			census.Settled, census.Torn, census.Contended, census.Unfenced)
+	}
+}
+
+func registryWithCodexPanes(t *testing.T, panes ...string) coremetadata.Registry {
+	t.Helper()
+	registry := coremetadata.Registry{}
+	for index, pane := range panes {
+		registry.Agents = append(registry.Agents, coremetadata.Agent{
+			Metadata: coremetadata.ObjectMeta{UID: "agent-" + strconv.Itoa(index)},
+			Spec:     coremetadata.AgentSpec{Provider: aiModeCodex},
+			Status:   coremetadata.AgentStatus{PaneRef: pane},
+		})
+	}
+	return registry
+}

--- a/internal/app/codex_controlplane_contract_test.go
+++ b/internal/app/codex_controlplane_contract_test.go
@@ -1,0 +1,93 @@
+package app
+
+// The regression-detection ledger for the Codex control plane.
+//
+// Three defects lived through a neighbouring eight-phase track closing green
+// from end to end, and the reason was not a weak track: it was that no test
+// reached these surfaces, and the one that did pinned a broken state as its
+// passing condition. Shipping the fixes without this ledger would leave the
+// same blind spot behind under new code.
+//
+// It lives in the test tree on purpose. It is a statement about which tests
+// hold which guarantee, and nothing the application does at runtime may depend
+// on it; the product surface is the diagnosis in codex_controlplane_surfaces.go.
+
+// codexControlPlaneSurfaceContract ties each diagnosed surface to the product
+// contract whose Guarantee it renders.
+var codexControlPlaneSurfaceContract = map[string]string{
+	codexSurfaceBrokerDiagnostics:    "C-1",
+	codexSurfaceHookAttribution:      "C-2",
+	codexSurfaceObserverReason:       "C-3",
+	codexSurfaceConnectionContinuity: "C-3-continuity",
+	codexSurfaceTurnAdmission:        "C-5",
+}
+
+// codexControlPlaneContractEnforcement is each contract's Enforcement cell,
+// carried as test names a build can resolve.
+//
+// Squash merges erase the branch that tied a fix to the test that holds it, so
+// a cell naming a test that no longer exists reads as enforced while enforcing
+// nothing. TestControlPlaneContractCellsNameLiveTests resolves every name here
+// against the declarations in the tree, which turns the roadmap's manual
+// release check into one a build performs.
+var codexControlPlaneContractEnforcement = map[string][]string{
+	// C-1: the broker diagnosis dials the endpoint the runtime published,
+	// rather than a key it assumed. Assuming it reported a live broker as
+	// absent, and an operator killed a process on that answer.
+	"C-1": {
+		"TestBrokerDiagnosticsDialTheEndpointTheRuntimePublished",
+		"TestBrokerDiagnosticsStayAbsentWhenOnlyAnUnpublishedArtifactRemains",
+		"TestBrokerDiagnosticsSelectEveryPublishedEndpointDeterministically",
+		"TestCodexBrokerDiagnosticsSurfaceNamesThePublishedButUnreachableRuntime",
+	},
+	// C-2: a hook event is attributed to the Pane that owns it, from an
+	// identity the hook was handed rather than one inherited from whatever
+	// environment happened to launch it.
+	"C-2": {
+		"TestProviderHookCommandsCarryTheirOwnPaneIdentity",
+		"TestProviderHookPaneArgumentIsProviderNeutral",
+		"TestCodexIntegrationStillOwnsThePaneBlindHookCommand",
+		"TestCodexIntegrationConvergesThePaneBlindHookCommandForward",
+		"TestMatchAIPaneResolvesTheHandedPaneWithoutTmuxEnvironment",
+		"TestMatchAIPanePrefersTheHandedPaneOverInheritedEvidence",
+		"TestMatchAIPaneKeepsTheEstablishedFallbackWhenNothingWasHandedOver",
+		"TestMatchAIPaneRefusesAHandedPaneThatIsGone",
+		"TestAttributionFailureReasonsAreDistinctAndClosed",
+		"TestHookIngestRoutesAcceptTheExplicitPaneArgument",
+		"TestHookAttributionSurfaceSeparatesTotalFailureFromPartial",
+	},
+	// C-3: every authority transition carries a captured reason and leaves a
+	// durable record, so a flapping observer can be told from a frozen one
+	// after the fact.
+	"C-3": {
+		"TestCodexObserverEventLoopExitsCarryTheirOwnReasonToken",
+		"TestCodexObserverExitPathsAreOneToOneWithTokens",
+		"TestCodexObserverReasonVocabularyIsClosed",
+		"TestCodexBrokerEpochRecordsWhyItsStreamClosed",
+		"TestCodexObserverJournalRecordsConnectDisconnectReconnectInOrder",
+		"TestCodexObserverJournalCoalescesRepeatedTransitions",
+		"TestCodexObserverJournalRecordFieldsAreWhitelisted",
+		"TestManagedCodexAuthorityDoctorSeparatesFlappingFrozenAndStopped",
+		"TestObserverReasonSurfaceRefusesToCallAnUncapturedReasonHealthy",
+	},
+	// C-3 continuity: the upstream connection survives a message past the
+	// frame bound instead of dying on it, which is what held the control plane
+	// in a reconnect cycle for hours.
+	"C-3-continuity": {
+		"TestClientDropsAnOversizedAnswerAndKeepsTheConnection",
+		"TestClientKeepsServingRequestsAfterAnOversizedAnswer",
+		"TestWebsocketStreamDropsAnOversizedMessageAndStaysFramed",
+		"TestOversizedAnswerEndsOneMutationAndNotTheConnectionEpoch",
+		"TestOversizedAnswerIsToldApartFromADisconnectBoundary",
+		"TestConnectionContinuitySurfaceReportsCumulativeReconnects",
+	},
+	// C-5: a turn admission judges a completed authority transition, never a
+	// triple sampled between two of its three writes.
+	"C-5": {
+		"TestSettledCodexAuthorityAdmissionIgnoresTornAuthorityWrites",
+		"TestCodexAuthorityAdmissionTakesTheExactWriterFence",
+		"TestConcurrentCodexAuthorityTransitionsNeverExposeATornAdmissionSnapshot",
+		"TestSettledCodexAuthorityReadKeepsTheRegistryRefusalForAPanelessAgent",
+		"TestTurnAdmissionSurfaceReportsATornAuthoritySnapshotAsBroken",
+	},
+}

--- a/internal/app/codex_controlplane_contract_test.go
+++ b/internal/app/codex_controlplane_contract_test.go
@@ -85,12 +85,18 @@ var codexControlPlaneContractEnforcement = map[string][]string{
 	},
 	// C-2 delivery: an attributed hook event changes the Pane it reached, and a
 	// write that cannot happen leaves a bounded reason rather than a raw
-	// process-exit string. Awaiting the Phase 7 vocabulary; the property gate
-	// below holds without naming its tokens.
+	// process-exit string.
+	//
+	// The last entry binds the reflection layer's own declarations, now that
+	// they exist. It asserts those tokens are the kind of answer the verdict
+	// accepts, not that a failure must be one of them -- requiring membership
+	// would tie one provider's vocabulary into a row all three report on.
 	"C-2-delivery": {
 		"TestHookDeliverySurfaceTreatsAnOpaqueFailureAsBroken",
 		"TestDeliveryHealthCountsOnlyAttributedEvents",
+		"TestDeliveryHealthKeepsTheQuietLaneOutOfTheRate",
 		"TestOpaqueDeliveryReasonsNeverReachTheDiagnosis",
+		"TestReflectionRefusalVocabularyIsNeverOpaque",
 	},
 	// C-2 ownership: an attributed hook event landed on a Pane of its own
 	// provider.

--- a/internal/app/codex_controlplane_contract_test.go
+++ b/internal/app/codex_controlplane_contract_test.go
@@ -46,6 +46,7 @@ var codexControlPlaneContractEnforcement = map[string][]string{
 		"TestControlPlaneContractCellsNameLiveTests",
 		"TestHookReflectionWritesNeverDiscardTheirErrorSilently",
 		"TestIngestReasonColumnCarriesOnlyBoundedValues",
+		"TestNoTestExpectsALeakedReason",
 	},
 	// C-1: the broker diagnosis dials the endpoint the runtime published,
 	// rather than a key it assumed. Assuming it reported a live broker as

--- a/internal/app/codex_controlplane_contract_test.go
+++ b/internal/app/codex_controlplane_contract_test.go
@@ -47,6 +47,9 @@ var codexControlPlaneContractEnforcement = map[string][]string{
 		"TestHookReflectionWritesNeverDiscardTheirErrorSilently",
 		"TestIngestReasonColumnCarriesOnlyBoundedValues",
 		"TestNoTestExpectsALeakedReason",
+		"TestHookProjectionBucketsPartitionTheirPopulation",
+		"TestAuthorityCensusBucketsPartitionTheirPopulation",
+		"TestReasonVocabularyIsDeliberatelyNotADoctorSurface",
 	},
 	// C-1: the broker diagnosis dials the endpoint the runtime published,
 	// rather than a key it assumed. Assuming it reported a live broker as

--- a/internal/app/codex_controlplane_contract_test.go
+++ b/internal/app/codex_controlplane_contract_test.go
@@ -20,6 +20,8 @@ var codexControlPlaneSurfaceContract = map[string]string{
 	codexSurfaceObserverReason:       "C-3",
 	codexSurfaceConnectionContinuity: "C-3-continuity",
 	codexSurfaceTurnAdmission:        "C-5",
+	codexSurfaceHookDelivery:         "C-2-delivery",
+	codexSurfacePaneOwnership:        "C-2-ownership",
 }
 
 // codexControlPlaneContractEnforcement is each contract's Enforcement cell,
@@ -80,6 +82,22 @@ var codexControlPlaneContractEnforcement = map[string][]string{
 		"TestOversizedAnswerEndsOneMutationAndNotTheConnectionEpoch",
 		"TestOversizedAnswerIsToldApartFromADisconnectBoundary",
 		"TestConnectionContinuitySurfaceReportsCumulativeReconnects",
+	},
+	// C-2 delivery: an attributed hook event changes the Pane it reached, and a
+	// write that cannot happen leaves a bounded reason rather than a raw
+	// process-exit string. Awaiting the Phase 7 vocabulary; the property gate
+	// below holds without naming its tokens.
+	"C-2-delivery": {
+		"TestHookDeliverySurfaceTreatsAnOpaqueFailureAsBroken",
+		"TestDeliveryHealthCountsOnlyAttributedEvents",
+		"TestOpaqueDeliveryReasonsNeverReachTheDiagnosis",
+	},
+	// C-2 ownership: an attributed hook event landed on a Pane of its own
+	// provider. Awaiting the Phase 8 vocabulary; the property gate below is
+	// provider-neutral and holds without naming its tokens.
+	"C-2-ownership": {
+		"TestPaneOwnershipSurfaceReportsAForeignAttributionAsBroken",
+		"TestOwnershipHealthCallsOnlyAPositivelyForeignPaneForeign",
 	},
 	// C-5: a turn admission judges a completed authority transition, never a
 	// triple sampled between two of its three writes.

--- a/internal/app/codex_controlplane_contract_test.go
+++ b/internal/app/codex_controlplane_contract_test.go
@@ -93,8 +93,32 @@ var codexControlPlaneContractEnforcement = map[string][]string{
 		"TestOpaqueDeliveryReasonsNeverReachTheDiagnosis",
 	},
 	// C-2 ownership: an attributed hook event landed on a Pane of its own
-	// provider. Awaiting the Phase 8 vocabulary; the property gate below is
-	// provider-neutral and holds without naming its tokens.
+	// provider.
+	//
+	// The two entries here are the runtime half, and they are provider-neutral:
+	// they judge attributions the log actually recorded, against the provider
+	// the Registry records for the Pane each one landed on. That half needs no
+	// vocabulary, which is why it exists already.
+	//
+	// The resolver half is still owed, and it cannot be written here yet: it
+	// names symbols the ownership fix introduces, and restating them as string
+	// literals would let a rename walk past this gate silently. Five properties
+	// are waiting on that rebase, and the fifth is the one most easily missed:
+	//
+	//  1. the composite "no other match" refusal is not swallowed by a
+	//     downstream general token;
+	//  2. a rejected explicit identity flows on to the Registry step and the
+	//     established ladder rather than being dropped;
+	//  3. the fall-through skips the inherited-environment step, which carries
+	//     the same envelope that was just rejected and would readmit the leak;
+	//  4. the three older explicit refusals keep their existing behaviour and
+	//     do not fall through, so this gate cannot mistake Phase 2's contract
+	//     for a regression;
+	//  5. the Pane the fall-through finally resolves is not foreign either.
+	//     The ladder's working-directory step matches on path alone, and on a
+	//     machine where two providers share a repository that step can hand
+	//     back the very Pane the explicit check refused. Closing the front door
+	//     and leaving that one open would pass every other property here.
 	"C-2-ownership": {
 		"TestPaneOwnershipSurfaceReportsAForeignAttributionAsBroken",
 		"TestOwnershipHealthCallsOnlyAPositivelyForeignPaneForeign",

--- a/internal/app/codex_controlplane_contract_test.go
+++ b/internal/app/codex_controlplane_contract_test.go
@@ -14,6 +14,8 @@ package app
 
 // codexControlPlaneSurfaceContract ties each diagnosed surface to the product
 // contract whose Guarantee it renders.
+// C-4 has no surface of its own: it is the claim the whole section makes, and
+// its enforcement below covers the section rather than any one row.
 var codexControlPlaneSurfaceContract = map[string]string{
 	codexSurfaceBrokerDiagnostics:    "C-1",
 	codexSurfaceHookAttribution:      "C-2",
@@ -33,6 +35,18 @@ var codexControlPlaneSurfaceContract = map[string]string{
 // against the declarations in the tree, which turns the roadmap's manual
 // release check into one a build performs.
 var codexControlPlaneContractEnforcement = map[string][]string{
+	// C-4 itself: the diagnosis does not mislead about its own numbers. Four
+	// verdicts here were wrong in one day for want of a stated range, and every
+	// one was caught by a person rather than a test.
+	"C-4": {
+		"TestEverySurfaceDeclaresWhatItsNumbersAreOver",
+		"TestEverySurfaceRendersTheScopeItDeclares",
+		"TestHookWindowSpanIsCarriedOntoTheSection",
+		"TestControlPlaneTestsNeverExpectAnUncapturedReason",
+		"TestControlPlaneContractCellsNameLiveTests",
+		"TestHookReflectionWritesNeverDiscardTheirErrorSilently",
+		"TestIngestReasonColumnCarriesOnlyBoundedValues",
+	},
 	// C-1: the broker diagnosis dials the endpoint the runtime published,
 	// rather than a key it assumed. Assuming it reported a live broker as
 	// absent, and an operator killed a process on that answer.

--- a/internal/app/codex_controlplane_contract_test.go
+++ b/internal/app/codex_controlplane_contract_test.go
@@ -95,33 +95,29 @@ var codexControlPlaneContractEnforcement = map[string][]string{
 	// C-2 ownership: an attributed hook event landed on a Pane of its own
 	// provider.
 	//
-	// The two entries here are the runtime half, and they are provider-neutral:
-	// they judge attributions the log actually recorded, against the provider
-	// the Registry records for the Pane each one landed on. That half needs no
-	// vocabulary, which is why it exists already.
+	// The runtime half judges attributions the log actually recorded, against
+	// the provider the Registry records for the Pane each one landed on. The
+	// resolver half is the ownership fix's own suite, named here so a rename
+	// reddens rather than quietly emptying this cell.
 	//
-	// The resolver half is still owed, and it cannot be written here yet: it
-	// names symbols the ownership fix introduces, and restating them as string
-	// literals would let a rename walk past this gate silently. Five properties
-	// are waiting on that rebase, and the fifth is the one most easily missed:
-	//
-	//  1. the composite "no other match" refusal is not swallowed by a
-	//     downstream general token;
-	//  2. a rejected explicit identity flows on to the Registry step and the
-	//     established ladder rather than being dropped;
-	//  3. the fall-through skips the inherited-environment step, which carries
-	//     the same envelope that was just rejected and would readmit the leak;
-	//  4. the three older explicit refusals keep their existing behaviour and
-	//     do not fall through, so this gate cannot mistake Phase 2's contract
-	//     for a regression;
-	//  5. the Pane the fall-through finally resolves is not foreign either.
-	//     The ladder's working-directory step matches on path alone, and on a
-	//     machine where two providers share a repository that step can hand
-	//     back the very Pane the explicit check refused. Closing the front door
-	//     and leaving that one open would pass every other property here.
+	// The last entry is the one most easily missed. The fall-through ladder's
+	// working-directory step matches on path alone, so on a machine where two
+	// providers share a repository it can hand the event straight back to a
+	// Pane of the provider the explicit check just refused. Closing the front
+	// door and leaving that one open satisfies every other property here.
 	"C-2-ownership": {
 		"TestPaneOwnershipSurfaceReportsAForeignAttributionAsBroken",
 		"TestOwnershipHealthCallsOnlyAPositivelyForeignPaneForeign",
+		"TestResolveExplicitAIPaneRefusesAnInheritedForeignIdentity",
+		"TestMatchAIPaneNeverAttributesAnInheritedForeignIdentity",
+		"TestMatchAIPaneKeepsAnExplicitPaneWithNoRecordedProvider",
+		"TestMatchAIPaneContinuesPastARefusedInheritedIdentity",
+		"TestForeignExplicitFallThroughIgnoresTheInheritedEnvironment",
+		"TestForeignExplicitRefusalLeavesTheRegistryPathUnchanged",
+		"TestNoExplicitPathStillTakesACwdMatchRegardlessOfProvider",
+		"TestForeignExplicitFallThroughStillTakesACoherentLadderAnswer",
+		"TestForeignExplicitFallThroughDoesNotTakeAForeignConversationPane",
+		"TestForeignExplicitFallThroughDoesNotLandOnAnotherProvidersPane",
 	},
 	// C-5: a turn admission judges a completed authority transition, never a
 	// triple sampled between two of its three writes.

--- a/internal/app/codex_controlplane_contract_test.go
+++ b/internal/app/codex_controlplane_contract_test.go
@@ -86,6 +86,7 @@ var codexControlPlaneContractEnforcement = map[string][]string{
 		"TestCodexObserverJournalRecordFieldsAreWhitelisted",
 		"TestManagedCodexAuthorityDoctorSeparatesFlappingFrozenAndStopped",
 		"TestObserverReasonSurfaceRefusesToCallAnUncapturedReasonHealthy",
+		"TestObserverReasonSurfaceRefusesToJudgeAnEmptyReasonSet",
 	},
 	// C-3 continuity: the upstream connection survives a message past the
 	// frame bound instead of dying on it, which is what held the control plane

--- a/internal/app/codex_controlplane_contract_test.go
+++ b/internal/app/codex_controlplane_contract_test.go
@@ -129,6 +129,8 @@ var codexControlPlaneContractEnforcement = map[string][]string{
 	"C-2-ownership": {
 		"TestPaneOwnershipSurfaceReportsAForeignAttributionAsBroken",
 		"TestOwnershipHealthCallsOnlyAPositivelyForeignPaneForeign",
+		"TestOwnershipHealthCountsAConversationCarriedByTheWrongSource",
+		"TestPaneOwnershipVerdictIgnoresForeignLifecycleChurn",
 		"TestResolveExplicitAIPaneRefusesAnInheritedForeignIdentity",
 		"TestMatchAIPaneNeverAttributesAnInheritedForeignIdentity",
 		"TestMatchAIPaneKeepsAnExplicitPaneWithNoRecordedProvider",

--- a/internal/app/codex_controlplane_gate_test.go
+++ b/internal/app/codex_controlplane_gate_test.go
@@ -52,6 +52,23 @@ const codexUncapturedGateFile = "codex_controlplane_gate_test.go"
 // The rule is deliberately about expectations rather than mentions. A test may
 // drive an uncaptured token as input all it likes; what it may not do is
 // require one to come back.
+//
+// One neighbouring category is deliberately out of reach, and saying so here
+// keeps it from being re-litigated. Tests were also found asserting that the
+// log carries a provider's own text -- a tool error spliced verbatim into a
+// reason -- which is the same failure in a purer form: a leak fixed as the
+// passing condition. It is not mechanically detectable from here. Matching the
+// shapes that leak (an absolute path, a subprocess phrase) over the test corpus
+// finds dozens of legitimate uses -- socket fixtures, executable paths,
+// transport tables -- and would make this gate the thing people switch off.
+// Matching narrowly on the reason field misses the actual instances, because
+// what made them leaks was the value's provenance rather than its spelling:
+// `unknown termination reason: FUTURE_SAFE_REASON` looks bounded and is not.
+//
+// Provenance is a runtime fact, so the enforceable half is a runtime check --
+// drive a failure and assert the log does not contain the input -- and it
+// belongs with whoever owns the vocabulary, where it now lives. A static sweep
+// that claimed this category would be claiming more than it can see.
 func TestControlPlaneTestsNeverExpectAnUncapturedReason(t *testing.T) {
 	root := repoRootForGate(t)
 	goToken := regexp.MustCompile(`"(` + strings.Join(codexUncapturedReasonTokens, "|") + `)"`)

--- a/internal/app/codex_controlplane_gate_test.go
+++ b/internal/app/codex_controlplane_gate_test.go
@@ -1,0 +1,223 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// codexUncapturedReasonTokens are the values that mean "nothing recorded why".
+//
+// They are legal to read and illegal to expect. Each one is either an explicit
+// nothing-recorded bucket, a literal a pre-instrumentation binary wrote before
+// any reason was captured, or the fallback a bounded read renders for a value
+// outside its vocabulary. None of them is the outcome of an observation, so a
+// test that fixes one as its expected value certifies that no observation
+// happened — which is what a whole neighbouring track shipped green against.
+var codexUncapturedReasonTokens = []string{
+	"unrecorded",
+	"disconnected",
+	"bounded reason unavailable",
+	"target-unmatched",
+}
+
+// codexUncapturedDefaultMarker admits one occurrence.
+//
+// The marker must carry a reason, because the point of the sweep is not to
+// count occurrences but to force each survivor to say why that value is a real
+// expectation. Every current survivor is a different vocabulary that happens to
+// spell a token the same way.
+const codexUncapturedDefaultMarker = "uncaptured-default:"
+
+// codexUncapturedGateFile is this file, which declares the vocabulary and is
+// therefore the one place the tokens appear as literals rather than as
+// expectations.
+const codexUncapturedGateFile = "codex_controlplane_gate_test.go"
+
+// TestControlPlaneTestsNeverExpectAnUncapturedReason is the false-certification
+// gate.
+//
+// It exists because the failure it guards against already happened here in a
+// worse form than an untested surface: `test/e2e/codex-lifecycle.sh` asserted
+// the literal `disconnected` for a managed Codex Pane's authority reason, and
+// `disconnected` is the bucket meaning no reason was captured. The suite was
+// not failing to reach that surface. It reached it and pinned the broken state
+// as the passing condition, so capturing a real reason would have turned the
+// job red.
+//
+// The rule is deliberately about expectations rather than mentions. A test may
+// drive an uncaptured token as input all it likes; what it may not do is
+// require one to come back.
+func TestControlPlaneTestsNeverExpectAnUncapturedReason(t *testing.T) {
+	root := repoRootForGate(t)
+	goToken := regexp.MustCompile(`"(` + strings.Join(codexUncapturedReasonTokens, "|") + `)"`)
+	shellToken := regexp.MustCompile(`(^|[\s"'=])(` + strings.Join(codexUncapturedReasonTokens, "|") + `)($|[\s"'\\])`)
+	var unjustified []string
+	for _, scope := range []struct {
+		dir     string
+		match   func(string) bool
+		pattern *regexp.Regexp
+	}{
+		{dir: "internal", match: func(name string) bool { return strings.HasSuffix(name, "_test.go") }, pattern: goToken},
+		{dir: filepath.Join("test", "e2e"), match: func(name string) bool { return strings.HasSuffix(name, ".sh") }, pattern: shellToken},
+	} {
+		err := filepath.WalkDir(filepath.Join(root, scope.dir), func(path string, entry os.DirEntry, err error) error {
+			if err != nil || entry.IsDir() || !scope.match(entry.Name()) {
+				return err
+			}
+			payload, readErr := os.ReadFile(path) // #nosec G304 -- repository source under test.
+			if readErr != nil {
+				return readErr
+			}
+			relative, _ := filepath.Rel(root, path)
+			lines := strings.Split(string(payload), "\n")
+			if entry.Name() == codexUncapturedGateFile {
+				// The file that declares the vocabulary is the one place the
+				// tokens have to appear as themselves.
+				return nil
+			}
+			for index, line := range lines {
+				if isGateComment(line) || !scope.pattern.MatchString(line) {
+					continue
+				}
+				if uncapturedDefaultJustified(lines, index) {
+					continue
+				}
+				unjustified = append(unjustified, relative+":"+strconv.Itoa(index+1)+": "+strings.TrimSpace(line))
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", scope.dir, err)
+		}
+	}
+	if len(unjustified) > 0 {
+		t.Fatalf("%d expectation(s) fix a value that means no reason was captured.\n"+
+			"Expect a captured token instead, or state on the line above why this value is a real expectation "+
+			"with a `%s <reason>` comment:\n  %s",
+			len(unjustified), codexUncapturedDefaultMarker, strings.Join(unjustified, "\n  "))
+	}
+}
+
+// isGateComment reports whether a line is prose rather than code. A comment
+// discussing an uncaptured token is not an expectation of one, and this gate
+// must not push the vocabulary out of the comments that explain it.
+func isGateComment(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "#")
+}
+
+// uncapturedDefaultJustified reports whether an occurrence carries its reason
+// on its own line or in the comment block directly above it.
+//
+// The whole block is searched rather than one line, because a reason worth
+// stating rarely fits on one and a gate that forced it to would be answered
+// with a shorter reason instead of a better one.
+func uncapturedDefaultJustified(lines []string, index int) bool {
+	if markerCarriesReason(lines[index]) {
+		return true
+	}
+	for above := index - 1; above >= 0 && isGateComment(lines[above]); above-- {
+		if markerCarriesReason(lines[above]) {
+			return true
+		}
+	}
+	return false
+}
+
+// markerCarriesReason reports whether one line states a reason after the
+// marker. An empty marker admits nothing: the sweep exists to collect reasons,
+// not to collect markers.
+func markerCarriesReason(line string) bool {
+	_, after, ok := strings.Cut(line, codexUncapturedDefaultMarker)
+	if !ok {
+		return false
+	}
+	return strings.TrimSpace(after) != ""
+}
+
+// TestControlPlaneContractCellsNameLiveTests is the mechanical half of the
+// release check the roadmap contract carries: every Enforcement cell of the
+// five product contracts must name a test that exists.
+//
+// A contract cell naming a renamed or deleted test is not a weaker guarantee,
+// it is a false one: the cell reads as enforced and nothing enforces it. Squash
+// merges erase the branch history that would otherwise tie the two together, so
+// the tie has to live somewhere a build can check.
+func TestControlPlaneContractCellsNameLiveTests(t *testing.T) {
+	root := repoRootForGate(t)
+	declared := map[string]bool{}
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
+			return err
+		}
+		payload, readErr := os.ReadFile(path) // #nosec G304 -- repository source under test.
+		if readErr != nil {
+			return readErr
+		}
+		for _, match := range regexp.MustCompile(`(?m)^func (Test\w+)\(`).FindAllStringSubmatch(string(payload), -1) {
+			declared[match[1]] = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repository: %v", err)
+	}
+	var missing []string
+	for contract, tests := range codexControlPlaneContractEnforcement {
+		for _, name := range tests {
+			if !declared[name] {
+				missing = append(missing, contract+" -> "+name)
+			}
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("%d contract Enforcement entr(ies) name no live test:\n  %s", len(missing), strings.Join(missing, "\n  "))
+	}
+}
+
+// TestControlPlaneContractEnforcementCoversEverySurface holds the other half:
+// each of the five surfaces this diagnosis names has at least one contract cell
+// behind it, and the contract map has no surface the diagnosis cannot render.
+func TestControlPlaneContractEnforcementCoversEverySurface(t *testing.T) {
+	for _, surface := range codexControlPlaneSurfaceOrder {
+		contract, ok := codexControlPlaneSurfaceContract[surface]
+		if !ok {
+			t.Fatalf("surface %q names no product contract", surface)
+		}
+		if len(codexControlPlaneContractEnforcement[contract]) == 0 {
+			t.Fatalf("surface %q maps to contract %q, which enforces nothing", surface, contract)
+		}
+	}
+	for surface := range codexControlPlaneSurfaceContract {
+		found := slices.Contains(codexControlPlaneSurfaceOrder, surface)
+		if !found {
+			t.Fatalf("contract map names surface %q, which the diagnosis does not render", surface)
+		}
+	}
+}
+
+// repoRootForGate walks up from the package directory to the module root.
+func repoRootForGate(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+	for range 8 {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("module root not found above the package directory")
+	return ""
+}

--- a/internal/app/codex_controlplane_partition_test.go
+++ b/internal/app/codex_controlplane_partition_test.go
@@ -1,0 +1,136 @@
+package app
+
+import (
+	"testing"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+)
+
+// Every count these projections render is a bucket of some population, and the
+// buckets have to partition it.
+//
+// That is true today by construction: each classifier sends one record down
+// exactly one branch and returns, and no rendered number is derived by
+// subtracting one count from another. But true-by-construction is not held --
+// it is a property of the code as currently written, and the next person to add
+// a bucket or a subtraction breaks it silently, because a miscounted total
+// still looks like a total.
+//
+// The failure mode is not hypothetical. Two instrumentation miscounts appeared
+// on this track in one day, both of the same shape: a summary line counted as a
+// finding, and lines counted as records. Both were in shell around the gates
+// rather than inside them, and nothing stops the next one being inside.
+//
+// So the invariant is asserted rather than noted, and the assertion is checked
+// against a fixture that exercises every branch of every classifier. A bucket
+// that starts double-counting fails here instead of quietly inflating a
+// denominator.
+
+// partitionFixture drives every branch of the three hook projections at once.
+func partitionFixture() []aiIngestLogEntry {
+	const owned = "conversation-owned"
+	return []aiIngestLogEntry{
+		// Attributed, and delivered by three different results.
+		{Source: "codex-hook", Result: "state", Pane: "%1", ThreadID: owned},
+		{Source: "codex-hook", Result: "notify", Pane: "%1", ThreadID: owned},
+		{Source: "codex-hook", Result: "quiet", Pane: "%1", ThreadID: owned},
+		// Attributed and failed, once opaquely and once with a bounded reason.
+		{Source: "codex-hook", Result: "error", Reason: "exit status 1", Pane: "%1", ThreadID: owned},
+		{Source: "codex-hook", Result: "error", Reason: "pane option write rejected: -S//tmp/s: no server", Pane: "%1", ThreadID: owned},
+		// Unattributed: one mechanism failure, one contractual refusal.
+		{Source: "codex-hook", Result: "ignored", Reason: aiPaneMatchReasonNoInventory, ThreadID: owned},
+		{Source: "codex-hook", Result: "ignored", Reason: aiPaneMatchReasonConversationUnknown, ThreadID: owned},
+		// Another provider: an ordinary record, and one carrying the first
+		// provider's conversation.
+		{Source: "claude-hook", Result: "state", Pane: "%2", ThreadID: "conversation-claude"},
+		{Source: "claude-hook", Result: "state", Pane: "%1", SessionID: owned},
+		// Neither an attribution nor a delivery outcome.
+		{Source: "codex-hook", Result: "error", Reason: "payload decode failed"},
+		{Source: "codex-observer", Result: "invalidating", Reason: "endpoint-suspended", Pane: "%1"},
+	}
+}
+
+// TestHookProjectionBucketsPartitionTheirPopulation asserts the invariant.
+func TestHookProjectionBucketsPartitionTheirPopulation(t *testing.T) {
+	entries := partitionFixture()
+
+	attribution := projectAIIngestAttributionHealth(entries)
+	attributionTotal := 0
+	for _, source := range attribution.Sources {
+		if source.Attributed < 0 || source.Unattributed < 0 || source.Refused < 0 {
+			t.Fatalf("attribution source %+v carries a negative bucket", source)
+		}
+		attributionTotal += source.Attributed + source.Unattributed + source.Refused
+	}
+	if attributionTotal != attribution.Records {
+		t.Fatalf("attribution buckets sum to %d over %d records; every counted record must land in exactly one",
+			attributionTotal, attribution.Records)
+	}
+
+	delivery := projectAIIngestDeliveryHealth(entries)
+	deliveryTotal := 0
+	for _, source := range delivery.Sources {
+		if source.Delivered < 0 || source.Failed < 0 || source.Quiet < 0 || source.Opaque < 0 {
+			t.Fatalf("delivery source %+v carries a negative bucket", source)
+		}
+		if source.Opaque > source.Failed {
+			t.Fatalf("delivery source %+v reports more opaque failures than failures", source)
+		}
+		if source.PathBearing > source.Delivered+source.Failed+source.Quiet {
+			t.Fatalf("delivery source %+v reports more path-bearing records than it saw", source)
+		}
+		deliveryTotal += source.Delivered + source.Failed
+	}
+	if deliveryTotal != delivery.Records {
+		t.Fatalf("delivery buckets sum to %d over %d write attempts; the quiet lane must stay outside both",
+			deliveryTotal, delivery.Records)
+	}
+
+	registry := registryForPartition()
+	ownership := projectAIIngestOwnershipHealth(entries, registry, true)
+	if ownership.Foreign > ownership.Classified {
+		t.Fatalf("ownership reports %d foreign among %d judged", ownership.Foreign, ownership.Classified)
+	}
+	if ownership.Classified < 0 || ownership.Unresolved < 0 || ownership.Unrecorded < 0 || ownership.Misrouted < 0 {
+		t.Fatalf("ownership carries a negative bucket: %+v", ownership)
+	}
+	// Misroute is a different axis with its own denominator, so it is checked
+	// against that rather than against the attribution population.
+	if ownership.Misrouted > 0 && ownership.OwnedConversations == 0 {
+		t.Fatalf("ownership found %d misrouted record(s) over no conversation it could check", ownership.Misrouted)
+	}
+}
+
+// TestAuthorityCensusBucketsPartitionTheirPopulation holds the same property
+// for the census, whose population is the managed Agents rather than records.
+func TestAuthorityCensusBucketsPartitionTheirPopulation(t *testing.T) {
+	diagnostics := map[string]codexLifecycleAuthorityDiagnostic{
+		"pane-settled":   {Source: codexAuthorityControlPlane, Epoch: "1-1", Fence: codexAuthorityFenceSettled},
+		"pane-torn":      {Source: codexAuthorityControlPlane, Fence: codexAuthorityFenceSettled, Torn: true},
+		"pane-contended": {Source: codexAuthorityControlPlane, Fence: codexAuthorityFenceContended},
+		"pane-unfenced":  {Source: codexAuthorityHook, Fence: codexAuthorityFenceUnfenced},
+	}
+	registry := registryWithCodexPanes(t, "pane-settled", "pane-torn", "pane-contended", "pane-unfenced")
+	census := censusCodexLifecycleAuthority(registry, func(pane string) codexLifecycleAuthorityDiagnostic {
+		return diagnostics[pane]
+	})
+	if sampled := census.Settled + census.Contended + census.Unfenced; sampled > census.Agents {
+		t.Fatalf("census classified %d snapshots over %d Agents", sampled, census.Agents)
+	}
+	if census.Torn > census.Settled {
+		t.Fatalf("census reports %d torn among %d settled; only a settled snapshot can be judged torn",
+			census.Torn, census.Settled)
+	}
+	sources := census.ControlPlane + census.Pending + census.Invalidating +
+		census.DeclaredHook + census.UnexplainedHook + census.Unavailable
+	if sources != census.Agents {
+		t.Fatalf("authority source buckets sum to %d over %d Agents", sources, census.Agents)
+	}
+}
+
+func registryForPartition() coremetadata.Registry {
+	return coremetadata.Registry{Panes: []coremetadata.Pane{
+		paneWithActivation("%1", coremetadata.PaneActivation{Codex: &coremetadata.CodexActivationBinding{ThreadID: "conversation-owned"}}),
+		paneWithActivation("%2", coremetadata.PaneActivation{Claude: &coremetadata.ClaudeActivationBinding{}}),
+	}}
+}

--- a/internal/app/codex_controlplane_scope_test.go
+++ b/internal/app/codex_controlplane_scope_test.go
@@ -117,3 +117,48 @@ func TestEverySurfaceRendersTheScopeItDeclares(t *testing.T) {
 		t.Fatal("the hook rows carry counts over a time span and the section does not name it")
 	}
 }
+
+// TestReasonVocabularyIsDeliberatelyNotADoctorSurface pins an absence.
+//
+// Seven surfaces are rendered. The eighth guarantee this section holds — that
+// the ingest log's reason column carries only bounded values — is a build-time
+// claim about source, and it stays out of the diagnosis on purpose.
+//
+// The reason is the one this whole section exists for. A static claim has no
+// honest runtime rendering: the check reads the writes, and at runtime the only
+// thing a diagnosis could report is whether the values it happened to observe
+// looked bounded. That answer is green on every window where nothing leaked,
+// including the windows where the leaking path simply did not fire — which is
+// "the check passes while the subject leaks", the exact failure this section
+// was built to end. A green row would be worse than no row.
+//
+// So the guarantee is enforced where it can be enforced completely, and a
+// future reader who notices the asymmetry and adds the missing row finds this.
+func TestReasonVocabularyIsDeliberatelyNotADoctorSurface(t *testing.T) {
+	if len(codexControlPlaneSurfaceOrder) != 7 {
+		t.Fatalf("the diagnosis renders %d surfaces, want the seven that have an honest runtime signal",
+			len(codexControlPlaneSurfaceOrder))
+	}
+	for _, surface := range codexControlPlaneSurfaceOrder {
+		for _, forbidden := range []string{"reason-vocabulary", "reason-column", "ingest-reason"} {
+			if surface == forbidden {
+				t.Fatalf("surface %q renders a build-time claim about source. At runtime it can only report "+
+					"that nothing it saw looked wrong, which is green on every window where the leaking path "+
+					"did not fire — a check passing while its subject leaks.", surface)
+			}
+		}
+	}
+	// The guarantee is still held, in the place that can hold it completely.
+	if len(codexControlPlaneContractEnforcement["C-4"]) == 0 {
+		t.Fatal("the reason-column guarantee has no enforcement at all")
+	}
+	var enforced bool
+	for _, name := range codexControlPlaneContractEnforcement["C-4"] {
+		if name == "TestIngestReasonColumnCarriesOnlyBoundedValues" {
+			enforced = true
+		}
+	}
+	if !enforced {
+		t.Fatal("the reason column is absent from the diagnosis and unenforced in the build; it must be one or the other")
+	}
+}

--- a/internal/app/codex_controlplane_scope_test.go
+++ b/internal/app/codex_controlplane_scope_test.go
@@ -1,0 +1,119 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+// Every count this diagnosis renders has to say what it is a count of.
+//
+// Four separate corrections were made here in one day, and they were the same
+// mistake wearing four faces. Each time the number was arithmetically right and
+// what it ranged over was unstated, so a reader supplied the wrong range:
+//
+//   - a refusal the contract never promised to attribute was counted among the
+//     failures it did promise, and a machine behaving to spec read as broken;
+//   - a judged count stood without its population, and 805 read as everything
+//     when a third of the window had not been judged at all;
+//   - a lane that deliberately writes nothing sat in the denominator of a write
+//     rate, and one failure in three read as one in twenty-nine;
+//   - records written by two different binaries were counted in one window, and
+//     a repair that had already landed read as having done nothing.
+//
+// Each was found by a person, none by a test. This is the test, and what it
+// asks of a new surface is the question all four failed to answer: your numbers
+// are over what?
+//
+// It cannot check that a scope is *correct* -- that is the author's judgment,
+// and the four above were all authored in good faith. It checks that one was
+// declared and that the rendering carries it, which is what turns the question
+// from optional into unavoidable.
+
+// codexSurfaceScope names, for each surface, the phrase its rendering must
+// carry to say what its counts range over.
+//
+// Adding a surface without adding a line here fails the completeness check
+// below. That is the point: the entry is cheap, and writing it forces the
+// author to answer the question before the number reaches an operator.
+var codexSurfaceScope = map[string]string{
+	// How many endpoints the domain published — the population the reachability
+	// verdict was reached over.
+	codexSurfaceBrokerDiagnostics: "published endpoints",
+	// Split per source, and refusals the contract excludes are named rather
+	// than folded into the failures.
+	codexSurfaceHookAttribution: "out of contract",
+	// Reasons that were captured against reasons that were not.
+	codexSurfaceObserverReason: "captured reasons",
+	// The reconnect total is over the runtime's life, which the epoch names.
+	codexSurfaceConnectionContinuity: "connection epoch",
+	// How each snapshot was taken, since only a settled one may be judged.
+	codexSurfaceTurnAdmission: "settled",
+	// Delivery is over writes that were attempted, not events that arrived.
+	codexSurfaceHookDelivery: "made no write",
+	// Judged against the whole window, since much of it cannot be judged.
+	codexSurfacePaneOwnership: "of",
+}
+
+// TestEverySurfaceDeclaresWhatItsNumbersAreOver is the completeness half.
+func TestEverySurfaceDeclaresWhatItsNumbersAreOver(t *testing.T) {
+	for _, surface := range codexControlPlaneSurfaceOrder {
+		if strings.TrimSpace(codexSurfaceScope[surface]) == "" {
+			t.Fatalf("surface %q renders counts and declares no scope for them.\n\n"+
+				"Say what its numbers range over -- a population, a lane, a time span, a contract "+
+				"limit -- and add the phrase its rendering carries. Four verdicts here have already "+
+				"been wrong for want of that answer, and every one of them was found by a person.",
+				surface)
+		}
+	}
+	for surface := range codexSurfaceScope {
+		if _, known := codexControlPlaneSurfaceContract[surface]; !known {
+			t.Fatalf("scope declared for %q, which the diagnosis does not render", surface)
+		}
+	}
+}
+
+// TestEverySurfaceRendersTheScopeItDeclares is the rendering half.
+//
+// A declaration nobody prints is a comment. The verdicts that misled were all
+// rendered ones, so the phrase has to reach the line an operator reads.
+func TestEverySurfaceRendersTheScopeItDeclares(t *testing.T) {
+	report := projectCodexControlPlaneSurfaces(
+		&codexBrokerDiagnostic{
+			State: codexBrokerStateRunning, Published: 1, Endpoint: "codex-app-server:g1:key",
+			ConnectionEpoch: 26500, Reconnects: 26499, Connections: 1,
+		},
+		&codexAuthorityCensus{
+			Agents: 2, Settled: 2,
+			Reasons: []codexAuthorityReasonCount{{Reason: string(codexObserverReasonReady), Count: 2}},
+		},
+		codexHookHealth{
+			Attribution: aiIngestAttributionHealth{Observed: true, Records: 3, Sources: []aiIngestAttributionSource{
+				{Source: "codex-hook", Attributed: 2, Refused: 1, RefusalReasons: []aiIngestAttributionReason{
+					{Reason: aiPaneMatchReasonConversationUnknown, Count: 1},
+				}},
+			}},
+			Delivery: aiIngestDeliveryHealth{Observed: true, Records: 2, Sources: []aiIngestDeliverySource{
+				{Source: "codex-hook", Delivered: 2, Quiet: 7},
+			}},
+			Ownership: aiIngestOwnershipHealth{Observed: true, Classified: 2, Unrecorded: 1},
+			From:      "2026-09-05T08:44:30Z",
+			To:        "2026-09-05T09:54:28Z",
+		},
+		codexControlPlaneVintage{Supported: true},
+	)
+	for _, surface := range report.Surfaces {
+		scope := codexSurfaceScope[surface.Surface]
+		if surface.Status == codexSurfaceStatusUnobserved {
+			t.Fatalf("surface %q read as unobserved on populated input; the fixture no longer exercises it", surface.Surface)
+		}
+		if !strings.Contains(surface.Detail, scope) {
+			t.Fatalf("surface %q renders %q, which does not carry its declared scope %q",
+				surface.Surface, surface.Detail, scope)
+		}
+	}
+	// The hook rows share one time span, and it is rendered once above them
+	// rather than repeated on each.
+	if report.HookWindow == "" {
+		t.Fatal("the hook rows carry counts over a time span and the section does not name it")
+	}
+}

--- a/internal/app/codex_controlplane_surfaces.go
+++ b/internal/app/codex_controlplane_surfaces.go
@@ -433,6 +433,14 @@ func codexPaneOwnershipSurface(ownership aiIngestOwnershipHealth) codexControlPl
 	surface.Detail = fmt.Sprintf("judged %d of %d attributions; foreign %d; unresolved %d; provider unrecorded %d",
 		ownership.Classified, ownership.Classified+ownership.Unresolved+ownership.Unrecorded,
 		ownership.Foreign, ownership.Unresolved, ownership.Unrecorded)
+	if ownership.Misrouted > 0 {
+		// Counted over the whole window rather than over the judged
+		// attributions, because most misrouted records never reach a Pane at
+		// all: they fail to attribute, land in the contractual refusal bucket
+		// where they belong, and become indistinguishable from an ordinary
+		// retired conversation. That is where 96 of 98 of them hid.
+		surface.Detail += fmt.Sprintf("; %d record(s) misrouted across providers in the window", ownership.Misrouted)
+	}
 	if directions := codexReasonBreakdown(ownership.Directions); directions != "" {
 		// Which way the mismatch runs is the whole diagnosis. One direction is
 		// a hook landing on the Pane that launched its host; the other is an
@@ -441,6 +449,15 @@ func codexPaneOwnershipSurface(ownership aiIngestOwnershipHealth) codexControlPl
 	}
 	if ownership.Foreign > 0 {
 		surface.Status = codexSurfaceStatusBroken
+		return surface
+	}
+	if ownership.Misrouted > 0 {
+		// Degraded rather than broken. A misrouted record is real and worth
+		// seeing, but the routing that produced it lives outside this
+		// application -- a provider host still serving a route its
+		// configuration no longer carries -- so there is nothing here to
+		// repair and a permanent red would train the row away.
+		surface.Status = codexSurfaceStatusDegraded
 		return surface
 	}
 	surface.Status = codexSurfaceStatusOK

--- a/internal/app/codex_controlplane_surfaces.go
+++ b/internal/app/codex_controlplane_surfaces.go
@@ -1,0 +1,302 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The five control-plane surfaces whose broken states this application had no
+// detection for.
+//
+// They are named here, in one closed list, for a reason this track paid for:
+// three defects survived a neighbouring eight-phase track closing green from
+// end to end, because nothing asserted that these surfaces were alive. A
+// diagnosis that reports subsystem counters without naming the surfaces leaves
+// an operator to infer which question each counter answers, and the inference
+// is exactly what went unmade.
+const (
+	codexSurfaceBrokerDiagnostics    = "broker-diagnostics"
+	codexSurfaceHookAttribution      = "hook-attribution"
+	codexSurfaceObserverReason       = "observer-reason"
+	codexSurfaceConnectionContinuity = "connection-continuity"
+	codexSurfaceTurnAdmission        = "turn-admission"
+)
+
+// The verdict one surface carries.
+//
+// `unobserved` is not a fourth degree of health. It says the reading was not
+// taken, and it is separate from `ok` because a surface nobody looked at and a
+// surface that answered well produce the same silence otherwise — which is the
+// silence this whole section exists to end.
+const (
+	codexSurfaceStatusOK         = "ok"
+	codexSurfaceStatusDegraded   = "degraded"
+	codexSurfaceStatusBroken     = "broken"
+	codexSurfaceStatusUnobserved = "unobserved"
+)
+
+// codexControlPlaneSurface is one surface's verdict and the evidence it was
+// reached on. Detail is assembled from counters and closed tokens only.
+type codexControlPlaneSurface struct {
+	Surface string `json:"surface"`
+	Status  string `json:"status"`
+	Detail  string `json:"detail"`
+}
+
+// codexControlPlaneReport is the whole projection: what the five surfaces say,
+// and how current the processes they were read from are.
+type codexControlPlaneReport struct {
+	Vintage  codexControlPlaneVintage   `json:"vintage"`
+	Surfaces []codexControlPlaneSurface `json:"surfaces"`
+}
+
+// projectCodexControlPlaneSurfaces reaches one verdict per surface from the
+// readings doctor already took.
+//
+// Nothing is read again here. The section is a projection of the same broker
+// telemetry, authority census, and hook log the detailed sections render, so a
+// verdict can never disagree with the numbers printed above it.
+func projectCodexControlPlaneSurfaces(
+	broker *codexBrokerDiagnostic,
+	census *codexAuthorityCensus,
+	attribution aiIngestAttributionHealth,
+	vintage codexControlPlaneVintage,
+) codexControlPlaneReport {
+	report := codexControlPlaneReport{Vintage: vintage}
+	report.Surfaces = []codexControlPlaneSurface{
+		codexBrokerDiagnosticsSurface(broker),
+		codexHookAttributionSurface(attribution),
+		codexObserverReasonSurface(census),
+		codexConnectionContinuitySurface(broker),
+		codexTurnAdmissionSurface(census),
+	}
+	return report
+}
+
+// codexBrokerDiagnosticsSurface judges whether the broker diagnosis is looking
+// at the runtime that actually serves this state domain.
+//
+// The broken shape is the exact one that cost this machine a foreign process:
+// a published discovery record with nothing answering behind it, rendered as
+// `absent`, read by an operator as "no broker is running".
+func codexBrokerDiagnosticsSurface(broker *codexBrokerDiagnostic) codexControlPlaneSurface {
+	surface := codexControlPlaneSurface{Surface: codexSurfaceBrokerDiagnostics}
+	if broker == nil {
+		surface.Status, surface.Detail = codexSurfaceStatusUnobserved, "no broker reading was taken"
+		return surface
+	}
+	switch broker.State {
+	case codexBrokerStateRunning:
+		surface.Status = codexSurfaceStatusOK
+		surface.Detail = fmt.Sprintf("runtime running; published endpoints %d; observed endpoint %s",
+			broker.Published, codexEndpointPresence(broker.Endpoint))
+	case codexBrokerStateAbsent:
+		if broker.Published > 0 {
+			surface.Status = codexSurfaceStatusBroken
+			surface.Detail = fmt.Sprintf("published endpoints %d answered none; reason %s",
+				broker.Published, codexSurfaceReasonOrNone(broker.Reason))
+			return surface
+		}
+		surface.Status = codexSurfaceStatusOK
+		surface.Detail = "no endpoint published; no native Agent is bound"
+	case codexBrokerStateUnsupported:
+		surface.Status = codexSurfaceStatusUnobserved
+		surface.Detail = "platform hosts no broker runtime"
+	default:
+		surface.Status = codexSurfaceStatusDegraded
+		surface.Detail = fmt.Sprintf("runtime %s; reason %s", broker.State, codexSurfaceReasonOrNone(broker.Reason))
+	}
+	return surface
+}
+
+// codexHookAttributionSurface judges whether provider hook events are reaching
+// the Pane that owns them.
+func codexHookAttributionSurface(attribution aiIngestAttributionHealth) codexControlPlaneSurface {
+	surface := codexControlPlaneSurface{Surface: codexSurfaceHookAttribution}
+	if !attribution.Observed {
+		surface.Status, surface.Detail = codexSurfaceStatusUnobserved, "no hook ingest log was readable"
+		return surface
+	}
+	if attribution.Records == 0 {
+		surface.Status, surface.Detail = codexSurfaceStatusUnobserved, "no hook event in the reading window"
+		return surface
+	}
+	parts := make([]string, 0, len(attribution.Sources))
+	for _, source := range attribution.Sources {
+		part := fmt.Sprintf("%s %d attributed, %d unattributed", source.Source, source.Attributed, source.Unattributed)
+		if len(source.Reasons) > 0 {
+			reasons := make([]string, 0, len(source.Reasons))
+			for _, reason := range source.Reasons {
+				reasons = append(reasons, fmt.Sprintf("%s=%d", reason.Reason, reason.Count))
+			}
+			part += " (" + strings.Join(reasons, ", ") + ")"
+		}
+		parts = append(parts, part)
+	}
+	surface.Detail = strings.Join(parts, "; ")
+	switch {
+	case attribution.Unattributed() == 0:
+		surface.Status = codexSurfaceStatusOK
+	case attribution.Attributed() == 0:
+		// Every event and no Pane is the state defect B held for the entire
+		// life of the neighbouring track, and it is not a degradation of
+		// attribution: it is attribution not happening.
+		surface.Status = codexSurfaceStatusBroken
+	default:
+		surface.Status = codexSurfaceStatusDegraded
+	}
+	return surface
+}
+
+// codexObserverReasonSurface judges whether authority transitions carry a
+// reason that was captured rather than assumed.
+//
+// The two tokens it fails on are the ones that mean "nothing recorded why":
+// the explicit unrecorded bucket, and the pre-instrumentation literal that a
+// process older than the reason vocabulary still publishes.
+func codexObserverReasonSurface(census *codexAuthorityCensus) codexControlPlaneSurface {
+	surface := codexControlPlaneSurface{Surface: codexSurfaceObserverReason}
+	if census == nil || census.Agents == 0 {
+		surface.Status, surface.Detail = codexSurfaceStatusUnobserved, "no managed Codex Agent to read"
+		return surface
+	}
+	captured, uncaptured := 0, 0
+	uncapturedTokens := make([]string, 0, 2)
+	for _, reason := range census.Reasons {
+		if codexReasonIsUncaptured(reason.Reason) {
+			uncaptured += reason.Count
+			uncapturedTokens = append(uncapturedTokens, fmt.Sprintf("%s=%d", reason.Reason, reason.Count))
+			continue
+		}
+		captured += reason.Count
+	}
+	surface.Detail = fmt.Sprintf("captured reasons %d; uncaptured %d", captured, uncaptured)
+	if uncaptured > 0 {
+		surface.Detail += " (" + strings.Join(uncapturedTokens, ", ") + ")"
+	}
+	switch {
+	case uncaptured == 0:
+		surface.Status = codexSurfaceStatusOK
+	case captured == 0:
+		surface.Status = codexSurfaceStatusBroken
+	default:
+		surface.Status = codexSurfaceStatusDegraded
+	}
+	return surface
+}
+
+// codexReasonIsUncaptured reports whether one authority reason token means that
+// no reason was captured.
+//
+// Both members are inside the closed vocabulary on purpose, so a reader can
+// render them truthfully. That is also why they must be named here: a token
+// that is legal to read is not thereby an observation, and treating one as an
+// observation is what let a test certify a silent control plane as healthy.
+func codexReasonIsUncaptured(reason string) bool {
+	return reason == string(codexObserverReasonUnrecorded) ||
+		reason == string(codexObserverReasonRetired) ||
+		reason == "bounded reason unavailable"
+}
+
+// codexConnectionContinuitySurface judges whether the upstream app-server
+// connection is staying up.
+//
+// The count is cumulative over the runtime's life and is reported as such. No
+// rate is derived from it: this reader does not know the runtime's uptime, and
+// inventing a rate from a single sample would put a number on the section that
+// the sample does not support.
+func codexConnectionContinuitySurface(broker *codexBrokerDiagnostic) codexControlPlaneSurface {
+	surface := codexControlPlaneSurface{Surface: codexSurfaceConnectionContinuity}
+	if broker == nil || broker.State != codexBrokerStateRunning {
+		surface.Status, surface.Detail = codexSurfaceStatusUnobserved, "no running runtime to read continuity from"
+		return surface
+	}
+	detail := fmt.Sprintf("connection epoch %d; reconnects %d; upstream connections %d",
+		broker.ConnectionEpoch, broker.Reconnects, broker.Connections)
+	if len(broker.Revocations) > 0 {
+		reasons := make([]string, 0, len(broker.Revocations))
+		for _, revocation := range broker.Revocations {
+			reasons = append(reasons, fmt.Sprintf("%s=%d", revocation.Reason, revocation.Count))
+		}
+		detail += " (revocations " + strings.Join(reasons, ", ") + ")"
+	}
+	surface.Detail = detail
+	if broker.Reconnects == 0 {
+		surface.Status = codexSurfaceStatusOK
+		return surface
+	}
+	surface.Status = codexSurfaceStatusDegraded
+	return surface
+}
+
+// codexTurnAdmissionSurface judges whether a turn admission would read a
+// completed authority transition.
+//
+// A torn snapshot is the observable signature of the read that refused live
+// Panes their turn. An unfenced Pane is reported beside it rather than folded
+// into it: that Pane's writer never took a fence, which is a statement about
+// which build is running, not about whether the fence works.
+func codexTurnAdmissionSurface(census *codexAuthorityCensus) codexControlPlaneSurface {
+	surface := codexControlPlaneSurface{Surface: codexSurfaceTurnAdmission}
+	if census == nil || census.Agents == 0 {
+		surface.Status, surface.Detail = codexSurfaceStatusUnobserved, "no managed Codex Agent to read"
+		return surface
+	}
+	observed := census.Settled + census.Contended + census.Unfenced
+	if observed == 0 {
+		surface.Status, surface.Detail = codexSurfaceStatusUnobserved, "no authority snapshot was classified"
+		return surface
+	}
+	surface.Detail = fmt.Sprintf("authority snapshots %d settled, %d contended, %d unfenced; torn %d",
+		census.Settled, census.Contended, census.Unfenced, census.Torn)
+	switch {
+	case census.Torn > 0:
+		surface.Status = codexSurfaceStatusBroken
+	case census.Unfenced > 0:
+		surface.Status = codexSurfaceStatusDegraded
+	default:
+		surface.Status = codexSurfaceStatusOK
+	}
+	return surface
+}
+
+func codexEndpointPresence(endpoint string) string {
+	if strings.TrimSpace(endpoint) == "" {
+		return "absent"
+	}
+	return "present"
+}
+
+func codexSurfaceReasonOrNone(reason string) string {
+	if strings.TrimSpace(reason) == "" {
+		return "none"
+	}
+	return reason
+}
+
+// codexControlPlaneVintageText renders the deployment vintage line.
+//
+// It leads the section rather than sitting inside it because it qualifies every
+// verdict below it. `make install` replaces the file on disk and leaves running
+// processes on the image they started with, so a green surface read from a
+// replaced-image process describes code that process never loaded.
+func codexControlPlaneVintageText(vintage codexControlPlaneVintage) string {
+	if !vintage.Supported {
+		return "unknown on this platform; a process running a replaced image cannot be told apart from one running the installed build"
+	}
+	if len(vintage.Roles) == 0 {
+		return "no control-plane process observed"
+	}
+	parts := make([]string, 0, len(vintage.Roles))
+	for _, role := range vintage.Roles {
+		parts = append(parts, fmt.Sprintf("%s %d (%s %d, %s %d)",
+			role.Role, role.Processes,
+			codexProcessVintageCurrent, role.Current,
+			codexProcessVintageReplaced, role.Replaced))
+	}
+	text := strings.Join(parts, "; ")
+	if vintage.Replaced() > 0 {
+		text += "; a replaced image did not load the installed build, so every verdict below it describes older code"
+	}
+	return text
+}

--- a/internal/app/codex_controlplane_surfaces.go
+++ b/internal/app/codex_controlplane_surfaces.go
@@ -48,8 +48,10 @@ type codexControlPlaneSurface struct {
 // codexControlPlaneReport is the whole projection: what the five surfaces say,
 // and how current the processes they were read from are.
 type codexControlPlaneReport struct {
-	Vintage  codexControlPlaneVintage   `json:"vintage"`
-	Surfaces []codexControlPlaneSurface `json:"surfaces"`
+	Vintage codexControlPlaneVintage `json:"vintage"`
+	// HookWindow is the record span the three hook surfaces were counted over.
+	HookWindow string                     `json:"hook_window,omitempty"`
+	Surfaces   []codexControlPlaneSurface `json:"surfaces"`
 }
 
 // projectCodexControlPlaneSurfaces reaches one verdict per surface from the
@@ -64,7 +66,7 @@ func projectCodexControlPlaneSurfaces(
 	hooks codexHookHealth,
 	vintage codexControlPlaneVintage,
 ) codexControlPlaneReport {
-	report := codexControlPlaneReport{Vintage: vintage}
+	report := codexControlPlaneReport{Vintage: vintage, HookWindow: codexHookWindowText(hooks)}
 	report.Surfaces = []codexControlPlaneSurface{
 		codexBrokerDiagnosticsSurface(broker),
 		codexHookAttributionSurface(hooks.Attribution),
@@ -88,6 +90,20 @@ type codexHookHealth struct {
 	Attribution aiIngestAttributionHealth
 	Delivery    aiIngestDeliveryHealth
 	Ownership   aiIngestOwnershipHealth
+	// From and To bound the records all three were counted over.
+	From string
+	To   string
+}
+
+// codexHookWindowText names the span the hook counts are cumulative over.
+//
+// Without it, a repair that lands mid-window looks like it did nothing until
+// the records that predate it scroll out, and then looks like time fixed it.
+func codexHookWindowText(hooks codexHookHealth) string {
+	if strings.TrimSpace(hooks.From) == "" || strings.TrimSpace(hooks.To) == "" {
+		return ""
+	}
+	return hooks.From + " to " + hooks.To
 }
 
 // codexBrokerDiagnosticsSurface judges whether the broker diagnosis is looking

--- a/internal/app/codex_controlplane_surfaces.go
+++ b/internal/app/codex_controlplane_surfaces.go
@@ -424,7 +424,12 @@ func codexPaneOwnershipSurface(ownership aiIngestOwnershipHealth) codexControlPl
 	if ownership.Classified == 0 {
 		surface.Status = codexSurfaceStatusUnobserved
 		surface.Detail = fmt.Sprintf("no attribution could be judged; %d landed on a Pane the Registry no longer holds", ownership.Unresolved)
-		return surface
+		// The misroute counts survive this branch. They are about which source
+		// carried a conversation, not about which Pane an event reached, so a
+		// window where nothing could be judged can still have plenty to say --
+		// and dropping them here would hide the reading exactly when the window
+		// is least informative.
+		return codexWithMisrouteDetail(surface, ownership)
 	}
 	// The denominator leads, because the verdict is only about the numerator.
 	// "judged 718" beside a separate "unrecorded 267" invites reading the first
@@ -433,20 +438,7 @@ func codexPaneOwnershipSurface(ownership aiIngestOwnershipHealth) codexControlPl
 	surface.Detail = fmt.Sprintf("judged %d of %d attributions; foreign %d; unresolved %d; provider unrecorded %d",
 		ownership.Classified, ownership.Classified+ownership.Unresolved+ownership.Unrecorded,
 		ownership.Foreign, ownership.Unresolved, ownership.Unrecorded)
-	if ownership.Misrouted > 0 {
-		// Counted over the whole window rather than over the judged
-		// attributions, because most misrouted records never reach a Pane at
-		// all: they fail to attribute, land in the contractual refusal bucket
-		// where they belong, and become indistinguishable from an ordinary
-		// retired conversation. That is where 96 of 98 of them hid.
-		surface.Detail += fmt.Sprintf("; %d record(s) misrouted across providers in the window", ownership.Misrouted)
-	}
-	if directions := codexReasonBreakdown(ownership.Directions); directions != "" {
-		// Which way the mismatch runs is the whole diagnosis. One direction is
-		// a hook landing on the Pane that launched its host; the other is an
-		// event that arrived under the wrong source before attribution ran.
-		surface.Detail += " (" + directions + ")"
-	}
+	surface = codexWithMisrouteDetail(surface, ownership)
 	if ownership.Foreign > 0 {
 		surface.Status = codexSurfaceStatusBroken
 		return surface
@@ -474,6 +466,27 @@ func codexReasonBreakdown(reasons []aiIngestAttributionReason) string {
 		rendered = append(rendered, fmt.Sprintf("%s=%d", reason.Reason, reason.Count))
 	}
 	return strings.Join(rendered, ", ")
+}
+
+// codexWithMisrouteDetail appends the cross-provider carriage reading.
+//
+// The count is over the whole window rather than over the judged attributions,
+// because most misrouted records never reach a Pane at all: they fail to
+// attribute, land in the contractual refusal bucket where they belong, and
+// become indistinguishable from an ordinary retired conversation. That is where
+// 96 of 98 of them hid.
+//
+// The denominator travels with it because the detector is a join -- a record is
+// only known to be misrouted while its conversation's owner is also in the
+// window. The log is trimmed by size, so the owner can age out while the
+// misrouted records remain, and the count returns to zero without anything
+// being repaired. That was observed: 98 fell to 2 across one trim. A zero over
+// a small denominator means little was visible; over a large one it means
+// little happened.
+func codexWithMisrouteDetail(surface codexControlPlaneSurface, ownership aiIngestOwnershipHealth) codexControlPlaneSurface {
+	surface.Detail += fmt.Sprintf("; %d record(s) misrouted across %d conversation(s) with a known owner",
+		ownership.Misrouted, ownership.OwnedConversations)
+	return surface
 }
 
 func codexEndpointPresence(endpoint string) string {

--- a/internal/app/codex_controlplane_surfaces.go
+++ b/internal/app/codex_controlplane_surfaces.go
@@ -321,24 +321,28 @@ func codexHookDeliverySurface(delivery aiIngestDeliveryHealth) codexControlPlane
 		return surface
 	}
 	if delivery.Records == 0 {
-		surface.Status, surface.Detail = codexSurfaceStatusUnobserved, "no attributed hook event in the reading window"
+		surface.Status, surface.Detail = codexSurfaceStatusUnobserved, "no reflection write was attempted in the reading window"
 		return surface
 	}
 	parts := make([]string, 0, len(delivery.Sources))
 	for _, source := range delivery.Sources {
 		part := fmt.Sprintf("%s %d delivered, %d failed", source.Source, source.Delivered, source.Failed)
+		if reasons := codexReasonBreakdown(source.Reasons); reasons != "" {
+			// The breakdown stays next to the count it explains. Anything
+			// pushed between them reads as explaining the wrong number.
+			part += " (" + reasons + ")"
+		}
+		if source.Quiet > 0 {
+			// Beside the two counts, never inside them. A lane that writes
+			// nothing cannot fail to write, and folding it in dilutes the rate
+			// the verdict is about.
+			part += fmt.Sprintf("; %d made no write", source.Quiet)
+		}
 		if source.PathBearing > 0 {
 			// Counted, never folded into the verdict. A reason can name its
 			// cause precisely and still carry a path in the explanation behind
 			// it; those are two properties about two halves of one string.
-			part += fmt.Sprintf(", %d carrying a path", source.PathBearing)
-		}
-		if len(source.Reasons) > 0 {
-			reasons := make([]string, 0, len(source.Reasons))
-			for _, reason := range source.Reasons {
-				reasons = append(reasons, fmt.Sprintf("%s=%d", reason.Reason, reason.Count))
-			}
-			part += " (" + strings.Join(reasons, ", ") + ")"
+			part += fmt.Sprintf("; %d carrying a path", source.PathBearing)
 		}
 		parts = append(parts, part)
 	}

--- a/internal/app/codex_controlplane_surfaces.go
+++ b/internal/app/codex_controlplane_surfaces.go
@@ -356,6 +356,13 @@ func codexHookDeliverySurface(delivery aiIngestDeliveryHealth) codexControlPlane
 // Pane it moved belongs to someone else. Nothing else in this diagnosis can
 // see it, which is why it is a surface of its own rather than a note on
 // attribution.
+//
+// An `ok` here is narrower than it looks, and the detail says so. The
+// guarantee behind it closed the case where a Pane positively records another
+// provider; a Pane the Registry holds without a provider, or one it no longer
+// holds at all, resolves the old way. Those are counted beside the verdict
+// rather than folded into it, so nobody reads a zero as "nothing was
+// misattributed" when what it means is "nothing provably was".
 func codexPaneOwnershipSurface(ownership aiIngestOwnershipHealth) codexControlPlaneSurface {
 	surface := codexControlPlaneSurface{Surface: codexSurfacePaneOwnership}
 	if !ownership.Observed {
@@ -367,8 +374,8 @@ func codexPaneOwnershipSurface(ownership aiIngestOwnershipHealth) codexControlPl
 		surface.Detail = fmt.Sprintf("no attribution could be judged; %d landed on a Pane the Registry no longer holds", ownership.Unresolved)
 		return surface
 	}
-	surface.Detail = fmt.Sprintf("attributions judged %d; foreign %d; unresolved %d",
-		ownership.Classified, ownership.Foreign, ownership.Unresolved)
+	surface.Detail = fmt.Sprintf("attributions judged %d; foreign %d; unresolved %d; provider unrecorded %d",
+		ownership.Classified, ownership.Foreign, ownership.Unresolved, ownership.Unrecorded)
 	if directions := codexReasonBreakdown(ownership.Directions); directions != "" {
 		// Which way the mismatch runs is the whole diagnosis. One direction is
 		// a hook landing on the Pane that launched its host; the other is an

--- a/internal/app/codex_controlplane_surfaces.go
+++ b/internal/app/codex_controlplane_surfaces.go
@@ -327,6 +327,12 @@ func codexHookDeliverySurface(delivery aiIngestDeliveryHealth) codexControlPlane
 	parts := make([]string, 0, len(delivery.Sources))
 	for _, source := range delivery.Sources {
 		part := fmt.Sprintf("%s %d delivered, %d failed", source.Source, source.Delivered, source.Failed)
+		if source.PathBearing > 0 {
+			// Counted, never folded into the verdict. A reason can name its
+			// cause precisely and still carry a path in the explanation behind
+			// it; those are two properties about two halves of one string.
+			part += fmt.Sprintf(", %d carrying a path", source.PathBearing)
+		}
 		if len(source.Reasons) > 0 {
 			reasons := make([]string, 0, len(source.Reasons))
 			for _, reason := range source.Reasons {
@@ -363,6 +369,23 @@ func codexHookDeliverySurface(delivery aiIngestDeliveryHealth) codexControlPlane
 // holds at all, resolves the old way. Those are counted beside the verdict
 // rather than folded into it, so nobody reads a zero as "nothing was
 // misattributed" when what it means is "nothing provably was".
+//
+// Why the unjudgeable share does not make this row red, when it has been more
+// than a third of the window on a live machine:
+//
+// It is not a fault. A Pane that records no provider is silence, and the
+// ownership rule deliberately treats silence as permission -- refusing there
+// would break attribution for every ordinary Pane. Colouring a designed,
+// permanent condition red would ask an operator to act on behaviour that is
+// specified, and a row that is always red is a row that gets skipped. This
+// diagnosis has already had to unlearn that once, when a contractual refusal
+// was being counted as breakage.
+//
+// What must not happen is the number being invisible, and it is not: the
+// denominator leads the detail, so `foreign 0` cannot be read without also
+// reading how much of the window it covers. If that share ever needs a verdict
+// of its own, it needs a contract of its own first -- a claim about how many
+// Panes ought to record a provider, which nothing here makes today.
 func codexPaneOwnershipSurface(ownership aiIngestOwnershipHealth) codexControlPlaneSurface {
 	surface := codexControlPlaneSurface{Surface: codexSurfacePaneOwnership}
 	if !ownership.Observed {
@@ -374,8 +397,13 @@ func codexPaneOwnershipSurface(ownership aiIngestOwnershipHealth) codexControlPl
 		surface.Detail = fmt.Sprintf("no attribution could be judged; %d landed on a Pane the Registry no longer holds", ownership.Unresolved)
 		return surface
 	}
-	surface.Detail = fmt.Sprintf("attributions judged %d; foreign %d; unresolved %d; provider unrecorded %d",
-		ownership.Classified, ownership.Foreign, ownership.Unresolved, ownership.Unrecorded)
+	// The denominator leads, because the verdict is only about the numerator.
+	// "judged 718" beside a separate "unrecorded 267" invites reading the first
+	// number as the whole population; "judged 718 of 989" cannot be read that
+	// way.
+	surface.Detail = fmt.Sprintf("judged %d of %d attributions; foreign %d; unresolved %d; provider unrecorded %d",
+		ownership.Classified, ownership.Classified+ownership.Unresolved+ownership.Unrecorded,
+		ownership.Foreign, ownership.Unresolved, ownership.Unrecorded)
 	if directions := codexReasonBreakdown(ownership.Directions); directions != "" {
 		// Which way the mismatch runs is the whole diagnosis. One direction is
 		// a hook landing on the Pane that launched its host; the other is an

--- a/internal/app/codex_controlplane_surfaces.go
+++ b/internal/app/codex_controlplane_surfaces.go
@@ -374,6 +374,15 @@ func codexHookDeliverySurface(delivery aiIngestDeliveryHealth) codexControlPlane
 // rather than folded into it, so nobody reads a zero as "nothing was
 // misattributed" when what it means is "nothing provably was".
 //
+// The same holds, for a different reason, of attributions naming a Pane the
+// Registry no longer has. That count moves with events this track does not
+// cause and cannot see: when a neighbouring track retired one worker, a single
+// Pane carrying 134 records in the window went from live to absent, and the
+// unresolved count went from zero to two hundred odd between two readings of
+// unchanged code. A verdict driven by that would go red and green on its own,
+// which is the definition of a signal nobody can act on. It is reported and
+// never judged.
+//
 // Why the unjudgeable share does not make this row red, when it has been more
 // than a third of the window on a live machine:
 //

--- a/internal/app/codex_controlplane_surfaces.go
+++ b/internal/app/codex_controlplane_surfaces.go
@@ -232,6 +232,15 @@ func codexObserverReasonSurface(census *codexAuthorityCensus) codexControlPlaneS
 		}
 		captured += reason.Count
 	}
+	if captured == 0 && uncaptured == 0 {
+		// Agents exist and not one of them published a reason, so there is
+		// nothing here to be healthy about. Reporting ok would be the vacuous
+		// pass this section keeps finding elsewhere: a verdict reached over an
+		// empty set reads exactly like a verdict reached over a clean one.
+		surface.Status = codexSurfaceStatusUnobserved
+		surface.Detail = fmt.Sprintf("%d managed Agent(s) and no authority reason published by any of them", census.Agents)
+		return surface
+	}
 	surface.Detail = fmt.Sprintf("captured reasons %d; uncaptured %d", captured, uncaptured)
 	if uncaptured > 0 {
 		surface.Detail += " (" + strings.Join(uncapturedTokens, ", ") + ")"
@@ -311,6 +320,14 @@ func codexTurnAdmissionSurface(census *codexAuthorityCensus) codexControlPlaneSu
 	}
 	surface.Detail = fmt.Sprintf("authority snapshots %d settled, %d contended, %d unfenced; torn %d",
 		census.Settled, census.Contended, census.Unfenced, census.Torn)
+	if census.Settled == 0 {
+		// Only a settled snapshot may be judged for coherence, so a window in
+		// which none settled has judged nothing. `torn 0` there is the absence
+		// of a reading rather than the absence of a fault, and the two must not
+		// render alike.
+		surface.Status = codexSurfaceStatusUnobserved
+		return surface
+	}
 	switch {
 	case census.Torn > 0:
 		surface.Status = codexSurfaceStatusBroken

--- a/internal/app/codex_controlplane_surfaces.go
+++ b/internal/app/codex_controlplane_surfaces.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// The five control-plane surfaces whose broken states this application had no
+// The seven control-plane surfaces whose broken states this application had no
 // detection for.
 //
 // They are named here, in one closed list, for a reason this track paid for:
@@ -20,6 +20,8 @@ const (
 	codexSurfaceObserverReason       = "observer-reason"
 	codexSurfaceConnectionContinuity = "connection-continuity"
 	codexSurfaceTurnAdmission        = "turn-admission"
+	codexSurfaceHookDelivery         = "hook-delivery"
+	codexSurfacePaneOwnership        = "pane-ownership"
 )
 
 // The verdict one surface carries.
@@ -59,18 +61,33 @@ type codexControlPlaneReport struct {
 func projectCodexControlPlaneSurfaces(
 	broker *codexBrokerDiagnostic,
 	census *codexAuthorityCensus,
-	attribution aiIngestAttributionHealth,
+	hooks codexHookHealth,
 	vintage codexControlPlaneVintage,
 ) codexControlPlaneReport {
 	report := codexControlPlaneReport{Vintage: vintage}
 	report.Surfaces = []codexControlPlaneSurface{
 		codexBrokerDiagnosticsSurface(broker),
-		codexHookAttributionSurface(attribution),
+		codexHookAttributionSurface(hooks.Attribution),
 		codexObserverReasonSurface(census),
 		codexConnectionContinuitySurface(broker),
 		codexTurnAdmissionSurface(census),
+		codexHookDeliverySurface(hooks.Delivery),
+		codexPaneOwnershipSurface(hooks.Ownership),
 	}
 	return report
+}
+
+// codexHookHealth is the three questions one read of the hook ingest log
+// answers: whether an event found its Pane, whether it changed it, and whether
+// that Pane was its own.
+//
+// They travel together because they are layers of one path and only make sense
+// read against each other. An event that never found a Pane cannot have failed
+// to change one, and an event that changed the wrong Pane is not a success.
+type codexHookHealth struct {
+	Attribution aiIngestAttributionHealth
+	Delivery    aiIngestDeliveryHealth
+	Ownership   aiIngestOwnershipHealth
 }
 
 // codexBrokerDiagnosticsSurface judges whether the broker diagnosis is looking
@@ -137,15 +154,31 @@ func codexHookAttributionSurface(attribution aiIngestAttributionHealth) codexCon
 	switch {
 	case attribution.Unattributed() == 0:
 		surface.Status = codexSurfaceStatusOK
-	case attribution.Attributed() == 0:
-		// Every event and no Pane is the state defect B held for the entire
-		// life of the neighbouring track, and it is not a degradation of
-		// attribution: it is attribution not happening.
+	case attributionSourceLostEveryEvent(attribution):
+		// Every event of one provider and no Pane is the state defect B held
+		// for the entire life of the neighbouring track, and it is not a
+		// degradation of attribution: it is attribution not happening.
+		//
+		// The test is per source rather than over the total, because that
+		// defect was one provider's. A busy neighbour attributing everything
+		// would carry the aggregate and render the dead provider as a few
+		// stale panes, which is the reading that let it live for eight phases.
 		surface.Status = codexSurfaceStatusBroken
 	default:
 		surface.Status = codexSurfaceStatusDegraded
 	}
 	return surface
+}
+
+// attributionSourceLostEveryEvent reports whether some provider hook source
+// failed to attribute every event it produced in the window.
+func attributionSourceLostEveryEvent(attribution aiIngestAttributionHealth) bool {
+	for _, source := range attribution.Sources {
+		if source.Attributed == 0 && source.Unattributed > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // codexObserverReasonSurface judges whether authority transitions carry a
@@ -257,6 +290,77 @@ func codexTurnAdmissionSurface(census *codexAuthorityCensus) codexControlPlaneSu
 	default:
 		surface.Status = codexSurfaceStatusOK
 	}
+	return surface
+}
+
+// codexHookDeliverySurface judges whether an attributed hook event actually
+// changed the Pane it reached.
+//
+// The verdict turns on whether a failure said anything. A delivery that fails
+// with a bounded reason is a fault an operator can act on; one that fails with
+// a raw process-exit string reports that something ended and nothing else, and
+// a path in that position is a leak besides. The two are separated because the
+// second is the state this surface was opened on.
+func codexHookDeliverySurface(delivery aiIngestDeliveryHealth) codexControlPlaneSurface {
+	surface := codexControlPlaneSurface{Surface: codexSurfaceHookDelivery}
+	if !delivery.Observed {
+		surface.Status, surface.Detail = codexSurfaceStatusUnobserved, "no hook ingest log was readable"
+		return surface
+	}
+	if delivery.Records == 0 {
+		surface.Status, surface.Detail = codexSurfaceStatusUnobserved, "no attributed hook event in the reading window"
+		return surface
+	}
+	parts := make([]string, 0, len(delivery.Sources))
+	for _, source := range delivery.Sources {
+		part := fmt.Sprintf("%s %d delivered, %d failed", source.Source, source.Delivered, source.Failed)
+		if len(source.Reasons) > 0 {
+			reasons := make([]string, 0, len(source.Reasons))
+			for _, reason := range source.Reasons {
+				reasons = append(reasons, fmt.Sprintf("%s=%d", reason.Reason, reason.Count))
+			}
+			part += " (" + strings.Join(reasons, ", ") + ")"
+		}
+		parts = append(parts, part)
+	}
+	surface.Detail = strings.Join(parts, "; ")
+	switch {
+	case delivery.Opaque() > 0:
+		surface.Status = codexSurfaceStatusBroken
+	case delivery.Failed() > 0:
+		surface.Status = codexSurfaceStatusDegraded
+	default:
+		surface.Status = codexSurfaceStatusOK
+	}
+	return surface
+}
+
+// codexPaneOwnershipSurface judges whether attributed hook events landed on a
+// Pane of their own provider.
+//
+// A foreign attribution is the one failure mode that looks like success from
+// every other angle: the event was attributed, the write succeeded, and the
+// Pane it moved belongs to someone else. Nothing else in this diagnosis can
+// see it, which is why it is a surface of its own rather than a note on
+// attribution.
+func codexPaneOwnershipSurface(ownership aiIngestOwnershipHealth) codexControlPlaneSurface {
+	surface := codexControlPlaneSurface{Surface: codexSurfacePaneOwnership}
+	if !ownership.Observed {
+		surface.Status, surface.Detail = codexSurfaceStatusUnobserved, "no hook ingest log and Registry pair was readable"
+		return surface
+	}
+	if ownership.Classified == 0 {
+		surface.Status = codexSurfaceStatusUnobserved
+		surface.Detail = fmt.Sprintf("no attribution could be judged; %d landed on a Pane the Registry no longer holds", ownership.Unresolved)
+		return surface
+	}
+	surface.Detail = fmt.Sprintf("attributions judged %d; foreign %d; unresolved %d",
+		ownership.Classified, ownership.Foreign, ownership.Unresolved)
+	if ownership.Foreign > 0 {
+		surface.Status = codexSurfaceStatusBroken
+		return surface
+	}
+	surface.Status = codexSurfaceStatusOK
 	return surface
 }
 

--- a/internal/app/codex_controlplane_surfaces.go
+++ b/internal/app/codex_controlplane_surfaces.go
@@ -128,6 +128,13 @@ func codexBrokerDiagnosticsSurface(broker *codexBrokerDiagnostic) codexControlPl
 
 // codexHookAttributionSurface judges whether provider hook events are reaching
 // the Pane that owns them.
+//
+// The verdict counts only the events the contract owed a Pane. An event whose
+// conversation no live Pane owns is outside that scope, and reporting the
+// refusal as breakage would make this row fire on a machine whose hooks are
+// behaving exactly as specified. A gate that cries wolf gets ignored, and being
+// ignored is how the defects this section exists to catch survived in the first
+// place.
 func codexHookAttributionSurface(attribution aiIngestAttributionHealth) codexControlPlaneSurface {
 	surface := codexControlPlaneSurface{Surface: codexSurfaceHookAttribution}
 	if !attribution.Observed {
@@ -141,12 +148,18 @@ func codexHookAttributionSurface(attribution aiIngestAttributionHealth) codexCon
 	parts := make([]string, 0, len(attribution.Sources))
 	for _, source := range attribution.Sources {
 		part := fmt.Sprintf("%s %d attributed, %d unattributed", source.Source, source.Attributed, source.Unattributed)
-		if len(source.Reasons) > 0 {
-			reasons := make([]string, 0, len(source.Reasons))
-			for _, reason := range source.Reasons {
-				reasons = append(reasons, fmt.Sprintf("%s=%d", reason.Reason, reason.Count))
+		if reasons := codexReasonBreakdown(source.Reasons); reasons != "" {
+			part += " (" + reasons + ")"
+		}
+		if source.Refused > 0 {
+			// Reported, never folded in. A retired conversation still firing
+			// hooks is the contract declining what it never promised, and an
+			// operator who cannot see that number would read the zero above it
+			// as nothing having happened.
+			part += fmt.Sprintf("; %d out of contract", source.Refused)
+			if reasons := codexReasonBreakdown(source.RefusalReasons); reasons != "" {
+				part += " (" + reasons + ")"
 			}
-			part += " (" + strings.Join(reasons, ", ") + ")"
 		}
 		parts = append(parts, part)
 	}
@@ -356,12 +369,30 @@ func codexPaneOwnershipSurface(ownership aiIngestOwnershipHealth) codexControlPl
 	}
 	surface.Detail = fmt.Sprintf("attributions judged %d; foreign %d; unresolved %d",
 		ownership.Classified, ownership.Foreign, ownership.Unresolved)
+	if directions := codexReasonBreakdown(ownership.Directions); directions != "" {
+		// Which way the mismatch runs is the whole diagnosis. One direction is
+		// a hook landing on the Pane that launched its host; the other is an
+		// event that arrived under the wrong source before attribution ran.
+		surface.Detail += " (" + directions + ")"
+	}
 	if ownership.Foreign > 0 {
 		surface.Status = codexSurfaceStatusBroken
 		return surface
 	}
 	surface.Status = codexSurfaceStatusOK
 	return surface
+}
+
+// codexReasonBreakdown renders one closed-token distribution.
+func codexReasonBreakdown(reasons []aiIngestAttributionReason) string {
+	if len(reasons) == 0 {
+		return ""
+	}
+	rendered := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		rendered = append(rendered, fmt.Sprintf("%s=%d", reason.Reason, reason.Count))
+	}
+	return strings.Join(rendered, ", ")
 }
 
 func codexEndpointPresence(endpoint string) string {

--- a/internal/app/codex_controlplane_surfaces_test.go
+++ b/internal/app/codex_controlplane_surfaces_test.go
@@ -274,9 +274,18 @@ func TestTurnAdmissionSurfaceReportsATornAuthoritySnapshotAsBroken(t *testing.T)
 			wantStatus: codexSurfaceStatusOK,
 		},
 		{
+			name:       "a pane whose writer never fenced still needs one settled read to judge",
+			census:     &codexAuthorityCensus{Agents: 2, Unfenced: 2},
+			wantStatus: codexSurfaceStatusUnobserved,
+		},
+		{
+			// The name of this case was right and its expectation was not. Only
+			// a settled snapshot may be judged for coherence, so a window where
+			// none settled has judged nothing -- and `torn 0` there is the
+			// absence of a reading, not the absence of a fault.
 			name:       "a transition caught in flight says nothing either way",
 			census:     &codexAuthorityCensus{Agents: 1, Contended: 1},
-			wantStatus: codexSurfaceStatusOK,
+			wantStatus: codexSurfaceStatusUnobserved,
 		},
 		{
 			name:       "no classified snapshot answers nothing",
@@ -433,4 +442,30 @@ func codexControlPlaneSurfacesComplete(report codexControlPlaneReport) bool {
 		}
 	}
 	return true
+}
+
+// TestObserverReasonSurfaceRefusesToJudgeAnEmptyReasonSet closes the other
+// vacuity the sweep found.
+//
+// Managed Agents can exist while not one of them has published an authority
+// reason, and the captured-versus-uncaptured split then reads 0 and 0. Calling
+// that healthy is a verdict reached over an empty set rendered exactly like a
+// verdict reached over a clean one — the shape this section has now corrected
+// in three separate places, each found on its own.
+func TestObserverReasonSurfaceRefusesToJudgeAnEmptyReasonSet(t *testing.T) {
+	surface := codexObserverReasonSurface(&codexAuthorityCensus{Agents: 6})
+	if surface.Status != codexSurfaceStatusUnobserved {
+		t.Fatalf("status = %q (detail %q), want %q when no Agent published a reason",
+			surface.Status, surface.Detail, codexSurfaceStatusUnobserved)
+	}
+	if !strings.Contains(surface.Detail, "6 managed Agent(s)") {
+		t.Fatalf("detail = %q, want the population it could not read from", surface.Detail)
+	}
+	// One captured reason is enough to have something to judge.
+	judged := codexObserverReasonSurface(&codexAuthorityCensus{Agents: 6, Reasons: []codexAuthorityReasonCount{
+		{Reason: string(codexObserverReasonReady), Count: 1},
+	}})
+	if judged.Status != codexSurfaceStatusOK {
+		t.Fatalf("status = %q, want %q once a reason was published", judged.Status, codexSurfaceStatusOK)
+	}
 }

--- a/internal/app/codex_controlplane_surfaces_test.go
+++ b/internal/app/codex_controlplane_surfaces_test.go
@@ -1,0 +1,411 @@
+package app
+
+import (
+	"bytes"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/integrations/agents/codexbroker"
+)
+
+// TestCodexBrokerDiagnosticsSurfaceNamesThePublishedButUnreachableRuntime
+// holds the C-1 verdict on the exact shape that cost this machine a process.
+//
+// A discovery record with nothing answering behind it used to render as
+// `absent`, which reads as "no broker is running". It is the opposite: a
+// runtime announced itself here and the diagnosis could not reach it. Nothing
+// published is the ordinary resting state and must stay quiet, or the row
+// trains an operator to skip it.
+func TestCodexBrokerDiagnosticsSurfaceNamesThePublishedButUnreachableRuntime(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		broker     *codexBrokerDiagnostic
+		wantStatus string
+		wantDetail string
+	}{
+		{
+			name:       "published and unreachable is broken",
+			broker:     &codexBrokerDiagnostic{State: codexBrokerStateAbsent, Reason: string(codexbroker.RefusalHostUnavailable), Published: 1},
+			wantStatus: codexSurfaceStatusBroken,
+			wantDetail: "published endpoints 1 answered none",
+		},
+		{
+			name:       "nothing published is the resting state",
+			broker:     &codexBrokerDiagnostic{State: codexBrokerStateAbsent, Reason: string(codexbroker.RefusalHostUnavailable)},
+			wantStatus: codexSurfaceStatusOK,
+			wantDetail: "no endpoint published",
+		},
+		{
+			name:       "a running runtime names the endpoint it was read on",
+			broker:     &codexBrokerDiagnostic{State: codexBrokerStateRunning, Published: 1, Endpoint: "codex-app-server:g1:key"},
+			wantStatus: codexSurfaceStatusOK,
+			wantDetail: "observed endpoint present",
+		},
+		{
+			name:       "no reading is not a healthy reading",
+			broker:     nil,
+			wantStatus: codexSurfaceStatusUnobserved,
+			wantDetail: "no broker reading",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			surface := codexBrokerDiagnosticsSurface(test.broker)
+			if surface.Surface != codexSurfaceBrokerDiagnostics {
+				t.Fatalf("surface = %q, want %q", surface.Surface, codexSurfaceBrokerDiagnostics)
+			}
+			if surface.Status != test.wantStatus {
+				t.Fatalf("status = %q, want %q (detail %q)", surface.Status, test.wantStatus, surface.Detail)
+			}
+			if !strings.Contains(surface.Detail, test.wantDetail) {
+				t.Fatalf("detail = %q, want it to contain %q", surface.Detail, test.wantDetail)
+			}
+		})
+	}
+}
+
+// TestHookAttributionSurfaceSeparatesTotalFailureFromPartial holds the C-2
+// verdict.
+//
+// Attribution failing for every event is not a degradation of attribution; it
+// is attribution not happening, and it is the state defect B held for the whole
+// life of a neighbouring track. Folding it in with a handful of stale panes
+// would put the two on one row and lose the difference an operator acts on.
+func TestHookAttributionSurfaceSeparatesTotalFailureFromPartial(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		health     aiIngestAttributionHealth
+		wantStatus string
+	}{
+		{
+			name:       "no readable log is unobserved, not healthy",
+			health:     aiIngestAttributionHealth{},
+			wantStatus: codexSurfaceStatusUnobserved,
+		},
+		{
+			name:       "a readable log with no hook event answers nothing",
+			health:     aiIngestAttributionHealth{Observed: true},
+			wantStatus: codexSurfaceStatusUnobserved,
+		},
+		{
+			name: "every event and no pane is broken",
+			health: aiIngestAttributionHealth{Observed: true, Records: 898, Sources: []aiIngestAttributionSource{
+				{Source: "codex-hook", Unattributed: 898, Reasons: []aiIngestAttributionReason{{Reason: aiPaneMatchReasonNoInventory, Count: 898}}},
+			}},
+			wantStatus: codexSurfaceStatusBroken,
+		},
+		{
+			name: "some events losing their pane is a degradation",
+			health: aiIngestAttributionHealth{Observed: true, Records: 100, Sources: []aiIngestAttributionSource{
+				{Source: "claude-hook", Attributed: 95, Unattributed: 5, Reasons: []aiIngestAttributionReason{{Reason: aiPaneMatchReasonExplicitStale, Count: 5}}},
+			}},
+			wantStatus: codexSurfaceStatusDegraded,
+		},
+		{
+			name: "every event reaching its pane is healthy",
+			health: aiIngestAttributionHealth{Observed: true, Records: 23, Sources: []aiIngestAttributionSource{
+				{Source: "codex-hook", Attributed: 23},
+			}},
+			wantStatus: codexSurfaceStatusOK,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			surface := codexHookAttributionSurface(test.health)
+			if surface.Surface != codexSurfaceHookAttribution {
+				t.Fatalf("surface = %q, want %q", surface.Surface, codexSurfaceHookAttribution)
+			}
+			if surface.Status != test.wantStatus {
+				t.Fatalf("status = %q, want %q (detail %q)", surface.Status, test.wantStatus, surface.Detail)
+			}
+			if strings.TrimSpace(surface.Detail) == "" {
+				t.Fatal("a verdict with no evidence behind it")
+			}
+		})
+	}
+}
+
+// TestObserverReasonSurfaceRefusesToCallAnUncapturedReasonHealthy holds the
+// C-3 verdict, and it is the product-side half of the false-certification gate.
+//
+// Every Pane reporting the pre-instrumentation literal is exactly the state
+// this track found in the field: six Panes, one reason, and that reason a
+// default that means nothing was recorded. A diagnosis that renders it as a
+// reason distribution and calls the row healthy repeats the E2E assertion that
+// pinned the same literal as its passing condition.
+func TestObserverReasonSurfaceRefusesToCallAnUncapturedReasonHealthy(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		census     *codexAuthorityCensus
+		wantStatus string
+	}{
+		{
+			name: "every reason uncaptured is broken",
+			census: &codexAuthorityCensus{Agents: 6, Reasons: []codexAuthorityReasonCount{
+				// uncaptured-default: the field state this Phase exists to make
+				// visible, driven as input so the verdict can be asserted.
+				{Reason: string(codexObserverReasonRetired), Count: 6},
+			}},
+			wantStatus: codexSurfaceStatusBroken,
+		},
+		{
+			name: "the explicit nothing-recorded bucket is never healthy",
+			census: &codexAuthorityCensus{Agents: 2, Reasons: []codexAuthorityReasonCount{
+				{Reason: string(codexObserverReasonEndpointSuspended), Count: 1},
+				// uncaptured-default: a producer reached the journal with no
+				// token; the bucket names that rather than hiding it.
+				{Reason: string(codexObserverReasonUnrecorded), Count: 1},
+			}},
+			wantStatus: codexSurfaceStatusDegraded,
+		},
+		{
+			name: "an out-of-vocabulary value read back is not an observation",
+			census: &codexAuthorityCensus{Agents: 1, Reasons: []codexAuthorityReasonCount{
+				// uncaptured-default: what a bounded read renders for a value
+				// outside the vocabulary, which is a read failure, not a reason.
+				{Reason: "bounded reason unavailable", Count: 1},
+			}},
+			wantStatus: codexSurfaceStatusBroken,
+		},
+		{
+			name: "captured tokens are healthy",
+			census: &codexAuthorityCensus{Agents: 2, Reasons: []codexAuthorityReasonCount{
+				{Reason: string(codexObserverReasonEndpointSuspended), Count: 1},
+				{Reason: string(codexObserverReasonReady), Count: 1},
+			}},
+			wantStatus: codexSurfaceStatusOK,
+		},
+		{
+			name:       "no managed Agent answers nothing",
+			census:     &codexAuthorityCensus{},
+			wantStatus: codexSurfaceStatusUnobserved,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			surface := codexObserverReasonSurface(test.census)
+			if surface.Surface != codexSurfaceObserverReason {
+				t.Fatalf("surface = %q, want %q", surface.Surface, codexSurfaceObserverReason)
+			}
+			if surface.Status != test.wantStatus {
+				t.Fatalf("status = %q, want %q (detail %q)", surface.Status, test.wantStatus, surface.Detail)
+			}
+		})
+	}
+}
+
+// TestConnectionContinuitySurfaceReportsCumulativeReconnects holds the Phase 3
+// verdict.
+//
+// The count is reported as what it is: a total over the runtime's life. No rate
+// is derived from a single sample, because this reader does not know how long
+// the runtime has been up and a fabricated rate is the kind of number an
+// operator would act on.
+func TestConnectionContinuitySurfaceReportsCumulativeReconnects(t *testing.T) {
+	cycling := codexConnectionContinuitySurface(&codexBrokerDiagnostic{
+		State:           codexBrokerStateRunning,
+		ConnectionEpoch: 26500,
+		Reconnects:      26499,
+		Connections:     1,
+		Revocations:     []codexBrokerRevocation{{Reason: string(codexbroker.RefusalSnapshotUnavailable), Count: 219}},
+	})
+	if cycling.Status != codexSurfaceStatusDegraded {
+		t.Fatalf("status = %q, want %q for a runtime that reconnected 26499 times", cycling.Status, codexSurfaceStatusDegraded)
+	}
+	for _, want := range []string{"reconnects 26499", "connection epoch 26500", string(codexbroker.RefusalSnapshotUnavailable)} {
+		if !strings.Contains(cycling.Detail, want) {
+			t.Fatalf("detail = %q, want it to contain %q", cycling.Detail, want)
+		}
+	}
+	if strings.Contains(cycling.Detail, "/s") {
+		t.Fatalf("detail = %q, want no rate derived from one sample", cycling.Detail)
+	}
+	steady := codexConnectionContinuitySurface(&codexBrokerDiagnostic{State: codexBrokerStateRunning, ConnectionEpoch: 1})
+	if steady.Status != codexSurfaceStatusOK {
+		t.Fatalf("status = %q, want %q for a connection that never dropped", steady.Status, codexSurfaceStatusOK)
+	}
+	absent := codexConnectionContinuitySurface(&codexBrokerDiagnostic{State: codexBrokerStateAbsent})
+	if absent.Status != codexSurfaceStatusUnobserved {
+		t.Fatalf("status = %q, want %q with no running runtime to read", absent.Status, codexSurfaceStatusUnobserved)
+	}
+}
+
+// TestTurnAdmissionSurfaceReportsATornAuthoritySnapshotAsBroken holds the C-5
+// verdict.
+//
+// A torn snapshot is the observable signature of the read that refused live
+// Panes their turn. An unfenced Pane is a different fact and stays a different
+// verdict: its writer never took a fence, which says which build is running
+// rather than that the fence stopped working.
+func TestTurnAdmissionSurfaceReportsATornAuthoritySnapshotAsBroken(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		census     *codexAuthorityCensus
+		wantStatus string
+	}{
+		{
+			name:       "a torn settled snapshot is broken",
+			census:     &codexAuthorityCensus{Agents: 4, Settled: 4, Torn: 1},
+			wantStatus: codexSurfaceStatusBroken,
+		},
+		{
+			name:       "a pane whose writer never fenced is a degradation",
+			census:     &codexAuthorityCensus{Agents: 4, Settled: 3, Unfenced: 1},
+			wantStatus: codexSurfaceStatusDegraded,
+		},
+		{
+			name:       "settled and coherent is healthy",
+			census:     &codexAuthorityCensus{Agents: 4, Settled: 4},
+			wantStatus: codexSurfaceStatusOK,
+		},
+		{
+			name:       "a transition caught in flight says nothing either way",
+			census:     &codexAuthorityCensus{Agents: 1, Contended: 1},
+			wantStatus: codexSurfaceStatusOK,
+		},
+		{
+			name:       "no classified snapshot answers nothing",
+			census:     &codexAuthorityCensus{Agents: 2},
+			wantStatus: codexSurfaceStatusUnobserved,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			surface := codexTurnAdmissionSurface(test.census)
+			if surface.Surface != codexSurfaceTurnAdmission {
+				t.Fatalf("surface = %q, want %q", surface.Surface, codexSurfaceTurnAdmission)
+			}
+			if surface.Status != test.wantStatus {
+				t.Fatalf("status = %q, want %q (detail %q)", surface.Status, test.wantStatus, surface.Detail)
+			}
+		})
+	}
+}
+
+// TestControlPlaneProjectionAnswersForEverySurface pins that the diagnosis
+// answers for all five surfaces, in contract order, on every input.
+//
+// A surface that silently drops out of the projection is the same silence this
+// section replaced: the row is gone, nothing is red, and the guarantee it
+// carried is unobserved.
+func TestControlPlaneProjectionAnswersForEverySurface(t *testing.T) {
+	empty := projectCodexControlPlaneSurfaces(nil, nil, aiIngestAttributionHealth{}, codexControlPlaneVintage{})
+	if !codexControlPlaneSurfacesComplete(empty) {
+		t.Fatalf("projection over empty readings = %+v, want one verdict per named surface", empty.Surfaces)
+	}
+	for _, surface := range empty.Surfaces {
+		if surface.Status != codexSurfaceStatusUnobserved {
+			t.Fatalf("surface %q = %q with nothing read, want %q", surface.Surface, surface.Status, codexSurfaceStatusUnobserved)
+		}
+	}
+	populated := projectCodexControlPlaneSurfaces(
+		&codexBrokerDiagnostic{State: codexBrokerStateRunning, Published: 1, Endpoint: "codex-app-server:g1:key"},
+		&codexAuthorityCensus{Agents: 1, Settled: 1, Reasons: []codexAuthorityReasonCount{{Reason: string(codexObserverReasonReady), Count: 1}}},
+		aiIngestAttributionHealth{Observed: true, Records: 1, Sources: []aiIngestAttributionSource{{Source: "codex-hook", Attributed: 1}}},
+		codexControlPlaneVintage{Supported: true},
+	)
+	if !codexControlPlaneSurfacesComplete(populated) {
+		t.Fatalf("projection over live readings = %+v, want one verdict per named surface", populated.Surfaces)
+	}
+	for _, name := range codexControlPlaneSurfaceOrder {
+		surface, ok := codexControlPlaneSurfaceOf(populated, name)
+		if !ok {
+			t.Fatalf("surface %q missing from a populated projection", name)
+		}
+		if surface.Status != codexSurfaceStatusOK {
+			t.Fatalf("surface %q = %q on healthy readings, want %q (detail %q)", name, surface.Status, codexSurfaceStatusOK, surface.Detail)
+		}
+	}
+}
+
+// TestDoctorRendersEveryControlPlaneSurfaceAndItsVintage is the installed-read
+// acceptance: an operator running `projmux doctor` can read each of the five
+// surfaces individually, and can see whether the processes those readings came
+// from are running the build that is installed.
+//
+// The vintage line is asserted alongside the surfaces because the two are one
+// answer. `make install` never replaces a running process image, so a section
+// of green verdicts read from a replaced-image process states that older code
+// is healthy — and this track lost two acceptance criteria to exactly that.
+func TestDoctorRendersEveryControlPlaneSurfaceAndItsVintage(t *testing.T) {
+	var buf bytes.Buffer
+	writeDoctorCodexControlPlaneText(&buf, &codexControlPlaneReport{
+		Vintage: codexControlPlaneVintage{Supported: true, Roles: []codexControlPlaneRoleVintage{
+			{Role: codexControlPlaneRoleBroker, Processes: 1, Replaced: 1},
+			{Role: codexControlPlaneRoleObserver, Processes: 8, Current: 1, Replaced: 7},
+		}},
+		Surfaces: []codexControlPlaneSurface{
+			{Surface: codexSurfaceBrokerDiagnostics, Status: codexSurfaceStatusBroken, Detail: "published endpoints 1 answered none"},
+			{Surface: codexSurfaceHookAttribution, Status: codexSurfaceStatusBroken, Detail: "codex-hook 0 attributed, 898 unattributed"},
+			{Surface: codexSurfaceObserverReason, Status: codexSurfaceStatusBroken, Detail: "captured reasons 0; uncaptured 6"},
+			{Surface: codexSurfaceConnectionContinuity, Status: codexSurfaceStatusDegraded, Detail: "reconnects 26499"},
+			{Surface: codexSurfaceTurnAdmission, Status: codexSurfaceStatusBroken, Detail: "torn 1"},
+		},
+	})
+	rendered := buf.String()
+	if !strings.Contains(rendered, "Codex control-plane surfaces") {
+		t.Fatalf("rendered:\n%s\nwant the section heading", rendered)
+	}
+	for _, surface := range codexControlPlaneSurfaceOrder {
+		if !strings.Contains(rendered, surface) {
+			t.Fatalf("rendered:\n%s\nwant surface %q to be individually readable", rendered, surface)
+		}
+	}
+	for _, want := range []string{
+		codexControlPlaneRoleBroker, codexControlPlaneRoleObserver,
+		codexProcessVintageReplaced, "older code",
+		codexSurfaceStatusBroken, codexSurfaceStatusDegraded,
+		"898 unattributed", "reconnects 26499", "torn 1",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered:\n%s\nwant it to contain %q", rendered, want)
+		}
+	}
+	var quiet bytes.Buffer
+	writeDoctorCodexControlPlaneText(&quiet, nil)
+	if quiet.Len() != 0 {
+		t.Fatalf("rendered %q with no projection, want nothing", quiet.String())
+	}
+}
+
+// codexControlPlaneSurfaceOrder is the audit order the diagnosis is checked against. It is the
+// contract order, so a reader comparing the section against the contract walks
+// both in one direction.
+var codexControlPlaneSurfaceOrder = []string{
+	codexSurfaceBrokerDiagnostics,
+	codexSurfaceHookAttribution,
+	codexSurfaceObserverReason,
+	codexSurfaceConnectionContinuity,
+	codexSurfaceTurnAdmission,
+}
+
+// codexControlPlaneSurfaceOf returns one surface by token. It exists so the
+// audit gate can address a surface by name rather than by position.
+func codexControlPlaneSurfaceOf(report codexControlPlaneReport, name string) (codexControlPlaneSurface, bool) {
+	for _, surface := range report.Surfaces {
+		if surface.Surface == name {
+			return surface, true
+		}
+	}
+	return codexControlPlaneSurface{}, false
+}
+
+// codexControlPlaneSurfacesComplete reports whether a projection answered for
+// every named surface exactly once.
+func codexControlPlaneSurfacesComplete(report codexControlPlaneReport) bool {
+	if len(report.Surfaces) != len(codexControlPlaneSurfaceOrder) {
+		return false
+	}
+	for index, surface := range report.Surfaces {
+		if surface.Surface != codexControlPlaneSurfaceOrder[index] {
+			return false
+		}
+		if !slices.Contains([]string{
+			codexSurfaceStatusOK, codexSurfaceStatusDegraded,
+			codexSurfaceStatusBroken, codexSurfaceStatusUnobserved,
+		}, surface.Status) {
+			return false
+		}
+		if strings.TrimSpace(surface.Detail) == "" {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/app/codex_controlplane_surfaces_test.go
+++ b/internal/app/codex_controlplane_surfaces_test.go
@@ -97,15 +97,24 @@ func TestHookAttributionSurfaceSeparatesTotalFailureFromPartial(t *testing.T) {
 		{
 			name: "one provider losing every event is broken even beside a healthy neighbour",
 			health: aiIngestAttributionHealth{Observed: true, Records: 926, Sources: []aiIngestAttributionSource{
-				{Source: "codex-hook", Unattributed: 28, Reasons: []aiIngestAttributionReason{{Reason: aiPaneMatchReasonConversationUnknown, Count: 28}}},
-				{Source: "claude-hook", Attributed: 870, Unattributed: 28, Reasons: []aiIngestAttributionReason{{Reason: aiPaneMatchReasonConversationUnknown, Count: 28}}},
+				{Source: "codex-hook", Unattributed: 28, Reasons: []aiIngestAttributionReason{{Reason: aiPaneMatchReasonNoInventory, Count: 28}}},
+				{Source: "claude-hook", Attributed: 870, Unattributed: 28, Reasons: []aiIngestAttributionReason{{Reason: aiPaneMatchReasonNoInventory, Count: 28}}},
 			}},
 			wantStatus: codexSurfaceStatusBroken,
 		},
 		{
+			name: "a retired conversation still firing hooks is the contract working",
+			health: aiIngestAttributionHealth{Observed: true, Records: 34, Sources: []aiIngestAttributionSource{
+				{Source: "codex-hook", Refused: 34, RefusalReasons: []aiIngestAttributionReason{
+					{Reason: aiPaneMatchReasonConversationUnknown, Count: 34},
+				}},
+			}},
+			wantStatus: codexSurfaceStatusOK,
+		},
+		{
 			name: "some events losing their pane is a degradation",
 			health: aiIngestAttributionHealth{Observed: true, Records: 100, Sources: []aiIngestAttributionSource{
-				{Source: "claude-hook", Attributed: 95, Unattributed: 5, Reasons: []aiIngestAttributionReason{{Reason: aiPaneMatchReasonExplicitStale, Count: 5}}},
+				{Source: "claude-hook", Attributed: 95, Unattributed: 5, Reasons: []aiIngestAttributionReason{{Reason: aiPaneMatchReasonNoMatch, Count: 5}}},
 			}},
 			wantStatus: codexSurfaceStatusDegraded,
 		},

--- a/internal/app/codex_controlplane_surfaces_test.go
+++ b/internal/app/codex_controlplane_surfaces_test.go
@@ -95,6 +95,14 @@ func TestHookAttributionSurfaceSeparatesTotalFailureFromPartial(t *testing.T) {
 			wantStatus: codexSurfaceStatusBroken,
 		},
 		{
+			name: "one provider losing every event is broken even beside a healthy neighbour",
+			health: aiIngestAttributionHealth{Observed: true, Records: 926, Sources: []aiIngestAttributionSource{
+				{Source: "codex-hook", Unattributed: 28, Reasons: []aiIngestAttributionReason{{Reason: aiPaneMatchReasonConversationUnknown, Count: 28}}},
+				{Source: "claude-hook", Attributed: 870, Unattributed: 28, Reasons: []aiIngestAttributionReason{{Reason: aiPaneMatchReasonConversationUnknown, Count: 28}}},
+			}},
+			wantStatus: codexSurfaceStatusBroken,
+		},
+		{
 			name: "some events losing their pane is a degradation",
 			health: aiIngestAttributionHealth{Observed: true, Records: 100, Sources: []aiIngestAttributionSource{
 				{Source: "claude-hook", Attributed: 95, Unattributed: 5, Reasons: []aiIngestAttributionReason{{Reason: aiPaneMatchReasonExplicitStale, Count: 5}}},
@@ -286,7 +294,7 @@ func TestTurnAdmissionSurfaceReportsATornAuthoritySnapshotAsBroken(t *testing.T)
 // section replaced: the row is gone, nothing is red, and the guarantee it
 // carried is unobserved.
 func TestControlPlaneProjectionAnswersForEverySurface(t *testing.T) {
-	empty := projectCodexControlPlaneSurfaces(nil, nil, aiIngestAttributionHealth{}, codexControlPlaneVintage{})
+	empty := projectCodexControlPlaneSurfaces(nil, nil, codexHookHealth{}, codexControlPlaneVintage{})
 	if !codexControlPlaneSurfacesComplete(empty) {
 		t.Fatalf("projection over empty readings = %+v, want one verdict per named surface", empty.Surfaces)
 	}
@@ -298,7 +306,11 @@ func TestControlPlaneProjectionAnswersForEverySurface(t *testing.T) {
 	populated := projectCodexControlPlaneSurfaces(
 		&codexBrokerDiagnostic{State: codexBrokerStateRunning, Published: 1, Endpoint: "codex-app-server:g1:key"},
 		&codexAuthorityCensus{Agents: 1, Settled: 1, Reasons: []codexAuthorityReasonCount{{Reason: string(codexObserverReasonReady), Count: 1}}},
-		aiIngestAttributionHealth{Observed: true, Records: 1, Sources: []aiIngestAttributionSource{{Source: "codex-hook", Attributed: 1}}},
+		codexHookHealth{
+			Attribution: aiIngestAttributionHealth{Observed: true, Records: 1, Sources: []aiIngestAttributionSource{{Source: "codex-hook", Attributed: 1}}},
+			Delivery:    aiIngestDeliveryHealth{Observed: true, Records: 1, Sources: []aiIngestDeliverySource{{Source: "codex-hook", Delivered: 1}}},
+			Ownership:   aiIngestOwnershipHealth{Observed: true, Classified: 1},
+		},
 		codexControlPlaneVintage{Supported: true},
 	)
 	if !codexControlPlaneSurfacesComplete(populated) {
@@ -337,6 +349,8 @@ func TestDoctorRendersEveryControlPlaneSurfaceAndItsVintage(t *testing.T) {
 			{Surface: codexSurfaceObserverReason, Status: codexSurfaceStatusBroken, Detail: "captured reasons 0; uncaptured 6"},
 			{Surface: codexSurfaceConnectionContinuity, Status: codexSurfaceStatusDegraded, Detail: "reconnects 26499"},
 			{Surface: codexSurfaceTurnAdmission, Status: codexSurfaceStatusBroken, Detail: "torn 1"},
+			{Surface: codexSurfaceHookDelivery, Status: codexSurfaceStatusBroken, Detail: "codex-hook 0 delivered, 8 failed"},
+			{Surface: codexSurfacePaneOwnership, Status: codexSurfaceStatusBroken, Detail: "attributions judged 23; foreign 0; unresolved 0"},
 		},
 	})
 	rendered := buf.String()
@@ -374,6 +388,8 @@ var codexControlPlaneSurfaceOrder = []string{
 	codexSurfaceObserverReason,
 	codexSurfaceConnectionContinuity,
 	codexSurfaceTurnAdmission,
+	codexSurfaceHookDelivery,
+	codexSurfacePaneOwnership,
 }
 
 // codexControlPlaneSurfaceOf returns one surface by token. It exists so the

--- a/internal/app/codex_controlplane_vintage.go
+++ b/internal/app/codex_controlplane_vintage.go
@@ -45,16 +45,16 @@ const procDeletedSuffix = " (deleted)"
 // codexProcessImage is one entry of the local process table, reduced to the two
 // facts this projection reads. Nothing here is provider content: the executable
 // link and the argv of this application's own children.
+//
+// The reader that produces these reports whether the platform exposes such a
+// table at all. A platform that does not is reported as unknown rather than as
+// current, because a diagnosis that cannot establish vintage must say so rather
+// than imply currency.
 type codexProcessImage struct {
 	PID     int
 	Exe     string
 	Cmdline []string
 }
-
-// codexProcessImageLister reads the local process table. It reports false when
-// the platform exposes no such table, which is not a failure: a diagnosis that
-// cannot establish vintage must say so rather than imply currency.
-type codexProcessImageLister func() ([]codexProcessImage, bool)
 
 // codexControlPlaneRoleVintage is the vintage census of one control-plane role.
 type codexControlPlaneRoleVintage struct {

--- a/internal/app/codex_controlplane_vintage.go
+++ b/internal/app/codex_controlplane_vintage.go
@@ -1,0 +1,174 @@
+package app
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// The binary vintage of one live projmux process, as a diagnostics reader can
+// establish it without touching the process.
+//
+// `make install` replaces the executable on disk; it does not replace the image
+// of a process that is already running. A diagnosis taken from the installed
+// build therefore describes code that a long-lived control-plane process may
+// never have loaded, and reporting that diagnosis as healthy certifies
+// "installed, therefore deployed", which is false. These two tokens are what
+// separate the two states an operator otherwise has to establish by reading
+// /proc/<pid>/exe by hand.
+const (
+	// codexProcessVintageCurrent is a process whose image is still the file
+	// the installed path resolves to.
+	codexProcessVintageCurrent = "current"
+	// codexProcessVintageReplaced is a process whose image was unlinked out
+	// from under it, which is what an atomic install leaves behind.
+	codexProcessVintageReplaced = "replaced"
+)
+
+// The control-plane roles a Codex diagnosis actually depends on. Both are
+// long-lived projmux children, and both are where this track lost an acceptance
+// criterion to a stale image: the lifecycle observer in Phase 0 and the broker
+// runtime in Phase 3.
+const (
+	codexControlPlaneRoleBroker   = "broker-runtime"
+	codexControlPlaneRoleObserver = "lifecycle-observer"
+)
+
+var codexControlPlaneRoleOrder = []string{codexControlPlaneRoleBroker, codexControlPlaneRoleObserver}
+
+// procDeletedSuffix is what the kernel appends to /proc/<pid>/exe once the
+// mapped file has been unlinked. It is the whole discriminator: the link target
+// still names the installed path, so only this suffix separates a process
+// running the installed build from one running an image that no longer exists.
+const procDeletedSuffix = " (deleted)"
+
+// codexProcessImage is one entry of the local process table, reduced to the two
+// facts this projection reads. Nothing here is provider content: the executable
+// link and the argv of this application's own children.
+type codexProcessImage struct {
+	PID     int
+	Exe     string
+	Cmdline []string
+}
+
+// codexProcessImageLister reads the local process table. It reports false when
+// the platform exposes no such table, which is not a failure: a diagnosis that
+// cannot establish vintage must say so rather than imply currency.
+type codexProcessImageLister func() ([]codexProcessImage, bool)
+
+// codexControlPlaneRoleVintage is the vintage census of one control-plane role.
+type codexControlPlaneRoleVintage struct {
+	Role      string `json:"role"`
+	Processes int    `json:"processes"`
+	Current   int    `json:"current"`
+	Replaced  int    `json:"replaced"`
+}
+
+// codexControlPlaneVintage is the whole answer to "is the diagnosis I am about
+// to read taken from the build I just installed".
+//
+// It counts processes by role and image age and names none of them, so it
+// carries no pid, no path, and no provider content onto a diagnostics surface.
+type codexControlPlaneVintage struct {
+	// Supported reports whether this platform exposes a process table this
+	// reader can establish vintage from. False is `unknown`, never `current`.
+	Supported bool                           `json:"supported"`
+	Roles     []codexControlPlaneRoleVintage `json:"roles,omitempty"`
+}
+
+// Replaced is how many observed control-plane processes run an image that is no
+// longer the installed one.
+func (v codexControlPlaneVintage) Replaced() int {
+	total := 0
+	for _, role := range v.Roles {
+		total += role.Replaced
+	}
+	return total
+}
+
+// Observed is how many control-plane processes this reader could classify.
+func (v codexControlPlaneVintage) Observed() int {
+	total := 0
+	for _, role := range v.Roles {
+		total += role.Processes
+	}
+	return total
+}
+
+// projectCodexControlPlaneVintage classifies the control-plane children of this
+// executable.
+//
+// Only processes whose image resolves back to this executable's own path are
+// considered. A process whose link cannot be read at all is skipped rather than
+// counted as unknown: this reader cannot tell such a process from another
+// user's, and inventing a category for it would put a number on the section
+// that no operator action follows from.
+func projectCodexControlPlaneVintage(self string, selfPID int, images []codexProcessImage, supported bool) codexControlPlaneVintage {
+	vintage := codexControlPlaneVintage{Supported: supported}
+	if !supported {
+		return vintage
+	}
+	self = strings.TrimSpace(self)
+	byRole := map[string]*codexControlPlaneRoleVintage{}
+	for _, role := range codexControlPlaneRoleOrder {
+		byRole[role] = &codexControlPlaneRoleVintage{Role: role}
+	}
+	for _, image := range images {
+		if image.PID == selfPID {
+			// The reader's own image is current by construction, and it is not
+			// one of the processes the Codex diagnosis is taken from.
+			continue
+		}
+		path, replaced := codexProcessImagePath(image.Exe)
+		if path == "" || self == "" || path != self {
+			continue
+		}
+		role := codexControlPlaneRole(image.Cmdline)
+		census, ok := byRole[role]
+		if !ok {
+			continue
+		}
+		census.Processes++
+		if replaced {
+			census.Replaced++
+		} else {
+			census.Current++
+		}
+	}
+	for _, role := range codexControlPlaneRoleOrder {
+		if census := byRole[role]; census.Processes > 0 {
+			vintage.Roles = append(vintage.Roles, *census)
+		}
+	}
+	return vintage
+}
+
+// codexProcessImagePath splits one /proc/<pid>/exe link target into the path it
+// names and whether that file has been unlinked.
+func codexProcessImagePath(exe string) (string, bool) {
+	exe = strings.TrimSpace(exe)
+	if exe == "" {
+		return "", false
+	}
+	if trimmed, found := strings.CutSuffix(exe, procDeletedSuffix); found {
+		return filepath.Clean(trimmed), true
+	}
+	return filepath.Clean(exe), false
+}
+
+// codexControlPlaneRole names which control-plane child one argv belongs to.
+//
+// The match is on the internal route words rather than on argv positions, so a
+// flag added ahead of the route does not silently drop a process out of the
+// census and report a fleet as smaller than it is.
+func codexControlPlaneRole(cmdline []string) string {
+	switch {
+	case slices.Contains(cmdline, "codex-broker") && slices.Contains(cmdline, "serve"):
+		return codexControlPlaneRoleBroker
+	case slices.Contains(cmdline, "agent-hook") && slices.Contains(cmdline, "ingest") &&
+		slices.Contains(cmdline, codexNativeLifecycleIngestRoute):
+		return codexControlPlaneRoleObserver
+	default:
+		return ""
+	}
+}

--- a/internal/app/codex_controlplane_vintage_darwin.go
+++ b/internal/app/codex_controlplane_vintage_darwin.go
@@ -1,0 +1,12 @@
+package app
+
+// defaultCodexProcessImages reports that this platform exposes no process table
+// this reader can establish binary vintage from.
+//
+// Reporting the absence is the whole contract. Darwin has no /proc/<pid>/exe
+// and therefore no way to tell a process running the installed image from one
+// whose image was replaced under it; answering `current` here would certify
+// exactly the falsehood this projection exists to prevent.
+func defaultCodexProcessImages() ([]codexProcessImage, bool) {
+	return nil, false
+}

--- a/internal/app/codex_controlplane_vintage_linux.go
+++ b/internal/app/codex_controlplane_vintage_linux.go
@@ -1,0 +1,74 @@
+package app
+
+import (
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// codexProcessScanLimit bounds one process-table read. A diagnostics section
+// that walked an unbounded table would turn `projmux doctor` into a scan of the
+// machine; this sits far above any real process count and exists only so that
+// a pathological /proc cannot hold the command open.
+const codexProcessScanLimit = 8192
+
+// codexProcessCmdlineLimit bounds one argv read. The routes this reader matches
+// are a few hundred bytes; anything past this bound is not one of them.
+const codexProcessCmdlineLimit = 8 << 10
+
+// defaultCodexProcessImages reads the local process table.
+//
+// It reads two files per process and never writes, signals, or opens anything
+// the process owns. A link it cannot read is skipped, which is the ordinary
+// answer for a process belonging to another user.
+func defaultCodexProcessImages() ([]codexProcessImage, bool) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, false
+	}
+	images := make([]codexProcessImage, 0, 64)
+	for _, entry := range entries {
+		if len(images) >= codexProcessScanLimit {
+			break
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid <= 0 {
+			continue
+		}
+		exe, err := os.Readlink("/proc/" + entry.Name() + "/exe")
+		if err != nil || strings.TrimSpace(exe) == "" {
+			continue
+		}
+		images = append(images, codexProcessImage{PID: pid, Exe: exe, Cmdline: readProcCmdline(entry.Name())})
+	}
+	return images, true
+}
+
+// readProcCmdline reads one process's argv. An unreadable or empty argv yields
+// no words, which classifies the process into no control-plane role rather than
+// into the wrong one.
+func readProcCmdline(pid string) []string {
+	// #nosec G304 -- pid is one numeric directory entry of /proc, rendered by
+	// the kernel; the fixed procfs path cannot carry caller traversal.
+	file, err := os.Open("/proc/" + pid + "/cmdline")
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+	payload, err := io.ReadAll(io.LimitReader(file, codexProcessCmdlineLimit))
+	if err != nil || len(payload) == 0 {
+		return nil
+	}
+	words := strings.Split(strings.TrimRight(string(payload), "\x00"), "\x00")
+	kept := words[:0]
+	for _, word := range words {
+		if word != "" {
+			kept = append(kept, word)
+		}
+	}
+	return kept
+}

--- a/internal/app/codex_controlplane_vintage_linux_test.go
+++ b/internal/app/codex_controlplane_vintage_linux_test.go
@@ -1,0 +1,54 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestProcessImageListerReadsTheLiveTable covers the one part of the vintage
+// signal that synthetic images cannot.
+//
+// Everything above it is a pure projection over a slice, and that projection is
+// pinned thoroughly — but a projection over an empty slice reports "no
+// control-plane process observed", which is exactly what a correct reader says
+// on a machine with none running. The two are indistinguishable from the
+// outside, so a lister that silently returned nothing would leave the whole
+// signal reporting a reassuring sentence forever.
+//
+// Reading the current process out of the table is the smallest claim that
+// separates them: this process certainly exists.
+func TestProcessImageListerReadsTheLiveTable(t *testing.T) {
+	images, supported := defaultCodexProcessImages()
+	if !supported {
+		t.Fatal("the process table was unreadable on a platform that has one")
+	}
+	if len(images) == 0 {
+		t.Fatal("the process table read as empty, which would make every vintage answer a silent no-op")
+	}
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve own executable: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(self)
+	if err != nil {
+		resolved = self
+	}
+	var found *codexProcessImage
+	for index, image := range images {
+		if image.PID == os.Getpid() {
+			found = &images[index]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("the reader listed %d process(es) and not itself", len(images))
+	}
+	path, replaced := codexProcessImagePath(found.Exe)
+	if path != resolved {
+		t.Fatalf("own image = %q (replaced=%v), want the running test binary at %q", path, replaced, resolved)
+	}
+	if len(found.Cmdline) == 0 {
+		t.Fatal("own argv read as empty, which would classify every process into no control-plane role")
+	}
+}

--- a/internal/app/codex_controlplane_vintage_test.go
+++ b/internal/app/codex_controlplane_vintage_test.go
@@ -1,0 +1,143 @@
+package app
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestControlPlaneVintageSeparatesAReplacedImageFromTheInstalledBuild is the
+// deployment-vintage gate.
+//
+// `make install` replaces the file on disk and leaves every running process on
+// the image it started with. This track lost two acceptance criteria to that
+// twice — a lifecycle observer in one phase and the broker runtime in another,
+// both still serving code from before the fix while the installed binary was
+// current. A diagnosis that reads those processes and reports green certifies
+// "installed, therefore deployed", and the operator's only way to catch it was
+// to resolve /proc/<pid>/exe by hand.
+func TestControlPlaneVintageSeparatesAReplacedImageFromTheInstalledBuild(t *testing.T) {
+	const self = "/home/user/go/bin/projmux"
+	images := []codexProcessImage{
+		// The reader's own process, which is current by construction and is not
+		// one of the processes a Codex diagnosis is taken from.
+		{PID: 100, Exe: self, Cmdline: []string{self, "doctor"}},
+		{PID: 200, Exe: self + procDeletedSuffix, Cmdline: []string{self, "internal", "codex-broker", "serve", "--state-domain", "/state"}},
+		{PID: 300, Exe: self + procDeletedSuffix, Cmdline: []string{self, "internal", "agent-hook", "ingest", codexNativeLifecycleIngestRoute, "--pane", "%1"}},
+		{PID: 301, Exe: self, Cmdline: []string{self, "internal", "agent-hook", "ingest", codexNativeLifecycleIngestRoute, "--pane", "%2"}},
+		// Another projmux process that serves no control-plane role.
+		{PID: 400, Exe: self, Cmdline: []string{self, "attach"}},
+		// A different binary at a path this reader does not own.
+		{PID: 500, Exe: "/usr/bin/tmux", Cmdline: []string{"tmux", "internal", "codex-broker", "serve"}},
+	}
+	vintage := projectCodexControlPlaneVintage(self, 100, images, true)
+	want := codexControlPlaneVintage{Supported: true, Roles: []codexControlPlaneRoleVintage{
+		{Role: codexControlPlaneRoleBroker, Processes: 1, Replaced: 1},
+		{Role: codexControlPlaneRoleObserver, Processes: 2, Current: 1, Replaced: 1},
+	}}
+	if !reflect.DeepEqual(vintage, want) {
+		t.Fatalf("vintage = %+v, want %+v", vintage, want)
+	}
+	if vintage.Replaced() != 2 || vintage.Observed() != 3 {
+		t.Fatalf("replaced = %d, observed = %d, want 2 and 3", vintage.Replaced(), vintage.Observed())
+	}
+	text := codexControlPlaneVintageText(vintage)
+	for _, want := range []string{codexControlPlaneRoleBroker, codexControlPlaneRoleObserver, codexProcessVintageReplaced, "older code"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("vintage text = %q, want it to contain %q", text, want)
+		}
+	}
+}
+
+// TestControlPlaneVintageStaysSilentWhenEveryImageIsCurrent pins that the
+// warning is earned rather than permanent. A section that always warns is one
+// an operator learns to skip.
+func TestControlPlaneVintageStaysSilentWhenEveryImageIsCurrent(t *testing.T) {
+	const self = "/opt/projmux"
+	vintage := projectCodexControlPlaneVintage(self, 1, []codexProcessImage{
+		{PID: 2, Exe: self, Cmdline: []string{self, "internal", "codex-broker", "serve"}},
+	}, true)
+	if vintage.Replaced() != 0 {
+		t.Fatalf("replaced = %d, want 0", vintage.Replaced())
+	}
+	if text := codexControlPlaneVintageText(vintage); strings.Contains(text, "older code") {
+		t.Fatalf("vintage text = %q, want no staleness warning when every image is current", text)
+	}
+}
+
+// TestControlPlaneVintageReportsAnUnreadableProcessTableAsUnknown pins that a
+// platform with no process table says so.
+//
+// Answering `current` there would certify exactly the falsehood this projection
+// exists to prevent, on the one platform where it cannot be checked.
+func TestControlPlaneVintageReportsAnUnreadableProcessTableAsUnknown(t *testing.T) {
+	vintage := projectCodexControlPlaneVintage("/opt/projmux", 1, []codexProcessImage{
+		{PID: 2, Exe: "/opt/projmux", Cmdline: []string{"/opt/projmux", "internal", "codex-broker", "serve"}},
+	}, false)
+	if vintage.Supported || len(vintage.Roles) != 0 {
+		t.Fatalf("vintage = %+v, want no classification without a process table", vintage)
+	}
+	text := codexControlPlaneVintageText(vintage)
+	if !strings.Contains(text, "unknown") {
+		t.Fatalf("vintage text = %q, want it to name the answer as unknown", text)
+	}
+	if strings.Contains(text, codexProcessVintageCurrent) {
+		t.Fatalf("vintage text = %q, want no currency claim on a platform that cannot check it", text)
+	}
+}
+
+// TestControlPlaneImagePathReadsTheDeletedMarker pins the discriminator itself.
+// The link target still names the installed path after a replace, so only the
+// suffix separates a current image from one that no longer exists on disk.
+func TestControlPlaneImagePathReadsTheDeletedMarker(t *testing.T) {
+	for _, test := range []struct {
+		exe          string
+		wantPath     string
+		wantReplaced bool
+	}{
+		{exe: "/home/user/go/bin/projmux", wantPath: "/home/user/go/bin/projmux"},
+		{exe: "/home/user/go/bin/projmux (deleted)", wantPath: "/home/user/go/bin/projmux", wantReplaced: true},
+		{exe: "  /home/user/go/bin/projmux  ", wantPath: "/home/user/go/bin/projmux"},
+		{exe: "", wantPath: ""},
+	} {
+		path, replaced := codexProcessImagePath(test.exe)
+		if path != test.wantPath || replaced != test.wantReplaced {
+			t.Fatalf("codexProcessImagePath(%q) = (%q, %v), want (%q, %v)", test.exe, path, replaced, test.wantPath, test.wantReplaced)
+		}
+	}
+}
+
+// TestControlPlaneRoleMatchesTheInternalRouteRatherThanArgvPosition pins that
+// a flag inserted ahead of the route does not drop a process out of the census
+// and report the fleet as smaller than it is.
+func TestControlPlaneRoleMatchesTheInternalRouteRatherThanArgvPosition(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		cmdline []string
+		want    string
+	}{
+		{name: "broker", cmdline: []string{"projmux", "internal", "codex-broker", "serve"}, want: codexControlPlaneRoleBroker},
+		{
+			name:    "broker behind a future flag",
+			cmdline: []string{"projmux", "--verbose", "internal", "codex-broker", "serve", "--state-domain", "/state"},
+			want:    codexControlPlaneRoleBroker,
+		},
+		{
+			name:    "observer",
+			cmdline: []string{"projmux", "internal", "agent-hook", "ingest", codexNativeLifecycleIngestRoute},
+			want:    codexControlPlaneRoleObserver,
+		},
+		{
+			name:    "a sibling hook ingest route is not an observer",
+			cmdline: []string{"projmux", "internal", "agent-hook", "ingest", "claude"},
+			want:    "",
+		},
+		{name: "no argv", cmdline: nil, want: ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := codexControlPlaneRole(test.cmdline); got != test.want {
+				t.Fatalf("role = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/app/codex_lifecycle_diagnostics.go
+++ b/internal/app/codex_lifecycle_diagnostics.go
@@ -15,7 +15,16 @@ import (
 type codexLifecycleAuthorityDiagnostic struct {
 	Source      string
 	Reason      string
+	Epoch       string
 	EpochStatus string
+	// Fence records how this observation was taken against the per-Pane
+	// authority fence the writer holds while it publishes the triple. It is
+	// what separates "the triple is genuinely inconsistent" from "the triple
+	// was read while its writer was mid-transition".
+	Fence string
+	// Torn reports that a settled observation returned a pairing no completed
+	// transition produces. It is only meaningful under a settled fence.
+	Torn bool
 	// Declared is the by-design reason this Agent has no native binding, from
 	// the closed declared vocabulary, or empty. A hook observation with no
 	// declared reason is an unexplained native fallback; one with a declared
@@ -59,6 +68,19 @@ type codexAuthorityCensus struct {
 	// first epoch, and one that stopped after flapping all land in the same
 	// invalidating bucket; what differs is the token that put them there.
 	Reasons []codexAuthorityReasonCount `json:"reasons,omitempty"`
+	// Settled, Contended and Unfenced classify how each Agent's authority
+	// triple was sampled, and Torn counts the settled samples whose authority
+	// and epoch could not both come from one completed transition.
+	//
+	// Torn is the number the turn-admission contract requires to be zero: it is
+	// the observable signature of the read that refused a live Pane its turn.
+	// Unfenced is a different fact and is kept apart from it — a Pane whose
+	// transitions were never published under a fence is one whose writer
+	// predates the fence, which is a deployment answer rather than a torn one.
+	Settled   int `json:"settled_snapshots"`
+	Contended int `json:"contended_snapshots"`
+	Unfenced  int `json:"unfenced_snapshots"`
+	Torn      int `json:"torn_snapshots"`
 }
 
 // codexAuthorityReasonCount is one bounded reason token and how many managed
@@ -88,6 +110,17 @@ func censusCodexLifecycleAuthority(
 		diagnostic := lookup(agent.Status.PaneRef)
 		if reason := strings.TrimSpace(diagnostic.Reason); reason != "" {
 			reasons[reason]++
+		}
+		switch diagnostic.Fence {
+		case codexAuthorityFenceSettled:
+			census.Settled++
+			if diagnostic.Torn {
+				census.Torn++
+			}
+		case codexAuthorityFenceContended:
+			census.Contended++
+		case codexAuthorityFenceUnfenced:
+			census.Unfenced++
 		}
 		switch diagnostic.Source {
 		case codexAuthorityControlPlane:
@@ -173,7 +206,12 @@ func observeCodexLifecycleAuthority(ctx context.Context, runner tmuxRunner, pane
 		} else if source == codexAuthorityPending {
 			epochStatus = "pending"
 		}
-		diagnostic := codexLifecycleAuthorityDiagnostic{Source: source, Reason: reason, EpochStatus: epochStatus}
+		diagnostic := codexLifecycleAuthorityDiagnostic{
+			Source:      source,
+			Reason:      reason,
+			Epoch:       strings.TrimSpace(parts[2]),
+			EpochStatus: epochStatus,
+		}
 		if len(parts) >= 7 {
 			diagnostic.Dropped = safeProgressCounter(parts[4])
 			diagnostic.Unknown = safeProgressCounter(parts[5])

--- a/internal/app/codex_native_declared_lane_test.go
+++ b/internal/app/codex_native_declared_lane_test.go
@@ -146,7 +146,7 @@ func TestManagedCodexAuthorityCensusSeparatesDeclaredFromUnexplainedFallback(t *
 		"pane-payload-free": {Source: codexAuthorityHook, Reason: codexNativeUnexplainedReason, Declared: codexNativeDeclaredPayloadFreeFallback},
 		"pane-lost":         {Source: codexAuthorityHook, Reason: codexNativeUnexplainedReason},
 		"pane-pending":      {Source: codexAuthorityPending, Reason: "connecting", EpochStatus: "pending"},
-		"pane-invalidating": {Source: codexAuthorityInvalidating, Reason: "disconnected", EpochStatus: "active"},
+		"pane-invalidating": {Source: codexAuthorityInvalidating, Reason: "endpoint-suspended", EpochStatus: "active"},
 		"pane-unreadable":   {Source: "unavailable", Reason: "tmux observation failed", EpochStatus: "unknown"},
 	}
 	registry := coremetadata.Registry{}
@@ -183,7 +183,7 @@ func TestManagedCodexAuthorityCensusSeparatesDeclaredFromUnexplainedFallback(t *
 		DeclaredHook: 3, PayloadFreeFallback: 1, UnexplainedHook: 1, Unavailable: 1,
 		Reasons: []codexAuthorityReasonCount{
 			{Reason: "connecting", Count: 1},
-			{Reason: "disconnected", Count: 1},
+			{Reason: "endpoint-suspended", Count: 1},
 			{Reason: codexNativeUnexplainedReason, Count: 4},
 			{Reason: "ready", Count: 1},
 			{Reason: "tmux observation failed", Count: 1},

--- a/internal/app/doctor.go
+++ b/internal/app/doctor.go
@@ -53,6 +53,14 @@ type doctorCommand struct {
 	// the create planner. Doctor only projects it; it never runs qualification or
 	// mutates a provider lifecycle.
 	codexPayloadFreeCapability func() codexgeneration.Record
+	// hookAttribution reads whether provider hook events reached the Pane that
+	// owns them. It is a bounded tail read of the ingest log and creates
+	// nothing, so asking the question on a machine that never ran a hook stays
+	// an unobserved answer rather than a new file.
+	hookAttribution func() aiIngestAttributionHealth
+	// controlPlaneVintage reads the binary vintage of the live control-plane
+	// processes this diagnosis is taken from.
+	controlPlaneVintage func() codexControlPlaneVintage
 }
 
 func newDoctorCommand() *doctorCommand {
@@ -73,7 +81,31 @@ func newDoctorCommand() *doctorCommand {
 		return health
 	}
 	c.brokerDiagnostic = defaultCodexBrokerDiagnosticLookup()
-	c.codexAuthority = defaultCodexLifecycleAuthorityLookup()
+	// The authority read is fenced here and unfenced elsewhere on purpose. A
+	// single-resource describe reports one Pane as it is right now; this
+	// section reaches a verdict about whether a completed transition is
+	// readable at all, and an unfenced sample cannot tell a torn triple from a
+	// transition caught in flight.
+	c.codexAuthority = defaultSettledCodexLifecycleAuthorityLookup(doctorStateDir(c.getenv))
+	c.hookAttribution = func() aiIngestAttributionHealth {
+		path, err := newAICommand().aiIngestLogPath()
+		if err != nil {
+			return aiIngestAttributionHealth{}
+		}
+		return readAIIngestAttributionHealth(path)
+	}
+	c.controlPlaneVintage = func() codexControlPlaneVintage {
+		executable, err := os.Executable()
+		if err != nil {
+			return codexControlPlaneVintage{}
+		}
+		resolved, err := filepath.EvalSymlinks(executable)
+		if err != nil {
+			resolved = executable
+		}
+		images, supported := defaultCodexProcessImages()
+		return projectCodexControlPlaneVintage(resolved, os.Getpid(), images, supported)
+	}
 	c.readRuntimeHealth = diagnostics.ReadRuntimeHealth
 	c.resolveOperationsPath = func() (string, error) { return diagnostics.DefaultPath(c.getenv, os.UserHomeDir) }
 	c.runtimeProbe = defaultDoctorRuntimeProbe
@@ -158,6 +190,7 @@ type doctorReport struct {
 	CodexAuthority       *codexAuthorityCensus                `json:"codex_authority,omitempty"`
 	CodexGenerationPool  *doctorCodexGenerationPool           `json:"codex_generation_pool,omitempty"`
 	CodexPayloadFree     *codexgeneration.Projection          `json:"codex_payload_free_capability,omitempty"`
+	CodexControlPlane    *codexControlPlaneReport             `json:"codex_control_plane,omitempty"`
 	SessionStateResume   []doctorSessionStateResumeDiagnostic `json:"session_state_resume,omitempty"`
 	SessionStatePrune    string                               `json:"session_state_prune"`
 	Runtime              []doctorFinding                      `json:"runtime"`
@@ -310,6 +343,13 @@ func (c *doctorCommand) evaluateReportForTrigger(section doctorSection, trigger 
 				report.CodexGenerationPool = c.codexGeneration(registry)
 			}
 		}
+		controlPlane := projectCodexControlPlaneSurfaces(
+			report.CodexBroker,
+			report.CodexAuthority,
+			doctorHookAttribution(c.hookAttribution),
+			doctorControlPlaneVintage(c.controlPlaneVintage),
+		)
+		report.CodexControlPlane = &controlPlane
 	}
 	if section == doctorSectionAll || section == doctorSectionSessionState {
 		report.SessionStateResume = c.evaluateSessionStateResume()
@@ -436,6 +476,7 @@ func writeDoctorText(w io.Writer, report doctorReport, section doctorSection, ve
 		writeDoctorCodexAuthorityText(&buf, report.CodexAuthority)
 		writeDoctorCodexGenerationText(&buf, report.CodexGenerationPool)
 		writeDoctorCodexPayloadFreeText(&buf, report.CodexPayloadFree)
+		writeDoctorCodexControlPlaneText(&buf, report.CodexControlPlane)
 	}
 	if section == doctorSectionAll || section == doctorSectionSessionState {
 		writeDoctorSessionStateText(&buf, report, verbose)
@@ -835,6 +876,7 @@ type doctorJSONReport struct {
 	CodexAuthority       *codexAuthorityCensus                 `json:"codex_authority,omitempty"`
 	CodexGenerationPool  *doctorCodexGenerationPool            `json:"codex_generation_pool,omitempty"`
 	CodexPayloadFree     *codexgeneration.Projection           `json:"codex_payload_free_capability,omitempty"`
+	CodexControlPlane    *codexControlPlaneReport              `json:"codex_control_plane,omitempty"`
 	SessionStateResume   *[]doctorSessionStateResumeDiagnostic `json:"session_state_resume,omitempty"`
 	SessionStatePrune    *string                               `json:"session_state_prune,omitempty"`
 	Runtime              *[]doctorFinding                      `json:"runtime,omitempty"`
@@ -855,6 +897,7 @@ func writeDoctorJSON(w io.Writer, report doctorReport, section doctorSection) er
 		out.CodexAuthority = report.CodexAuthority
 		out.CodexGenerationPool = report.CodexGenerationPool
 		out.CodexPayloadFree = report.CodexPayloadFree
+		out.CodexControlPlane = report.CodexControlPlane
 	}
 	if (section == doctorSectionAll && len(report.SessionStateResume) > 0) || section == doctorSectionSessionState {
 		out.SessionStateResume = &report.SessionStateResume
@@ -1002,4 +1045,48 @@ func defaultCommandVersion(name string) string {
 	}
 	first := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
 	return first
+}
+
+// doctorStateDir resolves the private state directory the authority fences live
+// in. An unresolvable path yields the empty string, which the fence observer
+// reports as unavailable rather than as an unfenced Pane.
+func doctorStateDir(lookupEnv func(string) string) string {
+	paths, err := configPaths(os.UserHomeDir, lookupEnv)
+	if err != nil {
+		return ""
+	}
+	return paths.StateDir
+}
+
+func doctorHookAttribution(read func() aiIngestAttributionHealth) aiIngestAttributionHealth {
+	if read == nil {
+		return aiIngestAttributionHealth{}
+	}
+	return read()
+}
+
+func doctorControlPlaneVintage(read func() codexControlPlaneVintage) codexControlPlaneVintage {
+	if read == nil {
+		return codexControlPlaneVintage{}
+	}
+	return read()
+}
+
+// writeDoctorCodexControlPlaneText renders the five named control-plane
+// surfaces and the vintage of the processes they were read from.
+//
+// The vintage line comes first because it qualifies every verdict under it:
+// `make install` never replaces the image of a running process, so a green
+// surface read from a replaced-image process is a statement about code that
+// process never loaded. Reading the surfaces without it is how "installed"
+// gets mistaken for "deployed".
+func writeDoctorCodexControlPlaneText(buf *bytes.Buffer, report *codexControlPlaneReport) {
+	if report == nil {
+		return
+	}
+	buf.WriteString("\nCodex control-plane surfaces\n")
+	fmt.Fprintf(buf, "  Diagnosis vintage: %s\n", codexControlPlaneVintageText(report.Vintage))
+	for _, surface := range report.Surfaces {
+		fmt.Fprintf(buf, "  [%-10s] %-22s %s\n", surface.Status, surface.Surface, surface.Detail)
+	}
 }

--- a/internal/app/doctor.go
+++ b/internal/app/doctor.go
@@ -1075,9 +1075,12 @@ func (c *doctorCommand) readCodexHookHealth() codexHookHealth {
 	if !ok {
 		return codexHookHealth{}
 	}
+	from, to := aiIngestWindowSpan(entries)
 	health := codexHookHealth{
 		Attribution: projectAIIngestAttributionHealth(entries),
 		Delivery:    projectAIIngestDeliveryHealth(entries),
+		From:        from,
+		To:          to,
 	}
 	registry, registryOK := coremetadata.Registry{}, false
 	if c.readRegistry != nil {
@@ -1110,6 +1113,11 @@ func writeDoctorCodexControlPlaneText(buf *bytes.Buffer, report *codexControlPla
 	}
 	buf.WriteString("\nCodex control-plane surfaces\n")
 	fmt.Fprintf(buf, "  Diagnosis vintage: %s\n", codexControlPlaneVintageText(report.Vintage))
+	if report.HookWindow != "" {
+		// The hook rows below are cumulative over this span, and a deployment
+		// inside it leaves records from both images in the same counts.
+		fmt.Fprintf(buf, "  Hook reading window: %s\n", report.HookWindow)
+	}
 	for _, surface := range report.Surfaces {
 		fmt.Fprintf(buf, "  [%-10s] %-22s %s\n", surface.Status, surface.Surface, surface.Detail)
 	}

--- a/internal/app/doctor.go
+++ b/internal/app/doctor.go
@@ -53,11 +53,13 @@ type doctorCommand struct {
 	// the create planner. Doctor only projects it; it never runs qualification or
 	// mutates a provider lifecycle.
 	codexPayloadFreeCapability func() codexgeneration.Record
-	// hookAttribution reads whether provider hook events reached the Pane that
-	// owns them. It is a bounded tail read of the ingest log and creates
-	// nothing, so asking the question on a machine that never ran a hook stays
-	// an unobserved answer rather than a new file.
-	hookAttribution func() aiIngestAttributionHealth
+	// hookRecords reads the tail of the provider hook ingest log. It is one
+	// bounded read that three projections share, because attribution, delivery
+	// and ownership are layers of one path and reading them separately would
+	// let a report pair counts taken at different moments. It creates nothing,
+	// so asking on a machine that never ran a hook stays an unobserved answer
+	// rather than a new file.
+	hookRecords func() ([]aiIngestLogEntry, bool)
 	// controlPlaneVintage reads the binary vintage of the live control-plane
 	// processes this diagnosis is taken from.
 	controlPlaneVintage func() codexControlPlaneVintage
@@ -87,12 +89,12 @@ func newDoctorCommand() *doctorCommand {
 	// readable at all, and an unfenced sample cannot tell a torn triple from a
 	// transition caught in flight.
 	c.codexAuthority = defaultSettledCodexLifecycleAuthorityLookup(doctorStateDir(c.getenv))
-	c.hookAttribution = func() aiIngestAttributionHealth {
+	c.hookRecords = func() ([]aiIngestLogEntry, bool) {
 		path, err := newAICommand().aiIngestLogPath()
 		if err != nil {
-			return aiIngestAttributionHealth{}
+			return nil, false
 		}
-		return readAIIngestAttributionHealth(path)
+		return readAIIngestLogTail(path, aiIngestAttributionWindow, aiIngestAttributionRecords)
 	}
 	c.controlPlaneVintage = func() codexControlPlaneVintage {
 		executable, err := os.Executable()
@@ -346,7 +348,7 @@ func (c *doctorCommand) evaluateReportForTrigger(section doctorSection, trigger 
 		controlPlane := projectCodexControlPlaneSurfaces(
 			report.CodexBroker,
 			report.CodexAuthority,
-			doctorHookAttribution(c.hookAttribution),
+			c.readCodexHookHealth(),
 			doctorControlPlaneVintage(c.controlPlaneVintage),
 		)
 		report.CodexControlPlane = &controlPlane
@@ -1058,11 +1060,33 @@ func doctorStateDir(lookupEnv func(string) string) string {
 	return paths.StateDir
 }
 
-func doctorHookAttribution(read func() aiIngestAttributionHealth) aiIngestAttributionHealth {
-	if read == nil {
-		return aiIngestAttributionHealth{}
+// readCodexHookHealth takes one bounded tail of the hook ingest log and derives
+// all three hook verdicts from it.
+//
+// The ownership verdict needs the Registry as well, and it is reported as
+// unobserved when either half is missing: a log with no Registry cannot say
+// whose Pane an event landed on, and answering nothing must not read as
+// answering well.
+func (c *doctorCommand) readCodexHookHealth() codexHookHealth {
+	if c == nil || c.hookRecords == nil {
+		return codexHookHealth{}
 	}
-	return read()
+	entries, ok := c.hookRecords()
+	if !ok {
+		return codexHookHealth{}
+	}
+	health := codexHookHealth{
+		Attribution: projectAIIngestAttributionHealth(entries),
+		Delivery:    projectAIIngestDeliveryHealth(entries),
+	}
+	registry, registryOK := coremetadata.Registry{}, false
+	if c.readRegistry != nil {
+		if read, err := c.readRegistry(); err == nil {
+			registry, registryOK = read, true
+		}
+	}
+	health.Ownership = projectAIIngestOwnershipHealth(entries, registry, registryOK)
+	return health
 }
 
 func doctorControlPlaneVintage(read func() codexControlPlaneVintage) codexControlPlaneVintage {

--- a/internal/app/notification.go
+++ b/internal/app/notification.go
@@ -228,6 +228,10 @@ func (c *aiCommand) ensureWSLLegacyAppIDCleaned(_ aiNotification) {
 	if err := c.run(powerShell, "-NoProfile", "-NonInteractive", "-EncodedCommand", encodeUTF16LEBase64(script)); err != nil {
 		return
 	}
+	// best-effort-write: a one-shot global marker recording that the legacy
+	// toast cleanup ran. Leaving it unset is the safe direction -- the next
+	// Notify simply retries the cleanup -- so a dropped failure here costs a
+	// repeated no-op, not a false report.
 	_ = c.run("tmux", "set-option", "-g", legacyAppIDCleanedTmuxOption, "1")
 }
 

--- a/internal/app/testdata/doctor/plain.golden
+++ b/internal/app/testdata/doctor/plain.golden
@@ -16,6 +16,14 @@ Codex payload-free capability
   Cache key: ; durable-zero-turn-resume: unknown; remote-new-session: unknown
   Create route: plain-fallback; reason: exact-capability-unknown
 
+Codex control-plane surfaces
+  Diagnosis vintage: unknown on this platform; a process running a replaced image cannot be told apart from one running the installed build
+  [unobserved] broker-diagnostics     no broker reading was taken
+  [unobserved] hook-attribution       no hook ingest log was readable
+  [unobserved] observer-reason        no managed Codex Agent to read
+  [unobserved] connection-continuity  no running runtime to read continuity from
+  [unobserved] turn-admission         no managed Codex Agent to read
+
 Session State resume metadata
   Summary: 0 available, 0 stale, 0 unavailable.
 

--- a/internal/app/testdata/doctor/plain.golden
+++ b/internal/app/testdata/doctor/plain.golden
@@ -23,6 +23,8 @@ Codex control-plane surfaces
   [unobserved] observer-reason        no managed Codex Agent to read
   [unobserved] connection-continuity  no running runtime to read continuity from
   [unobserved] turn-admission         no managed Codex Agent to read
+  [unobserved] hook-delivery          no hook ingest log was readable
+  [unobserved] pane-ownership         no hook ingest log and Registry pair was readable
 
 Session State resume metadata
   Summary: 0 available, 0 stale, 0 unavailable.

--- a/internal/app/testdata/doctor/report.golden.json
+++ b/internal/app/testdata/doctor/report.golden.json
@@ -57,6 +57,16 @@
         "surface": "turn-admission",
         "status": "unobserved",
         "detail": "no managed Codex Agent to read"
+      },
+      {
+        "surface": "hook-delivery",
+        "status": "unobserved",
+        "detail": "no hook ingest log was readable"
+      },
+      {
+        "surface": "pane-ownership",
+        "status": "unobserved",
+        "detail": "no hook ingest log and Registry pair was readable"
       }
     ]
   },

--- a/internal/app/testdata/doctor/report.golden.json
+++ b/internal/app/testdata/doctor/report.golden.json
@@ -28,6 +28,38 @@
     "create_route": "plain-fallback",
     "reason": "exact-capability-unknown"
   },
+  "codex_control_plane": {
+    "vintage": {
+      "supported": false
+    },
+    "surfaces": [
+      {
+        "surface": "broker-diagnostics",
+        "status": "unobserved",
+        "detail": "no broker reading was taken"
+      },
+      {
+        "surface": "hook-attribution",
+        "status": "unobserved",
+        "detail": "no hook ingest log was readable"
+      },
+      {
+        "surface": "observer-reason",
+        "status": "unobserved",
+        "detail": "no managed Codex Agent to read"
+      },
+      {
+        "surface": "connection-continuity",
+        "status": "unobserved",
+        "detail": "no running runtime to read continuity from"
+      },
+      {
+        "surface": "turn-admission",
+        "status": "unobserved",
+        "detail": "no managed Codex Agent to read"
+      }
+    ]
+  },
   "session_state_prune": "Snapshots are never automatically pruned; inspect stale candidates with `projmux prune snapshot` and delete only by explicit name.",
   "runtime": [
     {

--- a/internal/core/metadata/progress_test.go
+++ b/internal/core/metadata/progress_test.go
@@ -40,6 +40,8 @@ func TestAgentProgressClosedInventoryAndLifecycleClear(t *testing.T) {
 	if _, _, err := mutator.SetAgentProgress(&reg, "agent-1", "turn-other", progress); err == nil {
 		t.Fatal("independent turn authority was accepted")
 	}
+	// uncaptured-default: this is an Agent phase transition reason, a free-text
+	// field of a different subsystem that happens to spell the same word.
 	if _, err := mutator.TransitionAgent(&reg, "agent-1", PhaseOffline, "disconnected"); err != nil {
 		t.Fatal(err)
 	}
@@ -87,6 +89,7 @@ func TestAgentProgressClearsOnFailedRebindAndPaneRelease(t *testing.T) {
 	}
 
 	released := fixture()
+	// uncaptured-default: same Agent phase vocabulary as above.
 	if _, err := mutator.ReleaseAgentPane(&released, "agent-1", AgentExitUnknown, "disconnected"); err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/codex-lifecycle.sh
+++ b/test/e2e/codex-lifecycle.sh
@@ -157,6 +157,9 @@ lifecycle_topology_doctor external-ready "$lifecycle_topology_ready_shim" extern
   ready managed current managed disabled ready none none none
 lifecycle_topology_doctor managed-ready "$lifecycle_topology_ready_shim" managed-ready app-server available none none ready \
   ready managed current managed disabled ready none none none
+# uncaptured-default: this argument is the app-server `connection_state`, an
+# observed transport state, not the managed Codex authority reason whose
+# literal default this gate exists to keep out of assertions.
 lifecycle_topology_doctor endpoint-missing "$lifecycle_topology_missing_shim" external-cli-only unavailable unavailable hook-unavailable daemon-not-running disconnected \
   dead unknown unknown unknown unavailable ready none none none
 


### PR DESCRIPTION
## What

Phase 4 of the *Codex control-plane observability and reconnect truth* track: the
regression-detection gate for the five surfaces the preceding six phases fixed.

Three of those defects lived through a neighbouring eight-phase track closing
green from end to end. Nothing reached those surfaces, and the one test that did
— `test/e2e/codex-lifecycle.sh` — asserted the literal `disconnected` for a
managed Codex Pane's authority reason. `disconnected` is the bucket that means
no reason was captured, so capturing a real one would have turned the job red.
Shipping the fixes without this gate would leave the same blind spot under new
code.

## Repo gate

- `TestControlPlaneTestsNeverExpectAnUncapturedReason` sweeps every
  `internal/**/*_test.go` and `test/e2e/*.sh` for values meaning "nothing was
  recorded" (`unrecorded`, the retired `disconnected` literal, the
  `bounded reason unavailable` read fallback, `target-unmatched`) and fails on
  any that is an expectation rather than an input. A survivor is admitted only
  with an `uncaptured-default: <reason>` comment.
  - 18 assertions used the retired literal as an arbitrary payload; those now
    carry a captured token (`endpoint-suspended`) instead.
  - 9 survive with a stated reason. Every one is a different vocabulary that
    spells a token the same way — the app-server `connection_state`, the Agent
    phase transition reason, the operations-journal AI failure, and the bounded
    read fallback whose whole point is to render an out-of-vocabulary value.
- `TestControlPlaneContractCellsNameLiveTests` resolves every test named in the
  contract Enforcement ledger against the declarations in the tree. Squash
  merges erase the branch that tied a fix to the test holding it, so a cell
  naming a renamed test reads as enforced while enforcing nothing.
- `TestControlPlaneContractEnforcementCoversEverySurface` holds both directions
  of the surface↔contract map closed.

## Operator gate

`projmux doctor` gained **Codex control-plane surfaces**: one verdict per
surface with the counters it was reached on. Broker diagnostics, observer
reason and connection continuity had detailed sections but no verdict; hook
attribution and turn admission had no signal at all.

```
Codex control-plane surfaces
  Diagnosis vintage: broker-runtime 1 (current 0, replaced 1); lifecycle-observer 2 (current 1, replaced 1); a replaced image did not load the installed build, so every verdict below it describes older code
  [ok        ] broker-diagnostics     runtime running; published endpoints 1; observed endpoint present
  [degraded  ] hook-attribution       claude-hook 393 attributed, 5 unattributed (conversation is not registered to a pane=3, explicit pane is not registered=2)
  [degraded  ] observer-reason        captured reasons 2; uncaptured 2 (bounded reason unavailable=1, disconnected=1)
  [degraded  ] connection-continuity  connection epoch 27173; reconnects 27172; upstream connections 1 (revocations snapshot-unavailable=219)
  [ok        ] turn-admission         authority snapshots 4 settled, 0 contended, 0 unfenced; torn 0
```

Two things are deliberate.

**The authority triple is now sampled under the writer's own fence** — a shared,
non-creating hold, bounded by a 250 ms budget. Doctor's earlier read was the
same unfenced sample C-5 removed from the admission path: with a control plane
cycling once a second it eventually lands between two of the three writes.
Under the fence a torn pairing is a producer fact rather than a transition
caught in flight. A Pane with no fence file is reported `unfenced`, separately
from torn: its writer predates the fence, which is a deployment answer.

**The section leads with a deployment vintage line.** `make install` replaces
the executable on disk and never replaces the image of a running process, so a
green surface read from a replaced-image process describes code that process
never loaded. This track lost two acceptance criteria to that twice, both times
leaving the operator to resolve `/proc/<pid>/exe` by hand. On Linux the
diagnosis does it; on a platform with no process table it reports the answer as
unknown rather than claiming currency.

## Not in this change

- `projmux doctor`'s exit code is unchanged. A broken surface is a readable
  verdict, not a failed command; the CI half of the detection is the regression
  tests.
- No product behaviour outside the diagnosis moves. `defaultCodexLifecycleAuthorityLookup`
  stays unfenced for `describe`, which reports one Pane as it is right now.
- Foreign app-server lifecycle is untouched, and the generation pool is read-only
  here as everywhere else in this track.

## Verification

`make fmt`, `make fix`, `make test`, `make test-integration`, `make test-e2e`.

Five `make test` failures reproduce identically on clean `main` in this local
environment and are unrelated (real `$HOME` and `sun_path` length leaking into
tempdir-based fixtures): `TestResolveHomeDirectory`,
`TestHookTrust_RejectsWhenContextMissing`,
`TestHookList_ProjectOnlyDegradesWithoutContext`,
`TestCapabilityCacheRejectsWrongRoleTUIEndpointRestartSocketReboundAndStateDomainMismatch`,
`TestDirectResidualSocketReplacementIsPreserved`. CI is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — scope grew to seven surfaces, and one check is red on purpose

The track's confirmed defects went from five to seven while this branch was
open. `hook-delivery` (⑥) and `pane-ownership` (⑦) are both layers the earlier
surfaces cannot see: attribution succeeding says nothing about whether the write
that followed landed, and a write landing says nothing about whose Pane it
landed on.

**`TestHookReflectionWritesNeverDiscardTheirErrorSilently` fails on this branch,
and that is the intended state.** The scan finds 50 tmux writes whose error is
discarded at the call site. Each one lets the ingest log record `result:"state"`
for an event whose Pane never moved — the log reports success, and every
diagnosis built on it inherits that. It is the strongest form of the failure
this whole change exists to catch: `disconnected` and `no matching pane` were at
least wrong out loud.

Recording the current count as a baseline was considered and rejected. Pinning
today's state as the passing condition is the exact shape of the E2E assertion
that made a silent control plane the condition for green, and building that trap
inside the gate written to stop it is not a tradeoff worth making. The check
goes green when the phase that owns those writes fixes them; this PR merges
after it.

Two verdict corrections came out of running the gate against a live machine:

- The attribution verdict is reached **per source**, not over the total. Read
  over the total, a busy provider carried the aggregate and rendered a provider
  attributing *nothing* as a few stale panes — the exact reading that let the
  defect live through eight phases next door.
- It counts only events the contract owed a Pane. A conversation whose Pane was
  retired is outside C-2's scope, and reporting that refusal as breakage made
  `doctor` call a machine behaving to spec broken. Refusals are rendered beside
  the failure count, never inside it.

The foreign-attribution count is broken down by direction, because a hook
landing on the Pane that launched its host and an event arriving under the wrong
source have different causes and this machine has carried both.
