### PR TITLE
fix(hooks): refuse an inherited pane identity for a foreign provider

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1007,6 +1007,47 @@ Admission also does not reduce how often the native connection drops, and it
 says nothing about the `@projmux_ai_state` / `@projmux_ai_badge_kind` /
 `@projmux_attention_state` triple, which has no fence of its own.
 
+### Inherited pane identity refusal tests
+
+A provider host shared by several Panes inherits the activation envelope of
+whichever Pane happened to launch it, tmux environment included. The `--pane`
+argument therefore arrives holding a live, perfectly resolvable Pane that
+belongs to a different provider, and resolving it verbatim attributes the event
+to that Pane. Having an explicit value and owning it are different things; only
+the Registry, which already records which provider an Agent runs, can tell them
+apart.
+
+- `TestResolveExplicitAIPaneRefusesAnInheritedForeignIdentity` owns the decision
+  itself. Both spellings of the handed identity are refused whenever the
+  Registry positively records a different provider for that Pane, in every
+  direction between the catalogued providers, so the rule is symmetric rather
+  than a guard around one of them.
+- `TestMatchAIPaneNeverAttributesAnInheritedForeignIdentity` owns the same
+  fixture through the whole matcher: with nothing else able to answer, a refused
+  inherited identity ends as a named failure and never as the foreign Pane.
+- `TestMatchAIPaneKeepsAnExplicitPaneWithNoRecordedProvider` owns the silence
+  case. A Pane the Registry records no provider for — an unbound shell where
+  somebody ran a provider by hand — is not a contradiction, and neither is an
+  unrecognized spelling on either side; all of them resolve exactly as before.
+- `TestMatchAIPaneContinuesPastARefusedInheritedIdentity` owns the priority
+  ladder behind the refusal: the Registry conversation record answers first, the
+  established inventory ladder answers behind it, and only a fall-through that
+  also fails ends as a failure.
+- `TestForeignExplicitFallThroughIgnoresTheInheritedEnvironment` owns the one
+  step the fall-through deliberately skips. `TMUX_PANE` arrives in the same
+  envelope whose Pane identity was just refused, so honouring it would
+  reintroduce the misattribution through a second door; the path that was handed
+  nothing keeps that step exactly as before.
+- `TestForeignExplicitRefusalLeavesTheRegistryPathUnchanged` is the negative
+  audit. The stage writes nothing and defines no binding, and the Registry
+  conversation index returns the same map whether or not an Agent records a
+  provider, so the shared-host attribution path above is unchanged.
+- `TestAttributionFailureReasonsAreDistinctAndClosed` additionally owns the two
+  new tokens: the refusal itself, and the composite the matcher reports once the
+  fall-through has also failed. The composite is its own entry rather than the
+  downstream step's reason, so a record still says the hook was handed somebody
+  else's Pane. Every token stays provider-neutral in wording.
+
 ## Review Checklist
 - The branch stays within its stated scope.
 - The change preserves boundaries between portable `projmux` behavior and local machine policy.

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1048,6 +1048,28 @@ apart.
   downstream step's reason, so a record still says the hook was handed somebody
   else's Pane. Every token stays provider-neutral in wording.
 
+The fall-through has a second door of its own. Its inventory step matches on
+working directory alone, and where every provider Pane sits in the same
+repository that step would hand the event straight back to a Pane of the very
+provider just refused. Phase 8 is what routes a foreign-refused hook into that
+ladder at all, so the coherence check is applied once more to whatever the
+fall-through resolves — to the answer, never inside the shared ladder.
+
+- `TestForeignExplicitFallThroughDoesNotLandOnAnotherProvidersPane` owns that
+  door in both directions: a cwd-sharing Pane of the refused provider is not
+  taken, and the attempt ends with its own reason rather than with that Pane.
+- `TestForeignExplicitFallThroughStillTakesACoherentLadderAnswer` owns the
+  fail-open direction that keeps the Phase 2 contract intact: a ladder answer
+  running the hook's own provider, one the Registry records no provider for, and
+  one recording an unrecognized spelling are all still taken.
+- `TestForeignExplicitFallThroughDoesNotTakeAForeignConversationPane` owns the
+  same check on the Registry conversation record, and proves refusing it does
+  not consume the inventory ladder's turn behind it.
+- `TestNoExplicitPathStillTakesACwdMatchRegardlessOfProvider` is the proof that
+  the shared ladder is untouched: with no explicit value there is no refused
+  envelope and therefore no coherence question, and the cwd and thread steps
+  resolve exactly as before for every provider.
+
 ## Review Checklist
 - The branch stays within its stated scope.
 - The change preserves boundaries between portable `projmux` behavior and local machine policy.

--- a/internal/app/ai_hook_pane_identity_test.go
+++ b/internal/app/ai_hook_pane_identity_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -367,10 +368,26 @@ func TestAttributionFailureReasonsAreDistinctAndClosed(t *testing.T) {
 	_, reason = sharedHostCommand(t, twoPanes).matchAIPane(aiPaneMatchInput{ThreadID: "thread-shared"})
 	record(t, "conversation held by two panes", reason)
 
+	// Handed a live Pane that belongs to another provider: the decision itself,
+	// and the composite the whole matcher reports once the fall-through behind
+	// it has also failed. The second is its own token on purpose -- collapsing
+	// it into the downstream step's reason would hide that the hook was handed
+	// somebody else's Pane.
+	foreign := inheritedIdentityCommand(t, providerPaneRegistry("pane-claude", "%53", aiModeClaude), "%53")
+	_, reason = foreign.resolveExplicitAIPane(aiModeCodex, "pane-claude")
+	record(t, "explicit pane of another provider", reason)
+	_, reason = foreign.matchAIPane(aiPaneMatchInput{ExplicitPane: "pane-claude", Provider: aiModeCodex})
+	record(t, "another provider's pane and no fallback", reason)
+
 	// Every token stays a bounded phrase: no path, payload, or provider text.
 	for token := range seen {
 		if strings.ContainsAny(token, "/\\\"") || len(token) > 64 {
 			t.Fatalf("reason token is not a bounded vocabulary entry: %q", token)
+		}
+		for _, provider := range []string{"codex", "claude", "antigravity"} {
+			if strings.Contains(strings.ToLower(token), provider) {
+				t.Fatalf("reason token names provider %q: %q", provider, token)
+			}
 		}
 	}
 }
@@ -400,5 +417,311 @@ func TestHookIngestRoutesAcceptTheExplicitPaneArgument(t *testing.T) {
 				t.Fatal("a positional payload argument was accepted")
 			}
 		})
+	}
+}
+
+// providerPaneResource builds one intact Agent->Pane binding that also records
+// which provider the Agent runs. That record is the only thing separating an
+// explicit identity a hook owns from one it inherited, so every fixture below
+// states it explicitly -- including the empty spelling for a Pane the Registry
+// records no provider for.
+func providerPaneResource(paneUID, runtimeID, provider string, codex *coremetadata.CodexActivationBinding) (coremetadata.Agent, coremetadata.Pane) {
+	agentUID := "agent-for-" + paneUID
+	return coremetadata.Agent{
+			Metadata: coremetadata.ObjectMeta{UID: agentUID, Name: "provider-agent-" + paneUID},
+			Spec:     coremetadata.AgentSpec{Provider: provider},
+			Status:   coremetadata.AgentStatus{PaneRef: paneUID},
+		}, coremetadata.Pane{
+			Metadata: coremetadata.ObjectMeta{UID: paneUID, Name: "provider-pane-" + paneUID},
+			Status: coremetadata.PaneStatus{Activation: coremetadata.PaneActivation{
+				RuntimeID: runtimeID,
+				AgentUID:  agentUID,
+				Codex:     codex,
+			}},
+		}
+}
+
+func providerPaneRegistry(paneUID, runtimeID, provider string) coremetadata.Registry {
+	agent, pane := providerPaneResource(paneUID, runtimeID, provider, nil)
+	return coremetadata.Registry{
+		Agents: []coremetadata.Agent{agent},
+		Panes:  []coremetadata.Pane{pane},
+	}
+}
+
+// inheritedIdentityCommand is the app-server fixture: a hook process that
+// inherited the whole activation envelope of the Pane that launched its host,
+// including the tmux environment, and carries no Pane inventory of its own.
+func inheritedIdentityCommand(t *testing.T, registry coremetadata.Registry, inheritedPane string) *aiCommand {
+	t.Helper()
+	cmd := testAICommand(t.TempDir())
+	cmd.lookupEnv = func(name string) string {
+		if name == "TMUX_PANE" {
+			return inheritedPane
+		}
+		return ""
+	}
+	cmd.readCommand = func(context.Context, string, ...string) ([]byte, error) { return nil, os.ErrNotExist }
+	cmd.loadRegistry = func() (coremetadata.Registry, error) { return registry, nil }
+	cmd.updateRegistry = func(func(*coremetadata.Registry) error) (coremetadata.Registry, error) {
+		t.Fatal("refusing an inherited identity wrote to the registry; this stage is a lookup only")
+		return coremetadata.Registry{}, nil
+	}
+	return cmd
+}
+
+// Acceptance 1: a provider host is shared by several Panes and inherits the
+// activation envelope of whichever Pane launched it. The explicit value it hands
+// over is therefore live and resolvable and still not its own, and resolving it
+// verbatim is exactly how a Codex hook lands on a Claude Pane.
+func TestResolveExplicitAIPaneRefusesAnInheritedForeignIdentity(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		hook     string
+		pane     string
+		provider string
+	}{
+		{name: "codex hook handed a claude pane", hook: aiModeCodex, pane: "pane-claude", provider: aiModeClaude},
+		{name: "claude hook handed a codex pane", hook: aiModeClaude, pane: "pane-codex", provider: aiModeCodex},
+		{name: "antigravity hook handed a codex pane", hook: aiModeAntigravity, pane: "pane-codex", provider: aiModeCodex},
+		{name: "codex hook handed an antigravity pane", hook: aiModeCodex, pane: "pane-antigravity", provider: aiModeAntigravity},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			registry := providerPaneRegistry(tc.pane, "%53", tc.provider)
+			cmd := inheritedIdentityCommand(t, registry, "%53")
+			for _, ref := range []string{tc.pane, "%53"} {
+				paneID, reason := cmd.resolveExplicitAIPane(tc.hook, ref)
+				if paneID != "" {
+					t.Fatalf("resolveExplicitAIPane(%q, %q) attributed the event to %q", tc.hook, ref, paneID)
+				}
+				if reason != aiPaneMatchReasonExplicitForeign {
+					t.Fatalf("reason = %q, want %q", reason, aiPaneMatchReasonExplicitForeign)
+				}
+			}
+		})
+	}
+}
+
+// The same fixture through the whole matcher. Nothing else can answer here, so
+// the refusal has to end as a failure rather than as the foreign Pane or as the
+// `TMUX_PANE` the same envelope carried.
+func TestMatchAIPaneNeverAttributesAnInheritedForeignIdentity(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		hook     string
+		pane     string
+		provider string
+	}{
+		{name: "codex hook handed a claude pane", hook: aiModeCodex, pane: "pane-claude", provider: aiModeClaude},
+		{name: "claude hook handed a codex pane", hook: aiModeClaude, pane: "pane-codex", provider: aiModeCodex},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := inheritedIdentityCommand(t, providerPaneRegistry(tc.pane, "%53", tc.provider), "%53")
+			paneID, reason := cmd.matchAIPane(aiPaneMatchInput{
+				ExplicitPane: tc.pane,
+				Provider:     tc.hook,
+				CWD:          "/repo/projmux",
+			})
+			if paneID != "" {
+				t.Fatalf("matchAIPane() attributed the event to %q", paneID)
+			}
+			if reason != aiPaneMatchReasonExplicitForeignOnly {
+				t.Fatalf("reason = %q, want %q", reason, aiPaneMatchReasonExplicitForeignOnly)
+			}
+		})
+	}
+}
+
+// Acceptance 3 regression: an unbound Window shell where somebody just ran a
+// provider by hand records no provider at all. That is silence, not a
+// contradiction, and Phase 2 behavior has to survive it untouched. An
+// unrecognized spelling on either side is the same silence.
+func TestMatchAIPaneKeepsAnExplicitPaneWithNoRecordedProvider(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		hook string
+		pane string
+	}{
+		{name: "no recorded provider", hook: aiModeCodex, pane: ""},
+		{name: "no recorded provider, claude hook", hook: aiModeClaude, pane: ""},
+		{name: "matching provider", hook: aiModeCodex, pane: aiModeCodex},
+		{name: "matching provider, mixed case record", hook: aiModeClaude, pane: "Claude"},
+		{name: "unrecognized recorded provider", hook: aiModeCodex, pane: "some-future-provider"},
+		{name: "hook names no provider", hook: "", pane: aiModeClaude},
+		{name: "hook names an unrecognized provider", hook: "some-future-provider", pane: aiModeClaude},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := inheritedIdentityCommand(t, providerPaneRegistry("pane-handed", "%77", tc.pane), "")
+			for _, ref := range []string{"pane-handed", "%77"} {
+				paneID, reason := cmd.matchAIPane(aiPaneMatchInput{ExplicitPane: ref, Provider: tc.hook})
+				if paneID != "%77" || reason != "" {
+					t.Fatalf("matchAIPane(%q) = %q, reason %q, want %%77", ref, paneID, reason)
+				}
+			}
+		})
+	}
+}
+
+// Acceptance 2: a refused explicit value is not the end of the hook. It flows to
+// the steps that answer from what the hook itself carries -- the Registry
+// conversation record first, the established inventory ladder behind it -- and
+// only a step that also fails ends as a named failure.
+func TestMatchAIPaneContinuesPastARefusedInheritedIdentity(t *testing.T) {
+	t.Parallel()
+
+	claudeAgent, claudePane := providerPaneResource("pane-claude", "%53", aiModeClaude, nil)
+	codexAgent, codexPane := providerPaneResource("pane-codex", "%78", aiModeCodex,
+		&coremetadata.CodexActivationBinding{ThreadID: "thread-codex"})
+	registry := coremetadata.Registry{
+		Agents: []coremetadata.Agent{claudeAgent, codexAgent},
+		Panes:  []coremetadata.Pane{claudePane, codexPane},
+	}
+
+	t.Run("registry conversation answers", func(t *testing.T) {
+		t.Parallel()
+		cmd := inheritedIdentityCommand(t, registry, "%53")
+		paneID, reason := cmd.matchAIPane(aiPaneMatchInput{
+			ExplicitPane: "pane-claude",
+			Provider:     aiModeCodex,
+			ThreadID:     "thread-codex",
+		})
+		if paneID != "%78" || reason != "" {
+			t.Fatalf("matchAIPane() = %q, reason %q, want %%78", paneID, reason)
+		}
+	})
+
+	t.Run("inventory answers when the registry cannot", func(t *testing.T) {
+		t.Parallel()
+		cmd := inheritedIdentityCommand(t, registry, "%53")
+		cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if name == "tmux" && len(args) > 0 && args[0] == "list-panes" {
+				return []byte("%inventory\x1f/repo/projmux\x1fthread-inventory\x1fsession-inventory\n"), nil
+			}
+			return nil, os.ErrNotExist
+		}
+		paneID, reason := cmd.matchAIPane(aiPaneMatchInput{
+			ExplicitPane: "pane-claude",
+			Provider:     aiModeCodex,
+			CWD:          "/repo/projmux",
+			ThreadID:     "thread-no-pane-holds",
+		})
+		if paneID != "%inventory" || reason != "" {
+			t.Fatalf("matchAIPane() = %q, reason %q, want %%inventory", paneID, reason)
+		}
+	})
+
+	t.Run("nothing answers", func(t *testing.T) {
+		t.Parallel()
+		cmd := inheritedIdentityCommand(t, registry, "%53")
+		paneID, reason := cmd.matchAIPane(aiPaneMatchInput{
+			ExplicitPane: "pane-claude",
+			Provider:     aiModeCodex,
+			CWD:          "/repo/projmux",
+			ThreadID:     "thread-no-pane-holds",
+		})
+		if paneID != "" {
+			t.Fatalf("matchAIPane() attributed the event to %q", paneID)
+		}
+		if reason != aiPaneMatchReasonExplicitForeignOnly {
+			t.Fatalf("reason = %q, want %q", reason, aiPaneMatchReasonExplicitForeignOnly)
+		}
+	})
+}
+
+// The inherited `TMUX_PANE` arrives in the very envelope whose Pane identity was
+// just refused. Honouring it on the fall-through would reintroduce the same
+// misattribution through a second door, so the fall-through skips that step
+// entirely -- while the no-explicit path keeps it exactly as before.
+func TestForeignExplicitFallThroughIgnoresTheInheritedEnvironment(t *testing.T) {
+	t.Parallel()
+
+	registry := providerPaneRegistry("pane-claude", "%53", aiModeClaude)
+	inventory := func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "tmux" && len(args) > 0 && args[0] == "list-panes" {
+			return []byte("%inventory\x1f/repo/projmux\x1fthread-1\x1fsession-1\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	refused := inheritedIdentityCommand(t, registry, "%53")
+	refused.readCommand = inventory
+	paneID, reason := refused.matchAIPane(aiPaneMatchInput{
+		ExplicitPane: "pane-claude",
+		Provider:     aiModeCodex,
+		CWD:          "/repo/projmux",
+	})
+	if paneID == "%53" {
+		t.Fatal("the fall-through honoured the inherited TMUX_PANE of the refused envelope")
+	}
+	if paneID != "%inventory" || reason != "" {
+		t.Fatalf("matchAIPane() = %q, reason %q, want %%inventory", paneID, reason)
+	}
+
+	// The path that was handed nothing is untouched: inherited TMUX_PANE still
+	// wins there, ahead of the inventory.
+	blind := inheritedIdentityCommand(t, registry, "%53")
+	blind.readCommand = inventory
+	if paneID, reason := blind.matchAIPane(aiPaneMatchInput{Provider: aiModeCodex, CWD: "/repo/projmux"}); paneID != "%53" || reason != "" {
+		t.Fatalf("no-explicit path = %q, reason %q, want %%53", paneID, reason)
+	}
+}
+
+// Negative audit: the provider-coherence stage is a decision, not a binding. It
+// writes nothing, and it leaves the Phase 6 Registry conversation index exactly
+// as it found it -- that index reads the resource model and never a provider
+// name, so recording a provider on an Agent cannot change what it returns.
+func TestForeignExplicitRefusalLeavesTheRegistryPathUnchanged(t *testing.T) {
+	t.Parallel()
+
+	withProvider := coremetadata.Registry{}
+	withoutProvider := coremetadata.Registry{}
+	for _, spec := range []struct {
+		paneUID   string
+		runtimeID string
+		provider  string
+		thread    string
+	}{
+		{paneUID: "pane-codex", runtimeID: "%78", provider: aiModeCodex, thread: "thread-codex"},
+		{paneUID: "pane-claude", runtimeID: "%53", provider: aiModeClaude, thread: ""},
+	} {
+		var codex *coremetadata.CodexActivationBinding
+		if spec.thread != "" {
+			codex = &coremetadata.CodexActivationBinding{ThreadID: spec.thread}
+		}
+		agent, pane := providerPaneResource(spec.paneUID, spec.runtimeID, spec.provider, codex)
+		withProvider.Agents = append(withProvider.Agents, agent)
+		withProvider.Panes = append(withProvider.Panes, pane)
+
+		agent.Spec.Provider = ""
+		withoutProvider.Agents = append(withoutProvider.Agents, agent)
+		withoutProvider.Panes = append(withoutProvider.Panes, pane)
+	}
+
+	indexed := registeredConversationPanes(withProvider)
+	if !maps.Equal(indexed, registeredConversationPanes(withoutProvider)) {
+		t.Fatalf("the registry conversation index now depends on the recorded provider: %v", indexed)
+	}
+	if indexed["thread-codex"] != "%78" {
+		t.Fatalf("registeredConversationPanes()[thread-codex] = %q, want %%78", indexed["thread-codex"])
+	}
+
+	// The refusal itself neither writes nor rebinds: inheritedIdentityCommand
+	// fails the test on any registry write.
+	cmd := inheritedIdentityCommand(t, withProvider, "%53")
+	if paneID, reason := cmd.matchAIPane(aiPaneMatchInput{
+		ExplicitPane: "pane-claude",
+		Provider:     aiModeCodex,
+		ThreadID:     "thread-codex",
+	}); paneID != "%78" || reason != "" {
+		t.Fatalf("matchAIPane() = %q, reason %q, want %%78", paneID, reason)
 	}
 }

--- a/internal/app/ai_hook_pane_identity_test.go
+++ b/internal/app/ai_hook_pane_identity_test.go
@@ -725,3 +725,195 @@ func TestForeignExplicitRefusalLeavesTheRegistryPathUnchanged(t *testing.T) {
 		t.Fatalf("matchAIPane() = %q, reason %q, want %%78", paneID, reason)
 	}
 }
+
+// The second door. The fall-through's inventory step matches on working
+// directory alone, and on a machine where every provider Pane sits in the same
+// repository that step hands the event straight back to a Pane of the very
+// provider just refused. Phase 8 is what routes a foreign-refused hook into that
+// ladder at all, so the ladder's answer is checked for coherence too.
+func TestForeignExplicitFallThroughDoesNotLandOnAnotherProvidersPane(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		hook       string
+		handed     string
+		foreign    string
+		inventory  string
+		foreignRow string
+	}{
+		{
+			name: "codex hook, claude pane shares the cwd", hook: aiModeCodex,
+			handed: "pane-claude", foreign: aiModeClaude,
+			inventory: "pane-claude-sibling", foreignRow: "%54",
+		},
+		{
+			name: "claude hook, codex pane shares the cwd", hook: aiModeClaude,
+			handed: "pane-codex", foreign: aiModeCodex,
+			inventory: "pane-codex-sibling", foreignRow: "%79",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			handedAgent, handedPane := providerPaneResource(tc.handed, "%53", tc.foreign, nil)
+			rowAgent, rowPane := providerPaneResource(tc.inventory, tc.foreignRow, tc.foreign, nil)
+			registry := coremetadata.Registry{
+				Agents: []coremetadata.Agent{handedAgent, rowAgent},
+				Panes:  []coremetadata.Pane{handedPane, rowPane},
+			}
+			cmd := inheritedIdentityCommand(t, registry, "%53")
+			cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+				if name == "tmux" && len(args) > 0 && args[0] == "list-panes" {
+					return []byte(tc.foreignRow + "\x1f/repo/projmux\x1f\x1f\n"), nil
+				}
+				return nil, os.ErrNotExist
+			}
+
+			paneID, reason := cmd.matchAIPane(aiPaneMatchInput{
+				ExplicitPane: tc.handed,
+				Provider:     tc.hook,
+				CWD:          "/repo/projmux",
+			})
+			if paneID == tc.foreignRow {
+				t.Fatalf("the cwd step handed the event to another provider's Pane %q", paneID)
+			}
+			if paneID != "" {
+				t.Fatalf("matchAIPane() attributed the event to %q", paneID)
+			}
+			if reason != aiPaneMatchReasonExplicitForeignOnly {
+				t.Fatalf("reason = %q, want %q", reason, aiPaneMatchReasonExplicitForeignOnly)
+			}
+		})
+	}
+}
+
+// Fail-open is what keeps the Phase 2 contract intact: only a recorded and
+// different provider refuses. A cwd-sharing Pane running the hook's own
+// provider, and one the Registry records no provider for, both still answer.
+func TestForeignExplicitFallThroughStillTakesACoherentLadderAnswer(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		rowPane string
+	}{
+		{name: "ladder row runs the hook's own provider", rowPane: aiModeCodex},
+		{name: "ladder row records no provider", rowPane: ""},
+		{name: "ladder row records an unrecognized provider", rowPane: "some-future-provider"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			handedAgent, handedPane := providerPaneResource("pane-claude", "%53", aiModeClaude, nil)
+			rowAgent, rowPane := providerPaneResource("pane-row", "%80", tc.rowPane, nil)
+			registry := coremetadata.Registry{
+				Agents: []coremetadata.Agent{handedAgent, rowAgent},
+				Panes:  []coremetadata.Pane{handedPane, rowPane},
+			}
+			cmd := inheritedIdentityCommand(t, registry, "%53")
+			cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+				if name == "tmux" && len(args) > 0 && args[0] == "list-panes" {
+					return []byte("%80\x1f/repo/projmux\x1f\x1f\n"), nil
+				}
+				return nil, os.ErrNotExist
+			}
+			paneID, reason := cmd.matchAIPane(aiPaneMatchInput{
+				ExplicitPane: "pane-claude",
+				Provider:     aiModeCodex,
+				CWD:          "/repo/projmux",
+			})
+			if paneID != "%80" || reason != "" {
+				t.Fatalf("matchAIPane() = %q, reason %q, want %%80", paneID, reason)
+			}
+		})
+	}
+}
+
+// The Registry conversation record is checked the same way. A conversation the
+// Registry places on a Pane of another provider is not taken either, and
+// refusing it does not consume the ladder's turn behind it.
+func TestForeignExplicitFallThroughDoesNotTakeAForeignConversationPane(t *testing.T) {
+	t.Parallel()
+
+	claudeAgent, claudePane := providerPaneResource("pane-claude", "%53", aiModeClaude, nil)
+	claudeAgent.Status.SessionRef = &coremetadata.AgentSessionRef{
+		Provider: aiModeClaude,
+		Claude:   &coremetadata.ClaudeSessionRef{SessionID: "conversation-shared"},
+	}
+	codexAgent, codexPane := providerPaneResource("pane-codex", "%80", aiModeCodex, nil)
+	registry := coremetadata.Registry{
+		Agents: []coremetadata.Agent{claudeAgent, codexAgent},
+		Panes:  []coremetadata.Pane{claudePane, codexPane},
+	}
+
+	// The record resolves, and it points at a Pane of the wrong provider.
+	if held := registeredConversationPanes(registry)["conversation-shared"]; held != "%53" {
+		t.Fatalf("fixture does not record the conversation on the foreign pane: %q", held)
+	}
+
+	t.Run("ladder answers behind the refused conversation", func(t *testing.T) {
+		t.Parallel()
+		cmd := inheritedIdentityCommand(t, registry, "%53")
+		cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if name == "tmux" && len(args) > 0 && args[0] == "list-panes" {
+				return []byte("%80\x1f/repo/projmux\x1f\x1f\n"), nil
+			}
+			return nil, os.ErrNotExist
+		}
+		paneID, reason := cmd.matchAIPane(aiPaneMatchInput{
+			ExplicitPane: "pane-claude",
+			Provider:     aiModeCodex,
+			CWD:          "/repo/projmux",
+			SessionID:    "conversation-shared",
+		})
+		if paneID != "%80" || reason != "" {
+			t.Fatalf("matchAIPane() = %q, reason %q, want %%80", paneID, reason)
+		}
+	})
+
+	t.Run("nothing else answers", func(t *testing.T) {
+		t.Parallel()
+		cmd := inheritedIdentityCommand(t, registry, "%53")
+		paneID, reason := cmd.matchAIPane(aiPaneMatchInput{
+			ExplicitPane: "pane-claude",
+			Provider:     aiModeCodex,
+			SessionID:    "conversation-shared",
+		})
+		if paneID != "" {
+			t.Fatalf("matchAIPane() attributed the event to %q", paneID)
+		}
+		if reason != aiPaneMatchReasonExplicitForeignOnly {
+			t.Fatalf("reason = %q, want %q", reason, aiPaneMatchReasonExplicitForeignOnly)
+		}
+	})
+}
+
+// The global ladder is unchanged. With no explicit value there is no refused
+// envelope and therefore no coherence question: a cwd match resolves exactly as
+// it did before, foreign provider or not. This is the assertion that proves the
+// second-door fix did not leak into `matchAIPaneFromInventory`.
+func TestNoExplicitPathStillTakesACwdMatchRegardlessOfProvider(t *testing.T) {
+	t.Parallel()
+
+	claudeAgent, claudePane := providerPaneResource("pane-claude", "%53", aiModeClaude, nil)
+	registry := coremetadata.Registry{
+		Agents: []coremetadata.Agent{claudeAgent},
+		Panes:  []coremetadata.Pane{claudePane},
+	}
+	inventory := func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "tmux" && len(args) > 0 && args[0] == "list-panes" {
+			return []byte("%53\x1f/repo/projmux\x1fthread-1\x1fsession-1\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	for _, provider := range []string{aiModeCodex, aiModeClaude, aiModeAntigravity, ""} {
+		cmd := inheritedIdentityCommand(t, registry, "")
+		cmd.readCommand = inventory
+		if paneID, reason := cmd.matchAIPane(aiPaneMatchInput{Provider: provider, CWD: "/repo/projmux"}); paneID != "%53" || reason != "" {
+			t.Fatalf("no-explicit cwd step for provider %q = %q, reason %q, want %%53", provider, paneID, reason)
+		}
+		if paneID, reason := cmd.matchAIPane(aiPaneMatchInput{Provider: provider, ThreadID: "thread-1"}); paneID != "%53" || reason != "" {
+			t.Fatalf("no-explicit thread step for provider %q = %q, reason %q, want %%53", provider, paneID, reason)
+		}
+	}
+}

--- a/internal/app/ai_ingest.go
+++ b/internal/app/ai_ingest.go
@@ -55,8 +55,15 @@ var aiBellPaneFormat = intmux.JoinFormats(intmux.FieldDelimiter, aiBellPaneForma
 // belongs to. ExplicitPane is the identity the hook command was handed; the
 // remaining fields are the inherited-environment evidence the matcher has always
 // used and still uses whenever no explicit identity arrived.
+//
+// Provider is the hook's own provider, which every route already knows about
+// itself. It exists so the matcher can tell an explicit identity that is the
+// hook's own from one it merely inherited: a provider host launched from
+// somebody else's Pane carries that Pane's activation envelope verbatim, and
+// having a value and owning it are different things.
 type aiPaneMatchInput struct {
 	ExplicitPane string
+	Provider     string
 	CWD          string
 	ThreadID     string
 	SessionID    string
@@ -76,6 +83,8 @@ const (
 	aiPaneMatchReasonExplicitStale       = "explicit pane binding is stale"
 	aiPaneMatchReasonConversationUnknown = "conversation is not registered to a pane"
 	aiPaneMatchReasonConversationShared  = "conversation is registered to several panes"
+	aiPaneMatchReasonExplicitForeign     = "explicit pane belongs to another provider"
+	aiPaneMatchReasonExplicitForeignOnly = "explicit pane belongs to another provider; no other match"
 )
 
 type aiPaneMatchRow struct {
@@ -610,12 +619,22 @@ func (c *aiCommand) writeAIHookResumeMetadata(paneID, resumeID string) {
 }
 
 // matchAIPane resolves the Pane a hook event belongs to and, when it cannot,
-// says which step failed. An explicit identity handed to the hook command is the
-// whole answer: it is resolved through the Registry and never falls through to
-// the inherited-environment ladder, because falling through would attribute the
-// event to whichever other live Pane happens to share a working directory. The
-// established three-step ladder is unchanged and remains the answer whenever no
-// explicit identity arrived.
+// says which step failed. An explicit identity handed to the hook command is
+// normally the whole answer: it is resolved through the Registry and does not
+// fall through to the inherited-environment ladder, because falling through
+// would attribute the event to whichever other live Pane happens to share a
+// working directory. The established three-step ladder is unchanged and remains
+// the answer whenever no explicit identity arrived.
+//
+// The one explicit value that is not an answer is one that was never the hook's
+// own. A provider host shared by several Panes inherits the activation envelope
+// of whichever Pane happened to launch it, so the argument can arrive holding a
+// live, perfectly resolvable Pane that belongs to a different provider. Having a
+// value and owning it are different things, and only the Registry can tell them
+// apart: when it positively records a different provider for that Pane, the
+// value is refused and the event continues to the steps that answer from what
+// the hook itself carries. The inherited tmux environment is deliberately not
+// among them -- it comes from the same envelope that was just refused.
 //
 // Behind that ladder sits one further step for the hook nobody can hand an
 // identity to. A provider host shared by several Panes inherits neither the
@@ -627,7 +646,11 @@ func (c *aiCommand) writeAIHookResumeMetadata(paneID, resumeID string) {
 // conversation no Pane claims fails by name rather than landing on a neighbour.
 func (c *aiCommand) matchAIPane(in aiPaneMatchInput) (string, string) {
 	if explicit := strings.TrimSpace(in.ExplicitPane); explicit != "" {
-		return c.resolveExplicitAIPane(explicit)
+		paneID, reason := c.resolveExplicitAIPane(in.Provider, explicit)
+		if paneID != "" || reason != aiPaneMatchReasonExplicitForeign {
+			return paneID, reason
+		}
+		return c.matchAIPaneAfterForeignExplicit(in)
 	}
 	if envPane := strings.TrimSpace(c.env("TMUX_PANE")); envPane != "" {
 		return envPane, ""
@@ -640,6 +663,29 @@ func (c *aiCommand) matchAIPane(in aiPaneMatchInput) (string, string) {
 		return "", reason
 	}
 	return c.resolveRegisteredConversationPane(in.ThreadID, in.SessionID)
+}
+
+// matchAIPaneAfterForeignExplicit continues a refused inherited identity through
+// the steps that answer from what the hook itself carries. The Registry
+// conversation lookup goes first because it is the only step that answers from
+// the payload alone; the established inventory ladder follows it unchanged. The
+// inherited `TMUX_PANE` step is skipped on purpose: that variable arrives in the
+// very envelope whose Pane identity was just refused, so honouring it would
+// reintroduce the same misattribution through a second door.
+//
+// A failure here keeps the refusal legible. The reason is its own token rather
+// than the downstream step's, so the record still says the hook was handed
+// somebody else's Pane instead of only saying the inventory was unreadable.
+func (c *aiCommand) matchAIPaneAfterForeignExplicit(in aiPaneMatchInput) (string, string) {
+	if strings.TrimSpace(in.ThreadID) != "" || strings.TrimSpace(in.SessionID) != "" {
+		if paneID, _ := c.resolveRegisteredConversationPane(in.ThreadID, in.SessionID); paneID != "" {
+			return paneID, ""
+		}
+	}
+	if paneID, _ := c.matchAIPaneFromInventory(in); paneID != "" {
+		return paneID, ""
+	}
+	return "", aiPaneMatchReasonExplicitForeignOnly
 }
 
 // matchAIPaneFromInventory is the established three-step ladder over the live
@@ -753,7 +799,16 @@ func registeredConversationPanes(registry coremetadata.Registry) map[string]stri
 // a Pane whose Agent binding no longer round-trips, is a failure rather than a
 // second-best guess. Resolution reads no tmux server, so it survives an
 // app-server that inherited no tmux environment.
-func (c *aiCommand) resolveExplicitAIPane(ref string) (string, string) {
+//
+// The last check is coherence rather than liveness, and it is what separates an
+// identity the hook owns from one it inherited. The Registry already records
+// which provider an Agent runs, in exactly the shape markAIHookPane compares
+// against, so a Codex hook handed a Claude Pane is a contradiction the resource
+// model states outright. Only a recorded and different provider refuses: a Pane
+// the Registry records no provider for -- an unbound shell where somebody just
+// ran a provider by hand -- is not a contradiction and resolves as before. The
+// rule is symmetric over providers and names none of them.
+func (c *aiCommand) resolveExplicitAIPane(provider, ref string) (string, string) {
 	if c.loadRegistry == nil {
 		return "", aiPaneMatchReasonRegistryUnavailable
 	}
@@ -774,8 +829,21 @@ func (c *aiCommand) resolveExplicitAIPane(ref string) (string, string) {
 		if !ok || agent.Status.PaneRef != pane.Metadata.UID {
 			return "", aiPaneMatchReasonExplicitStale
 		}
+		if explicitAIPaneIsForeign(provider, agent.Spec.Provider) {
+			return "", aiPaneMatchReasonExplicitForeign
+		}
 	}
 	return runtimeID, ""
+}
+
+// explicitAIPaneIsForeign reports whether the Registry positively contradicts a
+// hook's claim on a Pane. Both sides are normalized through the one provider
+// vocabulary, and an unrecognized or absent value on either side is silence, not
+// disagreement: only two recognized providers that differ are a contradiction.
+func explicitAIPaneIsForeign(hookProvider, paneProvider string) bool {
+	hook := coremetadata.NormalizeProvider(hookProvider)
+	pane := coremetadata.NormalizeProvider(paneProvider)
+	return hook != "" && pane != "" && hook != pane
 }
 
 // explicitAIPaneResource accepts either spelling a hook can be handed: the

--- a/internal/app/ai_ingest.go
+++ b/internal/app/ai_ingest.go
@@ -673,19 +673,64 @@ func (c *aiCommand) matchAIPane(in aiPaneMatchInput) (string, string) {
 // very envelope whose Pane identity was just refused, so honouring it would
 // reintroduce the same misattribution through a second door.
 //
+// Provider coherence is applied once more here, to whatever these steps resolve.
+// This path exists only because the explicit value was foreign, and its second
+// step matches on working directory alone -- on a machine where every provider
+// Pane sits in the same repository that step would hand the event straight back
+// to a Pane of the very provider just refused. The check is applied to the
+// resolved answer rather than inside the ladder, so the ladder and the path that
+// was handed nothing keep their behavior exactly.
+//
+// A foreign answer ends the attempt rather than restarting the ladder looking
+// for a later row: refusing with a reason is the conservative end, and rescanning
+// would mean changing the shared ladder. Silence stays silence -- a Pane the
+// Registry records no provider for is not a contradiction and is still taken.
+//
 // A failure here keeps the refusal legible. The reason is its own token rather
 // than the downstream step's, so the record still says the hook was handed
 // somebody else's Pane instead of only saying the inventory was unreadable.
 func (c *aiCommand) matchAIPaneAfterForeignExplicit(in aiPaneMatchInput) (string, string) {
+	registry := coremetadata.Registry{}
+	if c.loadRegistry != nil {
+		if loaded, err := c.loadRegistry(); err == nil {
+			registry = loaded
+		}
+	}
+	own := func(paneID string) bool {
+		return !explicitAIPaneIsForeign(in.Provider, registeredPaneProvider(registry, paneID))
+	}
 	if strings.TrimSpace(in.ThreadID) != "" || strings.TrimSpace(in.SessionID) != "" {
-		if paneID, _ := c.resolveRegisteredConversationPane(in.ThreadID, in.SessionID); paneID != "" {
+		if paneID, _ := c.resolveRegisteredConversationPane(in.ThreadID, in.SessionID); paneID != "" && own(paneID) {
 			return paneID, ""
 		}
 	}
-	if paneID, _ := c.matchAIPaneFromInventory(in); paneID != "" {
+	if paneID, _ := c.matchAIPaneFromInventory(in); paneID != "" && own(paneID) {
 		return paneID, ""
 	}
 	return "", aiPaneMatchReasonExplicitForeignOnly
+}
+
+// registeredPaneProvider reports the provider the Registry records for a Pane,
+// addressed by either spelling a step can produce. It demands the same round
+// trip resolveExplicitAIPane does -- activation handle, owning Agent, and that
+// Agent pointing back at this Pane -- and reports nothing for anything short of
+// that. Nothing is silence, which the coherence predicate reads as agreement
+// rather than disagreement, so an unregistered or half-torn Pane never becomes a
+// refusal of its own.
+func registeredPaneProvider(registry coremetadata.Registry, ref string) string {
+	pane, ok := explicitAIPaneResource(registry, strings.TrimSpace(ref))
+	if !ok {
+		return ""
+	}
+	agentUID := strings.TrimSpace(pane.Status.Activation.AgentUID)
+	if agentUID == "" {
+		return ""
+	}
+	agent, ok := registry.Agent(agentUID)
+	if !ok || agent.Status.PaneRef != pane.Metadata.UID {
+		return ""
+	}
+	return agent.Spec.Provider
 }
 
 // matchAIPaneFromInventory is the established three-step ladder over the live

--- a/internal/app/ai_ingest_antigravity.go
+++ b/internal/app/ai_ingest_antigravity.go
@@ -65,6 +65,7 @@ func (c *aiCommand) ingestAntigravityHook(data []byte, explicitEvent, explicitPa
 
 	paneID, matchReason := c.matchAIPane(aiPaneMatchInput{
 		ExplicitPane: explicitPane,
+		Provider:     aiModeAntigravity,
 		CWD:          payload.CWD,
 		ThreadID:     payload.ConversationID,
 	})

--- a/internal/app/ai_ingest_claude.go
+++ b/internal/app/ai_ingest_claude.go
@@ -42,6 +42,7 @@ func (c *aiCommand) ingestClaudeHook(data []byte, explicitPane string) error {
 
 	paneID, matchReason := c.matchAIPane(aiPaneMatchInput{
 		ExplicitPane: explicitPane,
+		Provider:     aiModeClaude,
 		CWD:          payload.CWD,
 		SessionID:    payload.SessionID,
 	})

--- a/internal/app/ai_ingest_codex.go
+++ b/internal/app/ai_ingest_codex.go
@@ -40,6 +40,7 @@ func (c *aiCommand) ingestCodexHook(data []byte, explicitPane string) error {
 	if !nativeRouted {
 		paneID, matchReason = c.matchAIPane(aiPaneMatchInput{
 			ExplicitPane: explicitPane,
+			Provider:     aiModeCodex,
 			CWD:          payload.CWD,
 			ThreadID:     payload.matchThreadID(),
 			SessionID:    payload.SessionID,


### PR DESCRIPTION
## The mechanism

A Codex **app-server** is a host shared by several Panes. It inherits the activation envelope of whichever Pane launched it — observed: app-server pid 1612691 carrying the envelope of a **Claude** Pane `%53`.

The hook command is `--pane=${PMX_INTERNAL_ACTIVATION_PANE_UID:-}` (`aiHookPaneArgument`), so that inherited envelope becomes the explicit value. `routeNativeCodexHook` falls out with `handled=false` because the Claude Pane has no `activation.Codex`, and `matchAIPane` then treated the explicit value as the whole answer:

```go
if explicit := strings.TrimSpace(in.ExplicitPane); explicit != "" {
    return c.resolveExplicitAIPane(explicit)
}
```

The value is live and perfectly resolvable, so a Codex hook gets attributed to a Claude Pane. Contract C-2's Guarantee says hook execution receives **its own** Pane identifier explicitly; *having* an explicit value and that value being *your own* are different things, and only the Registry can tell them apart.

Latent, not yet fired.

## Design

**a) Provider coherence, provider-neutral.** `aiPaneMatchInput` gains a `Provider` field; each of the three callers passes the provider it already knows (`ai_ingest_claude.go`, `ai_ingest_codex.go`, `ai_ingest_antigravity.go`). `resolveExplicitAIPane` refuses the value **only when the Registry positively records a different provider** for that Pane — resolved from the Registry it already loaded (`activation.AgentUID` → `registry.Agent(...)` → `Spec.Provider`), in exactly the shape `markAIHookPane` already compares against, and never from a fresh tmux read.

A Pane that records **no** provider (an unbound shell where a user just ran `claude`) is silence, not a contradiction, and resolves unchanged; so is an unrecognized spelling on either side. Both sides normalize through `coremetadata.NormalizeProvider`. There is no provider-specific branch anywhere: the rule is symmetric and the tokens carry no provider text.

**b) New closed-vocabulary tokens** beside the existing ones:

- `aiPaneMatchReasonExplicitForeign = "explicit pane belongs to another provider"`
- `aiPaneMatchReasonExplicitForeignOnly = "explicit pane belongs to another provider; no other match"`

**c) Fall-through — this refusal only.** `ExplicitUnknown`, `ExplicitNoRuntime`, and `ExplicitStale` keep Phase 2 behavior: they refuse outright and do not fall through. Only provider coherence continues.

**d) Fall-through order.** `resolveRegisteredConversationPane` first, then `matchAIPaneFromInventory`. The inherited `TMUX_PANE` step is skipped on this path — that env arrives in the same envelope whose Pane identity was just refused, so honoring it would reintroduce the exact leak through a second door. The no-explicit path is unchanged (env → inventory ladder → Registry).

**e) Final failure stays legible.** If the fall-through also fails, the matcher reports the composite `aiPaneMatchReasonExplicitForeignOnly` rather than the downstream step's generic token, so the record still says the hook was handed somebody else's Pane. It is its own distinct vocabulary entry with its own test.

## The second door

The fall-through this Phase introduces ends in `matchAIPaneFromInventory`, whose **first step is a bare cwd match with no provider check**. On a machine where every Codex and Claude Pane shares the same repository cwd, a Codex hook whose inherited identity was just refused would land on a Claude Pane anyway — the exact outcome this Phase exists to prevent, reached through a second door.

That is pre-existing ladder behavior, but Phase 8 is what newly routes foreign-refused hooks into it: before this change such a hook went to the launcher Pane and never reached the ladder. Today the ladder usually dies at `pane inventory unavailable` first, so it rarely fires — Phase 7 makes the inventory readable and the cwd match goes live.

**The fix is narrow.** `explicitAIPaneIsForeign` is applied once more, to whatever `matchAIPaneAfterForeignExplicit` resolves, on that path only:

- Registry conversation lookup returns a Pane → if foreign, do not take it; the inventory ladder still gets its turn.
- Inventory ladder returns a Pane → if foreign, do not take it; end with `aiPaneMatchReasonExplicitForeignOnly`.

The check sits on the *answer*, not inside the ladder. A resolved `%N` maps back to its recorded provider through the shared `registeredPaneProvider` helper, which demands the same round trip `resolveExplicitAIPane` does. The Registry is loaded once for the fall-through. The ladder is not rescanned for a later non-foreign row — that would mean changing the shared ladder; refusing with a concrete reason is the conservative end C-2's Non-Guarantee asks for.

**Fail-open is unchanged**, and it is what keeps criterion 3 safe: `NormalizeProvider` returns `""` for absent or unrecognized values, so a Pane whose provider the Registry does not record is silence, not disagreement, and still resolves.

## Acceptance criteria → tests

| Criterion | Test |
| --- | --- |
| 1. Injecting another provider's Pane uid does not attribute to that Pane | `TestResolveExplicitAIPaneRefusesAnInheritedForeignIdentity` (both spellings, all four provider directions), `TestMatchAIPaneNeverAttributesAnInheritedForeignIdentity` (whole matcher) |
| 2. A refused value flows to the next step; final failure records a concrete reason | `TestMatchAIPaneContinuesPastARefusedInheritedIdentity` — registry conversation answers / inventory answers when the registry cannot / nothing answers → `ExplicitForeignOnly`; plus `TestForeignExplicitFallThroughIgnoresTheInheritedEnvironment` for the skipped env step |
| 3. A normal explicit value holding its own Pane behaves exactly as Phase 2 | `TestMatchAIPaneKeepsAnExplicitPaneWithNoRecordedProvider` (7 rows: no record, matching, mixed case, unrecognized on either side) plus every existing Phase 2 test unchanged and green — `TestMatchAIPaneResolvesTheHandedPaneWithoutTmuxEnvironment`, `TestMatchAIPanePrefersTheHandedPaneOverInheritedEvidence`, `TestMatchAIPaneKeepsTheEstablishedFallbackWhenNothingWasHandedOver`, `TestMatchAIPaneRefusesAHandedPaneThatIsGone` |
| Closed vocabulary | `TestAttributionFailureReasonsAreDistinctAndClosed`, extended with both new tokens and now also asserting no token contains provider text |
| Negative audit | `TestForeignExplicitRefusalLeavesTheRegistryPathUnchanged` |
| Second door: cwd step does not hand back a foreign Pane | `TestForeignExplicitFallThroughDoesNotLandOnAnotherProvidersPane` (both directions) |
| Second door: fail-open preserved | `TestForeignExplicitFallThroughStillTakesACoherentLadderAnswer` (own provider / no record / unrecognized) |
| Second door: Registry conversation branch | `TestForeignExplicitFallThroughDoesNotTakeAForeignConversationPane` (foreign record not taken; ladder still gets its turn) |
| Second door: global ladder untouched | `TestNoExplicitPathStillTakesACwdMatchRegardlessOfProvider` |

Criterion 4 (C-2 Non-Guarantee narrowing, verdict 부분 → YES) is the roadmap owner's doc; this branch does not touch the roadmap hub or detail.

## Boundaries verified untouched

- **`matchAIPaneFromInventory` and the no-explicit path.** Byte-identical to `origin/main`: hashing the function bodies out of `git show origin/main:internal/app/ai_ingest.go` and out of HEAD gives the same digest for `matchAIPaneFromInventory`, `resolveRegisteredConversationPane`, and `registeredConversationPanes`. `TestNoExplicitPathStillTakesACwdMatchRegardlessOfProvider` pins it behaviorally.
- **Phase 6 Registry mapping path.** `git diff` on `ai_ingest.go` shows exactly one line mentioning `resolveRegisteredConversationPane` — a new *call site*. The bodies of `resolveRegisteredConversationPane` and `registeredConversationPanes` are byte-identical. `TestForeignExplicitRefusalLeavesTheRegistryPathUnchanged` additionally proves 0 semantic change: the conversation index returns the same map whether or not an Agent records a provider, because it reads the resource model and never a provider name.
- **Conversation-binding authority.** This stage does lookup only. No `updateRegistry`, `stageAgentSessionRef`, or binding write is added; the test fixture fails on any registry write.
- **Delivery path.** `ai_ingest_codex.go` changes by one line (`Provider: aiModeCodex`) inside the existing `aiPaneMatchInput` literal; the Phase 7 delivery path is untouched.
- **Foreign / unmanaged app-server lifecycle.** Nothing terminates, restarts, or reclaims a host; the generation pool is not read or written.
- **Logging.** No secrets, tokens, prompts, paths, or conversation content. The two new tokens are bounded provider-neutral phrases.
- **`docs/agent-workflow.md`.** One new appended `###` section; no existing section rewritten.

## Files touched

`internal/app/ai_ingest.go` (the explicit `--pane` decision stage), the three callers (one field each), `internal/app/ai_hook_pane_identity_test.go`, `docs/agent-workflow.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
