### PR TITLE
fix(hooks): let an attributed codex hook reach its pane

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1070,6 +1070,56 @@ fall-through resolves — to the answer, never inside the shared ladder.
   envelope and therefore no coherence question, and the cwd and thread steps
   resolve exactly as before for every provider.
 
+### Attributed Codex hook delivery route tests
+
+Attribution and reflection are different layers. A Codex hook attributed to its
+Pane still has to write that Pane's options, and the hook the shared app-server
+launches inherits no tmux environment at all: its `tmux set-option` carried no
+socket argument, probed the operator's `default` server, found none, and handed
+back `exit status 1`. `ai-ingest.log` recorded that exit status where a cause
+belongs.
+
+`applyCodexHookSemanticDelivery` now resolves one exact server before it writes
+anything, and refuses by name when it cannot.
+
+- `TestCodexHookDeliveryWritesItsPaneWithoutAnyTmuxEnvironment` owns the case
+  the failure came from: with no `TMUX` at all the delivery still resolves a
+  route, and the argv it produces is pinned to the app-owned socket rather than
+  left unprefixed.
+- `TestCodexHookDeliveryPrefersTheInheritedReceiptOverTheAppRoute` owns the
+  precedence. A pane client's own `$TMUX` receipt names its server without a
+  search, is taken as an explicit socket path, and needs no containment probe.
+- `TestCodexHookDeliveryRefusesARouteItCannotProve` owns the proof. The
+  app-owned route is never trusted on its name: an unreachable runtime, an empty
+  answer, a server that is not app-owned, a runtime holding a different pane,
+  and a pane that is not a projmux Pane each produce their own reason and write
+  nothing.
+- `TestCodexHookDeliveryFailureReasonsAreConcreteAndClosed` owns the vocabulary.
+  Every token a refusal can render — the three reasons, the two route kinds, the
+  four tmux causes — is non-empty and carries no socket path, no routing flag,
+  and no process exit status.
+- `TestCodexHookDeliveryLeavesNoTransportDetailInTheIngestLog` owns the record
+  rather than the error value. It injects a transport failure whose tmux output
+  names its socket, drives the real ingest route, and reads the whole log file
+  back: a reason that leaks is caught there even when every assertion above
+  still passes.
+- `TestCodexHookDeliveryExplainsARejectedWriteByRereadingItsRoute` owns the
+  residual failure. A `set-option` that fails after the route was proven is
+  explained by re-reading the route — a pure read that repeats no write — so the
+  record says whether the pane vanished or the runtime rejected the option.
+
+tmux explains a refusal on stderr and that text carries the socket path it
+tried, so `codexHookDeliveryCause` is the only reader of tmux's own words here:
+it classifies them into a closed set and returns none of them. A reason names
+which lane answered — inherited or app-owned — and never which file backs it,
+because this track's change boundary keeps paths out of durable records.
+
+The route decides where a reflection is written, not which Pane it belongs to;
+attribution stays with the matcher and the Registry step above. Two other hook
+writers on the same shared-host path, `applyAIStatusInternalWithActivationPolicy`
+and `markAIHookPane`, still issue unrouted tmux calls and discard their errors,
+so their failures are invisible rather than fixed.
+
 ## Review Checklist
 - The branch stays within its stated scope.
 - The change preserves boundaries between portable `projmux` behavior and local machine policy.

--- a/internal/app/ai_ingest_codex.go
+++ b/internal/app/ai_ingest_codex.go
@@ -10,6 +10,9 @@ import (
 	"github.com/crevissepartners/projmux/internal/config"
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
 	"github.com/crevissepartners/projmux/internal/core/notify"
+	"github.com/crevissepartners/projmux/internal/core/resourcegraph"
+	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
+	"github.com/crevissepartners/projmux/internal/integrations/tmuxopts"
 )
 
 type codexHookPayload struct {
@@ -222,6 +225,187 @@ func codexHookSemanticLogResult(policy config.AISemanticPolicy, rawOverride bool
 	}
 }
 
+// A codex hook launched by a pane client inherits $TMUX, and that receipt names
+// its server without a search. A hook launched by the shared app-server that
+// several Panes talk to inherits nothing at all, so an unprefixed `tmux
+// set-option` there is a default-socket probe: it looks for the operator's
+// `default` server, does not find one, and dies. That is why an attributed
+// Stop reached its Pane and then failed with a bare `exit status 1`.
+//
+// These are the closed reasons a reflection refuses to write. Each names the
+// exact authority that was missing, so `ai-ingest.log` never carries a bare
+// process exit status where a cause belongs.
+const (
+	// codexHookRouteUnavailableReason is raised when the hook has no inherited
+	// receipt and projmux's own app-owned runtime could not be observed.
+	codexHookRouteUnavailableReason = "pane runtime route unavailable"
+	// codexHookRouteForeignPaneReason is raised when a runtime answered but the
+	// attributed pane is not a projmux Pane living on it.
+	codexHookRouteForeignPaneReason = "pane runtime route does not hold this pane"
+	// codexHookWriteRejectedReason is raised when the routed set-option itself
+	// failed. It always carries the exact option and a re-read classification
+	// of the route, never the write's process exit status.
+	codexHookWriteRejectedReason = "pane option write rejected"
+)
+
+// codexHookDeliveryError is the self-describing refusal a reflection returns.
+// Its Error() is what `ai-ingest.log` records as the reason, so every value it
+// can render is a sentence about authority, never an exit status alone.
+type codexHookDeliveryError struct {
+	Reason string
+	Detail string
+}
+
+func (e *codexHookDeliveryError) Error() string {
+	if e == nil {
+		return codexHookRouteUnavailableReason
+	}
+	if strings.TrimSpace(e.Detail) == "" {
+		return e.Reason
+	}
+	return e.Reason + ": " + e.Detail
+}
+
+// The route a reflection took, named by kind. The socket behind it is an
+// absolute path, and this track's change boundary keeps paths out of durable
+// records, so a reason says which lane answered and never which file it is.
+const (
+	codexHookInheritedRoute = "inherited route"
+	codexHookAppOwnedRoute  = "app-owned route"
+)
+
+// What tmux refused, as a closed set. tmux explains itself on stderr and that
+// text carries socket paths, so the explanation is read, classified, and
+// dropped -- the classification is what a record may keep.
+const (
+	codexHookCauseNoServer     = "no server on this route"
+	codexHookCauseNoPane       = "pane not found on this route"
+	codexHookCauseDenied       = "permission denied on this route"
+	codexHookCauseUnclassified = "unclassified tmux failure"
+)
+
+// codexHookDeliveryCause folds one tmux failure into that closed set. It is the
+// only reader of tmux's own words on this path, and it returns none of them:
+// a bare exit status says nothing, and the message that would say something
+// names the socket.
+func codexHookDeliveryCause(output []byte, err error) string {
+	message := strings.ToLower(strings.TrimSpace(string(output)))
+	switch {
+	case message == "" && err == nil:
+		return codexHookCauseUnclassified
+	case strings.Contains(message, "no server running"),
+		strings.Contains(message, "error connecting"),
+		strings.Contains(message, "failed to connect"),
+		strings.Contains(message, "no such file or directory"):
+		return codexHookCauseNoServer
+	case strings.Contains(message, "can't find pane"),
+		strings.Contains(message, "cant find pane"),
+		strings.Contains(message, "no such pane"),
+		strings.Contains(message, "pane not found"):
+		return codexHookCauseNoPane
+	case strings.Contains(message, "permission denied"):
+		return codexHookCauseDenied
+	default:
+		return codexHookCauseUnclassified
+	}
+}
+
+// codexHookDeliveryRouteFormat reads the three facts that decide whether a
+// candidate runtime may receive this Pane's reflection, in one call.
+var codexHookDeliveryRouteFormat = tmuxRowFormat(
+	intmux.TmuxFormat(tmuxopts.AppGlobal),
+	"#{pane_id}",
+	intmux.TmuxFormat(tmuxopts.PaneUID),
+)
+
+// codexHookDeliveryTarget is the one tmux server a reflection may write to.
+// Every write carries its routing argv, so no reflection call is ever the
+// unprefixed default-server probe that killed an attributed Stop.
+type codexHookDeliveryTarget struct {
+	command   *aiCommand
+	transport tmuxTransport
+	// kind names the lane that answered. It is what a refusal may record; the
+	// transport's own value is a socket path and stays out of every record.
+	kind string
+}
+
+func (t codexHookDeliveryTarget) args(args ...string) []string {
+	routed := make([]string, 0, len(args)+2)
+	routed = append(routed, t.transport.Args()...)
+	return append(routed, args...)
+}
+
+// contained re-reads whether this route still holds paneID as a projmux Pane.
+// It is the pure-read classifier a rejected write is explained by: no write is
+// repeated, and the answer names a cause instead of a process exit status.
+func (t codexHookDeliveryTarget) contained(paneID string) (bool, string) {
+	runner := explicitTmuxRunner{
+		runner: aiCommandMuxBackend{runCommand: t.command.runCommand, readCommand: t.command.readCommand},
+		target: t.transport,
+	}
+	output, err := runner.Run(context.Background(), "tmux",
+		"display-message", "-p", "-t", paneID, "-F", codexHookDeliveryRouteFormat)
+	if err != nil {
+		return false, "runtime is no longer reachable: " + codexHookDeliveryCause(output, err)
+	}
+	rows := splitTmuxRows(string(output), 3)
+	if len(rows) != 1 || rows[0][1] != paneID || strings.TrimSpace(rows[0][2]) == "" {
+		return false, "pane is gone from this runtime"
+	}
+	return true, "runtime still holds this pane and rejected the option write"
+}
+
+// codexHookDeliveryRoute pins every reflection write to one exact tmux server.
+//
+// An inherited receipt is taken as-is: an absolute socket path is the only
+// shape tmux writes, and it names the client's own server without a search.
+// Without one, the route is projmux's own app-owned runtime -- the same route
+// every detached projmux invocation already takes -- and it is never trusted on
+// its name alone. The Pane the hook was already attributed to is the
+// discriminator: that server must be app-owned and must actually hold the
+// attributed pane as a projmux Pane. A candidate that cannot prove the
+// containment receives no write at all, because answering one server's question
+// with another server's objects is worse than refusing.
+func (c *aiCommand) codexHookDeliveryRoute(paneID string) (codexHookDeliveryTarget, error) {
+	inherited, err := resourcegraph.ResolveTransport(resourcegraph.TransportRequest{InheritedTMUX: c.env("TMUX")})
+	if err == nil && inherited.Present() {
+		return codexHookDeliveryTarget{command: c, transport: inherited, kind: codexHookInheritedRoute}, nil
+	}
+	target := codexHookDeliveryTarget{command: c, transport: defaultRuntimeMutationRoute().target, kind: codexHookAppOwnedRoute}
+	runner := explicitTmuxRunner{
+		runner: aiCommandMuxBackend{runCommand: c.runCommand, readCommand: c.readCommand},
+		target: target.transport,
+	}
+	output, runErr := runner.Run(context.Background(), "tmux",
+		"display-message", "-p", "-t", paneID, "-F", codexHookDeliveryRouteFormat)
+	if runErr != nil {
+		return codexHookDeliveryTarget{}, &codexHookDeliveryError{
+			Reason: codexHookRouteUnavailableReason,
+			Detail: target.kind + ": " + codexHookDeliveryCause(output, runErr),
+		}
+	}
+	rows := splitTmuxRows(string(output), 3)
+	if len(rows) != 1 {
+		return codexHookDeliveryTarget{}, &codexHookDeliveryError{
+			Reason: codexHookRouteUnavailableReason,
+			Detail: target.kind + ": containment probe returned no single row",
+		}
+	}
+	if resourcegraph.HostModeFromAppMarker(rows[0][0]) != resourcegraph.HostModeAppOwned {
+		return codexHookDeliveryTarget{}, &codexHookDeliveryError{
+			Reason: codexHookRouteUnavailableReason,
+			Detail: target.kind + ": server is not app-owned",
+		}
+	}
+	if rows[0][1] != paneID || strings.TrimSpace(rows[0][2]) == "" {
+		return codexHookDeliveryTarget{}, &codexHookDeliveryError{
+			Reason: codexHookRouteForeignPaneReason,
+			Detail: target.kind + ": " + paneID,
+		}
+	}
+	return target, nil
+}
+
 // applyCodexHookSemanticDelivery mirrors the native lifecycle delivery intent
 // for the hook authority without routing through the legacy waiting reducer,
 // whose state-only branch intentionally retains reply attention. The hook was
@@ -250,6 +434,10 @@ func (c *aiCommand) applyCodexHookSemanticDelivery(paneID string, interaction co
 		c.publishNotifyQueueRefreshBestEffort()
 	}
 
+	route, err := c.codexHookDeliveryRoute(paneID)
+	if err != nil {
+		return err
+	}
 	for _, field := range []struct{ option, value string }{
 		{aiPaneStateOption, delivery.State},
 		{aiPaneBadgeKindOption, delivery.Badge},
@@ -259,8 +447,12 @@ func (c *aiCommand) applyCodexHookSemanticDelivery(paneID string, interaction co
 		if field.value == "" {
 			args = []string{"set-option", "-p", "-u", "-t", paneID, field.option}
 		}
-		if err := c.run("tmux", args...); err != nil {
-			return err
+		if runErr := c.run("tmux", route.args(args...)...); runErr != nil {
+			_, cause := route.contained(paneID)
+			return &codexHookDeliveryError{
+				Reason: codexHookWriteRejectedReason,
+				Detail: field.option + " on " + route.kind + ": " + cause,
+			}
 		}
 	}
 	if !delivery.Notify {

--- a/internal/app/ai_ingest_codex_delivery_route_test.go
+++ b/internal/app/ai_ingest_codex_delivery_route_test.go
@@ -1,0 +1,297 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/config"
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+)
+
+// stripRecordedTmuxRoute drops the exact -L/-S route prefix a recorded tmux
+// call carries. An assertion names the command that was issued; which server it
+// was pinned to is the routing contract's own subject, held by the tests below.
+func stripRecordedTmuxRoute(args []string) []string {
+	if len(args) >= 2 && (args[0] == "-L" || args[0] == "-S") {
+		return args[2:]
+	}
+	return args
+}
+
+// routedAppSocketArgs spells a reflection write the way the delivery issues it
+// when the hook inherited no tmux environment: pinned to the app-owned route
+// the containment proof accepted, never to the default socket.
+func routedAppSocketArgs(args ...string) []string {
+	return append([]string{"-L", defaultAppSocket}, args...)
+}
+
+// codexHookDeliveryRouteRow renders the containment probe answer of a runtime
+// that is app-owned and really does hold paneID as a projmux Pane.
+func codexHookDeliveryRouteRow(paneID, paneUID string) []byte {
+	return []byte(strings.Join([]string{"1", paneID, paneUID}, tmuxRowSep) + "\n")
+}
+
+func codexHookDeliveryTestCommand(t *testing.T, paneID string) *aiCommand {
+	t.Helper()
+	cmd := testAICommand(t.TempDir())
+	cmd.readCommand = codexHookIngestReadCommand(paneID)
+	return cmd
+}
+
+// A hook launched by the shared app-server inherits no tmux environment at all.
+// The reflection must still reach its Pane, and it must do so on a route it
+// proved rather than on the default socket an unprefixed call would probe.
+func TestCodexHookDeliveryWritesItsPaneWithoutAnyTmuxEnvironment(t *testing.T) {
+	const paneID = "%7"
+	cmd := codexHookDeliveryTestCommand(t, paneID)
+	if got := cmd.env("TMUX"); got != "" {
+		t.Fatalf("fixture TMUX = %q, want the app-server's empty environment", got)
+	}
+	route, err := cmd.codexHookDeliveryRoute(paneID)
+	if err != nil {
+		t.Fatalf("resolve delivery route without TMUX: %v", err)
+	}
+	if route.transport.Kind != tmuxSocketName || route.transport.Value != defaultAppSocket {
+		t.Fatalf("delivery route = %#v, want the app-owned socket-name route", route.transport)
+	}
+	if got := route.args("set-option", "-p", "-t", paneID, aiPaneStateOption, "waiting"); !reflect.DeepEqual(
+		got, []string{"-L", defaultAppSocket, "set-option", "-p", "-t", paneID, aiPaneStateOption, "waiting"}) {
+		t.Fatalf("routed argv = %#v", got)
+	}
+}
+
+// An inherited receipt already names the client's own server. It is taken
+// as-is, and it is taken as an explicit -S route rather than left unprefixed.
+func TestCodexHookDeliveryPrefersTheInheritedReceiptOverTheAppRoute(t *testing.T) {
+	const paneID = "%7"
+	cmd := codexHookDeliveryTestCommand(t, paneID)
+	cmd.readCommand = func(context.Context, string, ...string) ([]byte, error) {
+		return nil, errors.New("an inherited receipt must not need a containment probe")
+	}
+	base := cmd.lookupEnv
+	cmd.lookupEnv = func(name string) string {
+		if name == "TMUX" {
+			return "/tmp/tmux-1000/projmux,4242,1"
+		}
+		return base(name)
+	}
+	route, err := cmd.codexHookDeliveryRoute(paneID)
+	if err != nil {
+		t.Fatalf("resolve delivery route from inherited receipt: %v", err)
+	}
+	if route.transport.Kind != tmuxSocketPath || route.transport.Value != "/tmp/tmux-1000/projmux" {
+		t.Fatalf("delivery route = %#v, want the inherited socket path", route.transport)
+	}
+	if route.transport.Source != tmuxInheritedSource {
+		t.Fatalf("delivery route source = %q, want the inherited env provenance", route.transport.Source)
+	}
+}
+
+// The app-owned route is never trusted on its name. Each way the containment
+// proof can fail names its own cause, and none of them writes anything.
+func TestCodexHookDeliveryRefusesARouteItCannotProve(t *testing.T) {
+	const paneID = "%7"
+	for _, test := range []struct {
+		name       string
+		probe      func() ([]byte, error)
+		wantReason string
+		wantDetail string
+	}{
+		{
+			name:       "runtime is unreachable",
+			probe:      func() ([]byte, error) { return []byte("no server running on /tmp/tmux-1000/projmux"), os.ErrNotExist },
+			wantReason: codexHookRouteUnavailableReason,
+			wantDetail: codexHookCauseNoServer,
+		},
+		{
+			name:       "runtime answers nothing",
+			probe:      func() ([]byte, error) { return []byte("\n"), nil },
+			wantReason: codexHookRouteUnavailableReason,
+			wantDetail: "containment probe returned no single row",
+		},
+		{
+			name: "runtime is not app-owned",
+			probe: func() ([]byte, error) {
+				return []byte(strings.Join([]string{"", paneID, "pan-alpha"}, tmuxRowSep) + "\n"), nil
+			},
+			wantReason: codexHookRouteUnavailableReason,
+			wantDetail: "server is not app-owned",
+		},
+		{
+			name: "runtime holds a different pane",
+			probe: func() ([]byte, error) {
+				return codexHookDeliveryRouteRow("%9", "pan-alpha"), nil
+			},
+			wantReason: codexHookRouteForeignPaneReason,
+			wantDetail: paneID,
+		},
+		{
+			name: "pane is not a projmux Pane",
+			probe: func() ([]byte, error) {
+				return codexHookDeliveryRouteRow(paneID, ""), nil
+			},
+			wantReason: codexHookRouteForeignPaneReason,
+			wantDetail: paneID,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := codexHookDeliveryTestCommand(t, paneID)
+			cmd.readCommand = func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+				return test.probe()
+			}
+			_, err := cmd.codexHookDeliveryRoute(paneID)
+			if err == nil {
+				t.Fatal("unproven route resolved without a refusal")
+			}
+			assertCodexHookDeliveryReason(t, err, test.wantReason, test.wantDetail)
+			if writes := cmdRecorder(cmd).commands; len(writes) != 0 {
+				t.Fatalf("refused route still ran %#v", writes)
+			}
+		})
+	}
+}
+
+// The reflection's own failure surface: an attributed hook that cannot write
+// records why, and the reason is never the process exit status the discarding
+// runner used to hand back.
+func TestCodexHookDeliveryFailureReasonsAreConcreteAndClosed(t *testing.T) {
+	const paneID = "%7"
+	cmd := codexHookDeliveryTestCommand(t, paneID)
+	cmd.readCommand = func(context.Context, string, ...string) ([]byte, error) { return nil, os.ErrNotExist }
+	err := cmd.applyCodexHookSemanticDelivery(paneID, coremetadata.InteractionResponseComplete, config.AISemanticStateOnly, attentionNotifyInput{})
+	if err == nil {
+		t.Fatal("delivery on an unroutable hook returned no error")
+	}
+	assertCodexHookDeliveryReason(t, err, codexHookRouteUnavailableReason, "")
+	for _, token := range []string{
+		codexHookRouteUnavailableReason,
+		codexHookRouteForeignPaneReason,
+		codexHookWriteRejectedReason,
+		codexHookInheritedRoute,
+		codexHookAppOwnedRoute,
+		codexHookCauseNoServer,
+		codexHookCauseNoPane,
+		codexHookCauseDenied,
+		codexHookCauseUnclassified,
+	} {
+		if strings.TrimSpace(token) == "" {
+			t.Fatal("a delivery vocabulary token is empty")
+		}
+		assertNoLeakedTransportDetail(t, "vocabulary token", token)
+	}
+}
+
+// A write that fails after the route was proven is explained by re-reading the
+// route, not by the write's exit status. The classifier is a pure read, so no
+// pane option is written twice on the way to the explanation.
+func TestCodexHookDeliveryExplainsARejectedWriteByRereadingItsRoute(t *testing.T) {
+	const paneID = "%7"
+	for _, test := range []struct {
+		name       string
+		stillThere bool
+		wantDetail string
+	}{
+		{name: "pane vanished", stillThere: false, wantDetail: "pane is gone from this runtime"},
+		{name: "pane survived", stillThere: true, wantDetail: "runtime still holds this pane and rejected the option write"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := codexHookDeliveryTestCommand(t, paneID)
+			probes := 0
+			cmd.readCommand = func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+				probes++
+				if probes > 1 && !test.stillThere {
+					return codexHookDeliveryRouteRow("%9", "pan-alpha"), nil
+				}
+				return codexHookDeliveryRouteRow(paneID, "pan-alpha"), nil
+			}
+			writes := 0
+			cmd.runCommand = func(_ context.Context, name string, args ...string) error {
+				cmdRecorder(cmd).commands = append(cmdRecorder(cmd).commands, recordedAICommand{name: name, args: append([]string(nil), args...)})
+				writes++
+				return errors.New("exit status 1")
+			}
+			err := cmd.applyCodexHookSemanticDelivery(paneID, coremetadata.InteractionResponseComplete, config.AISemanticStateOnly, attentionNotifyInput{})
+			if err == nil {
+				t.Fatal("rejected write returned no error")
+			}
+			assertCodexHookDeliveryReason(t, err, codexHookWriteRejectedReason, test.wantDetail)
+			if !strings.Contains(err.Error(), aiPaneStateOption) {
+				t.Fatalf("rejected write reason %q does not name the option", err)
+			}
+			if writes != 1 {
+				t.Fatalf("rejected write repeated the option write %d times", writes)
+			}
+		})
+	}
+}
+
+func assertCodexHookDeliveryReason(t *testing.T, err error, wantReason, wantDetail string) {
+	t.Helper()
+	var delivery *codexHookDeliveryError
+	if !errors.As(err, &delivery) {
+		t.Fatalf("error %v is not a codex hook delivery refusal", err)
+	}
+	if delivery.Reason != wantReason {
+		t.Fatalf("delivery reason = %q, want %q", delivery.Reason, wantReason)
+	}
+	if wantDetail != "" && !strings.Contains(delivery.Detail, wantDetail) {
+		t.Fatalf("delivery detail = %q, want it to name %q", delivery.Detail, wantDetail)
+	}
+	assertNoLeakedTransportDetail(t, "delivery reason", err.Error())
+}
+
+// forbiddenDeliveryDetail is what a durable record must never carry: the socket
+// the route resolved to, the shape that names it, tmux's own words, and the
+// process exit status this whole layer exists to stop recording.
+var forbiddenDeliveryDetail = []string{"/tmp/", "-S/", "-L/", "-S ", "-L ", "exit status", "no server running"}
+
+func assertNoLeakedTransportDetail(t *testing.T, what, value string) {
+	t.Helper()
+	for _, forbidden := range forbiddenDeliveryDetail {
+		if strings.Contains(value, forbidden) {
+			t.Fatalf("%s carries %q, which the change boundary keeps out of durable records: %s", what, forbidden, value)
+		}
+	}
+}
+
+// The record is the surface, not the error value. This injects a transport
+// failure whose tmux output names its socket, drives the real ingest route, and
+// then reads back the whole log file: a reason that leaks is caught here even
+// if every unit assertion above still passes.
+func TestCodexHookDeliveryLeavesNoTransportDetailInTheIngestLog(t *testing.T) {
+	const paneID = "%7"
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.stdin = bytes.NewBufferString(
+		`{"hook_event_name":"Stop","thread_id":"codex-session","turn_id":"turn-leak","cwd":"/repo/projmux"}`)
+	base := codexHookIngestReadCommand(paneID)
+	cmd.readCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		if name == "tmux" && slices.Contains(args, codexHookDeliveryRouteFormat) {
+			// Exactly what a real tmux prints when the route has no server, and
+			// exactly the string that must not survive into the record.
+			return []byte("no server running on /tmp/tmux-1000/default"), os.ErrNotExist
+		}
+		return base(ctx, name, args...)
+	}
+	if err := cmd.Run([]string{"ingest", "codex-hook"}, &bytes.Buffer{}, &bytes.Buffer{}); err == nil {
+		t.Fatal("an unroutable Stop was ingested without an error")
+	}
+	path, err := cmd.aiIngestLogPath()
+	if err != nil {
+		t.Fatalf("resolve ingest log path: %v", err)
+	}
+	recorded, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read ingest log: %v", err)
+	}
+	if !strings.Contains(string(recorded), codexHookRouteUnavailableReason) {
+		t.Fatalf("ingest log did not record the refusal at all: %s", recorded)
+	}
+	assertNoLeakedTransportDetail(t, "ingest log", string(recorded))
+}

--- a/internal/app/ai_ingest_codex_native_test.go
+++ b/internal/app/ai_ingest_codex_native_test.go
@@ -104,13 +104,14 @@ func phase1GenerationAuthorityFixture(t *testing.T) (*fakeResourceStore, codexLi
 func phase0RSemanticPaneWrites(commands []recordedAICommand) map[string][]string {
 	writes := map[string][]string{}
 	for _, command := range commands {
-		if command.name != "tmux" || len(command.args) < 5 || command.args[0] != "set-option" {
+		args := stripRecordedTmuxRoute(command.args)
+		if command.name != "tmux" || len(args) < 5 || args[0] != "set-option" {
 			continue
 		}
-		option := command.args[len(command.args)-2]
-		value := command.args[len(command.args)-1]
-		if slices.Contains(command.args, "-u") {
-			option, value = command.args[len(command.args)-1], ""
+		option := args[len(args)-2]
+		value := args[len(args)-1]
+		if slices.Contains(args, "-u") {
+			option, value = args[len(args)-1], ""
 		}
 		if slices.Contains([]string{aiPaneStateOption, aiPaneBadgeKindOption, attentionStateOption}, option) {
 			writes[option] = append(writes[option], value)
@@ -2530,16 +2531,16 @@ func TestCodexHookFallbackSemanticDeliverySurfacesAndExactAck(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				badgeArgs := []string{"set-option", "-p", "-t", "%7", aiPaneBadgeKindOption, event.badge}
+				badgeArgs := routedAppSocketArgs("set-option", "-p", "-t", "%7", aiPaneBadgeKindOption, event.badge)
 				if !policy.wantBadge {
-					badgeArgs = []string{"set-option", "-p", "-u", "-t", "%7", aiPaneBadgeKindOption}
+					badgeArgs = routedAppSocketArgs("set-option", "-p", "-u", "-t", "%7", aiPaneBadgeKindOption)
 				}
 				if !hasRecordedAICommand(cmdRecorder(cmd).commands, recordedAICommand{name: "tmux", args: badgeArgs}) {
 					t.Fatalf("commands = %#v, want badge projection %#v", cmdRecorder(cmd).commands, badgeArgs)
 				}
-				attentionArgs := []string{"set-option", "-p", "-u", "-t", "%7", attentionStateOption}
+				attentionArgs := routedAppSocketArgs("set-option", "-p", "-u", "-t", "%7", attentionStateOption)
 				if policy.wantAttention {
-					attentionArgs = []string{"set-option", "-p", "-t", "%7", attentionStateOption, attentionStateReply}
+					attentionArgs = routedAppSocketArgs("set-option", "-p", "-t", "%7", attentionStateOption, attentionStateReply)
 				}
 				if !hasRecordedAICommand(cmdRecorder(cmd).commands, recordedAICommand{name: "tmux", args: attentionArgs}) {
 					t.Fatalf("commands = %#v, want attention projection %#v", cmdRecorder(cmd).commands, attentionArgs)
@@ -2622,8 +2623,10 @@ func TestCodexHookFallbackQuietHidesManagedRegistryAggregate(t *testing.T) {
 	if !reflect.DeepEqual(notifyStore.ackedIDs, []string{"stale-hook-notice"}) {
 		t.Fatalf("quiet fallback acked ids = %#v", notifyStore.ackedIDs)
 	}
+	// The hook inherits no tmux environment here, so every reflection write
+	// must carry the app-owned route the delivery proved before writing.
 	for _, option := range []string{aiPaneBadgeKindOption, attentionStateOption} {
-		if !hasRecordedAICommand(cmdRecorder(cmd).commands, recordedAICommand{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", identity.RuntimeID, option}}) {
+		if !hasRecordedAICommand(cmdRecorder(cmd).commands, recordedAICommand{name: "tmux", args: []string{"-L", defaultAppSocket, "set-option", "-p", "-u", "-t", identity.RuntimeID, option}}) {
 			t.Fatalf("quiet fallback commands = %#v, want unset %s", cmdRecorder(cmd).commands, option)
 		}
 	}

--- a/internal/app/ai_ingest_test.go
+++ b/internal/app/ai_ingest_test.go
@@ -288,8 +288,8 @@ func TestIngestCodexHookPermissionPushesCriticalQueueEntryAndMetadata(t *testing
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiPaneResumeIDOption, "codex-session"}},
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiPaneResumeSourceOption, "hook"}},
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiPaneResumeUpdatedAtOption, "1970-01-01T00:00:00Z"}},
-		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiPaneStateOption, "waiting"}},
-		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiPaneBadgeKindOption, aiBadgeKindApprovalRequired}},
+		{name: "tmux", args: routedAppSocketArgs("set-option", "-p", "-t", "%7", aiPaneStateOption, "waiting")},
+		{name: "tmux", args: routedAppSocketArgs("set-option", "-p", "-t", "%7", aiPaneBadgeKindOption, aiBadgeKindApprovalRequired)},
 	} {
 		if !hasRecordedAICommand(cmdRecorder(cmd).commands, want) {
 			t.Fatalf("commands = %#v, missing %#v", cmdRecorder(cmd).commands, want)
@@ -337,7 +337,7 @@ func TestIngestCodexHookStopPushesInfoQueueEntry(t *testing.T) {
 	if got.ID != "ai:codex:stop:codex-session:turn-456" || got.Text != "Ready" || got.Severity != notify.SeverityInfo || got.Metadata["category"] != "response_complete" {
 		t.Fatalf("pushed = %#v", got)
 	}
-	if !hasRecordedAICommand(cmdRecorder(cmd).commands, recordedAICommand{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", aiPaneBadgeKindOption, aiBadgeKindResponseComplete}}) {
+	if !hasRecordedAICommand(cmdRecorder(cmd).commands, recordedAICommand{name: "tmux", args: routedAppSocketArgs("set-option", "-p", "-t", "%7", aiPaneBadgeKindOption, aiBadgeKindResponseComplete)}) {
 		t.Fatalf("commands = %#v, want response_complete semantic badge", cmdRecorder(cmd).commands)
 	}
 }
@@ -2570,6 +2570,11 @@ func codexHookIngestReadCommand(paneID string) func(context.Context, string, ...
 			return []byte(paneID + "\n"), nil
 		case reflect.DeepEqual(args, []string{"display-message", "-p", "-t", paneID, "#{socket_path}"}):
 			return []byte("/tmp/tmux-1000/projmux\n"), nil
+		// The hook ingest fixture stands in for a hook the shared app-server
+		// launched: it inherits no tmux environment, so the reflection proves
+		// projmux's own app-owned route holds this Pane before writing to it.
+		case reflect.DeepEqual(args, []string{"-L", defaultAppSocket, "display-message", "-p", "-t", paneID, "-F", codexHookDeliveryRouteFormat}):
+			return codexHookDeliveryRouteRow(paneID, "pan-"+strings.TrimPrefix(paneID, "%")), nil
 		}
 		return nil, os.ErrNotExist
 	}
@@ -2609,7 +2614,8 @@ func hasRecordedAICommand(commands []recordedAICommand, want recordedAICommand) 
 
 func hasRecordedAISetOption(commands []recordedAICommand, option string) bool {
 	for _, got := range commands {
-		if got.name == "tmux" && len(got.args) >= 6 && got.args[0] == "set-option" && got.args[4] == option {
+		args := stripRecordedTmuxRoute(got.args)
+		if got.name == "tmux" && len(args) >= 6 && args[0] == "set-option" && args[4] == option {
 			return true
 		}
 	}


### PR DESCRIPTION
## What

An attributed Codex hook could find its Pane and still fail to write it.
`applyCodexHookSemanticDelivery` issued `tmux set-option` with no socket
argument. A hook launched by a pane client inherits `$TMUX` and tmux resolves
that; a hook launched by the **shared app-server** inherits nothing, so the
same call probed the operator's `default` server, found none, and returned
`exit status 1` — which is exactly what `ai-ingest.log` recorded as the reason.

Observed on this machine at 2026-09-05: `codex app-server --remote-control`
(pid 1612691) carries no `TMUX` and no `TMUX_PANE`, and
`env -u TMUX tmux set-option -p -t %124 …` fails with
`error connecting to /tmp/tmux-1000/default (No such file or directory)`, rc=1.
This is not a new regression — the reflection layer had simply never been
reached while attribution was at 0%.

## How

Every reflection write is now pinned to one exact server, resolved before
anything is written:

1. An inherited `$TMUX` receipt is taken as-is. An absolute socket path is the
   only shape tmux writes and it names the client's own server without a
   search, so it becomes an explicit `-S <path>` route.
2. Without a receipt, the candidate is projmux's own app-owned route —
   `defaultRuntimeMutationRoute()`, the same route every detached projmux
   invocation already takes. **It is not trusted on its name.** The Pane the
   hook was already attributed to is the discriminator: one `display-message`
   must show that server is app-owned (`@projmux_app`) and that the attributed
   `%N` really lives there as a projmux Pane (non-empty `@projmux_pane_uid`).

No socket path is constructed or guessed anywhere in the change; a candidate
that cannot prove the containment receives no write at all.

## Failure vocabulary

Three closed reasons replace the opaque exit status. None of them contains one:

| Reason | Meaning | Writes |
| --- | --- | --- |
| `pane runtime route unavailable` | no inherited receipt and the app-owned runtime could not be observed (unreachable, empty answer, or not app-owned) | none |
| `pane runtime route does not hold this pane` | a runtime answered but the attributed `%N` is absent or is not a projmux Pane | none |
| `pane option write rejected` | the routed `set-option` failed after the route was proven | the failed one |

The third is classified by **re-reading** the route — a pure read that repeats
no write — so the record says `pane is gone from this runtime`,
`runtime still holds this pane and rejected the option write`, or
`runtime is no longer reachable: <tmux's own message>`.

## Scope

- Attribution is untouched. `matchAIPane`, the Registry step, and the explicit
  `--pane` stage are unchanged; `internal/app/ai_ingest.go` and
  `internal/app/ai_integrate.go` have zero product-code diff.
- Nothing branches on provider. The routing helper names no provider and the
  hook command string is not changed.
- No app-server lifecycle is touched, and the generation pool is not read or
  written here.

Two other writers on the same shared-host path,
`applyAIStatusInternalWithActivationPolicy` and `markAIHookPane`, still issue
unrouted tmux calls and discard their errors with `_ =`, so those writes fail
silently and are logged as successes. They live in files another change owns
and are left alone; the gap is recorded in `docs/agent-workflow.md`.

## Tests

New `internal/app/ai_ingest_codex_delivery_route_test.go`:

- `TestCodexHookDeliveryWritesItsPaneWithoutAnyTmuxEnvironment` — the failing
  case: no `TMUX` at all still resolves a route, and the argv is pinned.
- `TestCodexHookDeliveryPrefersTheInheritedReceiptOverTheAppRoute` — precedence,
  and an inherited receipt needs no containment probe.
- `TestCodexHookDeliveryRefusesARouteItCannotProve` — five ways the proof fails,
  each with its own reason and zero writes.
- `TestCodexHookDeliveryFailureReasonsAreConcreteAndClosed` — the vocabulary is
  closed and carries no exit status.
- `TestCodexHookDeliveryExplainsARejectedWriteByRereadingItsRoute` — a rejected
  write is explained by a read, and the write is not repeated.

Existing hook fixtures now answer the containment probe and assert the routed
argv, because the unrouted spelling they certified is the defect.

## Commands

`make fmt` · `make fix` · `make test` green locally; `make test-integration`
and `make test-e2e` run against this exact head while CI runs.
