### PR TITLE
fix(tmux): route shared AI pane option writes

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1280,6 +1280,36 @@ The gate does not change `projmux doctor`'s exit code. A broken surface is a
 readable verdict, not a failed command, and the CI half of the detection is the
 regression tests themselves.
 
+### Shared AI pane option routing tests
+
+`TestSharedPaneRoutingCodexIngest` drives the marker (`PreToolUse`) and ordinary
+state (`UserPromptSubmit`) caller paths through full Codex ingest. Both require
+writes on the verified app route and honest records; removing the shared argv
+prefix makes both fail. `TestSharedPaneRoutingSetClearRecord` pins exact inherited
+`-S` and detached app `-L` argv. `TestSharedPaneRoutingDenialIsBoundedAndWritesNothing`
+rejects unreachable servers, missing panes, foreign servers and absent resource
+identity without writes or success records. Existing Codex delivery authority,
+semantic, refusal-vocabulary and diagnostics gates remain in force.
+
+`TestSharedPaneRoutingProviderConsumers` covers Codex, Claude, Antigravity and
+bell hook consumers, including state and resume markers.
+`TestSharedPaneRoutingLaunchBeforeFirstMarker` checks inherited configure and
+canonical detached materialization through its supplied exact runner before any
+managed marker or Pane UID exists. Existing topic/status semantic fixtures retain
+their option expectations while their mock server supplies explicit containment.
+Managed interaction/topic projection outside the shared helpers remains a
+separate transport boundary.
+
+`TestSharedPaneRoutingRealTmux` uses two real isolated servers with the same pane
+ID and checks set, clear, marker and full hook state against target readback and
+opposite-server sentinels for detached and inherited routes. It refuses a missing
+inherited route without fallback. Every server starts with a unique socket name
+inside a dedicated tmux root; only a verified private alias exposes the fixed app
+locator. Cleanup rechecks the observed exact socket before `-S` shutdown. The test
+runs with `make test` where tmux is available; an explicit installed smoke runs the
+same hook assertions against `PROJMUX_TEST_PANE_ROUTE_BINARY=<absolute binary>`.
+This is a test-only selector, not a product environment contract.
+
 ### Attributed Codex hook delivery route tests
 
 Attribution and reflection are different layers. A Codex hook attributed to its

--- a/internal/app/agent_session_ref_test.go
+++ b/internal/app/agent_session_ref_test.go
@@ -108,6 +108,9 @@ func newSessionRefHarness(t *testing.T, provider string) *sessionRefHarness {
 			return nil
 		},
 		readCommand: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if row, ok := testAIPaneRouteProbe(name, args); ok {
+				return row, nil
+			}
 			h.tmuxCalls = append(h.tmuxCalls, name+" "+strings.Join(args, " "))
 			if len(args) >= 5 && args[0] == "display-message" && args[4] == "#{"+tmuxopts.PaneUID+"}" {
 				return []byte(h.paneUID + "\n"), nil
@@ -423,10 +426,10 @@ func TestIngestStillWritesThePaneSessionOptionUnchanged(t *testing.T) {
 		`{"hook_event_name":"UserPromptSubmit","thread_id":"codex-thread-1","session_id":"codex-session-1","cwd":"/src/app"}`)
 
 	wantOptions := []string{
-		"tmux set-option -p -t %7 " + aiPaneSessionIDOption + " codex-session-1",
-		"tmux set-option -p -t %7 " + aiPaneThreadIDOption + " codex-thread-1",
-		"tmux set-option -p -t %7 " + aiPaneAgentOption + " codex",
-		"tmux set-option -p -t %7 " + aiPaneResumeIDOption + " codex-session-1",
+		"tmux -L projmux set-option -p -t %7 " + aiPaneSessionIDOption + " codex-session-1",
+		"tmux -L projmux set-option -p -t %7 " + aiPaneThreadIDOption + " codex-thread-1",
+		"tmux -L projmux set-option -p -t %7 " + aiPaneAgentOption + " codex",
+		"tmux -L projmux set-option -p -t %7 " + aiPaneResumeIDOption + " codex-session-1",
 	}
 	for _, want := range wantOptions {
 		if !slices.Contains(h.tmuxCalls, want) {

--- a/internal/app/ai_ingest_codex.go
+++ b/internal/app/ai_ingest_codex.go
@@ -10,9 +10,6 @@ import (
 	"github.com/crevissepartners/projmux/internal/config"
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
 	"github.com/crevissepartners/projmux/internal/core/notify"
-	"github.com/crevissepartners/projmux/internal/core/resourcegraph"
-	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
-	"github.com/crevissepartners/projmux/internal/integrations/tmuxopts"
 )
 
 type codexHookPayload struct {
@@ -312,11 +309,7 @@ func codexHookDeliveryCause(output []byte, err error) string {
 
 // codexHookDeliveryRouteFormat reads the three facts that decide whether a
 // candidate runtime may receive this Pane's reflection, in one call.
-var codexHookDeliveryRouteFormat = tmuxRowFormat(
-	intmux.TmuxFormat(tmuxopts.AppGlobal),
-	"#{pane_id}",
-	intmux.TmuxFormat(tmuxopts.PaneUID),
-)
+var codexHookDeliveryRouteFormat = aiPaneOptionRouteFormat
 
 // codexHookDeliveryTarget is the one tmux server a reflection may write to.
 // Every write carries its routing argv, so no reflection call is ever the
@@ -355,55 +348,32 @@ func (t codexHookDeliveryTarget) contained(paneID string) (bool, string) {
 	return true, "runtime still holds this pane and rejected the option write"
 }
 
-// codexHookDeliveryRoute pins every reflection write to one exact tmux server.
-//
-// An inherited receipt is taken as-is: an absolute socket path is the only
-// shape tmux writes, and it names the client's own server without a search.
-// Without one, the route is projmux's own app-owned runtime -- the same route
-// every detached projmux invocation already takes -- and it is never trusted on
-// its name alone. The Pane the hook was already attributed to is the
-// discriminator: that server must be app-owned and must actually hold the
-// attributed pane as a projmux Pane. A candidate that cannot prove the
-// containment receives no write at all, because answering one server's question
-// with another server's objects is worse than refusing.
+// codexHookDeliveryRoute retains the Codex delivery vocabulary and policy;
+// provider-neutral resolution owns only transport and containment facts.
 func (c *aiCommand) codexHookDeliveryRoute(paneID string) (codexHookDeliveryTarget, error) {
-	inherited, err := resourcegraph.ResolveTransport(resourcegraph.TransportRequest{InheritedTMUX: c.env("TMUX")})
-	if err == nil && inherited.Present() {
-		return codexHookDeliveryTarget{command: c, transport: inherited, kind: codexHookInheritedRoute}, nil
+	route, refusal := c.aiPaneOptionRoute(paneID)
+	kind := codexHookAppOwnedRoute
+	if route.transport.Source == tmuxInheritedSource {
+		kind = codexHookInheritedRoute
 	}
-	target := codexHookDeliveryTarget{command: c, transport: defaultRuntimeMutationRoute().target, kind: codexHookAppOwnedRoute}
-	runner := explicitTmuxRunner{
-		runner: aiCommandMuxBackend{runCommand: c.runCommand, readCommand: c.readCommand},
-		target: target.transport,
+	target := codexHookDeliveryTarget{command: c, transport: route.transport, kind: kind}
+	if refusal == nil {
+		return target, nil
 	}
-	output, runErr := runner.Run(context.Background(), "tmux",
-		"display-message", "-p", "-t", paneID, "-F", codexHookDeliveryRouteFormat)
-	if runErr != nil {
-		return codexHookDeliveryTarget{}, &codexHookDeliveryError{
-			Reason: codexHookRouteUnavailableReason,
-			Detail: target.kind + ": " + codexHookDeliveryCause(output, runErr),
-		}
+	reason := codexHookRouteUnavailableReason
+	detail := ""
+	switch refusal.kind {
+	case aiPaneRouteProbeFailed:
+		detail = codexHookDeliveryCause(refusal.output, refusal.err)
+	case aiPaneRouteNoRow:
+		detail = "containment probe returned no single row"
+	case aiPaneRouteNotOwned:
+		detail = "server is not app-owned"
+	case aiPaneRouteForeign:
+		reason = codexHookRouteForeignPaneReason
+		detail = paneID
 	}
-	rows := splitTmuxRows(string(output), 3)
-	if len(rows) != 1 {
-		return codexHookDeliveryTarget{}, &codexHookDeliveryError{
-			Reason: codexHookRouteUnavailableReason,
-			Detail: target.kind + ": containment probe returned no single row",
-		}
-	}
-	if resourcegraph.HostModeFromAppMarker(rows[0][0]) != resourcegraph.HostModeAppOwned {
-		return codexHookDeliveryTarget{}, &codexHookDeliveryError{
-			Reason: codexHookRouteUnavailableReason,
-			Detail: target.kind + ": server is not app-owned",
-		}
-	}
-	if rows[0][1] != paneID || strings.TrimSpace(rows[0][2]) == "" {
-		return codexHookDeliveryTarget{}, &codexHookDeliveryError{
-			Reason: codexHookRouteForeignPaneReason,
-			Detail: target.kind + ": " + paneID,
-		}
-	}
-	return target, nil
+	return codexHookDeliveryTarget{}, &codexHookDeliveryError{Reason: reason, Detail: kind + ": " + detail}
 }
 
 // applyCodexHookSemanticDelivery mirrors the native lifecycle delivery intent

--- a/internal/app/ai_ingest_diagnostics_test.go
+++ b/internal/app/ai_ingest_diagnostics_test.go
@@ -496,6 +496,9 @@ func assertSingleAIBellOutcome(t *testing.T, store *diagnostics.Store, result, f
 
 func wireAIDiagnosticsBellPane(cmd *aiCommand, paneID string) {
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name != "tmux" {
 			return nil, os.ErrNotExist
 		}

--- a/internal/app/ai_ingest_test.go
+++ b/internal/app/ai_ingest_test.go
@@ -48,6 +48,9 @@ func TestMarkAIHookPaneSeparatesTransientShellObservationFromOwnedAgentStatus(t 
 		return registry.Clone(), nil
 	}
 	owned.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name == "tmux" && len(args) >= 5 && args[0] == "display-message" && args[4] == "#{"+tmuxopts.PaneUID+"}" {
 			return []byte("pan-alpha-codex\n"), nil
 		}
@@ -694,12 +697,15 @@ func TestIngestBellPushesQueueEntryAndDedupesPane(t *testing.T) {
 	recorder := cmdRecorder(cmd)
 	cmd.runCommand = func(_ context.Context, name string, args ...string) error {
 		recorder.commands = append(recorder.commands, recordedAICommand{name: name, args: append([]string(nil), args...)})
-		if name == "tmux" && reflect.DeepEqual(args, []string{"set-option", "-p", "-t", "%7", aiBellDedupeOption, "100"}) {
+		if name == "tmux" && reflect.DeepEqual(args, routedAppSocketArgs("set-option", "-p", "-t", "%7", aiBellDedupeOption, "100")) {
 			lastBellAt = "100"
 		}
 		return nil
 	}
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name != "tmux" {
 			return nil, os.ErrNotExist
 		}
@@ -1943,6 +1949,9 @@ func TestIngestAntigravityRawV1112FixtureRoutesExplicitPreInvocationByWorkspace(
 	}
 	cmd.stdin = bytes.NewReader(data)
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name == "tmux" && reflect.DeepEqual(args, []string{"list-panes", "-a", "-F", aiIngestListPanesFormat}) {
 			return []byte("%workspace\x1f/workspace/sanitized-project\x1f\x1f\n"), nil
 		}
@@ -2399,6 +2408,8 @@ func TestIngestAntigravityStopThenLateBusyAndIdlePreservesCompletion(t *testing.
 	}
 	baseRun := cmd.runCommand
 	cmd.runCommand = func(ctx context.Context, name string, args ...string) error {
+		recordedArgs := args
+		args = stripRecordedTmuxRoute(args)
 		if name == "tmux" && len(args) == 6 && reflect.DeepEqual(args[:4], []string{"set-option", "-p", "-t", "%7"}) {
 			switch args[4] {
 			case aiPaneStateOption:
@@ -2413,7 +2424,7 @@ func TestIngestAntigravityStopThenLateBusyAndIdlePreservesCompletion(t *testing.
 		if name == "tmux" && len(args) == 6 && reflect.DeepEqual(args[:5], []string{"set-option", "-p", "-u", "-t", "%7"}) && args[5] == attentionStateOption {
 			attentionState = ""
 		}
-		return baseRun(ctx, name, args...)
+		return baseRun(ctx, name, recordedArgs...)
 	}
 
 	run := func(event, payload string) {
@@ -2541,6 +2552,9 @@ func TestAIWatchTitleSkipsHookActivePane(t *testing.T) {
 
 func claudeIngestReadCommand(paneID string) func(context.Context, string, ...string) ([]byte, error) {
 	return func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name != "tmux" {
 			return nil, os.ErrNotExist
 		}
@@ -2592,6 +2606,9 @@ func codexHookIngestReadCommand(paneID string) func(context.Context, string, ...
 
 func antigravityIngestReadCommand(paneID string) func(context.Context, string, ...string) ([]byte, error) {
 	return func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name != "tmux" {
 			return nil, os.ErrNotExist
 		}
@@ -2615,7 +2632,7 @@ func antigravityIngestReadCommand(paneID string) func(context.Context, string, .
 
 func hasRecordedAICommand(commands []recordedAICommand, want recordedAICommand) bool {
 	for _, got := range commands {
-		if got.name == want.name && reflect.DeepEqual(got.args, want.args) {
+		if got.name == want.name && sameRecordedAICommandArgs(got.name, got.args, want.args) {
 			return true
 		}
 	}

--- a/internal/app/ai_pane_route.go
+++ b/internal/app/ai_pane_route.go
@@ -1,0 +1,76 @@
+package app
+
+import (
+	"context"
+	"strings"
+
+	"github.com/crevissepartners/projmux/internal/core/resourcegraph"
+	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
+	"github.com/crevissepartners/projmux/internal/integrations/tmuxopts"
+)
+
+var aiPaneOptionRouteFormat = tmuxRowFormat(
+	intmux.TmuxFormat(tmuxopts.AppGlobal),
+	"#{pane_id}",
+	intmux.TmuxFormat(tmuxopts.PaneUID),
+)
+
+// aiPaneOptionTarget carries transport only. Provider authority, semantic
+// delivery, and durable failure vocabulary remain with their existing callers.
+type aiPaneOptionTarget struct {
+	transport tmuxTransport
+}
+
+func (t aiPaneOptionTarget) args(args ...string) []string {
+	return append(t.transport.Args(), args...)
+}
+
+type aiPaneRouteFailureKind uint8
+
+const (
+	aiPaneRouteProbeFailed aiPaneRouteFailureKind = iota
+	aiPaneRouteNoRow
+	aiPaneRouteNotOwned
+	aiPaneRouteForeign
+)
+
+// Raw probe output stays transient; only the Codex adapter classifies it into
+// its existing closed reason vocabulary. Shared writes expose one bounded token.
+type aiPaneRouteFailure struct {
+	kind   aiPaneRouteFailureKind
+	output []byte
+	err    error
+}
+
+// aiPaneOptionRoute preserves an inherited exact server receipt. Detached
+// callers use the existing app runtime only after it proves both app ownership
+// and containment of the already-attributed resource Pane. No server search is
+// performed. Inherited launch configuration needs no prior Pane option: its
+// receipt already binds materialization before the first marker is written.
+func (c *aiCommand) aiPaneOptionRoute(paneID string) (aiPaneOptionTarget, *aiPaneRouteFailure) {
+	inherited, err := resourcegraph.ResolveTransport(resourcegraph.TransportRequest{InheritedTMUX: c.env("TMUX")})
+	if err == nil && inherited.Present() {
+		return aiPaneOptionTarget{transport: inherited}, nil
+	}
+	target := aiPaneOptionTarget{transport: defaultRuntimeMutationRoute().target}
+	runner := explicitTmuxRunner{
+		runner: aiCommandMuxBackend{runCommand: c.runCommand, readCommand: c.readCommand},
+		target: target.transport,
+	}
+	output, runErr := runner.Run(context.Background(), "tmux",
+		"display-message", "-p", "-t", paneID, "-F", aiPaneOptionRouteFormat)
+	if runErr != nil {
+		return target, &aiPaneRouteFailure{kind: aiPaneRouteProbeFailed, output: output, err: runErr}
+	}
+	rows := splitTmuxRows(string(output), 3)
+	if len(rows) != 1 {
+		return target, &aiPaneRouteFailure{kind: aiPaneRouteNoRow}
+	}
+	if resourcegraph.HostModeFromAppMarker(rows[0][0]) != resourcegraph.HostModeAppOwned {
+		return target, &aiPaneRouteFailure{kind: aiPaneRouteNotOwned}
+	}
+	if rows[0][1] != paneID || strings.TrimSpace(rows[0][2]) == "" {
+		return target, &aiPaneRouteFailure{kind: aiPaneRouteForeign}
+	}
+	return target, nil
+}

--- a/internal/app/ai_pane_route_test.go
+++ b/internal/app/ai_pane_route_test.go
@@ -1,0 +1,309 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/integrations/tmuxopts"
+)
+
+// Existing semantic fixtures model a known, reachable Pane. Give their fake
+// app server the containment answer shared writes now require. Route-denial
+// tests use their own reader and never opt into this successful probe.
+func testAIPaneRouteProbe(name string, args []string) ([]byte, bool) {
+	if name == "tmux" && len(args) == 8 && args[0] == "-L" && args[1] == defaultAppSocket &&
+		args[2] == "display-message" && args[3] == "-p" && args[4] == "-t" &&
+		args[6] == "-F" && args[7] == aiPaneOptionRouteFormat {
+		return codexHookDeliveryRouteRow(args[5], "test-pane-uid"), true
+	}
+	return nil, false
+}
+
+func TestSharedPaneRoutingSetClearRecord(t *testing.T) {
+	for _, inherited := range []bool{false, true} {
+		t.Run(map[bool]string{false: "detached", true: "inherited"}[inherited], func(t *testing.T) {
+			cmd := codexHookDeliveryTestCommand(t, "%7")
+			prefix := []string{"-L", defaultAppSocket}
+			if inherited {
+				base := cmd.lookupEnv
+				cmd.lookupEnv = func(name string) string {
+					if name == "TMUX" {
+						return "/tmp/test-inherited/socket,42,0"
+					}
+					return base(name)
+				}
+				prefix = []string{"-S", "/tmp/test-inherited/socket"}
+				cmd.readCommand = func(context.Context, string, ...string) ([]byte, error) {
+					t.Fatal("inherited bootstrap must not require existing marker or UID")
+					return nil, os.ErrNotExist
+				}
+			}
+			if err := cmd.setAIPaneOption("%7", aiPaneStateOption, "thinking"); err != nil {
+				t.Fatal(err)
+			}
+			if err := cmd.clearAIPaneOption("%7", attentionAckOption); err != nil {
+				t.Fatal(err)
+			}
+			cmd.recordAIPaneOption("%7", aiPaneHookActiveOption, "1")
+			want := [][]string{
+				{"set-option", "-p", "-t", "%7", aiPaneStateOption, "thinking"},
+				{"set-option", "-p", "-u", "-t", "%7", attentionAckOption},
+				{"set-option", "-p", "-t", "%7", aiPaneHookActiveOption, "1"},
+			}
+			commands := cmdRecorder(cmd).commands
+			if len(commands) != len(want) {
+				t.Fatalf("writes = %#v", commands)
+			}
+			for i, args := range want {
+				if !reflect.DeepEqual(commands[i].args, append(slices.Clone(prefix), args...)) {
+					t.Fatalf("write %d = %q, want exact route %q and option %q", i, commands[i].args, prefix, args)
+				}
+			}
+			if reason := cmd.recordedAIPaneWriteFailure(); reason != "" {
+				t.Fatalf("marker failed: %s", reason)
+			}
+		})
+	}
+}
+
+func TestSharedPaneRoutingDenialIsBoundedAndWritesNothing(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		row  []byte
+		err  error
+	}{
+		{"missing server", []byte("no server running on /tmp/private/socket"), os.ErrNotExist},
+		{"missing pane", nil, errors.New("can't find pane: %7")},
+		{"empty answer", []byte("\n"), nil},
+		{"foreign server", []byte(strings.Join([]string{"", "%7", "pane-7"}, tmuxRowSep)), nil},
+		{"different pane", codexHookDeliveryRouteRow("%8", "pane-8"), nil},
+		{"unmanaged pane", codexHookDeliveryRouteRow("%7", ""), nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := codexHookDeliveryTestCommand(t, "%7")
+			cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+				want := routedAppSocketArgs("display-message", "-p", "-t", "%7", "-F", aiPaneOptionRouteFormat)
+				if name != "tmux" || !reflect.DeepEqual(args, want) {
+					t.Fatalf("unexpected probe %s %q", name, args)
+				}
+				return tc.row, tc.err
+			}
+			for _, err := range []error{cmd.setAIPaneOption("%7", aiPaneStateOption, "thinking"), cmd.clearAIPaneOption("%7", attentionAckOption)} {
+				if !errors.Is(err, errAIPaneWriteUnavailable) {
+					t.Fatalf("refusal = %v", err)
+				}
+			}
+			cmd.recordAIPaneOption("%7", aiPaneHookActiveOption, "1")
+			if got := cmdRecorder(cmd).commands; len(got) != 0 {
+				t.Fatalf("refusal wrote %q", got)
+			}
+			entry := cmd.honestAIIngestResult(aiIngestLogEntry{Source: "claude-hook", Result: "state"})
+			if entry.Result != "error" || entry.Reason != aiPaneWriteReasonMarkerUnavailable {
+				t.Fatalf("dishonest record: %+v", entry)
+			}
+		})
+	}
+}
+
+func TestSharedPaneRoutingProviderConsumers(t *testing.T) {
+	for _, tc := range []struct {
+		source, payload, result string
+		args                    []string
+	}{
+		{"codex-hook", `{"hook_event_name":"UserPromptSubmit","session_id":"session","cwd":"/repo"}`, "state", nil},
+		{"claude-hook", `{"hook_event_name":"UserPromptSubmit","session_id":"session","cwd":"/repo"}`, "state", nil},
+		{"antigravity-hook", `{"conversationId":"session","workspacePaths":["/repo"]}`, "state", []string{"--event", "pre_invocation"}},
+		{"bell", `{}`, "notify", []string{"--pane", "%7"}},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			cmd := codexHookDeliveryTestCommand(t, "%7")
+			baseEnv := cmd.lookupEnv
+			cmd.lookupEnv = func(name string) string {
+				if name == "TMUX_PANE" {
+					return "%7"
+				}
+				return baseEnv(name)
+			}
+			baseRead := cmd.readCommand
+			cmd.readCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				if name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%7", aiBellPaneFormat}) {
+					return []byte(strings.Join([]string{"project", "@1", "window", "%7", "title", "sh", "/tmp/test/socket"}, tmuxRowSep)), nil
+				}
+				return baseRead(ctx, name, args...)
+			}
+			cmd.notifyStore = &stubNotifyStore{}
+			cmd.stdin = strings.NewReader(tc.payload)
+			cmd.now = func() time.Time { return time.Unix(100, 0) }
+			if err := cmd.Run(append([]string{"ingest", tc.source}, tc.args...), &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+				t.Fatal(err)
+			}
+			writes := cmdRecorder(cmd).commands
+			seen := map[string]bool{}
+			for _, command := range writes {
+				plain := stripRecordedTmuxRoute(command.args)
+				if command.name != "tmux" || len(plain) == 0 || plain[0] != "set-option" {
+					continue
+				}
+				if !reflect.DeepEqual(command.args[:len(command.args)-len(plain)], []string{"-L", defaultAppSocket}) {
+					t.Fatalf("provider bypass: %q", command.args)
+				}
+				if len(plain) == 6 && plain[2] == "-t" {
+					seen[plain[4]] = true
+				}
+			}
+			if tc.source == "bell" {
+				if !seen[aiBellDedupeOption] {
+					t.Fatal("bell marker missing")
+				}
+			} else if !seen[aiPaneHookActiveOption] || !seen[aiPaneStateOption] || !seen[aiPaneResumeIDOption] {
+				t.Fatalf("provider marker/status/resume writes missing: %v", seen)
+			}
+			path, _ := cmd.aiIngestLogPath()
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var entry aiIngestLogEntry
+			if err := json.Unmarshal(bytes.TrimSpace(data), &entry); err != nil {
+				t.Fatal(err)
+			}
+			if entry.Result != tc.result {
+				t.Fatalf("record = %+v", entry)
+			}
+		})
+	}
+}
+
+func TestSharedPaneRoutingLaunchBeforeFirstMarker(t *testing.T) {
+	for _, provider := range []string{aiModeCodex, aiModeClaude, aiModeAntigravity} {
+		t.Run(provider, func(t *testing.T) {
+			cmd := testAICommand(t.TempDir())
+			base := cmd.lookupEnv
+			cmd.lookupEnv = func(name string) string {
+				if name == "TMUX" {
+					return "/tmp/launch/socket,1,0"
+				}
+				return base(name)
+			}
+			cmd.readCommand = func(context.Context, string, ...string) ([]byte, error) {
+				t.Fatal("legacy inherited configure probed for an unwritten marker")
+				return nil, os.ErrNotExist
+			}
+			cmd.configureAIPane("%7", provider, "/repo", "topic", aiPaneResumeMetadata{sessionID: "session", resumeID: "session"})
+			if cmd.recordedAIPaneWriteFailure() != "" {
+				t.Fatal("configure failed before first marker")
+			}
+			for _, call := range cmdRecorder(cmd).commands {
+				if !slices.Equal(call.args[:2], []string{"-S", "/tmp/launch/socket"}) {
+					t.Fatalf("unrouted configure: %q", call.args)
+				}
+			}
+			// Canonical detached materialization already owns an exact runner.
+			// Both resource UID and managed marker are absent before binding.
+			options := map[string]string{}
+			runner := phase0RTmuxRunner(func(_ context.Context, name string, args ...string) ([]byte, error) {
+				if name != "tmux" || !slices.Equal(args[:2], []string{"-S", "/tmp/materialization/socket"}) {
+					t.Fatalf("materialization route escaped: %s %q", name, args)
+				}
+				args = args[2:]
+				switch args[0] {
+				case "show-options":
+					return []byte(options[args[len(args)-1]]), nil
+				case "set-option":
+					if slices.Contains(args, "-u") {
+						delete(options, args[len(args)-1])
+					} else {
+						options[args[len(args)-2]] = args[len(args)-1]
+					}
+				}
+				return nil, nil
+			})
+			exact := explicitTmuxRunner{runner: runner, target: tmuxTransport{Kind: tmuxSocketPath, Value: "/tmp/materialization/socket", Source: tmuxSocketPathSource}}
+			if err := cmd.BindAgentPaneOnRoute(context.Background(), exact, agentPaneBinding{PaneID: "%7", Provider: provider, ContextDir: "/repo", Title: "topic", ConversationID: "session"}); err != nil {
+				t.Fatal(err)
+			}
+			if options[aiPaneManagedOption] != "1" || options[aiPaneAgentOption] != provider || options[aiPaneResumeIDOption] != "session" || options[tmuxopts.PaneUID] != "" {
+				t.Fatalf("pre-UID materialization failed: %v", options)
+			}
+		})
+	}
+}
+
+// Semantic command assertions can omit the route; an expectation that names
+// -L or -S still compares the entire exact argv. Dedicated routing assertions
+// below always require their route explicitly.
+func sameRecordedAICommandArgs(name string, got, want []string) bool {
+	if name == "tmux" && len(want) > 0 && want[0] != "-L" && want[0] != "-S" {
+		got = stripRecordedTmuxRoute(got)
+	}
+	return reflect.DeepEqual(got, want)
+}
+
+func sameRecordedAICommands(got, want []recordedAICommand) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i].name != want[i].name || !sameRecordedAICommandArgs(got[i].name, got[i].args, want[i].args) {
+			return false
+		}
+	}
+	return true
+}
+
+// This fixture drives the two caller paths in the preserved failure cohort.
+// The only injected fault is tmux's rejection of an unprefixed write when the
+// hook has no inherited server. Attribution and the app route both succeed.
+func TestSharedPaneRoutingCodexIngest(t *testing.T) {
+	for _, tc := range []struct{ name, event, result, option, value string }{
+		{"marker", "PreToolUse", "quiet", aiPaneHookActiveOption, "1"},
+		{"ordinary", "UserPromptSubmit", "state", aiPaneStateOption, "thinking"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := codexHookDeliveryTestCommand(t, "%7")
+			cmd.stdin = strings.NewReader(`{"hook_event_name":"` + tc.event + `","session_id":"codex-session","cwd":"/repo/projmux"}`)
+			landed := map[string]string{}
+			cmd.runCommand = func(_ context.Context, name string, args ...string) error {
+				plain := stripRecordedTmuxRoute(args)
+				if name != "tmux" || len(plain) == 0 || plain[0] != "set-option" {
+					return nil
+				}
+				if !reflect.DeepEqual(args[:len(args)-len(plain)], []string{"-L", defaultAppSocket}) {
+					return errors.New("no server running on /tmp/isolated/default")
+				}
+				if len(plain) == 6 && plain[1] == "-p" && plain[2] == "-t" {
+					landed[plain[4]] = plain[5]
+				}
+				return nil
+			}
+			err := cmd.Run([]string{"ingest", "codex-hook"}, &bytes.Buffer{}, &bytes.Buffer{})
+			path, pathErr := cmd.aiIngestLogPath()
+			if pathErr != nil {
+				t.Fatal(pathErr)
+			}
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			lines := nonEmptyLines(string(data))
+			var record aiIngestLogEntry
+			if len(lines) != 1 {
+				t.Fatalf("records = %d, want 1", len(lines))
+			}
+			if decodeErr := json.Unmarshal([]byte(lines[0]), &record); decodeErr != nil {
+				t.Fatal(decodeErr)
+			}
+			if err != nil || record.Result != tc.result || landed[tc.option] != tc.value {
+				t.Fatalf("%s caller did not reach its proven route: err=%v result=%q reason=%q %s=%q; want result=%q %s=%q", tc.name, err, record.Result, record.Reason, tc.option, landed[tc.option], tc.result, tc.option, tc.value)
+			}
+		})
+	}
+}

--- a/internal/app/ai_pane_route_tmux_test.go
+++ b/internal/app/ai_pane_route_tmux_test.go
@@ -1,0 +1,284 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
+	"github.com/crevissepartners/projmux/internal/integrations/tmuxopts"
+)
+
+// The optional binary is used only by the post-install smoke. With it, the
+// same detached/inherited hook assertions execute the installed entrypoint;
+// normal test runs exercise the real ingest command with real tmux subprocesses.
+func TestSharedPaneRoutingRealTmux(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	binary := os.Getenv("PROJMUX_TEST_PANE_ROUTE_BINARY")
+	if binary != "" && !filepath.IsAbs(binary) {
+		t.Fatal("installed smoke binary must be absolute")
+	}
+	// Darwin's inherited TMPDIR can exhaust the Unix socket path limit. Both
+	// supported hosts provide /tmp; resolve its spelling before containment
+	// checks because Darwin commonly exposes it through /private/tmp.
+	root, err := os.MkdirTemp("/tmp", "pmx-pane-route-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		_ = os.RemoveAll(root)
+		t.Fatal(err)
+	}
+	root = resolvedRoot
+	cleanupVerified := true
+	t.Cleanup(func() {
+		if cleanupVerified {
+			_ = os.RemoveAll(root)
+		}
+	})
+	env := []string{}
+	for _, value := range os.Environ() {
+		key, _, _ := strings.Cut(value, "=")
+		if key == "HOME" || key == "TMUX" || key == "TMUX_PANE" || key == "TMUX_TMPDIR" || strings.HasPrefix(key, "XDG_") || strings.HasPrefix(key, "PROJMUX_") || strings.HasPrefix(key, "__PROJMUX_") {
+			continue
+		}
+		env = append(env, value)
+	}
+	env = append(env, "HOME="+root, "TMUX_TMPDIR="+root,
+		"XDG_STATE_HOME="+filepath.Join(root, "state"), "XDG_CONFIG_HOME="+filepath.Join(root, "config"),
+		"XDG_DATA_HOME="+filepath.Join(root, "data"), "XDG_CACHE_HOME="+filepath.Join(root, "cache"),
+		"XDG_RUNTIME_DIR="+filepath.Join(root, "runtime"))
+	if err := os.Mkdir(filepath.Join(root, "runtime"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	run := func(extra []string, name string, args ...string) ([]byte, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		process := exec.CommandContext(ctx, name, args...)
+		process.Env = append(append([]string{}, env...), extra...)
+		return process.CombinedOutput()
+	}
+	tmux := func(args ...string) string {
+		t.Helper()
+		out, err := run(nil, "tmux", args...)
+		if err != nil {
+			t.Fatalf("isolated tmux %q: %v: %s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	otherName := fmt.Sprintf("other-%d", os.Getpid())
+	sockets := []string{}
+	panes := []string{}
+	for _, name := range []string{fmt.Sprintf("app-%d", os.Getpid()), otherName} {
+		pane := tmux("-L", name, "-f", "/dev/null", "new-session", "-d", "-s", "fixture", "-P", "-F", "#{pane_id}", "sleep 600")
+		socket := tmux("-L", name, "display-message", "-p", "-t", pane, "#{socket_path}")
+		if !strings.HasPrefix(socket, root+string(os.PathSeparator)) {
+			t.Fatalf("unsafe smoke socket %q", socket)
+		}
+		sockets = append(sockets, socket)
+		panes = append(panes, pane)
+		t.Cleanup(func() {
+			// Re-observe exactly the owned route before exact-path cleanup.
+			out, queryErr := run(nil, "tmux", "-S", socket, "display-message", "-p", "#{socket_path}")
+			if queryErr != nil {
+				cleanupVerified = false
+				t.Errorf("cleanup route cannot be verified: %v", queryErr)
+				return
+			}
+			if strings.TrimSpace(string(out)) != socket || !strings.HasPrefix(socket, root+string(os.PathSeparator)) {
+				cleanupVerified = false
+				t.Errorf("cleanup route drifted: %q", out)
+				return
+			}
+			if out, err := run(nil, "tmux", "-S", socket, "kill-server"); err != nil {
+				cleanupVerified = false
+				t.Errorf("cleanup: %v: %s", err, out)
+			}
+		})
+	}
+	// Detached production lookup keeps its fixed logical name. The servers
+	// themselves are created with unique names; this private alias names only
+	// the exact socket observed above, inside this test's dedicated root.
+	alias := filepath.Join(filepath.Dir(sockets[0]), defaultAppSocket)
+	if err := os.Symlink(sockets[0], alias); err != nil {
+		t.Fatal(err)
+	}
+	if resolved, err := filepath.EvalSymlinks(alias); err != nil || resolved != sockets[0] {
+		t.Fatalf("app alias failed containment: %q %v", resolved, err)
+	}
+	if panes[0] != panes[1] {
+		t.Fatalf("collision fixture needs identical pane ids, got %v", panes)
+	}
+	pane := panes[0]
+	registry := coremetadata.Registry{APIVersion: coremetadata.APIVersion, SchemaVersion: coremetadata.SchemaVersion}
+	mutator := coremetadata.Mutator{NewUID: sequentialTestUID(), DirExists: func(path string) (bool, error) { info, err := os.Stat(path); return err == nil && info.IsDir(), err }}
+	registered, err := mutator.RegisterProject(&registry, coremetadata.RegisterProjectOptions{Root: root, OperationID: "fixture"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paneUID := registered.Panes[0].Metadata.UID
+	if _, err := mutator.RecordPaneActivation(&registry, paneUID, coremetadata.PaneActivationOptions{Generation: "fixture-generation", RuntimeID: pane, OperationID: "fixture"}); err != nil {
+		t.Fatal(err)
+	}
+	store := intmetadata.NewStore(intmetadata.PathFor(filepath.Join(root, "state", "projmux")))
+	if _, err := store.Update(func(reg *coremetadata.Registry) error { *reg = registry.Clone(); return nil }); err != nil {
+		t.Fatal(err)
+	}
+	for i, socket := range sockets {
+		tmux("-S", socket, "set-option", "-g", tmuxopts.AppGlobal, "1")
+		tmux("-S", socket, "set-option", "-p", "-t", pane, tmuxopts.PaneUID, paneUID)
+		t.Logf("owned server %d socket=%s pane=%s", i, socket, pane)
+	}
+	option := func(socket, key string) string {
+		return tmux("-S", socket, "show-options", "-p", "-qv", "-t", pane, key)
+	}
+	keys := []string{aiPaneStateOption, aiPaneHookActiveOption, attentionAckOption, attentionFocusArmedOption, aiPaneTopicOption, aiPaneResumeIDOption, aiPaneResumeSourceOption}
+	reset := func() {
+		for _, socket := range sockets {
+			for _, key := range keys {
+				tmux("-S", socket, "set-option", "-p", "-t", pane, key, "sentinel")
+			}
+		}
+	}
+	for _, inherited := range []bool{false, true} {
+		label := map[bool]string{false: "detached", true: "inherited"}[inherited]
+		t.Run(label, func(t *testing.T) {
+			reset()
+			target, opposite := sockets[0], sockets[1]
+			extra := []string{}
+			if inherited {
+				target, opposite = sockets[1], sockets[0]
+				extra = []string{"TMUX=" + target + ",42,0", "TMUX_PANE=" + pane}
+			}
+			cmdEnv := append(append([]string{}, env...), extra...)
+			command := func() *aiCommand {
+				cmd := testAICommand(root)
+				cmd.lookupEnv = func(name string) string {
+					for _, value := range cmdEnv {
+						if key, val, ok := strings.Cut(value, "="); ok && key == name {
+							return val
+						}
+					}
+					return ""
+				}
+				cmd.readFile = os.ReadFile
+				cmd.loadRegistry = func() (coremetadata.Registry, error) { return registry.Clone(), nil }
+				cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) { return run(extra, name, args...) }
+				cmd.runCommand = func(_ context.Context, name string, args ...string) error {
+					_, err := run(extra, name, args...)
+					return err
+				}
+				cmd.notifyStore = &stubNotifyStore{}
+				cmd.producer = &storeAttentionNotifyProducer{store: &stubNotifyStore{}, ttl: time.Minute}
+				return cmd
+			}
+			// Direct option set/clear/record checks the entire shared boundary.
+			cmd := command()
+			if err := cmd.setAIPaneOption(pane, aiPaneTopicOption, "routed-topic"); err != nil {
+				t.Fatal(err)
+			}
+			if err := cmd.clearAIPaneOption(pane, attentionAckOption); err != nil {
+				t.Fatal(err)
+			}
+			cmd.recordAIPaneOption(pane, aiPaneHookActiveOption, "1")
+			if option(target, aiPaneTopicOption) != "routed-topic" || option(target, attentionAckOption) != "" || option(target, aiPaneHookActiveOption) != "1" {
+				t.Fatal("shared options missed target")
+			}
+			for _, key := range keys {
+				if option(opposite, key) != "sentinel" {
+					t.Fatalf("shared helper changed other server %s", key)
+				}
+			}
+			for _, event := range []string{"PreToolUse", "UserPromptSubmit"} {
+				for _, key := range []string{aiPaneStateOption, aiPaneHookActiveOption, attentionAckOption, attentionFocusArmedOption, aiPaneResumeIDOption, aiPaneResumeSourceOption} {
+					tmux("-S", target, "set-option", "-p", "-t", pane, key, "sentinel")
+				}
+				payload := `{"hook_event_name":"` + event + `","session_id":"fixture-session","cwd":"` + root + `"}`
+				if binary != "" {
+					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					process := exec.CommandContext(ctx, binary, "internal", "agent-hook", "ingest", "codex-hook", "--pane", paneUID)
+					process.Env = cmdEnv
+					process.Stdin = strings.NewReader(payload)
+					out, err := process.CombinedOutput()
+					cancel()
+					if err != nil {
+						t.Fatalf("installed hook %s: %v: %s", event, err, out)
+					}
+				} else {
+					cmd := command()
+					cmd.stdin = strings.NewReader(payload)
+					if err := cmd.Run([]string{"ingest", "codex-hook", "--pane", paneUID}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if option(target, aiPaneHookActiveOption) != "1" || option(target, aiPaneResumeIDOption) != "fixture-session" || option(target, aiPaneResumeSourceOption) != "hook" {
+					t.Fatalf("%s hook marker/resume writes missed target", event)
+				}
+				data, err := os.ReadFile(filepath.Join(root, "state", "projmux", aiIngestLogName))
+				if err != nil {
+					t.Fatal(err)
+				}
+				lines := nonEmptyLines(string(data))
+				var record aiIngestLogEntry
+				if len(lines) == 0 {
+					t.Fatal("hook wrote no ingest record")
+				}
+				if err := json.Unmarshal([]byte(lines[len(lines)-1]), &record); err != nil {
+					t.Fatal(err)
+				}
+				wantResult := "quiet"
+				if event == "UserPromptSubmit" {
+					wantResult = "state"
+				}
+				if record.Event != event || record.Result != wantResult {
+					t.Fatalf("%s hook record=%+v", event, record)
+				}
+				if event == "PreToolUse" && option(target, aiPaneStateOption) != "sentinel" {
+					t.Fatal("quiet marker event changed ordinary state")
+				}
+				for _, key := range keys {
+					if option(opposite, key) != "sentinel" {
+						t.Fatalf("%s hook changed opposite server %s", event, key)
+					}
+				}
+			}
+			if option(target, aiPaneStateOption) != "thinking" || option(target, aiPaneHookActiveOption) != "1" || option(target, attentionFocusArmedOption) != "" {
+				t.Fatal("hook state/marker/clear missed target")
+			}
+			for _, key := range keys {
+				if option(opposite, key) != "sentinel" {
+					t.Fatalf("hook changed opposite server %s", key)
+				}
+			}
+
+			// A missing exact inherited server cannot fall back to app-owned.
+			missing := command()
+			baseEnv := missing.lookupEnv
+			missing.lookupEnv = func(name string) string {
+				if name == "TMUX" {
+					return filepath.Join(root, "missing") + ",1,0"
+				}
+				return baseEnv(name)
+			}
+			if err := missing.setAIPaneOption(pane, aiPaneTopicOption, "wrong"); !errors.Is(err, errAIPaneWriteUnavailable) {
+				t.Fatalf("missing-route error=%v", err)
+			}
+			if option(target, aiPaneTopicOption) != "routed-topic" || option(opposite, aiPaneTopicOption) != "sentinel" {
+				t.Fatal("missing route fell back")
+			}
+			t.Logf("%s: target state=thinking marker=1 cleared focus; opposite identical-%s sentinels unchanged; missing route refused; binary=%s", label, pane, binary)
+		})
+	}
+}

--- a/internal/app/ai_pane_write.go
+++ b/internal/app/ai_pane_write.go
@@ -40,12 +40,22 @@ var errAIPaneWriteUnavailable = errors.New(aiPaneWriteReasonUnavailable)
 
 // setAIPaneOption writes one Pane option and says whether it landed.
 func (c *aiCommand) setAIPaneOption(paneID, option, value string) error {
-	return classifyAIPaneWrite(c.run("tmux", "set-option", "-p", "-t", paneID, option, value))
+	return c.writeAIPaneOption(paneID, "set-option", "-p", "-t", paneID, option, value)
 }
 
 // clearAIPaneOption unsets one Pane option and says whether it landed.
 func (c *aiCommand) clearAIPaneOption(paneID, option string) error {
-	return classifyAIPaneWrite(c.run("tmux", "set-option", "-p", "-u", "-t", paneID, option))
+	return c.writeAIPaneOption(paneID, "set-option", "-p", "-u", "-t", paneID, option)
+}
+
+// writeAIPaneOption resolves each attempt without retaining a route after its
+// server or Pane disappears. A refusal cannot fall back to tmux's default.
+func (c *aiCommand) writeAIPaneOption(paneID string, args ...string) error {
+	route, refusal := c.aiPaneOptionRoute(paneID)
+	if refusal != nil {
+		return errAIPaneWriteUnavailable
+	}
+	return classifyAIPaneWrite(c.run("tmux", route.args(args...)...))
 }
 
 // recordAIPaneOption is setAIPaneOption for a caller with no error channel of

--- a/internal/app/ai_pane_write_test.go
+++ b/internal/app/ai_pane_write_test.go
@@ -54,6 +54,8 @@ func newPaneWriteHarness(t *testing.T, fails func(option string) bool) *paneWrit
 			return home
 		case "XDG_STATE_HOME":
 			return stateHome
+		case "TMUX":
+			return "/tmp/test-pane-writes/socket,1,0"
 		case "TMUX_PANE":
 			return "%7"
 		default:
@@ -61,6 +63,7 @@ func newPaneWriteHarness(t *testing.T, fails func(option string) bool) *paneWrit
 		}
 	}
 	cmd.runCommand = func(_ context.Context, name string, args ...string) error {
+		args = stripRecordedTmuxRoute(args)
 		if name == "tmux" && len(args) > 0 && args[0] == "set-option" {
 			h.attempts++
 			option := args[len(args)-1]

--- a/internal/app/ai_test.go
+++ b/internal/app/ai_test.go
@@ -1053,6 +1053,9 @@ func TestAIStatusSetThinkingMarksPaneBusy(t *testing.T) {
 	home := t.TempDir()
 	cmd := testAICommand(home)
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name == "tmux" && reflect.DeepEqual(args, []string{"display-message", "-p", "-t", "%1", "#{pane_title}"}) {
 			return []byte("codex: repo\n"), nil
 		}
@@ -1070,7 +1073,7 @@ func TestAIStatusSetThinkingMarksPaneBusy(t *testing.T) {
 		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%1", "@projmux_attention_ack"}},
 		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%1", "@projmux_attention_focus_armed"}},
 	}
-	if !reflect.DeepEqual(cmdRecorder(cmd).commands, want) {
+	if !sameRecordedAICommands(cmdRecorder(cmd).commands, want) {
 		t.Fatalf("commands = %#v, want %#v", cmdRecorder(cmd).commands, want)
 	}
 }
@@ -1084,6 +1087,9 @@ func TestAIStatusSetWaitingMarksPaneReplyAndNotifies(t *testing.T) {
 	cmd := testAICommand(home)
 	cmd.now = func() time.Time { return time.Unix(1000, 0) }
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name == "command" && len(args) == 2 && args[0] == "-v" {
 			switch args[1] {
 			case "notify-send":
@@ -1133,7 +1139,7 @@ func TestAIStatusSetWaitingMarksPaneReplyAndNotifies(t *testing.T) {
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%2", "@projmux_attention_state", "reply"}},
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%2", "@projmux_attention_focus_armed", "1"}},
 	}
-	if len(commands) < len(wantPrefix) || !reflect.DeepEqual(commands[:len(wantPrefix)], wantPrefix) {
+	if len(commands) < len(wantPrefix) || !sameRecordedAICommands(commands[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("command prefix = %#v, want %#v", commands, wantPrefix)
 	}
 	if !containsAICommand(commands, "notify-send") {
@@ -1174,6 +1180,9 @@ func TestAIStatusSetWaitingUsesNotificationHook(t *testing.T) {
 		}
 	}
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name == "command" && reflect.DeepEqual(args, []string{"-v", "notify-send"}) {
 			t.Fatalf("notify-send lookup should not run when PROJMUX_NOTIFY_HOOK is set")
 		}
@@ -1253,6 +1262,9 @@ func TestAIStatusSetWaitingInWSLRegistersToastAppIDAndDispatchesToast(t *testing
 		}
 	}
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name == "command" && len(args) == 2 && args[0] == "-v" {
 			switch args[1] {
 			case "powershell.exe":
@@ -1408,6 +1420,9 @@ func TestAIStatusSetWaitingAcksVisiblePane(t *testing.T) {
 	home := t.TempDir()
 	cmd := testAICommand(home)
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name == "tmux" && reflect.DeepEqual(args, []string{"list-clients", "-F", "#{client_active_pane}"}) {
 			return []byte("%15\n"), nil
 		}
@@ -1427,7 +1442,7 @@ func TestAIStatusSetWaitingAcksVisiblePane(t *testing.T) {
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%15", "@projmux_attention_ack", "1"}},
 		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%15", "@projmux_attention_focus_armed"}},
 	}
-	if len(commands) < len(wantPrefix) || !reflect.DeepEqual(commands[:len(wantPrefix)], wantPrefix) {
+	if len(commands) < len(wantPrefix) || !sameRecordedAICommands(commands[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("command prefix = %#v, want %#v", commands, wantPrefix)
 	}
 	if containsAICommand(commands, "notify-send") {
@@ -1442,6 +1457,9 @@ func TestAIStatusSetWaitingDoesNotAckWhenNoClientViewingPane(t *testing.T) {
 	home := t.TempDir()
 	cmd := testAICommand(home)
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name == "tmux" && reflect.DeepEqual(args, []string{"list-clients", "-F", "#{client_active_pane}"}) {
 			return []byte("%99\n"), nil
 		}
@@ -1460,7 +1478,7 @@ func TestAIStatusSetWaitingDoesNotAckWhenNoClientViewingPane(t *testing.T) {
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%15", "@projmux_attention_state", "reply"}},
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%15", "@projmux_attention_focus_armed", "1"}},
 	}
-	if len(commands) < len(wantPrefix) || !reflect.DeepEqual(commands[:len(wantPrefix)], wantPrefix) {
+	if len(commands) < len(wantPrefix) || !sameRecordedAICommands(commands[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("command prefix = %#v, want %#v", commands, wantPrefix)
 	}
 }
@@ -1477,6 +1495,9 @@ func TestAIStatusSetWaitingForceDoesNotSetBadgeWhenVisible(t *testing.T) {
 	cmd := testAICommand(home)
 	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: 10 * time.Minute}
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name == "command" && len(args) == 2 && args[0] == "-v" && args[1] == "notify-send" {
 			return []byte("/usr/bin/notify-send\n"), nil
 		}
@@ -1529,7 +1550,7 @@ func TestAIStatusSetWaitingForceDoesNotSetBadgeWhenVisible(t *testing.T) {
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%21", "@projmux_attention_ack", "1"}},
 		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%21", "@projmux_attention_focus_armed"}},
 	}
-	if len(commands) < len(wantPrefix) || !reflect.DeepEqual(commands[:len(wantPrefix)], wantPrefix) {
+	if len(commands) < len(wantPrefix) || !sameRecordedAICommands(commands[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("command prefix = %#v, want %#v", commands, wantPrefix)
 	}
 	// attention_state must never be set to "reply" on the visible path,
@@ -1716,6 +1737,9 @@ func TestAIWatchTitlePromotesBusyPaneToThinking(t *testing.T) {
 	cmd := testAICommand(home)
 	checks := 0
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name != "tmux" {
 			return nil, os.ErrNotExist
 		}
@@ -1769,6 +1793,9 @@ func TestAIWatchTitleUsesCapturePaneAsReplySignal(t *testing.T) {
 	cmd := testAICommand(home)
 	checks := 0
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name == "command" && reflect.DeepEqual(args, []string{"-v", "notify-send"}) {
 			return []byte("/usr/bin/notify-send\n"), nil
 		}
@@ -1811,6 +1838,9 @@ func TestAIWatchTitleMapsPermissionTitleToApprovalRequired(t *testing.T) {
 	cmd := testAICommand(home)
 	checks := 0
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name == "command" && reflect.DeepEqual(args, []string{"-v", "notify-send"}) {
 			return []byte("/usr/bin/notify-send\n"), nil
 		}
@@ -1850,6 +1880,9 @@ func TestAIWatchTitlePreservesManualAITopic(t *testing.T) {
 	cmd := testAICommand(home)
 	checks := 0
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name == "command" && reflect.DeepEqual(args, []string{"-v", "notify-send"}) {
 			return []byte("/usr/bin/notify-send\n"), nil
 		}
@@ -1889,6 +1922,9 @@ func TestAIWatchTitleBootstrapsMetadataForExistingCodexPane(t *testing.T) {
 	cmd := testAICommand(home)
 	checks := 0
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name != "tmux" {
 			return nil, os.ErrNotExist
 		}
@@ -1935,7 +1971,7 @@ func TestConfigureAIPaneWritesCanonicalLaunchReceipt(t *testing.T) {
 	want := recordedAICommand{name: "tmux", args: []string{"set-option", "-p", "-t", "%21", aiPaneLaunchAuthorshipOption, "1"}}
 	count := 0
 	for _, command := range commands {
-		if reflect.DeepEqual(command, want) {
+		if command.name == want.name && sameRecordedAICommandArgs(command.name, command.args, want.args) {
 			count++
 		}
 	}
@@ -2003,6 +2039,9 @@ func TestAIWatchTitleSettledBusyBecomesWaitingReply(t *testing.T) {
 		"repo__PROJMUX_TMUX_AI_SEP__busy__PROJMUX_TMUX_AI_SEP__",
 	}
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name == "command" && reflect.DeepEqual(args, []string{"-v", "notify-send"}) {
 			return []byte("/usr/bin/notify-send\n"), nil
 		}
@@ -2048,6 +2087,9 @@ func TestAIWatchTitleIgnoresStaleBusyCaptureHistory(t *testing.T) {
 	cmd := testAICommand(home)
 	checks := 0
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name != "tmux" {
 			return nil, os.ErrNotExist
 		}
@@ -2094,6 +2136,9 @@ func TestAIWatchTitleSettlesUnchangedSpinnerTitle(t *testing.T) {
 	}
 	checks := 0
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name != "tmux" {
 			return nil, os.ErrNotExist
 		}
@@ -2243,7 +2288,10 @@ func testAICommand(home string) *aiCommand {
 			recorder.commands = append(recorder.commands, recordedAICommand{name: name, args: append([]string(nil), args...)})
 			return nil
 		},
-		readCommand: func(context.Context, string, ...string) ([]byte, error) {
+		readCommand: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if row, ok := testAIPaneRouteProbe(name, args); ok {
+				return row, nil
+			}
 			return nil, os.ErrNotExist
 		},
 	}
@@ -2305,6 +2353,9 @@ func containsAICommand(commands []recordedAICommand, name string) bool {
 
 func containsAICommandArgs(commands []recordedAICommand, name string, prefix []string) bool {
 	for _, command := range commands {
+		if name == "tmux" && len(prefix) > 0 && prefix[0] != "-L" && prefix[0] != "-S" {
+			command.args = stripRecordedTmuxRoute(command.args)
+		}
 		if command.name != name || len(command.args) < len(prefix) {
 			continue
 		}
@@ -2317,7 +2368,7 @@ func containsAICommandArgs(commands []recordedAICommand, name string, prefix []s
 
 func containsRecordedAICommand(commands []recordedAICommand, want recordedAICommand) bool {
 	for _, command := range commands {
-		if command.name == want.name && reflect.DeepEqual(command.args, want.args) {
+		if command.name == want.name && sameRecordedAICommandArgs(command.name, command.args, want.args) {
 			return true
 		}
 	}
@@ -2395,7 +2446,7 @@ func TestAITopicSetWritesPaneOptionAndManualFlag(t *testing.T) {
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%3", "@projmux_ai_topic", "fix login bug"}},
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%3", "@projmux_ai_topic_manual", "on"}},
 	}
-	if !reflect.DeepEqual(cmdRecorder(cmd).commands, want) {
+	if !sameRecordedAICommands(cmdRecorder(cmd).commands, want) {
 		t.Fatalf("commands = %#v, want %#v", cmdRecorder(cmd).commands, want)
 	}
 }
@@ -2422,7 +2473,7 @@ func TestAITopicSetUsesEnvPaneWhenFlagOmitted(t *testing.T) {
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", "@projmux_ai_topic", "review PR"}},
 		{name: "tmux", args: []string{"set-option", "-p", "-t", "%7", "@projmux_ai_topic_manual", "on"}},
 	}
-	if !reflect.DeepEqual(cmdRecorder(cmd).commands, want) {
+	if !sameRecordedAICommands(cmdRecorder(cmd).commands, want) {
 		t.Fatalf("commands = %#v, want %#v", cmdRecorder(cmd).commands, want)
 	}
 }
@@ -2439,7 +2490,7 @@ func TestAITopicClearUnsetsBothPaneOptions(t *testing.T) {
 		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%4", "@projmux_ai_topic"}},
 		{name: "tmux", args: []string{"set-option", "-p", "-u", "-t", "%4", "@projmux_ai_topic_manual"}},
 	}
-	if !reflect.DeepEqual(cmdRecorder(cmd).commands, want) {
+	if !sameRecordedAICommands(cmdRecorder(cmd).commands, want) {
 		t.Fatalf("commands = %#v, want %#v", cmdRecorder(cmd).commands, want)
 	}
 }

--- a/internal/app/notify_focus_diagnostics_test.go
+++ b/internal/app/notify_focus_diagnostics_test.go
@@ -357,6 +357,9 @@ func TestNotifyDeliveryDiagnosticsCoalescesActualSuppressionHotPaths(t *testing.
 		return ""
 	}
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name != "tmux" {
 			return nil, os.ErrNotExist
 		}

--- a/internal/app/notify_producer_test.go
+++ b/internal/app/notify_producer_test.go
@@ -461,6 +461,9 @@ func TestAIStatusSetWaitingPushesQueueWhenInactive(t *testing.T) {
 	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: 10 * time.Minute}
 
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name != "tmux" {
 			return nil, nil
 		}
@@ -527,6 +530,9 @@ func TestAIStatusSetThinkingKeepsQueue(t *testing.T) {
 	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: 10 * time.Minute}
 
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name != "tmux" {
 			return nil, nil
 		}
@@ -561,6 +567,9 @@ func TestAIStatusSetIdleKeepsQueue(t *testing.T) {
 	cmd.producer = &storeAttentionNotifyProducer{store: store, ttl: 10 * time.Minute}
 
 	cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if row, ok := testAIPaneRouteProbe(name, args); ok {
+			return row, nil
+		}
 		if name != "tmux" {
 			return nil, nil
 		}

--- a/internal/app/runtime_mutation_plan_test.go
+++ b/internal/app/runtime_mutation_plan_test.go
@@ -2933,8 +2933,7 @@ func TestPlanOnlyMutationNegativeAuditHasZeroBypass(t *testing.T) {
 		// Every AI reflection write now passes through these two helpers, so
 		// the twelve exempt call sites that used to spell `set-option` inline
 		// collapsed into one chokepoint pair that also classifies the failure.
-		"ai_pane_write.go:setAIPaneOption:set-option":                     "agent.presentation",
-		"ai_pane_write.go:clearAIPaneOption:set-option":                   "agent.presentation",
+		"ai_pane_write.go:writeAIPaneOption:variable-argv":                "agent.presentation",
 		"ai.go:BindAgentPaneOnRoute:variable-argv":                        "agent.presentation",
 		"ai.go:writeAgentPaneOptionOnRoute:variable-argv":                 "codex.native-lifecycle-authority",
 		"ai.go:projectManagedAgentInteraction:variable-argv":              "agent.presentation",


### PR DESCRIPTION
## Summary
- Detached AI hooks could find their pane while shared option writes went to tmux's default server. Route shared set, clear, and marker writes through the existing inherited socket or verified app-owned server, and refuse writes when containment cannot be established.
- Extract only transport resolution from Codex delivery; preserve its authority, semantic policy, failure reasons, and the exact runner used during launch before initial pane markers exist.
- Add provider, launch, refusal, and real two-server regression coverage. Managed interaction/topic projections outside these shared helpers remain a separate follow-up.

## Test plan
- [x] Marker and UserPromptSubmit full-ingest regressions: baseline red, fixed green, prefix-removal mutant red; fixed source restored.
- [x] Codex, Claude, Antigravity, bell, launch, and bounded-refusal coverage.
- [x] Real tmux detached/inherited target readback with identical pane IDs and unchanged opposite-server sentinels; missing route refuses fallback.
- [x] `make fmt` → `make fix` → `make test`
- An existing create-window ledger test crossed a wall-clock second in one local run. Its only difference was the operation timestamp; the focused test and full unit suite passed again on the unchanged head. No assertion was changed.
- [x] `make test-integration` → `make test-e2e`
- [x] Required five CI jobs and aggregate `Test`
- The first CI L10 attempt failed its immediate provider-launch assertion. The unchanged full local E2E suite passed, and the affected replay/activation code matches the previous passing head. A provider-start timing race is a hypothesis; the available artifact does not establish the cause. One same-head failed-job replay passed; all 20 checks are green. The original failure is retained and its cause remains unconfirmed.

## Globalization
- [x] No user-facing string changes.
