### PR TITLE
fix(doctor): count every long-lived projmux child in the vintage census

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1276,6 +1276,34 @@ resolves `/proc/<pid>/exe` for the broker runtime and the lifecycle observers
 and reports how many run a replaced image; on a platform with no such table it
 reports the answer as unknown rather than claiming currency.
 
+That line answers which image the Codex verdicts under it were read from, so it
+counts only those two roles. It is not the fleet answer, and reading it as one
+understated the fleet by a factor of five: on 2026-09-05 it named six processes
+while thirty-two children of the same executable were live, eighteen of them
+per-pane `internal supervise` supervisors that matched no named route and were
+dropped at a map lookup. `projmux doctor` therefore carries a second census
+under `Runtime`, rendered as `Projmux process vintage` and owned by
+`TestProjmuxProcessVintage*`, `TestProjmuxProcessRole*` and
+`TestDoctorSeparatesTheCodexDiagnosisVintageFromTheFleetCensus`.
+
+- It is provider-neutral, which is why it is not on the Codex line. A
+  supervisor supervises a Claude pane exactly as it supervises a Codex one, and
+  `TestCodexControlPlaneVintageIgnoresProviderNeutralProcesses` keeps it off the
+  line that qualifies Codex verdicts.
+- It has no unmatched case. A child whose route this reader cannot name is
+  counted under `other` rather than dropped, so an unknown route can never make
+  the fleet look smaller than it is.
+- Route words are argv without argv[0] and without anything behind a bare `--`.
+  `projmux agent turn ... -- <text>` carries arbitrary prose, including the very
+  route words this census matches on, and counting a message about the broker as
+  a broker is the same class of error in the other direction.
+- Both censuses come from one process-table read, so the two lines can never
+  disagree about the same process, and both answer `unknown` where the platform
+  exposes no table.
+- Neither line names a process. `TestProcessVintageNamesNoProcess` audits both
+  rendered strings for pids, paths and argv; the section is counts and nothing
+  else, which is what makes a process census printable at all.
+
 The gate does not change `projmux doctor`'s exit code. A broken surface is a
 readable verdict, not a failed command, and the CI half of the detection is the
 regression tests themselves.

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1020,7 +1020,12 @@ versions, paths, confidence/source metadata, and displayed remediation.
 dependencies, `integrations` selects AI notify integrations, and
 `session-state` selects resume metadata plus retention guidance. `runtime`
 selects the fixed `tmux` backend, an actual one-second read-only probe of the
-app socket, and generated-versus-live config digest state. `logs` selects the
+app socket, generated-versus-live config digest state, and a
+`projmux_process_vintage` census of this executable's live children by role and
+image age. That census is provider-neutral and counts every child, naming
+per-pane supervisors and keeping an `other` remainder so a route it has no name
+for cannot shrink the total; on a platform with no process table it reports
+`unknown` rather than claiming currency. `logs` selects the
 state/log/journal presence, private permissions and metadata-only writability
 checks plus a bounded aggregate of recent safe operational error codes. These
 sections expose only closed status codes and counts: no path, socket name,

--- a/internal/app/codex_controlplane_surfaces.go
+++ b/internal/app/codex_controlplane_surfaces.go
@@ -528,21 +528,56 @@ func codexSurfaceReasonOrNone(reason string) string {
 // replaced-image process describes code that process never loaded.
 func codexControlPlaneVintageText(vintage codexControlPlaneVintage) string {
 	if !vintage.Supported {
-		return "unknown on this platform; a process running a replaced image cannot be told apart from one running the installed build"
+		return codexProcessVintageUnknownText
 	}
 	if len(vintage.Roles) == 0 {
 		return "no control-plane process observed"
 	}
-	parts := make([]string, 0, len(vintage.Roles))
-	for _, role := range vintage.Roles {
+	text := projmuxProcessRolesText(vintage.Roles)
+	if vintage.Replaced() > 0 {
+		text += "; a replaced image did not load the installed build, so every verdict below it describes older code"
+	}
+	return text
+}
+
+// projmuxProcessVintageText renders the whole-fleet vintage line.
+//
+// It answers a different question from the line above it and therefore prints
+// somewhere else: that one qualifies the Codex verdicts printed under it, this
+// one says how much of the running fleet the last install did not reach. Naming
+// a provider-neutral supervisor on the Codex line would have merged the two
+// questions into an answer to neither.
+func projmuxProcessVintageText(vintage projmuxProcessVintage) string {
+	if !vintage.Supported {
+		return codexProcessVintageUnknownText
+	}
+	if len(vintage.Roles) == 0 {
+		return "no projmux process observed"
+	}
+	text := projmuxProcessRolesText(vintage.Roles)
+	if replaced := vintage.Replaced(); replaced > 0 {
+		text += fmt.Sprintf("; %d of %d run an image the installed build replaced, so they are executing code from before that install",
+			replaced, vintage.Observed())
+	}
+	return text
+}
+
+// codexProcessVintageUnknownText is the answer on a platform with no process
+// table. It is shared so that neither line can drift into implying currency on
+// the one platform where currency cannot be established.
+const codexProcessVintageUnknownText = "unknown on this platform; a process running a replaced image cannot be told apart from one running the installed build"
+
+// projmuxProcessRolesText renders one census as counts per role.
+//
+// Every number here is a count. No pid, path, or argv reaches this string,
+// which is what keeps a process census printable on a diagnostics surface.
+func projmuxProcessRolesText(roles []projmuxProcessRoleVintage) string {
+	parts := make([]string, 0, len(roles))
+	for _, role := range roles {
 		parts = append(parts, fmt.Sprintf("%s %d (%s %d, %s %d)",
 			role.Role, role.Processes,
 			codexProcessVintageCurrent, role.Current,
 			codexProcessVintageReplaced, role.Replaced))
 	}
-	text := strings.Join(parts, "; ")
-	if vintage.Replaced() > 0 {
-		text += "; a replaced image did not load the installed build, so every verdict below it describes older code"
-	}
-	return text
+	return strings.Join(parts, "; ")
 }

--- a/internal/app/codex_controlplane_surfaces_test.go
+++ b/internal/app/codex_controlplane_surfaces_test.go
@@ -357,7 +357,7 @@ func TestControlPlaneProjectionAnswersForEverySurface(t *testing.T) {
 func TestDoctorRendersEveryControlPlaneSurfaceAndItsVintage(t *testing.T) {
 	var buf bytes.Buffer
 	writeDoctorCodexControlPlaneText(&buf, &codexControlPlaneReport{
-		Vintage: codexControlPlaneVintage{Supported: true, Roles: []codexControlPlaneRoleVintage{
+		Vintage: codexControlPlaneVintage{Supported: true, Roles: []projmuxProcessRoleVintage{
 			{Role: codexControlPlaneRoleBroker, Processes: 1, Replaced: 1},
 			{Role: codexControlPlaneRoleObserver, Processes: 8, Current: 1, Replaced: 7},
 		}},

--- a/internal/app/codex_controlplane_vintage.go
+++ b/internal/app/codex_controlplane_vintage.go
@@ -36,6 +36,35 @@ const (
 
 var codexControlPlaneRoleOrder = []string{codexControlPlaneRoleBroker, codexControlPlaneRoleObserver}
 
+// The remaining long-lived children of this executable, named without reference
+// to a provider.
+//
+// `internal supervise` is one per pane and is provider-neutral: it supervises a
+// Claude pane exactly as it supervises a Codex one. Naming it as a Codex
+// control-plane role would answer the wrong question, so the roles below are
+// counted in their own census and never appear on the Codex section's line.
+const (
+	// projmuxProcessRoleSupervisor is the per-pane supervisor.
+	projmuxProcessRoleSupervisor = "supervisor"
+	// projmuxProcessRoleOther is every remaining child of this executable.
+	//
+	// It exists so that a route this census does not know cannot make the
+	// fleet look smaller than it is. Before this bucket, a child that matched
+	// no named route was dropped on the floor, and the section reported six of
+	// thirty-two live children as if that were the whole fleet.
+	projmuxProcessRoleOther = "other"
+)
+
+// projmuxProcessRoleOrder is the render order of the whole-fleet census. Named
+// roles come first and the unnamed remainder last, so the roles an operator can
+// act on lead and the bucket that only guards the total trails.
+var projmuxProcessRoleOrder = []string{
+	codexControlPlaneRoleBroker,
+	codexControlPlaneRoleObserver,
+	projmuxProcessRoleSupervisor,
+	projmuxProcessRoleOther,
+}
+
 // procDeletedSuffix is what the kernel appends to /proc/<pid>/exe once the
 // mapped file has been unlinked. It is the whole discriminator: the link target
 // still names the installed path, so only this suffix separates a process
@@ -56,8 +85,8 @@ type codexProcessImage struct {
 	Cmdline []string
 }
 
-// codexControlPlaneRoleVintage is the vintage census of one control-plane role.
-type codexControlPlaneRoleVintage struct {
+// projmuxProcessRoleVintage is the vintage census of one process role.
+type projmuxProcessRoleVintage struct {
 	Role      string `json:"role"`
 	Processes int    `json:"processes"`
 	Current   int    `json:"current"`
@@ -72,24 +101,55 @@ type codexControlPlaneRoleVintage struct {
 type codexControlPlaneVintage struct {
 	// Supported reports whether this platform exposes a process table this
 	// reader can establish vintage from. False is `unknown`, never `current`.
-	Supported bool                           `json:"supported"`
-	Roles     []codexControlPlaneRoleVintage `json:"roles,omitempty"`
+	Supported bool                        `json:"supported"`
+	Roles     []projmuxProcessRoleVintage `json:"roles,omitempty"`
 }
 
 // Replaced is how many observed control-plane processes run an image that is no
 // longer the installed one.
-func (v codexControlPlaneVintage) Replaced() int {
+func (v codexControlPlaneVintage) Replaced() int { return projmuxProcessRolesReplaced(v.Roles) }
+
+// Observed is how many control-plane processes this reader could classify.
+func (v codexControlPlaneVintage) Observed() int { return projmuxProcessRolesObserved(v.Roles) }
+
+// projmuxProcessVintage is the census of every child of this executable,
+// counted without reference to a provider.
+//
+// It answers a different question from codexControlPlaneVintage, and the two
+// are kept apart on purpose. That one qualifies the Codex verdicts printed
+// under it and therefore counts only the two roles those verdicts are read
+// from. This one answers "how many projmux processes are still running the
+// image from before the last install", which is a fleet question, so it counts
+// the per-pane supervisors and keeps an unnamed remainder rather than letting a
+// route it does not know shrink the total.
+//
+// Like the Codex census it names no process: no pid, no path, no argv reaches
+// a diagnostics surface from here.
+type projmuxProcessVintage struct {
+	// Supported reports whether this platform exposes a process table this
+	// reader can establish vintage from. False is `unknown`, never `current`.
+	Supported bool                        `json:"supported"`
+	Roles     []projmuxProcessRoleVintage `json:"roles,omitempty"`
+}
+
+// Replaced is how many observed projmux processes run an image that is no
+// longer the installed one.
+func (v projmuxProcessVintage) Replaced() int { return projmuxProcessRolesReplaced(v.Roles) }
+
+// Observed is how many projmux processes this reader classified.
+func (v projmuxProcessVintage) Observed() int { return projmuxProcessRolesObserved(v.Roles) }
+
+func projmuxProcessRolesReplaced(roles []projmuxProcessRoleVintage) int {
 	total := 0
-	for _, role := range v.Roles {
+	for _, role := range roles {
 		total += role.Replaced
 	}
 	return total
 }
 
-// Observed is how many control-plane processes this reader could classify.
-func (v codexControlPlaneVintage) Observed() int {
+func projmuxProcessRolesObserved(roles []projmuxProcessRoleVintage) int {
 	total := 0
-	for _, role := range v.Roles {
+	for _, role := range roles {
 		total += role.Processes
 	}
 	return total
@@ -98,33 +158,70 @@ func (v codexControlPlaneVintage) Observed() int {
 // projectCodexControlPlaneVintage classifies the control-plane children of this
 // executable.
 //
+// It counts only the two roles the Codex section's verdicts are read from, so
+// that line keeps qualifying exactly those verdicts. A provider-neutral process
+// is not one of them and is never named here.
+func projectCodexControlPlaneVintage(self string, selfPID int, images []codexProcessImage, supported bool) codexControlPlaneVintage {
+	if !supported {
+		return codexControlPlaneVintage{}
+	}
+	return codexControlPlaneVintage{
+		Supported: true,
+		Roles:     censusProjmuxProcessImages(self, selfPID, images, codexControlPlaneRoleOrder, codexControlPlaneRole),
+	}
+}
+
+// projectProjmuxProcessVintage classifies every child of this executable.
+//
+// This is the projection that must not lose anyone. `make install` replaces the
+// file on disk and leaves every running process on the image it started with,
+// and the number an operator needs is how many processes that is — not how many
+// of them happen to sit on a route this reader has a name for.
+func projectProjmuxProcessVintage(self string, selfPID int, images []codexProcessImage, supported bool) projmuxProcessVintage {
+	if !supported {
+		return projmuxProcessVintage{}
+	}
+	return projmuxProcessVintage{
+		Supported: true,
+		Roles:     censusProjmuxProcessImages(self, selfPID, images, projmuxProcessRoleOrder, projmuxProcessRole),
+	}
+}
+
+// censusProjmuxProcessImages counts this executable's children by role and
+// image age.
+//
 // Only processes whose image resolves back to this executable's own path are
 // considered. A process whose link cannot be read at all is skipped rather than
 // counted as unknown: this reader cannot tell such a process from another
 // user's, and inventing a category for it would put a number on the section
 // that no operator action follows from.
-func projectCodexControlPlaneVintage(self string, selfPID int, images []codexProcessImage, supported bool) codexControlPlaneVintage {
-	vintage := codexControlPlaneVintage{Supported: supported}
-	if !supported {
-		return vintage
-	}
+//
+// roleOf naming a role that order does not carry is what keeps a process out of
+// a census on purpose, and it is the only difference between the two
+// projections above.
+func censusProjmuxProcessImages(
+	self string,
+	selfPID int,
+	images []codexProcessImage,
+	order []string,
+	roleOf func([]string) string,
+) []projmuxProcessRoleVintage {
 	self = strings.TrimSpace(self)
-	byRole := map[string]*codexControlPlaneRoleVintage{}
-	for _, role := range codexControlPlaneRoleOrder {
-		byRole[role] = &codexControlPlaneRoleVintage{Role: role}
+	byRole := map[string]*projmuxProcessRoleVintage{}
+	for _, role := range order {
+		byRole[role] = &projmuxProcessRoleVintage{Role: role}
 	}
 	for _, image := range images {
 		if image.PID == selfPID {
 			// The reader's own image is current by construction, and it is not
-			// one of the processes the Codex diagnosis is taken from.
+			// one of the processes a diagnosis is taken from.
 			continue
 		}
 		path, replaced := codexProcessImagePath(image.Exe)
 		if path == "" || self == "" || path != self {
 			continue
 		}
-		role := codexControlPlaneRole(image.Cmdline)
-		census, ok := byRole[role]
+		census, ok := byRole[roleOf(image.Cmdline)]
 		if !ok {
 			continue
 		}
@@ -135,12 +232,13 @@ func projectCodexControlPlaneVintage(self string, selfPID int, images []codexPro
 			census.Current++
 		}
 	}
-	for _, role := range codexControlPlaneRoleOrder {
+	var rows []projmuxProcessRoleVintage
+	for _, role := range order {
 		if census := byRole[role]; census.Processes > 0 {
-			vintage.Roles = append(vintage.Roles, *census)
+			rows = append(rows, *census)
 		}
 	}
-	return vintage
+	return rows
 }
 
 // codexProcessImagePath splits one /proc/<pid>/exe link target into the path it
@@ -156,18 +254,59 @@ func codexProcessImagePath(exe string) (string, bool) {
 	return filepath.Clean(exe), false
 }
 
-// codexControlPlaneRole names which control-plane child one argv belongs to.
+// projmuxProcessRouteWords is the part of one argv that names an internal
+// route.
+//
+// It drops argv[0] and everything after a bare `--`. Neither is a route:
+// argv[0] is the executable path, and the words behind `--` are a caller's own
+// text. `projmux agent turn ... -- <message>` carries arbitrary prose there,
+// including the very words this census matches on, and reading a message about
+// the broker as a broker would overcount the fleet with a process that is not
+// one.
+func projmuxProcessRouteWords(cmdline []string) []string {
+	if len(cmdline) < 2 {
+		return nil
+	}
+	words := cmdline[1:]
+	if index := slices.Index(words, "--"); index >= 0 {
+		words = words[:index]
+	}
+	return words
+}
+
+// projmuxProcessRole names which child of this executable one argv belongs to.
 //
 // The match is on the internal route words rather than on argv positions, so a
 // flag added ahead of the route does not silently drop a process out of the
-// census and report a fleet as smaller than it is.
-func codexControlPlaneRole(cmdline []string) string {
+// census and report a fleet as smaller than it is. For the same reason there is
+// no unmatched case: an argv this function cannot name still belongs to a
+// running projmux process, and the remainder bucket is where it stays counted.
+func projmuxProcessRole(cmdline []string) string {
+	words := projmuxProcessRouteWords(cmdline)
 	switch {
-	case slices.Contains(cmdline, "codex-broker") && slices.Contains(cmdline, "serve"):
+	case slices.Contains(words, "codex-broker") && slices.Contains(words, "serve"):
 		return codexControlPlaneRoleBroker
-	case slices.Contains(cmdline, "agent-hook") && slices.Contains(cmdline, "ingest") &&
-		slices.Contains(cmdline, codexNativeLifecycleIngestRoute):
+	case slices.Contains(words, "agent-hook") && slices.Contains(words, "ingest") &&
+		slices.Contains(words, codexNativeLifecycleIngestRoute):
 		return codexControlPlaneRoleObserver
+	case slices.Contains(words, "supervise"):
+		return projmuxProcessRoleSupervisor
+	default:
+		return projmuxProcessRoleOther
+	}
+}
+
+// codexControlPlaneRole names which Codex control-plane child one argv belongs
+// to, and "" for every other process.
+//
+// The empty answer is the whole point: it keeps a provider-neutral process off
+// the line that qualifies the Codex verdicts. Those two roles are the ones
+// those verdicts are read from; a supervisor is not, and calling it one would
+// answer a question the section never asked.
+func codexControlPlaneRole(cmdline []string) string {
+	switch role := projmuxProcessRole(cmdline); role {
+	case codexControlPlaneRoleBroker, codexControlPlaneRoleObserver:
+		return role
 	default:
 		return ""
 	}

--- a/internal/app/codex_controlplane_vintage_test.go
+++ b/internal/app/codex_controlplane_vintage_test.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"bytes"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -31,7 +33,7 @@ func TestControlPlaneVintageSeparatesAReplacedImageFromTheInstalledBuild(t *test
 		{PID: 500, Exe: "/usr/bin/tmux", Cmdline: []string{"tmux", "internal", "codex-broker", "serve"}},
 	}
 	vintage := projectCodexControlPlaneVintage(self, 100, images, true)
-	want := codexControlPlaneVintage{Supported: true, Roles: []codexControlPlaneRoleVintage{
+	want := codexControlPlaneVintage{Supported: true, Roles: []projmuxProcessRoleVintage{
 		{Role: codexControlPlaneRoleBroker, Processes: 1, Replaced: 1},
 		{Role: codexControlPlaneRoleObserver, Processes: 2, Current: 1, Replaced: 1},
 	}}
@@ -139,5 +141,297 @@ func TestControlPlaneRoleMatchesTheInternalRouteRatherThanArgvPosition(t *testin
 				t.Fatalf("role = %q, want %q", got, test.want)
 			}
 		})
+	}
+}
+
+// TestProjmuxProcessVintageCountsEveryChildOfThisExecutable is the census
+// completeness gate.
+//
+// The Codex census counts the two roles its verdicts are read from and drops
+// everything else, which is correct for the line it qualifies and wrong as an
+// answer to "how much of the running fleet did the last install not reach". On
+// 2026-09-05 that difference was six named processes against thirty-two live
+// children, with eighteen per-pane supervisors among the twenty-six the section
+// never mentioned. A number that small reads as reassurance.
+//
+// The assertion that matters is the last one: the observed total equals the
+// number of this executable's children in the table, so no route this reader
+// has no name for can shrink it.
+func TestProjmuxProcessVintageCountsEveryChildOfThisExecutable(t *testing.T) {
+	const self = "/home/user/go/bin/projmux"
+	images := []codexProcessImage{
+		// The reader's own process, which is current by construction.
+		{PID: 100, Exe: self, Cmdline: []string{self, "doctor"}},
+		{PID: 200, Exe: self + procDeletedSuffix, Cmdline: []string{self, "internal", "codex-broker", "serve", "--state-domain", "/state"}},
+		{PID: 300, Exe: self + procDeletedSuffix, Cmdline: []string{self, "internal", "agent-hook", "ingest", codexNativeLifecycleIngestRoute, "--pane", "%1"}},
+		{PID: 301, Exe: self, Cmdline: []string{self, "internal", "agent-hook", "ingest", codexNativeLifecycleIngestRoute, "--pane", "%2"}},
+		{PID: 400, Exe: self + procDeletedSuffix, Cmdline: []string{self, "internal", "supervise", "--pane-uid", "pane-a"}},
+		{PID: 401, Exe: self + procDeletedSuffix, Cmdline: []string{self, "internal", "supervise", "--pane-uid", "pane-b"}},
+		{PID: 402, Exe: self, Cmdline: []string{self, "internal", "supervise", "--pane-uid", "pane-c"}},
+		// Routes this census has no name for. They are still projmux processes
+		// running a projmux image, so they stay counted.
+		{PID: 500, Exe: self + procDeletedSuffix, Cmdline: []string{self, "internal", "claude-endpoint-helper"}},
+		{PID: 501, Exe: self, Cmdline: []string{self, "attach"}},
+		// An argv this reader could not read at all.
+		{PID: 502, Exe: self, Cmdline: nil},
+		// A different binary at a path this reader does not own.
+		{PID: 600, Exe: "/usr/bin/tmux", Cmdline: []string{"tmux", "internal", "supervise"}},
+	}
+	fleet := projectProjmuxProcessVintage(self, 100, images, true)
+	want := projmuxProcessVintage{Supported: true, Roles: []projmuxProcessRoleVintage{
+		{Role: codexControlPlaneRoleBroker, Processes: 1, Replaced: 1},
+		{Role: codexControlPlaneRoleObserver, Processes: 2, Current: 1, Replaced: 1},
+		{Role: projmuxProcessRoleSupervisor, Processes: 3, Current: 1, Replaced: 2},
+		{Role: projmuxProcessRoleOther, Processes: 3, Current: 2, Replaced: 1},
+	}}
+	if !reflect.DeepEqual(fleet, want) {
+		t.Fatalf("fleet vintage = %+v, want %+v", fleet, want)
+	}
+	children := 0
+	for _, image := range images {
+		if path, _ := codexProcessImagePath(image.Exe); path == self && image.PID != 100 {
+			children++
+		}
+	}
+	if fleet.Observed() != children {
+		t.Fatalf("observed = %d, want every one of the %d children of this executable", fleet.Observed(), children)
+	}
+	if fleet.Replaced() != 5 {
+		t.Fatalf("replaced = %d, want 5", fleet.Replaced())
+	}
+	text := projmuxProcessVintageText(fleet)
+	for _, want := range []string{projmuxProcessRoleSupervisor, projmuxProcessRoleOther, "5 of 9"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("fleet vintage text = %q, want it to contain %q", text, want)
+		}
+	}
+}
+
+// TestCodexControlPlaneVintageIgnoresProviderNeutralProcesses pins the other
+// half of the split. The fleet census gained supervisors and a remainder
+// bucket; the Codex line must not, because it qualifies verdicts read from two
+// specific processes and a supervisor is not one of them. It supervises a
+// Claude pane exactly as it supervises a Codex one.
+func TestCodexControlPlaneVintageIgnoresProviderNeutralProcesses(t *testing.T) {
+	const self = "/opt/projmux"
+	images := []codexProcessImage{
+		{PID: 200, Exe: self, Cmdline: []string{self, "internal", "codex-broker", "serve"}},
+		{PID: 400, Exe: self + procDeletedSuffix, Cmdline: []string{self, "internal", "supervise", "--pane-uid", "pane-a"}},
+		{PID: 500, Exe: self + procDeletedSuffix, Cmdline: []string{self, "internal", "claude-endpoint-helper"}},
+	}
+	vintage := projectCodexControlPlaneVintage(self, 1, images, true)
+	want := codexControlPlaneVintage{Supported: true, Roles: []projmuxProcessRoleVintage{
+		{Role: codexControlPlaneRoleBroker, Processes: 1, Current: 1},
+	}}
+	if !reflect.DeepEqual(vintage, want) {
+		t.Fatalf("codex vintage = %+v, want only the roles this section reads its verdicts from", vintage)
+	}
+	text := codexControlPlaneVintageText(vintage)
+	for _, unwanted := range []string{projmuxProcessRoleSupervisor, projmuxProcessRoleOther} {
+		if strings.Contains(text, unwanted) {
+			t.Fatalf("codex vintage text = %q, want no provider-neutral role named as a Codex control-plane role", text)
+		}
+	}
+	if strings.Contains(text, "older code") {
+		t.Fatalf("codex vintage text = %q, want a replaced supervisor not to warn about the Codex verdicts below it", text)
+	}
+}
+
+// TestProjmuxProcessRoleNamesEveryChildIncludingTheOnesItCannotName is the
+// classification table.
+//
+// The default arm is the point. Before it, an argv that matched no named route
+// resolved to "" and then failed a map lookup, and the process left the census
+// without leaving a trace of having been there.
+func TestProjmuxProcessRoleNamesEveryChildIncludingTheOnesItCannotName(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		cmdline []string
+		want    string
+		codex   string
+	}{
+		{
+			name:    "broker",
+			cmdline: []string{"projmux", "internal", "codex-broker", "serve"},
+			want:    codexControlPlaneRoleBroker,
+			codex:   codexControlPlaneRoleBroker,
+		},
+		{
+			name:    "observer",
+			cmdline: []string{"projmux", "internal", "agent-hook", "ingest", codexNativeLifecycleIngestRoute},
+			want:    codexControlPlaneRoleObserver,
+			codex:   codexControlPlaneRoleObserver,
+		},
+		{
+			name:    "supervisor",
+			cmdline: []string{"projmux", "internal", "supervise", "--pane-uid", "pane-a"},
+			want:    projmuxProcessRoleSupervisor,
+		},
+		{
+			name:    "supervisor behind a future flag",
+			cmdline: []string{"projmux", "--verbose", "internal", "supervise", "--pane-uid", "pane-a"},
+			want:    projmuxProcessRoleSupervisor,
+		},
+		{
+			name:    "a route this census has no name for",
+			cmdline: []string{"projmux", "internal", "claude-endpoint-helper"},
+			want:    projmuxProcessRoleOther,
+		},
+		{
+			name:    "a sibling hook ingest route",
+			cmdline: []string{"projmux", "internal", "agent-hook", "ingest", "claude"},
+			want:    projmuxProcessRoleOther,
+		},
+		{name: "an argv this reader could not read", cmdline: nil, want: projmuxProcessRoleOther},
+		{name: "an argv that is only the executable", cmdline: []string{"projmux"}, want: projmuxProcessRoleOther},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := projmuxProcessRole(test.cmdline); got != test.want {
+				t.Fatalf("role = %q, want %q", got, test.want)
+			}
+			if got := codexControlPlaneRole(test.cmdline); got != test.codex {
+				t.Fatalf("codex role = %q, want %q", got, test.codex)
+			}
+		})
+	}
+}
+
+// TestProjmuxProcessRouteWordsStopAtTheArgvSeparator keeps a message about a
+// process from being counted as one.
+//
+// `projmux agent turn ... -- <text>` puts arbitrary prose in argv, and this
+// track's own delegation prompts name `codex-broker serve` and `supervise` in
+// that text. Matching route words anywhere in argv would count a message about
+// the broker as a second broker and report a fleet larger than it is, which is
+// the same class of error as reporting one smaller.
+func TestProjmuxProcessRouteWordsStopAtTheArgvSeparator(t *testing.T) {
+	message := []string{
+		"projmux", "agent", "turn", "steer", "uid:agent-1", "--",
+		"do", "not", "kill", "the", "codex-broker", "serve", "process", "or", "any", "supervise", "child",
+	}
+	if got := projmuxProcessRole(message); got != projmuxProcessRoleOther {
+		t.Fatalf("role = %q, want the words behind `--` to be read as a message rather than a route", got)
+	}
+	if got := codexControlPlaneRole(message); got != "" {
+		t.Fatalf("codex role = %q, want no control-plane role for a message that merely names one", got)
+	}
+	route := []string{"projmux", "internal", "supervise", "--pane-uid", "pane-a"}
+	if got := projmuxProcessRouteWords(route); !reflect.DeepEqual(got, []string{"internal", "supervise", "--pane-uid", "pane-a"}) {
+		t.Fatalf("route words = %q, want the argv without its executable path", got)
+	}
+	if got := projmuxProcessRouteWords([]string{"/opt/serve/projmux", "attach"}); slices.Contains(got, "/opt/serve/projmux") {
+		t.Fatalf("route words = %q, want argv[0] excluded so an executable path cannot spell a route", got)
+	}
+}
+
+// TestProjmuxProcessVintageReportsAnUnreadableProcessTableAsUnknown pins that
+// the fleet census answers `unknown` where the Codex one does.
+//
+// Darwin exposes no /proc/<pid>/exe, so a replaced image cannot be told apart
+// from the installed one there. Answering `current` would certify exactly the
+// falsehood this projection exists to prevent, on the one platform where it
+// cannot be checked.
+func TestProjmuxProcessVintageReportsAnUnreadableProcessTableAsUnknown(t *testing.T) {
+	fleet := projectProjmuxProcessVintage("/opt/projmux", 1, []codexProcessImage{
+		{PID: 2, Exe: "/opt/projmux", Cmdline: []string{"/opt/projmux", "internal", "supervise"}},
+	}, false)
+	if fleet.Supported || len(fleet.Roles) != 0 {
+		t.Fatalf("fleet vintage = %+v, want no classification without a process table", fleet)
+	}
+	if fleet.Observed() != 0 || fleet.Replaced() != 0 {
+		t.Fatalf("observed = %d, replaced = %d, want no counts without a process table", fleet.Observed(), fleet.Replaced())
+	}
+	text := projmuxProcessVintageText(fleet)
+	if !strings.Contains(text, "unknown") {
+		t.Fatalf("fleet vintage text = %q, want it to name the answer as unknown", text)
+	}
+	if strings.Contains(text, codexProcessVintageCurrent) {
+		t.Fatalf("fleet vintage text = %q, want no currency claim on a platform that cannot check it", text)
+	}
+}
+
+// TestProcessVintageNamesNoProcess is the negative audit.
+//
+// A census is printable on a diagnostics surface only because it is counts and
+// nothing else. Adding roles widened what the reader classifies; it must not
+// widen what the reader says.
+func TestProcessVintageNamesNoProcess(t *testing.T) {
+	const self = "/home/operator/go/bin/projmux"
+	images := []codexProcessImage{
+		{PID: 987654, Exe: self + procDeletedSuffix, Cmdline: []string{self, "internal", "supervise", "--pane-uid", "pane-secret"}},
+		{PID: 987655, Exe: self, Cmdline: []string{self, "internal", "codex-broker", "serve", "--state-domain", "/home/operator/state"}},
+		{PID: 987656, Exe: self, Cmdline: []string{self, "internal", "claude-endpoint-helper", "--endpoint", "/home/operator/socket"}},
+	}
+	rendered := []string{
+		projmuxProcessVintageText(projectProjmuxProcessVintage(self, 1, images, true)),
+		codexControlPlaneVintageText(projectCodexControlPlaneVintage(self, 1, images, true)),
+	}
+	for _, text := range rendered {
+		for _, leak := range []string{
+			self, "987654", "987655", "987656",
+			"pane-secret", "--pane-uid", "--state-domain", "--endpoint",
+			"/home/operator", "claude-endpoint-helper", "internal",
+		} {
+			if strings.Contains(text, leak) {
+				t.Fatalf("vintage text = %q, want no pid, path or argv on a diagnostics surface; found %q", text, leak)
+			}
+		}
+	}
+}
+
+// TestDoctorSeparatesTheCodexDiagnosisVintageFromTheFleetCensus pins that the
+// two questions read as two questions.
+//
+// "Which image was this Codex diagnosis read from" qualifies the verdicts
+// printed under it. "How many projmux processes are still running the image
+// from before the last install" is a fleet question with no provider in it.
+// Merging them would have put a provider-neutral supervisor on a Codex line and
+// answered neither.
+func TestDoctorSeparatesTheCodexDiagnosisVintageFromTheFleetCensus(t *testing.T) {
+	fleet := projmuxProcessVintage{Supported: true, Roles: []projmuxProcessRoleVintage{
+		{Role: codexControlPlaneRoleBroker, Processes: 1, Replaced: 1},
+		{Role: projmuxProcessRoleSupervisor, Processes: 18, Replaced: 18},
+		{Role: projmuxProcessRoleOther, Processes: 8, Current: 8},
+	}}
+	report := doctorReport{
+		SchemaVersion: doctorSchemaVersion,
+		CodexControlPlane: &codexControlPlaneReport{Vintage: codexControlPlaneVintage{
+			Supported: true,
+			Roles: []projmuxProcessRoleVintage{
+				{Role: codexControlPlaneRoleBroker, Processes: 1, Replaced: 1},
+			},
+		}},
+		ProcessVintage: &fleet,
+	}
+	var buf bytes.Buffer
+	if err := writeDoctorText(&buf, report, doctorSectionAll, false); err != nil {
+		t.Fatalf("writeDoctorText: %v", err)
+	}
+	text := buf.String()
+	codexLine, fleetLine := "", ""
+	for line := range strings.SplitSeq(text, "\n") {
+		switch {
+		case strings.Contains(line, "Diagnosis vintage:"):
+			codexLine = line
+		case strings.Contains(line, "Children of this executable:"):
+			fleetLine = line
+		}
+	}
+	if codexLine == "" || fleetLine == "" {
+		t.Fatalf("doctor text = %q, want both a Codex diagnosis vintage line and a fleet census line", text)
+	}
+	if strings.Contains(codexLine, projmuxProcessRoleSupervisor) {
+		t.Fatalf("codex line = %q, want no provider-neutral role on the line that qualifies Codex verdicts", codexLine)
+	}
+	if !strings.Contains(fleetLine, projmuxProcessRoleSupervisor) || !strings.Contains(fleetLine, "18") {
+		t.Fatalf("fleet line = %q, want the per-pane supervisors counted", fleetLine)
+	}
+	if !strings.Contains(text, "\nProjmux process vintage\n") {
+		t.Fatalf("doctor text = %q, want the fleet census under its own heading", text)
+	}
+	fleetHeading := strings.Index(text, "\nProjmux process vintage\n")
+	codexHeading := strings.Index(text, "\nCodex control-plane surfaces\n")
+	if fleetHeading < 0 || codexHeading < 0 || fleetHeading > codexHeading {
+		t.Fatalf("doctor text = %q, want the fleet census as its own block outside the Codex section", text)
 	}
 }

--- a/internal/app/doctor.go
+++ b/internal/app/doctor.go
@@ -16,6 +16,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
@@ -63,6 +64,11 @@ type doctorCommand struct {
 	// controlPlaneVintage reads the binary vintage of the live control-plane
 	// processes this diagnosis is taken from.
 	controlPlaneVintage func() codexControlPlaneVintage
+	// projmuxProcessVintage reads the binary vintage of every live child of
+	// this executable. It is a separate seam from the one above because it
+	// answers a fleet question rather than qualifying a Codex verdict, and the
+	// two render in different sections.
+	projmuxProcessVintage func() projmuxProcessVintage
 }
 
 func newDoctorCommand() *doctorCommand {
@@ -96,17 +102,14 @@ func newDoctorCommand() *doctorCommand {
 		}
 		return readAIIngestLogTail(path, aiIngestAttributionWindow, aiIngestAttributionRecords)
 	}
+	readVintage := defaultProcessVintageReader()
 	c.controlPlaneVintage = func() codexControlPlaneVintage {
-		executable, err := os.Executable()
-		if err != nil {
-			return codexControlPlaneVintage{}
-		}
-		resolved, err := filepath.EvalSymlinks(executable)
-		if err != nil {
-			resolved = executable
-		}
-		images, supported := defaultCodexProcessImages()
-		return projectCodexControlPlaneVintage(resolved, os.Getpid(), images, supported)
+		controlPlane, _ := readVintage()
+		return controlPlane
+	}
+	c.projmuxProcessVintage = func() projmuxProcessVintage {
+		_, fleet := readVintage()
+		return fleet
 	}
 	c.readRuntimeHealth = diagnostics.ReadRuntimeHealth
 	c.resolveOperationsPath = func() (string, error) { return diagnostics.DefaultPath(c.getenv, os.UserHomeDir) }
@@ -193,6 +196,7 @@ type doctorReport struct {
 	CodexGenerationPool  *doctorCodexGenerationPool           `json:"codex_generation_pool,omitempty"`
 	CodexPayloadFree     *codexgeneration.Projection          `json:"codex_payload_free_capability,omitempty"`
 	CodexControlPlane    *codexControlPlaneReport             `json:"codex_control_plane,omitempty"`
+	ProcessVintage       *projmuxProcessVintage               `json:"projmux_process_vintage,omitempty"`
 	SessionStateResume   []doctorSessionStateResumeDiagnostic `json:"session_state_resume,omitempty"`
 	SessionStatePrune    string                               `json:"session_state_prune"`
 	Runtime              []doctorFinding                      `json:"runtime"`
@@ -358,6 +362,10 @@ func (c *doctorCommand) evaluateReportForTrigger(section doctorSection, trigger 
 		report.SessionStatePrune = doctorSessionStatePruneGuidance
 	}
 	if section == doctorSectionAll || section == doctorSectionRuntime {
+		if c.projmuxProcessVintage != nil {
+			vintage := c.projmuxProcessVintage()
+			report.ProcessVintage = &vintage
+		}
 		report.Runtime = c.evaluateRuntimeFindings()
 	}
 	if section == doctorSectionAll || section == doctorSectionLogs {
@@ -470,6 +478,7 @@ func writeDoctorText(w io.Writer, report doctorReport, section doctorSection, ve
 	}
 	if section == doctorSectionAll || section == doctorSectionRuntime {
 		writeDoctorFindingsText(&buf, "Runtime", report.Runtime, verbose)
+		writeDoctorProcessVintageText(&buf, report.ProcessVintage)
 	}
 	if section == doctorSectionAll || section == doctorSectionIntegrations {
 		writeDoctorIntegrationsText(&buf, report.AINotifyIntegrations, verbose)
@@ -879,6 +888,7 @@ type doctorJSONReport struct {
 	CodexGenerationPool  *doctorCodexGenerationPool            `json:"codex_generation_pool,omitempty"`
 	CodexPayloadFree     *codexgeneration.Projection           `json:"codex_payload_free_capability,omitempty"`
 	CodexControlPlane    *codexControlPlaneReport              `json:"codex_control_plane,omitempty"`
+	ProcessVintage       *projmuxProcessVintage                `json:"projmux_process_vintage,omitempty"`
 	SessionStateResume   *[]doctorSessionStateResumeDiagnostic `json:"session_state_resume,omitempty"`
 	SessionStatePrune    *string                               `json:"session_state_prune,omitempty"`
 	Runtime              *[]doctorFinding                      `json:"runtime,omitempty"`
@@ -909,6 +919,7 @@ func writeDoctorJSON(w io.Writer, report doctorReport, section doctorSection) er
 	}
 	if section == doctorSectionAll || section == doctorSectionRuntime {
 		out.Runtime = &report.Runtime
+		out.ProcessVintage = report.ProcessVintage
 	}
 	if section == doctorSectionAll || section == doctorSectionLogs {
 		out.Logs = &report.Logs
@@ -1097,6 +1108,52 @@ func doctorControlPlaneVintage(read func() codexControlPlaneVintage) codexContro
 		return codexControlPlaneVintage{}
 	}
 	return read()
+}
+
+// defaultProcessVintageReader takes one process-table read and projects it two
+// ways.
+//
+// One read rather than two, because the projections are counted over the same
+// processes and a report whose Codex line and fleet line were sampled moments
+// apart could print two numbers that disagree about the same broker. Memoizing
+// also keeps an unfiltered `projmux doctor` to a single walk of the table.
+func defaultProcessVintageReader() func() (codexControlPlaneVintage, projmuxProcessVintage) {
+	var once sync.Once
+	var controlPlane codexControlPlaneVintage
+	var fleet projmuxProcessVintage
+	return func() (codexControlPlaneVintage, projmuxProcessVintage) {
+		once.Do(func() {
+			executable, err := os.Executable()
+			if err != nil {
+				return
+			}
+			resolved, err := filepath.EvalSymlinks(executable)
+			if err != nil {
+				resolved = executable
+			}
+			images, supported := defaultCodexProcessImages()
+			controlPlane = projectCodexControlPlaneVintage(resolved, os.Getpid(), images, supported)
+			fleet = projectProjmuxProcessVintage(resolved, os.Getpid(), images, supported)
+		})
+		return controlPlane, fleet
+	}
+}
+
+// writeDoctorProcessVintageText renders how much of the running fleet the last
+// install did not reach.
+//
+// It sits under Runtime rather than in the Codex section because a per-pane
+// supervisor is provider-neutral: it supervises a Claude pane exactly as it
+// supervises a Codex one. The Codex line answers "which image was this
+// diagnosis read from"; this one answers "how many projmux processes are still
+// running the image from before the last install", and merging them would have
+// answered neither.
+func writeDoctorProcessVintageText(buf *bytes.Buffer, vintage *projmuxProcessVintage) {
+	if vintage == nil {
+		return
+	}
+	buf.WriteString("\nProjmux process vintage\n")
+	fmt.Fprintf(buf, "  Children of this executable: %s\n", projmuxProcessVintageText(*vintage))
 }
 
 // writeDoctorCodexControlPlaneText renders the five named control-plane


### PR DESCRIPTION
## Problem

`projmux doctor`'s deployment-vintage line names six processes while thirty-two
children of the same executable are live. Eighteen of the twenty-six it never
mentions are per-pane `internal supervise` supervisors: they match no named
route, resolve to the empty role, and are dropped at a `byRole` lookup with
nothing recording that they were there.

`make install` replaces the file on disk and leaves every running process on the
image it started with, so this line is how an operator finds out that "installed"
is not "deployed". A census that reports a fifth of the fleet reads as
reassurance instead.

Detection only. No process is killed, started, or restarted.

## What changed

**The classifier has no unmatched case.** `internal supervise` is a named role,
and every remaining child of this executable is counted under `other`. A route
this reader has no name for can no longer shrink the total.

**The new roles are not on the Codex line.** That line qualifies the verdicts
printed under it and is read from exactly two processes. A supervisor supervises
a Claude pane exactly as it supervises a Codex one, so naming it a Codex
control-plane role would answer a question the section never asked. `doctor`
carries the fleet answer under `Runtime` as `Projmux process vintage`, and the
two questions read as two questions:

```
Runtime
  Summary: 0 info, 0 warning, 0 error.

Projmux process vintage
  Children of this executable: broker-runtime 1 (current 0, replaced 1); lifecycle-observer 6 (current 1, replaced 5); supervisor 22 (current 4, replaced 18); other 10 (current 3, replaced 7); 31 of 39 run an image the installed build replaced, so they are executing code from before that install

Codex control-plane surfaces
  Diagnosis vintage: broker-runtime 1 (current 0, replaced 1); lifecycle-observer 6 (current 1, replaced 5); a replaced image did not load the installed build, so every verdict below it describes older code
```

**Route matching stops at argv[0] and at a bare `--`.** `projmux agent turn ... --
<text>` carries arbitrary prose, and the delegation prompts on this machine name
`codex-broker serve` and `supervise` in exactly that position. Counting a message
about the broker as a broker is the same class of error in the other direction.

**Both censuses come from one process-table read**, so the two lines can never
disagree about the same process, and both still answer `unknown` where the
platform exposes no table rather than claiming currency.

## Surface constraints held

- No pid, executable path, or argv reaches either rendered line.
  `TestProcessVintageNamesNoProcess` audits both strings for all three.
- No process-kill or process-start call in the diff.
- Darwin still reports `unknown`, never `current`.
- `schema_version` stays 2; `projmux_process_vintage` is an additive optional
  field on the `runtime` projection.

## Verification

`make fmt`, `make fix`, `make test`, `make test-integration`, `make test-e2e`.

Mutants, each confirmed red against the new tests and green when reverted:

| mutant | tests that go red |
| --- | --- |
| drop the `supervise` arm | `TestProjmuxProcessRoleNamesEveryChildIncludingTheOnesItCannotName`, `TestProjmuxProcessVintageCountsEveryChildOfThisExecutable` |
| drop the `other` remainder (unknown routes vanish again) | same two |
| put the supervisor on the Codex line | `TestCodexControlPlaneVintageIgnoresProviderNeutralProcesses`, `TestProjmuxProcessRoleNamesEveryChildIncludingTheOnesItCannotName` |

New tests: `TestProjmuxProcessVintageCountsEveryChildOfThisExecutable`,
`TestCodexControlPlaneVintageIgnoresProviderNeutralProcesses`,
`TestProjmuxProcessRoleNamesEveryChildIncludingTheOnesItCannotName`,
`TestProjmuxProcessRouteWordsStopAtTheArgvSeparator`,
`TestProjmuxProcessVintageReportsAnUnreadableProcessTableAsUnknown`,
`TestProcessVintageNamesNoProcess`,
`TestDoctorSeparatesTheCodexDiagnosisVintageFromTheFleetCensus`.

## Out of scope

Replacement policy — killing, draining, or restarting a long-lived process, and
any `Makefile`/install change — is deliberately absent. This change only makes
the census stop losing people.
