### PR TITLE
feat(codex): emit a version-pair qualification receipt for any declared pair

### DIFF
--- a/.deadcode-must-keep.txt
+++ b/.deadcode-must-keep.txt
@@ -23,6 +23,7 @@ CurrentProtocol	The build's local IPC version window accessor is retained as the
 DecideAuthority	Phase 0 pure five-axis Codex authority decision is retained for the generation-aware projection phase.
 DecideSuccessorResume	Phase 0 pure same-thread old-stop decision is retained for the journaled handover phase.
 DecideTeardownEvent	The pure teardown decision API is retained for lifecycle authority proofs and planned consumers.
+DeclaredGenerationPair	The declared version pair of the generation-pool qualification is retained as the only entry point that turns operator-declared versions into a receipt version pair; no main package reaches it.
 DecodeCapabilityLedger	Test-only installed qualification API retained for strict checked-in capability-ledger validation.
 DecodeQualificationResult	Phase 0 strict content-free generation qualification receipt decoder is retained for later upgrade gates.
 DecodeRecord	Phase 1 strict capability decoder is retained for cache fixed-point and future-schema refusal.
@@ -31,6 +32,7 @@ DirectEndpoint.Health	Test-only installed qualification API retained for canonic
 DirectEndpoint.forceCleanup	Test-only installed qualification helper retained for injected direct startup-failure cleanup proof.
 DirectEndpoint.markClosed	Test-only installed qualification helper retained for single-consumer bounded direct exit finalization proof.
 Discover	The background-context discovery wrapper is retained as a test and compatibility seam.
+EmitGenerationQualificationReceipt	The canonical qualification receipt writer is retained as the single supported receipt exit for the declared-pair harness and its upgrade-request round trip; no main package reaches it.
 Error.Error	Phase 0 bundle refusal renderer is retained as the content-free immutable lease error contract.
 EvaluateQualification	Phase 0 exact-version-pair qualification reducer is retained for installed pool admission gates.
 EvaluateTurnFreeThreadLiveAttach	Test-only installed qualification API retained for method-independent semantic capability reduction.

--- a/.github/workflows/generation-pool-qualification.yml
+++ b/.github/workflows/generation-pool-qualification.yml
@@ -1,0 +1,108 @@
+name: Generation Pool Qualification
+
+# There is deliberately no schedule. The declared-pair qualification needs a
+# credentialed Codex state domain that a GitHub-hosted runner does not have, so
+# a nightly run could only ever report `unsupported`. Dispatch is the trigger,
+# and the lane reaches one terminal typed record on every run regardless.
+on:
+  workflow_dispatch:
+    inputs:
+      old-version:
+        description: Declared old Codex version of the pair under test
+        required: true
+        default: "0.152.0"
+      new-version:
+        description: Declared new Codex version of the pair under test
+        required: true
+        default: "0.152.1"
+
+permissions:
+  contents: read
+
+# A manual observation run queues behind an active one instead of cancelling it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # This real-binary lane is intentionally separate from every required and
+  # aggregate PR context. It reports its own non-required status, uploads the
+  # typed record it produced, and is fail-closed: only a `pass` record — an
+  # actually measured YES receipt for the declared pair — leaves it green.
+  generation-pool-qualification:
+    name: Generation Pool Qualification
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install the declared Codex version pair
+        id: install-pair
+        env:
+          OLD_VERSION: ${{ inputs.old-version }}
+          NEW_VERSION: ${{ inputs.new-version }}
+          NODE_AUTH_TOKEN: ""
+        run: |
+          for version in "$OLD_VERSION" "$NEW_VERSION"; do
+            npm_prefix="${RUNNER_TEMP}/generation-pool-npm/${version}"
+            release_root="${RUNNER_TEMP}/generation-pool-release/${version}-x86_64-unknown-linux-musl"
+            npm install --prefix "$npm_prefix" --ignore-scripts --no-audit --no-fund "@openai/codex@${version}"
+            scripts/stage-installed-codex-release.sh "$npm_prefix" "$release_root" "$version"
+            test "$("$release_root/bin/codex" --version)" = "codex-cli ${version}"
+          done
+
+      - name: Run the declared-pair qualification
+        if: always()
+        env:
+          OLD_VERSION: ${{ inputs.old-version }}
+          NEW_VERSION: ${{ inputs.new-version }}
+          OPENAI_API_KEY: ""
+          CODEX_API_KEY: ""
+          CODEX_TOKEN: ""
+          PROJMUX_CODEX_GENERATION_BUNDLE_TMPDIR: ${{ runner.temp }}
+        run: |
+          release_root="${RUNNER_TEMP}/generation-pool-release"
+          export PROJMUX_CODEX_GENERATION_OLD="${release_root}/${OLD_VERSION}-x86_64-unknown-linux-musl/bin/codex"
+          export PROJMUX_CODEX_GENERATION_NEW="${release_root}/${NEW_VERSION}-x86_64-unknown-linux-musl/bin/codex"
+          scripts/test-generation-pool-qualification.sh \
+            "$OLD_VERSION" \
+            "$NEW_VERSION" \
+            artifacts/generation-pool-qualification
+
+      - name: Upload the typed qualification record
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: generation-pool-qualification-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/generation-pool-qualification
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Require a measured qualified record
+        if: always()
+        run: |
+          outcome="artifacts/generation-pool-qualification/outcome.json"
+          test -f "$outcome"
+          cat "$outcome" >> "$GITHUB_STEP_SUMMARY"
+          python3 -c '
+          import json, sys
+          record = json.load(open(sys.argv[1]))
+          if record["class"] != "pass":
+              sys.exit(
+                  "generation pool qualification did not qualify the declared pair: "
+                  + "class=" + record["class"] + " reason=" + record["reason"]
+              )
+          ' "$outcome"

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -669,12 +669,39 @@
   `TestBundleRefusesNonCanonicalRootsAndVersions` own immutable complete
   release-bundle retention and refusal, including manifest/artifact links and
   noncanonical mutation roots.
-- Opt-in `TestInstalledIsolatedGenerationPoolQualification` is the fixed
-  0.152.0/0.152.1 shared-state conformance. It strips inherited tmux identity,
-  uses one unique private state root and two private sockets, records no
-  provider content or secrets, requires distinct-thread overlap plus the
-  old-stop same-thread barrier, and performs exact cleanup. See
+- Opt-in `TestInstalledIsolatedGenerationPoolQualification` is the
+  declared-pair shared-state conformance. The pair under test comes from
+  `PROJMUX_CODEX_GENERATION_OLD_VERSION`/`_NEW_VERSION` and each declared
+  version must match what its binary reports; the canonical receipt is written
+  to `PROJMUX_CODEX_GENERATION_RECEIPT` before the verdict is asserted, so a
+  refusal is on disk too. It strips inherited tmux identity, uses one unique
+  private state root and two private sockets, records no provider content or
+  secrets, requires distinct-thread overlap plus the old-stop same-thread
+  barrier, and performs exact cleanup. See
   [codex-generation-pool.md](codex-generation-pool.md).
+- `TestDeclaredGenerationPairAcceptsAnyDistinctReceiptVersionPair`,
+  `TestDeclaredGenerationPairRefusesEmptyEqualAndNonVersionTokens`,
+  `TestEmittedReceiptFileRoundTripsToTheIdenticalResult`,
+  `TestEmittedReceiptReplacesAnEarlierVerdictAndRefusesRelativePaths`, and
+  `TestGenerationQualificationSourcesCarryNoVersionLiteral` own the declared
+  pair and the receipt file: any distinct receipt version pair is accepted, the
+  emitted file is `0600` and byte-identical to the canonical result, a rerun
+  never republishes a stale verdict, and neither harness source may pin a
+  version literal again. Only the pair is declared — every evidence boolean and
+  counter stays measured.
+- `TestEmittedQualificationReceiptEntersTheUpgradeRequestVerbatim` carries the
+  emitted receipt file into the `qualification` field of an `agent app-server
+  upgrade --request` document and reloads it through the real request loader.
+  The declared pair, every counter, `Validate`, and `GateQualification` survive
+  the hop, and a tampered evidence counter stops decoding instead of keeping
+  its verdict.
+- `CIWorkflowContractTest.test_generation_pool_lane_is_dispatch_only_and_fail_closed`
+  and `test_generation_pool_runner_types_every_terminal_outcome` own the
+  dispatch-only lane and `scripts/test-generation-pool-qualification.sh`: the
+  lane never schedules, never joins a required aggregate, always uploads its
+  typed record, and is green only on a measured `pass`; the runner refuses a
+  non-version pair before creating any root and still types an unavailable
+  binary as `unsupported`.
 
 ### Codex app-server generation Phase 1 tests
 

--- a/docs/codex-generation-pool.md
+++ b/docs/codex-generation-pool.md
@@ -139,8 +139,27 @@ does not affect a valid lease.
 ## Validation workflow
 
 The deterministic suite is part of `make test`. The real-Codex test is opt-in
-and requires exact 0.152.0 and 0.152.1 standalone executables plus a source
-Codex home containing `auth.json` and `config.toml`:
+and qualifies whichever version pair the operator declares. It needs the two
+standalone executables of that pair plus a source Codex home containing
+`auth.json` and `config.toml`. `scripts/test-generation-pool-qualification.sh`
+owns the isolated roots and always leaves one terminal typed record behind:
+
+```sh
+PROJMUX_CODEX_GENERATION_OLD="/absolute/path/to/old/bin/codex" \
+PROJMUX_CODEX_GENERATION_NEW="/absolute/path/to/new/bin/codex" \
+PROJMUX_CODEX_GENERATION_SOURCE_HOME="/absolute/path/to/source-codex-home" \
+  scripts/test-generation-pool-qualification.sh <old-version> <new-version> artifacts/pair
+```
+
+The runner writes `artifacts/pair/outcome.json` on every exit — `pass`, `fail`,
+`unsupported` when a declared binary or the credentialed state is unavailable,
+or `infra-error` — and `artifacts/pair/receipt.json` whenever the harness
+reached a verdict. Set `PROJMUX_CODEX_GENERATION_BUNDLE_TMPDIR` to place the
+~700 MiB bundle root somewhere other than the temporary directory; the smoke
+root itself must stay there so the private sockets fit `sun_path`.
+
+The test can also be driven directly. Each declared version must match what its
+binary reports, and the receipt path must be absolute:
 
 ```sh
 smoke_root="$(mktemp -d /tmp/projmux-codex-generation-XXXXXX)"
@@ -148,9 +167,12 @@ bundle_root="$(mktemp -d /path/with/at-least-700MiB/projmux-codex-bundles-XXXXXX
 env -u TMUX -u TMUX_PANE \
   PROJMUX_CODEX_GENERATION_SMOKE_ROOT="$smoke_root" \
   PROJMUX_CODEX_GENERATION_BUNDLE_SMOKE_ROOT="$bundle_root" \
-  PROJMUX_CODEX_GENERATION_OLD="/absolute/path/to/0.152.0/bin/codex" \
-  PROJMUX_CODEX_GENERATION_NEW="/absolute/path/to/0.152.1/bin/codex" \
+  PROJMUX_CODEX_GENERATION_OLD="/absolute/path/to/old/bin/codex" \
+  PROJMUX_CODEX_GENERATION_NEW="/absolute/path/to/new/bin/codex" \
+  PROJMUX_CODEX_GENERATION_OLD_VERSION="<old-version>" \
+  PROJMUX_CODEX_GENERATION_NEW_VERSION="<new-version>" \
   PROJMUX_CODEX_GENERATION_SOURCE_HOME="/absolute/path/to/source-codex-home" \
+  PROJMUX_CODEX_GENERATION_RECEIPT="/absolute/path/to/receipt.json" \
   go test ./internal/testutil/codexinstalled \
     -run '^TestInstalledIsolatedGenerationPoolQualification$' -count=1 -v
 ```
@@ -159,6 +181,24 @@ The root must be an empty child of the system temporary directory. The test
 uses two root-contained sockets, performs semantic readiness/completion/exit
 barriers rather than fixed sleeps, removes the leased source directories, and
 deletes only the exact owned root after both children and sockets are gone.
+
+The declared pair is the only operator input. Every evidence boolean and
+counter in the receipt stays measured by the harness, and `Validate` recomputes
+the verdict from that evidence, so editing either a counter or the verdict in
+the file makes it stop decoding rather than pass a stronger claim.
+
+The emitted `receipt.json` is exactly what goes into the `qualification` field
+of an `agent app-server upgrade plan|apply --request <absolute>.json`
+document. The upgrade request requires that receipt's version pair to match the
+exact current and target generation versions, so a receipt qualifies the one
+pair it names and no other.
+
+The `Generation Pool Qualification` workflow is the scheduled-lane counterpart.
+It is `workflow_dispatch`-only and takes the pair as inputs: the qualification
+needs a credentialed Codex state domain, which a GitHub-hosted runner does not
+have, so a nightly run could only ever report `unsupported`. The lane installs
+both declared versions, runs the same script, uploads the typed record, and is
+green only on a measured `pass`.
 
 Payload-free fresh create now has a stronger product boundary than the
 generation model: canonical CLI, shortcut, and default AI intent choose the

--- a/internal/app/codex_upgrade_qualification_receipt_test.go
+++ b/internal/app/codex_upgrade_qualification_receipt_test.go
@@ -1,0 +1,79 @@
+package app
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/core/codexgeneration"
+	"github.com/crevissepartners/projmux/internal/testutil/codexinstalled"
+)
+
+// The emitted receipt file is what an operator embeds in the `qualification`
+// field of `agent app-server upgrade --request`. The upgrade request requires
+// the receipt's version pair to match the exact current/target generations, so
+// the declared pair and every evidence counter must survive the file → request
+// hop byte for byte.
+func TestEmittedQualificationReceiptEntersTheUpgradeRequestVerbatim(t *testing.T) {
+	pair, err := codexinstalled.DeclaredGenerationPair("3.4.5", "3.4.6")
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := codexgeneration.EvaluateQualification(pair, codexgeneration.QualificationEvidence{
+		SharedStateDomain: true, DistinctPrivateEndpoints: true,
+		DistinctThreadCreateTurn: true, DistinctThreadReadList: true, CrashRestart: true,
+		OldStoppedBeforeResume: true, PersistedResumeSnapshot: true,
+		SharedAuthConfigPrivate: true, BundleSourceRemovalLaunch: true,
+		BundleDriftRefused: true, ProtocolMismatchRefused: true,
+	})
+	if result.Verdict != codexgeneration.VerdictYes {
+		t.Fatalf("measured-pass evidence produced %+v", result)
+	}
+
+	directory := t.TempDir()
+	receiptPath := filepath.Join(directory, "receipt.json")
+	if _, err := codexinstalled.EmitGenerationQualificationReceipt(receiptPath, result); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := os.ReadFile(receiptPath) // #nosec G304 -- test-owned temporary receipt.
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	requestPath := filepath.Join(directory, "request.json")
+	document := append(append([]byte(`{"operationRef":"upgrade-one","qualification":`), receipt...), '}')
+	if err := os.WriteFile(requestPath, document, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	command := &codexUpgradeCommand{}
+	request, err := command.loadRequest(requestPath)
+	if err != nil {
+		t.Fatalf("load request carrying the emitted receipt: %v", err)
+	}
+	if request.Qualification != result {
+		t.Fatalf("loaded qualification=%+v, want the emitted receipt %+v", request.Qualification, result)
+	}
+	if request.Qualification.Versions != pair {
+		t.Fatalf("loaded version pair=%+v, want the declared %+v", request.Qualification.Versions, pair)
+	}
+	// The two conditions the upgrade request itself applies to the receipt.
+	if err := request.Qualification.Validate(); err != nil {
+		t.Fatalf("loaded receipt is not self-consistent: %v", err)
+	}
+	if !codexgeneration.GateQualification(request.Qualification).Phase2Ready {
+		t.Fatalf("loaded receipt does not open Phase 2: %+v", request.Qualification)
+	}
+
+	// A tampered counter must not survive as a verdict: evidence is what the
+	// receipt is judged on, so editing it re-decides the verdict and the
+	// receipt stops decoding.
+	tampered := bytes.Replace(receipt, []byte(`"crossThreadWrites": 0`), []byte(`"crossThreadWrites": 1`), 1)
+	if bytes.Equal(tampered, receipt) {
+		t.Fatal("receipt does not carry the crossThreadWrites counter")
+	}
+	if _, err := codexgeneration.DecodeQualificationResult(tampered); err == nil {
+		t.Fatal("a tampered evidence counter kept the yes verdict")
+	}
+}

--- a/internal/testutil/codexinstalled/generation_conformance_installed_test.go
+++ b/internal/testutil/codexinstalled/generation_conformance_installed_test.go
@@ -22,18 +22,27 @@ import (
 )
 
 const (
-	generationSmokeRootEnv  = "PROJMUX_CODEX_GENERATION_SMOKE_ROOT"
-	generationOldEnv        = "PROJMUX_CODEX_GENERATION_OLD"
-	generationNewEnv        = "PROJMUX_CODEX_GENERATION_NEW"
-	generationStateEnv      = "PROJMUX_CODEX_GENERATION_SOURCE_HOME"
-	generationBundleRootEnv = "PROJMUX_CODEX_GENERATION_BUNDLE_SMOKE_ROOT"
+	generationSmokeRootEnv   = "PROJMUX_CODEX_GENERATION_SMOKE_ROOT"
+	generationOldEnv         = "PROJMUX_CODEX_GENERATION_OLD"
+	generationNewEnv         = "PROJMUX_CODEX_GENERATION_NEW"
+	generationOldVersionEnv  = "PROJMUX_CODEX_GENERATION_OLD_VERSION"
+	generationNewVersionEnv  = "PROJMUX_CODEX_GENERATION_NEW_VERSION"
+	generationStateEnv       = "PROJMUX_CODEX_GENERATION_SOURCE_HOME"
+	generationBundleRootEnv  = "PROJMUX_CODEX_GENERATION_BUNDLE_SMOKE_ROOT"
+	generationReceiptPathEnv = "PROJMUX_CODEX_GENERATION_RECEIPT"
 )
 
-// TestInstalledIsolatedGenerationPoolQualification is the fixed 0.152.0 /
-// 0.152.1 Phase 0 conformance gate. It is opt-in because it uses the installed
-// Codex service and performs two bounded, minimal canary turns. The fixture
-// owns only its explicit /tmp root, private sockets, child processes, and copied
-// state. It neither discovers nor mutates the ambient/default daemon or tmux.
+// TestInstalledIsolatedGenerationPoolQualification is the declared-pair Phase 0
+// conformance gate. The pair under test is declared through
+// PROJMUX_CODEX_GENERATION_OLD_VERSION / _NEW_VERSION and its two absolute
+// executables through PROJMUX_CODEX_GENERATION_OLD / _NEW; each binary must
+// report the version declared for it before anything is measured, and the
+// canonical receipt is written to PROJMUX_CODEX_GENERATION_RECEIPT. The pair is
+// the only declared input: every evidence boolean and counter below stays
+// measured by this fixture. It is opt-in because it uses the installed Codex
+// service and performs two bounded, minimal canary turns. The fixture owns only
+// its explicit /tmp root, private sockets, child processes, and copied state. It
+// neither discovers nor mutates the ambient/default daemon or tmux.
 func TestInstalledIsolatedGenerationPoolQualification(t *testing.T) {
 	root, enabled, err := SmokeRoot(generationSmokeRootEnv)
 	if err != nil {
@@ -45,8 +54,16 @@ func TestInstalledIsolatedGenerationPoolQualification(t *testing.T) {
 	if err := validateInheritedEnvironment(); err != nil {
 		t.Fatal(err)
 	}
-	oldBinary := exactGenerationBinary(t, generationOldEnv, "0.152.0")
-	newBinary := exactGenerationBinary(t, generationNewEnv, "0.152.1")
+	pair, err := DeclaredGenerationPair(os.Getenv(generationOldVersionEnv), os.Getenv(generationNewVersionEnv))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptPath := filepath.Clean(strings.TrimSpace(os.Getenv(generationReceiptPathEnv)))
+	if !filepath.IsAbs(receiptPath) {
+		t.Fatalf("%s must be absolute", generationReceiptPathEnv)
+	}
+	oldBinary := exactGenerationBinary(t, generationOldEnv, pair.Old)
+	newBinary := exactGenerationBinary(t, generationNewEnv, pair.New)
 	stateSource := filepath.Clean(strings.TrimSpace(os.Getenv(generationStateEnv)))
 	if !filepath.IsAbs(stateSource) {
 		t.Fatalf("%s must be absolute", generationStateEnv)
@@ -97,8 +114,8 @@ func TestInstalledIsolatedGenerationPoolQualification(t *testing.T) {
 	ledger.recordFilesystem(pathWithin(root, stateDomain), "shared-auth-config")
 
 	protocol := codexbundle.ProtocolRange{Min: 2, Max: 2}
-	oldLease := leaseInstalledBundle(t, filepath.Join(bundleRoot, "bundle-store"), oldBinary, "0.152.0", protocol)
-	newLease := leaseInstalledBundle(t, filepath.Join(bundleRoot, "bundle-store"), newBinary, "0.152.1", protocol)
+	oldLease := leaseInstalledBundle(t, filepath.Join(bundleRoot, "bundle-store"), oldBinary, pair.Old, protocol)
+	newLease := leaseInstalledBundle(t, filepath.Join(bundleRoot, "bundle-store"), newBinary, pair.New, protocol)
 	ledger.recordFilesystem(pathWithin(bundleRoot, oldLease.Root) && pathWithin(bundleRoot, newLease.Root), "bundle-leases")
 	bundleDriftRefused, protocolMismatchRefused := true, true
 	for _, lease := range []codexbundle.Lease{oldLease, newLease} {
@@ -168,8 +185,8 @@ func TestInstalledIsolatedGenerationPoolQualification(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	oldRef := metadata.CodexEndpointRef{StateDomainID: "state-domain-qualification", EndpointGenerationID: "g-0.152.0"}
-	newRef := metadata.CodexEndpointRef{StateDomainID: "state-domain-qualification", EndpointGenerationID: "g-0.152.1"}
+	oldRef := metadata.CodexEndpointRef{StateDomainID: "state-domain-qualification", EndpointGenerationID: "g-" + pair.Old}
+	newRef := metadata.CodexEndpointRef{StateDomainID: "state-domain-qualification", EndpointGenerationID: "g-" + pair.New}
 	if decision := codexgeneration.ApplySuccessorResume(oldRef, newRef, false, true, func() {
 		_, _ = newClient.ResumeThread(ctx, oldThread.ThreadID, workspace, nil)
 	}); decision != codexgeneration.ResumeOwnerStillLive {
@@ -215,14 +232,14 @@ func TestInstalledIsolatedGenerationPoolQualification(t *testing.T) {
 		CrossThreadWrites: crossThreadWrites, StoreCorruptions: storeCorruptions, LiveOwnerResumeWrites: liveOwnerResumeWrites,
 		OldStoppedBeforeResume: true, PersistedResumeSnapshot: true,
 		SharedAuthConfigPrivate:   sharedConfigPrivate(t, stateDomain),
-		BundleSourceRemovalLaunch: bundleLaunches && bundleVersionTuple == "0.152.0/0.152.1",
+		BundleSourceRemovalLaunch: bundleLaunches && bundleVersionTuple == pair.Old+"/"+pair.New,
 		BundleDriftRefused:        bundleDriftRefused, ProtocolMismatchRefused: protocolMismatchRefused, AmbientMutations: ambientMutations,
 	}
-	result := codexgeneration.EvaluateQualification(codexgeneration.VersionPair{Old: "0.152.0", New: "0.152.1"}, evidence)
-	if result.Verdict != codexgeneration.VerdictYes {
-		t.Fatalf("generation qualification: %+v", result)
-	}
-	raw, err := result.JSON()
+	result := codexgeneration.EvaluateQualification(pair, evidence)
+	// The receipt is emitted before the verdict is asserted: a refusal is
+	// exactly the outcome a consumer needs on disk, and the emitted bytes are
+	// the same ones an upgrade request embeds verbatim.
+	raw, err := EmitGenerationQualificationReceipt(receiptPath, result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +247,10 @@ func TestInstalledIsolatedGenerationPoolQualification(t *testing.T) {
 	if err != nil || reopened != result {
 		t.Fatalf("content-free receipt reopen=%+v err=%v", reopened, err)
 	}
-	t.Logf("generation-qualification=%s", raw)
+	t.Logf("generation-qualification=%s receipt=%s", raw, receiptPath)
+	if result.Verdict != codexgeneration.VerdictYes {
+		t.Fatalf("generation qualification: %+v", result)
+	}
 
 	if err := os.RemoveAll(root); err != nil {
 		t.Fatal(err)

--- a/internal/testutil/codexinstalled/generation_qualification_pair.go
+++ b/internal/testutil/codexinstalled/generation_qualification_pair.go
@@ -1,0 +1,80 @@
+package codexinstalled
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/crevissepartners/projmux/internal/core/codexgeneration"
+)
+
+// Declared version-pair and receipt wiring for the isolated generation-pool
+// qualification.
+//
+// These helpers carry two things and nothing else: which version pair the
+// operator declares is under test, and the canonical receipt out of the test
+// process. Every evidence field stays measured by the harness itself. No
+// evidence boolean or counter is ever sourced from an environment variable, a
+// flag, or a constant, and neither helper touches the verdict.
+
+// DeclaredGenerationPair resolves the declared old/new version pair.
+//
+// Validity is decided by the product's own receipt rule rather than a second
+// copy of the version-token grammar: an all-zero evidence set evaluates to a
+// self-consistent receipt, so Validate reports exactly the version-token
+// verdict and nothing else.
+func DeclaredGenerationPair(oldVersion, newVersion string) (codexgeneration.VersionPair, error) {
+	pair := codexgeneration.VersionPair{Old: strings.TrimSpace(oldVersion), New: strings.TrimSpace(newVersion)}
+	if pair.Old == pair.New {
+		return codexgeneration.VersionPair{}, fmt.Errorf("declared generation pair must name two different versions, got %q twice", pair.Old)
+	}
+	if err := codexgeneration.EvaluateQualification(pair, codexgeneration.QualificationEvidence{}).Validate(); err != nil {
+		return codexgeneration.VersionPair{}, fmt.Errorf("declared generation pair %q/%q is not a receipt version pair", pair.Old, pair.New)
+	}
+	return pair, nil
+}
+
+// EmitGenerationQualificationReceipt writes the canonical receipt to path and
+// returns the exact bytes written.
+//
+// The bytes are the receipt's own canonical encoding, so the file content is
+// byte-identical to what a consumer embeds in the `qualification` field of an
+// `agent app-server upgrade --request` document. The file is replaced on every
+// run so a repeated qualification can never publish a stale verdict, and it is
+// reopened through DecodeQualificationResult before returning so an unreadable
+// or non-round-tripping receipt fails here instead of at the upgrade gate.
+func EmitGenerationQualificationReceipt(path string, result codexgeneration.QualificationResult) ([]byte, error) {
+	receipt := filepath.Clean(strings.TrimSpace(path))
+	if !filepath.IsAbs(receipt) {
+		return nil, fmt.Errorf("generation qualification receipt path must be absolute, got %q", path)
+	}
+	raw, err := result.JSON()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(receipt), 0o700); err != nil {
+		return nil, err
+	}
+	if err := os.Remove(receipt); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+	if err := os.WriteFile(receipt, raw, 0o600); err != nil {
+		return nil, err
+	}
+	written, err := os.ReadFile(receipt) // #nosec G304 -- exact caller-declared receipt path.
+	if err != nil {
+		return nil, err
+	}
+	reopened, err := codexgeneration.DecodeQualificationResult(written)
+	if err != nil {
+		return nil, fmt.Errorf("emitted generation qualification receipt does not reopen: %w", err)
+	}
+	if reopened != result || !bytes.Equal(written, raw) {
+		return nil, errors.New("emitted generation qualification receipt is not byte-identical to the canonical result")
+	}
+	return written, nil
+}

--- a/internal/testutil/codexinstalled/generation_qualification_pair_test.go
+++ b/internal/testutil/codexinstalled/generation_qualification_pair_test.go
@@ -1,0 +1,138 @@
+package codexinstalled
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/crevissepartners/projmux/internal/core/codexgeneration"
+)
+
+// qualifiedEvidence is the all-measured-pass evidence shape. It exists only so
+// these wiring tests have a receipt to carry; the harness never builds its
+// evidence from a literal like this.
+func qualifiedEvidence() codexgeneration.QualificationEvidence {
+	return codexgeneration.QualificationEvidence{
+		SharedStateDomain: true, DistinctPrivateEndpoints: true,
+		DistinctThreadCreateTurn: true, DistinctThreadReadList: true, CrashRestart: true,
+		CrossThreadWrites: 0, StoreCorruptions: 0, LiveOwnerResumeWrites: 0,
+		OldStoppedBeforeResume: true, PersistedResumeSnapshot: true,
+		SharedAuthConfigPrivate: true, BundleSourceRemovalLaunch: true,
+		BundleDriftRefused: true, ProtocolMismatchRefused: true, AmbientMutations: 0,
+	}
+}
+
+func TestDeclaredGenerationPairAcceptsAnyDistinctReceiptVersionPair(t *testing.T) {
+	for _, declared := range [][2]string{
+		{"0.152.0", "0.152.1"},
+		{"0.153.0", "0.153.2"},
+		{"1.0.0", "2.0.0-1"},
+		{"  9.9.9  ", "10.0.0"},
+	} {
+		pair, err := DeclaredGenerationPair(declared[0], declared[1])
+		if err != nil {
+			t.Fatalf("declared pair %q/%q: %v", declared[0], declared[1], err)
+		}
+		result := codexgeneration.EvaluateQualification(pair, qualifiedEvidence())
+		if result.Verdict != codexgeneration.VerdictYes || result.Versions != pair {
+			t.Fatalf("declared pair %+v produced %+v", pair, result)
+		}
+		if err := result.Validate(); err != nil {
+			t.Fatalf("declared pair %+v receipt is invalid: %v", pair, err)
+		}
+	}
+}
+
+func TestDeclaredGenerationPairRefusesEmptyEqualAndNonVersionTokens(t *testing.T) {
+	for _, declared := range [][2]string{
+		{"", "0.152.1"},
+		{"0.152.0", ""},
+		{"0.152.0", "0.152.0"},
+		{"   ", "\t"},
+		{"v0.152.0", "0.152.1"},
+		{"0.152.0", "0.152 1"},
+		{"0.152.0", "0.152.1;rm"},
+	} {
+		if pair, err := DeclaredGenerationPair(declared[0], declared[1]); err == nil {
+			t.Fatalf("declared pair %q/%q was accepted as %+v", declared[0], declared[1], pair)
+		}
+	}
+}
+
+func TestEmittedReceiptFileRoundTripsToTheIdenticalResult(t *testing.T) {
+	pair, err := DeclaredGenerationPair("7.1.0", "7.2.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := codexgeneration.EvaluateQualification(pair, qualifiedEvidence())
+	path := filepath.Join(t.TempDir(), "nested", "receipt.json")
+	raw, err := EmitGenerationQualificationReceipt(path, result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, err := os.ReadFile(path) // #nosec G304 -- test-owned temporary receipt.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(stored, raw) {
+		t.Fatalf("emitted bytes differ from the file: file=%q returned=%q", stored, raw)
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("receipt mode=%v err=%v, want 0600", info.Mode().Perm(), err)
+	}
+	reopened, err := codexgeneration.DecodeQualificationResult(stored)
+	if err != nil || reopened != result {
+		t.Fatalf("receipt reopen=%+v err=%v, want %+v", reopened, err, result)
+	}
+}
+
+func TestEmittedReceiptReplacesAnEarlierVerdictAndRefusesRelativePaths(t *testing.T) {
+	pair, err := DeclaredGenerationPair("7.1.0", "7.2.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "receipt.json")
+	refused := codexgeneration.EvaluateQualification(pair, codexgeneration.QualificationEvidence{})
+	if refused.Verdict != codexgeneration.VerdictNo {
+		t.Fatalf("zero evidence verdict=%s, want no", refused.Verdict)
+	}
+	if _, err := EmitGenerationQualificationReceipt(path, refused); err != nil {
+		t.Fatal(err)
+	}
+	qualified := codexgeneration.EvaluateQualification(pair, qualifiedEvidence())
+	if _, err := EmitGenerationQualificationReceipt(path, qualified); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := os.ReadFile(path) // #nosec G304 -- test-owned temporary receipt.
+	if err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := codexgeneration.DecodeQualificationResult(stored)
+	if err != nil || reopened != qualified {
+		t.Fatalf("rerun receipt reopen=%+v err=%v, want the fresh verdict %+v", reopened, err, qualified)
+	}
+	if _, err := EmitGenerationQualificationReceipt("relative/receipt.json", qualified); err == nil {
+		t.Fatal("relative receipt path was accepted")
+	}
+}
+
+// The declared pair is the only place a version may appear. A literal in either
+// source file would silently pin the harness to one pair again.
+func TestGenerationQualificationSourcesCarryNoVersionLiteral(t *testing.T) {
+	version := regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+`)
+	for _, name := range []string{
+		"generation_conformance_installed_test.go",
+		"generation_qualification_pair.go",
+	} {
+		source, err := os.ReadFile(name) // #nosec G304 -- closed list of package sources.
+		if err != nil {
+			t.Fatal(err)
+		}
+		if found := version.FindAll(source, -1); found != nil {
+			t.Fatalf("%s pins version literals %q", name, found)
+		}
+	}
+}

--- a/scripts/test-generation-pool-qualification.sh
+++ b/scripts/test-generation-pool-qualification.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs the declared-pair isolated generation-pool qualification and always
+# leaves one terminal typed record behind.
+#
+# The runner declares nothing about the outcome. It only names which version
+# pair is under test, owns the two isolated roots it creates, and carries the
+# canonical receipt out. Every evidence boolean and counter stays measured by
+# the harness itself.
+
+usage() {
+	echo "usage: $0 <old-version> <new-version> <output-dir>" >&2
+	exit 2
+}
+
+(($# == 3)) || usage
+old_version="$1"
+new_version="$2"
+output_dir="$3"
+
+for declared in "$old_version" "$new_version"; do
+	case "$declared" in
+	'' | *[!0-9.-]*)
+		echo "declared version is not a receipt version token: '$declared'" >&2
+		exit 2
+		;;
+	esac
+done
+if [ "$old_version" = "$new_version" ]; then
+	echo "declared pair must name two different versions, got '$old_version' twice" >&2
+	exit 2
+fi
+
+mkdir -p "$output_dir"
+output_dir="$(cd "$output_dir" && pwd)"
+receipt="$output_dir/receipt.json"
+outcome="$output_dir/outcome.json"
+rm -f "$receipt" "$outcome"
+
+attempted="false"
+class="infra-error"
+reason="runner-aborted"
+smoke_root=""
+bundle_root=""
+
+finish() {
+	local status=$?
+	local emitted=""
+	if [ -f "$receipt" ]; then
+		emitted="receipt.json"
+	fi
+	if [ -n "$smoke_root" ]; then
+		rm -rf "$smoke_root"
+	fi
+	if [ -n "$bundle_root" ]; then
+		rm -rf "$bundle_root"
+	fi
+	cat >"$outcome" <<JSON
+{
+  "schemaVersion": 1,
+  "versions": {"old": "$old_version", "new": "$new_version"},
+  "attempted": $attempted,
+  "class": "$class",
+  "reason": "$reason",
+  "receipt": "$emitted"
+}
+JSON
+	echo "generation-pool-qualification class=$class reason=$reason receipt=${emitted:-none}" >&2
+	exit "$status"
+}
+trap finish EXIT
+
+unsupported() {
+	class="unsupported"
+	reason="$1"
+	exit 0
+}
+
+old_binary="${PROJMUX_CODEX_GENERATION_OLD:-}"
+new_binary="${PROJMUX_CODEX_GENERATION_NEW:-}"
+source_home="${PROJMUX_CODEX_GENERATION_SOURCE_HOME:-${CODEX_HOME:-$HOME/.codex}}"
+
+[ -x "$old_binary" ] || unsupported "declared-old-binary-unavailable"
+[ -x "$new_binary" ] || unsupported "declared-new-binary-unavailable"
+for name in auth.json config.toml; do
+	[ -s "$source_home/$name" ] || unsupported "credentialed-state-unavailable"
+done
+
+# Both roots are short children of the temporary directory: the harness refuses
+# a root outside it, and the private sockets it binds inside must stay within
+# the 108-byte sun_path limit.
+smoke_root="$(mktemp -d "${TMPDIR:-/tmp}/pmxgq-XXXXXX")"
+bundle_root="$(mktemp -d "${PROJMUX_CODEX_GENERATION_BUNDLE_TMPDIR:-${TMPDIR:-/tmp}}/pmxgb-XXXXXX")"
+
+attempted="true"
+class="fail"
+reason="harness-refused"
+env -u TMUX -u TMUX_PANE \
+	PROJMUX_CODEX_GENERATION_SMOKE_ROOT="$smoke_root" \
+	PROJMUX_CODEX_GENERATION_BUNDLE_SMOKE_ROOT="$bundle_root" \
+	PROJMUX_CODEX_GENERATION_OLD="$old_binary" \
+	PROJMUX_CODEX_GENERATION_NEW="$new_binary" \
+	PROJMUX_CODEX_GENERATION_OLD_VERSION="$old_version" \
+	PROJMUX_CODEX_GENERATION_NEW_VERSION="$new_version" \
+	PROJMUX_CODEX_GENERATION_SOURCE_HOME="$source_home" \
+	PROJMUX_CODEX_GENERATION_RECEIPT="$receipt" \
+	go test ./internal/testutil/codexinstalled \
+	-run '^TestInstalledIsolatedGenerationPoolQualification$' -count=1 -v -timeout 30m
+
+class="pass"
+reason="qualified"

--- a/test/ci_workflow_contract_test.py
+++ b/test/ci_workflow_contract_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -103,6 +104,93 @@ class CIWorkflowContractTest(unittest.TestCase):
         # can neither replace fake C01 nor flow into either stable aggregate.
         for stable_aggregate in (e2e_required, required_test):
             self.assertNotIn("installed-codex", stable_aggregate)
+
+    def test_generation_pool_lane_is_dispatch_only_and_fail_closed(self) -> None:
+        ci_workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        workflow = (
+            ROOT / ".github/workflows/generation-pool-qualification.yml"
+        ).read_text(encoding="utf-8")
+        lane = workflow_job(workflow, "generation-pool-qualification")
+        e2e_required = workflow_job(ci_workflow, "e2e-tests")
+        required_test = workflow_job(ci_workflow, "test")
+
+        # A credentialed state domain is what this lane needs and what a hosted
+        # runner lacks, so it is dispatched, never scheduled.
+        self.assertIn("  workflow_dispatch:", workflow)
+        self.assertNotIn("  schedule:", workflow)
+        self.assertNotIn("    - cron:", workflow)
+        self.assertIn("  cancel-in-progress: false", workflow)
+        self.assertNotIn("  generation-pool-qualification:", ci_workflow)
+
+        # The pair is declared per run, never pinned in the lane.
+        for declared in ("old-version", "new-version"):
+            self.assertIn(f"      {declared}:", workflow)
+        self.assertIn("          OLD_VERSION: ${{ inputs.old-version }}", lane)
+        self.assertIn("          NEW_VERSION: ${{ inputs.new-version }}", lane)
+
+        self.assertIn(
+            'npm install --prefix "$npm_prefix" --ignore-scripts --no-audit '
+            '--no-fund "@openai/codex@${version}"',
+            lane,
+        )
+        self.assertIn("scripts/stage-installed-codex-release.sh", lane)
+        self.assertIn("scripts/test-generation-pool-qualification.sh", lane)
+        self.assertIn('          OPENAI_API_KEY: ""', lane)
+        self.assertIn('          CODEX_API_KEY: ""', lane)
+        self.assertIn('          CODEX_TOKEN: ""', lane)
+
+        self.assertIn("      - name: Upload the typed qualification record", lane)
+        self.assertIn("          path: artifacts/generation-pool-qualification", lane)
+        self.assertIn("          if-no-files-found: error", lane)
+        self.assertIn("          retention-days: 14", lane)
+        self.assertIn("      - name: Require a measured qualified record", lane)
+        self.assertIn('record["class"] != "pass"', lane)
+
+        # The volatile real-binary lane can never flow into a stable aggregate.
+        for stable_aggregate in (e2e_required, required_test):
+            self.assertNotIn("generation-pool-qualification", stable_aggregate)
+
+    def test_generation_pool_runner_types_every_terminal_outcome(self) -> None:
+        runner = ROOT / "scripts/test-generation-pool-qualification.sh"
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "artifacts"
+
+            # A declared pair that is not a receipt version pair is refused
+            # before any root is created, so no record is written.
+            for arguments in (
+                ["v1.2.3", "1.2.4"],
+                ["1.2.3", "1.2.3"],
+                ["1.2.3", "1.2 4"],
+            ):
+                refused = subprocess.run(
+                    ["bash", str(runner), *arguments, str(output)],
+                    cwd=ROOT,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(refused.returncode, 2, refused.stderr)
+
+            # An unavailable declared binary still reaches one typed record.
+            unsupported = subprocess.run(
+                ["bash", str(runner), "1.2.3", "1.2.4", str(output)],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "PROJMUX_CODEX_GENERATION_OLD": str(output / "absent-old"),
+                    "PROJMUX_CODEX_GENERATION_NEW": str(output / "absent-new"),
+                },
+            )
+            self.assertEqual(unsupported.returncode, 0, unsupported.stderr)
+            record = json.loads((output / "outcome.json").read_text(encoding="utf-8"))
+            self.assertEqual(record["versions"], {"old": "1.2.3", "new": "1.2.4"})
+            self.assertFalse(record["attempted"])
+            self.assertEqual(record["class"], "unsupported")
+            self.assertEqual(record["reason"], "declared-old-binary-unavailable")
+            self.assertEqual(record["receipt"], "")
 
     def test_native_platform_payload_stages_as_canonical_release(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## What

`TestInstalledIsolatedGenerationPoolQualification` already performed the seven shared-state conformance items and counted all fifteen evidence fields into a canonical `QualificationResult`. Three things were missing around it: the version pair was a literal, the receipt left the process only through `t.Logf`, and no lane ever ran it. This wires those three.

That receipt is the exact value an `agent app-server upgrade plan|apply --request` document must carry in its `qualification` field, and the upgrade request requires the receipt's pair to equal the exact current/target generation versions — so a receipt qualifies only the pair it names, and the pinning was the bottleneck.

## Changes

- **Declared pair.** `PROJMUX_CODEX_GENERATION_OLD_VERSION` / `_NEW_VERSION` declare the pair beside the absolute binaries already passed that way. Every removed literal — head comment, `exactGenerationBinary`, `leaseInstalledBundle`, both `CodexEndpointRef` ids, the `bundleVersionTuple` comparison, and `VersionPair{}` — now reads the declared pair, and each binary must report the version declared for it before anything is measured.
- **Receipt file.** `PROJMUX_CODEX_GENERATION_RECEIPT` names an absolute path. The receipt is emitted *before* the verdict is asserted, so a refusal lands on disk too, and it is reopened through `DecodeQualificationResult` inside the emitter so a receipt that cannot round-trip fails at the harness instead of at the upgrade gate.
- **Lane.** `Generation Pool Qualification` is `workflow_dispatch`-only and takes the pair as inputs. It installs both declared versions, runs `scripts/test-generation-pool-qualification.sh`, uploads the typed record, and is green only on a measured `pass`. There is no schedule on purpose: the qualification needs a credentialed Codex state domain that a GitHub-hosted runner does not have, so a nightly run could only ever report `unsupported`.
- **Runner.** `scripts/test-generation-pool-qualification.sh` owns the isolated roots and always leaves one terminal typed record behind — `pass`, `fail`, `unsupported`, or `infra-error` — plus `receipt.json` whenever the harness reached a verdict.

## Evidence stays measured

The pair is the only declared input. No evidence boolean or counter is sourced from an env var, flag, or constant, and `EvaluateQualification` / `Validate` are untouched: the verdict is still recomputed from evidence and compared, so a tampered counter makes the receipt stop decoding rather than carry a stronger claim.

`DeclaredGenerationPair` deliberately validates through the product's own receipt rule rather than a second copy of the version-token grammar.

## Verification

Ran the harness for real against two locally installed standalone releases, using a pair that is **not** the removed literals:

```
versions: {"old": "0.153.0", "new": "0.153.2"}
verdict:  yes / qualified
evidence: 15/15 measured, all counters 0
```

That is a measured YES receipt for an arbitrary declared pair, written to a file and round-tripped.

The same runner against `0.152.0`/`0.152.1` (the pair the harness used to pin) refuses on this host, and so does `0.152.0`/`0.153.2`, both at the canary turn. Cause is environmental and predates this change: the source `config.toml` pins a model that 0.152.x cannot use, and the service answers HTTP 400 `The '<model>' model requires a newer version of Codex`. Confirmed with a direct `codex exec` probe on 0.152.0 (fails) and 0.153.0 (succeeds).

Local gates on this head: `make fmt`, `make fix` green. `make test` green except `TestSharedPaneRoutingRealTmux`, which fails identically on this host with this branch's `internal/app` addition removed, so it is not from this change.

## Not in scope

The seven-item verification logic, `codexhandover/coordinator.go` qualification blocking, `codex_generation_doctor.go`, running qualification against a live pool, and any pool `apply`/`resume`.
