### PR TITLE
feat(install): report the long-lived processes an install left behind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /projmux
 /.bin/
 /dist/
+/npm/.install-residue-reported

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ install: build
 	}
 	@echo ">> reconciling notify queue..."
 	@$(INSTALL_BIN) notification reconcile || true
+	@PROJMUX_INSTALLER=make $(INSTALL_BIN) internal install-residue || true
 
 npm-pack:
 	scripts/package-npm.sh --pack

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1486,6 +1486,74 @@ writers on the same shared-host path, `applyAIStatusInternalWithActivationPolicy
 and `markAIHookPane`, still issue unrouted tmux calls and discard their errors,
 so their failures are invisible rather than fixed.
 
+### Install residue census tests
+
+`make install` and `npm install` replace the executable and leave every
+long-lived projmux child on the image it started with. `projmux internal
+install-residue` measures how much of the fleet that is, appends one record to
+`install-residue.jsonl`, and prints at most one stderr notice; see
+[operational-diagnostics.md](operational-diagnostics.md#install-residue-ledger)
+for the ledger format and the mapping from its fields to the questions a
+bounded drain of those processes has to answer.
+
+The deliverable is the measurement, not the message, so the tests are weighted
+toward the record rather than the wording.
+
+- `TestProjmuxProcessVintageMeasuresTheResidualAgeDistribution` owns the age
+  half of the census: only replaced-image processes contribute an age, the
+  distribution is stored ascending and whole, and a clock that moved backwards
+  floors at zero rather than reporting a process started after the census that
+  observed it.
+- `TestProjmuxProcessVintageKeepsAnUnknownStartTimeOutOfTheDistribution` owns
+  both halves of the unknown case: the process still counts as residue, and no
+  age is invented for it.
+- `TestProjmuxProcessVintageCapsOneRoleAgeDistribution` owns the per-role sample
+  bound and pins that a census which hit it says so, rather than reporting a
+  prefix as a whole distribution.
+- `TestDoctorProcessVintageProjectionCarriesNoAges` keeps `projmux doctor`'s
+  record exactly what it was: the age fields populate only when a caller
+  supplies a reference instant.
+- `TestProcessImageListerReadsAPlausibleStartTime` (Linux) covers the one part
+  a synthetic process table cannot. A reader that silently returned the zero
+  time would leave every distribution empty, which is indistinguishable from a
+  platform where start times are unknowable.
+- `TestInstallResidueReportsPerRoleResidualCountsAndAges` owns the record
+  field-for-field, including the per-role distribution being as long as that
+  role's residual count and ascending.
+- `TestInstallResidueZeroResidualPrintsNothing` owns the boundary that keeps the
+  notice worth reading: an install that reached the whole fleet prints
+  absolutely nothing, and still records that it did.
+- `TestInstallResidueUnsupportedPlatformPrintsNothingButRecordsTheGap` owns the
+  macOS path: no terminal output where the census cannot be taken, and a
+  `supported:false` record so the coverage gap is measured rather than absent.
+- `TestInstallResidueCarriesNoProcessIdentity` is the privacy gate, asserted
+  negatively over the rendered notice and the ledger bytes at once: sentinel
+  pids, executable path, and argv appear in neither.
+- `TestInstallResidueLedgerAppendsAndDerivesTheInstallGap` owns the frequency
+  half — records accumulate and each carries the gap to the one before it.
+- `TestInstallResidueLedgerRotatesAtItsRecordBound` owns growth: the oldest rows
+  go, the newest stay, and the file keeps mode `0600` across the rotation.
+- `TestInstallResidueNoticeOrdersRolesByResidualCount` and
+  `TestInstallResidueNoticeTiesBreakOnTheCensusRoleOrder` own the render
+  contract: biggest residual first, census role order on a tie, zero-residual
+  roles omitted entirely.
+- `TestInstallResidueAgeTextRendersDurationsAnOperatorReads` owns the duration
+  format, the median of both odd and even distributions, and the unknown case,
+  which must not render as a zero age.
+- `TestInstallResidueNeverFailsAnInstall` owns the hard edge: an unresolvable
+  state directory, an unwritable ledger, and the route entrypoint itself all end
+  in a silent success.
+- `TestInstallResidueInstallerComesFromTheExistingEnvVar` pins that installer
+  identity is read from `PROJMUX_INSTALLER` and that no new `PROJMUX_*` variable
+  is introduced, since any such variable is a minor-release input to the hook
+  contract.
+- `TestInstallResidueRouteIsRegisteredAsInternalPlumbing` pins the spelling the
+  installer invokes and keeps the census out of the legacy hook migration path.
+
+Nothing in this feature terminates, starts, signals, or restarts a process.
+The census is two file reads per process; replacing the residual processes is a
+separate decision this measurement exists to inform.
+
 ## Review Checklist
 - The branch stays within its stated scope.
 - The change preserves boundaries between portable `projmux` behavior and local machine policy.

--- a/docs/npm-distribution.md
+++ b/docs/npm-distribution.md
@@ -20,6 +20,37 @@ npm-specific guidance. npm is only an update/install source label here; the
 keybinding flow remains `projmux shell` first, then `projmux setup` and
 `projmux setup terminal` only for terminals that swallow shortcuts.
 
+## Install residue notice
+
+There is no `postinstall` script in this package, and there is no plan to add
+one. A lifecycle script is skipped by `--ignore-scripts` and by many global and
+CI installs, and npm buffers or reorders its output unless
+`--foreground-scripts`. The bin shim cannot be skipped — it *is* the entrypoint
+— and it writes straight to the user's terminal.
+
+So the shim carries the install residue notice
+([operational-diagnostics.md](operational-diagnostics.md#install-residue-ledger)).
+`npm install -g projmux` and `npm update` delete and rewrite the package
+directory, so a missing `npm/.install-residue-reported` watermark inside that
+directory *is* the "this install is new" signal — no fingerprinting, no second
+copy of the Go side's XDG path logic in JavaScript, and nothing written outside
+the package directory. The watermark is not in the published `files` list, so
+it never ships in a tarball.
+
+On the first run after an install, if stderr is a TTY, the shim creates the
+watermark and then — **after** the user's command has finished, so the notice is
+the last thing on screen and never delays or interleaves with the real command
+— runs `projmux internal install-residue`. A non-TTY run (a hook, CI, a pipe)
+does nothing and leaves the watermark missing, so the next interactive run is
+the one that reports; the notice should land on a run a human is looking at. If
+the watermark cannot be written the notice is never shown, so an unwritable
+package directory cannot produce it on every invocation forever. None of this
+can change the shim's exit code.
+
+The trade-off is deliberate: for npm the notice appears on the first
+interactive run after the install rather than during `npm install` itself. The
+ledger's `at` timestamp is the install-detection moment either way.
+
 ## Local Packaging
 
 Build and dry-run pack all npm packages:

--- a/docs/operational-diagnostics.md
+++ b/docs/operational-diagnostics.md
@@ -353,3 +353,106 @@ JSON schema version 2 and the bounded operations decoder are reused rather than
 duplicated. AI ingest contributes count-only allowlisted source/result rows,
 never raw legacy lines. Existing output files survive collisions and partial
 temporary archives are removed.
+
+## Install residue ledger
+
+`make install` and `npm install` replace the executable on disk. Neither
+replaces the image of a process that is already running, so every long-lived
+projmux child — the Codex broker runtime, the lifecycle observers, the per-pane
+supervisors — keeps executing the code it started with until it exits on its
+own. The install reports success while most of the running fleet is still on
+the previous build.
+
+`projmux internal install-residue` is the census of exactly that. It is hidden
+internal plumbing invoked by the installer, not a command to type: `make
+install` runs it as its last step, and the npm bin wrapper runs it once on the
+first interactive run after an install. It reads the process table, appends one
+record, prints at most one notice, and always exits `0` — a diagnostic that can
+fail the install it reports on is worse than no diagnostic.
+
+The notice goes to **stderr** and is printed only when the census was taken and
+found residual processes:
+
+```
+>> 24 projmux processes are still running the image this install replaced
+     supervisor          20   oldest 3h02m   median 45m
+     lifecycle-observer   3   oldest 2h14m   median 41m
+     broker-runtime       1   oldest 2h14m   median 2h14m
+   They keep executing code from before this install until each one exits.
+   Recreating a pane moves that pane onto the installed build; the broker
+   follows when its last binding goes.
+   Recorded to ~/.local/state/projmux/install-residue.jsonl (17 installs, last 38m ago).
+```
+
+An install that reached the whole fleet prints nothing at all. A platform with
+no readable process table (macOS, which has no `/proc/<pid>/exe`) also prints
+nothing: the census cannot be taken there and the operator has no action
+available, so a line at every install would be permanent noise. Both cases
+still write a record.
+
+### Ledger format
+
+The path is `${XDG_STATE_HOME:-$HOME/.local/state}/projmux/install-residue.jsonl`,
+resolved through the same `internal/config` layout as every other state file.
+It is JSON Lines, appended one object per install, created `0600` in the
+private state directory, and trimmed to approximately the newest 1000 records.
+Every failure — an unresolvable state directory, an unwritable file — is
+silent.
+
+```json
+{
+  "at": "2026-09-06T04:12:33Z",
+  "installer": "make",
+  "supported": true,
+  "observed": 41,
+  "replaced": 37,
+  "sinceLastInstallSeconds": 3612,
+  "roles": [
+    {"role":"supervisor","processes":22,"current":2,"replaced":20,
+     "replacedAgeSeconds":[610,1200,4300,8800]}
+  ]
+}
+```
+
+| field | meaning |
+| --- | --- |
+| `at` | when the census was taken, RFC3339 UTC |
+| `installer` | the existing `PROJMUX_INSTALLER` value; `unknown` when unset |
+| `supported` | whether this platform exposes a process table the census can be taken from |
+| `observed` | projmux processes classified |
+| `replaced` | how many of them run the image this install replaced |
+| `sinceLastInstallSeconds` | gap to the previous record; absent on the first |
+| `roles[].role` | `broker-runtime`, `lifecycle-observer`, `supervisor`, or `other` |
+| `roles[].processes` / `current` / `replaced` | that role's census |
+| `roles[].replacedAgeSeconds` | ascending age distribution of that role's residual processes, whole seconds |
+| `roles[].replacedAgeCapped` | present when the 512-sample per-role bound was reached, so the distribution above is a prefix |
+
+The record carries **no pid, no executable path, and no argv**, on the terminal
+and in the file alike. Counts and durations are the whole of it; process
+identity is exactly what the census is built not to record. A residual process
+whose start time could not be read is still counted in `replaced` and
+contributes no entry to `replacedAgeSeconds`, so that array can be shorter than
+`replaced`.
+
+Ages come from the modification time of `/proc/<pid>`, which the kernel stamps
+at process creation and never moves. That is chosen over `/proc/<pid>/stat`
+field 22 plus `/proc/stat` `btime` because it needs no `USER_HZ` assumption, no
+boot-time read, and no parsing around the `comm` field, which is an executable
+name in parentheses and may itself contain `)` and spaces.
+
+### What the ledger is for
+
+The ledger is the deliverable; the notice is a courtesy. An automatic
+replacement of residual processes cannot be designed without a termination
+condition for the drain, and these three fields are what such a condition is
+derived from:
+
+| field | the question it answers |
+| --- | --- |
+| `roles[].replaced` (per role) | what to make a replacement target |
+| `roles[].replacedAgeSeconds` (the full sorted distribution, not a mean) | does a bounded drain finish in finite time, and what cutoff `T` covers which fraction |
+| `at` + `sinceLastInstallSeconds` across records | how often this happens per install, hence whether a forced cutoff is needed at all |
+
+A mean would destroy the second answer: twenty supervisors averaging forty
+minutes says nothing about the one that outlives every plausible bound. That is
+why the distribution is stored whole.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -644,7 +644,7 @@ func shouldRunLegacyHookMigrations(args []string) bool {
 			return false
 		}
 	case "internal":
-		if len(args) >= 2 && args[1] == "codex-generation-launch" {
+		if len(args) >= 2 && (args[1] == "codex-generation-launch" || args[1] == "install-residue") {
 			return false
 		}
 	case "current", "kill", "notify", "sessions", "session-state", "tag", "upgrade", "usage",

--- a/internal/app/codex_controlplane_vintage.go
+++ b/internal/app/codex_controlplane_vintage.go
@@ -3,7 +3,9 @@ package app
 import (
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
+	"time"
 )
 
 // The binary vintage of one live projmux process, as a diagnostics reader can
@@ -83,14 +85,44 @@ type codexProcessImage struct {
 	PID     int
 	Exe     string
 	Cmdline []string
+	// StartedAt is when this process began, zero when the reader could not
+	// establish it. It is not process identity: it carries no pid, no path,
+	// and no argv, and it is the only fact that answers how long a process
+	// that an install left behind has already been running.
+	StartedAt time.Time
 }
 
+// projmuxProcessRoleAgeSampleLimit bounds how many residual ages one role
+// carries.
+//
+// The distribution is the point, so this sits far above any plausible fleet;
+// it exists only so that a pathological process table cannot make one record
+// unbounded. A census that hit the bound says so rather than silently
+// reporting a truncated distribution as a whole one.
+const projmuxProcessRoleAgeSampleLimit = 512
+
 // projmuxProcessRoleVintage is the vintage census of one process role.
+//
+// Role/Processes/Current/Replaced are the counts a diagnosis renders. The two
+// age fields are the residual measurement: they are populated only when a
+// caller asks for them by supplying a reference instant, so the diagnosis
+// projection is byte-identical to what it was before they existed.
 type projmuxProcessRoleVintage struct {
 	Role      string `json:"role"`
 	Processes int    `json:"processes"`
 	Current   int    `json:"current"`
 	Replaced  int    `json:"replaced"`
+	// ReplacedAgeSeconds is the ascending age distribution of this role's
+	// replaced-image processes, in whole seconds.
+	//
+	// A distribution rather than a mean: the question a bounded drain has to
+	// answer is "what fraction of these outlive T", and a mean cannot answer
+	// it. A replaced process whose start time was unreadable contributes no
+	// sample, so this can be shorter than Replaced.
+	ReplacedAgeSeconds []int `json:"replacedAgeSeconds,omitempty"`
+	// ReplacedAgeCapped reports that the sample bound was reached and the
+	// distribution above is therefore a prefix, not the whole of it.
+	ReplacedAgeCapped bool `json:"replacedAgeCapped,omitempty"`
 }
 
 // codexControlPlaneVintage is the whole answer to "is the diagnosis I am about
@@ -167,7 +199,7 @@ func projectCodexControlPlaneVintage(self string, selfPID int, images []codexPro
 	}
 	return codexControlPlaneVintage{
 		Supported: true,
-		Roles:     censusProjmuxProcessImages(self, selfPID, images, codexControlPlaneRoleOrder, codexControlPlaneRole),
+		Roles:     censusProjmuxProcessImages(self, selfPID, images, codexControlPlaneRoleOrder, codexControlPlaneRole, time.Time{}),
 	}
 }
 
@@ -178,12 +210,25 @@ func projectCodexControlPlaneVintage(self string, selfPID int, images []codexPro
 // and the number an operator needs is how many processes that is — not how many
 // of them happen to sit on a route this reader has a name for.
 func projectProjmuxProcessVintage(self string, selfPID int, images []codexProcessImage, supported bool) projmuxProcessVintage {
+	return projectProjmuxProcessVintageAt(self, selfPID, images, supported, time.Time{})
+}
+
+// projectProjmuxProcessVintageAt is the same projection with the residual age
+// distribution measured against now.
+//
+// A zero now means "count only", which is what a diagnosis wants: `projmux
+// doctor` renders counts and would gain nothing from an age column, and
+// leaving its record untouched keeps the rendered section and its JSON exactly
+// as they were. The install residue census supplies a real instant because the
+// whole question it exists to answer -- can a bounded drain of these processes
+// finish in finite time -- is a question about their ages.
+func projectProjmuxProcessVintageAt(self string, selfPID int, images []codexProcessImage, supported bool, now time.Time) projmuxProcessVintage {
 	if !supported {
 		return projmuxProcessVintage{}
 	}
 	return projmuxProcessVintage{
 		Supported: true,
-		Roles:     censusProjmuxProcessImages(self, selfPID, images, projmuxProcessRoleOrder, projmuxProcessRole),
+		Roles:     censusProjmuxProcessImages(self, selfPID, images, projmuxProcessRoleOrder, projmuxProcessRole, now),
 	}
 }
 
@@ -205,6 +250,7 @@ func censusProjmuxProcessImages(
 	images []codexProcessImage,
 	order []string,
 	roleOf func([]string) string,
+	now time.Time,
 ) []projmuxProcessRoleVintage {
 	self = strings.TrimSpace(self)
 	byRole := map[string]*projmuxProcessRoleVintage{}
@@ -226,17 +272,36 @@ func censusProjmuxProcessImages(
 			continue
 		}
 		census.Processes++
-		if replaced {
-			census.Replaced++
-		} else {
+		if !replaced {
 			census.Current++
+			continue
 		}
+		census.Replaced++
+		if now.IsZero() || image.StartedAt.IsZero() {
+			// No reference instant, or a start time this platform could not
+			// establish. The process is still counted as residual; only its
+			// age is unknown, and inventing one would put a number into the
+			// distribution that no drain bound could be read from.
+			continue
+		}
+		if len(census.ReplacedAgeSeconds) >= projmuxProcessRoleAgeSampleLimit {
+			census.ReplacedAgeCapped = true
+			continue
+		}
+		// A clock that moved backwards between the two reads floors at zero.
+		// A negative age would read as a process started after the census
+		// that observed it.
+		age := max(int(now.Sub(image.StartedAt)/time.Second), 0)
+		census.ReplacedAgeSeconds = append(census.ReplacedAgeSeconds, age)
 	}
 	var rows []projmuxProcessRoleVintage
 	for _, role := range order {
-		if census := byRole[role]; census.Processes > 0 {
-			rows = append(rows, *census)
+		census := byRole[role]
+		if census.Processes == 0 {
+			continue
 		}
+		sort.Ints(census.ReplacedAgeSeconds)
+		rows = append(rows, *census)
 	}
 	return rows
 }

--- a/internal/app/codex_controlplane_vintage_linux.go
+++ b/internal/app/codex_controlplane_vintage_linux.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // codexProcessScanLimit bounds one process-table read. A diagnostics section
@@ -43,7 +44,12 @@ func defaultCodexProcessImages() ([]codexProcessImage, bool) {
 		if err != nil || strings.TrimSpace(exe) == "" {
 			continue
 		}
-		images = append(images, codexProcessImage{PID: pid, Exe: exe, Cmdline: readProcCmdline(entry.Name())})
+		images = append(images, codexProcessImage{
+			PID:       pid,
+			Exe:       exe,
+			Cmdline:   readProcCmdline(entry.Name()),
+			StartedAt: readProcStartedAt(entry.Name()),
+		})
 	}
 	return images, true
 }
@@ -71,4 +77,31 @@ func readProcCmdline(pid string) []string {
 		}
 	}
 	return kept
+}
+
+// readProcStartedAt reads when one process started, and the zero time when that
+// cannot be established.
+//
+// The source is the modification time of /proc/<pid> itself. The kernel stamps
+// that directory when it creates the process and never moves it afterwards, so
+// it is the process's start instant with one-second resolution. Verified on
+// this machine against `ps -o etimes=` for three live long-lived projmux
+// children: agreement within one second in all three.
+//
+// Chosen over the classic /proc/<pid>/stat field 22 plus /proc/stat btime
+// arithmetic because that path needs a USER_HZ assumption, a second file read
+// for boot time, and parsing around the comm field -- which is an executable
+// name in parentheses and may itself contain ')' and spaces, the standard way
+// /proc/<pid>/stat parsers get the field offsets wrong. Second resolution is
+// far below what the question needs: a drain bound is chosen in minutes and
+// hours, not in milliseconds.
+//
+// This reads a directory's metadata. It opens nothing the process owns, writes
+// nothing, and signals nothing.
+func readProcStartedAt(pid string) time.Time {
+	info, err := os.Stat("/proc/" + pid)
+	if err != nil {
+		return time.Time{}
+	}
+	return info.ModTime()
 }

--- a/internal/app/codex_controlplane_vintage_linux_test.go
+++ b/internal/app/codex_controlplane_vintage_linux_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestProcessImageListerReadsTheLiveTable covers the one part of the vintage
@@ -50,5 +51,44 @@ func TestProcessImageListerReadsTheLiveTable(t *testing.T) {
 	}
 	if len(found.Cmdline) == 0 {
 		t.Fatal("own argv read as empty, which would classify every process into no control-plane role")
+	}
+}
+
+// TestProcessImageListerReadsAPlausibleStartTime covers the one part of the age
+// signal that a synthetic process table cannot.
+//
+// The projection over the ages is pinned thoroughly above, but a reader that
+// silently returned the zero time would leave every distribution empty and the
+// install residue ledger would carry counts with no ages -- which reads exactly
+// like a platform where start times are unknowable, forever.
+//
+// The claim is deliberately loose. The exact instant is the kernel's, and this
+// test only proves the reader produced a start time that belongs to a process
+// this test run started: not zero, not in the future, and not older than this
+// machine has been up.
+func TestProcessImageListerReadsAPlausibleStartTime(t *testing.T) {
+	images, supported := defaultCodexProcessImages()
+	if !supported {
+		t.Fatal("the process table was unreadable on a platform that has one")
+	}
+	var self *codexProcessImage
+	for index, image := range images {
+		if image.PID == os.Getpid() {
+			self = &images[index]
+			break
+		}
+	}
+	if self == nil {
+		t.Fatalf("the reader listed %d process(es) and not itself", len(images))
+	}
+	if self.StartedAt.IsZero() {
+		t.Fatal("own start time read as zero, which would leave every residual age distribution silently empty")
+	}
+	now := time.Now()
+	if self.StartedAt.After(now.Add(time.Second)) {
+		t.Fatalf("own start time = %s, which is after the census that observed it (%s)", self.StartedAt, now)
+	}
+	if age := now.Sub(self.StartedAt); age > 24*time.Hour {
+		t.Fatalf("own start time = %s, an age of %s for a process this test run started", self.StartedAt, age)
 	}
 }

--- a/internal/app/codex_controlplane_vintage_test.go
+++ b/internal/app/codex_controlplane_vintage_test.go
@@ -2,10 +2,12 @@ package app
 
 import (
 	"bytes"
+	"encoding/json"
 	"reflect"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestControlPlaneVintageSeparatesAReplacedImageFromTheInstalledBuild is the
@@ -433,5 +435,155 @@ func TestDoctorSeparatesTheCodexDiagnosisVintageFromTheFleetCensus(t *testing.T)
 	codexHeading := strings.Index(text, "\nCodex control-plane surfaces\n")
 	if fleetHeading < 0 || codexHeading < 0 || fleetHeading > codexHeading {
 		t.Fatalf("doctor text = %q, want the fleet census as its own block outside the Codex section", text)
+	}
+}
+
+// TestProjmuxProcessVintageMeasuresTheResidualAgeDistribution is the age half
+// of the install residue measurement.
+//
+// A bounded drain of the processes an install left behind can only be designed
+// against how long those processes have already been alive, and the shape of
+// that answer has to be the distribution: a mean over twenty supervisors says
+// nothing about the one that outlives every plausible bound. Ages are collected
+// only for the replaced processes -- a current-image process is not residue and
+// has nothing to drain.
+func TestProjmuxProcessVintageMeasuresTheResidualAgeDistribution(t *testing.T) {
+	const self = "/home/user/go/bin/projmux"
+	now := time.Date(2026, 9, 6, 4, 12, 33, 0, time.UTC)
+	images := []codexProcessImage{
+		{PID: 100, Exe: self, Cmdline: []string{self, "doctor"}, StartedAt: now.Add(-time.Second)},
+		{
+			PID: 200, Exe: self + procDeletedSuffix,
+			Cmdline:   []string{self, "internal", "codex-broker", "serve"},
+			StartedAt: now.Add(-2*time.Hour - 14*time.Minute),
+		},
+		{
+			PID: 400, Exe: self + procDeletedSuffix,
+			Cmdline:   []string{self, "internal", "supervise", "--pane-uid", "pane-a"},
+			StartedAt: now.Add(-3*time.Hour - 2*time.Minute),
+		},
+		{
+			PID: 401, Exe: self + procDeletedSuffix,
+			Cmdline:   []string{self, "internal", "supervise", "--pane-uid", "pane-b"},
+			StartedAt: now.Add(-41 * time.Second),
+		},
+		// A current-image supervisor. It is not residue, so it contributes no
+		// age even though its start time is perfectly readable.
+		{
+			PID: 402, Exe: self,
+			Cmdline:   []string{self, "internal", "supervise", "--pane-uid", "pane-c"},
+			StartedAt: now.Add(-9 * time.Hour),
+		},
+		// A clock that moved backwards between the two reads. Zero is the
+		// honest floor; a negative age would read as a process started after
+		// the census that observed it.
+		{
+			PID: 403, Exe: self + procDeletedSuffix,
+			Cmdline:   []string{self, "internal", "supervise", "--pane-uid", "pane-d"},
+			StartedAt: now.Add(5 * time.Second),
+		},
+	}
+	fleet := projectProjmuxProcessVintageAt(self, 100, images, true, now)
+	want := projmuxProcessVintage{Supported: true, Roles: []projmuxProcessRoleVintage{
+		{Role: codexControlPlaneRoleBroker, Processes: 1, Replaced: 1, ReplacedAgeSeconds: []int{8040}},
+		{
+			Role: projmuxProcessRoleSupervisor, Processes: 4, Current: 1, Replaced: 3,
+			ReplacedAgeSeconds: []int{0, 41, 10920},
+		},
+	}}
+	if !reflect.DeepEqual(fleet, want) {
+		t.Fatalf("fleet vintage = %+v, want %+v", fleet, want)
+	}
+}
+
+// TestProjmuxProcessVintageKeepsAnUnknownStartTimeOutOfTheDistribution pins
+// that a process whose start time could not be read still counts as residue and
+// still contributes no age.
+//
+// Both halves matter. Dropping the process would report the install as having
+// left less behind than it did; inventing an age for it would put a number into
+// the distribution a drain bound is read from that no observation supports.
+func TestProjmuxProcessVintageKeepsAnUnknownStartTimeOutOfTheDistribution(t *testing.T) {
+	const self = "/opt/projmux"
+	now := time.Date(2026, 9, 6, 4, 12, 33, 0, time.UTC)
+	fleet := projectProjmuxProcessVintageAt(self, 1, []codexProcessImage{
+		{PID: 2, Exe: self + procDeletedSuffix, Cmdline: []string{self, "internal", "supervise"}},
+		{
+			PID: 3, Exe: self + procDeletedSuffix,
+			Cmdline:   []string{self, "internal", "supervise"},
+			StartedAt: now.Add(-10 * time.Minute),
+		},
+	}, true, now)
+	want := []projmuxProcessRoleVintage{
+		{Role: projmuxProcessRoleSupervisor, Processes: 2, Replaced: 2, ReplacedAgeSeconds: []int{600}},
+	}
+	if !reflect.DeepEqual(fleet.Roles, want) {
+		t.Fatalf("roles = %+v, want %+v", fleet.Roles, want)
+	}
+	if fleet.Replaced() != 2 {
+		t.Fatalf("replaced = %d, want both residual processes counted", fleet.Replaced())
+	}
+}
+
+// TestProjmuxProcessVintageCapsOneRoleAgeDistribution keeps a pathological
+// process table from making one record unbounded, and makes the census say that
+// the distribution it carries is a prefix rather than the whole of it.
+func TestProjmuxProcessVintageCapsOneRoleAgeDistribution(t *testing.T) {
+	const self = "/opt/projmux"
+	now := time.Date(2026, 9, 6, 4, 12, 33, 0, time.UTC)
+	images := []codexProcessImage{{PID: 1, Exe: self, Cmdline: []string{self, "doctor"}}}
+	for index := range projmuxProcessRoleAgeSampleLimit + 7 {
+		images = append(images, codexProcessImage{
+			PID: 1000 + index, Exe: self + procDeletedSuffix,
+			Cmdline:   []string{self, "internal", "supervise"},
+			StartedAt: now.Add(-time.Duration(index+1) * time.Second),
+		})
+	}
+	fleet := projectProjmuxProcessVintageAt(self, 1, images, true, now)
+	if len(fleet.Roles) != 1 {
+		t.Fatalf("roles = %+v, want one supervisor role", fleet.Roles)
+	}
+	role := fleet.Roles[0]
+	if role.Replaced != projmuxProcessRoleAgeSampleLimit+7 {
+		t.Fatalf("replaced = %d, want every residual process still counted", role.Replaced)
+	}
+	if len(role.ReplacedAgeSeconds) != projmuxProcessRoleAgeSampleLimit {
+		t.Fatalf("ages = %d, want the sample bound of %d", len(role.ReplacedAgeSeconds), projmuxProcessRoleAgeSampleLimit)
+	}
+	if !role.ReplacedAgeCapped {
+		t.Fatal("the census hit its sample bound and did not say so, which reports a prefix as a whole distribution")
+	}
+}
+
+// TestDoctorProcessVintageProjectionCarriesNoAges pins that the diagnosis
+// projection is untouched by the residual measurement.
+//
+// `projmux doctor` renders counts and its record is read by other surfaces. The
+// age fields are populated only when a caller supplies a reference instant, so
+// the doctor projection stays exactly the record it was.
+func TestDoctorProcessVintageProjectionCarriesNoAges(t *testing.T) {
+	const self = "/opt/projmux"
+	now := time.Date(2026, 9, 6, 4, 12, 33, 0, time.UTC)
+	images := []codexProcessImage{
+		{PID: 1, Exe: self, Cmdline: []string{self, "doctor"}},
+		{
+			PID: 2, Exe: self + procDeletedSuffix,
+			Cmdline:   []string{self, "internal", "supervise"},
+			StartedAt: now.Add(-time.Hour),
+		},
+	}
+	fleet := projectProjmuxProcessVintage(self, 1, images, true)
+	want := []projmuxProcessRoleVintage{{Role: projmuxProcessRoleSupervisor, Processes: 1, Replaced: 1}}
+	if !reflect.DeepEqual(fleet.Roles, want) {
+		t.Fatalf("doctor roles = %+v, want %+v", fleet.Roles, want)
+	}
+	body, err := json.Marshal(fleet)
+	if err != nil {
+		t.Fatalf("marshal fleet vintage: %v", err)
+	}
+	for _, absent := range []string{"replacedAgeSeconds", "replacedAgeCapped"} {
+		if strings.Contains(string(body), absent) {
+			t.Fatalf("doctor vintage JSON = %s, want %q absent", body, absent)
+		}
 	}
 }

--- a/internal/app/install_residue.go
+++ b/internal/app/install_residue.go
@@ -1,0 +1,476 @@
+package app
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/config"
+	localstate "github.com/crevissepartners/projmux/internal/state"
+)
+
+// The install residue census: how much of the running fleet an install did not
+// reach, measured at the moment the install finished.
+//
+// `make install` and `npm install` replace the executable on disk. Neither
+// replaces the image of a process that is already running, so every long-lived
+// projmux child keeps executing the code it started with until it exits on its
+// own. The operator is never told, and `projmux doctor` is a place they have no
+// reason to look right after an install that reported success.
+//
+// This route is the measurement, not the message. Three numbers have to survive
+// it, because a later automatic-replacement design cannot choose a drain
+// termination condition without them: how many residual processes there are per
+// role, how old they are as a distribution, and how often an install leaves any
+// behind at all. The terminal line is a courtesy; the ledger is the deliverable.
+//
+// Nothing in this file terminates, starts, signals, or restarts a process. The
+// census is two file reads per process and the report is text.
+const (
+	// installResidueLedgerFile is the append ledger, under the projmux state
+	// directory alongside the other JSON Lines journals.
+	installResidueLedgerFile = "install-residue.jsonl"
+	// installResidueLedgerRecords bounds how many install records the ledger
+	// keeps. Frequency is read across records, so the history has to be long
+	// enough to carry many installs and bounded so it cannot grow without end.
+	installResidueLedgerRecords = 1000
+	// installResidueLedgerReadLimit bounds one ledger read. A ledger larger
+	// than this is read from its tail, which is the end every derived number
+	// comes from anyway.
+	installResidueLedgerReadLimit = 8 << 20
+	// installResidueLedgerLineLimit bounds one ledger row while scanning.
+	installResidueLedgerLineLimit = 1 << 20
+)
+
+// installResidueRecord is one install's census, as one JSON Lines row.
+//
+// It carries counts and durations only. No pid, no executable path, no argv,
+// and no provider content reaches this file: process identity is exactly what
+// the census is built to avoid recording, and the fields below are the whole
+// record.
+type installResidueRecord struct {
+	// At is when the census was taken, in RFC3339 UTC. Across records this is
+	// how often an install leaves residue behind.
+	At string `json:"at"`
+	// Installer is the install path that produced this record, from the
+	// existing PROJMUX_INSTALLER env var. Unset reads as "unknown".
+	Installer string `json:"installer"`
+	// Supported reports whether this platform exposes a process table the
+	// census can be taken from. A false record is the measurement's own
+	// coverage gap, recorded rather than omitted.
+	Supported bool `json:"supported"`
+	// Observed is how many projmux processes the census classified.
+	Observed int `json:"observed"`
+	// Replaced is how many of them run the image this install replaced.
+	Replaced int `json:"replaced"`
+	// SinceLastInstallSeconds is the gap to the previous record, absent on the
+	// first one.
+	SinceLastInstallSeconds *int64 `json:"sinceLastInstallSeconds,omitempty"`
+	// Roles is the per-role census, including each role's residual age
+	// distribution.
+	Roles []projmuxProcessRoleVintage `json:"roles,omitempty"`
+}
+
+const installerUnknown = "unknown"
+
+// installResidueCommand is the hidden `internal install-residue` route.
+//
+// Every dependency is injected so the whole report -- census, ledger, and
+// rendered text -- is exercised without a process table, a clock, or the real
+// state directory.
+type installResidueCommand struct {
+	now         func() time.Time
+	getenv      func(string) string
+	stateDir    func() (string, error)
+	readVintage func(now time.Time) projmuxProcessVintage
+}
+
+func newInstallResidueCommand() *installResidueCommand {
+	return &installResidueCommand{
+		now:    time.Now,
+		getenv: os.Getenv,
+		stateDir: func() (string, error) {
+			paths, err := config.DefaultPathsFromEnv()
+			if err != nil {
+				return "", err
+			}
+			return paths.StateDir, nil
+		},
+		readVintage: defaultInstallResidueVintage,
+	}
+}
+
+// runInstallResidueReport is the route entrypoint.
+//
+// It always returns nil. This runs as the last step of an install that has
+// already succeeded, and a diagnostic that can fail the thing it reports on is
+// worse than no diagnostic: an unwritable state directory must not turn a
+// completed install into a failed one.
+func runInstallResidueReport(_ []string, _ io.Writer, stderr io.Writer) error {
+	newInstallResidueCommand().Run(stderr)
+	return nil
+}
+
+// Run takes the census, appends the ledger record, and renders the notice.
+//
+// Every failure is swallowed on purpose; see runInstallResidueReport.
+func (c *installResidueCommand) Run(stderr io.Writer) {
+	if c == nil {
+		return
+	}
+	now := time.Now()
+	if c.now != nil {
+		now = c.now()
+	}
+	now = now.UTC()
+
+	vintage := projmuxProcessVintage{}
+	if c.readVintage != nil {
+		vintage = c.readVintage(now)
+	}
+
+	record := installResidueRecord{
+		At:        now.Format(time.RFC3339),
+		Installer: installResidueInstaller(c.getenv),
+		Supported: vintage.Supported,
+		Observed:  vintage.Observed(),
+		Replaced:  vintage.Replaced(),
+		Roles:     vintage.Roles,
+	}
+
+	path := c.ledgerPath()
+	previous, existing := readInstallResidueLedger(path)
+	if !previous.IsZero() {
+		seconds := max(int64(now.Sub(previous)/time.Second), 0)
+		record.SinceLastInstallSeconds = &seconds
+	}
+	written := appendInstallResidueRecord(path, record)
+
+	pointer := ""
+	if written {
+		pointer = renderInstallResiduePointer(path, existing+1, record.SinceLastInstallSeconds)
+	}
+	// An unsupported platform prints nothing. The operator there has no action
+	// available and no way to take the census, so a line at every install would
+	// be permanent noise; the ledger still records that the measurement was
+	// attempted and was impossible, which is the macOS coverage gap a later
+	// replacement design has to know about.
+	if !record.Supported || record.Replaced == 0 || stderr == nil {
+		return
+	}
+	if text := renderInstallResidueNotice(record, pointer); text != "" {
+		_, _ = io.WriteString(stderr, text)
+	}
+}
+
+func (c *installResidueCommand) ledgerPath() string {
+	if c.stateDir == nil {
+		return ""
+	}
+	dir, err := c.stateDir()
+	if err != nil || strings.TrimSpace(dir) == "" {
+		return ""
+	}
+	return filepath.Join(dir, installResidueLedgerFile)
+}
+
+// installResidueInstaller names the install path that produced this record.
+//
+// It reads the existing PROJMUX_INSTALLER variable rather than introducing a
+// new one: the hook contract makes any new PROJMUX_* env var a minor-release
+// input, and this variable already carries exactly this fact.
+func installResidueInstaller(getenv func(string) string) string {
+	if getenv == nil {
+		return installerUnknown
+	}
+	if installer := strings.TrimSpace(getenv("PROJMUX_INSTALLER")); installer != "" {
+		return installer
+	}
+	return installerUnknown
+}
+
+// defaultInstallResidueVintage takes one process-table read and projects the
+// whole-fleet census from it, with residual ages measured against now.
+//
+// A platform with no readable process table, and an executable this process
+// cannot resolve, both report unsupported. Neither can produce a census, and
+// reporting one of them as an empty fleet would claim an install left nothing
+// behind on evidence that says nothing at all.
+func defaultInstallResidueVintage(now time.Time) projmuxProcessVintage {
+	executable, err := os.Executable()
+	if err != nil {
+		return projmuxProcessVintage{}
+	}
+	resolved, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		resolved = executable
+	}
+	images, supported := defaultCodexProcessImages()
+	return projectProjmuxProcessVintageAt(resolved, os.Getpid(), images, supported, now)
+}
+
+// readInstallResidueLedger reports the previous record's instant and how many
+// records the ledger already holds.
+//
+// A missing, unreadable, or malformed ledger reads as no history rather than as
+// an error: the record about to be written is still worth keeping, and the only
+// thing lost is one derived gap.
+func readInstallResidueLedger(path string) (time.Time, int) {
+	if strings.TrimSpace(path) == "" {
+		return time.Time{}, 0
+	}
+	lines, ok := readInstallResidueLedgerLines(path)
+	if !ok {
+		return time.Time{}, 0
+	}
+	previous := time.Time{}
+	for index := len(lines) - 1; index >= 0; index-- {
+		var record installResidueRecord
+		if err := json.Unmarshal(lines[index], &record); err != nil {
+			continue
+		}
+		at, err := time.Parse(time.RFC3339, strings.TrimSpace(record.At))
+		if err != nil {
+			continue
+		}
+		previous = at
+		break
+	}
+	return previous, len(lines)
+}
+
+// readInstallResidueLedgerLines reads the ledger's rows, from its tail when the
+// file is larger than one bounded read.
+func readInstallResidueLedgerLines(path string) ([][]byte, bool) {
+	// #nosec G304 -- the path is resolved from projmux's own state directory.
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, false
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, false
+	}
+	partial := false
+	if info.Size() > installResidueLedgerReadLimit {
+		if _, err := file.Seek(info.Size()-installResidueLedgerReadLimit, io.SeekStart); err != nil {
+			return nil, false
+		}
+		partial = true
+	}
+	var lines [][]byte
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 4096), installResidueLedgerLineLimit)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		lines = append(lines, append([]byte(nil), line...))
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, false
+	}
+	if partial && len(lines) > 0 {
+		// The first row of a tail read may have been cut mid-line.
+		lines = lines[1:]
+	}
+	return lines, true
+}
+
+// appendInstallResidueRecord places one row and reports whether it landed.
+//
+// The common path is a single O_APPEND write. The ledger is rewritten only when
+// it has grown past its bound, and that rewrite goes through a temp file and a
+// rename so a failed trim cannot leave a truncated history behind.
+func appendInstallResidueRecord(path string, record installResidueRecord) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	body, err := json.Marshal(record)
+	if err != nil {
+		return false
+	}
+	if err := localstate.EnsurePrivateDir(filepath.Dir(path)); err != nil {
+		return false
+	}
+	// #nosec G304 -- the path is resolved from projmux's own state directory.
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, localstate.PrivateFileMode)
+	if err != nil {
+		return false
+	}
+	written := true
+	if _, err := file.Write(append(body, '\n')); err != nil {
+		written = false
+	}
+	if err := file.Close(); err != nil {
+		written = false
+	}
+	if written {
+		trimInstallResidueLedger(path)
+	}
+	return written
+}
+
+// trimInstallResidueLedger drops the oldest rows once the ledger is over its
+// record bound. A failure here leaves the ledger longer than the bound, which
+// is strictly better than leaving it damaged.
+func trimInstallResidueLedger(path string) {
+	lines, ok := readInstallResidueLedgerLines(path)
+	if !ok || len(lines) <= installResidueLedgerRecords {
+		return
+	}
+	kept := lines[len(lines)-installResidueLedgerRecords:]
+	var buf bytes.Buffer
+	for _, line := range kept {
+		buf.Write(line)
+		buf.WriteByte('\n')
+	}
+	temp := path + ".trim"
+	// #nosec G306 -- localstate.PrivateFileMode is 0600.
+	if err := os.WriteFile(temp, buf.Bytes(), localstate.PrivateFileMode); err != nil {
+		_ = os.Remove(temp)
+		return
+	}
+	if err := os.Rename(temp, path); err != nil {
+		_ = os.Remove(temp)
+	}
+}
+
+// renderInstallResiduePointer names the ledger and summarizes its history.
+func renderInstallResiduePointer(path string, records int, since *int64) string {
+	installs := "1 install"
+	if records != 1 {
+		installs = fmt.Sprintf("%d installs", records)
+	}
+	if since == nil {
+		return fmt.Sprintf("%s (%s recorded)", path, installs)
+	}
+	return fmt.Sprintf("%s (%s, last %s ago)", path, installs, formatInstallResidueAge(*since))
+}
+
+// renderInstallResidueNotice writes the residual census as the last thing an
+// install prints.
+//
+// Roles are ordered by residual count descending so the biggest one leads, with
+// the census's own role order breaking ties. A role with no residual process is
+// omitted entirely rather than printed as a zero: a zero row is a line an
+// operator has to read to learn there was nothing to read.
+func renderInstallResidueNotice(record installResidueRecord, pointer string) string {
+	rows := installResidueRows(record.Roles)
+	if len(rows) == 0 {
+		return ""
+	}
+	width := 0
+	count := 0
+	for _, row := range rows {
+		if len(row.Role) > width {
+			width = len(row.Role)
+		}
+		if digits := len(fmt.Sprintf("%d", row.Replaced)); digits > count {
+			count = digits
+		}
+	}
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, ">> %d projmux %s still running the image this install replaced\n",
+		record.Replaced, pluralizeInstallResidueProcesses(record.Replaced))
+	for _, row := range rows {
+		fmt.Fprintf(&buf, "     %-*s  %*d   %s\n", width, row.Role, count, row.Replaced, installResidueAgeText(row))
+	}
+	buf.WriteString("   They keep executing code from before this install until each one exits.\n")
+	buf.WriteString("   Recreating a pane moves that pane onto the installed build; the broker\n")
+	buf.WriteString("   follows when its last binding goes.\n")
+	if pointer != "" {
+		fmt.Fprintf(&buf, "   Recorded to %s.\n", pointer)
+	}
+	return buf.String()
+}
+
+func pluralizeInstallResidueProcesses(count int) string {
+	if count == 1 {
+		return "process is"
+	}
+	return "processes are"
+}
+
+// installResidueRows selects the roles with residual processes, biggest first.
+func installResidueRows(roles []projmuxProcessRoleVintage) []projmuxProcessRoleVintage {
+	var rows []projmuxProcessRoleVintage
+	for _, role := range roles {
+		if role.Replaced > 0 {
+			rows = append(rows, role)
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Replaced != rows[j].Replaced {
+			return rows[i].Replaced > rows[j].Replaced
+		}
+		return projmuxProcessRoleRank(rows[i].Role) < projmuxProcessRoleRank(rows[j].Role)
+	})
+	return rows
+}
+
+// projmuxProcessRoleRank is the census's own role order, used to break a tie in
+// residual count.
+func projmuxProcessRoleRank(role string) int {
+	for index, known := range projmuxProcessRoleOrder {
+		if known == role {
+			return index
+		}
+	}
+	return len(projmuxProcessRoleOrder)
+}
+
+// installResidueAgeText renders one role's oldest and median residual age.
+//
+// A role whose start times were all unreadable says so rather than rendering a
+// zero, which would read as processes that had just started.
+func installResidueAgeText(role projmuxProcessRoleVintage) string {
+	ages := role.ReplacedAgeSeconds
+	if len(ages) == 0 {
+		return "age unknown"
+	}
+	oldest := ages[len(ages)-1]
+	text := fmt.Sprintf("oldest %s   median %s",
+		formatInstallResidueAge(int64(oldest)), formatInstallResidueAge(int64(installResidueMedian(ages))))
+	if role.ReplacedAgeCapped || len(ages) < role.Replaced {
+		text += fmt.Sprintf("   (%d of %d timed)", len(ages), role.Replaced)
+	}
+	return text
+}
+
+// installResidueMedian is the median of an ascending age distribution.
+func installResidueMedian(ages []int) int {
+	if len(ages) == 0 {
+		return 0
+	}
+	middle := len(ages) / 2
+	if len(ages)%2 == 1 {
+		return ages[middle]
+	}
+	return (ages[middle-1] + ages[middle]) / 2
+}
+
+// formatInstallResidueAge renders a whole-second age the way an operator reads
+// one: seconds under a minute, minutes under an hour, hours and minutes above.
+func formatInstallResidueAge(seconds int64) string {
+	if seconds < 0 {
+		seconds = 0
+	}
+	if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	}
+	minutes := seconds / 60
+	if minutes < 60 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	return fmt.Sprintf("%dh%02dm", minutes/60, minutes%60)
+}

--- a/internal/app/install_residue_test.go
+++ b/internal/app/install_residue_test.go
@@ -1,0 +1,527 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// installResidueFixture builds a command whose census, clock, installer, and
+// ledger location are all supplied, so the whole route runs without a process
+// table and without the real state directory.
+func installResidueFixture(t *testing.T, now time.Time, installer string, vintage projmuxProcessVintage) (*installResidueCommand, string) {
+	t.Helper()
+	dir := t.TempDir()
+	return &installResidueCommand{
+		now: func() time.Time { return now },
+		getenv: func(name string) string {
+			if name == "PROJMUX_INSTALLER" {
+				return installer
+			}
+			return ""
+		},
+		stateDir:    func() (string, error) { return dir, nil },
+		readVintage: func(time.Time) projmuxProcessVintage { return vintage },
+	}, filepath.Join(dir, installResidueLedgerFile)
+}
+
+func readInstallResidueRecords(t *testing.T, path string) []installResidueRecord {
+	t.Helper()
+	payload, err := os.ReadFile(path) // #nosec G304 -- test-owned temp path.
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	var records []installResidueRecord
+	for line := range strings.SplitSeq(strings.TrimSpace(string(payload)), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var record installResidueRecord
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("ledger row %q is not one JSON object: %v", line, err)
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+// residueFleet is a fleet census with the shape an install actually leaves
+// behind: many supervisors, a few observers, one broker, all of them on the
+// image the install replaced.
+func residueFleet() projmuxProcessVintage {
+	return projmuxProcessVintage{Supported: true, Roles: []projmuxProcessRoleVintage{
+		{Role: codexControlPlaneRoleBroker, Processes: 1, Replaced: 1, ReplacedAgeSeconds: []int{8040}},
+		{Role: codexControlPlaneRoleObserver, Processes: 4, Current: 1, Replaced: 3, ReplacedAgeSeconds: []int{2460, 2470, 8040}},
+		{Role: projmuxProcessRoleSupervisor, Processes: 22, Current: 2, Replaced: 20, ReplacedAgeSeconds: []int{
+			60, 120, 180, 240, 300, 600, 900, 1200, 1800, 2400,
+			3000, 3300, 3600, 4200, 4800, 5400, 6000, 7200, 9000, 10920,
+		}},
+	}}
+}
+
+// TestInstallResidueReportsPerRoleResidualCountsAndAges is the measurement
+// gate.
+//
+// The deliverable of this route is not the sentence, it is the three numbers a
+// later automatic-replacement design has to choose a drain termination
+// condition from: how many residual processes there are per role, how old they
+// are as a distribution, and how often an install leaves any behind. A notice
+// that printed only a warning would satisfy the wording and answer none of
+// them.
+func TestInstallResidueReportsPerRoleResidualCountsAndAges(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 6, 4, 12, 33, 0, time.UTC)
+	cmd, ledger := installResidueFixture(t, now, "make", residueFleet())
+	var stderr bytes.Buffer
+	cmd.Run(&stderr)
+
+	records := readInstallResidueRecords(t, ledger)
+	if len(records) != 1 {
+		t.Fatalf("ledger records = %d, want 1", len(records))
+	}
+	record := records[0]
+	if record.At != "2026-09-06T04:12:33Z" {
+		t.Fatalf("at = %q, want the census instant in RFC3339 UTC", record.At)
+	}
+	if record.Installer != "make" {
+		t.Fatalf("installer = %q, want make", record.Installer)
+	}
+	if !record.Supported {
+		t.Fatalf("supported = false, want the census to report itself as taken")
+	}
+	if record.Observed != 27 || record.Replaced != 24 {
+		t.Fatalf("observed = %d, replaced = %d, want 27 and 24", record.Observed, record.Replaced)
+	}
+	if record.SinceLastInstallSeconds != nil {
+		t.Fatalf("sinceLastInstallSeconds = %d, want it absent on the first record", *record.SinceLastInstallSeconds)
+	}
+	if len(record.Roles) != 3 {
+		t.Fatalf("roles = %d, want the three roles with residual processes", len(record.Roles))
+	}
+	for _, role := range record.Roles {
+		if len(role.ReplacedAgeSeconds) != role.Replaced {
+			t.Fatalf("role %q carried %d ages for %d replaced processes, want the whole distribution",
+				role.Role, len(role.ReplacedAgeSeconds), role.Replaced)
+		}
+		for index := 1; index < len(role.ReplacedAgeSeconds); index++ {
+			if role.ReplacedAgeSeconds[index-1] > role.ReplacedAgeSeconds[index] {
+				t.Fatalf("role %q ages = %v, want them ascending", role.Role, role.ReplacedAgeSeconds)
+			}
+		}
+	}
+
+	text := stderr.String()
+	for _, want := range []string{
+		"24 projmux processes are still running the image this install replaced",
+		"supervisor",
+		"lifecycle-observer",
+		"broker-runtime",
+		"oldest 3h02m",
+		"oldest 2h14m",
+		"median 45m",
+		installResidueLedgerFile,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("notice = %q, want it to contain %q", text, want)
+		}
+	}
+}
+
+// TestInstallResidueZeroResidualPrintsNothing is the boundary that keeps this
+// notice worth reading.
+//
+// An install that reached the whole fleet has nothing to report, and a line
+// printed at every install is a line an operator learns to skip. The ledger
+// still gets its record: "this install left nothing behind" is one of the
+// frequency observations the drain design is derived from.
+func TestInstallResidueZeroResidualPrintsNothing(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 6, 4, 12, 33, 0, time.UTC)
+	cmd, ledger := installResidueFixture(t, now, "make", projmuxProcessVintage{
+		Supported: true,
+		Roles: []projmuxProcessRoleVintage{
+			{Role: projmuxProcessRoleSupervisor, Processes: 3, Current: 3},
+		},
+	})
+	var stderr bytes.Buffer
+	cmd.Run(&stderr)
+
+	if stderr.Len() != 0 {
+		t.Fatalf("notice = %q, want absolutely no output when nothing was left behind", stderr.String())
+	}
+	records := readInstallResidueRecords(t, ledger)
+	if len(records) != 1 {
+		t.Fatalf("ledger records = %d, want the silent install still recorded", len(records))
+	}
+	if records[0].Replaced != 0 || records[0].Observed != 3 || !records[0].Supported {
+		t.Fatalf("record = %+v, want a supported census with zero residual", records[0])
+	}
+}
+
+// TestInstallResidueUnsupportedPlatformPrintsNothingButRecordsTheGap pins the
+// darwin path.
+//
+// There is no /proc there, so the census cannot be taken and the operator has
+// no action available; a line at every install would be permanent noise. The
+// record is still written with supported:false, because the replacement design
+// has to know its macOS coverage gap rather than read an absent record as an
+// install that left nothing behind.
+func TestInstallResidueUnsupportedPlatformPrintsNothingButRecordsTheGap(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 6, 4, 12, 33, 0, time.UTC)
+	cmd, ledger := installResidueFixture(t, now, "npm", projmuxProcessVintage{})
+	var stderr bytes.Buffer
+	cmd.Run(&stderr)
+
+	if stderr.Len() != 0 {
+		t.Fatalf("notice = %q, want no terminal output where the census cannot be taken", stderr.String())
+	}
+	records := readInstallResidueRecords(t, ledger)
+	if len(records) != 1 {
+		t.Fatalf("ledger records = %d, want 1", len(records))
+	}
+	if records[0].Supported {
+		t.Fatalf("supported = true, want the record to say the measurement was impossible")
+	}
+	if records[0].Installer != "npm" {
+		t.Fatalf("installer = %q, want npm", records[0].Installer)
+	}
+	if len(records[0].Roles) != 0 {
+		t.Fatalf("roles = %+v, want no census without a process table", records[0].Roles)
+	}
+}
+
+// TestInstallResidueCarriesNoProcessIdentity is the privacy gate, asserted
+// negatively over both surfaces at once.
+//
+// The census exists because reading /proc/<pid>/exe by hand was the only way to
+// establish this, and the whole reason it is safe to print at every install is
+// that it names nobody. A pid, an executable path, or one word of a caller's
+// argv reaching either the terminal or the ledger would make this a diagnostic
+// that has to be redacted before it is shared.
+func TestInstallResidueCarriesNoProcessIdentity(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sentinelExe  = "/home/user/go/bin/projmux"
+		sentinelArgv = "PANE-SENTINEL-ARGV"
+	)
+	sentinelPIDs := []int{987654, 987655, 987656}
+	now := time.Date(2026, 9, 6, 4, 12, 33, 0, time.UTC)
+	images := []codexProcessImage{
+		{PID: 987650, Exe: sentinelExe, Cmdline: []string{sentinelExe, "doctor"}, StartedAt: now.Add(-time.Minute)},
+		{
+			PID: sentinelPIDs[0], Exe: sentinelExe + procDeletedSuffix,
+			Cmdline:   []string{sentinelExe, "internal", "codex-broker", "serve", "--state-domain", sentinelArgv},
+			StartedAt: now.Add(-2*time.Hour - 14*time.Minute),
+		},
+		{
+			PID: sentinelPIDs[1], Exe: sentinelExe + procDeletedSuffix,
+			Cmdline:   []string{sentinelExe, "internal", "supervise", "--pane-uid", sentinelArgv},
+			StartedAt: now.Add(-55 * time.Minute),
+		},
+		{
+			PID: sentinelPIDs[2], Exe: sentinelExe + procDeletedSuffix,
+			Cmdline:   []string{sentinelExe, "internal", "agent-hook", "ingest", codexNativeLifecycleIngestRoute, "--pane", sentinelArgv},
+			StartedAt: now.Add(-41 * time.Minute),
+		},
+	}
+	fleet := projectProjmuxProcessVintageAt(sentinelExe, 987650, images, true, now)
+	cmd, ledger := installResidueFixture(t, now, "make", fleet)
+	var stderr bytes.Buffer
+	cmd.Run(&stderr)
+
+	payload, err := os.ReadFile(ledger) // #nosec G304 -- test-owned temp path.
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	for name, surface := range map[string]string{"notice": stderr.String(), "ledger": string(payload)} {
+		if strings.Contains(surface, sentinelExe) {
+			t.Fatalf("%s exposed the executable path: %q", name, surface)
+		}
+		if strings.Contains(surface, sentinelArgv) {
+			t.Fatalf("%s exposed caller argv: %q", name, surface)
+		}
+		for _, pid := range sentinelPIDs {
+			if strings.Contains(surface, strconv.Itoa(pid)) {
+				t.Fatalf("%s exposed pid %d: %q", name, pid, surface)
+			}
+		}
+	}
+	if !strings.Contains(stderr.String(), "3 projmux processes are still running") {
+		t.Fatalf("notice = %q, want the residual count that makes this measurement worth taking", stderr.String())
+	}
+}
+
+// TestInstallResidueLedgerAppendsAndDerivesTheInstallGap pins the frequency
+// half of the measurement.
+//
+// "How often does an install leave residue behind" is only answerable across
+// records, so each new row has to land beside the old ones and carry the gap to
+// the one before it. Overwriting would leave one sample and no frequency at
+// all.
+func TestInstallResidueLedgerAppendsAndDerivesTheInstallGap(t *testing.T) {
+	t.Parallel()
+
+	first := time.Date(2026, 9, 6, 3, 12, 21, 0, time.UTC)
+	cmd, ledger := installResidueFixture(t, first, "make", residueFleet())
+	cmd.Run(&bytes.Buffer{})
+
+	cmd.now = func() time.Time { return first.Add(3612 * time.Second) }
+	var stderr bytes.Buffer
+	cmd.Run(&stderr)
+
+	records := readInstallResidueRecords(t, ledger)
+	if len(records) != 2 {
+		t.Fatalf("ledger records = %d, want the second install appended beside the first", len(records))
+	}
+	if records[0].SinceLastInstallSeconds != nil {
+		t.Fatalf("first record carried a gap, want it absent")
+	}
+	if records[1].SinceLastInstallSeconds == nil || *records[1].SinceLastInstallSeconds != 3612 {
+		t.Fatalf("second record gap = %v, want 3612", records[1].SinceLastInstallSeconds)
+	}
+	if !strings.Contains(stderr.String(), "2 installs, last 1h00m ago") {
+		t.Fatalf("notice = %q, want the ledger pointer to carry the install history", stderr.String())
+	}
+}
+
+// TestInstallResidueLedgerRotatesAtItsRecordBound keeps a ledger that is
+// appended to at every install from growing without end, while keeping the
+// newest records, which are the ones every derived number is read from.
+func TestInstallResidueLedgerRotatesAtItsRecordBound(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 6, 4, 12, 33, 0, time.UTC)
+	cmd, ledger := installResidueFixture(t, now, "make", residueFleet())
+
+	var seed bytes.Buffer
+	for index := range installResidueLedgerRecords + 5 {
+		fmt.Fprintf(&seed, "{\"at\":\"2026-01-01T00:00:%02dZ\",\"installer\":\"seed-%d\"}\n", index%60, index)
+	}
+	if err := os.WriteFile(ledger, seed.Bytes(), 0o600); err != nil {
+		t.Fatalf("seed ledger: %v", err)
+	}
+	cmd.Run(&bytes.Buffer{})
+
+	records := readInstallResidueRecords(t, ledger)
+	if len(records) != installResidueLedgerRecords {
+		t.Fatalf("ledger records = %d, want the bound of %d", len(records), installResidueLedgerRecords)
+	}
+	if records[len(records)-1].At != "2026-09-06T04:12:33Z" {
+		t.Fatalf("newest record = %+v, want the install just recorded", records[len(records)-1])
+	}
+	if records[0].Installer == "seed-0" {
+		t.Fatalf("oldest record = %+v, want the oldest rows dropped rather than the newest", records[0])
+	}
+	info, err := os.Stat(ledger)
+	if err != nil {
+		t.Fatalf("stat ledger: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("ledger mode = %v, want 0600 across a rotation", info.Mode().Perm())
+	}
+}
+
+// TestInstallResidueNoticeOrdersRolesByResidualCount pins the render contract:
+// the role with the most residual processes leads, because that is the one an
+// operator acts on first, and a role with none is absent rather than printed as
+// a zero.
+func TestInstallResidueNoticeOrdersRolesByResidualCount(t *testing.T) {
+	t.Parallel()
+
+	notice := renderInstallResidueNotice(installResidueRecord{
+		Supported: true,
+		Replaced:  24,
+		Roles: []projmuxProcessRoleVintage{
+			{Role: codexControlPlaneRoleBroker, Processes: 1, Replaced: 1, ReplacedAgeSeconds: []int{8040}},
+			{Role: codexControlPlaneRoleObserver, Processes: 3, Replaced: 3, ReplacedAgeSeconds: []int{2460, 2470, 8040}},
+			{Role: projmuxProcessRoleSupervisor, Processes: 22, Replaced: 20, ReplacedAgeSeconds: []int{
+				60, 120, 180, 240, 300, 600, 900, 1200, 1800, 2400,
+				3000, 3300, 3600, 4200, 4800, 5400, 6000, 7200, 9000, 10920,
+			}},
+			// A role the install did reach. It has nothing to act on.
+			{Role: projmuxProcessRoleOther, Processes: 4, Current: 4},
+		},
+	}, "")
+
+	if strings.Contains(notice, projmuxProcessRoleOther) {
+		t.Fatalf("notice = %q, want a role with no residual process omitted entirely", notice)
+	}
+	order := []string{projmuxProcessRoleSupervisor, codexControlPlaneRoleObserver, codexControlPlaneRoleBroker}
+	previous := -1
+	for _, role := range order {
+		index := strings.Index(notice, role)
+		if index < 0 {
+			t.Fatalf("notice = %q, want it to name %q", notice, role)
+		}
+		if index < previous {
+			t.Fatalf("notice = %q, want roles ordered by residual count descending", notice)
+		}
+		previous = index
+	}
+	if strings.Contains(notice, "Recorded to") {
+		t.Fatalf("notice = %q, want no ledger pointer when nothing was recorded", notice)
+	}
+}
+
+// TestInstallResidueNoticeTiesBreakOnTheCensusRoleOrder pins that two roles
+// with the same residual count render in the census's own order rather than in
+// whatever order the map iteration produced.
+func TestInstallResidueNoticeTiesBreakOnTheCensusRoleOrder(t *testing.T) {
+	t.Parallel()
+
+	rows := installResidueRows([]projmuxProcessRoleVintage{
+		{Role: projmuxProcessRoleSupervisor, Processes: 2, Replaced: 2},
+		{Role: codexControlPlaneRoleObserver, Processes: 2, Replaced: 2},
+		{Role: codexControlPlaneRoleBroker, Processes: 2, Replaced: 2},
+	})
+	got := []string{rows[0].Role, rows[1].Role, rows[2].Role}
+	want := []string{codexControlPlaneRoleBroker, codexControlPlaneRoleObserver, projmuxProcessRoleSupervisor}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("tie order = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestInstallResidueAgeTextRendersDurationsAnOperatorReads pins the format the
+// oldest and median columns are read in, including the unknown case, which must
+// not render as a zero age.
+func TestInstallResidueAgeTextRendersDurationsAnOperatorReads(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		seconds int64
+		want    string
+	}{
+		{seconds: 0, want: "0s"},
+		{seconds: 41, want: "41s"},
+		{seconds: 59, want: "59s"},
+		{seconds: 60, want: "1m"},
+		{seconds: 3300, want: "55m"},
+		{seconds: 3599, want: "59m"},
+		{seconds: 3600, want: "1h00m"},
+		{seconds: 10920, want: "3h02m"},
+		{seconds: -5, want: "0s"},
+	} {
+		if got := formatInstallResidueAge(test.seconds); got != test.want {
+			t.Fatalf("formatInstallResidueAge(%d) = %q, want %q", test.seconds, got, test.want)
+		}
+	}
+	if got := installResidueAgeText(projmuxProcessRoleVintage{Role: "supervisor", Replaced: 2}); got != "age unknown" {
+		t.Fatalf("age text with no samples = %q, want it to say the ages are unknown", got)
+	}
+	partial := installResidueAgeText(projmuxProcessRoleVintage{Role: "supervisor", Replaced: 4, ReplacedAgeSeconds: []int{60, 120}})
+	if !strings.Contains(partial, "2 of 4 timed") {
+		t.Fatalf("partial age text = %q, want it to say how much of the role it timed", partial)
+	}
+	if got := installResidueMedian([]int{610, 1200, 4300, 8800}); got != 2750 {
+		t.Fatalf("median of an even distribution = %d, want 2750", got)
+	}
+	if got := installResidueMedian([]int{610, 1200, 4300}); got != 1200 {
+		t.Fatalf("median of an odd distribution = %d, want 1200", got)
+	}
+}
+
+// TestInstallResidueNeverFailsAnInstall is acceptance's hard edge.
+//
+// This runs as the last step of an install that has already succeeded. A
+// diagnostic that can turn a completed install into a failed one is worse than
+// no diagnostic at all, so every failure path here -- an unresolvable state
+// directory, an unwritable ledger -- has to end in a silent exit 0.
+func TestInstallResidueNeverFailsAnInstall(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unresolvable state directory", func(t *testing.T) {
+		cmd := &installResidueCommand{
+			now:         time.Now,
+			getenv:      func(string) string { return "" },
+			stateDir:    func() (string, error) { return "", os.ErrNotExist },
+			readVintage: func(time.Time) projmuxProcessVintage { return residueFleet() },
+		}
+		var stderr bytes.Buffer
+		cmd.Run(&stderr)
+		if strings.Contains(stderr.String(), "Recorded to") {
+			t.Fatalf("notice = %q, want no ledger pointer when nothing could be recorded", stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "still running the image this install replaced") {
+			t.Fatalf("notice = %q, want the census still reported without a ledger", stderr.String())
+		}
+	})
+
+	t.Run("unwritable ledger", func(t *testing.T) {
+		dir := t.TempDir()
+		blocked := filepath.Join(dir, "blocked")
+		if err := os.WriteFile(blocked, []byte("not a directory\n"), 0o600); err != nil {
+			t.Fatalf("seed blocker: %v", err)
+		}
+		cmd := &installResidueCommand{
+			now:         time.Now,
+			getenv:      func(string) string { return "" },
+			stateDir:    func() (string, error) { return blocked, nil },
+			readVintage: func(time.Time) projmuxProcessVintage { return residueFleet() },
+		}
+		cmd.Run(&bytes.Buffer{})
+	})
+
+	t.Run("route always exits zero", func(t *testing.T) {
+		if err := runInstallResidueReport(nil, nil, nil); err != nil {
+			t.Fatalf("runInstallResidueReport() error = %v, want nil on every path", err)
+		}
+	})
+}
+
+// TestInstallResidueInstallerComesFromTheExistingEnvVar pins that the installer
+// identity is read from PROJMUX_INSTALLER rather than from a new variable. Any
+// new PROJMUX_* env var is a minor-release input to the hook contract, and this
+// route needs no such input.
+func TestInstallResidueInstallerComesFromTheExistingEnvVar(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		env  string
+		want string
+	}{
+		{env: "make", want: "make"},
+		{env: "npm", want: "npm"},
+		{env: "  github-release  ", want: "github-release"},
+		{env: "", want: installerUnknown},
+	} {
+		got := installResidueInstaller(func(name string) string {
+			if name != "PROJMUX_INSTALLER" {
+				t.Fatalf("read env %q, want only PROJMUX_INSTALLER", name)
+			}
+			return test.env
+		})
+		if got != test.want {
+			t.Fatalf("installer for %q = %q, want %q", test.env, got, test.want)
+		}
+	}
+	if got := installResidueInstaller(nil); got != installerUnknown {
+		t.Fatalf("installer with no environment = %q, want %q", got, installerUnknown)
+	}
+}
+
+// TestInstallResidueRouteIsRegisteredAsInternalPlumbing pins that the census is
+// reachable at the spelling `make install` and the npm wrapper invoke, and that
+// it stays hidden internal plumbing rather than a public command.
+func TestInstallResidueRouteIsRegisteredAsInternalPlumbing(t *testing.T) {
+	t.Parallel()
+
+	if !containsRoute(internalSubcommands, "install-residue") {
+		t.Fatalf("internal subcommands = %v, want install-residue", internalSubcommands)
+	}
+	if shouldRunLegacyHookMigrations([]string{"internal", "install-residue"}) {
+		t.Fatal("the install residue census triggered the legacy hook migration; it is a read-and-record route")
+	}
+}

--- a/internal/app/internal_routes.go
+++ b/internal/app/internal_routes.go
@@ -25,6 +25,7 @@ var internalSubcommands = []string{
 	"activation-exec",
 	"codex-broker",
 	"codex-generation-launch",
+	"install-residue",
 }
 
 // internalAgentHookSubcommands lists the provider hook plumbing routes.
@@ -115,6 +116,13 @@ func (c *internalCommand) Run(args []string, stdout, stderr io.Writer) error {
 		return forwardRawArgv(c.codexBroker, "internal codex-broker", "codex-broker", nil, rest, stdout, stderr)
 	case "codex-generation-launch":
 		return codexgenerationhost.RunDurableLaunchSupervisor(rest)
+	case "install-residue":
+		// The install residue census. It is machine-invoked plumbing -- the
+		// last step of `make install` and of the npm wrapper's first
+		// interactive run after an install -- rather than a command a user
+		// types, which is exactly what this namespace is for. It reads the
+		// process table, appends one ledger row, and never fails.
+		return runInstallResidueReport(rest, stdout, stderr)
 	default:
 		return usageError(fmt.Sprintf("internal %s is not available; this release implements: %s",
 			args[0], strings.Join(internalSubcommands, ", ")))

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -1931,6 +1931,12 @@ var routes = []Route{
 			// user reaches for, and the canonical graph is the surface a
 			// generated reference and a release boundary are built from.
 			"projmux internal codex-broker serve|probe [--state-domain <absolute>] ...",
+			// The install residue census, invoked by `make install` and by the
+			// npm wrapper's first interactive run after an install. Like the
+			// broker runtime it is deliberately absent from the canonical
+			// command projection: it is installer plumbing, not a command
+			// spelling a user reaches for.
+			"projmux internal install-residue",
 		},
 		Canonical: []string{
 			"internal tmux",

--- a/npm/projmux.js
+++ b/npm/projmux.js
@@ -58,6 +58,70 @@ if (!exe) {
   process.exit(1);
 }
 
+// The install residue notice.
+//
+// `npm install -g projmux` replaces the binary on disk and leaves every
+// long-lived projmux process on the image it started with. npm users have no
+// reason to run `projmux doctor`, so without this they are never told.
+//
+// There is no postinstall hook here on purpose. A lifecycle script is skipped
+// by `--ignore-scripts` and by many global and CI installs, and npm buffers or
+// reorders its output unless `--foreground-scripts`. This wrapper is the bin
+// entrypoint: it cannot be skipped, and it writes straight to the user's
+// terminal.
+//
+// The install signal is the absence of this watermark. npm deletes and rewrites
+// the package directory on install and update, so a missing watermark is
+// exactly "this package directory is new". No fingerprinting, no second copy of
+// the Go side's XDG path logic, and nothing written outside this directory.
+const installResidueWatermark = path.join(__dirname, ".install-residue-reported");
+
+// claimInstallResidueReport reports whether this invocation owns the one notice
+// this install gets.
+//
+// The watermark is created before the report runs, so a crash in the report
+// cannot arm it again. A watermark that cannot be written means the notice is
+// never shown: an unwritable package directory must not produce this notice on
+// every single invocation forever.
+//
+// A non-TTY run (a hook, CI, a pipe) claims nothing and leaves the watermark
+// missing, so the next interactive run is the one that reports. That is the
+// point: the notice should land on a run a human is looking at.
+function claimInstallResidueReport() {
+  try {
+    if (!process.stderr.isTTY) {
+      return false;
+    }
+    fs.writeFileSync(installResidueWatermark, `${new Date().toISOString()}\n`, {
+      flag: "wx"
+    });
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+// reportInstallResidue runs the census after the user's command has finished,
+// so it is the last thing on screen and never delays or interleaves with the
+// real command. It is strictly additive: it cannot throw and it cannot change
+// this wrapper's exit code.
+function reportInstallResidue(binary) {
+  try {
+    if (!claimInstallResidueReport()) {
+      return;
+    }
+    spawnSync(binary, ["internal", "install-residue"], {
+      stdio: ["ignore", "ignore", "inherit"],
+      env: {
+        ...process.env,
+        PROJMUX_INSTALLER: "npm"
+      }
+    });
+  } catch (_) {
+    // The wrapper's job is to run projmux. A failed notice is not a failure.
+  }
+}
+
 const result = spawnSync(exe, process.argv.slice(2), {
   stdio: "inherit",
   env: {
@@ -70,4 +134,5 @@ if (result.error) {
   console.error(`projmux: failed to execute ${exe}: ${result.error.message}`);
   process.exit(1);
 }
+reportInstallResidue(exe);
 process.exit(result.status === null ? 1 : result.status);


### PR DESCRIPTION
## The problem

`make install` and `npm install` replace the executable on disk. Neither replaces the image of a process that is already running. Every long-lived projmux child — the Codex broker runtime, the lifecycle observers, the per-pane supervisors — keeps executing the code it started with until it exits on its own. The install prints success while most of the running fleet is still on the previous build, and the operator is never told. `projmux doctor` can establish it, but that is a place nobody looks right after an install that reported success.

## What this adds

`projmux internal install-residue` — a hidden, machine-invoked census. `make install` runs it as its last step; the npm bin wrapper runs it once on the first interactive run after an install. It reads the process table once, appends one record to `<state>/install-residue.jsonl`, prints at most one stderr notice, and **always exits 0**.

```
>> 24 projmux processes are still running the image this install replaced
     supervisor          20   oldest 3h02m   median 45m
     lifecycle-observer   3   oldest 2h14m   median 41m
     broker-runtime       1   oldest 2h14m   median 2h14m
   They keep executing code from before this install until each one exits.
   Recreating a pane moves that pane onto the installed build; the broker
   follows when its last binding goes.
   Recorded to ~/.local/state/projmux/install-residue.jsonl (17 installs, last 38m ago).
```

**The deliverable is the measurement, not the message.** A warning string alone would be worthless. The ledger record carries the three things an automatic replacement of these processes cannot be designed without:

| field | the question it answers |
| --- | --- |
| `roles[].replaced` (per role) | what to make a replacement target |
| `roles[].replacedAgeSeconds` (the full sorted distribution, not a mean) | does a bounded drain finish in finite time, and what cutoff `T` covers which fraction |
| `at` + `sinceLastInstallSeconds` across records | how often this happens per install, hence whether a forced cutoff is needed at all |

A mean would destroy the second answer: twenty supervisors averaging forty minutes says nothing about the one that outlives every plausible bound. The distribution is stored whole, capped at 512 samples per role, with the record saying so when the cap was reached.

## Design decisions worth calling out

**Age source is `os.Stat("/proc/<pid>").ModTime()`.** The kernel stamps that directory at process creation and never moves it. Verified on this machine against `ps -o etimes=` for three live long-lived projmux children: agreement within one second in all three. Chosen over `/proc/<pid>/stat` field 22 + `/proc/stat` `btime` because that path needs a `USER_HZ` assumption, a second file read for boot time, and parsing around the `comm` field — which is an executable name in parentheses and may itself contain `)` and spaces, the standard way `/proc/<pid>/stat` parsers get the offsets wrong. Second resolution is far below what the question needs; a drain bound is chosen in minutes and hours.

**Silence is earned, twice.** Zero residual prints absolutely nothing. A line printed at every install is a line an operator learns to skip.

**Unsupported platform (macOS) prints nothing but still records.** There is no `/proc/<pid>/exe` there, the census cannot be taken, and the operator has no action available — so a line at every install would be permanent noise forever. The ledger still gets a `"supported": false` record, because the replacement design has to know its macOS coverage gap rather than read an absent record as "this install left nothing behind".

**No new `PROJMUX_*` env var.** Installer identity comes from the existing `PROJMUX_INSTALLER` (`npm/projmux.js` already sets `npm`; the Makefile line sets `make`; unset reads as `unknown`). AGENTS.md makes any new `PROJMUX_*` variable a minor-release input to the hook contract, and this route needs no such input.

**Hidden internal route, not public.** This is installer plumbing invoked by a machine, exactly what `internal/app/internal_routes.go` documents that namespace for. The public CLI surface and its compatibility obligations are unchanged; `make docs` regenerates `docs/cli.md` byte-identically.

**`projmux doctor` is untouched.** The age fields populate only when a caller supplies a reference instant. The doctor projection passes the zero time, so its record and its rendered section are exactly what they were, including the JSON. Pinned by `TestDoctorProcessVintageProjectionCarriesNoAges`.

### The npm path

npm has no `postinstall` script here and `package.json` needs no change. The mechanism is a watermark at `npm/.install-residue-reported`, inside the installed package's own directory.

1. A `postinstall` script is skipped by `--ignore-scripts` and by many global and CI installs. The bin wrapper cannot be skipped — it *is* the entrypoint.
2. npm buffers and reorders lifecycle-script output unless `--foreground-scripts`. The wrapper writes straight to the user's terminal.
3. It needs no `package.json` change, and `files` is an explicit allowlist that does not carry the watermark, so it can never ship in a tarball.
4. `npm install -g` and `npm update` delete and rewrite the package directory, so a **missing watermark is the "this install is new" signal** — no fingerprinting, no second copy of the Go side's XDG path logic in JavaScript, nothing written outside the package directory.

The notice runs only when `process.stderr.isTTY`, only after the watermark write succeeds (so an unwritable package directory can never produce it on every invocation forever), and only **after** the user's command has exited — so it is the last thing on screen, never delays or interleaves with the real command, and cannot change the wrapper's exit code. A non-TTY run (a hook, CI, a pipe) does nothing and leaves the watermark missing, so the next interactive run is the one that reports; the notice should land on a run a human is looking at.

**The timing trade-off, stated honestly:** for npm the notice appears on the **first interactive run after the install**, not during `npm install` itself. That is deliberate — visibility over immediacy — and the ledger's `at` timestamp is the install-detection moment either way.

## Safety

**Not one line of code that terminates, starts, signals, or restarts a process.** The census is two file reads per process; the report is text. Replacing the residual processes is a separate decision this measurement exists to inform.

Negative audit over the whole diff (`git diff afc94f3f`):

```
# non-comment added code lines (*.go, *.js, Makefile) matching
# Kill|Signal|SIGTERM|SIGKILL|syscall|drain|Terminate|exec.Command|os/exec|child_process|.Process
count=0

# Kill|SIGTERM|SIGKILL|syscall.Kill|Process.Signal anywhere in the diff, docs included
count=0
```

The 13 remaining `drain` matches are all prose in comments and docs describing the question this measurement is *for*.

**No pid, no executable path, no argv** on the terminal or in the ledger. `TestInstallResidueCarriesNoProcessIdentity` drives the real route over a fixture whose pids, executable path, and argv are sentinels, then reads back both the rendered notice and the ledger bytes and asserts none of them appear.

## Tests

New, all in `internal/app`:

- `TestProjmuxProcessVintageMeasuresTheResidualAgeDistribution`
- `TestProjmuxProcessVintageKeepsAnUnknownStartTimeOutOfTheDistribution`
- `TestProjmuxProcessVintageCapsOneRoleAgeDistribution`
- `TestDoctorProcessVintageProjectionCarriesNoAges`
- `TestProcessImageListerReadsAPlausibleStartTime` (Linux)
- `TestInstallResidueReportsPerRoleResidualCountsAndAges`
- `TestInstallResidueZeroResidualPrintsNothing`
- `TestInstallResidueUnsupportedPlatformPrintsNothingButRecordsTheGap`
- `TestInstallResidueCarriesNoProcessIdentity`
- `TestInstallResidueLedgerAppendsAndDerivesTheInstallGap`
- `TestInstallResidueLedgerRotatesAtItsRecordBound`
- `TestInstallResidueNoticeOrdersRolesByResidualCount`
- `TestInstallResidueNoticeTiesBreakOnTheCensusRoleOrder`
- `TestInstallResidueAgeTextRendersDurationsAnOperatorReads`
- `TestInstallResidueNeverFailsAnInstall`
- `TestInstallResidueInstallerComesFromTheExistingEnvVar`
- `TestInstallResidueRouteIsRegisteredAsInternalPlumbing`

Mutation-checked (flip the logic, confirm red): role ordering, the doctor zero-time gate, ledger append vs truncate, the rotation bound direction, the age sort, the per-role sample cap, the negative-age floor, the unknown-start-time skip, the even-length median, the install-gap derivation, the `supported` flag in the record, and an injected pid into the rendered line. All twelve turn red.

One honest note: the zero-residual silence is enforced by two independent guards (the `Replaced == 0` early return and the row filter that drops zero-residual roles). Flipping either alone still produces silence; flipping both turns `TestInstallResidueZeroResidualPrintsNothing` red.

## Docs

- `docs/operational-diagnostics.md` — new "Install residue ledger" section: the notice, the record shape field-by-field, the privacy contract, the `/proc` rationale, and the field→question mapping table.
- `docs/npm-distribution.md` — new "Install residue notice" section: why the bin wrapper rather than `postinstall`, the watermark, the TTY gate, and the timing trade-off.
- `docs/agent-workflow.md` — the maintained test list entry.
- `docs/cli.md` — regenerated by `make docs`, byte-identical (the route is hidden internal plumbing and is deliberately absent from the canonical command projection, like `internal codex-broker`).

## Verification

Rebased onto `3f007e82` and revalidated there.

| gate | result |
| --- | --- |
| `make fmt` / `make fix` | clean; deadcode baseline exact (332 findings / 331 symbols) |
| `make docs` | `docs/cli.md` regenerated byte-identical — the route is hidden plumbing and stays out of the canonical projection |
| `make test` | green except one pre-existing local failure, see below |
| `make test-integration` | green (first run hit the known local `window sleep` flake under load; the rerun passed) |
| `make test-e2e` | green, `E2E contract-result-sha256=2e16735b7181118d3d79e904d2be9278d120996445f8e39af932d24b70a37e51` |
| CI | all 20 checks green, `E2E npm-staging` and `Security / Repository policy` included |

`make test` has one pre-existing failure on this machine, `TestSharedPaneRoutingRealTmux/{detached,inherited}`. Confirmed identical on a clean base checkout with these changes stashed. It is another track's file and is untouched here.

### npm staging, real output

Staged the root shim package plus a locally built binary, started one throwaway projmux supervisor from the staged path, unlinked the binary and republished it at the same path — the exact shape of an atomic install — then drove the staged wrapper under a pty.

```
$ node <pkg>/npm/projmux.js version          # stderr is a TTY, watermark missing
projmux 0.14.2
>> 1 projmux process is still running the image this install replaced
     supervisor  1   oldest 11s   median 11s
   They keep executing code from before this install until each one exits.
   Recreating a pane moves that pane onto the installed build; the broker
   follows when its last binding goes.
   Recorded to <sandbox>/state/projmux/install-residue.jsonl (1 install recorded).

$ ls -la <pkg>/npm/
-rw-rw-r--  25  .install-residue-reported     # 2026-09-05T16:07:56.206Z

$ node <pkg>/npm/projmux.js version          # same install, TTY -> silent
projmux 0.14.2

$ rm <pkg>/npm/.install-residue-reported     # a fresh npm install rewrites the dir
$ node <pkg>/npm/projmux.js version | cat    # non-TTY -> silent, watermark stays missing
projmux 0.14.2
watermark present? no

$ node <pkg>/npm/projmux.js version          # the next interactive run reports
projmux 0.14.2
>> 1 projmux process is still running the image this install replaced
     supervisor  1   oldest 32s   median 32s
   ...
   Recorded to <sandbox>/state/projmux/install-residue.jsonl (2 installs, last 20s ago).
watermark present? yes

wrapper exit for an unknown command = 1
wrapper exit for a good command      = 0
```

The Makefile line, run verbatim against the same staged binary, writes nothing to stdout and records `"installer":"make"`:

```
$ PROJMUX_INSTALLER=make <bin>/projmux internal install-residue
exit=0 ; stdout=0 bytes ; the notice above on stderr
```

Real ledger rows from that session:

```json
{"at":"2026-09-05T16:07:56Z","installer":"npm","supported":true,"observed":1,"replaced":1,"roles":[{"role":"supervisor","processes":1,"current":0,"replaced":1,"replacedAgeSeconds":[11]}]}
{"at":"2026-09-05T16:08:16Z","installer":"npm","supported":true,"observed":1,"replaced":1,"sinceLastInstallSeconds":20,"roles":[{"role":"supervisor","processes":1,"current":0,"replaced":1,"replacedAgeSeconds":[32]}]}
{"at":"2026-09-05T16:08:30Z","installer":"make","supported":true,"observed":1,"replaced":1,"sinceLastInstallSeconds":14,"roles":[{"role":"supervisor","processes":1,"current":0,"replaced":1,"replacedAgeSeconds":[46]}]}
```

Mode `0600`. Negative audit over that real notice and that real ledger, against the live residual process's actual identity:

```
pid 3956938                              0 occurrences
<sandbox>/pkg/bin/projmux (its exe)      0 occurrences
smoke-pane-residue (its argv)            0 occurrences
"pane-uid" / "supervise --" / "/proc/"   0 occurrences
```

The throwaway supervisor was launched supervising `sleep 90` so it exited on its own. **No signal was sent to any process at any point.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
