### PR TITLE
fix(codex): keep the lifecycle observer recoverable when the last binding leaves

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -913,6 +913,51 @@
   that merely failed, and the recovery scheduler took its only non-cancel exit
   on a single such sample. It now makes the same bounded wait the loop head has
   always made, so a transient read failure no longer retires a live activation.
+- `TestObserverRecoversWhenTheOverflowedBindingWasTheBrokersLast` and
+  `TestLastBindingOverflowRecordsEveryFailedReplacementOpen` own the same
+  overflow under the opposite premise: no sibling binding, so the resync takes
+  the runtime to zero bindings. `Broker.wanted()` is `len(b.bindings) > 0` and
+  therefore broker-global, so `serve` folds the shared upstream connection and
+  no replacement barrier can exist until it is reopened. That premise is not
+  exotic - it holds permanently for a user who runs one Codex pane - and the
+  fold itself is a race, because a rebind that lands before `serve` processes
+  the unbind wake leaves the connection up. The fixture gates every replacement
+  Open on the fold so the premise is a fact rather than a hope. The first pins
+  that the fold self-heals whenever upstream is reachable. The second owns the
+  defect: while upstream is away every replacement Open blocks to its own open
+  timeout - 15s in production - and the scheduler computed the failure's
+  vocabulary token and discarded it, so a Pane sat on
+  `invalidating|<epoch>|backlog-overflow` with no record of any attempt, which
+  is byte-identical to the stuck Pane `observer.stopped` exists to name except
+  that recovery really was running and so no terminal record arrived either.
+  The failure is now recorded on the retry transition, keyed apart from the
+  epoch-loss token so the journal's coalescing window folds a long outage into
+  one line plus a repeat count, and the disconnect's reason column is untouched.
+- `TestLastBindingRevokedByOverflowFoldsTheUpstreamConnection`
+  (`internal/integrations/agents/codexbroker`) owns the invariant `wanted()`
+  exists for, against the involuntary revocation paths. `Bind` and
+  `Binding.Close` both signal the supervisor because both change what the
+  connection has left to serve; the involuntary paths - a bounded delivery queue
+  that overflowed, a thread-scoped snapshot refusal - deleted the binding from
+  routing with no wake, so a runtime could reach zero bindings with nothing
+  pending on the wake channel and `serve` would stay in its select holding an
+  upstream connection nothing is bound to until the host idle timer recycled the
+  whole runtime. A one-deep queue makes the overflow exact rather than a volume
+  guess, and the test binds exactly one thread and never replaces it, because a
+  rebind carries its own signal and would hide the gap.
+- `TestLiveEpochSurvivesATransientBindingReadFailure` and
+  `TestLiveEpochBindingLossLeavesATerminalRecord` own the live epoch's
+  `bindingTicker` exit, which carried the same single-sample defect the recovery
+  scheduler had. One false from `BindingCurrent` ended the observer, and that
+  exit wrote no authority - correctly, because `SetAuthority` refuses once the
+  predicate is false - and no record, so the Pane kept
+  `provider-control-plane|ready` with no producer behind it. That is the inverse
+  of a stuck Pane: nothing looks wrong at all. The path now makes the same
+  bounded wait as the loop head, and a binding that is provably gone leaves an
+  `observer.stopped` record with result `stuck` and reason `binding-replaced`.
+  That token is deliberately not `binding-revoked`: the four close-cause tokens
+  answer "who closed the stream" and come from the broker epoch, and here the
+  stream was never closed at all.
 - `test/e2e/codex-lifecycle.sh` (C01) pins the exact disconnect token at its
   disconnect projection barrier and at the reconnect-gap hook comparison. It
   waited on the literal `disconnected` before, which was the bucket published

--- a/internal/app/ai_ingest_codex_native.go
+++ b/internal/app/ai_ingest_codex_native.go
@@ -137,6 +137,18 @@ const (
 	codexObserverReasonBacklogOverflow   codexObserverReason = "backlog-overflow"
 	codexObserverReasonEpochClosed       codexObserverReason = "epoch-closed"
 
+	// codexObserverReasonBindingReplaced is the exact binding this observer
+	// serves no longer being current, observed from the sink predicate rather
+	// than from the broker epoch.
+	//
+	// It is deliberately not one of the four tokens above. Those answer "who
+	// closed the stream" and come from the epoch itself; here the stream was
+	// never closed at all - the activation under it was replaced while its
+	// epoch was still live and ready. Spelling that with binding-revoked would
+	// make a broker-epoch cause appear from a producer that is not the broker
+	// epoch, which is the one property of this vocabulary that has to hold.
+	codexObserverReasonBindingReplaced codexObserverReason = "binding-replaced"
+
 	// Supervisor-side tokens. The parent process writes these when the child
 	// observer never reached its own authority write.
 	codexObserverReasonObserverTimeout     codexObserverReason = "observer-timeout"
@@ -179,6 +191,7 @@ var codexObserverReasons = []codexObserverReason{
 	codexObserverReasonBindingRevoked,
 	codexObserverReasonBacklogOverflow,
 	codexObserverReasonEpochClosed,
+	codexObserverReasonBindingReplaced,
 	codexObserverReasonObserverTimeout,
 	codexObserverReasonObserverStartFailed,
 	codexObserverReasonObserverExited,
@@ -397,7 +410,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 			reason := codexNativeReason(err)
 			if recovering {
 				recoveryAttempts++
-				if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts); recoveryErr != nil {
+				if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts, reason); recoveryErr != nil {
 					return recoveryErr
 				} else if !retry {
 					return nil
@@ -414,7 +427,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 			_ = client.Close()
 			if recovering {
 				recoveryAttempts++
-				if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts); recoveryErr != nil {
+				if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts, codexObserverReasonUnsupported); recoveryErr != nil {
 					return recoveryErr
 				} else if !retry {
 					return nil
@@ -441,7 +454,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 			}
 			if recovering {
 				recoveryAttempts++
-				if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts); recoveryErr != nil {
+				if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts, codexNativeReason(snapshotErr)); recoveryErr != nil {
 					return recoveryErr
 				} else if !retry {
 					return nil
@@ -461,7 +474,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 			_ = client.Close()
 			if recovering {
 				recoveryAttempts++
-				if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts); recoveryErr != nil {
+				if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts, codexObserverReasonProtocolError); recoveryErr != nil {
 					return recoveryErr
 				} else if !retry {
 					return nil
@@ -480,7 +493,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 				o.discardRecoveryEpoch(epoch)
 				_ = client.Close()
 				recoveryAttempts++
-				if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts); recoveryErr != nil {
+				if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts, codexObserverReasonThreadUnloaded); recoveryErr != nil {
 					return recoveryErr
 				} else if !retry {
 					return nil
@@ -535,7 +548,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 				o.discardRecoveryEpoch(epoch)
 				_ = client.Close()
 				recoveryAttempts++
-				if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts); recoveryErr != nil {
+				if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts, codexObserverReasonControlUnavailable); recoveryErr != nil {
 					return recoveryErr
 				} else if !retry {
 					return nil
@@ -549,7 +562,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 			}
 			if recovering {
 				recoveryAttempts++
-				if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts); recoveryErr != nil {
+				if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts, codexObserverReasonControlUnavailable); recoveryErr != nil {
 					return recoveryErr
 				} else if !retry {
 					return nil
@@ -610,14 +623,37 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 				exit = codexObserverExitCancelled
 				break eventLoop
 			case <-bindingTicker.C:
-				if !o.sink.BindingCurrent(o.identity) {
-					bindingTicker.Stop()
-					if control != nil {
-						_ = control.Close()
-					}
-					_ = client.Close()
-					return nil
+				if o.sink.BindingCurrent(o.identity) {
+					continue
 				}
+				// BindingCurrent answers one false for two different questions:
+				// this activation was replaced, and the binding could not be
+				// read right now - a Registry load that failed, or a tmux
+				// invocation that did. Ending the live epoch on a single sample
+				// retired a healthy producer on one failed read. The loop head
+				// and the recovery scheduler both wait that window out, so this
+				// path makes the same bounded wait.
+				if waitForCodexLifecycleBinding(ctx, o.sink, o.identity, bindingTimeout) {
+					continue
+				}
+				// The exact binding is provably gone, so ending here is right:
+				// a replaced activation has its own observer. What was wrong is
+				// that this exit was invisible. It publishes no authority - and
+				// must not, because SetAuthority refuses that write once the
+				// predicate is false - so the Pane keeps the ready projection
+				// this epoch committed with no producer left behind it. That is
+				// the inverse of a stuck Pane: nothing looks wrong at all. The
+				// terminal record is the only surface the two differ on, and it
+				// is the same record the recovery scheduler writes.
+				o.journal(codexObserverTransitionStopped, epochLabel, codexObserverReasonBindingReplaced)
+				o.reportStartupResult(codexObserverStartupResult{Status: codexObserverStartupStale})
+				bindingTicker.Stop()
+				progressTicker.Stop()
+				if control != nil {
+					_ = control.Close()
+				}
+				_ = client.Close()
+				return nil
 			case <-progressTicker.C:
 				if err := o.flushProgress(); err != nil {
 					if control != nil {
@@ -767,7 +803,7 @@ func (o *codexNativeObserver) Run(ctx context.Context) error {
 		recoveryAttempts = 0
 		o.recovery = codexObserverRecovery{epochLabel: epochLabel, reason: exit.reason}
 		o.journal(codexObserverTransitionReconnecting, epochLabel, exit.reason)
-		if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts); recoveryErr != nil {
+		if retry, recoveryErr := o.continueRecovery(ctx, recoveryAttempts, exit.reason); recoveryErr != nil {
 			return recoveryErr
 		} else if !retry {
 			return nil
@@ -816,7 +852,8 @@ func (o *codexNativeObserver) generationLifecycle() (coremetadata.CodexGeneratio
 // invalidation projection is published before this method is called. Every
 // caller increments the attempt count only after one failed replacement open,
 // snapshot, or control proof, so the count paces the backoff; it never
-// terminates the recovery.
+// terminates the recovery. A non-zero count therefore means one attempt failed,
+// and the token that names that failure is recorded before the next wait.
 //
 // The only exits are a binding that is no longer current and a cancelled
 // context. A live activation whose endpoint is merely away remains
@@ -832,7 +869,21 @@ func (o *codexNativeObserver) generationLifecycle() (coremetadata.CodexGeneratio
 // terminal exit on one sample here meant a transient read failure retired a
 // live activation permanently, leaving its Pane on the invalidating projection
 // this method was called after with no producer left to move it.
-func (o *codexNativeObserver) continueRecovery(ctx context.Context, attempts int) (bool, error) {
+func (o *codexNativeObserver) continueRecovery(ctx context.Context, attempts int, failed codexObserverReason) (bool, error) {
+	if attempts > 0 {
+		// One replacement attempt just failed. Every caller already computed
+		// the vocabulary token for its own failure and this scheduler used to
+		// discard it, so a recovery that could not make progress produced no
+		// record at all: the Pane held the one invalidating projection and an
+		// operator could not tell a retrying observer from a stuck one in
+		// either direction. Naming the failure on the retry transition is the
+		// whole difference, and the journal's coalescing window keeps a long
+		// outage to one line plus a repeat count.
+		//
+		// The reason column of the disconnect that opened recovery is
+		// untouched, so which side closed the stream is still read there.
+		o.journal(codexObserverTransitionReconnecting, o.recovery.epochLabel, failed)
+	}
 	bindingTimeout := o.bindingTimeout
 	if bindingTimeout <= 0 {
 		bindingTimeout = codexObserverBindingTimeout

--- a/internal/app/ai_ingest_codex_native_test.go
+++ b/internal/app/ai_ingest_codex_native_test.go
@@ -1155,7 +1155,11 @@ func TestCodexNativeObserverForeignThreadSameTurnWritesNoRegistryProgressOrDiagn
 	sink := &recordingCodexProgressSink{recordingCodexLifecycleSink: newRecordingCodexLifecycleSink()}
 	observer := codexNativeObserver{
 		identity: identity, delay: time.Millisecond, sink: sink,
-		open: func(context.Context) (codexLifecycleConnection, error) { return conn, nil },
+		// The binding loss at the end of this test exits through a bounded
+		// wait, not a single sample, so the window is set short here rather
+		// than left at the three-second production default.
+		bindingTimeout: 20 * time.Millisecond,
+		open:           func(context.Context) (codexLifecycleConnection, error) { return conn, nil },
 	}
 	done := make(chan error, 1)
 	go func() { done <- observer.Run(ctx) }()
@@ -1985,7 +1989,15 @@ func TestCodexNativeObserverBindingLossExitsSilentConnectionWithoutWrites(t *tes
 	}
 	ctx := t.Context()
 	sink := newRecordingCodexLifecycleSink()
-	observer := codexNativeObserver{identity: identity, delay: time.Millisecond, sink: sink, open: func(context.Context) (codexLifecycleConnection, error) { return conn, nil }}
+	// The exit this test owns waits the binding window out before it terminates,
+	// because BindingCurrent returns the same false for a replaced binding and
+	// for one that could not be read right now. The window is short here; the
+	// contract below is unchanged - a provably lost binding still writes no
+	// stale cleanup and no fallback authority.
+	observer := codexNativeObserver{
+		identity: identity, delay: time.Millisecond, sink: sink, bindingTimeout: 20 * time.Millisecond,
+		open: func(context.Context) (codexLifecycleConnection, error) { return conn, nil },
+	}
 	done := make(chan error, 1)
 	go func() { done <- observer.Run(ctx) }()
 	waitForCodexObserverEvents(t, sink, 2)

--- a/internal/app/codex_broker_lifecycle_test.go
+++ b/internal/app/codex_broker_lifecycle_test.go
@@ -82,15 +82,47 @@ func (e *brokerTestEndpoint) Close() error {
 	return nil
 }
 
+// isClosed reports whether the broker retired this upstream connection. It is
+// how a last-binding test proves the fold it is named for actually happened
+// rather than passing because the connection stayed up.
+func (e *brokerTestEndpoint) isClosed() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.closed
+}
+
 func (e *brokerTestEndpoint) respondWith(method, payload string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.responses[method] = payload
 }
 
+// emit delivers one notification into the live upstream connection.
+//
+// The send is taken under the same lock Close uses. That matters as soon as a
+// test drives the last-binding premise: the broker retires the connection while
+// the test is still emitting, so a bare send would race the channel close
+// outright - which the recover this replaced only ever hid. Once the endpoint
+// is retired the emit is a no-op, because there is no connection left to carry
+// it, and while it is live the send is retried rather than dropped: a test that
+// overruns a bounded queue needs every event it declared to actually arrive.
 func (e *brokerTestEndpoint) emit(notification codexappserver.Notification) {
-	defer func() { _ = recover() }()
-	e.events <- notification
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		e.mu.Lock()
+		if e.closed {
+			e.mu.Unlock()
+			return
+		}
+		select {
+		case e.events <- notification:
+			e.mu.Unlock()
+			return
+		default:
+		}
+		e.mu.Unlock()
+		time.Sleep(50 * time.Microsecond)
+	}
 }
 
 func (e *brokerTestEndpoint) requestCount(method string) int {
@@ -926,23 +958,132 @@ func (r codexOverflowRun) lastOpenError() string {
 	return "<none>"
 }
 
+// codexOverflowTopology is the premise one overflow run is taken under: how
+// many bindings the broker holds, and whether its upstream can be reopened.
+//
+// The two travel together because they are one fact. `Broker.wanted()` is
+// `len(b.bindings) > 0`, so it is broker-global rather than per binding. With a
+// sibling binding the resync retires only the overflowing binding and the
+// shared upstream connection keeps running, so the replacement barrier is
+// immediate. With no sibling the resync takes the runtime to zero bindings,
+// `serve` folds the upstream connection, and no replacement barrier can exist
+// until that connection is reopened - which makes the reopen's own outcome part
+// of the premise.
+type codexOverflowTopology struct {
+	// sibling pins one extra Agent's binding on the same shared connection for
+	// the whole run.
+	sibling bool
+	// reopenFailures is how many upstream reopens fail before one succeeds.
+	reopenFailures int
+	// foldFirst holds every replacement Open until the upstream connection has
+	// actually been folded.
+	//
+	// The fold is a race in production, which is itself worth knowing: the
+	// broker unbinds, signals, and `serve` decides on `wanted()`, so a rebind
+	// that lands before `serve` processes that wake leaves the connection up
+	// and the run never takes the last-binding path at all. Gating the rebind
+	// makes the premise a fact of the fixture rather than something the test
+	// hopes for. It cannot hang: nothing can make `wanted()` true again while
+	// the gate holds, and every revocation now wakes the supervisor - which
+	// `TestLastBindingRevokedByOverflowFoldsTheUpstreamConnection` owns.
+	foldFirst bool
+}
+
+// codexOverflowWithSibling is the crowded fleet: another Codex pane is bound,
+// so the overflowing binding is never the broker's last one and no upstream
+// reopen is needed at all.
+var codexOverflowWithSibling = codexOverflowTopology{sibling: true}
+
+// codexOverflowLastBinding is the one-Codex-pane fleet. It is not an exotic
+// arrangement: it holds permanently for any user who runs a single Codex pane,
+// so this is the premise under which the last-binding fold is always taken.
+var codexOverflowLastBinding = codexOverflowTopology{foldFirst: true}
+
+// codexOverflowLastBindingFlakyUpstream is the same fleet whose folded upstream
+// refuses a few reopens before it comes back. It is the production shape of a
+// dial that is momentarily away.
+var codexOverflowLastBindingFlakyUpstream = codexOverflowTopology{reopenFailures: 3, foldFirst: true}
+
+// startCodexOverflowRuntime publishes one real runtime host whose upstream
+// reopen outcome is part of the fixture rather than a race with it.
+//
+// The first open always serves the endpoint the caller emits into. Every open
+// after it is a reopen, and the topology decides whether it fails.
+func startCodexOverflowRuntime(
+	t *testing.T, threadID string, topology codexOverflowTopology,
+) (codexbroker.Discovery, *brokerTestEndpoint) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("codex broker runtime requires Unix filesystem semantics")
+	}
+	discovery, err := codexbroker.NewDiscovery(shortTempDomain(t), codexbroker.DefaultEndpointKey)
+	if err != nil {
+		t.Fatalf("discovery: %v", err)
+	}
+	newEndpoint := func() *brokerTestEndpoint {
+		endpoint := newBrokerTestEndpoint()
+		endpoint.respondWith("thread/read", `{"thread":{"id":"`+threadID+`","status":{"type":"active"}}}`)
+		return endpoint
+	}
+	first := newEndpoint()
+	var mu sync.Mutex
+	opens, refused := 0, 0
+	broker, err := codexbroker.NewBroker(codexbroker.Config{
+		Opener: func(context.Context) (codexbroker.Endpoint, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			opens++
+			if opens == 1 {
+				return first, nil
+			}
+			if refused < topology.reopenFailures {
+				refused++
+				return nil, errors.New("fixture upstream is away")
+			}
+			return newEndpoint(), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("broker: %v", err)
+	}
+	host, err := codexbroker.StartHost(codexbroker.HostConfig{Discovery: discovery, Broker: broker, IdleTimeout: -1})
+	if err != nil {
+		_ = broker.Close()
+		t.Fatalf("host: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = host.Close()
+		_ = broker.Close()
+	})
+	return discovery, first
+}
+
 // startCodexOverflowObserver wires the real broker session under the real
 // observer loop and returns once the first epoch is ready.
 func startCodexOverflowObserver(t *testing.T, threadID string, sink *codexOverflowFixture) codexOverflowRun {
 	t.Helper()
-	endpoint := newBrokerTestEndpoint()
-	endpoint.respondWith("thread/read", `{"thread":{"id":"`+threadID+`","status":{"type":"active"}}}`)
-	discovery, _ := startBrokerRuntimeForTest(t, endpoint)
+	return startCodexOverflowObserverOn(t, threadID, sink, codexOverflowWithSibling)
+}
 
-	// One sibling Agent holds its own binding on the same shared connection for
-	// the whole run. It is what the fleet always looks like, and it keeps this
-	// fixture measuring the thing it is named for: without it the overflowing
-	// binding is the broker's last one, so the resync also retires the upstream
-	// connection, and the replacement Open would be waiting on a full endpoint
-	// reconnect rather than on this Phase's recovery path.
-	sibling := newCodexBrokerObserverSessionOn(brokerTestIdentity(threadID+"-sibling"), "", nil, discovery, nil)
-	t.Cleanup(func() { _ = sibling.Close() })
-	openBrokerEpoch(t, sibling)
+// startCodexOverflowObserverOn is startCodexOverflowObserver under an explicit
+// binding topology.
+func startCodexOverflowObserverOn(
+	t *testing.T, threadID string, sink *codexOverflowFixture, topology codexOverflowTopology,
+) codexOverflowRun {
+	t.Helper()
+	discovery, endpoint := startCodexOverflowRuntime(t, threadID, topology)
+
+	if topology.sibling {
+		// One sibling Agent holds its own binding on the same shared connection
+		// for the whole run. It keeps this fixture measuring the thing it is
+		// named for: without it the overflowing binding is the broker's last
+		// one, so the resync also retires the upstream connection, and the
+		// replacement Open waits on a full endpoint reconnect rather than on
+		// the recovery path under test.
+		sibling := newCodexBrokerObserverSessionOn(brokerTestIdentity(threadID+"-sibling"), "", nil, discovery, nil)
+		t.Cleanup(func() { _ = sibling.Close() })
+		openBrokerEpoch(t, sibling)
+	}
 
 	identity := brokerTestIdentity(threadID)
 	session := newCodexBrokerObserverSessionOn(identity, "", nil, discovery, nil)
@@ -956,7 +1097,9 @@ func startCodexOverflowObserver(t *testing.T, threadID string, sink *codexOverfl
 		identity: identity, sink: sink,
 		delay: time.Millisecond, maxDelay: 2 * time.Millisecond, bindingTimeout: 100 * time.Millisecond,
 		open: func(ctx context.Context) (codexLifecycleConnection, error) {
-			opens.Add(1)
+			if opens.Add(1) > 1 && topology.foldFirst {
+				waitForFoldedUpstream(t, endpoint)
+			}
 			connection, err := session.Open(ctx)
 			if err != nil {
 				rendered := err.Error()
@@ -985,6 +1128,20 @@ func startCodexOverflowObserver(t *testing.T, threadID string, sink *codexOverfl
 	return codexOverflowRun{
 		endpoint: endpoint, session: session, journal: journal, startups: startups,
 		done: done, cancel: cancel, opens: opens, openErr: openErr, firstEpoch: first,
+	}
+}
+
+// waitForFoldedUpstream blocks until the broker has retired the shared upstream
+// connection, which is what the last binding leaving means downstream.
+func waitForFoldedUpstream(t *testing.T, endpoint *brokerTestEndpoint) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for !endpoint.isClosed() {
+		if time.Now().After(deadline) {
+			t.Error("the last binding left and the upstream connection was never folded, so this run cannot take the premise under test")
+			return
+		}
+		time.Sleep(time.Millisecond)
 	}
 }
 
@@ -1213,5 +1370,243 @@ func TestBacklogOverflowRecoverySurvivesATransientBindingReadFailure(t *testing.
 			t.Fatalf("no replacement epoch after the blip: lastOpen=%s records=%v",
 				run.lastOpenError(), run.journal.snapshot())
 		}
+	}
+}
+
+// TestObserverRecoversWhenTheOverflowedBindingWasTheBrokersLast is the first
+// half of Phase 3 ledger 1: the same consumer overflow, taken under the premise
+// that this binding is the only one the broker holds.
+//
+// `Broker.wanted()` is `len(b.bindings) > 0`, so it is broker-global rather
+// than per binding. The resync's unbind therefore takes the whole runtime to
+// zero bindings, `serve` folds the shared upstream connection, and the
+// replacement Open cannot receive a barrier until that connection is reopened.
+// The premise is not exotic - it holds permanently for a user who runs one
+// Codex pane - so this test pins that the fold self-heals whenever upstream is
+// reachable, and it asserts the fold happened rather than trusting that it did.
+func TestObserverRecoversWhenTheOverflowedBindingWasTheBrokersLast(t *testing.T) {
+	const threadID = "thread-overflow-alone"
+	sink := newCodexOverflowFixture()
+	run := startCodexOverflowObserverOn(t, threadID, sink, codexOverflowLastBinding)
+	openedBefore := run.opens.Load()
+
+	overflowTheConsumerBacklog(t, run, sink, threadID)
+
+	deadline := time.After(20 * time.Second)
+	var recovered codexObserverStartupResult
+	for recovered.Status != codexObserverStartupReady {
+		select {
+		case result := <-run.startups:
+			recovered = result
+		case err := <-run.done:
+			t.Fatalf("the observer stopped instead of recovering: err=%v authorities=%v records=%v",
+				err, sink.authoritySnapshot(), run.journal.snapshot())
+		case <-deadline:
+			t.Fatalf("no replacement epoch: opens=%d(before %d) authorities=%v lastOpen=%s records=%v",
+				run.opens.Load(), openedBefore, sink.authoritySnapshot(), run.lastOpenError(), run.journal.snapshot())
+		}
+	}
+	if recovered.Epoch == run.firstEpoch {
+		t.Fatalf("the replacement epoch reused the overflowed label %q", run.firstEpoch)
+	}
+	run.cancel()
+	<-run.done
+
+	// The fixture gates every replacement Open on the fold, so this only
+	// confirms the gate was actually in force for this topology.
+	if !run.endpoint.isClosed() {
+		t.Fatal("the run reached a replacement epoch without the upstream ever folding, so it never took the premise under test")
+	}
+	if reasons := journalReasons(run.journal.snapshot(), codexObserverTransitionStopped); len(reasons) != 0 {
+		t.Fatalf("a recovered observer recorded a terminal stop: %v", reasons)
+	}
+}
+
+// TestLastBindingOverflowRecordsEveryFailedReplacementOpen is the production
+// defect of Phase 3 ledger 1.
+//
+// Once the last binding's overflow folds the upstream connection, every
+// replacement Open blocks on the snapshot barrier until its own open timeout -
+// 15s in production - and then fails. The recovery scheduler computed the
+// failure's vocabulary token and threw it away: `codexNativeReason(err)` was
+// read into a local that the recovering branch never used, so the Pane sat at
+// `invalidating|<epoch>|backlog-overflow` while the observer retried forever
+// with no record of any attempt. That is byte-identical to the stuck Pane
+// Phase 1's terminal record exists to distinguish, except that here recovery
+// really is running, so no terminal record ever arrives either and an operator
+// has no positive evidence in either direction.
+//
+// The failure is now named on the retry transition it belongs to. The reason
+// column of the disconnect is untouched, so `backlog-overflow` remains the
+// discriminator of who closed the stream.
+func TestLastBindingOverflowRecordsEveryFailedReplacementOpen(t *testing.T) {
+	const threadID = "thread-overflow-mute"
+	sink := newCodexOverflowFixture()
+	run := startCodexOverflowObserverOn(t, threadID, sink, codexOverflowLastBindingFlakyUpstream)
+
+	overflowTheConsumerBacklog(t, run, sink, threadID)
+
+	deadline := time.After(20 * time.Second)
+	var recovered codexObserverStartupResult
+	for recovered.Status != codexObserverStartupReady {
+		select {
+		case result := <-run.startups:
+			recovered = result
+		case err := <-run.done:
+			t.Fatalf("the observer stopped instead of waiting out the upstream: err=%v records=%v",
+				err, run.journal.snapshot())
+		case <-deadline:
+			t.Fatalf("no replacement epoch after the upstream came back: lastOpen=%s records=%v",
+				run.lastOpenError(), run.journal.snapshot())
+		}
+	}
+	run.cancel()
+	<-run.done
+
+	entries := run.journal.snapshot()
+	// The epoch loss itself. Its reason is the discriminator and must still
+	// name the consumer side.
+	lost := []string{}
+	for _, entry := range entries {
+		if entry.Event == string(codexObserverTransitionDisconnected) {
+			lost = append(lost, string(entry.Reason))
+		}
+	}
+	if !slices.Contains(lost, string(codexObserverReasonBacklogOverflow)) {
+		t.Fatalf("the disconnect stopped naming the consumer side: %+v", entries)
+	}
+	// The failed replacement opens. They are retry records whose reason is the
+	// open failure, not the epoch-loss token, so they are readable apart from
+	// the one record that opened recovery.
+	failures := []aiIngestLogEntry{}
+	for _, entry := range entries {
+		if entry.Event != string(codexObserverTransitionReconnecting) {
+			continue
+		}
+		if string(entry.Reason) == string(codexObserverReasonBacklogOverflow) {
+			continue
+		}
+		failures = append(failures, entry)
+	}
+	if len(failures) == 0 {
+		t.Fatalf("every failed replacement open was silent, so a retrying observer is indistinguishable from a stuck one: %+v", entries)
+	}
+	for _, entry := range failures {
+		if codexObserverReasonFor(string(entry.Reason)) == "" {
+			t.Fatalf("a failed replacement open recorded an out-of-vocabulary reason: %+v", entry)
+		}
+		if entry.Epoch != run.firstEpoch {
+			t.Fatalf("a failed replacement open lost the epoch it is recovering from: %+v (want %q)", entry, run.firstEpoch)
+		}
+		if entry.Pane == "" || entry.ThreadID != threadID {
+			t.Fatalf("a failed replacement open lost its routing identity: %+v", entry)
+		}
+	}
+	// Recovery ran to a ready epoch, so nothing here may claim it gave up.
+	if reasons := journalReasons(entries, codexObserverTransitionStopped); len(reasons) != 0 {
+		t.Fatalf("a recovered observer recorded a terminal stop: %v", reasons)
+	}
+	if recovered.Epoch == run.firstEpoch {
+		t.Fatalf("the replacement epoch reused the overflowed label %q", run.firstEpoch)
+	}
+}
+
+// TestLiveEpochSurvivesATransientBindingReadFailure is Phase 3 ledger 2, the
+// half Phase 1 named but left open.
+//
+// The live epoch's bindingTicker sampled BindingCurrent once and ended the
+// observer on that single false. The predicate folds two different answers into
+// one false - the binding was replaced, and the binding could not be read right
+// now - so one failed Registry load or one failed `tmux show-options` retired a
+// healthy producer whose activation was still live. The loop head and the
+// recovery scheduler both wait that window out; this path now makes the same
+// bounded wait.
+func TestLiveEpochSurvivesATransientBindingReadFailure(t *testing.T) {
+	const threadID = "thread-live-blip"
+	sink := newCodexOverflowFixture()
+	// Three unreadable samples once the epoch is ready, then the same live
+	// binding reads normally again.
+	sink.loseBindingOn(codexAuthorityControlPlane+":"+string(codexObserverReasonReady), 3, false)
+	run := startCodexOverflowObserver(t, threadID, sink)
+
+	select {
+	case err := <-run.done:
+		t.Fatalf("a transient binding read failure retired a live epoch: err=%v authorities=%v records=%v",
+			err, sink.authoritySnapshot(), run.journal.snapshot())
+	case result := <-run.startups:
+		t.Fatalf("the live epoch was torn down and restarted: %+v records=%v", result, run.journal.snapshot())
+	case <-time.After(time.Second):
+	}
+
+	// The epoch is still the one that went ready, and nothing recorded a
+	// disconnect or a stop for it.
+	entries := run.journal.snapshot()
+	for _, entry := range entries {
+		if entry.Event != string(codexObserverTransitionConnected) {
+			t.Fatalf("a transient read failure moved the live epoch: %+v (all: %+v)", entry, entries)
+		}
+	}
+	run.cancel()
+	<-run.done
+}
+
+// TestLiveEpochBindingLossLeavesATerminalRecord is the Failure.Detection half
+// of Phase 3 ledger 2.
+//
+// When the exact binding really is gone the bindingTicker path is right to end
+// the observer: a replaced activation has its own producer. What was wrong is
+// that it ended invisibly. It returned nil without a journal record and without
+// an authority write, and SetAuthority refuses every later correction once the
+// predicate is false, so the Pane keeps `provider-control-plane|ready` with no
+// producer behind it. That is the inverse of the field sample this track chased:
+// nothing looks wrong at all. The terminal record is the only surface the two
+// can be told apart on.
+func TestLiveEpochBindingLossLeavesATerminalRecord(t *testing.T) {
+	const threadID = "thread-live-gone"
+	sink := newCodexOverflowFixture()
+	sink.loseBindingOn(codexAuthorityControlPlane+":"+string(codexObserverReasonReady), 0, true)
+	run := startCodexOverflowObserver(t, threadID, sink)
+
+	select {
+	case err := <-run.done:
+		if err != nil {
+			t.Fatalf("the terminal stop reported an error: %v", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatalf("the observer neither survived nor stopped: %v", run.journal.snapshot())
+	}
+
+	// The Pane is left holding the ready projection by design - SetAuthority
+	// refuses the correction - so the record is what has to carry the fact.
+	authorities := sink.authoritySnapshot()
+	last := authorities[len(authorities)-1]
+	if last != codexAuthorityControlPlane+":"+string(codexObserverReasonReady) {
+		t.Fatalf("the abandoned Pane's last authority = %q, want the held ready projection (all: %v)", last, authorities)
+	}
+
+	entries := run.journal.snapshot()
+	var stopped *aiIngestLogEntry
+	for index := range entries {
+		if entries[index].Event == string(codexObserverTransitionStopped) {
+			stopped = &entries[index]
+		}
+	}
+	if stopped == nil {
+		t.Fatalf("the live epoch's producer left with no record, so a Pane with no producer reads as healthy: %+v", entries)
+	}
+	if stopped.Result != codexObserverTransitionStuckResult {
+		t.Fatalf("the terminal record result = %q, want %q", stopped.Result, codexObserverTransitionStuckResult)
+	}
+	if string(stopped.Reason) != string(codexObserverReasonBindingReplaced) {
+		t.Fatalf("the terminal record did not name the binding loss: %+v", *stopped)
+	}
+	if stopped.Epoch != run.firstEpoch {
+		t.Fatalf("the terminal record lost the epoch it ended: %+v (want %q)", *stopped, run.firstEpoch)
+	}
+	if stopped.Pane == "" || stopped.ThreadID != threadID {
+		t.Fatalf("the terminal record lost its routing identity: %+v", *stopped)
+	}
+	if entries[len(entries)-1].Event != string(codexObserverTransitionStopped) {
+		t.Fatalf("a transition followed the terminal stop: %+v", entries)
 	}
 }

--- a/internal/integrations/agents/codexbroker/broker.go
+++ b/internal/integrations/agents/codexbroker/broker.go
@@ -404,6 +404,18 @@ func (b *Broker) revokeBindingLocked(binding *Binding, reason Refusal) {
 	}
 	binding.revokeLocked(reason)
 	delete(b.bindings, binding.threadID)
+	// Wake the supervisor for the same reason Bind and Close do: what this
+	// connection has left to serve just changed. Binding.Close signalled and
+	// the involuntary paths did not, so a bounded queue that overflowed or a
+	// thread-scoped snapshot refusal could take the broker to zero bindings
+	// with no wake pending at all. serve then stays parked in its select
+	// holding an upstream connection nothing is bound to - the exact state
+	// wanted() exists to end, and the one its own wake comment already claims
+	// to cover ("a bind joined, or the last binding left").
+	//
+	// signal takes no lock and cannot block, so raising it from under b.mu is
+	// safe. Close's later signal is coalesced by the one-slot channel.
+	b.signal()
 	switch reason {
 	case RefusalBindingClosed, RefusalBrokerClosed:
 		b.diag.ReleasedBindings++

--- a/internal/integrations/agents/codexbroker/broker_test.go
+++ b/internal/integrations/agents/codexbroker/broker_test.go
@@ -1,0 +1,54 @@
+package codexbroker
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestLastBindingRevokedByOverflowFoldsTheUpstreamConnection pins the invariant
+// wanted() exists for against the involuntary revocation paths.
+//
+// Bind and Binding.Close both signal the supervisor, because both change what
+// the connection has left to serve. The involuntary paths - a bounded delivery
+// queue that overflowed, a thread-scoped snapshot refusal - removed the binding
+// from routing without a wake, so a runtime could reach zero bindings with
+// nothing pending on the wake channel. serve then stays in its select on a
+// connection nobody is bound to, and its own comment on that case already says
+// what should have happened: "a bind joined, or the last binding left".
+//
+// The observable consequence is an upstream app-server connection held for a
+// runtime that has no work, until the host's idle timer eventually recycles the
+// whole runtime. Nothing rebinding is what makes it reachable, so this test
+// binds exactly one thread and never replaces it.
+func TestLastBindingRevokedByOverflowFoldsTheUpstreamConnection(t *testing.T) {
+	before := runtime.NumGoroutine()
+	endpoint := newFakeEndpoint()
+	// A one-deep queue makes the overflow exact rather than a volume guess:
+	// the barrier snapshot is consumed by boundBinding, the first live event
+	// fills the slot, the second has nowhere to go.
+	broker, _, _ := newTestBroker(t, 1, endpoint)
+	binding, _ := boundBinding(t, broker, "thread-alone")
+
+	endpoint.push(threadEvent("thread-alone", "item/started"))
+	endpoint.push(threadEvent("thread-alone", "item/completed"))
+
+	waitUntil(t, "the unread binding to be revoked for resync", func() bool {
+		return binding.Revocation() == RefusalResyncRequired
+	})
+	if bindings := broker.Diagnostics().Bindings; bindings != 0 {
+		t.Fatalf("bindings after the only one was revoked = %d, want 0", bindings)
+	}
+
+	waitUntil(t, "the upstream connection to be folded", func() bool {
+		select {
+		case <-endpoint.dead:
+			return true
+		default:
+			return false
+		}
+	})
+	if err := broker.Close(); err != nil {
+		t.Fatalf("Close() = %v", err)
+	}
+	assertNoGoroutineLeak(t, before)
+}


### PR DESCRIPTION
Phase 3 of the `Install does not replace projmux long-lived processes` track closes
the two holes Phase 1 left open in C-2 (`backlog-overflow` observer recovery).
Both are the same shape: a recovery path that is *right* about what to do and
silent about having done it, so an operator cannot tell a working observer from
a dead one.

## Ledger 1 — the last binding's overflow folds the upstream connection

`Broker.wanted()` is `len(b.bindings) > 0`, so it is broker-global rather than
per binding. When the overflowing binding is the only one the runtime holds, the
`resync` unbind takes it to zero, `serve` revokes the epoch and closes the
endpoint, and no replacement snapshot barrier can exist until upstream is
reopened. That premise is not exotic — it holds permanently for anyone running a
single Codex pane, so this defect gets *more* likely as the fleet gets smaller.

Three facts came out of pinning it:

- **The fold self-heals whenever upstream is reachable.** Measured, not assumed:
  the replacement `Open` rebinds, the supervisor reopens, and a new epoch label
  is published. `wanted()`/`serve` are unchanged.
- **The fold is itself a race.** A rebind that lands before `serve` processes the
  unbind wake leaves the connection up, and the run never takes the path at all.
  The fixture gates every replacement `Open` on the fold so the premise is a
  fact rather than a hope.
- **The fold could be missed entirely, and that is a separate defect.**
  `Bind` and `Binding.Close` both signal the supervisor because both change what
  the connection has left to serve. `revokeBindingLocked` — the *involuntary*
  path, taken when a bounded delivery queue overflows or a thread-scoped
  snapshot is refused — deleted the binding from routing with no wake at all. So
  a runtime could reach zero bindings with nothing pending on the wake channel,
  and `serve` would sit in its select holding an upstream app-server connection
  nothing is bound to. `serve`'s own comment on that wake already claims to
  cover it ("a bind joined, or the last binding left"). It is now signalled from
  the one place every revocation goes through.

  Blast radius stated precisely: this is a held upstream connection plus an
  unnecessary runtime recycle when the host idle timer (30s) eventually fires —
  **not** the stuck-Pane mechanism, because anything that rebinds carries its own
  signal and recovers. It surfaced as a 2-in-30 hang in the app-level fixture,
  which is what a missed wake looks like when nothing rebinds.

The real defect is what happens while upstream *is* away. Every replacement
`Open` blocks on the barrier to its own open timeout — 15s in production — and
then fails. The scheduler computed the failure's vocabulary token and threw it
away: `codexNativeReason(err)` was read into a local the recovering branch never
used. So the Pane sat on `invalidating|<epoch>|backlog-overflow` while the
observer retried forever with no record of a single attempt. That is
byte-identical to the stuck Pane Phase 1's `observer.stopped` record exists to
name — except that here recovery really is running, so no terminal record
arrives either and there is no positive evidence in either direction. Measured
baseline: 8 failed replacement opens in 6s, journal holds three records, none of
them about any attempt.

`continueRecovery` now takes the token its caller already computed and records it
on the retry transition whenever an attempt actually failed. The journal's
existing coalescing window folds a long outage into one line plus a repeat count.
The reason column of the disconnect that opened recovery is untouched, so
`backlog-overflow` vs `endpoint-suspended` remains the discriminator of who
closed the stream.

## Ledger 2 — the live epoch's `bindingTicker` exit

The same single-sample defect Phase 1 fixed in `continueRecovery` was still in
the live event loop: one `false` from `BindingCurrent` ended the observer. That
predicate folds "this activation was replaced" and "the binding could not be read
right now" (a failed Registry load, a failed `tmux` invocation) into one answer,
so a single failed read retired a healthy producer. The path now makes the same
bounded wait as the loop head and the recovery scheduler.

When the binding really is gone, ending is correct — a replaced activation has
its own observer. What was wrong is that it ended invisibly: no authority write
(correctly — `SetAuthority` refuses once the predicate is false) and no record,
so the Pane keeps `provider-control-plane|ready` with nothing behind it. **That
is the inverse of the field sample this track chased: nothing looks wrong at
all.** It now leaves an `observer.stopped` record, result `stuck`, reason
`binding-replaced`.

`binding-replaced` is deliberately a new token rather than a reuse of
`binding-revoked`. The four close-cause tokens answer "who closed the stream" and
come from the broker epoch; here the stream was never closed. Reusing one would
make a broker-epoch cause appear from a producer that is not the broker epoch,
which is the one property of that vocabulary that has to hold. The token is
additive and only ever reaches the journal, never a pane option, and
`aiIngestReasons` already folds in `codexObserverReasons`, so no reader changes.

## Verification

New test in `internal/integrations/agents/codexbroker/broker_test.go`:

- `TestLastBindingRevokedByOverflowFoldsTheUpstreamConnection` — deterministic,
  no wall-clock waits: a one-deep queue makes the overflow exact. Baseline with
  the signal reverted fails on "timed out waiting for the upstream connection to
  be folded".

New tests in `internal/app/codex_broker_lifecycle_test.go`:

- `TestObserverRecoversWhenTheOverflowedBindingWasTheBrokersLast`
- `TestLastBindingOverflowRecordsEveryFailedReplacementOpen`
- `TestLiveEpochSurvivesATransientBindingReadFailure`
- `TestLiveEpochBindingLossLeavesATerminalRecord`

Baseline with the fixes reverted and the fixtures final: the last three fail with
the exact defect named in each message; the first passes, which is intentional —
it is the "reopen succeeds" half of the acceptance criterion and the guard that
the fold self-heals.

One fixture defect surfaced with them and is fixed in the same file:
`brokerTestEndpoint.emit` sent on the notification channel while `Close` closed
it. Nothing had exercised that before, because only the last-binding premise
retires the connection while a test is still emitting; the `recover()` that used
to sit in `emit` was hiding a genuine send/close race that `-race` reports
outright. The send is now taken under the same lock `Close` uses, and it is
retried rather than dropped so a test that overruns a bounded queue still gets
every event it declared.

Phase 1's three tests stay green. Two existing tests
(`TestCodexNativeObserverForeignThreadSameTurnWritesNoRegistryProgressOrDiagnostics`,
`TestCodexNativeObserverBindingLossExitsSilentConnectionWithoutWrites`) now set a
short `bindingTimeout` because the exit they drive is bounded rather than
instant; the contracts they own — no stale cleanup, no fallback authority — are
unchanged.

Not touched: `wanted()` and `serve` themselves, the `end`/`resync`
"never silently drop" design (`codex_broker_lifecycle.go` diff is 0 lines), the
broker wire protocol and refusal vocabulary, replacement policy, and `install`.
No process is killed or signalled anywhere in the diff.

Roadmap: Install does not replace projmux long-lived processes / Phase 3 C-2 remaining holes
Contract: C-2 Guarantee, C-2 Failure.Detection
