### PR TITLE
fix(tmux): route managed Agent pane projections

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1423,8 +1423,27 @@ bell hook consumers, including state and resume markers.
 canonical detached materialization through its supplied exact runner before any
 managed marker or Pane UID exists. Existing topic/status semantic fixtures retain
 their option expectations while their mock server supplies explicit containment.
-Managed interaction/topic projection outside the shared helpers remains a
-separate transport boundary.
+`TestManagedProjectionRoutingCallers` enters managed interaction through Claude
+`UserPromptSubmit` hook ingest and managed topic through the internal
+`aiCommand.Run` compatibility set/clear path. Its internal status-idle companion
+covers badge/attention unset; hooks do not emit idle. Caller result, committed
+Registry state, exact route argv, target values and actual unset are asserted
+together. `TestManagedProjectionRoutingFailureKeepsCommit` refuses disappeared,
+denied and foreign routes after commit, with no fallback writes, and retains the
+existing committed-mirror error and first-write-failure behavior.
+
+`TestManagedProjectionRoutingRealTmux` repeats these managed caller cases on two
+isolated real servers with identical pane IDs and opposite-server sentinels.
+Detached attribution reads use the fixture's exact route; projection writes run
+unaltered. Baseline detached raw projections and a shared-prefix-removal mutant
+both fail the target assertions. Inherited raw baseline writes can already work
+through the tmux environment; the argv fixture additionally pins explicit routing.
+An optional `PROJMUX_TEST_MANAGED_ROUTE_BINARY=<absolute binary>` executes
+the reachable hook case and a separate canonical public status/topic parity
+subtest through that binary. Internal topic and idle cases always
+compile this source; there is no installed target-topic CLI. Canonical public
+`agent status/topic` uses its separate already-routed mirror and is parity evidence,
+not proof of these compatibility projections.
 
 `TestSharedPaneRoutingRealTmux` uses two real isolated servers with the same pane
 ID and checks set, clear, marker and full hook state against target readback and
@@ -1434,7 +1453,9 @@ inside a dedicated tmux root; only a verified private alias exposes the fixed ap
 locator. Cleanup rechecks the observed exact socket before `-S` shutdown. The test
 runs with `make test` where tmux is available; an explicit installed smoke runs the
 same hook assertions against `PROJMUX_TEST_PANE_ROUTE_BINARY=<absolute binary>`.
-This is a test-only selector, not a product environment contract.
+This is a test-only selector, not a product environment contract. The fixture
+seeds and strips the caller's internal activation Pane/generation envelope so a
+managed test process cannot suppress the isolated hook as a stale activation.
 
 ### Attributed Codex hook delivery route tests
 

--- a/internal/app/ai.go
+++ b/internal/app/ai.go
@@ -439,11 +439,13 @@ func (c *aiCommand) projectManagedAgentInteraction(paneID string, kind coremetad
 		{aiPaneBadgeKindOption, badge},
 		{attentionStateOption, attention},
 	} {
-		args := []string{"set-option", "-p", "-t", paneID, field.option, field.value}
+		var err error
 		if field.value == "" {
-			args = []string{"set-option", "-p", "-u", "-t", paneID, field.option}
+			err = c.clearAIPaneOption(paneID, field.option)
+		} else {
+			err = c.setAIPaneOption(paneID, field.option, field.value)
 		}
-		if err := c.run("tmux", args...); err != nil {
+		if err != nil {
 			return err
 		}
 	}
@@ -860,11 +862,13 @@ func (c *aiCommand) projectManagedAgentTopic(paneID, topic string) error {
 		{aiPaneTopicOption, strings.TrimSpace(topic)},
 		{aiPaneTopicManualOption, map[bool]string{true: "on"}[strings.TrimSpace(topic) != ""]},
 	} {
-		args := []string{"set-option", "-p", "-t", paneID, field.option, field.value}
+		var err error
 		if field.value == "" {
-			args = []string{"set-option", "-p", "-u", "-t", paneID, field.option}
+			err = c.clearAIPaneOption(paneID, field.option)
+		} else {
+			err = c.setAIPaneOption(paneID, field.option, field.value)
 		}
-		if err := c.run("tmux", args...); err != nil {
+		if err != nil {
 			return err
 		}
 	}

--- a/internal/app/ai_managed_projection_route_test.go
+++ b/internal/app/ai_managed_projection_route_test.go
@@ -1,0 +1,217 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+)
+
+// These fixtures enter hook ingest and the internal compatibility handler through Run, with a real
+// managed Registry binding. Attribution reads are separate from the write
+// transport, so a permissive/already-routed fake cannot conceal a raw write.
+type managedProjectionCase struct {
+	name  string
+	args  []string
+	want  map[string]string
+	kind  coremetadata.AgentInteractionKind
+	topic string
+}
+
+func managedProjectionCases(pane string) []managedProjectionCase {
+	return []managedProjectionCase{
+		{"interaction_hook_set", []string{"ingest", "claude-hook"}, map[string]string{aiPaneStateOption: "thinking", aiPaneBadgeKindOption: "in_progress", attentionStateOption: "busy"}, coremetadata.InteractionInProgress, ""},
+		{"interaction_internal_idle", []string{"status", "set", "idle", pane}, map[string]string{aiPaneStateOption: "idle", aiPaneBadgeKindOption: "", attentionStateOption: ""}, coremetadata.InteractionIdle, ""},
+		{"topic_set", []string{"topic", "set", "routed topic", "--pane", pane}, map[string]string{aiPaneTopicOption: "routed topic", aiPaneTopicManualOption: "on"}, "", "routed topic"},
+		{"topic_clear", []string{"topic", "clear", "--pane", pane}, map[string]string{aiPaneTopicOption: "", aiPaneTopicManualOption: ""}, "", ""},
+	}
+}
+
+func assertManagedProjectionRegistry(t *testing.T, h *sessionRefHarness, tc managedProjectionCase) {
+	t.Helper()
+	a := h.agent(t)
+	if strings.HasPrefix(tc.name, "interaction") {
+		source := "compatibility-ai"
+		if tc.args[0] == "ingest" {
+			source = "provider-hook"
+		}
+		if a.Status.Interaction.Kind != tc.kind || a.Status.Interaction.Source != source {
+			t.Errorf("committed interaction = %+v, want %s %s", a.Status.Interaction, tc.kind, source)
+		}
+	} else if got := a.Metadata.Annotations[coremetadata.AnnotationAgentTopic]; got != tc.topic {
+		t.Errorf("committed topic = %q, want %q", got, tc.topic)
+	}
+}
+
+func prepareManagedProjection(t *testing.T) *sessionRefHarness {
+	t.Helper()
+	h := newSessionRefHarness(t, aiModeClaude)
+	a, _ := h.registry.Agent(h.agentUID)
+	a.Status.Interaction = coremetadata.AgentInteraction{Kind: coremetadata.InteractionInProgress, Source: "manual", ObservedAt: sessionRefObservedAt.Add(-time.Minute)}
+	if a.Metadata.Annotations == nil {
+		a.Metadata.Annotations = map[string]string{}
+	}
+	a.Metadata.Annotations[coremetadata.AnnotationAgentTopic] = "old topic"
+	h.cmd.notifyStore = &stubNotifyStore{}
+	h.cmd.producer = &storeAttentionNotifyProducer{store: &stubNotifyStore{}, ttl: time.Minute}
+	return h
+}
+
+func TestManagedProjectionRoutingCallers(t *testing.T) {
+	for _, tc := range managedProjectionCases("%7") {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, inherited := range []bool{false, true} {
+				t.Run(map[bool]string{false: "detached", true: "inherited"}[inherited], func(t *testing.T) {
+					h := prepareManagedProjection(t)
+					prefix := []string{"-L", defaultAppSocket}
+					if inherited {
+						prefix = []string{"-S", "/tmp/managed-fixture/socket"}
+						base := h.cmd.lookupEnv
+						h.cmd.lookupEnv = func(key string) string {
+							if key == "TMUX" {
+								return "/tmp/managed-fixture/socket,42,0"
+							}
+							return base(key)
+						}
+					}
+					values := map[string]string{}
+					for key := range tc.want {
+						values[key] = "sentinel"
+					}
+					writes := 0
+					h.cmd.runCommand = func(_ context.Context, name string, args ...string) error {
+
+						if name != "tmux" || len(args) < 3 || !reflect.DeepEqual(args[:2], prefix) {
+							return fmt.Errorf("unrouted managed projection: %q", args)
+						}
+						plain := args[2:]
+						if len(plain) != 6 || plain[0] != "set-option" {
+							return fmt.Errorf("unexpected write: %q", args)
+						}
+						key := plain[4]
+						if plain[2] == "-u" {
+							key = plain[5]
+						}
+						if _, projected := tc.want[key]; projected && h.updates != 1 {
+							t.Error("projection attempted before Registry commit")
+						}
+						writes++
+						if plain[2] == "-u" {
+							delete(values, plain[5])
+						} else {
+							values[plain[4]] = plain[5]
+						}
+						return nil
+					}
+					var out, errOut bytes.Buffer
+					err := runManagedProjectionCase(h, tc, &out, &errOut)
+					if h.updates != 1 {
+						t.Errorf("managed caller committed %d Registry updates, want 1", h.updates)
+					}
+					assertManagedProjectionRegistry(t, h, tc)
+					if err != nil || out.Len() != 0 || errOut.Len() != 0 {
+						t.Errorf("managed caller result=%v stdout=%q stderr=%q", err, out.String(), errOut.String())
+					}
+					for key, want := range tc.want {
+						if got := values[key]; got != want {
+							t.Errorf("managed target %s=%q, want %q (successful writes=%d)", key, got, want, writes)
+						}
+						if want == "" {
+							if _, exists := values[key]; exists {
+								t.Errorf("managed target %s must be unset", key)
+							}
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestManagedProjectionRoutingFailureKeepsCommit(t *testing.T) {
+	for _, tc := range managedProjectionCases("%7") {
+		for _, refusal := range []string{"disappeared", "denied", "foreign", "write-refused", "inherited-disappeared"} {
+			t.Run(tc.name+"/"+refusal, func(t *testing.T) {
+				h := prepareManagedProjection(t)
+				prefix := []string{"-L", defaultAppSocket}
+				if refusal == "inherited-disappeared" {
+					prefix = []string{"-S", "/tmp/managed-fixture/disappeared"}
+					baseEnv := h.cmd.lookupEnv
+					h.cmd.lookupEnv = func(key string) string {
+						if key == "TMUX" {
+							return "/tmp/managed-fixture/disappeared,42,0"
+						}
+						return baseEnv(key)
+					}
+				}
+				baseRead := h.cmd.readCommand
+				h.cmd.readCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+					if h.updates > 0 && len(args) > 0 && args[len(args)-1] == aiPaneOptionRouteFormat {
+						if h.updates != 1 {
+							t.Fatal("route refusal must occur after managed commit")
+						}
+						switch refusal {
+						case "disappeared":
+							return nil, os.ErrNotExist
+						case "denied":
+							return nil, os.ErrPermission
+						case "foreign":
+							return []byte(strings.Join([]string{"1", "%8", h.paneUID}, tmuxRowSep)), nil
+						}
+					}
+					return baseRead(ctx, name, args...)
+				}
+				attempts := 0
+				h.cmd.runCommand = func(_ context.Context, name string, args ...string) error {
+					if h.updates == 0 {
+						return nil
+					} // Hook markers precede the managed commit.
+					attempts++
+					if h.updates != 1 {
+						t.Error("write before commit")
+					}
+					if !reflect.DeepEqual(args[:min(len(args), 2)], prefix) {
+						t.Errorf("fallback write %s %q", name, args)
+					}
+					return errors.New("fixture write refused")
+				}
+				err := runManagedProjectionCase(h, tc, &bytes.Buffer{}, &bytes.Buffer{})
+				if h.updates != 1 {
+					t.Errorf("managed caller committed %d Registry updates, want 1", h.updates)
+				}
+				assertManagedProjectionRegistry(t, h, tc)
+				verb := "ai " + tc.args[0]
+				if tc.args[0] == "ingest" {
+					verb = "ai status"
+				}
+				wantErr := committedMirrorError(verb, coremetadata.KindAgent, h.agentUID, errAIPaneWriteUnavailable).Error()
+				if err == nil || err.Error() != wantErr {
+					t.Errorf("committedMirrorError = %v, want %q", err, wantErr)
+				}
+				wantAttempts := 0
+				if refusal == "write-refused" || refusal == "inherited-disappeared" {
+					wantAttempts = 1
+				}
+				if attempts != wantAttempts {
+					t.Errorf("write attempts=%d, want %d; no fallback or later option allowed", attempts, wantAttempts)
+				}
+			})
+		}
+	}
+}
+
+func runManagedProjectionCase(h *sessionRefHarness, tc managedProjectionCase, out, errOut *bytes.Buffer) error {
+	args := append([]string{}, tc.args...)
+	if tc.args[0] == "ingest" {
+		h.cmd.stdin = strings.NewReader(`{"hook_event_name":"UserPromptSubmit","cwd":"/src/app"}`)
+		args = append(args, "--pane", h.paneUID)
+	}
+	return h.cmd.Run(args, out, errOut)
+}

--- a/internal/app/ai_managed_projection_route_tmux_test.go
+++ b/internal/app/ai_managed_projection_route_tmux_test.go
@@ -1,0 +1,324 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
+	"github.com/crevissepartners/projmux/internal/integrations/tmuxopts"
+)
+
+// The optional installed binary covers the reachable hook interaction only.
+// Internal topic/idle cases always compile this source; they are not installed
+// CLI calls. Canonical agent status/topic uses a separate already-routed mirror.
+func TestManagedProjectionRoutingRealTmux(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	binary := os.Getenv("PROJMUX_TEST_MANAGED_ROUTE_BINARY")
+	if binary != "" && !filepath.IsAbs(binary) {
+		t.Fatal("installed smoke binary must be absolute")
+	}
+	// Darwin's inherited TMPDIR can exhaust the Unix socket path limit. Both
+	// supported hosts provide /tmp; resolve its spelling before containment
+	// checks because Darwin commonly exposes it through /private/tmp.
+	root, err := os.MkdirTemp("/tmp", "pmx-managed-route-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		_ = os.RemoveAll(root)
+		t.Fatal(err)
+	}
+	root = resolvedRoot
+	cleanupVerified := true
+	t.Cleanup(func() {
+		if cleanupVerified {
+			_ = os.RemoveAll(root)
+		}
+	})
+	env := []string{}
+	for _, value := range os.Environ() {
+		key, _, _ := strings.Cut(value, "=")
+		if key == "HOME" || key == "TMUX" || key == "TMUX_PANE" || key == "TMUX_TMPDIR" || strings.HasPrefix(key, "XDG_") || strings.HasPrefix(key, "PROJMUX_") || strings.HasPrefix(key, "__PROJMUX_") || key == internalActivationPaneUIDEnv || key == internalActivationGenerationEnv {
+			continue
+		}
+		env = append(env, value)
+	}
+	env = append(env, "HOME="+root, "TMUX_TMPDIR="+root,
+		"XDG_STATE_HOME="+filepath.Join(root, "state"), "XDG_CONFIG_HOME="+filepath.Join(root, "config"),
+		"XDG_DATA_HOME="+filepath.Join(root, "data"), "XDG_CACHE_HOME="+filepath.Join(root, "cache"),
+		"XDG_RUNTIME_DIR="+filepath.Join(root, "runtime"))
+	if err := os.Mkdir(filepath.Join(root, "runtime"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	run := func(extra []string, name string, args ...string) ([]byte, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		process := exec.CommandContext(ctx, name, args...)
+		process.Env = append(append([]string{}, env...), extra...)
+		return process.CombinedOutput()
+	}
+	tmux := func(args ...string) string {
+		t.Helper()
+		out, err := run(nil, "tmux", args...)
+		if err != nil {
+			t.Fatalf("isolated tmux %q: %v: %s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	otherName := fmt.Sprintf("other-%d", os.Getpid())
+	sockets := []string{}
+	panes := []string{}
+	for _, name := range []string{fmt.Sprintf("app-%d", os.Getpid()), otherName} {
+		pane := tmux("-L", name, "-f", "/dev/null", "new-session", "-d", "-s", "fixture", "-P", "-F", "#{pane_id}", "sleep 600")
+		socket := tmux("-L", name, "display-message", "-p", "-t", pane, "#{socket_path}")
+		if !strings.HasPrefix(socket, root+string(os.PathSeparator)) {
+			t.Fatalf("unsafe smoke socket %q", socket)
+		}
+		sockets = append(sockets, socket)
+		panes = append(panes, pane)
+		t.Cleanup(func() {
+			// Re-observe exactly the owned route before exact-path cleanup.
+			out, queryErr := run(nil, "tmux", "-S", socket, "display-message", "-p", "#{socket_path}")
+			if queryErr != nil {
+				cleanupVerified = false
+				t.Errorf("cleanup route cannot be verified: %v", queryErr)
+				return
+			}
+			if strings.TrimSpace(string(out)) != socket || !strings.HasPrefix(socket, root+string(os.PathSeparator)) {
+				cleanupVerified = false
+				t.Errorf("cleanup route drifted: %q", out)
+				return
+			}
+			if out, err := run(nil, "tmux", "-S", socket, "kill-server"); err != nil {
+				cleanupVerified = false
+				t.Errorf("cleanup: %v: %s", err, out)
+			}
+		})
+	}
+	// Detached production lookup keeps its fixed logical name. The servers
+	// themselves are created with unique names; this private alias names only
+	// the exact socket observed above, inside this test's dedicated root.
+	alias := filepath.Join(filepath.Dir(sockets[0]), defaultAppSocket)
+	if err := os.Symlink(sockets[0], alias); err != nil {
+		t.Fatal(err)
+	}
+	if resolved, err := filepath.EvalSymlinks(alias); err != nil || resolved != sockets[0] {
+		t.Fatalf("app alias failed containment: %q %v", resolved, err)
+	}
+	if panes[0] != panes[1] {
+		t.Fatalf("collision fixture needs identical pane ids, got %v", panes)
+	}
+	pane := panes[0]
+
+	h := newSessionRefHarness(t, aiModeClaude)
+	paneUID := h.paneUID
+	registeredPane, _ := h.registry.Pane(paneUID)
+	registeredPane.Status.Activation.RuntimeID = pane
+	store := intmetadata.NewStore(intmetadata.PathFor(filepath.Join(root, "state", "projmux")))
+	for i, socket := range sockets {
+		tmux("-S", socket, "set-option", "-g", tmuxopts.AppGlobal, "1")
+		tmux("-S", socket, "set-option", "-p", "-t", pane, tmuxopts.PaneUID, paneUID)
+		t.Logf("owned server %d socket=%s pane=%s", i, socket, pane)
+	}
+	option := func(socket, key string) string {
+		return tmux("-S", socket, "show-options", "-p", "-qv", "-t", pane, key)
+	}
+	keys := []string{aiPaneStateOption, aiPaneBadgeKindOption, attentionStateOption, aiPaneTopicOption, aiPaneTopicManualOption}
+	for _, inherited := range []bool{false, true} {
+		label := map[bool]string{false: "detached", true: "inherited"}[inherited]
+		t.Run(label, func(t *testing.T) {
+			target, opposite := sockets[0], sockets[1]
+			extra := []string{}
+			if inherited {
+				target, opposite = sockets[1], sockets[0]
+				extra = []string{"TMUX=" + target + ",42,0", "TMUX_PANE=" + pane}
+			}
+			for _, tc := range managedProjectionCases(pane) {
+				t.Run(tc.name, func(t *testing.T) {
+					for _, socket := range sockets {
+						for _, key := range keys {
+							tmux("-S", socket, "set-option", "-p", "-t", pane, key, "sentinel")
+						}
+					}
+					a, _ := h.registry.Agent(h.agentUID)
+					a.Status.Interaction = coremetadata.AgentInteraction{Kind: coremetadata.InteractionInProgress, Source: "manual", ObservedAt: sessionRefObservedAt.Add(-time.Minute)}
+					if a.Metadata.Annotations == nil {
+						a.Metadata.Annotations = map[string]string{}
+					}
+					a.Metadata.Annotations[coremetadata.AnnotationAgentTopic] = "old topic"
+					if _, err := store.Update(func(reg *coremetadata.Registry) error { *reg = h.registry.Clone(); return nil }); err != nil {
+						t.Fatal(err)
+					}
+					h.updates = 0
+					cmd := testAICommand(root)
+					cmdEnv := append(append([]string{}, env...), extra...)
+					cmd.lookupEnv = func(name string) string {
+						for _, val := range cmdEnv {
+							if key, value, ok := strings.Cut(val, "="); ok && key == name {
+								return value
+							}
+						}
+						return ""
+					}
+					cmd.readFile = os.ReadFile
+					cmd.loadRegistry = store.Load
+					cmd.updateRegistry = func(fn func(*coremetadata.Registry) error) (coremetadata.Registry, error) {
+						reg, err := store.Update(fn)
+						if err == nil {
+							h.updates++
+							*h.registry = reg.Clone()
+						}
+						return reg, err
+					}
+					// Existing managed attribution reads receive the known exact route.
+					// Writes use real argv unchanged, making detached raw writes fail rather
+					// than being silently repaired by the fixture's runner.
+					cmd.readCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+						if name == "tmux" && (len(args) == 0 || (args[0] != "-L" && args[0] != "-S")) {
+							args = append([]string{"-S", target}, args...)
+						}
+						return run(extra, name, args...)
+					}
+					cmd.runCommand = func(_ context.Context, name string, args ...string) error {
+						out, err := run(extra, name, args...)
+						if err != nil {
+							return fmt.Errorf("%w: %s", err, out)
+						}
+						return nil
+					}
+					cmd.notifyStore = &stubNotifyStore{}
+					cmd.producer = &storeAttentionNotifyProducer{store: &stubNotifyStore{}, ttl: time.Minute}
+					h.cmd = cmd
+					var out, errOut bytes.Buffer
+					var result error
+					installed := binary != "" && tc.args[0] == "ingest"
+					if installed {
+						// The old attribution reader is unprefixed. A private default alias to
+						// the opposite server supplies the same registered PaneUID; only the
+						// shared write route may change the app target. No live default exists
+						// inside this fixture root.
+						defaultAlias := filepath.Join(filepath.Dir(sockets[0]), "default")
+						if err := os.Symlink(opposite, defaultAlias); err != nil {
+							t.Fatal(err)
+						}
+						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+						process := exec.CommandContext(ctx, binary, "internal", "agent-hook", "ingest", "claude-hook", "--pane", paneUID)
+						process.Env = cmdEnv
+						process.Stdin = strings.NewReader(`{"hook_event_name":"UserPromptSubmit","cwd":"/src/app"}`)
+						process.Stdout, process.Stderr = &out, &errOut
+						result = process.Run()
+						cancel()
+						if err := os.Remove(defaultAlias); err != nil {
+							t.Fatal(err)
+						}
+						reg, err := store.Load()
+						if err != nil {
+							t.Fatal(err)
+						}
+						*h.registry = reg
+					} else {
+						result = runManagedProjectionCase(h, tc, &out, &errOut)
+					}
+					if !installed && h.updates != 1 {
+						t.Errorf("managed caller committed %d Registry updates, want 1", h.updates)
+					}
+					assertManagedProjectionRegistry(t, h, tc)
+					if result != nil || out.Len() != 0 || errOut.Len() != 0 {
+						t.Errorf("managed caller result=%v stdout=%q stderr=%q", result, out.String(), errOut.String())
+					}
+					for key, want := range tc.want {
+						if got := option(target, key); got != want {
+							t.Errorf("managed target %s=%q, want %q", key, got, want)
+						}
+					}
+					// Empty show-options is not enough: the option must actually be absent.
+					options := tmux("-S", target, "show-options", "-p", "-t", pane)
+					for key, want := range tc.want {
+						if want == "" && strings.Contains(options, key+" ") {
+							t.Errorf("managed target %s must be unset", key)
+						}
+					}
+					for _, key := range keys {
+						if got := option(opposite, key); got != "sentinel" {
+							t.Errorf("opposite same-%s %s=%q, want sentinel", pane, key, got)
+						}
+					}
+					t.Logf("%s target=%s opposite=%s installed-hook=%t registry interaction=%s topic=%q", tc.name, target, opposite, installed, h.agent(t).Status.Interaction.Kind, h.agent(t).Metadata.Annotations[coremetadata.AnnotationAgentTopic])
+				})
+			}
+		})
+	}
+
+	if binary != "" {
+		t.Run("installed_canonical_parity", func(t *testing.T) {
+			target, opposite := sockets[1], sockets[0]
+			extra := []string{"TMUX=" + target + ",42,0", "TMUX_PANE=" + pane}
+			for _, tc := range managedProjectionCases(pane) {
+				t.Run(tc.name, func(t *testing.T) {
+					for _, socket := range sockets {
+						for _, key := range keys {
+							tmux("-S", socket, "set-option", "-p", "-t", pane, key, "sentinel")
+						}
+					}
+					args := []string{"agent"}
+					switch tc.name {
+					case "interaction_hook_set":
+						args = append(args, "status", "set", "in_progress")
+					case "interaction_internal_idle":
+						args = append(args, "status", "set", "idle")
+					case "topic_set":
+						args = append(args, "topic", "set", tc.topic)
+					case "topic_clear":
+						args = append(args, "topic", "clear")
+					}
+					args = append(args, "uid:"+h.agentUID)
+					out, err := run(extra, binary, args...)
+					if err != nil || len(out) != 0 {
+						t.Fatalf("installed canonical %q result=%v output=%q", args, err, out)
+					}
+					reg, err := store.Load()
+					if err != nil {
+						t.Fatal(err)
+					}
+					a, ok := reg.Agent(h.agentUID)
+					if !ok {
+						t.Fatal("canonical Agent disappeared")
+					}
+					if strings.HasPrefix(tc.name, "interaction") {
+						if a.Status.Interaction.Kind != tc.kind || a.Status.Interaction.Source != "manual" {
+							t.Errorf("canonical Registry interaction=%+v", a.Status.Interaction)
+						}
+					} else if got := a.Metadata.Annotations[coremetadata.AnnotationAgentTopic]; got != tc.topic {
+						t.Errorf("canonical Registry topic=%q, want %q", got, tc.topic)
+					}
+					options := tmux("-S", target, "show-options", "-p", "-t", pane)
+					for key, want := range tc.want {
+						if got := option(target, key); got != want {
+							t.Errorf("canonical target %s=%q, want %q", key, got, want)
+						}
+						if want == "" && strings.Contains(options, key+" ") {
+							t.Errorf("canonical target %s must be unset", key)
+						}
+					}
+					for _, key := range keys {
+						if got := option(opposite, key); got != "sentinel" {
+							t.Errorf("canonical opposite %s=%q, want sentinel", key, got)
+						}
+					}
+					t.Logf("installed canonical parity args=%q target=%s opposite=%s; separate mirror, not internal topic proof", args, target, opposite)
+				})
+			}
+		})
+	}
+}

--- a/internal/app/ai_pane_route_tmux_test.go
+++ b/internal/app/ai_pane_route_tmux_test.go
@@ -25,6 +25,11 @@ func TestSharedPaneRoutingRealTmux(t *testing.T) {
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux is not installed")
 	}
+	// A test process may itself be a managed Agent; its activation belongs to
+	// the caller, never to either isolated fixture server. Seed stale values so
+	// removing the filter below is detected even in a clean CI environment.
+	t.Setenv(internalActivationPaneUIDEnv, "fixture-foreign-pane")
+	t.Setenv(internalActivationGenerationEnv, "fixture-foreign-generation")
 	binary := os.Getenv("PROJMUX_TEST_PANE_ROUTE_BINARY")
 	if binary != "" && !filepath.IsAbs(binary) {
 		t.Fatal("installed smoke binary must be absolute")
@@ -51,7 +56,7 @@ func TestSharedPaneRoutingRealTmux(t *testing.T) {
 	env := []string{}
 	for _, value := range os.Environ() {
 		key, _, _ := strings.Cut(value, "=")
-		if key == "HOME" || key == "TMUX" || key == "TMUX_PANE" || key == "TMUX_TMPDIR" || strings.HasPrefix(key, "XDG_") || strings.HasPrefix(key, "PROJMUX_") || strings.HasPrefix(key, "__PROJMUX_") {
+		if key == "HOME" || key == "TMUX" || key == "TMUX_PANE" || key == "TMUX_TMPDIR" || key == internalActivationPaneUIDEnv || key == internalActivationGenerationEnv || strings.HasPrefix(key, "XDG_") || strings.HasPrefix(key, "PROJMUX_") || strings.HasPrefix(key, "__PROJMUX_") {
 			continue
 		}
 		env = append(env, value)
@@ -224,7 +229,7 @@ func TestSharedPaneRoutingRealTmux(t *testing.T) {
 					}
 				}
 				if option(target, aiPaneHookActiveOption) != "1" || option(target, aiPaneResumeIDOption) != "fixture-session" || option(target, aiPaneResumeSourceOption) != "hook" {
-					t.Fatalf("%s hook marker/resume writes missed target", event)
+					t.Fatalf("%s hook marker/resume writes missed target: hook-active=%q resume-id=%q resume-source=%q", event, option(target, aiPaneHookActiveOption), option(target, aiPaneResumeIDOption), option(target, aiPaneResumeSourceOption))
 				}
 				data, err := os.ReadFile(filepath.Join(root, "state", "projmux", aiIngestLogName))
 				if err != nil {

--- a/internal/app/runtime_mutation_plan_test.go
+++ b/internal/app/runtime_mutation_plan_test.go
@@ -2936,8 +2936,6 @@ func TestPlanOnlyMutationNegativeAuditHasZeroBypass(t *testing.T) {
 		"ai_pane_write.go:writeAIPaneOption:variable-argv":                "agent.presentation",
 		"ai.go:BindAgentPaneOnRoute:variable-argv":                        "agent.presentation",
 		"ai.go:writeAgentPaneOptionOnRoute:variable-argv":                 "codex.native-lifecycle-authority",
-		"ai.go:projectManagedAgentInteraction:variable-argv":              "agent.presentation",
-		"ai.go:projectManagedAgentTopic:variable-argv":                    "agent.presentation",
 		"../integrations/metadata/tmuxmirror.go:RenameProject:set-option": "resource.rename-project",
 		"../integrations/metadata/tmuxmirror.go:RebindProject:set-option": "resource.rebind-project",
 		"../integrations/metadata/tmuxmirror.go:writePaneName:set-option": "resource.rename-pane",


### PR DESCRIPTION
## Summary
- Route Registry-managed interaction and topic pane projections through the shared exact tmux route, so detached or inherited callers update the bound server even when another server has the same `%N`.
- Preserve Registry commit-before-mirror behavior and the existing committed mirror error when the target route disappears, is denied, is foreign, or refuses a write.
- Add managed caller, real two-server tmux, failure, baseline/mutant, and installed-binary smoke coverage; document the maintained workflow tests.

## Test plan
- [x] `make fmt`
- [x] `make fix`
- [x] `make test`
- [x] focused managed caller and real tmux routing tests
- [x] prefix-ignored mutant fails both interaction and topic caller assertions
- [x] candidate binary managed hook and canonical `agent status/topic` isolated smoke
- [x] `make test-integration`
- [x] `make test-e2e`
- [x] required CI jobs and aggregate `Test`
- [x] merged installed binary isolated smoke

## Globalization
- [x] No user-facing string changes.
