### PR TITLE
feat(agent): add Claude coordination ingress

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1014,21 +1014,34 @@
 - `TestClaudeCoordinationHub*` owns single-waiter CAS/supersede, no-waiter hold,
   TTL, receipt timeout, duplicate/out-of-order refusal, helper replacement, and
   zero automatic resend after an ambiguous provider-pipe outcome.
+- `TestClaudeCoordinationDeadHookChildNeverBeginsHandoff` and
+  `TestClaudeCoordinationDisconnectedHookResponseFailsBeforeHandoff` keep a dead
+  child fenced as held with handoff zero and a failed helper response as a
+  non-ambiguous terminal result. `TestClaudeCoordinationAssignmentTimeoutFailsBeforeHandoff`
+  pins the same non-ambiguous terminal boundary after a complete assignment but
+  before the child acknowledges `begin-handoff`. The process integration also
+  refuses a same-provider direct child when fd 2 is a regular file rather than
+  the provider-owned pipe.
 - `TestOwnedSocketCleanupPreservesReplacementAndPathModeBounds`,
+  `TestSocketIncarnationIdentityRejectsLegacyAxisReuse`,
   `TestClaudeEndpointDeadLeaseWatcherInvalidatesWhileProviderLives`, and
   `TestCleanupClaudeActivationLeasesPreservesCoordinationReplacement` require
   listener close, dead-helper reaping, and supervisor cleanup to unlink only
-  the exact receipt-bound socket inode while preserving a same-path replacement.
+  the exact receipt-bound socket incarnation, including change time when a
+  filesystem reuses device and inode, while preserving a same-path replacement.
 - `TestClaudeCoordinationHookOwnedUDSAndProviderPipe` uses only a disposable
   Projmux-owned Unix socket and pipe, with a waiter-ready barrier and structured
   receipt, to cover exact `SessionStart` and `Stop` final-hop delivery. Its peer
   record stays explicitly untrusted and slash commands remain plaintext; no
   provider/model/vendor socket, MCP, connector, interrupt, approval, or tool is run.
 - `TestAIIntegrateClaude*` and
-  `TestClaudeAutomaticMigrationPreservesCoordinationPresenceAndSettingsBytes`
+  `TestClaudeAutomaticMigrationPreservesCoordinationPresenceAndSettingsBytes`,
+  plus `TestConfigApplyNoReloadPreservesClaudeSettingsBytesWithCoordinationAbsentOrPresent`,
   pin one managed asyncRewake hook for each of `SessionStart` and `Stop`, preserve
-  user and existing managed hooks, and keep automatic install-time migration
-  byte-identical unless the coordination family was explicitly present already.
+  user and existing managed hooks, make repeated remove byte/write-count
+  idempotent, and keep automatic install-time migration and
+  `config apply --no-reload` byte-identical for both absent and present
+  coordination families.
 
 ### Provider hook pane identity tests
 

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -993,8 +993,9 @@
   `TestClaudeEndpointProcessIntegration` through supervisor, activation gate,
   public SessionStart hook, and detached helper. It covers registration
   replacement, actual helper death while the provider remains alive, automatic
-  lease cleanup, nested/forged entrypoint refusal, provider exit, zero provider
-  connections, and zero token/locator residue in output and live lease files.
+  lease cleanup, nested/forged entrypoint refusal, provider exit with bounded
+  convergence of every captured helper birth, zero provider connections, and
+  zero token/locator residue in output and live lease files.
 - `TestClaudeEndpointInstalledSourceGate` is opt-in evidence from a disposable
   installed Claude one-shot. It checks public SessionStart identity, exact
   readiness, exit invalidation, empty tools/MCP/plugins, and zero tool-use.
@@ -1012,8 +1013,9 @@
   after one exact waiter fully writes the bounded frame and the same helper
   commits its receipt; it never claims model processing, reply, or turn completion.
 - `TestClaudeCoordinationHub*` owns single-waiter CAS/supersede, no-waiter hold,
-  TTL, receipt timeout, duplicate/out-of-order refusal, helper replacement, and
-  zero automatic resend after an ambiguous provider-pipe outcome.
+  TTL before and after waiter assignment, the final pre-handoff deadline fence,
+  receipt timeout, duplicate/out-of-order refusal, helper replacement, and zero
+  automatic resend after an ambiguous provider-pipe outcome.
 - `TestClaudeCoordinationDeadHookChildNeverBeginsHandoff` and
   `TestClaudeCoordinationDisconnectedHookResponseFailsBeforeHandoff` keep a dead
   child fenced as held with handoff zero and a failed helper response as a

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1003,6 +1003,33 @@
   safe-mode delivery gate. Setup and limits are in
   [claude-coordination-endpoints.md](claude-coordination-endpoints.md).
 
+### Claude coordination ingress Phase 2 tests
+
+- `TestDeliveryTransitionTable` and its deterministic randomized sequence test
+  own the private provider-final-hop `queued`/`held`/`handoff` lifecycle and
+  terminal-once outcomes. This state sits below, and does not redefine, the
+  future public broker `accepted` projection. A handoff is `delivered` only
+  after one exact waiter fully writes the bounded frame and the same helper
+  commits its receipt; it never claims model processing, reply, or turn completion.
+- `TestClaudeCoordinationHub*` owns single-waiter CAS/supersede, no-waiter hold,
+  TTL, receipt timeout, duplicate/out-of-order refusal, helper replacement, and
+  zero automatic resend after an ambiguous provider-pipe outcome.
+- `TestOwnedSocketCleanupPreservesReplacementAndPathModeBounds`,
+  `TestClaudeEndpointDeadLeaseWatcherInvalidatesWhileProviderLives`, and
+  `TestCleanupClaudeActivationLeasesPreservesCoordinationReplacement` require
+  listener close, dead-helper reaping, and supervisor cleanup to unlink only
+  the exact receipt-bound socket inode while preserving a same-path replacement.
+- `TestClaudeCoordinationHookOwnedUDSAndProviderPipe` uses only a disposable
+  Projmux-owned Unix socket and pipe, with a waiter-ready barrier and structured
+  receipt, to cover exact `SessionStart` and `Stop` final-hop delivery. Its peer
+  record stays explicitly untrusted and slash commands remain plaintext; no
+  provider/model/vendor socket, MCP, connector, interrupt, approval, or tool is run.
+- `TestAIIntegrateClaude*` and
+  `TestClaudeAutomaticMigrationPreservesCoordinationPresenceAndSettingsBytes`
+  pin one managed asyncRewake hook for each of `SessionStart` and `Stop`, preserve
+  user and existing managed hooks, and keep automatic install-time migration
+  byte-identical unless the coordination family was explicitly present already.
+
 ### Provider hook pane identity tests
 
 - `TestProviderHookCommandsCarryTheirOwnPaneIdentity` and

--- a/docs/claude-coordination-endpoints.md
+++ b/docs/claude-coordination-endpoints.md
@@ -92,10 +92,21 @@ Claude hook process. User hooks and the existing status/registration hooks are
 retained, while explicit install and remove remain idempotent.
 
 Each hook child validates its SessionStart/Stop session ID, private activation
-envelope, direct provider parent, and exact helper peer. The helper admits only
-one waiter: a newer execution supersedes the prior one, which handles the
-documented per-execution non-dedup behavior. Hook and receipt timeouts are
-explicit state-machine inputs rather than evidence that delivery did not occur.
+envelope, direct provider parent, exact helper peer, and fd 2 as an owned pipe.
+A same-provider child whose stderr is a regular file fails closed before it can
+arm a waiter. The helper admits only one waiter: a newer execution supersedes
+the prior one, which handles the documented per-execution non-dedup behavior.
+Hook and receipt timeouts are explicit state-machine inputs rather than evidence
+that delivery did not occur.
+
+Assignment is not handoff. The helper keeps the message in `queued` or `held`
+until it has written the complete assignment response and the still-current hook
+child acknowledges `begin-handoff` immediately before writing fd 2. A dead child
+is dropped before assignment and leaves the message held with provider-pipe
+writes equal to zero. A disconnected response pipe or assignment timeout ends
+before handoff as a non-ambiguous failure with the same zero-write guarantee.
+Once the begin acknowledgement succeeds, partial/EPIPE, child exit, and receipt
+timeout remain ambiguous failures and are never automatically resent.
 
 The bounded versioned envelope labels peer content as an untrusted
 coordination-only record. A slash command is ordinary string data. Delivery is

--- a/docs/claude-coordination-endpoints.md
+++ b/docs/claude-coordination-endpoints.md
@@ -71,5 +71,47 @@ Inbound cross-session messaging is explicitly refused during the one-shot.
 This is a Phase 1 registration source gate without `--safe-mode`.
 It does not establish or relax the later mandatory safe-mode delivery gate.
 
+## Phase 2 owned coordination ingress
+
+The exact registration helper also owns a second private Unix socket for the
+same lease. Its address is derived from `AgentRouteRef` and
+`ClaudeAuthorityRef`; Agent and Pane names, tmux runtime IDs, provider titles,
+the vendor socket, and the vendor token do not enter the address or protocol.
+Readiness now requires this socket, its unchanged inode and 0600 ownership, the
+provider and helper process births, and the exact current Registry authority.
+The helper's non-secret crash receipt also records that socket identity, so
+normal close, dead-helper reaping, and supervisor cleanup unlink only the exact
+owned inode and preserve any replacement that has claimed the same path.
+
+Explicit `projmux agent integrate claude` convergence installs one managed
+`asyncRewake` command hook for each of `SessionStart` and `Stop`. The fixed
+command invokes only the hidden `internal claude-message-wait` route. Automatic
+config-apply migration preserves whether this coordination hook family is
+present, so installing a newly merged binary does not silently activate a new
+Claude hook process. User hooks and the existing status/registration hooks are
+retained, while explicit install and remove remain idempotent.
+
+Each hook child validates its SessionStart/Stop session ID, private activation
+envelope, direct provider parent, and exact helper peer. The helper admits only
+one waiter: a newer execution supersedes the prior one, which handles the
+documented per-execution non-dedup behavior. Hook and receipt timeouts are
+explicit state-machine inputs rather than evidence that delivery did not occur.
+
+The bounded versioned envelope labels peer content as an untrusted
+coordination-only record. A slash command is ordinary string data. Delivery is
+committed only after the exact hook child writes the complete JSON frame and
+newline to its stderr pipe and the same message/waiter/process tuple returns a
+helper receipt. `delivered` ends at that provider pipe boundary; it does not
+claim that the Claude model read, processed, or replied to the message, or that
+a turn completed. A partial/EPIPE or post-handoff timeout is an ambiguous
+terminal failure and is never retried automatically.
+
+The private Phase 2 lifecycle is `queued`, `held`, and `handoff`, followed by
+one of `delivered`, `refused`, `expired`, `stale`, or `failed`. It is an adapter
+layer beneath the future public broker acceptance state and does not add public
+message send/wait/status commands. The fake process integration exercises only
+Projmux-owned UDS and provider stderr pipes; it makes zero provider inbox, MCP,
+model, connector, interrupt, approval, configuration, or tool calls.
+
 Provider sources: [SessionStart hooks](https://code.claude.com/docs/en/hooks)
 and [cross-session messaging](https://code.claude.com/docs/en/cross-session-messaging).

--- a/internal/app/agent_control_transport_unix.go
+++ b/internal/app/agent_control_transport_unix.go
@@ -12,24 +12,24 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
 )
 
 const (
 	agentControlDirName      = "agent-control"
-	agentControlMaxFrame     = 64 << 10
-	agentControlDeadline     = 5 * time.Second
-	agentControlDialTimeout  = 500 * time.Millisecond
-	agentControlMaxSocketLen = 100
+	agentControlMaxFrame     = localipc.MaxFrameBytes
+	agentControlDeadline     = localipc.Deadline
+	agentControlDialTimeout  = localipc.DialTimeout
+	agentControlMaxSocketLen = localipc.MaxSocketPath
 )
 
 type codexControlServer struct {
 	listener *net.UnixListener
 	path     string
-	info     os.FileInfo
+	info     localipc.SocketIdentity
 	epoch    *codexControlEpoch
 	done     chan struct{}
 }
@@ -49,13 +49,14 @@ func startCodexControlServer(stateDir string, endpoint coremetadata.CodexEndpoin
 	if err != nil {
 		return nil, fmt.Errorf("listen exact Agent control socket: %w", err)
 	}
+	listener.SetUnlinkOnClose(false)
 	if err := os.Chmod(path, 0o600); err != nil {
 		_ = listener.Close()
 		_ = os.Remove(path)
 		return nil, fmt.Errorf("secure exact Agent control socket: %w", err)
 	}
-	info, err := os.Lstat(path)
-	if err != nil || info.Mode()&os.ModeSocket == 0 {
+	info, err := localipc.InspectOwnedSocket(path)
+	if err != nil {
 		_ = listener.Close()
 		_ = os.Remove(path)
 		return nil, errors.New("exact Agent control listener is not a socket")
@@ -79,15 +80,13 @@ func (s *codexControlServer) serve() {
 func (s *codexControlServer) handle(conn *net.UnixConn) {
 	defer conn.Close()
 	_ = conn.SetDeadline(time.Now().Add(agentControlDeadline))
-	payload, err := io.ReadAll(io.LimitReader(conn, agentControlMaxFrame+1))
-	if err != nil || len(payload) > agentControlMaxFrame {
-		s.writeResponse(conn, refusedControl("invalid-frame", "exact Agent control request exceeded the bounded frame"))
-		return
-	}
 	var request agentControlRequest
-	decoder := json.NewDecoder(bytes.NewReader(payload))
-	if err := decoder.Decode(&request); err != nil || hasTrailingJSON(decoder) {
-		s.writeResponse(conn, refusedControl("invalid-frame", "exact Agent control request was malformed"))
+	if err := localipc.ReadJSON(conn, &request); err != nil {
+		detail := "exact Agent control request was malformed"
+		if errors.Is(err, localipc.ErrFrameTooLarge) {
+			detail = "exact Agent control request exceeded the bounded frame"
+		}
+		s.writeResponse(conn, refusedControl("invalid-frame", detail))
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), agentControlDeadline)
@@ -96,12 +95,11 @@ func (s *codexControlServer) handle(conn *net.UnixConn) {
 }
 
 func (s *codexControlServer) writeResponse(conn *net.UnixConn, response agentControlResponse) {
-	var payload bytes.Buffer
-	if err := json.NewEncoder(&payload).Encode(response); err != nil || payload.Len() > agentControlMaxFrame {
-		payload.Reset()
-		_ = json.NewEncoder(&payload).Encode(refusedControl("response-too-large", "exact Agent control detail is too large to display safely"))
+	payload, err := localipc.MarshalJSON(response)
+	if err != nil {
+		payload, _ = localipc.MarshalJSON(refusedControl("response-too-large", "exact Agent control detail is too large to display safely"))
 	}
-	_, _ = conn.Write(payload.Bytes())
+	_, _ = conn.Write(payload)
 }
 
 func (s *codexControlServer) Close() error {
@@ -118,7 +116,7 @@ func (s *codexControlServer) Close() error {
 	}
 	err := s.listener.Close()
 	<-s.done
-	if current, statErr := os.Lstat(s.path); statErr == nil && os.SameFile(s.info, current) && current.Mode()&os.ModeSocket != 0 {
+	if current, statErr := localipc.InspectOwnedSocket(s.path); statErr == nil && current == s.info {
 		_ = os.Remove(s.path)
 	}
 	return err
@@ -192,44 +190,5 @@ func agentControlSocketPath(stateDir string, endpoint coremetadata.CodexEndpoint
 }
 
 func prepareAgentControlSocket(path string) error {
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("create exact Agent control directory: %w", err)
-	}
-	info, err := os.Lstat(dir)
-	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || !ownedByCurrentUser(info) {
-		return errors.New("exact Agent control directory is not a private owned directory")
-	}
-	// #nosec G302 -- 0700 is the intentional private mode for the owner-traversable control socket directory.
-	if err := os.Chmod(dir, 0o700); err != nil {
-		return fmt.Errorf("secure exact Agent control directory: %w", err)
-	}
-	info, err = os.Lstat(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("inspect exact Agent control socket: %w", err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 || info.Mode()&os.ModeSocket == 0 || !ownedByCurrentUser(info) {
-		return errors.New("exact Agent control endpoint collision is not an owned socket")
-	}
-	conn, dialErr := net.DialTimeout("unix", path, agentControlDialTimeout)
-	if dialErr == nil {
-		_ = conn.Close()
-		return errors.New("exact Agent control endpoint is already active")
-	}
-	latest, latestErr := os.Lstat(path)
-	if latestErr != nil || !os.SameFile(info, latest) || latest.Mode()&os.ModeSocket == 0 || !ownedByCurrentUser(latest) {
-		return errors.New("exact Agent control stale endpoint changed during ownership check")
-	}
-	if err := os.Remove(path); err != nil {
-		return fmt.Errorf("remove stale exact Agent control socket: %w", err)
-	}
-	return nil
-}
-
-func ownedByCurrentUser(info os.FileInfo) bool {
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	return ok && int(stat.Uid) == os.Getuid()
+	return localipc.PrepareSocket(path)
 }

--- a/internal/app/ai_integrate.go
+++ b/internal/app/ai_integrate.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/crevissepartners/projmux/internal/aiprovider"
 	intmux "github.com/crevissepartners/projmux/internal/integrations/mux"
@@ -340,6 +341,14 @@ func (c *aiCommand) planCodexHooksIntegration(remove bool) (codexIntegrationPlan
 }
 
 func (c *aiCommand) planClaudeHookIntegration(remove bool) (claudeHookPlan, error) {
+	return c.planClaudeHookIntegrationMode(remove, !remove)
+}
+
+// planClaudeHookMigration converges only the managed hook families already
+// present in the file. Automatic config apply/install migration must not plant
+// a new async provider process into a user's live Claude settings; the explicit
+// integrate command is the sole installer for coordination hooks.
+func (c *aiCommand) planClaudeHookMigration() (claudeHookPlan, error) {
 	home, err := c.homeDir()
 	if err != nil {
 		return claudeHookPlan{}, fmt.Errorf("resolve home directory: %w", err)
@@ -349,7 +358,23 @@ func (c *aiCommand) planClaudeHookIntegration(remove bool) (claudeHookPlan, erro
 	if err != nil {
 		return claudeHookPlan{}, err
 	}
+	return c.planClaudeHookIntegrationFromCurrent(false, strings.Contains(current, claudeCoordinationManagedMarker), path, current)
+}
 
+func (c *aiCommand) planClaudeHookIntegrationMode(remove, includeCoordination bool) (claudeHookPlan, error) {
+	home, err := c.homeDir()
+	if err != nil {
+		return claudeHookPlan{}, fmt.Errorf("resolve home directory: %w", err)
+	}
+	path := filepath.Join(home, claudeSettingsRelativePath)
+	current, err := c.readClaudeSettings(path)
+	if err != nil {
+		return claudeHookPlan{}, err
+	}
+	return c.planClaudeHookIntegrationFromCurrent(remove, includeCoordination, path, current)
+}
+
+func (c *aiCommand) planClaudeHookIntegrationFromCurrent(remove, includeCoordination bool, path, current string) (claudeHookPlan, error) {
 	settings, err := parseClaudeSettings(current, path)
 	if err != nil {
 		return claudeHookPlan{}, err
@@ -415,6 +440,11 @@ func (c *aiCommand) planClaudeHookIntegration(remove bool) (claudeHookPlan, erro
 			})
 		}
 		hooks[event] = append(claudeHookEntrySlice(hooks[event]), entry)
+	}
+	if includeCoordination {
+		for _, event := range []string{"SessionStart", "Stop"} {
+			hooks[event] = append(claudeHookEntrySlice(hooks[event]), claudeCoordinationManagedEntry())
+		}
 	}
 	next, err := encodeClaudeSettings(settings)
 	if err != nil {
@@ -1044,11 +1074,11 @@ func claudeHookEntriesWithoutManaged(value any, event, path string) ([]any, bool
 				continue
 			}
 			command, _ := hook["command"].(string)
-			if hook["type"] == "command" && strings.Contains(command, claudeHookManagedMarker) {
+			if hook["type"] == "command" && (strings.Contains(command, claudeHookManagedMarker) || strings.Contains(command, claudeCoordinationManagedMarker)) {
 				removed = true
 				continue
 			}
-			if hook["type"] == "command" && (strings.Contains(command, legacyClaudeHookRoute) || strings.Contains(command, canonicalClaudeHookRoute)) && conflict == "" {
+			if hook["type"] == "command" && (strings.Contains(command, legacyClaudeHookRoute) || strings.Contains(command, canonicalClaudeHookRoute) || strings.Contains(command, "internal claude-message-wait")) && conflict == "" {
 				conflict = fmt.Sprintf("Claude Code hook %s already contains unmanaged projmux ingest command in %s: %s", event, path, command)
 			}
 			nextHooks = append(nextHooks, hookValue)
@@ -1079,6 +1109,19 @@ func claudeHookManagedEntry() map[string]any {
 			map[string]any{
 				"type":    "command",
 				"command": claudeHookCommand,
+			},
+		},
+	}
+}
+
+func claudeCoordinationManagedEntry() map[string]any {
+	return map[string]any{
+		"hooks": []any{
+			map[string]any{
+				"type":        "command",
+				"command":     claudeCoordinationHookCommand,
+				"timeout":     int(claudeCoordinationHookTimeout / time.Second),
+				"asyncRewake": true,
 			},
 		},
 	}

--- a/internal/app/ai_integrate_apply_test.go
+++ b/internal/app/ai_integrate_apply_test.go
@@ -193,6 +193,49 @@ func TestTmuxApplyNoReloadMigratesManagedFilesWithoutLiveCalls(t *testing.T) {
 	}
 }
 
+func TestConfigApplyNoReloadPreservesClaudeSettingsBytesWithCoordinationAbsentOrPresent(t *testing.T) {
+	for _, present := range []bool{false, true} {
+		t.Run(fmt.Sprintf("coordination-present-%t", present), func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("PROJMUX_CWD", "")
+			runner := &recordingTmuxRunner{}
+			cmd := managedIngestApplyFixture(home, runner)
+			plan, err := cmd.ai.planClaudeHookIntegrationMode(false, present)
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeCodexTestFile(t, plan.path, plan.next)
+			before, err := os.ReadFile(plan.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			claudeWrites := 0
+			cmd.ai.writeFile = func(path string, data []byte, mode os.FileMode) error {
+				if path == plan.path {
+					claudeWrites++
+				}
+				return os.WriteFile(path, data, mode)
+			}
+			app := &App{tmux: cmd, config: &configCommand{tmux: cmd}}
+			var stdout, stderr bytes.Buffer
+			if err := app.Run([]string{"config", "apply", "--no-reload", "--config", filepath.Join(home, "tmux.conf")}, &stdout, &stderr); err != nil {
+				t.Fatalf("config apply --no-reload error = %v; stderr=%q", err, stderr.String())
+			}
+			after, err := os.ReadFile(plan.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(after, before) || claudeWrites != 0 {
+				t.Fatalf("settings changed: present=%t writes=%d bytesEqual=%t", present, claudeWrites, bytes.Equal(after, before))
+			}
+			if len(runner.calls) != 0 || !strings.Contains(stdout.String(), "skipped reload: --no-reload") || stderr.Len() != 0 {
+				t.Fatalf("apply effects: calls=%#v stdout=%q stderr=%q", runner.calls, stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
 func TestTmuxApplyMigratesBellOnlyThroughExactSocket(t *testing.T) {
 	home := t.TempDir()
 	socket := "phase0-exact-socket"

--- a/internal/app/ai_integrate_migration.go
+++ b/internal/app/ai_integrate_migration.go
@@ -27,7 +27,7 @@ func (c *aiCommand) beginManagedIngestProducerFileMigration() (int, func() error
 	if err != nil {
 		return 0, nil, err
 	}
-	claudePlan, err := c.planClaudeHookIntegration(false)
+	claudePlan, err := c.planClaudeHookMigration()
 	if err != nil {
 		return 0, nil, err
 	}
@@ -57,7 +57,7 @@ func (c *aiCommand) beginManagedIngestProducerFileMigration() (int, func() error
 			write: func() error { return c.writeCodexConfig(codexPlan.path, []byte(codexPlan.next)) },
 		})
 	}
-	if strings.Contains(claudePlan.current, claudeHookManagedMarker) && claudePlan.changed {
+	if (strings.Contains(claudePlan.current, claudeHookManagedMarker) || strings.Contains(claudePlan.current, claudeCoordinationManagedMarker)) && claudePlan.changed {
 		mutations = append(mutations, managedIngestFileMutation{
 			path: claudePlan.path, current: claudePlan.current, next: claudePlan.next, mode: 0o644, label: "Claude settings",
 			write: func() error { return c.writeClaudeSettings(claudePlan.path, []byte(claudePlan.next)) },

--- a/internal/app/ai_integrate_test.go
+++ b/internal/app/ai_integrate_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestAIIntegrateAntigravityInstallsNamedEntryWithAbsoluteExplicitEvents(t *testing.T) {
@@ -803,6 +804,20 @@ func TestAIIntegrateClaudeInstallsManagedHooks(t *testing.T) {
 			t.Fatalf("settings missing managed command for %s:\n%s", event, readCodexTestFile(t, path))
 		}
 	}
+	for _, event := range []string{"SessionStart", "Stop"} {
+		coordination := claudeSettingsCommands(t, settings, event, claudeCoordinationHookCommand)
+		if len(coordination) != 1 {
+			t.Fatalf("%s coordination hooks = %d, want exactly one", event, len(coordination))
+		}
+		if coordination[0]["asyncRewake"] != true || coordination[0]["timeout"] != float64(claudeCoordinationHookTimeout/time.Second) {
+			t.Fatalf("%s coordination hook contract = %#v", event, coordination[0])
+		}
+		for _, undocumented := range []string{"async", "rewakeMessage"} {
+			if _, ok := coordination[0][undocumented]; ok {
+				t.Fatalf("%s coordination hook depends on undocumented %s", event, undocumented)
+			}
+		}
+	}
 	if !strings.Contains(readCodexTestFile(t, path), `"PostToolUse"`) || !strings.Contains(readCodexTestFile(t, path), "echo keep") {
 		t.Fatalf("settings did not preserve user hook:\n%s", readCodexTestFile(t, path))
 	}
@@ -832,6 +847,59 @@ func TestAIIntegrateClaudeInstallIsIdempotent(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "no changes") {
 		t.Fatalf("stdout = %q, want no changes", stdout.String())
+	}
+}
+
+func TestClaudeAutomaticMigrationPreservesCoordinationPresenceAndSettingsBytes(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.readFile = os.ReadFile
+	path := filepath.Join(home, claudeSettingsRelativePath)
+
+	legacyOnly, err := cmd.planClaudeHookIntegrationMode(false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeCodexTestFile(t, path, legacyOnly.next)
+	before := readCodexTestFile(t, path)
+	automatic, err := cmd.planClaudeHookMigration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if automatic.changed || automatic.next != before || strings.Contains(automatic.next, claudeCoordinationManagedMarker) {
+		t.Fatalf("automatic migration planted a new coordination hook:\n%s", automatic.next)
+	}
+
+	explicit, err := cmd.planClaudeHookIntegration(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !explicit.changed || !strings.Contains(explicit.next, claudeCoordinationManagedMarker) {
+		t.Fatal("explicit integration did not plan coordination hooks")
+	}
+	writeCodexTestFile(t, path, explicit.next)
+	installed := readCodexTestFile(t, path)
+	automatic, err = cmd.planClaudeHookMigration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if automatic.changed || automatic.next != installed {
+		t.Fatalf("automatic migration changed explicitly installed settings:\nbefore:\n%s\nafter:\n%s", installed, automatic.next)
+	}
+}
+
+func TestAIIntegrateClaudeRefusesUnmanagedCoordinationHook(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.readFile = os.ReadFile
+	path := filepath.Join(home, claudeSettingsRelativePath)
+	writeCodexTestFile(t, path, `{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"exec projmux internal claude-message-wait"}]}]}}`+"\n")
+	before := readCodexTestFile(t, path)
+	if err := cmd.Run([]string{"integrate", "claude"}, &bytes.Buffer{}, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "unmanaged projmux ingest command") {
+		t.Fatalf("unmanaged coordination conflict error = %v", err)
+	}
+	if got := readCodexTestFile(t, path); got != before {
+		t.Fatal("unmanaged coordination conflict changed settings")
 	}
 }
 
@@ -927,7 +995,7 @@ func TestAIIntegrateClaudeRemoveOnlyManagedHooks(t *testing.T) {
 		t.Fatalf("Run integrate claude --remove error = %v", err)
 	}
 	got := readCodexTestFile(t, path)
-	if strings.Contains(got, claudeHookManagedMarker) || !strings.Contains(got, "echo user-notify") {
+	if strings.Contains(got, claudeHookManagedMarker) || strings.Contains(got, claudeCoordinationManagedMarker) || !strings.Contains(got, "echo user-notify") {
 		t.Fatalf("settings after remove =\n%s", got)
 	}
 	claudeHookEvents := defaultAIHookInstallEvents(aiHookProviderClaude)
@@ -1559,6 +1627,33 @@ func claudeSettingsHasManagedCommand(t *testing.T, settings map[string]any, even
 		}
 	}
 	return false
+}
+
+func claudeSettingsCommands(t *testing.T, settings map[string]any, event, command string) []map[string]any {
+	t.Helper()
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	entries, ok := hooks[event].([]any)
+	if !ok {
+		return nil
+	}
+	var matches []map[string]any
+	for _, entryValue := range entries {
+		entry, ok := entryValue.(map[string]any)
+		if !ok {
+			continue
+		}
+		hookValues, _ := entry["hooks"].([]any)
+		for _, hookValue := range hookValues {
+			hook, ok := hookValue.(map[string]any)
+			if ok && hook["type"] == "command" && hook["command"] == command {
+				matches = append(matches, hook)
+			}
+		}
+	}
+	return matches
 }
 
 func assertCodexHookNestedHandler(t *testing.T, config, event string) {

--- a/internal/app/ai_integrate_test.go
+++ b/internal/app/ai_integrate_test.go
@@ -1012,6 +1012,46 @@ func TestAIIntegrateClaudeRemoveOnlyManagedHooks(t *testing.T) {
 	}
 }
 
+func TestAIIntegrateClaudeRemoveTwiceIsByteAndWriteCountIdempotent(t *testing.T) {
+	home := t.TempDir()
+	cmd := testAICommand(home)
+	cmd.readFile = os.ReadFile
+	path := filepath.Join(home, claudeSettingsRelativePath)
+	if err := cmd.Run([]string{"integrate", "claude"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	settings := readClaudeSettingsTestFile(t, path)
+	hooks := settings["hooks"].(map[string]any)
+	hooks["Stop"] = append(hooks["Stop"].([]any), map[string]any{"hooks": []any{
+		map[string]any{"type": "command", "command": "echo preserve-user-stop"},
+	}})
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeCodexTestFile(t, path, string(data)+"\n")
+	writes := 0
+	cmd.writeFile = func(path string, data []byte, mode os.FileMode) error {
+		writes++
+		return os.WriteFile(path, data, mode)
+	}
+	if err := cmd.Run([]string{"integrate", "claude", "--remove"}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	first := readCodexTestFile(t, path)
+	if writes != 1 || !strings.Contains(first, "echo preserve-user-stop") || strings.Contains(first, claudeCoordinationManagedMarker) {
+		t.Fatalf("first remove writes=%d settings=%s", writes, first)
+	}
+	var stdout bytes.Buffer
+	if err := cmd.Run([]string{"integrate", "claude", "--remove"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	second := readCodexTestFile(t, path)
+	if writes != 1 || second != first || !strings.Contains(stdout.String(), "no changes") {
+		t.Fatalf("repeat remove writes=%d bytesEqual=%t stdout=%q", writes, second == first, stdout.String())
+	}
+}
+
 func TestAIIntegrateCodexHooksUsesCatalogOverride(t *testing.T) {
 	home := t.TempDir()
 	configHome := filepath.Join(home, ".xdg-config")
@@ -1258,7 +1298,9 @@ func TestManagedIngestProducerMigrationUpgradesV0101AndRepeatsWithoutWrites(t *t
 	writeCodexTestFile(t, codexPath, strings.ReplaceAll(codexHooksBlock(true), codexHookCommand, legacyCodexHookCommand))
 	claudePath := filepath.Join(home, claudeSettingsRelativePath)
 	legacyClaude := strings.ReplaceAll(claudeHookCommand, canonicalClaudeHookRoute, legacyClaudeHookRoute)
-	writeCodexTestFile(t, claudePath, "{\n  \"hooks\": {\n    \"Notification\": [{\"hooks\": [{\"type\": \"command\", \"command\": "+string(mustJSONMarshal(legacyClaude))+"}]}]\n  }\n}\n")
+	writeCodexTestFile(t, claudePath, "{\n  \"hooks\": {\n    \"Notification\": ["+
+		"{\"hooks\": [{\"type\": \"command\", \"command\": "+string(mustJSONMarshal(legacyClaude))+"}]},"+
+		"{\"hooks\": [{\"type\": \"command\", \"command\": \"echo preserve-user-migration\"}]}]\n  }\n}\n")
 	hooksPath := filepath.Join(home, antigravityHooksRelativePath)
 	hooks, err := encodeAntigravityManagedHook("/opt/projmux/bin/projmux")
 	if err != nil {
@@ -1289,6 +1331,9 @@ func TestManagedIngestProducerMigrationUpgradesV0101AndRepeatsWithoutWrites(t *t
 		if strings.Contains(got, " ai ingest ") || !strings.Contains(got, "internal agent-hook ingest") {
 			t.Fatalf("%s did not converge to canonical ingest:\n%s", path, got)
 		}
+	}
+	if got := readCodexTestFile(t, claudePath); !strings.Contains(got, "echo preserve-user-migration") || strings.Contains(got, claudeCoordinationManagedMarker) {
+		t.Fatalf("automatic Claude migration changed user hook or planted coordination:\n%s", got)
 	}
 	count, _, err = cmd.beginManagedIngestProducerFileMigration()
 	if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -644,7 +644,7 @@ func shouldRunLegacyHookMigrations(args []string) bool {
 			return false
 		}
 	case "internal":
-		if len(args) >= 2 && (args[1] == "codex-generation-launch" || args[1] == "install-residue") {
+		if len(args) >= 2 && (args[1] == "codex-generation-launch" || args[1] == "install-residue" || args[1] == "claude-message-wait") {
 			return false
 		}
 	case "current", "kill", "notify", "sessions", "session-state", "tag", "upgrade", "usage",

--- a/internal/app/claude_coordination.go
+++ b/internal/app/claude_coordination.go
@@ -115,25 +115,34 @@ type claudeCoordinationWaiter struct {
 }
 
 type claudeCoordinationMessage struct {
-	envelope claudeCoordinationEnvelope
-	delivery agentdelivery.Delivery
-	process  coremetadata.ProcessIdentity
+	envelope          claudeCoordinationEnvelope
+	delivery          agentdelivery.Delivery
+	assignedWaiterRef string
+	process           coremetadata.ProcessIdentity
 }
 
 type claudeCoordinationHub struct {
-	mu            sync.Mutex
-	now           func() time.Time
-	receiptWindow time.Duration
-	waiter        *claudeCoordinationWaiter
-	messages      map[string]*claudeCoordinationMessage
-	pending       []string
-	waiterReady   chan string
-	closed        bool
+	mu               sync.Mutex
+	now              func() time.Time
+	processCurrent   func(coremetadata.ProcessIdentity) bool
+	assignmentWindow time.Duration
+	receiptWindow    time.Duration
+	waiter           *claudeCoordinationWaiter
+	messages         map[string]*claudeCoordinationMessage
+	pending          []string
+	waiterReady      chan string
+	closed           bool
 }
 
 func newClaudeCoordinationHub() *claudeCoordinationHub {
-	return &claudeCoordinationHub{now: time.Now, receiptWindow: claudeCoordinationReceiptWindow,
+	return &claudeCoordinationHub{now: time.Now, processCurrent: exactCoordinationProcessCurrent,
+		assignmentWindow: localipc.Deadline, receiptWindow: claudeCoordinationReceiptWindow,
 		messages: make(map[string]*claudeCoordinationMessage), waiterReady: make(chan string, 1)}
+}
+
+func exactCoordinationProcessCurrent(expected coremetadata.ProcessIdentity) bool {
+	actual, _, err := localipc.Process(expected.PID)
+	return err == nil && actual == expected
 }
 
 func (h *claudeCoordinationHub) submit(envelope claudeCoordinationEnvelope) agentdelivery.Delivery {
@@ -155,6 +164,12 @@ func (h *claudeCoordinationHub) submit(envelope claudeCoordinationEnvelope) agen
 	}
 	if h.waiter == nil {
 		message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventHold, MessageRef: envelope.MessageRef, Reason: "no-waiter"})
+		h.pending = append(h.pending, envelope.MessageRef)
+		h.scheduleTTL(envelope.MessageRef, envelope.Deadline)
+		return message.delivery
+	}
+	if h.retireDeadWaiterLocked() {
+		message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventHold, MessageRef: envelope.MessageRef, Reason: "no-live-waiter"})
 		h.pending = append(h.pending, envelope.MessageRef)
 		h.scheduleTTL(envelope.MessageRef, envelope.Deadline)
 		return message.delivery
@@ -209,25 +224,85 @@ func (h *claudeCoordinationHub) cancelWaiter(waiter *claudeCoordinationWaiter, k
 func (h *claudeCoordinationHub) hasWaiter() bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	return !h.closed && h.waiter != nil
+	return !h.closed && h.waiter != nil && !h.retireDeadWaiterLocked()
+}
+
+func (h *claudeCoordinationHub) retireDeadWaiterLocked() bool {
+	if h.waiter == nil || h.processCurrent(h.waiter.process) {
+		return false
+	}
+	stale := h.waiter
+	h.waiter = nil
+	stale.result <- claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "stale", WaiterRef: stale.ref}
+	return true
 }
 
 func (h *claudeCoordinationHub) assignLocked(message *claudeCoordinationMessage, waiter *claudeCoordinationWaiter) {
-	message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventBeginHandoff,
-		MessageRef: message.envelope.MessageRef, WaiterRef: waiter.ref})
+	message.assignedWaiterRef = waiter.ref
 	message.process = waiter.process
 	if h.waiter == waiter {
 		h.waiter = nil
 	}
-	waiter.result <- claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "handoff", WaiterRef: waiter.ref,
+	waiter.result <- claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "assignment", WaiterRef: waiter.ref,
 		Envelope: &message.envelope, Delivery: message.delivery}
+	window := h.assignmentWindow
+	go func(messageRef, waiterRef string) {
+		timer := time.NewTimer(window)
+		defer timer.Stop()
+		<-timer.C
+		h.expireAssignment(messageRef, waiterRef)
+	}(message.envelope.MessageRef, waiter.ref)
+}
+
+func (h *claudeCoordinationHub) beginHandoff(messageRef, waiterRef string, process coremetadata.ProcessIdentity) agentdelivery.Delivery {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	message := h.messages[messageRef]
+	if message == nil {
+		return agentdelivery.Delivery{MessageRef: messageRef, State: agentdelivery.StateStale, Reason: "unknown-message"}
+	}
+	if message.assignedWaiterRef != waiterRef || message.process != process || !h.processCurrent(process) {
+		return message.delivery
+	}
+	message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventBeginHandoff,
+		MessageRef: messageRef, WaiterRef: waiterRef})
+	message.assignedWaiterRef = ""
 	window := h.receiptWindow
 	go func(messageRef, waiterRef string) {
 		timer := time.NewTimer(window)
 		defer timer.Stop()
 		<-timer.C
 		h.expireHandoff(messageRef, waiterRef)
-	}(message.envelope.MessageRef, waiter.ref)
+	}(message.envelope.MessageRef, waiterRef)
+	return message.delivery
+}
+
+func (h *claudeCoordinationHub) failAssignment(messageRef, waiterRef string, process coremetadata.ProcessIdentity, reason string) agentdelivery.Delivery {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	message := h.messages[messageRef]
+	if message == nil {
+		return agentdelivery.Delivery{MessageRef: messageRef, State: agentdelivery.StateStale, Reason: "unknown-message"}
+	}
+	if message.assignedWaiterRef != waiterRef || message.process != process {
+		return message.delivery
+	}
+	message.assignedWaiterRef = ""
+	message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventFail,
+		MessageRef: messageRef, WaiterRef: waiterRef, Reason: reason})
+	return message.delivery
+}
+
+func (h *claudeCoordinationHub) expireAssignment(messageRef, waiterRef string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	message := h.messages[messageRef]
+	if message == nil || message.assignedWaiterRef != waiterRef {
+		return
+	}
+	message.assignedWaiterRef = ""
+	message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventFail,
+		MessageRef: messageRef, WaiterRef: waiterRef, Reason: "waiter-disconnected"})
 }
 
 func (h *claudeCoordinationHub) expireHandoff(messageRef, waiterRef string) {
@@ -364,7 +439,7 @@ func (s *claudeCoordinationServer) handle(conn *net.UnixConn) {
 		return
 	}
 	peer, parent, err := localipc.PeerProcess(conn)
-	if err != nil || peer.OwnerUID != uint32(os.Getuid()) {
+	if err != nil || int64(peer.OwnerUID) != int64(os.Getuid()) {
 		_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "refused"})
 		return
 	}
@@ -402,11 +477,18 @@ func (s *claudeCoordinationServer) handle(conn *net.UnixConn) {
 		select {
 		case response := <-waiter.result:
 			_ = conn.SetWriteDeadline(time.Now().Add(localipc.Deadline))
-			_ = localipc.WriteJSON(conn, response)
+			_ = s.writeWaiterResponse(conn, response, peer)
 		case <-timer.C:
 			s.hub.cancelWaiter(waiter, "timeout")
 			_ = localipc.WriteJSON(conn, <-waiter.result)
 		}
+	case "begin-handoff":
+		if parent != authority.Process.PID || request.SessionID != authority.SessionID {
+			_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "refused"})
+			return
+		}
+		delivery := s.hub.beginHandoff(request.MessageRef, request.WaiterRef, peer)
+		_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: string(delivery.State), Delivery: delivery})
 	case "submit":
 		if request.Envelope == nil || !request.Envelope.valid(time.Now(), s.route) {
 			_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "refused"})
@@ -429,6 +511,14 @@ func (s *claudeCoordinationServer) handle(conn *net.UnixConn) {
 	}
 }
 
+func (s *claudeCoordinationServer) writeWaiterResponse(writer io.Writer, response claudeCoordinationResponse, process coremetadata.ProcessIdentity) error {
+	err := localipc.WriteJSON(writer, response)
+	if err != nil && response.Kind == "assignment" && response.Envelope != nil {
+		s.hub.failAssignment(response.Envelope.MessageRef, response.WaiterRef, process, "helper-response-write-failed")
+	}
+	return err
+}
+
 func (s *claudeCoordinationServer) Close() {
 	if s == nil {
 		return
@@ -441,33 +531,33 @@ func (s *claudeCoordinationServer) Close() {
 func callClaudeCoordination(ctx context.Context, registryPath string, route coremetadata.AgentRouteRef, request claudeCoordinationRequest) (claudeCoordinationResponse, error) {
 	target, ok := claudeTargetForRoute(route)
 	if !ok || request.Target != target {
-		return claudeCoordinationResponse{}, errors.New("Claude coordination route is stale")
+		return claudeCoordinationResponse{}, errors.New("claude coordination route is stale")
 	}
 	path := claudeCoordinationSocket(registryPath, target)
 	dialer := net.Dialer{Timeout: localipc.DialTimeout}
 	connection, err := dialer.DialContext(ctx, "unix", path)
 	if err != nil {
-		return claudeCoordinationResponse{}, errors.New("Claude coordination helper is unavailable")
+		return claudeCoordinationResponse{}, errors.New("claude coordination helper is unavailable")
 	}
 	defer connection.Close()
 	unixConnection, ok := connection.(*net.UnixConn)
 	if !ok {
-		return claudeCoordinationResponse{}, errors.New("Claude coordination helper is unavailable")
+		return claudeCoordinationResponse{}, errors.New("claude coordination helper is unavailable")
 	}
 	peer, _, err := localipc.PeerProcess(unixConnection)
 	if err != nil || peer != target.Authority.LeaseProcess {
-		return claudeCoordinationResponse{}, errors.New("Claude coordination helper peer is stale")
+		return claudeCoordinationResponse{}, errors.New("claude coordination helper peer is stale")
 	}
 	if deadline, ok := ctx.Deadline(); ok {
 		_ = connection.SetDeadline(deadline)
 	}
 	if err := localipc.WriteJSON(connection, request); err != nil {
-		return claudeCoordinationResponse{}, errors.New("Claude coordination request failed")
+		return claudeCoordinationResponse{}, errors.New("claude coordination request failed")
 	}
 	_ = unixConnection.CloseWrite()
 	var response claudeCoordinationResponse
 	if err := localipc.ReadJSON(connection, &response); err != nil || response.Version != claudeCoordinationVersion {
-		return claudeCoordinationResponse{}, errors.New("Claude coordination response failed")
+		return claudeCoordinationResponse{}, errors.New("claude coordination response failed")
 	}
 	return response, nil
 }
@@ -499,7 +589,19 @@ func (claudeHookWakeError) ExitCode() int { return 2 }
 // remains an explicitly untrusted coordination record; a slash command has no
 // special authority and is transferred as ordinary JSON string data.
 func runClaudeMessageWait(args []string, stderr io.Writer) error {
+	if !providerOwnedStderrPipe(stderr) {
+		return nil
+	}
 	return runClaudeMessageWaitInput(args, os.Stdin, stderr, os.Getenv)
+}
+
+func providerOwnedStderrPipe(stderr io.Writer) bool {
+	file, ok := stderr.(*os.File)
+	if !ok || file.Fd() != os.Stderr.Fd() {
+		return false
+	}
+	info, err := file.Stat()
+	return err == nil && info.Mode()&os.ModeNamedPipe != 0 && localipc.OwnedByCurrentUser(info)
 }
 
 func runClaudeMessageWaitInput(args []string, stdin io.Reader, stderr io.Writer, getenv func(string) string) error {
@@ -540,8 +642,17 @@ func runClaudeMessageWaitInput(args []string, stdin io.Reader, stderr io.Writer,
 	defer cancel()
 	response, err := callClaudeCoordination(ctx, registryPath, route, claudeCoordinationRequest{Version: claudeCoordinationVersion,
 		Operation: "wait", Target: target, HookEvent: hook.Event, SessionID: hook.SessionID, WaitUntil: time.Now().Add(claudeCoordinationWaitTimeout)})
-	if err != nil || response.Kind != "handoff" || response.Envelope == nil || response.WaiterRef == "" ||
+	if err != nil || response.Kind != "assignment" || response.Envelope == nil || response.WaiterRef == "" ||
 		!response.Envelope.valid(time.Now(), route) || response.Envelope.MessageRef != response.Delivery.MessageRef {
+		return nil
+	}
+	beginCtx, beginCancel := context.WithTimeout(context.Background(), localipc.Deadline)
+	begin, err := callClaudeCoordination(beginCtx, registryPath, route, claudeCoordinationRequest{Version: claudeCoordinationVersion,
+		Operation: "begin-handoff", Target: target, SessionID: hook.SessionID, MessageRef: response.Envelope.MessageRef,
+		WaiterRef: response.WaiterRef})
+	beginCancel()
+	if err != nil || begin.Delivery.MessageRef != response.Envelope.MessageRef || begin.Delivery.WaiterRef != response.WaiterRef ||
+		begin.Delivery.State != agentdelivery.StateHandoff {
 		return nil
 	}
 	payload, err := json.Marshal(response.Envelope)

--- a/internal/app/claude_coordination.go
+++ b/internal/app/claude_coordination.go
@@ -162,16 +162,15 @@ func (h *claudeCoordinationHub) submit(envelope claudeCoordinationEnvelope) agen
 		message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventExpire, MessageRef: envelope.MessageRef, Reason: "ttl"})
 		return message.delivery
 	}
+	h.scheduleTTL(envelope.MessageRef, envelope.Deadline)
 	if h.waiter == nil {
 		message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventHold, MessageRef: envelope.MessageRef, Reason: "no-waiter"})
 		h.pending = append(h.pending, envelope.MessageRef)
-		h.scheduleTTL(envelope.MessageRef, envelope.Deadline)
 		return message.delivery
 	}
 	if h.retireDeadWaiterLocked() {
 		message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventHold, MessageRef: envelope.MessageRef, Reason: "no-live-waiter"})
 		h.pending = append(h.pending, envelope.MessageRef)
-		h.scheduleTTL(envelope.MessageRef, envelope.Deadline)
 		return message.delivery
 	}
 	h.assignLocked(message, h.waiter)
@@ -264,6 +263,9 @@ func (h *claudeCoordinationHub) beginHandoff(messageRef, waiterRef string, proce
 	if message.assignedWaiterRef != waiterRef || message.process != process || !h.processCurrent(process) {
 		return message.delivery
 	}
+	if h.expireDeadlineLocked(message) {
+		return message.delivery
+	}
 	message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventBeginHandoff,
 		MessageRef: messageRef, WaiterRef: waiterRef})
 	message.assignedWaiterRef = ""
@@ -341,6 +343,7 @@ func (h *claudeCoordinationHub) status(messageRef string) agentdelivery.Delivery
 	defer h.mu.Unlock()
 	h.expirePendingLocked()
 	if message := h.messages[messageRef]; message != nil {
+		h.expireDeadlineLocked(message)
 		return message.delivery
 	}
 	return agentdelivery.Delivery{MessageRef: messageRef, State: agentdelivery.StateStale, Reason: "unknown-message"}
@@ -373,19 +376,29 @@ func (h *claudeCoordinationHub) scheduleTTL(messageRef string, deadline time.Tim
 		defer h.mu.Unlock()
 		message := h.messages[messageRef]
 		if message != nil {
-			message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventExpire,
-				MessageRef: messageRef, Reason: "ttl"})
+			h.expireDeadlineLocked(message)
 		}
 	}()
 }
 
+func (h *claudeCoordinationHub) expireDeadlineLocked(message *claudeCoordinationMessage) bool {
+	if message.envelope.Deadline.After(h.now()) {
+		return false
+	}
+	next, changed := agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventExpire,
+		MessageRef: message.envelope.MessageRef, Reason: "ttl"})
+	if changed {
+		message.delivery = next
+		message.assignedWaiterRef = ""
+	}
+	return true
+}
+
 func (h *claudeCoordinationHub) expirePendingLocked() {
-	now := h.now()
 	for _, ref := range h.pending {
 		message := h.messages[ref]
-		if message != nil && !message.envelope.Deadline.After(now) {
-			message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventExpire,
-				MessageRef: ref, Reason: "ttl"})
+		if message != nil {
+			h.expireDeadlineLocked(message)
 		}
 	}
 }

--- a/internal/app/claude_coordination.go
+++ b/internal/app/claude_coordination.go
@@ -1,0 +1,581 @@
+package app
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/agentdelivery"
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
+	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
+)
+
+const (
+	claudeCoordinationVersion       = 1
+	claudeProviderFrameMaxBytes     = 8 << 10
+	claudeCoordinationHookTimeout   = 24 * time.Hour
+	claudeCoordinationWaitTimeout   = claudeCoordinationHookTimeout - 10*time.Second
+	claudeCoordinationReceiptWindow = 5 * time.Second
+	claudeCoordinationManagedMarker = "projmux-managed:claude-coordination:v1"
+	claudeCoordinationHookCommand   = "exec projmux internal claude-message-wait # " + claudeCoordinationManagedMarker
+)
+
+type claudeCoordinationTarget struct {
+	AgentUID   string                          `json:"agentUID"`
+	PaneUID    string                          `json:"paneUID"`
+	Generation string                          `json:"generation"`
+	Provider   string                          `json:"provider"`
+	Authority  coremetadata.ClaudeAuthorityRef `json:"authority"`
+}
+
+func claudeTargetForRoute(route coremetadata.AgentRouteRef) (claudeCoordinationTarget, bool) {
+	authority, ok := route.Authority().(coremetadata.ClaudeAuthorityRef)
+	if !ok || !authority.Valid() || !route.Same(route) {
+		return claudeCoordinationTarget{}, false
+	}
+	return claudeCoordinationTarget{AgentUID: route.AgentUID, PaneUID: route.PaneUID, Generation: route.Generation,
+		Provider: aiModeClaude, Authority: authority}, true
+}
+
+func (t claudeCoordinationTarget) matches(route coremetadata.AgentRouteRef) bool {
+	expected, ok := claudeTargetForRoute(route)
+	return ok && t == expected
+}
+
+// claudeCoordinationSocket is derived only from the exact stable activation
+// and its typed Claude authority. Names, tmux runtime IDs, provider titles,
+// vendor locators, and tokens never enter this address.
+func claudeCoordinationSocket(registryPath string, target claudeCoordinationTarget) string {
+	identity, _ := json.Marshal(target)
+	digest := sha256.Sum256(identity)
+	return claudeActivationLeaseDir(registryPath, target.PaneUID, target.Generation) + "/coord-" + hex.EncodeToString(digest[:12]) + ".sock"
+}
+
+type claudeCoordinationSource struct {
+	Kind      string `json:"kind"`
+	Trust     string `json:"trust"`
+	Authority string `json:"authority"`
+}
+
+type claudeCoordinationEnvelope struct {
+	Version    int                      `json:"version"`
+	MessageRef string                   `json:"messageRef"`
+	Target     claudeCoordinationTarget `json:"target"`
+	Source     claudeCoordinationSource `json:"source"`
+	Payload    string                   `json:"payload"`
+	Deadline   time.Time                `json:"deadline"`
+}
+
+func (e claudeCoordinationEnvelope) valid(now time.Time, route coremetadata.AgentRouteRef) bool {
+	if e.Version != claudeCoordinationVersion || !validCoordinationRef(e.MessageRef) || !e.Target.matches(route) ||
+		e.Source.Kind != "peer" || e.Source.Trust != "untrusted" || e.Source.Authority != "coordination-only" ||
+		e.Payload == "" || e.Deadline.IsZero() {
+		return false
+	}
+	payload, err := json.Marshal(e)
+	return err == nil && len(payload)+1 <= claudeProviderFrameMaxBytes && e.Deadline.After(now) &&
+		!e.Deadline.After(now.Add(claudeCoordinationHookTimeout))
+}
+
+type claudeCoordinationRequest struct {
+	Version          int                         `json:"version"`
+	Operation        string                      `json:"operation"`
+	Target           claudeCoordinationTarget    `json:"target"`
+	HookEvent        string                      `json:"hookEvent,omitempty"`
+	SessionID        string                      `json:"sessionId,omitempty"`
+	WaitUntil        time.Time                   `json:"waitUntil,omitzero"`
+	Envelope         *claudeCoordinationEnvelope `json:"envelope,omitempty"`
+	MessageRef       string                      `json:"messageRef,omitempty"`
+	WaiterRef        string                      `json:"waiterRef,omitempty"`
+	FullFrameWritten bool                        `json:"fullFrameWritten,omitempty"`
+}
+
+type claudeCoordinationResponse struct {
+	Version   int                         `json:"version"`
+	Kind      string                      `json:"kind"`
+	WaiterRef string                      `json:"waiterRef,omitempty"`
+	Envelope  *claudeCoordinationEnvelope `json:"envelope,omitempty"`
+	Delivery  agentdelivery.Delivery      `json:"delivery,omitzero"`
+}
+
+type claudeCoordinationWaiter struct {
+	ref     string
+	process coremetadata.ProcessIdentity
+	result  chan claudeCoordinationResponse
+}
+
+type claudeCoordinationMessage struct {
+	envelope claudeCoordinationEnvelope
+	delivery agentdelivery.Delivery
+	process  coremetadata.ProcessIdentity
+}
+
+type claudeCoordinationHub struct {
+	mu            sync.Mutex
+	now           func() time.Time
+	receiptWindow time.Duration
+	waiter        *claudeCoordinationWaiter
+	messages      map[string]*claudeCoordinationMessage
+	pending       []string
+	waiterReady   chan string
+	closed        bool
+}
+
+func newClaudeCoordinationHub() *claudeCoordinationHub {
+	return &claudeCoordinationHub{now: time.Now, receiptWindow: claudeCoordinationReceiptWindow,
+		messages: make(map[string]*claudeCoordinationMessage), waiterReady: make(chan string, 1)}
+}
+
+func (h *claudeCoordinationHub) submit(envelope claudeCoordinationEnvelope) agentdelivery.Delivery {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if existing := h.messages[envelope.MessageRef]; existing != nil {
+		return existing.delivery
+	}
+	delivery, _ := agentdelivery.Reduce(agentdelivery.Delivery{}, agentdelivery.Event{Kind: agentdelivery.EventQueue, MessageRef: envelope.MessageRef})
+	message := &claudeCoordinationMessage{envelope: envelope, delivery: delivery}
+	h.messages[envelope.MessageRef] = message
+	if h.closed {
+		message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventStale, MessageRef: envelope.MessageRef, Reason: "helper-stale"})
+		return message.delivery
+	}
+	if !envelope.Deadline.After(h.now()) {
+		message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventExpire, MessageRef: envelope.MessageRef, Reason: "ttl"})
+		return message.delivery
+	}
+	if h.waiter == nil {
+		message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventHold, MessageRef: envelope.MessageRef, Reason: "no-waiter"})
+		h.pending = append(h.pending, envelope.MessageRef)
+		h.scheduleTTL(envelope.MessageRef, envelope.Deadline)
+		return message.delivery
+	}
+	h.assignLocked(message, h.waiter)
+	return message.delivery
+}
+
+func (h *claudeCoordinationHub) arm(process coremetadata.ProcessIdentity) (*claudeCoordinationWaiter, *claudeCoordinationWaiter) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return nil, nil
+	}
+	waiter := &claudeCoordinationWaiter{ref: newCoordinationRef("waiter"), process: process, result: make(chan claudeCoordinationResponse, 1)}
+	superseded := h.waiter
+	h.waiter = waiter
+	if superseded != nil {
+		superseded.result <- claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "superseded", WaiterRef: superseded.ref}
+	}
+	select {
+	case h.waiterReady <- waiter.ref:
+	default:
+	}
+	h.expirePendingLocked()
+	for len(h.pending) > 0 {
+		ref := h.pending[0]
+		h.pending = h.pending[1:]
+		message := h.messages[ref]
+		if message == nil || message.delivery.State.Terminal() || message.delivery.State == agentdelivery.StateHandoff {
+			continue
+		}
+		h.assignLocked(message, waiter)
+		break
+	}
+	return waiter, superseded
+}
+
+func (h *claudeCoordinationHub) cancelWaiter(waiter *claudeCoordinationWaiter, kind string) {
+	if waiter == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.waiter != waiter {
+		return
+	}
+	h.waiter = nil
+	waiter.result <- claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: kind, WaiterRef: waiter.ref}
+}
+
+func (h *claudeCoordinationHub) hasWaiter() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return !h.closed && h.waiter != nil
+}
+
+func (h *claudeCoordinationHub) assignLocked(message *claudeCoordinationMessage, waiter *claudeCoordinationWaiter) {
+	message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventBeginHandoff,
+		MessageRef: message.envelope.MessageRef, WaiterRef: waiter.ref})
+	message.process = waiter.process
+	if h.waiter == waiter {
+		h.waiter = nil
+	}
+	waiter.result <- claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "handoff", WaiterRef: waiter.ref,
+		Envelope: &message.envelope, Delivery: message.delivery}
+	window := h.receiptWindow
+	go func(messageRef, waiterRef string) {
+		timer := time.NewTimer(window)
+		defer timer.Stop()
+		<-timer.C
+		h.expireHandoff(messageRef, waiterRef)
+	}(message.envelope.MessageRef, waiter.ref)
+}
+
+func (h *claudeCoordinationHub) expireHandoff(messageRef, waiterRef string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	tracked := h.messages[messageRef]
+	if tracked == nil || tracked.delivery.WaiterRef != waiterRef {
+		return
+	}
+	tracked.delivery, _ = agentdelivery.Reduce(tracked.delivery, agentdelivery.Event{Kind: agentdelivery.EventExpire,
+		MessageRef: messageRef, WaiterRef: waiterRef})
+}
+
+func (h *claudeCoordinationHub) receipt(messageRef, waiterRef string, process coremetadata.ProcessIdentity, full bool) agentdelivery.Delivery {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	message := h.messages[messageRef]
+	if message == nil {
+		return agentdelivery.Delivery{MessageRef: messageRef, State: agentdelivery.StateStale, Reason: "unknown-message"}
+	}
+	if message.delivery.State != agentdelivery.StateHandoff || message.delivery.WaiterRef != waiterRef || message.process != process {
+		return message.delivery
+	}
+	if !full {
+		message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventFail,
+			MessageRef: messageRef, WaiterRef: waiterRef, Reason: "provider-pipe-write-failed"})
+		return message.delivery
+	}
+	message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventDeliver,
+		MessageRef: messageRef, WaiterRef: waiterRef, FullFrameWritten: true, HelperReceipt: true})
+	return message.delivery
+}
+
+func (h *claudeCoordinationHub) status(messageRef string) agentdelivery.Delivery {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.expirePendingLocked()
+	if message := h.messages[messageRef]; message != nil {
+		return message.delivery
+	}
+	return agentdelivery.Delivery{MessageRef: messageRef, State: agentdelivery.StateStale, Reason: "unknown-message"}
+}
+
+func (h *claudeCoordinationHub) close() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
+	h.closed = true
+	if h.waiter != nil {
+		h.waiter.result <- claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "stale", WaiterRef: h.waiter.ref}
+		h.waiter = nil
+	}
+	for _, message := range h.messages {
+		message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventStale,
+			MessageRef: message.envelope.MessageRef, Reason: "helper-restart"})
+	}
+}
+
+func (h *claudeCoordinationHub) scheduleTTL(messageRef string, deadline time.Time) {
+	delay := max(deadline.Sub(h.now()), 0)
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		<-timer.C
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		message := h.messages[messageRef]
+		if message != nil {
+			message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventExpire,
+				MessageRef: messageRef, Reason: "ttl"})
+		}
+	}()
+}
+
+func (h *claudeCoordinationHub) expirePendingLocked() {
+	now := h.now()
+	for _, ref := range h.pending {
+		message := h.messages[ref]
+		if message != nil && !message.envelope.Deadline.After(now) {
+			message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{Kind: agentdelivery.EventExpire,
+				MessageRef: ref, Reason: "ttl"})
+		}
+	}
+}
+
+func newCoordinationRef(prefix string) string {
+	data := make([]byte, 18)
+	if _, err := rand.Read(data); err != nil {
+		sum := sha256.Sum256([]byte(time.Now().UTC().Format(time.RFC3339Nano)))
+		copy(data, sum[:])
+	}
+	return prefix + "-" + hex.EncodeToString(data)
+}
+
+func validCoordinationRef(value string) bool {
+	value = strings.TrimSpace(value)
+	return value != "" && len(value) <= 160 && !strings.ContainsAny(value, "\r\n\x00")
+}
+
+type claudeCoordinationServer struct {
+	listener *localipc.Listener
+	hub      *claudeCoordinationHub
+	route    coremetadata.AgentRouteRef
+	current  func() bool
+	done     chan struct{}
+}
+
+func startClaudeCoordinationServer(listener *localipc.Listener, route coremetadata.AgentRouteRef, current func() bool) *claudeCoordinationServer {
+	server := &claudeCoordinationServer{listener: listener, hub: newClaudeCoordinationHub(), route: route, current: current, done: make(chan struct{})}
+	go server.serve()
+	return server
+}
+
+func (s *claudeCoordinationServer) serve() {
+	defer close(s.done)
+	defer s.hub.close()
+	for {
+		conn, err := s.listener.Unix.AcceptUnix()
+		if err != nil {
+			return
+		}
+		go s.handle(conn)
+	}
+}
+
+func (s *claudeCoordinationServer) handle(conn *net.UnixConn) {
+	defer conn.Close()
+	_ = conn.SetReadDeadline(time.Now().Add(localipc.Deadline))
+	var request claudeCoordinationRequest
+	if localipc.ReadJSON(conn, &request) != nil || request.Version != claudeCoordinationVersion || !request.Target.matches(s.route) || !s.current() {
+		_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "stale"})
+		return
+	}
+	peer, parent, err := localipc.PeerProcess(conn)
+	if err != nil || peer.OwnerUID != uint32(os.Getuid()) {
+		_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "refused"})
+		return
+	}
+	authority := request.Target.Authority
+	switch request.Operation {
+	case "probe":
+		_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "ready"})
+	case "waiter-ready":
+		kind := "no-waiter"
+		if s.hub.hasWaiter() {
+			kind = "waiter-ready"
+		}
+		_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: kind})
+	case "wait":
+		if (request.HookEvent != "SessionStart" && request.HookEvent != "Stop") || request.SessionID != authority.SessionID || parent != authority.Process.PID {
+			_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "refused"})
+			return
+		}
+		actual, _, processErr := localipc.Process(parent)
+		if processErr != nil || actual != authority.Process {
+			_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "refused"})
+			return
+		}
+		waiter, _ := s.hub.arm(peer)
+		if waiter == nil {
+			_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "stale"})
+			return
+		}
+		waitUntil := request.WaitUntil
+		if waitUntil.IsZero() || waitUntil.After(time.Now().Add(claudeCoordinationHookTimeout)) {
+			waitUntil = time.Now().Add(claudeCoordinationHookTimeout)
+		}
+		timer := time.NewTimer(time.Until(waitUntil))
+		defer timer.Stop()
+		select {
+		case response := <-waiter.result:
+			_ = conn.SetWriteDeadline(time.Now().Add(localipc.Deadline))
+			_ = localipc.WriteJSON(conn, response)
+		case <-timer.C:
+			s.hub.cancelWaiter(waiter, "timeout")
+			_ = localipc.WriteJSON(conn, <-waiter.result)
+		}
+	case "submit":
+		if request.Envelope == nil || !request.Envelope.valid(time.Now(), s.route) {
+			_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "refused"})
+			return
+		}
+		delivery := s.hub.submit(*request.Envelope)
+		_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: string(delivery.State), Delivery: delivery})
+	case "receipt":
+		if parent != authority.Process.PID || request.SessionID != authority.SessionID {
+			_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "refused"})
+			return
+		}
+		delivery := s.hub.receipt(request.MessageRef, request.WaiterRef, peer, request.FullFrameWritten)
+		_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: string(delivery.State), Delivery: delivery})
+	case "status":
+		delivery := s.hub.status(request.MessageRef)
+		_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: string(delivery.State), Delivery: delivery})
+	default:
+		_ = localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "refused"})
+	}
+}
+
+func (s *claudeCoordinationServer) Close() {
+	if s == nil {
+		return
+	}
+	s.hub.close()
+	_ = s.listener.Close()
+	<-s.done
+}
+
+func callClaudeCoordination(ctx context.Context, registryPath string, route coremetadata.AgentRouteRef, request claudeCoordinationRequest) (claudeCoordinationResponse, error) {
+	target, ok := claudeTargetForRoute(route)
+	if !ok || request.Target != target {
+		return claudeCoordinationResponse{}, errors.New("Claude coordination route is stale")
+	}
+	path := claudeCoordinationSocket(registryPath, target)
+	dialer := net.Dialer{Timeout: localipc.DialTimeout}
+	connection, err := dialer.DialContext(ctx, "unix", path)
+	if err != nil {
+		return claudeCoordinationResponse{}, errors.New("Claude coordination helper is unavailable")
+	}
+	defer connection.Close()
+	unixConnection, ok := connection.(*net.UnixConn)
+	if !ok {
+		return claudeCoordinationResponse{}, errors.New("Claude coordination helper is unavailable")
+	}
+	peer, _, err := localipc.PeerProcess(unixConnection)
+	if err != nil || peer != target.Authority.LeaseProcess {
+		return claudeCoordinationResponse{}, errors.New("Claude coordination helper peer is stale")
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = connection.SetDeadline(deadline)
+	}
+	if err := localipc.WriteJSON(connection, request); err != nil {
+		return claudeCoordinationResponse{}, errors.New("Claude coordination request failed")
+	}
+	_ = unixConnection.CloseWrite()
+	var response claudeCoordinationResponse
+	if err := localipc.ReadJSON(connection, &response); err != nil || response.Version != claudeCoordinationVersion {
+		return claudeCoordinationResponse{}, errors.New("Claude coordination response failed")
+	}
+	return response, nil
+}
+
+func resolveCurrentClaudeCoordinationRoute(registryPath, paneUID, generation, sessionID string) (coremetadata.AgentRouteRef, bool) {
+	if exactActivationRegistryPath(registryPath) != nil {
+		return coremetadata.AgentRouteRef{}, false
+	}
+	reg, err := intmetadata.NewStore(registryPath).LoadDegradedReadOnly()
+	if err != nil {
+		return coremetadata.AgentRouteRef{}, false
+	}
+	pane, ok := reg.Pane(paneUID)
+	if !ok || pane.Status.Activation.Generation != generation || pane.Status.Activation.AgentUID == "" {
+		return coremetadata.AgentRouteRef{}, false
+	}
+	route, reason := coremetadata.ResolveAgentRoute(reg, pane.Status.Activation.AgentUID)
+	authority, authorityOK := route.Authority().(coremetadata.ClaudeAuthorityRef)
+	return route, reason == "" && authorityOK && route.PaneUID == paneUID && route.Generation == generation && authority.SessionID == sessionID
+}
+
+type claudeHookWakeError struct{}
+
+func (claudeHookWakeError) Error() string { return "Claude coordination handoff complete" }
+func (claudeHookWakeError) ExitCode() int { return 2 }
+
+// runClaudeMessageWait is invoked only by the managed asyncRewake hook. It
+// writes no diagnostics or migration output to the provider pipe. The payload
+// remains an explicitly untrusted coordination record; a slash command has no
+// special authority and is transferred as ordinary JSON string data.
+func runClaudeMessageWait(args []string, stderr io.Writer) error {
+	return runClaudeMessageWaitInput(args, os.Stdin, stderr, os.Getenv)
+}
+
+func runClaudeMessageWaitInput(args []string, stdin io.Reader, stderr io.Writer, getenv func(string) string) error {
+	if len(args) != 0 {
+		return nil
+	}
+	data, err := io.ReadAll(io.LimitReader(stdin, localipc.MaxFrameBytes+1))
+	if err != nil || len(data) > localipc.MaxFrameBytes {
+		return nil
+	}
+	var hook struct {
+		Event     string `json:"hook_event_name"`
+		SessionID string `json:"session_id"`
+	}
+	if json.Unmarshal(data, &hook) != nil || (hook.Event != "SessionStart" && hook.Event != "Stop") || !validCoordinationRef(hook.SessionID) {
+		return nil
+	}
+	registryPath := getenv(internalClaudeRegistryPathEnv)
+	paneUID := getenv(internalActivationPaneUIDEnv)
+	generation := getenv(internalActivationGenerationEnv)
+	deadline := time.Now().Add(5 * time.Second)
+	var route coremetadata.AgentRouteRef
+	for {
+		var current bool
+		if route, current = resolveCurrentClaudeCoordinationRoute(registryPath, paneUID, generation, hook.SessionID); current {
+			break
+		}
+		if time.Now().After(deadline) {
+			return nil
+		}
+		time.Sleep(claudeEndpointPollInterval)
+	}
+	target, ok := claudeTargetForRoute(route)
+	if !ok {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), claudeCoordinationWaitTimeout)
+	defer cancel()
+	response, err := callClaudeCoordination(ctx, registryPath, route, claudeCoordinationRequest{Version: claudeCoordinationVersion,
+		Operation: "wait", Target: target, HookEvent: hook.Event, SessionID: hook.SessionID, WaitUntil: time.Now().Add(claudeCoordinationWaitTimeout)})
+	if err != nil || response.Kind != "handoff" || response.Envelope == nil || response.WaiterRef == "" ||
+		!response.Envelope.valid(time.Now(), route) || response.Envelope.MessageRef != response.Delivery.MessageRef {
+		return nil
+	}
+	payload, err := json.Marshal(response.Envelope)
+	if err != nil || len(payload)+1 > claudeProviderFrameMaxBytes {
+		return nil
+	}
+	payload = append(payload, '\n')
+	fullWrite := writeFullProviderFrame(stderr, payload) == nil
+	receiptCtx, receiptCancel := context.WithTimeout(context.Background(), localipc.Deadline)
+	defer receiptCancel()
+	receipt, err := callClaudeCoordination(receiptCtx, registryPath, route, claudeCoordinationRequest{Version: claudeCoordinationVersion,
+		Operation: "receipt", Target: target, SessionID: hook.SessionID, MessageRef: response.Envelope.MessageRef,
+		WaiterRef: response.WaiterRef, FullFrameWritten: fullWrite})
+	if err != nil || !fullWrite || receipt.Delivery.MessageRef != response.Envelope.MessageRef || receipt.Delivery.State != agentdelivery.StateDelivered {
+		return nil
+	}
+	if receipt.Delivery.WaiterRef != response.WaiterRef {
+		return nil
+	}
+	return claudeHookWakeError{}
+}
+
+func writeFullProviderFrame(writer io.Writer, payload []byte) error {
+	for len(payload) > 0 {
+		n, err := writer.Write(payload)
+		if n > 0 {
+			payload = payload[n:]
+		}
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+	}
+	return nil
+}

--- a/internal/app/claude_coordination_test.go
+++ b/internal/app/claude_coordination_test.go
@@ -1,0 +1,453 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/agentdelivery"
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
+	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
+)
+
+func coordinationEnvelope(ref string, deadline time.Time) claudeCoordinationEnvelope {
+	return claudeCoordinationEnvelope{
+		Version: claudeCoordinationVersion, MessageRef: ref,
+		Source:  claudeCoordinationSource{Kind: "peer", Trust: "untrusted", Authority: "coordination-only"},
+		Payload: "/status --plain-text", Deadline: deadline,
+	}
+}
+
+func TestClaudeCoordinationHubTransitionsAreTerminalOnce(t *testing.T) {
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	process := coremetadata.ProcessIdentity{PID: 101, OwnerUID: 1000, Start: "test:hook-1"}
+
+	t.Run("held handoff exact receipt and no automatic resend", func(t *testing.T) {
+		hub := newClaudeCoordinationHub()
+		hub.now = func() time.Time { return now }
+		hub.receiptWindow = time.Hour
+		envelope := coordinationEnvelope("message-delivered", now.Add(time.Hour))
+		if got := hub.submit(envelope); got.State != agentdelivery.StateHeld {
+			t.Fatalf("submit state = %s, want held", got.State)
+		}
+		waiter, _ := hub.arm(process)
+		response := <-waiter.result
+		if response.Kind != "handoff" || response.Envelope == nil || response.Envelope.MessageRef != envelope.MessageRef {
+			t.Fatalf("handoff response = %+v", response)
+		}
+		if got := hub.receipt(envelope.MessageRef, "foreign-waiter", process, true); got.State != agentdelivery.StateHandoff {
+			t.Fatalf("foreign receipt state = %s, want handoff", got.State)
+		}
+		if got := hub.receipt(envelope.MessageRef, waiter.ref, process, true); got.State != agentdelivery.StateDelivered || got.Ambiguous {
+			t.Fatalf("delivery = %+v", got)
+		}
+		if got := hub.submit(envelope); got.State != agentdelivery.StateDelivered {
+			t.Fatalf("duplicate submit changed terminal delivery: %+v", got)
+		}
+		second, _ := hub.arm(process)
+		select {
+		case got := <-second.result:
+			t.Fatalf("terminal message was automatically resent: %+v", got)
+		default:
+		}
+		hub.cancelWaiter(second, "test-cleanup")
+	})
+
+	t.Run("partial pipe receipt is ambiguous failure", func(t *testing.T) {
+		hub := newClaudeCoordinationHub()
+		hub.now = func() time.Time { return now }
+		hub.receiptWindow = time.Hour
+		waiter, _ := hub.arm(process)
+		envelope := coordinationEnvelope("message-partial", now.Add(time.Hour))
+		hub.submit(envelope)
+		<-waiter.result
+		got := hub.receipt(envelope.MessageRef, waiter.ref, process, false)
+		if got.State != agentdelivery.StateFailed || !got.Ambiguous || got.Reason != "provider-pipe-write-failed" {
+			t.Fatalf("partial receipt = %+v", got)
+		}
+	})
+
+	t.Run("receipt timeout is terminal ambiguous failure", func(t *testing.T) {
+		hub := newClaudeCoordinationHub()
+		hub.now = func() time.Time { return now }
+		hub.receiptWindow = time.Hour
+		waiter, _ := hub.arm(process)
+		envelope := coordinationEnvelope("message-timeout", now.Add(time.Hour))
+		hub.submit(envelope)
+		<-waiter.result
+		hub.expireHandoff(envelope.MessageRef, waiter.ref)
+		got := hub.status(envelope.MessageRef)
+		if got.State != agentdelivery.StateFailed || !got.Ambiguous || got.Reason != "observation-timeout" {
+			t.Fatalf("receipt timeout = %+v", got)
+		}
+	})
+
+	t.Run("ttl before handoff expires without ambiguity", func(t *testing.T) {
+		hub := newClaudeCoordinationHub()
+		hub.now = func() time.Time { return now }
+		hub.receiptWindow = time.Hour
+		envelope := coordinationEnvelope("message-ttl", now.Add(time.Minute))
+		hub.submit(envelope)
+		now = now.Add(2 * time.Minute)
+		got := hub.status(envelope.MessageRef)
+		if got.State != agentdelivery.StateExpired || got.Ambiguous {
+			t.Fatalf("ttl result = %+v", got)
+		}
+		now = now.Add(-2 * time.Minute)
+	})
+
+	t.Run("helper restart distinguishes held from handoff", func(t *testing.T) {
+		heldHub := newClaudeCoordinationHub()
+		heldHub.now = func() time.Time { return now }
+		heldHub.submit(coordinationEnvelope("message-held-restart", now.Add(time.Hour)))
+		heldHub.close()
+		if got := heldHub.status("message-held-restart"); got.State != agentdelivery.StateStale || got.Ambiguous {
+			t.Fatalf("held restart = %+v", got)
+		}
+
+		handoffHub := newClaudeCoordinationHub()
+		handoffHub.now = func() time.Time { return now }
+		handoffHub.receiptWindow = time.Hour
+		waiter, _ := handoffHub.arm(process)
+		handoffHub.submit(coordinationEnvelope("message-handoff-restart", now.Add(time.Hour)))
+		<-waiter.result
+		handoffHub.close()
+		if got := handoffHub.status("message-handoff-restart"); got.State != agentdelivery.StateFailed || !got.Ambiguous {
+			t.Fatalf("handoff restart = %+v", got)
+		}
+	})
+}
+
+func TestClaudeCoordinationSingleWaiterCASAndSupersede(t *testing.T) {
+	hub := newClaudeCoordinationHub()
+	hub.receiptWindow = time.Hour
+	first, _ := hub.arm(coremetadata.ProcessIdentity{PID: 101, OwnerUID: 1000, Start: "test:first"})
+	second, superseded := hub.arm(coremetadata.ProcessIdentity{PID: 102, OwnerUID: 1000, Start: "test:second"})
+	if superseded != first {
+		t.Fatal("second waiter did not CAS-supersede first")
+	}
+	if got := <-first.result; got.Kind != "superseded" || got.WaiterRef != first.ref {
+		t.Fatalf("first waiter result = %+v", got)
+	}
+	envelope := coordinationEnvelope("message-single-waiter", time.Now().Add(time.Hour))
+	if got := hub.submit(envelope); got.State != agentdelivery.StateHandoff || got.WaiterRef != second.ref {
+		t.Fatalf("submit chose wrong waiter: %+v", got)
+	}
+	if got := <-second.result; got.Kind != "handoff" || got.WaiterRef != second.ref {
+		t.Fatalf("second waiter result = %+v", got)
+	}
+}
+
+func TestClaudeCoordinationOverlappingHookChildrenLeaveOneActiveWaiter(t *testing.T) {
+	hub := newClaudeCoordinationHub()
+	const count = 32
+	waiters := make(chan *claudeCoordinationWaiter, count)
+	var group sync.WaitGroup
+	for index := range count {
+		group.Add(1)
+		go func(index int) {
+			defer group.Done()
+			waiter, _ := hub.arm(coremetadata.ProcessIdentity{PID: index + 1, OwnerUID: 1000, Start: "test:overlap"})
+			waiters <- waiter
+		}(index)
+	}
+	group.Wait()
+	close(waiters)
+	hub.mu.Lock()
+	active := hub.waiter
+	hub.mu.Unlock()
+	if active == nil {
+		t.Fatal("overlapping hook children left no active waiter")
+	}
+	superseded := 0
+	for waiter := range waiters {
+		if waiter == active {
+			continue
+		}
+		select {
+		case result := <-waiter.result:
+			if result.Kind != "superseded" || result.WaiterRef != waiter.ref {
+				t.Fatalf("superseded result = %+v", result)
+			}
+			superseded++
+		default:
+			t.Fatalf("inactive waiter %s did not receive supersede", waiter.ref)
+		}
+	}
+	if superseded != count-1 {
+		t.Fatalf("superseded = %d, want %d", superseded, count-1)
+	}
+	hub.cancelWaiter(active, "test-cleanup")
+}
+
+type partialPipeWriter struct {
+	written int
+	err     error
+}
+
+func (w *partialPipeWriter) Write(payload []byte) (int, error) {
+	if w.written != 0 {
+		return 0, w.err
+	}
+	n := len(payload) / 2
+	if n == 0 {
+		n = 1
+	}
+	w.written = n
+	return n, w.err
+}
+
+func TestWriteFullProviderFrameHandlesPartialAndEPIPE(t *testing.T) {
+	payload := []byte("bounded provider frame\n")
+	var chunked bytes.Buffer
+	if err := writeFullProviderFrame(writerLimitedTo{writer: &chunked, limit: 3}, payload); err != nil || !bytes.Equal(chunked.Bytes(), payload) {
+		t.Fatalf("chunked full write bytes=%q err=%v", chunked.Bytes(), err)
+	}
+	partial := &partialPipeWriter{err: io.ErrClosedPipe}
+	if err := writeFullProviderFrame(partial, payload); !errors.Is(err, io.ErrClosedPipe) || partial.written == len(payload) {
+		t.Fatalf("partial EPIPE written=%d err=%v", partial.written, err)
+	}
+	if err := writeFullProviderFrame(zeroWriter{}, payload); !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("zero write err=%v, want short write", err)
+	}
+}
+
+type writerLimitedTo struct {
+	writer io.Writer
+	limit  int
+}
+
+func (w writerLimitedTo) Write(payload []byte) (int, error) {
+	if len(payload) > w.limit {
+		payload = payload[:w.limit]
+	}
+	return w.writer.Write(payload)
+}
+
+type zeroWriter struct{}
+
+func (zeroWriter) Write([]byte) (int, error) { return 0, nil }
+
+type claudeCoordinationTestFixture struct {
+	registryPath string
+	route        coremetadata.AgentRouteRef
+	target       claudeCoordinationTarget
+	server       *claudeCoordinationServer
+	sessionID    string
+	paneUID      string
+	generation   string
+}
+
+func newClaudeCoordinationTestFixture(t *testing.T) *claudeCoordinationTestFixture {
+	t.Helper()
+	h := newSessionRefHarness(t, aiModeClaude)
+	provider, _, err := localipc.Process(os.Getppid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	helper, _, err := localipc.Process(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutator := intmetadata.DefaultMutator()
+	if err := mutator.RecordClaudeProcess(h.registry, h.paneUID, h.agentUID, h.envGeneration, provider); err != nil {
+		t.Fatal(err)
+	}
+	authority := coremetadata.ClaudeAuthorityRef{SessionID: "synthetic-session", Process: provider,
+		RegistrationGeneration: "synthetic-registration", LeaseProcess: helper}
+	if err := mutator.BeginClaudeRegistration(h.registry, h.paneUID, h.agentUID, h.envGeneration, authority); err != nil {
+		t.Fatal(err)
+	}
+	if err := mutator.RecordClaudeRegistration(h.registry, h.paneUID, h.agentUID, h.envGeneration,
+		coremetadata.ClaudeRegistration{Authority: authority}); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.MkdirTemp("", "pmx-coordination-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	registryPath := intmetadata.PathFor(filepath.Join(root, "state"))
+	store := intmetadata.NewStore(registryPath)
+	if _, err := store.Update(func(reg *coremetadata.Registry) error { *reg = h.registry.Clone(); return nil }); err != nil {
+		t.Fatal(err)
+	}
+	route, reason := coremetadata.ResolveAgentRoute(*h.registry, h.agentUID)
+	if reason != "" {
+		t.Fatal(reason)
+	}
+	target, ok := claudeTargetForRoute(route)
+	if !ok {
+		t.Fatal("exact Claude target unavailable")
+	}
+	listener, err := localipc.Listen(claudeCoordinationSocket(registryPath, target))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := startClaudeCoordinationServer(listener, route, func() bool { return true })
+	t.Cleanup(func() {
+		server.Close()
+		_ = os.RemoveAll(claudeActivationLeaseDir(registryPath, h.paneUID, h.envGeneration))
+	})
+	return &claudeCoordinationTestFixture{registryPath: registryPath, route: route, target: target, server: server,
+		sessionID: authority.SessionID, paneUID: h.paneUID, generation: h.envGeneration}
+}
+
+func (f *claudeCoordinationTestFixture) call(t *testing.T, request claudeCoordinationRequest) claudeCoordinationResponse {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	response, err := callClaudeCoordination(ctx, f.registryPath, f.route, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return response
+}
+
+func TestClaudeCoordinationHookOwnedUDSAndProviderPipe(t *testing.T) {
+	for _, event := range []string{"SessionStart", "Stop"} {
+		t.Run(event, func(t *testing.T) {
+			fixture := newClaudeCoordinationTestFixture(t)
+			getenv := func(key string) string {
+				switch key {
+				case internalClaudeRegistryPathEnv:
+					return fixture.registryPath
+				case internalActivationPaneUIDEnv:
+					return fixture.paneUID
+				case internalActivationGenerationEnv:
+					return fixture.generation
+				default:
+					return ""
+				}
+			}
+			input, _ := json.Marshal(map[string]string{"hook_event_name": event, "session_id": fixture.sessionID})
+			readPipe, writePipe, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer readPipe.Close()
+			output := make(chan []byte, 1)
+			go func() {
+				data, _ := io.ReadAll(readPipe)
+				output <- data
+			}()
+			hookDone := make(chan error, 1)
+			go func() {
+				hookDone <- runClaudeMessageWaitInput(nil, bytes.NewReader(input), writePipe, getenv)
+				_ = writePipe.Close()
+			}()
+			select {
+			case <-fixture.server.hub.waiterReady:
+			case <-time.After(3 * time.Second):
+				t.Fatal("hook waiter-ready barrier timed out")
+			}
+			envelope := coordinationEnvelope("message-"+strings.ToLower(event), time.Now().Add(time.Minute))
+			envelope.Target = fixture.target
+			response := fixture.call(t, claudeCoordinationRequest{Version: claudeCoordinationVersion, Operation: "submit",
+				Target: fixture.target, Envelope: &envelope})
+			if response.Delivery.State != agentdelivery.StateHandoff {
+				t.Fatalf("submit response = %+v", response)
+			}
+			var hookErr error
+			select {
+			case hookErr = <-hookDone:
+			case <-time.After(3 * time.Second):
+				t.Fatal("hook handoff timed out")
+			}
+			var exitCode interface{ ExitCode() int }
+			if !errors.As(hookErr, &exitCode) || exitCode.ExitCode() != 2 {
+				t.Fatalf("hook error = %v, want typed exit 2", hookErr)
+			}
+			providerFrame := <-output
+			if len(providerFrame) == 0 || providerFrame[len(providerFrame)-1] != '\n' {
+				t.Fatalf("provider frame = %q", providerFrame)
+			}
+			var got claudeCoordinationEnvelope
+			if err := json.Unmarshal(providerFrame, &got); err != nil || got.MessageRef != envelope.MessageRef || got.Payload != "/status --plain-text" || got.Source.Trust != "untrusted" {
+				t.Fatalf("provider frame = %+v err=%v", got, err)
+			}
+			status := fixture.call(t, claudeCoordinationRequest{Version: claudeCoordinationVersion, Operation: "status",
+				Target: fixture.target, MessageRef: envelope.MessageRef})
+			if status.Delivery.State != agentdelivery.StateDelivered || status.Delivery.Reason != "provider-pipe-full-frame" {
+				t.Fatalf("structured receipt = %+v", status.Delivery)
+			}
+		})
+	}
+}
+
+func TestClaudeCoordinationRefusesHookIdentityMismatches(t *testing.T) {
+	fixture := newClaudeCoordinationTestFixture(t)
+	for _, test := range []struct {
+		name    string
+		event   string
+		session string
+	}{
+		{name: "foreign event", event: "Notification", session: fixture.sessionID},
+		{name: "foreign session", event: "Stop", session: "other-session"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			response := fixture.call(t, claudeCoordinationRequest{Version: claudeCoordinationVersion, Operation: "wait",
+				Target: fixture.target, HookEvent: test.event, SessionID: test.session, WaitUntil: time.Now()})
+			if response.Kind != "refused" {
+				t.Fatalf("mismatched hook response = %+v", response)
+			}
+		})
+	}
+	staleTarget := fixture.target
+	staleTarget.Generation += "-replacement"
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if _, err := callClaudeCoordination(ctx, fixture.registryPath, fixture.route, claudeCoordinationRequest{
+		Version: claudeCoordinationVersion, Operation: "probe", Target: staleTarget}); err == nil {
+		t.Fatal("stale activation target accepted")
+	}
+}
+
+func TestClaudeCoordinationEnvelopeBoundsAndPlainTextAuthority(t *testing.T) {
+	fixture := newClaudeCoordinationTestFixture(t)
+	envelope := coordinationEnvelope("message-bounds", time.Now().Add(time.Minute))
+	envelope.Target = fixture.target
+	if !envelope.valid(time.Now(), fixture.route) {
+		t.Fatal("bounded exact envelope refused")
+	}
+	envelope.Payload = strings.Repeat("x", claudeProviderFrameMaxBytes)
+	if envelope.valid(time.Now(), fixture.route) {
+		t.Fatal("oversized provider frame accepted")
+	}
+	envelope = coordinationEnvelope("message-command", time.Now().Add(time.Minute))
+	envelope.Target = fixture.target
+	envelope.Payload = "/dangerous-looking-command --still-plain-text"
+	data, err := json.Marshal(envelope)
+	if err != nil || !bytes.Contains(data, []byte(`/dangerous-looking-command`)) || envelope.Source.Authority != "coordination-only" {
+		t.Fatalf("slash command was not preserved as untrusted plaintext: %s", data)
+	}
+}
+
+func TestClaudeCoordinationHookRouteIsHiddenQuietAndShellSafe(t *testing.T) {
+	if shouldRunLegacyHookMigrations([]string{"internal", "claude-message-wait"}) {
+		t.Fatal("private hook route would write migration diagnostics to the provider pipe")
+	}
+	for _, command := range internalSubcommands {
+		if command == "claude-message-wait" {
+			t.Fatal("private hook route was exposed in the public internal catalog")
+		}
+	}
+	if claudeCoordinationHookCommand != "exec projmux internal claude-message-wait # "+claudeCoordinationManagedMarker {
+		t.Fatalf("hook command is not the fixed shell-safe exec route: %q", claudeCoordinationHookCommand)
+	}
+	for _, input := range []string{"{", `{"hook_event_name":"Notification","session_id":"foreign"}`} {
+		var providerPipe bytes.Buffer
+		if err := runClaudeMessageWaitInput(nil, strings.NewReader(input), &providerPipe, func(string) string { return "" }); err != nil || providerPipe.Len() != 0 {
+			t.Fatalf("invalid hook input err=%v output=%q, want quiet refusal", err, providerPipe.String())
+		}
+	}
+}

--- a/internal/app/claude_coordination_test.go
+++ b/internal/app/claude_coordination_test.go
@@ -27,22 +27,32 @@ func coordinationEnvelope(ref string, deadline time.Time) claudeCoordinationEnve
 	}
 }
 
+func newLiveCoordinationTestHub() *claudeCoordinationHub {
+	hub := newClaudeCoordinationHub()
+	hub.processCurrent = func(coremetadata.ProcessIdentity) bool { return true }
+	hub.assignmentWindow = time.Hour
+	hub.receiptWindow = time.Hour
+	return hub
+}
+
 func TestClaudeCoordinationHubTransitionsAreTerminalOnce(t *testing.T) {
 	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
 	process := coremetadata.ProcessIdentity{PID: 101, OwnerUID: 1000, Start: "test:hook-1"}
 
 	t.Run("held handoff exact receipt and no automatic resend", func(t *testing.T) {
-		hub := newClaudeCoordinationHub()
+		hub := newLiveCoordinationTestHub()
 		hub.now = func() time.Time { return now }
-		hub.receiptWindow = time.Hour
 		envelope := coordinationEnvelope("message-delivered", now.Add(time.Hour))
 		if got := hub.submit(envelope); got.State != agentdelivery.StateHeld {
 			t.Fatalf("submit state = %s, want held", got.State)
 		}
 		waiter, _ := hub.arm(process)
 		response := <-waiter.result
-		if response.Kind != "handoff" || response.Envelope == nil || response.Envelope.MessageRef != envelope.MessageRef {
+		if response.Kind != "assignment" || response.Envelope == nil || response.Envelope.MessageRef != envelope.MessageRef {
 			t.Fatalf("handoff response = %+v", response)
+		}
+		if got := hub.beginHandoff(envelope.MessageRef, waiter.ref, process); got.State != agentdelivery.StateHandoff {
+			t.Fatalf("begin handoff = %+v", got)
 		}
 		if got := hub.receipt(envelope.MessageRef, "foreign-waiter", process, true); got.State != agentdelivery.StateHandoff {
 			t.Fatalf("foreign receipt state = %s, want handoff", got.State)
@@ -63,27 +73,34 @@ func TestClaudeCoordinationHubTransitionsAreTerminalOnce(t *testing.T) {
 	})
 
 	t.Run("partial pipe receipt is ambiguous failure", func(t *testing.T) {
-		hub := newClaudeCoordinationHub()
+		hub := newLiveCoordinationTestHub()
 		hub.now = func() time.Time { return now }
-		hub.receiptWindow = time.Hour
 		waiter, _ := hub.arm(process)
 		envelope := coordinationEnvelope("message-partial", now.Add(time.Hour))
 		hub.submit(envelope)
 		<-waiter.result
+		hub.beginHandoff(envelope.MessageRef, waiter.ref, process)
 		got := hub.receipt(envelope.MessageRef, waiter.ref, process, false)
 		if got.State != agentdelivery.StateFailed || !got.Ambiguous || got.Reason != "provider-pipe-write-failed" {
 			t.Fatalf("partial receipt = %+v", got)
 		}
+		second, _ := hub.arm(process)
+		select {
+		case response := <-second.result:
+			t.Fatalf("ambiguous post-handoff failure was automatically resent: %+v", response)
+		default:
+		}
+		hub.cancelWaiter(second, "test-cleanup")
 	})
 
 	t.Run("receipt timeout is terminal ambiguous failure", func(t *testing.T) {
-		hub := newClaudeCoordinationHub()
+		hub := newLiveCoordinationTestHub()
 		hub.now = func() time.Time { return now }
-		hub.receiptWindow = time.Hour
 		waiter, _ := hub.arm(process)
 		envelope := coordinationEnvelope("message-timeout", now.Add(time.Hour))
 		hub.submit(envelope)
 		<-waiter.result
+		hub.beginHandoff(envelope.MessageRef, waiter.ref, process)
 		hub.expireHandoff(envelope.MessageRef, waiter.ref)
 		got := hub.status(envelope.MessageRef)
 		if got.State != agentdelivery.StateFailed || !got.Ambiguous || got.Reason != "observation-timeout" {
@@ -92,9 +109,8 @@ func TestClaudeCoordinationHubTransitionsAreTerminalOnce(t *testing.T) {
 	})
 
 	t.Run("ttl before handoff expires without ambiguity", func(t *testing.T) {
-		hub := newClaudeCoordinationHub()
+		hub := newLiveCoordinationTestHub()
 		hub.now = func() time.Time { return now }
-		hub.receiptWindow = time.Hour
 		envelope := coordinationEnvelope("message-ttl", now.Add(time.Minute))
 		hub.submit(envelope)
 		now = now.Add(2 * time.Minute)
@@ -106,7 +122,7 @@ func TestClaudeCoordinationHubTransitionsAreTerminalOnce(t *testing.T) {
 	})
 
 	t.Run("helper restart distinguishes held from handoff", func(t *testing.T) {
-		heldHub := newClaudeCoordinationHub()
+		heldHub := newLiveCoordinationTestHub()
 		heldHub.now = func() time.Time { return now }
 		heldHub.submit(coordinationEnvelope("message-held-restart", now.Add(time.Hour)))
 		heldHub.close()
@@ -114,12 +130,12 @@ func TestClaudeCoordinationHubTransitionsAreTerminalOnce(t *testing.T) {
 			t.Fatalf("held restart = %+v", got)
 		}
 
-		handoffHub := newClaudeCoordinationHub()
+		handoffHub := newLiveCoordinationTestHub()
 		handoffHub.now = func() time.Time { return now }
-		handoffHub.receiptWindow = time.Hour
 		waiter, _ := handoffHub.arm(process)
 		handoffHub.submit(coordinationEnvelope("message-handoff-restart", now.Add(time.Hour)))
 		<-waiter.result
+		handoffHub.beginHandoff("message-handoff-restart", waiter.ref, process)
 		handoffHub.close()
 		if got := handoffHub.status("message-handoff-restart"); got.State != agentdelivery.StateFailed || !got.Ambiguous {
 			t.Fatalf("handoff restart = %+v", got)
@@ -128,8 +144,7 @@ func TestClaudeCoordinationHubTransitionsAreTerminalOnce(t *testing.T) {
 }
 
 func TestClaudeCoordinationSingleWaiterCASAndSupersede(t *testing.T) {
-	hub := newClaudeCoordinationHub()
-	hub.receiptWindow = time.Hour
+	hub := newLiveCoordinationTestHub()
 	first, _ := hub.arm(coremetadata.ProcessIdentity{PID: 101, OwnerUID: 1000, Start: "test:first"})
 	second, superseded := hub.arm(coremetadata.ProcessIdentity{PID: 102, OwnerUID: 1000, Start: "test:second"})
 	if superseded != first {
@@ -139,16 +154,19 @@ func TestClaudeCoordinationSingleWaiterCASAndSupersede(t *testing.T) {
 		t.Fatalf("first waiter result = %+v", got)
 	}
 	envelope := coordinationEnvelope("message-single-waiter", time.Now().Add(time.Hour))
-	if got := hub.submit(envelope); got.State != agentdelivery.StateHandoff || got.WaiterRef != second.ref {
+	if got := hub.submit(envelope); got.State != agentdelivery.StateQueued || got.WaiterRef != "" {
 		t.Fatalf("submit chose wrong waiter: %+v", got)
 	}
-	if got := <-second.result; got.Kind != "handoff" || got.WaiterRef != second.ref {
+	if got := <-second.result; got.Kind != "assignment" || got.WaiterRef != second.ref {
 		t.Fatalf("second waiter result = %+v", got)
+	}
+	if got := hub.beginHandoff(envelope.MessageRef, second.ref, second.process); got.State != agentdelivery.StateHandoff || got.WaiterRef != second.ref {
+		t.Fatalf("second waiter did not begin handoff: %+v", got)
 	}
 }
 
 func TestClaudeCoordinationOverlappingHookChildrenLeaveOneActiveWaiter(t *testing.T) {
-	hub := newClaudeCoordinationHub()
+	hub := newLiveCoordinationTestHub()
 	const count = 32
 	waiters := make(chan *claudeCoordinationWaiter, count)
 	var group sync.WaitGroup
@@ -188,6 +206,66 @@ func TestClaudeCoordinationOverlappingHookChildrenLeaveOneActiveWaiter(t *testin
 	}
 	hub.cancelWaiter(active, "test-cleanup")
 }
+
+func TestClaudeCoordinationDeadHookChildNeverBeginsHandoff(t *testing.T) {
+	hub := newLiveCoordinationTestHub()
+	hub.processCurrent = func(coremetadata.ProcessIdentity) bool { return false }
+	process := coremetadata.ProcessIdentity{PID: 404, OwnerUID: 1000, Start: "test:dead-hook"}
+	waiter, _ := hub.arm(process)
+	delivery := hub.submit(coordinationEnvelope("message-dead-hook", time.Now().Add(time.Hour)))
+	if delivery.State != agentdelivery.StateHeld || delivery.WaiterRef != "" || delivery.Ambiguous {
+		t.Fatalf("dead hook delivery = %+v, want held before handoff", delivery)
+	}
+	if result := <-waiter.result; result.Kind != "stale" || result.WaiterRef != waiter.ref {
+		t.Fatalf("dead hook waiter result = %+v", result)
+	}
+	if hub.hasWaiter() {
+		t.Fatal("dead hook remained the active waiter")
+	}
+	hub.close()
+}
+
+func TestClaudeCoordinationDisconnectedHookResponseFailsBeforeHandoff(t *testing.T) {
+	hub := newLiveCoordinationTestHub()
+	process := coremetadata.ProcessIdentity{PID: 101, OwnerUID: 1000, Start: "test:disconnected-hook"}
+	waiter, _ := hub.arm(process)
+	envelope := coordinationEnvelope("message-disconnected-hook", time.Now().Add(time.Hour))
+	if delivery := hub.submit(envelope); delivery.State != agentdelivery.StateQueued || delivery.WaiterRef != "" {
+		t.Fatalf("disconnected assignment leaked handoff: %+v", delivery)
+	}
+	response := <-waiter.result
+	server := &claudeCoordinationServer{hub: hub}
+	if err := server.writeWaiterResponse(errorWriter{err: io.ErrClosedPipe}, response, process); !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("forced response-write error = %v", err)
+	}
+	status := hub.status(envelope.MessageRef)
+	if status.State != agentdelivery.StateFailed || status.Ambiguous || status.WaiterRef != "" || status.Reason != "helper-response-write-failed" {
+		t.Fatalf("disconnected hook terminal = %+v", status)
+	}
+}
+
+func TestClaudeCoordinationAssignmentTimeoutFailsBeforeHandoff(t *testing.T) {
+	hub := newLiveCoordinationTestHub()
+	process := coremetadata.ProcessIdentity{PID: 102, OwnerUID: 1000, Start: "test:assignment-timeout"}
+	waiter, _ := hub.arm(process)
+	envelope := coordinationEnvelope("message-assignment-timeout", time.Now().Add(time.Hour))
+	if delivery := hub.submit(envelope); delivery.State != agentdelivery.StateQueued || delivery.WaiterRef != "" {
+		t.Fatalf("assignment leaked handoff: %+v", delivery)
+	}
+	response := <-waiter.result
+	if response.Kind != "assignment" || response.WaiterRef != waiter.ref {
+		t.Fatalf("assignment response = %+v", response)
+	}
+	hub.expireAssignment(envelope.MessageRef, waiter.ref)
+	status := hub.status(envelope.MessageRef)
+	if status.State != agentdelivery.StateFailed || status.Ambiguous || status.WaiterRef != "" || status.Reason != "waiter-disconnected" {
+		t.Fatalf("assignment timeout terminal = %+v", status)
+	}
+}
+
+type errorWriter struct{ err error }
+
+func (w errorWriter) Write([]byte) (int, error) { return 0, w.err }
 
 type partialPipeWriter struct {
 	written int
@@ -354,7 +432,7 @@ func TestClaudeCoordinationHookOwnedUDSAndProviderPipe(t *testing.T) {
 			envelope.Target = fixture.target
 			response := fixture.call(t, claudeCoordinationRequest{Version: claudeCoordinationVersion, Operation: "submit",
 				Target: fixture.target, Envelope: &envelope})
-			if response.Delivery.State != agentdelivery.StateHandoff {
+			if response.Delivery.State != agentdelivery.StateQueued {
 				t.Fatalf("submit response = %+v", response)
 			}
 			var hookErr error

--- a/internal/app/claude_coordination_test.go
+++ b/internal/app/claude_coordination_test.go
@@ -121,6 +121,53 @@ func TestClaudeCoordinationHubTransitionsAreTerminalOnce(t *testing.T) {
 		now = now.Add(-2 * time.Minute)
 	})
 
+	t.Run("assigned waiter cannot begin handoff after ttl", func(t *testing.T) {
+		testNow := now
+		hub := newLiveCoordinationTestHub()
+		hub.now = func() time.Time { return testNow }
+		waiter, _ := hub.arm(process)
+		envelope := coordinationEnvelope("message-assigned-ttl", testNow.Add(time.Minute))
+		if got := hub.submit(envelope); got.State != agentdelivery.StateQueued {
+			t.Fatalf("assigned submit = %+v", got)
+		}
+		if response := <-waiter.result; response.Kind != "assignment" || response.WaiterRef != waiter.ref {
+			t.Fatalf("assigned waiter response = %+v", response)
+		}
+		testNow = envelope.Deadline
+		got := hub.status(envelope.MessageRef)
+		if got.State != agentdelivery.StateExpired || got.Ambiguous || got.WaiterRef != "" || got.Reason != "ttl" {
+			t.Fatalf("post-deadline status = %+v", got)
+		}
+		if handoff := hub.beginHandoff(envelope.MessageRef, waiter.ref, process); handoff != got {
+			t.Fatalf("late handoff changed terminal expiry: got %+v want %+v", handoff, got)
+		}
+		if receipt := hub.receipt(envelope.MessageRef, waiter.ref, process, true); receipt != got {
+			t.Fatalf("late receipt changed terminal expiry: got %+v want %+v", receipt, got)
+		}
+		second, _ := hub.arm(process)
+		select {
+		case response := <-second.result:
+			t.Fatalf("expired assignment was automatically resent: %+v", response)
+		default:
+		}
+		hub.cancelWaiter(second, "test-cleanup")
+	})
+
+	t.Run("handoff deadline fence does not depend on status or timer", func(t *testing.T) {
+		testNow := now
+		hub := newLiveCoordinationTestHub()
+		hub.now = func() time.Time { return testNow }
+		waiter, _ := hub.arm(process)
+		envelope := coordinationEnvelope("message-direct-handoff-ttl", testNow.Add(time.Minute))
+		hub.submit(envelope)
+		<-waiter.result
+		testNow = envelope.Deadline
+		got := hub.beginHandoff(envelope.MessageRef, waiter.ref, process)
+		if got.State != agentdelivery.StateExpired || got.Ambiguous || got.WaiterRef != "" || got.Reason != "ttl" {
+			t.Fatalf("post-deadline handoff = %+v", got)
+		}
+	})
+
 	t.Run("helper restart distinguishes held from handoff", func(t *testing.T) {
 		heldHub := newLiveCoordinationTestHub()
 		heldHub.now = func() time.Time { return now }

--- a/internal/app/claude_endpoint.go
+++ b/internal/app/claude_endpoint.go
@@ -19,6 +19,7 @@ import (
 
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
 	claudeadapter "github.com/crevissepartners/projmux/internal/integrations/agents/claude"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
 	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
 )
 
@@ -330,6 +331,11 @@ func cleanupClaudeActivationLeases(spec superviseSpec) {
 		if strings.HasSuffix(name, ".sock.json") {
 			path := filepath.Join(dir, name)
 			if receipt, ok := readClaudeLeaseOwner(path, spec); ok && path == claudeLeaseSocket(spec.RegistryPath, spec.PaneUID, spec.Generation, receipt.Authority.RegistrationGeneration)+".json" {
+				target := claudeCoordinationTarget{AgentUID: receipt.AgentUID, PaneUID: receipt.PaneUID, Generation: receipt.Generation,
+					Provider: aiModeClaude, Authority: receipt.Authority}
+				if coordination := claudeCoordinationSocket(spec.RegistryPath, target); filepath.Dir(coordination) == dir {
+					_ = localipc.RemoveOwnedSocket(coordination, receipt.CoordinationSocket)
+				}
 				_ = os.Remove(path)
 			}
 			continue
@@ -337,7 +343,8 @@ func cleanupClaudeActivationLeases(spec superviseSpec) {
 		if len(name) != 37 || !strings.HasSuffix(name, ".sock") {
 			continue
 		}
-		if _, err := hex.DecodeString(strings.TrimSuffix(name, ".sock")); err != nil {
+		digest := strings.TrimSuffix(name, ".sock")
+		if _, err := hex.DecodeString(digest); err != nil {
 			continue
 		}
 		path := filepath.Join(dir, name)
@@ -391,7 +398,20 @@ func serveClaudeEndpoint(ctx context.Context, bootstrap claudeEndpointBootstrap,
 	if err != nil {
 		return errors.New("claude helper lease unavailable")
 	}
-	if writeClaudeLeaseOwner(leasePath+".json", bootstrap) != nil {
+	coordinationTarget := claudeCoordinationTarget{AgentUID: bootstrap.AgentUID, PaneUID: bootstrap.PaneUID,
+		Generation: bootstrap.Generation, Provider: aiModeClaude, Authority: bootstrap.Registration.Authority}
+	coordinationListener, err := localipc.Listen(claudeCoordinationSocket(bootstrap.RegistryPath, coordinationTarget))
+	if err != nil {
+		return errors.New("claude coordination listener is unavailable")
+	}
+	coordinationListenerOwned := true
+	defer func() {
+		if coordinationListenerOwned {
+			_ = coordinationListener.Close()
+		}
+	}()
+	coordinationIdentity := coordinationListener.Identity()
+	if writeClaudeLeaseOwner(leasePath+".json", bootstrap, coordinationIdentity) != nil {
 		return errors.New("claude helper ownership unavailable")
 	}
 	defer os.Remove(leasePath + ".json")
@@ -417,11 +437,14 @@ func serveClaudeEndpoint(ctx context.Context, bootstrap claudeEndpointBootstrap,
 		return errors.New("claude registration is unavailable")
 	}
 	expectedRoute, reason := coremetadata.ResolveAgentRoute(initial, bootstrap.AgentUID)
-	if reason != "" {
+	if reason != "" || !coordinationTarget.matches(expectedRoute) {
 		return errors.New("claude registration is unavailable")
 	}
 	current := func() bool {
 		if observed, err := inspectClaudeSocket(leasePath); err != nil || observed != leaseIdentity {
+			return false
+		}
+		if observed, err := localipc.InspectOwnedSocket(coordinationListener.Path); err != nil || observed != coordinationIdentity {
 			return false
 		}
 		actual, _, err := claudeadapter.Process(bootstrap.Registration.Authority.Process.PID)
@@ -440,6 +463,9 @@ func serveClaudeEndpoint(ctx context.Context, bootstrap claudeEndpointBootstrap,
 		authority, ok := route.Authority().(coremetadata.ClaudeAuthorityRef)
 		return reason == "" && ok && route.Same(expectedRoute) && route.PaneUID == bootstrap.PaneUID && route.Generation == bootstrap.Generation && authority == bootstrap.Registration.Authority
 	}
+	coordination := startClaudeCoordinationServer(coordinationListener, expectedRoute, current)
+	coordinationListenerOwned = false
+	defer coordination.Close()
 	if !current() {
 		return errors.New("claude registration is stale")
 	}
@@ -499,5 +525,17 @@ func probeClaudeRegistrationLease(registryPath string, route coremetadata.AgentR
 	_ = connection.SetDeadline(time.Now().Add(200 * time.Millisecond))
 	var ready [1]byte
 	_, err = io.ReadFull(connection, ready[:])
-	return err == nil && ready[0] == 1
+	if err != nil || ready[0] != 1 {
+		return false
+	}
+	target, ok := claudeTargetForRoute(route)
+	if !ok {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	response, err := callClaudeCoordination(ctx, registryPath, route, claudeCoordinationRequest{
+		Version: claudeCoordinationVersion, Operation: "probe", Target: target,
+	})
+	return err == nil && response.Kind == "ready"
 }

--- a/internal/app/claude_endpoint_process_test.go
+++ b/internal/app/claude_endpoint_process_test.go
@@ -52,6 +52,12 @@ for line in sys.stdin:
         receipt.write(json.dumps({'wait_started': child.pid}) + '\n'); receipt.flush()
         out, err = child.communicate(input=json.dumps({'hook_event_name':'Stop','session_id':'synthetic-session-1'}).encode(), timeout=8)
         receipt.write(json.dumps({'wait_rc': child.returncode, 'stdout_len': len(out), 'stderr': err.decode()}) + '\n'); receipt.flush()
+    elif line.strip() == 'wake-file':
+        sink_path = os.path.join(os.environ['PMX_TEST_ROOT'], 'non-provider-pipe.stderr')
+        with open(sink_path, 'wb') as sink:
+            child = subprocess.Popen([os.environ['PMX_TEST_BIN'], 'internal', 'claude-message-wait'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=sink)
+            out, _ = child.communicate(input=json.dumps({'hook_event_name':'Stop','session_id':'synthetic-session-1'}).encode(), timeout=8)
+        receipt.write(json.dumps({'file_wait_rc': child.returncode, 'stdout_len': len(out), 'stderr_len': os.path.getsize(sink_path)}) + '\n'); receipt.flush()
     elif line.strip() == 'repeat':
         hook('synthetic-session-2')
         receipt.write('hook-returned\n'); receipt.flush()
@@ -188,6 +194,30 @@ func TestClaudeEndpointProcessIntegration(t *testing.T) {
 	}
 	first := getRoute()
 	assertNoClaudeSecretResidue(t, claudeActivationLeaseDir(registryPath, h.paneUID, h.envGeneration), []string{private.Token, private.Socket})
+	target, ok := claudeTargetForRoute(first)
+	if !ok {
+		t.Fatal("exact coordination target unavailable")
+	}
+	// A same-provider direct child with fd 2 redirected to a regular file must
+	// fail closed before it can arm a waiter or emit any provider-pipe bytes.
+	_, _ = io.WriteString(writeControl, "wake-file\n")
+	line, err = reader.ReadBytes('\n')
+	var fileWake struct {
+		RC        int `json:"file_wait_rc"`
+		StdoutLen int `json:"stdout_len"`
+		StderrLen int `json:"stderr_len"`
+	}
+	if err != nil || json.Unmarshal(line, &fileWake) != nil || fileWake.RC != 0 || fileWake.StdoutLen != 0 || fileWake.StderrLen != 0 {
+		t.Fatalf("non-pipe hook result = %+v err=%v", fileWake, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	fileWaiter, callErr := callClaudeCoordination(ctx, registryPath, first, claudeCoordinationRequest{
+		Version: claudeCoordinationVersion, Operation: "waiter-ready", Target: target,
+	})
+	cancel()
+	if callErr != nil || fileWaiter.Kind != "no-waiter" {
+		t.Fatalf("non-pipe hook armed a waiter: %+v err=%v", fileWaiter, callErr)
+	}
 	// The disposable provider starts its direct Stop hook child, reports a
 	// barrier without sleeping, and then blocks on the provider stderr pipe.
 	// The test submits only a Projmux-owned coordination frame and waits for the
@@ -199,10 +229,6 @@ func TestClaudeEndpointProcessIntegration(t *testing.T) {
 	}
 	if err != nil || json.Unmarshal(line, &waitStarted) != nil || waitStarted.PID <= 0 {
 		t.Fatal("coordination waiter start barrier failed")
-	}
-	target, ok := claudeTargetForRoute(first)
-	if !ok {
-		t.Fatal("exact coordination target unavailable")
 	}
 	waiterDeadline := time.Now().Add(3 * time.Second)
 	for {
@@ -220,12 +246,12 @@ func TestClaudeEndpointProcessIntegration(t *testing.T) {
 	}
 	envelope := coordinationEnvelope("process-message-1", time.Now().Add(time.Minute))
 	envelope.Target = target
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
 	response, callErr := callClaudeCoordination(ctx, registryPath, first, claudeCoordinationRequest{
 		Version: claudeCoordinationVersion, Operation: "submit", Target: target, Envelope: &envelope,
 	})
 	cancel()
-	if callErr != nil || response.Delivery.State != agentdelivery.StateHandoff {
+	if callErr != nil || response.Delivery.State != agentdelivery.StateQueued {
 		t.Fatalf("coordination submit = %+v err=%v", response, callErr)
 	}
 	line, err = reader.ReadBytes('\n')

--- a/internal/app/claude_endpoint_process_test.go
+++ b/internal/app/claude_endpoint_process_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net"
@@ -14,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/crevissepartners/projmux/internal/core/agentdelivery"
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
 	claudeadapter "github.com/crevissepartners/projmux/internal/integrations/agents/claude"
 	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
@@ -45,7 +47,12 @@ def hook(session):
 hook('synthetic-session-1')
 receipt.write('hook-returned\n'); receipt.flush()
 for line in sys.stdin:
-    if line.strip() == 'repeat':
+    if line.strip() == 'wake':
+        child = subprocess.Popen([os.environ['PMX_TEST_BIN'], 'internal', 'claude-message-wait'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        receipt.write(json.dumps({'wait_started': child.pid}) + '\n'); receipt.flush()
+        out, err = child.communicate(input=json.dumps({'hook_event_name':'Stop','session_id':'synthetic-session-1'}).encode(), timeout=8)
+        receipt.write(json.dumps({'wait_rc': child.returncode, 'stdout_len': len(out), 'stderr': err.decode()}) + '\n'); receipt.flush()
+    elif line.strip() == 'repeat':
         hook('synthetic-session-2')
         receipt.write('hook-returned\n'); receipt.flush()
     elif line.strip() == 'nested':
@@ -181,6 +188,82 @@ func TestClaudeEndpointProcessIntegration(t *testing.T) {
 	}
 	first := getRoute()
 	assertNoClaudeSecretResidue(t, claudeActivationLeaseDir(registryPath, h.paneUID, h.envGeneration), []string{private.Token, private.Socket})
+	// The disposable provider starts its direct Stop hook child, reports a
+	// barrier without sleeping, and then blocks on the provider stderr pipe.
+	// The test submits only a Projmux-owned coordination frame and waits for the
+	// child's exact helper receipt; no provider/model/vendor transport is used.
+	_, _ = io.WriteString(writeControl, "wake\n")
+	line, err = reader.ReadBytes('\n')
+	var waitStarted struct {
+		PID int `json:"wait_started"`
+	}
+	if err != nil || json.Unmarshal(line, &waitStarted) != nil || waitStarted.PID <= 0 {
+		t.Fatal("coordination waiter start barrier failed")
+	}
+	target, ok := claudeTargetForRoute(first)
+	if !ok {
+		t.Fatal("exact coordination target unavailable")
+	}
+	waiterDeadline := time.Now().Add(3 * time.Second)
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		barrier, barrierErr := callClaudeCoordination(ctx, registryPath, first, claudeCoordinationRequest{
+			Version: claudeCoordinationVersion, Operation: "waiter-ready", Target: target,
+		})
+		cancel()
+		if barrierErr == nil && barrier.Kind == "waiter-ready" {
+			break
+		}
+		if time.Now().After(waiterDeadline) {
+			t.Fatalf("coordination waiter-ready barrier = %+v err=%v", barrier, barrierErr)
+		}
+	}
+	envelope := coordinationEnvelope("process-message-1", time.Now().Add(time.Minute))
+	envelope.Target = target
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	response, callErr := callClaudeCoordination(ctx, registryPath, first, claudeCoordinationRequest{
+		Version: claudeCoordinationVersion, Operation: "submit", Target: target, Envelope: &envelope,
+	})
+	cancel()
+	if callErr != nil || response.Delivery.State != agentdelivery.StateHandoff {
+		t.Fatalf("coordination submit = %+v err=%v", response, callErr)
+	}
+	line, err = reader.ReadBytes('\n')
+	var wake struct {
+		RC        int    `json:"wait_rc"`
+		StdoutLen int    `json:"stdout_len"`
+		Stderr    string `json:"stderr"`
+	}
+	if err != nil || json.Unmarshal(line, &wake) != nil || wake.RC != 2 || wake.StdoutLen != 0 {
+		t.Fatalf("coordination hook result rc=%d stdout=%d err=%v", wake.RC, wake.StdoutLen, err)
+	}
+	var providerFrame claudeCoordinationEnvelope
+	if json.Unmarshal([]byte(wake.Stderr), &providerFrame) != nil || providerFrame.MessageRef != envelope.MessageRef || providerFrame.Payload != envelope.Payload {
+		t.Fatal("provider stderr did not receive the exact bounded coordination frame")
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+	status, callErr := callClaudeCoordination(ctx, registryPath, first, claudeCoordinationRequest{
+		Version: claudeCoordinationVersion, Operation: "status", Target: target, MessageRef: envelope.MessageRef,
+	})
+	cancel()
+	if callErr != nil || status.Delivery.State != agentdelivery.StateDelivered || status.Delivery.WaiterRef == "" {
+		t.Fatalf("coordination delivery receipt = %+v err=%v", status.Delivery, callErr)
+	}
+	foreignHook := exec.Command(binary, "internal", "claude-message-wait")
+	foreignHook.Stdin = strings.NewReader(`{"hook_event_name":"Stop","session_id":"synthetic-session-1"}`)
+	foreignHook.Env = append(claudeEndpointProcessEnv(root, binary), internalClaudeRegistryPathEnv+"="+registryPath,
+		internalActivationPaneUIDEnv+"="+h.paneUID, internalActivationGenerationEnv+"="+h.envGeneration)
+	if output, runErr := foreignHook.CombinedOutput(); runErr != nil || len(output) != 0 {
+		t.Fatalf("foreign hook process was not quietly refused: err=%v output=%q", runErr, output)
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+	waiterStatus, callErr := callClaudeCoordination(ctx, registryPath, first, claudeCoordinationRequest{
+		Version: claudeCoordinationVersion, Operation: "waiter-ready", Target: target,
+	})
+	cancel()
+	if callErr != nil || waiterStatus.Kind != "no-waiter" {
+		t.Fatalf("foreign hook armed a waiter: %+v err=%v", waiterStatus, callErr)
+	}
 	// Exercise actual entrypoints with malformed, oversized, and foreign
 	// bootstrap input. The output/diagnostic scanner must never echo stdin.
 	beforeNegative, _ := os.ReadFile(registryPath)

--- a/internal/app/claude_endpoint_process_test.go
+++ b/internal/app/claude_endpoint_process_test.go
@@ -388,6 +388,10 @@ func TestClaudeEndpointProcessIntegration(t *testing.T) {
 	case <-time.After(8 * time.Second):
 		t.Fatal("provider exit deadline")
 	}
+	helpers := make([]coremetadata.ProcessIdentity, 0, 3)
+	for _, route := range []coremetadata.AgentRouteRef{first, second, third} {
+		helpers = append(helpers, route.Authority().(coremetadata.ClaudeAuthorityRef).LeaseProcess)
+	}
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		reg, err := store.LoadDegradedReadOnly()
@@ -396,19 +400,23 @@ func TestClaudeEndpointProcessIntegration(t *testing.T) {
 		}
 		_, reason := coremetadata.ResolveAgentRoute(reg, h.agentUID)
 		_, statErr := os.Lstat(claudeActivationLeaseDir(registryPath, h.paneUID, h.envGeneration))
-		if reason != "" && os.IsNotExist(statErr) {
+		helperCurrent := false
+		for _, helper := range helpers {
+			if observed, _, err := claudeadapter.Process(helper.PID); err == nil && observed == helper {
+				helperCurrent = true
+				break
+			}
+		}
+		if reason != "" && os.IsNotExist(statErr) && !helperCurrent {
 			break
 		}
 		if time.Now().After(deadline) {
+			if helperCurrent {
+				t.Fatal("helper process survived activation")
+			}
 			t.Fatal("registration or helper files survived provider exit")
 		}
 		time.Sleep(20 * time.Millisecond)
-	}
-	for _, route := range []coremetadata.AgentRouteRef{first, second, third} {
-		helper := route.Authority().(coremetadata.ClaudeAuthorityRef).LeaseProcess
-		if observed, _, err := claudeadapter.Process(helper.PID); err == nil && observed == helper {
-			t.Fatal("helper process survived activation")
-		}
 	}
 	if stdout.Len() != 0 || stderr.Len() != 0 {
 		t.Fatal("registration process wrote stdout or stderr")

--- a/internal/app/claude_endpoint_test.go
+++ b/internal/app/claude_endpoint_test.go
@@ -19,6 +19,7 @@ import (
 
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
 	claudeadapter "github.com/crevissepartners/projmux/internal/integrations/agents/claude"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
 	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
 )
 
@@ -55,7 +56,7 @@ func TestClaudeEndpointHookMigrationPreservesStatusAndUserHooks(t *testing.T) {
 	}
 	installed := readClaudeSettingsTestFile(t, path)
 	hooks := installed["hooks"].(map[string]any)["SessionStart"].([]any)
-	status, registration, user := 0, 0, 0
+	status, registration, coordination, user := 0, 0, 0, 0
 	for _, entry := range hooks {
 		for _, raw := range entry.(map[string]any)["hooks"].([]any) {
 			hook := raw.(map[string]any)
@@ -67,12 +68,14 @@ func TestClaudeEndpointHookMigrationPreservesStatusAndUserHooks(t *testing.T) {
 				if hook["timeout"] != float64(5) {
 					t.Fatal("registration bootstrap timeout is not bounded")
 				}
+			case claudeCoordinationHookCommand:
+				coordination++
 			case "echo user-session-start":
 				user++
 			}
 		}
 	}
-	if status != 1 || registration != 1 || user != 1 {
+	if status != 1 || registration != 1 || coordination != 1 || user != 1 {
 		t.Fatal("migration changed status/user hooks or duplicated registration")
 	}
 	first, _ := os.ReadFile(path)
@@ -86,7 +89,7 @@ func TestClaudeEndpointHookMigrationPreservesStatusAndUserHooks(t *testing.T) {
 		t.Fatal(err)
 	}
 	removed, _ := os.ReadFile(path)
-	if bytes.Contains(removed, []byte(claudeHookManagedMarker)) || !bytes.Contains(removed, []byte("echo user-session-start")) {
+	if bytes.Contains(removed, []byte(claudeHookManagedMarker)) || bytes.Contains(removed, []byte(claudeCoordinationManagedMarker)) || !bytes.Contains(removed, []byte("echo user-session-start")) {
 		t.Fatal("removal retained managed hook or removed user hook")
 	}
 }
@@ -308,12 +311,56 @@ func TestClaudeEndpointRenamePreservesAndSocketReplacementInvalidates(t *testing
 		t.Fatal("provider socket replacement remained eligible")
 	}
 	select {
-	case <-done:
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
 	case <-time.After(4 * time.Second):
 		t.Fatal("socket replacement did not stop helper")
 	}
 	if _, err := os.Lstat(f.bootstrap.Socket); err != nil {
 		t.Fatal("helper removed replacement provider socket")
+	}
+}
+
+func TestClaudeCoordinationSocketReplacementInvalidatesWithoutRemovingReplacement(t *testing.T) {
+	t.Parallel()
+	f := newClaudeEndpointTestFixture(t)
+	_, done := f.start(t)
+	route, reason := f.route(t)
+	if reason != "" || !probeClaudeRegistrationLease(f.bootstrap.RegistryPath, route) {
+		t.Fatal("exact registration not ready")
+	}
+	target, ok := claudeTargetForRoute(route)
+	if !ok {
+		t.Fatal("exact coordination target unavailable")
+	}
+	path := claudeCoordinationSocket(f.bootstrap.RegistryPath, target)
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement.SetUnlinkOnClose(false)
+	defer replacement.Close()
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if probeClaudeRegistrationLease(f.bootstrap.RegistryPath, route) {
+		t.Fatal("replacement coordination socket remained eligible")
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("coordination socket replacement did not stop helper")
+	}
+	if _, err := os.Lstat(path); err != nil {
+		t.Fatal("helper removed replacement coordination socket")
 	}
 }
 
@@ -455,7 +502,33 @@ func TestClaudeEndpointDeadLeaseWatcherInvalidatesWhileProviderLives(t *testing.
 	if err := os.Chmod(lease, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeClaudeLeaseOwner(lease+".json", f.bootstrap); err != nil {
+	target := claudeCoordinationTarget{AgentUID: f.bootstrap.AgentUID, PaneUID: f.bootstrap.PaneUID,
+		Generation: f.bootstrap.Generation, Provider: aiModeClaude, Authority: f.bootstrap.Registration.Authority}
+	coordinationPath := claudeCoordinationSocket(f.bootstrap.RegistryPath, target)
+	coordination, err := localipc.Listen(coordinationPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coordinationIdentity := coordination.Identity()
+	if err := coordination.Unix.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(coordinationPath); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := net.ListenUnix("unix", &net.UnixAddr{Name: coordinationPath, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement.SetUnlinkOnClose(false)
+	t.Cleanup(func() {
+		_ = replacement.Close()
+		_ = os.Remove(coordinationPath)
+	})
+	if err := os.Chmod(coordinationPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeClaudeLeaseOwner(lease+".json", f.bootstrap, coordinationIdentity); err != nil {
 		t.Fatal(err)
 	}
 	if err := helper.Process.Kill(); err != nil {
@@ -479,7 +552,9 @@ func TestClaudeEndpointDeadLeaseWatcherInvalidatesWhileProviderLives(t *testing.
 		t.Fatal("provider did not remain alive")
 	}
 	for {
-		if _, err := os.Lstat(filepath.Dir(lease)); os.IsNotExist(err) {
+		_, leaseErr := os.Lstat(lease)
+		_, receiptErr := os.Lstat(lease + ".json")
+		if os.IsNotExist(leaseErr) && os.IsNotExist(receiptErr) {
 			break
 		}
 		if time.Now().After(deadline) {
@@ -487,7 +562,63 @@ func TestClaudeEndpointDeadLeaseWatcherInvalidatesWhileProviderLives(t *testing.
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	if _, err := localipc.InspectOwnedSocket(coordinationPath); err != nil {
+		t.Fatalf("dead-lease reaper removed replacement coordination socket: %v", err)
+	}
 	assertNoClaudeSecretResidue(t, f.root, []string{f.bootstrap.Token, f.bootstrap.Socket})
+}
+
+func TestCleanupClaudeActivationLeasesPreservesCoordinationReplacement(t *testing.T) {
+	t.Parallel()
+	f := newClaudeEndpointTestFixture(t)
+	dir := claudeActivationLeaseDir(f.bootstrap.RegistryPath, f.bootstrap.PaneUID, f.bootstrap.Generation)
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	lease := claudeLeaseSocket(f.bootstrap.RegistryPath, f.bootstrap.PaneUID, f.bootstrap.Generation,
+		f.bootstrap.Registration.Authority.RegistrationGeneration)
+	readiness, err := net.ListenUnix("unix", &net.UnixAddr{Name: lease, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	readiness.SetUnlinkOnClose(false)
+	defer readiness.Close()
+	if err := os.Chmod(lease, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := claudeCoordinationTarget{AgentUID: f.bootstrap.AgentUID, PaneUID: f.bootstrap.PaneUID,
+		Generation: f.bootstrap.Generation, Provider: aiModeClaude, Authority: f.bootstrap.Registration.Authority}
+	coordinationPath := claudeCoordinationSocket(f.bootstrap.RegistryPath, target)
+	coordination, err := localipc.Listen(coordinationPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalIdentity := coordination.Identity()
+	if err := coordination.Unix.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(coordinationPath); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := net.ListenUnix("unix", &net.UnixAddr{Name: coordinationPath, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement.SetUnlinkOnClose(false)
+	defer replacement.Close()
+	if err := os.Chmod(coordinationPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeClaudeLeaseOwner(lease+".json", f.bootstrap, originalIdentity); err != nil {
+		t.Fatal(err)
+	}
+	spec := superviseSpec{RegistryPath: f.bootstrap.RegistryPath, PaneUID: f.bootstrap.PaneUID,
+		AgentUID: f.bootstrap.AgentUID, Generation: f.bootstrap.Generation}
+	cleanupClaudeActivationLeases(spec)
+	if _, err := localipc.InspectOwnedSocket(coordinationPath); err != nil {
+		t.Fatalf("supervisor cleanup removed replacement coordination socket: %v", err)
+	}
 }
 
 func TestClaudeEndpointCreatorRegistryContextIsPrivateAndExact(t *testing.T) {

--- a/internal/app/claude_endpoint_watch.go
+++ b/internal/app/claude_endpoint_watch.go
@@ -12,19 +12,21 @@ import (
 
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
 	claudeadapter "github.com/crevissepartners/projmux/internal/integrations/agents/claude"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
 	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
 )
 
 // claudeLeaseOwnerReceipt is crash-cleanup evidence, not a provider locator.
 // Its file contains only identities already safe for Registry persistence.
 type claudeLeaseOwnerReceipt struct {
-	AgentUID   string                          `json:"agentUID"`
-	PaneUID    string                          `json:"paneUID"`
-	Generation string                          `json:"generation"`
-	Authority  coremetadata.ClaudeAuthorityRef `json:"authority"`
+	AgentUID           string                          `json:"agentUID"`
+	PaneUID            string                          `json:"paneUID"`
+	Generation         string                          `json:"generation"`
+	Authority          coremetadata.ClaudeAuthorityRef `json:"authority"`
+	CoordinationSocket localipc.SocketIdentity         `json:"coordinationSocket,omitzero"`
 }
 
-func writeClaudeLeaseOwner(path string, bootstrap claudeEndpointBootstrap) error {
+func writeClaudeLeaseOwner(path string, bootstrap claudeEndpointBootstrap, coordination localipc.SocketIdentity) error {
 	// #nosec G304 -- the caller derives this receipt from hashed exact activation
 	// and registration identities under an owned 0700 lease directory. Exclusive
 	// creation refuses an existing path or symlink; no provider locator is used.
@@ -34,7 +36,7 @@ func writeClaudeLeaseOwner(path string, bootstrap claudeEndpointBootstrap) error
 	}
 	defer file.Close()
 	return json.NewEncoder(file).Encode(claudeLeaseOwnerReceipt{AgentUID: bootstrap.AgentUID, PaneUID: bootstrap.PaneUID,
-		Generation: bootstrap.Generation, Authority: bootstrap.Registration.Authority})
+		Generation: bootstrap.Generation, Authority: bootstrap.Registration.Authority, CoordinationSocket: coordination})
 }
 
 func readClaudeLeaseOwner(path string, spec superviseSpec) (claudeLeaseOwnerReceipt, bool) {
@@ -116,6 +118,11 @@ func reapDeadClaudeLeases(spec superviseSpec) {
 		}
 		if _, err := inspectClaudeSocket(socket); err == nil {
 			_ = os.Remove(socket)
+		}
+		target := claudeCoordinationTarget{AgentUID: receipt.AgentUID, PaneUID: receipt.PaneUID, Generation: receipt.Generation,
+			Provider: aiModeClaude, Authority: receipt.Authority}
+		if coordination := claudeCoordinationSocket(spec.RegistryPath, target); filepath.Dir(coordination) == dir {
+			_ = localipc.RemoveOwnedSocket(coordination, receipt.CoordinationSocket)
 		}
 		_ = os.Remove(path)
 	}

--- a/internal/app/internal_routes.go
+++ b/internal/app/internal_routes.go
@@ -112,6 +112,8 @@ func (c *internalCommand) Run(args []string, stdout, stderr io.Writer) error {
 		return runClaudeEndpointRegistration(rest)
 	case "claude-endpoint-helper":
 		return runClaudeEndpointHelper(rest)
+	case "claude-message-wait":
+		return runClaudeMessageWait(rest, stderr)
 	case "codex-broker":
 		return forwardRawArgv(c.codexBroker, "internal codex-broker", "codex-broker", nil, rest, stdout, stderr)
 	case "codex-generation-launch":

--- a/internal/core/agentdelivery/reducer.go
+++ b/internal/core/agentdelivery/reducer.go
@@ -1,0 +1,153 @@
+// Package agentdelivery owns the private provider-final-hop lifecycle used by
+// Phase 2. Its queued state is deliberately below the future public broker's
+// accepted state: Phase 3 may project broker acceptance into this adapter, but
+// this package neither defines nor exposes that public broker contract.
+package agentdelivery
+
+import "strings"
+
+type State string
+
+const (
+	StateQueued    State = "queued"
+	StateHeld      State = "held"
+	StateHandoff   State = "handoff"
+	StateDelivered State = "delivered"
+	StateRefused   State = "refused"
+	StateExpired   State = "expired"
+	StateStale     State = "stale"
+	StateFailed    State = "failed"
+)
+
+func (s State) Terminal() bool {
+	switch s {
+	case StateDelivered, StateRefused, StateExpired, StateStale, StateFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+type EventKind string
+
+const (
+	EventQueue        EventKind = "queue"
+	EventHold         EventKind = "hold"
+	EventBeginHandoff EventKind = "begin-handoff"
+	EventDeliver      EventKind = "deliver"
+	EventRefuse       EventKind = "refuse"
+	EventExpire       EventKind = "expire"
+	EventStale        EventKind = "stale"
+	EventFail         EventKind = "fail"
+)
+
+// Delivery contains no message payload or provider locator. Ambiguous is set
+// whenever bytes may have crossed the provider pipe but no exact full-write
+// receipt committed; callers must never automatically resend that outcome.
+type Delivery struct {
+	MessageRef string `json:"messageRef"`
+	State      State  `json:"state"`
+	WaiterRef  string `json:"waiterRef,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+	Ambiguous  bool   `json:"ambiguous,omitempty"`
+}
+
+type Event struct {
+	Kind             EventKind
+	MessageRef       string
+	WaiterRef        string
+	Reason           string
+	FullFrameWritten bool
+	HelperReceipt    bool
+}
+
+// Reduce is terminal-once and fail-closed. Duplicate, foreign, stale, and
+// out-of-order events are no-ops. The bool reports whether state changed.
+func Reduce(current Delivery, event Event) (Delivery, bool) {
+	if !validRef(event.MessageRef) || (current.MessageRef != "" && event.MessageRef != current.MessageRef) || current.State.Terminal() {
+		return current, false
+	}
+	if current.MessageRef == "" {
+		if event.Kind != EventQueue {
+			return current, false
+		}
+		return Delivery{MessageRef: event.MessageRef, State: StateQueued}, true
+	}
+
+	next := current
+	switch event.Kind {
+	case EventHold:
+		if current.State != StateQueued {
+			return current, false
+		}
+		next.State = StateHeld
+		next.Reason = boundedReason(event.Reason)
+	case EventBeginHandoff:
+		if (current.State != StateQueued && current.State != StateHeld) || !validRef(event.WaiterRef) {
+			return current, false
+		}
+		next.State = StateHandoff
+		next.WaiterRef = event.WaiterRef
+		next.Reason = ""
+	case EventDeliver:
+		if current.State != StateHandoff || event.WaiterRef != current.WaiterRef || !event.FullFrameWritten || !event.HelperReceipt {
+			return current, false
+		}
+		next.State = StateDelivered
+		next.Reason = "provider-pipe-full-frame"
+	case EventRefuse:
+		if current.State != StateQueued && current.State != StateHeld {
+			return current, false
+		}
+		next.State = StateRefused
+		next.Reason = boundedReason(event.Reason)
+	case EventExpire:
+		if current.State == StateHandoff {
+			next.State = StateFailed
+			next.Reason = "observation-timeout"
+			next.Ambiguous = true
+		} else if current.State == StateQueued || current.State == StateHeld {
+			next.State = StateExpired
+			next.Reason = boundedReason(event.Reason)
+		} else {
+			return current, false
+		}
+	case EventStale:
+		if current.State == StateHandoff {
+			next.State = StateFailed
+			next.Reason = "delivery-outcome-unknown"
+			next.Ambiguous = true
+		} else if current.State == StateQueued || current.State == StateHeld {
+			next.State = StateStale
+			next.Reason = boundedReason(event.Reason)
+		} else {
+			return current, false
+		}
+	case EventFail:
+		if current.State != StateQueued && current.State != StateHeld && current.State != StateHandoff {
+			return current, false
+		}
+		next.State = StateFailed
+		next.Reason = boundedReason(event.Reason)
+		next.Ambiguous = current.State == StateHandoff
+	default:
+		return current, false
+	}
+	return next, true
+}
+
+func validRef(value string) bool {
+	value = strings.TrimSpace(value)
+	return value != "" && len(value) <= 160 && !strings.ContainsAny(value, "\r\n\x00")
+}
+
+func boundedReason(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unspecified"
+	}
+	if len(value) > 160 {
+		return value[:160]
+	}
+	return value
+}

--- a/internal/core/agentdelivery/reducer_test.go
+++ b/internal/core/agentdelivery/reducer_test.go
@@ -1,0 +1,69 @@
+package agentdelivery
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestDeliveryTransitionTable(t *testing.T) {
+	queue := Delivery{MessageRef: "message-1", State: StateQueued}
+	held := Delivery{MessageRef: "message-1", State: StateHeld}
+	handoff := Delivery{MessageRef: "message-1", State: StateHandoff, WaiterRef: "waiter-1"}
+	for _, test := range []struct {
+		name       string
+		current    Delivery
+		event      Event
+		want       State
+		changed    bool
+		ambiguous  bool
+		wantReason string
+	}{
+		{name: "empty queues", event: Event{Kind: EventQueue, MessageRef: "message-1"}, want: StateQueued, changed: true},
+		{name: "queued holds without waiter", current: queue, event: Event{Kind: EventHold, MessageRef: "message-1", Reason: "no-waiter"}, want: StateHeld, changed: true, wantReason: "no-waiter"},
+		{name: "queued begins handoff", current: queue, event: Event{Kind: EventBeginHandoff, MessageRef: "message-1", WaiterRef: "waiter-1"}, want: StateHandoff, changed: true},
+		{name: "held begins handoff", current: held, event: Event{Kind: EventBeginHandoff, MessageRef: "message-1", WaiterRef: "waiter-1"}, want: StateHandoff, changed: true},
+		{name: "full write and exact helper receipt delivers", current: handoff, event: Event{Kind: EventDeliver, MessageRef: "message-1", WaiterRef: "waiter-1", FullFrameWritten: true, HelperReceipt: true}, want: StateDelivered, changed: true, wantReason: "provider-pipe-full-frame"},
+		{name: "partial write cannot deliver", current: handoff, event: Event{Kind: EventDeliver, MessageRef: "message-1", WaiterRef: "waiter-1", FullFrameWritten: false, HelperReceipt: true}, want: StateHandoff},
+		{name: "missing helper receipt cannot deliver", current: handoff, event: Event{Kind: EventDeliver, MessageRef: "message-1", WaiterRef: "waiter-1", FullFrameWritten: true, HelperReceipt: false}, want: StateHandoff},
+		{name: "foreign waiter cannot deliver", current: handoff, event: Event{Kind: EventDeliver, MessageRef: "message-1", WaiterRef: "waiter-2", FullFrameWritten: true, HelperReceipt: true}, want: StateHandoff},
+		{name: "provider refusal is terminal", current: held, event: Event{Kind: EventRefuse, MessageRef: "message-1", Reason: "provider-refused"}, want: StateRefused, changed: true, wantReason: "provider-refused"},
+		{name: "pre-handoff ttl expires", current: held, event: Event{Kind: EventExpire, MessageRef: "message-1", Reason: "ttl"}, want: StateExpired, changed: true, wantReason: "ttl"},
+		{name: "handoff timeout is ambiguous failure", current: handoff, event: Event{Kind: EventExpire, MessageRef: "message-1"}, want: StateFailed, changed: true, ambiguous: true, wantReason: "observation-timeout"},
+		{name: "pre-handoff replacement is stale", current: held, event: Event{Kind: EventStale, MessageRef: "message-1", Reason: "helper-restart"}, want: StateStale, changed: true, wantReason: "helper-restart"},
+		{name: "post-handoff replacement is ambiguous failure", current: handoff, event: Event{Kind: EventStale, MessageRef: "message-1"}, want: StateFailed, changed: true, ambiguous: true, wantReason: "delivery-outcome-unknown"},
+		{name: "pre-handoff failure is terminal", current: queue, event: Event{Kind: EventFail, MessageRef: "message-1", Reason: "transport-failed"}, want: StateFailed, changed: true, wantReason: "transport-failed"},
+		{name: "out of order delivery is ignored", current: queue, event: Event{Kind: EventDeliver, MessageRef: "message-1", WaiterRef: "waiter-1", FullFrameWritten: true, HelperReceipt: true}, want: StateQueued},
+		{name: "foreign message is ignored", current: held, event: Event{Kind: EventExpire, MessageRef: "message-2"}, want: StateHeld},
+		{name: "duplicate queue is ignored", current: queue, event: Event{Kind: EventQueue, MessageRef: "message-1"}, want: StateQueued},
+		{name: "terminal is once", current: Delivery{MessageRef: "message-1", State: StateDelivered}, event: Event{Kind: EventFail, MessageRef: "message-1"}, want: StateDelivered},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, changed := Reduce(test.current, test.event)
+			if got.State != test.want || changed != test.changed || got.Ambiguous != test.ambiguous || (test.wantReason != "" && got.Reason != test.wantReason) {
+				t.Fatalf("Reduce(%+v, %+v) = (%+v, %v)", test.current, test.event, got, changed)
+			}
+		})
+	}
+}
+
+func TestDeliveryReducerRandomSequencesAreTerminalOnceAndNeverAutoResend(t *testing.T) {
+	for seed := range int64(256) {
+		random := rand.New(rand.NewSource(seed)) // #nosec G404 -- deterministic state-machine exploration.
+		state := Delivery{}
+		terminal := Delivery{}
+		for step := range 256 {
+			event := Event{Kind: []EventKind{EventQueue, EventHold, EventBeginHandoff, EventDeliver, EventRefuse, EventExpire, EventStale, EventFail}[random.Intn(8)], MessageRef: "message-1", WaiterRef: "waiter-1", FullFrameWritten: random.Intn(2) == 1, HelperReceipt: random.Intn(2) == 1}
+			next, _ := Reduce(state, event)
+			if terminal.State != "" && next != terminal {
+				t.Fatalf("seed %d step %d changed terminal %+v to %+v", seed, step, terminal, next)
+			}
+			if state.State == StateHandoff && next.State == StateQueued {
+				t.Fatalf("seed %d step %d automatically resent handoff", seed, step)
+			}
+			state = next
+			if state.State.Terminal() {
+				terminal = state
+			}
+		}
+	}
+}

--- a/internal/integrations/agents/claude/peer_darwin.go
+++ b/internal/integrations/agents/claude/peer_darwin.go
@@ -5,21 +5,11 @@ import (
 	"net"
 
 	"github.com/crevissepartners/projmux/internal/core/metadata"
-	"golang.org/x/sys/unix"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
 )
 
 func PeerProcess(conn *net.UnixConn) (metadata.ProcessIdentity, error) {
-	raw, err := conn.SyscallConn()
-	if err != nil {
-		return metadata.ProcessIdentity{}, errors.New("helper peer unavailable")
-	}
-	var pid int
-	var peerErr error
-	err = raw.Control(func(fd uintptr) { pid, peerErr = unix.GetsockoptInt(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERPID) })
-	if err != nil || peerErr != nil {
-		return metadata.ProcessIdentity{}, errors.New("helper peer unavailable")
-	}
-	identity, _, err := Process(pid)
+	identity, _, err := localipc.PeerProcess(conn)
 	if err != nil {
 		return metadata.ProcessIdentity{}, errors.New("helper peer unavailable")
 	}

--- a/internal/integrations/agents/claude/peer_linux.go
+++ b/internal/integrations/agents/claude/peer_linux.go
@@ -5,24 +5,14 @@ import (
 	"net"
 
 	"github.com/crevissepartners/projmux/internal/core/metadata"
-	"golang.org/x/sys/unix"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
 )
 
 // PeerProcess authenticates Projmux's private readiness helper, not a Claude
 // transport peer. No provider socket is opened by this adapter.
 func PeerProcess(conn *net.UnixConn) (metadata.ProcessIdentity, error) {
-	raw, err := conn.SyscallConn()
+	identity, _, err := localipc.PeerProcess(conn)
 	if err != nil {
-		return metadata.ProcessIdentity{}, errors.New("helper peer unavailable")
-	}
-	var peer *unix.Ucred
-	var peerErr error
-	err = raw.Control(func(fd uintptr) { peer, peerErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED) })
-	if err != nil || peerErr != nil || peer == nil {
-		return metadata.ProcessIdentity{}, errors.New("helper peer unavailable")
-	}
-	identity, _, err := Process(int(peer.Pid))
-	if err != nil || identity.OwnerUID != peer.Uid {
 		return metadata.ProcessIdentity{}, errors.New("helper peer unavailable")
 	}
 	return identity, nil

--- a/internal/integrations/agents/claude/process_darwin.go
+++ b/internal/integrations/agents/claude/process_darwin.go
@@ -1,23 +1,11 @@
 package claude
 
 import (
-	"errors"
-	"strconv"
-
 	"github.com/crevissepartners/projmux/internal/core/metadata"
-	"golang.org/x/sys/unix"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
 )
 
 // Process uses the kernel's absolute process birth time on both Darwin targets.
 func Process(pid int) (metadata.ProcessIdentity, int, error) {
-	if pid <= 0 {
-		return metadata.ProcessIdentity{}, 0, errors.New("process unavailable")
-	}
-	info, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
-	if err != nil || info == nil || int(info.Proc.P_pid) != pid || info.Proc.P_stat == 5 {
-		return metadata.ProcessIdentity{}, 0, errors.New("process unavailable")
-	}
-	start := info.Proc.P_starttime
-	return metadata.ProcessIdentity{PID: pid, OwnerUID: info.Eproc.Ucred.Uid,
-		Start: "darwin:" + strconv.FormatInt(start.Sec, 10) + ":" + strconv.FormatInt(int64(start.Usec), 10)}, int(info.Eproc.Ppid), nil
+	return localipc.Process(pid)
 }

--- a/internal/integrations/agents/claude/process_linux.go
+++ b/internal/integrations/agents/claude/process_linux.go
@@ -1,54 +1,12 @@
 package claude
 
 import (
-	"errors"
-	"os"
-	"strconv"
-	"strings"
-	"syscall"
-
 	"github.com/crevissepartners/projmux/internal/core/metadata"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
 )
 
 // Process reads kernel birth identity. No command line, environment, transcript,
 // or provider registration store is inspected.
 func Process(pid int) (metadata.ProcessIdentity, int, error) {
-	if pid <= 0 {
-		return metadata.ProcessIdentity{}, 0, errors.New("process unavailable")
-	}
-	path := "/proc/" + strconv.Itoa(pid) + "/stat"
-	// #nosec G304 -- pid is a checked positive integer rendered in decimal;
-	// the fixed procfs stat path cannot contain caller-supplied traversal.
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return metadata.ProcessIdentity{}, 0, errors.New("process unavailable")
-	}
-	end := strings.LastIndexByte(string(data), ')')
-	if end < 0 {
-		return metadata.ProcessIdentity{}, 0, errors.New("process identity unavailable")
-	}
-	fields := strings.Fields(string(data[end+1:]))
-	if len(fields) < 20 || fields[0] == "Z" || fields[0] == "X" {
-		return metadata.ProcessIdentity{}, 0, errors.New("process unavailable")
-	}
-	parent, err := strconv.Atoi(fields[1])
-	if err != nil {
-		return metadata.ProcessIdentity{}, 0, errors.New("process identity unavailable")
-	}
-	if _, err = strconv.ParseUint(fields[19], 10, 64); err != nil {
-		return metadata.ProcessIdentity{}, 0, errors.New("process identity unavailable")
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return metadata.ProcessIdentity{}, 0, errors.New("process unavailable")
-	}
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return metadata.ProcessIdentity{}, 0, errors.New("process owner unavailable")
-	}
-	boot, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
-	if err != nil {
-		return metadata.ProcessIdentity{}, 0, errors.New("process boot identity unavailable")
-	}
-	return metadata.ProcessIdentity{PID: pid, OwnerUID: stat.Uid, Start: "linux:" + strings.TrimSpace(string(boot)) + ":" + fields[19]}, parent, nil
+	return localipc.Process(pid)
 }

--- a/internal/integrations/agents/localipc/peer_darwin.go
+++ b/internal/integrations/agents/localipc/peer_darwin.go
@@ -1,0 +1,27 @@
+package localipc
+
+import (
+	"errors"
+	"net"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	"golang.org/x/sys/unix"
+)
+
+func PeerProcess(conn *net.UnixConn) (coremetadata.ProcessIdentity, int, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("peer unavailable")
+	}
+	var pid int
+	var peerErr error
+	err = raw.Control(func(fd uintptr) { pid, peerErr = unix.GetsockoptInt(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERPID) })
+	if err != nil || peerErr != nil {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("peer unavailable")
+	}
+	identity, parent, err := Process(pid)
+	if err != nil {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("peer unavailable")
+	}
+	return identity, parent, nil
+}

--- a/internal/integrations/agents/localipc/peer_linux.go
+++ b/internal/integrations/agents/localipc/peer_linux.go
@@ -1,0 +1,27 @@
+package localipc
+
+import (
+	"errors"
+	"net"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	"golang.org/x/sys/unix"
+)
+
+func PeerProcess(conn *net.UnixConn) (coremetadata.ProcessIdentity, int, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("peer unavailable")
+	}
+	var peer *unix.Ucred
+	var peerErr error
+	err = raw.Control(func(fd uintptr) { peer, peerErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED) })
+	if err != nil || peerErr != nil || peer == nil {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("peer unavailable")
+	}
+	identity, parent, err := Process(int(peer.Pid))
+	if err != nil || identity.OwnerUID != peer.Uid {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("peer unavailable")
+	}
+	return identity, parent, nil
+}

--- a/internal/integrations/agents/localipc/process_darwin.go
+++ b/internal/integrations/agents/localipc/process_darwin.go
@@ -1,0 +1,22 @@
+package localipc
+
+import (
+	"errors"
+	"strconv"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	"golang.org/x/sys/unix"
+)
+
+func Process(pid int) (coremetadata.ProcessIdentity, int, error) {
+	if pid <= 0 {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("process unavailable")
+	}
+	info, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil || info == nil || int(info.Proc.P_pid) != pid || info.Proc.P_stat == 5 {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("process unavailable")
+	}
+	start := info.Proc.P_starttime
+	return coremetadata.ProcessIdentity{PID: pid, OwnerUID: info.Eproc.Ucred.Uid,
+		Start: "darwin:" + strconv.FormatInt(start.Sec, 10) + ":" + strconv.FormatInt(int64(start.Usec), 10)}, int(info.Eproc.Ppid), nil
+}

--- a/internal/integrations/agents/localipc/process_linux.go
+++ b/internal/integrations/agents/localipc/process_linux.go
@@ -1,0 +1,53 @@
+package localipc
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+)
+
+// Process reads kernel birth identity without inspecting argv, environment, or
+// provider state.
+func Process(pid int) (coremetadata.ProcessIdentity, int, error) {
+	if pid <= 0 {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("process unavailable")
+	}
+	path := "/proc/" + strconv.Itoa(pid) + "/stat"
+	// #nosec G304 -- pid is a checked decimal integer in a fixed procfs path.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("process unavailable")
+	}
+	end := strings.LastIndexByte(string(data), ')')
+	if end < 0 {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("process identity unavailable")
+	}
+	fields := strings.Fields(string(data[end+1:]))
+	if len(fields) < 20 || fields[0] == "Z" || fields[0] == "X" {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("process unavailable")
+	}
+	parent, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("process identity unavailable")
+	}
+	if _, err = strconv.ParseUint(fields[19], 10, 64); err != nil {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("process identity unavailable")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("process unavailable")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("process owner unavailable")
+	}
+	boot, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return coremetadata.ProcessIdentity{}, 0, errors.New("process boot identity unavailable")
+	}
+	return coremetadata.ProcessIdentity{PID: pid, OwnerUID: stat.Uid, Start: "linux:" + strings.TrimSpace(string(boot)) + ":" + fields[19]}, parent, nil
+}

--- a/internal/integrations/agents/localipc/transport.go
+++ b/internal/integrations/agents/localipc/transport.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"syscall"
 	"time"
 )
@@ -33,10 +34,13 @@ var (
 // SocketIdentity is the stable kernel identity of one owned Unix socket.
 // Paths alone are never sufficient when deciding whether cleanup is safe.
 type SocketIdentity struct {
-	Device uint64
-	Inode  uint64
-	Owner  uint32
-	Mode   os.FileMode
+	Device                uint64      `json:"device"`
+	Inode                 uint64      `json:"inode"`
+	Owner                 uint32      `json:"owner"`
+	Mode                  os.FileMode `json:"mode"`
+	Size                  int64       `json:"size"`
+	ChangeTimeSeconds     int64       `json:"changeTimeSeconds"`
+	ChangeTimeNanoseconds int64       `json:"changeTimeNanoseconds"`
 }
 
 // InspectOwnedSocket rejects symlinks, non-sockets, foreign owners, and modes
@@ -50,11 +54,11 @@ func InspectOwnedSocket(path string) (SocketIdentity, error) {
 		info.Mode().Perm() != 0o600 || !OwnedByCurrentUser(info) {
 		return SocketIdentity{}, errors.New("private endpoint is unavailable")
 	}
-	stat, ok := info.Sys().(*syscall.Stat_t)
+	identity, ok := socketIdentity(info)
 	if !ok {
 		return SocketIdentity{}, errors.New("private endpoint is unavailable")
 	}
-	return SocketIdentity{Device: uint64(stat.Dev), Inode: stat.Ino, Owner: stat.Uid, Mode: info.Mode()}, nil
+	return identity, nil
 }
 
 // PrepareSocket creates and secures the parent directory, refuses live or
@@ -85,13 +89,18 @@ func PrepareSocket(path string) error {
 	if info.Mode()&os.ModeSymlink != 0 || info.Mode()&os.ModeSocket == 0 || !OwnedByCurrentUser(info) {
 		return errors.New("private endpoint collision is not an owned socket")
 	}
+	before, ok := socketIdentity(info)
+	if !ok {
+		return errors.New("private endpoint collision identity is unavailable")
+	}
 	conn, dialErr := net.DialTimeout("unix", path, DialTimeout)
 	if dialErr == nil {
 		_ = conn.Close()
 		return errors.New("private endpoint is already active")
 	}
 	latest, latestErr := os.Lstat(path)
-	if latestErr != nil || !os.SameFile(info, latest) || latest.Mode()&os.ModeSocket == 0 || !OwnedByCurrentUser(latest) {
+	after, identityOK := socketIdentity(latest)
+	if latestErr != nil || !identityOK || !sameSocketIdentity(before, after) || latest.Mode()&os.ModeSocket == 0 || !OwnedByCurrentUser(latest) {
 		return errors.New("private stale endpoint changed during ownership check")
 	}
 	if err := os.Remove(path); err != nil {
@@ -157,7 +166,7 @@ func RemoveOwnedSocket(path string, expected SocketIdentity) error {
 	if err != nil {
 		return err
 	}
-	if current != expected {
+	if !sameSocketIdentity(current, expected) {
 		return ErrSocketReplaced
 	}
 	return os.Remove(path)
@@ -215,4 +224,46 @@ func WriteJSON(writer io.Writer, value any) error {
 func OwnedByCurrentUser(info os.FileInfo) bool {
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	return ok && int(stat.Uid) == os.Getuid()
+}
+
+func socketIdentity(info os.FileInfo) (SocketIdentity, bool) {
+	if info == nil {
+		return SocketIdentity{}, false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return SocketIdentity{}, false
+	}
+	seconds, nanoseconds := statChangeTime(stat)
+	return SocketIdentity{
+		Device:                uint64(stat.Dev),
+		Inode:                 stat.Ino,
+		Owner:                 stat.Uid,
+		Mode:                  info.Mode(),
+		Size:                  info.Size(),
+		ChangeTimeSeconds:     seconds,
+		ChangeTimeNanoseconds: nanoseconds,
+	}, true
+}
+
+func sameSocketIdentity(first, second SocketIdentity) bool {
+	return first == second
+}
+
+// Stat_t spells the change-time field Ctim on Linux and Ctimespec on Darwin.
+// Reflection keeps this package inside the repository's explicit two-OS
+// contract without build constraints or narrowing conversions.
+func statChangeTime(stat *syscall.Stat_t) (int64, int64) {
+	value := reflect.ValueOf(stat).Elem()
+	for _, name := range []string{"Ctim", "Ctimespec"} {
+		field := value.FieldByName(name)
+		if !field.IsValid() {
+			continue
+		}
+		seconds, nanoseconds := field.FieldByName("Sec"), field.FieldByName("Nsec")
+		if seconds.IsValid() && nanoseconds.IsValid() && seconds.CanInt() && nanoseconds.CanInt() {
+			return seconds.Int(), nanoseconds.Int()
+		}
+	}
+	return 0, 0
 }

--- a/internal/integrations/agents/localipc/transport.go
+++ b/internal/integrations/agents/localipc/transport.go
@@ -1,0 +1,218 @@
+// Package localipc owns the provider-neutral Unix transport discipline shared
+// by exact Agent adapters. Protocol identity and operation semantics remain in
+// the provider adapters; this package only owns private sockets and bounded
+// one-object JSON frames.
+package localipc
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+const (
+	MaxFrameBytes = 64 << 10
+	MaxSocketPath = 100
+	DialTimeout   = 500 * time.Millisecond
+	Deadline      = 5 * time.Second
+)
+
+var (
+	ErrFrameTooLarge  = errors.New("bounded frame is too large")
+	ErrFrameMalformed = errors.New("bounded frame is malformed")
+	ErrSocketReplaced = errors.New("private endpoint identity changed")
+)
+
+// SocketIdentity is the stable kernel identity of one owned Unix socket.
+// Paths alone are never sufficient when deciding whether cleanup is safe.
+type SocketIdentity struct {
+	Device uint64
+	Inode  uint64
+	Owner  uint32
+	Mode   os.FileMode
+}
+
+// InspectOwnedSocket rejects symlinks, non-sockets, foreign owners, and modes
+// other than 0600.
+func InspectOwnedSocket(path string) (SocketIdentity, error) {
+	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path || len(path) > MaxSocketPath {
+		return SocketIdentity{}, errors.New("private endpoint is unavailable")
+	}
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || info.Mode()&os.ModeSocket == 0 ||
+		info.Mode().Perm() != 0o600 || !OwnedByCurrentUser(info) {
+		return SocketIdentity{}, errors.New("private endpoint is unavailable")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return SocketIdentity{}, errors.New("private endpoint is unavailable")
+	}
+	return SocketIdentity{Device: uint64(stat.Dev), Inode: stat.Ino, Owner: stat.Uid, Mode: info.Mode()}, nil
+}
+
+// PrepareSocket creates and secures the parent directory, refuses live or
+// foreign collisions, and removes only an unchanged owned stale socket.
+func PrepareSocket(path string) error {
+	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path || len(path) > MaxSocketPath {
+		return errors.New("private endpoint path exceeds the platform-safe bound")
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create private endpoint directory: %w", err)
+	}
+	info, err := os.Lstat(dir)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || !OwnedByCurrentUser(info) {
+		return errors.New("private endpoint directory is not a private owned directory")
+	}
+	// #nosec G302 -- 0700 is the intentional owner-only directory mode.
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return fmt.Errorf("secure private endpoint directory: %w", err)
+	}
+	info, err = os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect private endpoint: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || info.Mode()&os.ModeSocket == 0 || !OwnedByCurrentUser(info) {
+		return errors.New("private endpoint collision is not an owned socket")
+	}
+	conn, dialErr := net.DialTimeout("unix", path, DialTimeout)
+	if dialErr == nil {
+		_ = conn.Close()
+		return errors.New("private endpoint is already active")
+	}
+	latest, latestErr := os.Lstat(path)
+	if latestErr != nil || !os.SameFile(info, latest) || latest.Mode()&os.ModeSocket == 0 || !OwnedByCurrentUser(latest) {
+		return errors.New("private stale endpoint changed during ownership check")
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("remove stale private endpoint: %w", err)
+	}
+	return nil
+}
+
+// Listener remembers the created inode so Close never unlinks a replacement.
+type Listener struct {
+	Unix     *net.UnixListener
+	Path     string
+	identity SocketIdentity
+}
+
+func (l *Listener) Identity() SocketIdentity {
+	if l == nil {
+		return SocketIdentity{}
+	}
+	return l.identity
+}
+
+func Listen(path string) (*Listener, error) {
+	if err := PrepareSocket(path); err != nil {
+		return nil, err
+	}
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		return nil, fmt.Errorf("listen private endpoint: %w", err)
+	}
+	listener.SetUnlinkOnClose(false)
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = listener.Close()
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("secure private endpoint: %w", err)
+	}
+	identity, err := InspectOwnedSocket(path)
+	if err != nil {
+		_ = listener.Close()
+		_ = os.Remove(path)
+		return nil, err
+	}
+	return &Listener{Unix: listener, Path: path, identity: identity}, nil
+}
+
+func (l *Listener) Close() error {
+	if l == nil || l.Unix == nil {
+		return nil
+	}
+	err := l.Unix.Close()
+	_ = RemoveOwnedSocket(l.Path, l.identity)
+	return err
+}
+
+// RemoveOwnedSocket unlinks only the exact socket inode recorded by its owner.
+// Crash cleanup may carry this identity in a non-secret lease receipt; a
+// replacement which has claimed the same path is never removed.
+func RemoveOwnedSocket(path string, expected SocketIdentity) error {
+	if expected.Inode == 0 || expected.Mode&os.ModeSocket == 0 || expected.Mode.Perm() != 0o600 {
+		return ErrSocketReplaced
+	}
+	current, err := InspectOwnedSocket(path)
+	if err != nil {
+		return err
+	}
+	if current != expected {
+		return ErrSocketReplaced
+	}
+	return os.Remove(path)
+}
+
+// ReadJSON reads exactly one complete JSON value bounded by MaxFrameBytes.
+func ReadJSON(reader io.Reader, value any) error {
+	payload, err := io.ReadAll(io.LimitReader(reader, MaxFrameBytes+1))
+	if len(payload) > MaxFrameBytes {
+		return ErrFrameTooLarge
+	}
+	if err != nil {
+		return errors.New("bounded frame read failed")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	if err := decoder.Decode(value); err != nil {
+		return ErrFrameMalformed
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return ErrFrameMalformed
+	}
+	return nil
+}
+
+// MarshalJSON emits the same newline-terminated single frame as json.Encoder.
+func MarshalJSON(value any) ([]byte, error) {
+	var payload bytes.Buffer
+	if err := json.NewEncoder(&payload).Encode(value); err != nil || payload.Len() > MaxFrameBytes {
+		return nil, errors.New("bounded frame encode failed")
+	}
+	return payload.Bytes(), nil
+}
+
+func WriteJSON(writer io.Writer, value any) error {
+	payload, err := MarshalJSON(value)
+	if err != nil {
+		return err
+	}
+	for len(payload) > 0 {
+		n, writeErr := writer.Write(payload)
+		if n > 0 {
+			payload = payload[n:]
+		}
+		if writeErr != nil {
+			return writeErr
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+	}
+	return nil
+}
+
+func OwnedByCurrentUser(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && int(stat.Uid) == os.Getuid()
+}

--- a/internal/integrations/agents/localipc/transport_test.go
+++ b/internal/integrations/agents/localipc/transport_test.go
@@ -125,6 +125,20 @@ func TestOwnedSocketCleanupPreservesReplacementAndPathModeBounds(t *testing.T) {
 	}
 }
 
+func TestSocketIncarnationIdentityRejectsLegacyAxisReuse(t *testing.T) {
+	current := SocketIdentity{
+		Device: 41, Inode: 73, Owner: 1000, Mode: os.ModeSocket | 0o600, Size: 0,
+		ChangeTimeSeconds: 900, ChangeTimeNanoseconds: 12,
+	}
+	stale := current
+	// Simulate immediate filesystem reuse: every legacy device/inode/owner/
+	// mode/size axis is identical and only the socket incarnation time differs.
+	stale.ChangeTimeNanoseconds ^= 1
+	if sameSocketIdentity(current, stale) {
+		t.Fatal("socket identity accepted a replacement with reused legacy axes")
+	}
+}
+
 func TestBoundedJSONRoundTripTrailingAndOversize(t *testing.T) {
 	type frame struct {
 		Value string `json:"value"`

--- a/internal/integrations/agents/localipc/transport_test.go
+++ b/internal/integrations/agents/localipc/transport_test.go
@@ -1,0 +1,244 @@
+package localipc
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestOwnedSocketLifecycleAndSingleJSONBoundaries(t *testing.T) {
+	root, err := os.MkdirTemp("/tmp", "pmx-localipc-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	path := filepath.Join(root, "private", "test.sock")
+	listener, err := Listen(path)
+	if errors.Is(err, syscall.EPERM) {
+		t.Skip("Unix sockets unavailable")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Stat(filepath.Dir(path)); err != nil || info.Mode().Perm() != 0o700 {
+		t.Fatalf("dir info=%v err=%v", info, err)
+	}
+	if identity, err := InspectOwnedSocket(path); err != nil || identity.Inode == 0 || identity.Mode.Perm() != 0o600 {
+		t.Fatalf("socket identity=%+v err=%v", identity, err)
+	}
+	if err := PrepareSocket(path); err == nil {
+		t.Fatal("active collision accepted")
+	}
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("closed owned socket remains: %v", err)
+	}
+
+	stale, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale.SetUnlinkOnClose(false)
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_ = stale.Close()
+	if err := PrepareSocket(path); err != nil {
+		t.Fatalf("owned stale socket not replaced: %v", err)
+	}
+	if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stale socket remains: %v", err)
+	}
+
+	if err := os.Symlink(filepath.Join(root, "elsewhere"), path); err != nil {
+		t.Fatal(err)
+	}
+	if err := PrepareSocket(path); err == nil {
+		t.Fatal("symlink collision accepted")
+	}
+}
+
+func TestOwnedSocketCleanupPreservesReplacementAndPathModeBounds(t *testing.T) {
+	root, err := os.MkdirTemp("/tmp", "pmx-localipc-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	path := filepath.Join(root, "private", "cleanup.sock")
+	listener, err := Listen(path)
+	if errors.Is(err, syscall.EPERM) {
+		t.Skip("Unix sockets unavailable")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := listener.Identity()
+	if err := listener.Unix.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement.SetUnlinkOnClose(false)
+	defer func() {
+		_ = replacement.Close()
+		_ = os.Remove(path)
+	}()
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveOwnedSocket(path, original); !errors.Is(err, ErrSocketReplaced) {
+		t.Fatalf("replacement cleanup err = %v, want identity change", err)
+	}
+	if _, err := InspectOwnedSocket(path); err != nil {
+		t.Fatalf("replacement was removed: %v", err)
+	}
+	if err := os.Chmod(path, 0o666); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InspectOwnedSocket(path); err == nil {
+		t.Fatal("open socket mode accepted")
+	}
+	if err := PrepareSocket(strings.Repeat("/x", MaxSocketPath)); err == nil {
+		t.Fatal("overlong socket path accepted")
+	}
+	if err := os.Chmod(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := PrepareSocket(filepath.Join(filepath.Dir(path), "mode-check.sock")); err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Stat(filepath.Dir(path)); err != nil || info.Mode().Perm() != 0o700 {
+		t.Fatalf("owned directory mode was not converged: info=%v err=%v", info, err)
+	}
+}
+
+func TestBoundedJSONRoundTripTrailingAndOversize(t *testing.T) {
+	type frame struct {
+		Value string `json:"value"`
+	}
+	var got frame
+	if err := ReadJSON(strings.NewReader("{\"value\":\"ok\"}\n\t"), &got); err != nil || got.Value != "ok" {
+		t.Fatalf("valid frame got=%+v err=%v", got, err)
+	}
+	for _, input := range []string{"{} {}", strings.Repeat("x", MaxFrameBytes+1)} {
+		if err := ReadJSON(strings.NewReader(input), &got); err == nil {
+			t.Fatalf("invalid frame accepted len=%d", len(input))
+		}
+	}
+	payload, err := MarshalJSON(frame{Value: "ok"})
+	if err != nil || len(payload) == 0 || payload[len(payload)-1] != '\n' {
+		t.Fatalf("payload=%q err=%v", payload, err)
+	}
+	var wire bytes.Buffer
+	if err := WriteJSON(&wire, frame{Value: "ok"}); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(wire.Bytes(), payload) {
+		t.Fatalf("wire=%q payload=%q", wire.Bytes(), payload)
+	}
+}
+
+func TestPrimitivesUseOneHalfClosedRequestAndOneResponse(t *testing.T) {
+	root, err := os.MkdirTemp("/tmp", "pmx-localipc-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	listener, err := Listen(filepath.Join(root, "private", "call.sock"))
+	if errors.Is(err, syscall.EPERM) {
+		t.Skip("Unix sockets unavailable")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	done := make(chan error, 1)
+	go func() {
+		conn, err := listener.Unix.AcceptUnix()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer conn.Close()
+		var request map[string]string
+		if err := ReadJSON(conn, &request); err != nil {
+			done <- err
+			return
+		}
+		done <- WriteJSON(conn, map[string]string{"reply": request["request"]})
+	}()
+	connection, err := net.Dial("unix", listener.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer connection.Close()
+	if err := WriteJSON(connection, map[string]string{"request": "exact"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := connection.(*net.UnixConn).CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+	var response map[string]string
+	if err := ReadJSON(connection, &response); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done; err != nil || response["reply"] != "exact" {
+		t.Fatalf("response=%v serverErr=%v", response, err)
+	}
+}
+
+func TestPeerProcessReturnsExactKernelBirth(t *testing.T) {
+	root, err := os.MkdirTemp("/tmp", "pmx-localipc-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	listener, err := Listen(filepath.Join(root, "private", "peer.sock"))
+	if errors.Is(err, syscall.EPERM) {
+		t.Skip("Unix sockets unavailable")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	want, _, err := Process(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		conn, err := listener.Unix.AcceptUnix()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer conn.Close()
+		got, _, err := PeerProcess(conn)
+		if err == nil && got != want {
+			err = errors.New("peer birth mismatch")
+		}
+		done <- err
+	}()
+	conn, err := net.Dial("unix", listener.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = json.NewEncoder(conn).Encode(map[string]bool{"ready": true})
+	_ = conn.Close()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/integration/claude-endpoint-binding.sh
+++ b/test/integration/claude-endpoint-binding.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Disposable own-child SessionStart registration. No tmux, provider account,
-# model, external tools, MCP, or provider transport is used by this fixture.
+# Disposable own-child SessionStart registration plus Projmux-owned UDS/pipe
+# handoff. No tmux, provider account, model, external tools, MCP, vendor socket,
+# connector, or provider transport is used by this fixture.
 unset TMUX TMUX_PANE
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 build_root="$(mktemp -d "${TMPDIR:-/tmp}/projmux-claude-endpoint-build.XXXXXX")"


### PR DESCRIPTION
## Summary
- Extract the private bounded Unix-socket framing, ownership, and peer/process inspection discipline from the Codex-only control transport without changing its request, response, path, or epoch semantics.
- Add an exact AgentRouteRef plus ClaudeAuthorityRef coordination endpoint, a single-waiter SessionStart/Stop asyncRewake handoff, and a terminal-once private reducer whose delivered boundary is the full stderr frame plus same-ref helper receipt.
- Converge one explicit managed coordination hook family while keeping automatic install-time migration byte-preserving unless that family was already installed.

## Test plan
- [x] make fmt
- [x] make fix
- [x] make test
- [x] make test-integration (twice on the final tree)
- [x] focused race and replacement-cleanup stress tests
- [x] test/integration/agent-control-binding-frame.sh
- [x] test/integration/claude-endpoint-binding.sh
- [x] Phase-2 selectorless fake E2E audit: N/A; no such E2E exists
- [x] provider/model E2E not run by Phase contract

## Scope and safety
- No public agent message send/wait/status, peer broker route, provider inbox, model session, MCP/Channel, connector, approval, interrupt, config/tool operation, external write, or secret persistence.
- No parallel-worker-owned lifecycle/runtime/vintage/Makefile/npm/broker/journal file changed.
- Same-path socket replacements are preserved by exact inode identity during normal close, dead-helper reap, and supervisor cleanup.

## Globalization
- [x] No user-facing string changes; new strings are internal diagnostics, commands, protocol values, or provider payload data.

Roadmap: Provider capability matrix and heterogeneous Agent dialogue / Phase 2 Claude owned ingress and deterministic handoff
Contract: C-3 Delivery lifecycle and authority