### PR TITLE
fix(agent): reconcile stale turn state before start

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -342,6 +342,21 @@
   command, path, permission, and request content out of Registry, tmux, notify,
   diagnostics, support, and Archive sinks.
 
+- `make test`: Exact Codex turn-start admission reads one fresh, content-free
+  lifecycle snapshot through the bound control epoch immediately before the
+  provider mutation. `TestExactAgentControlStartFreshLifecycleAdmissionTable`
+  pins the cached/fresh matrix, exact `turn-in-progress` and
+  `turn-state-unavailable` tokens, read-before-start ordering, cross-thread and
+  structurally inconsistent snapshot refusal, private-detail exclusion, and
+  zero mutation on every refusal.
+  `TestExactAgentControlStartRechecksBindingAfterFreshLifecycleRead` keeps the
+  Agent/Pane/runtime/generation/thread binding current across the fresh read,
+  while `TestExactAgentControlFreshTerminalReconcileClearsCachedApproval`
+  proves that an idle/terminal snapshot repairs stale turn and approval state
+  before the same request starts exactly one new turn. Existing steer,
+  interrupt, approval, old-epoch, and canonical generation-consumer fences are
+  unchanged.
+
 - `make test` / `make test-integration`: Codex public turn control live-binding
   compatibility uses one strict six-field tmux frame. Unit tests accept only
   literal `\037` and raw unit-separator spellings without generic escape

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -446,9 +446,14 @@ must be selected from the exact Agent's provider and capability.
 `agent approval review` use the live Codex app-server connection only when the
 selected Agent, its owned Pane, activation generation, thread, current turn,
 and connection epoch still match exactly. `start` sends only the exact thread
-id and one text input; `steer` supplies the current expected turn id; and
-`interrupt` supplies that exact turn id. These commands never install sticky
-model, effort, cwd, sandbox, permission, or collaboration overrides.
+id and one text input. Immediately before that write it reads one bounded,
+content-free lifecycle snapshot: fresh active/in-progress returns
+`turn-in-progress`, fresh idle/terminal repairs stale cached state and starts
+once, and an unavailable or inconsistent snapshot returns
+`turn-state-unavailable` with no turn mutation. `steer` supplies the current
+expected turn id; and `interrupt` supplies that exact turn id. These commands
+never install sticky model, effort, cwd, sandbox, permission, or collaboration
+overrides.
 
 Approval review shows only the safe one-shot intersection supplied by the
 exact pending request. Command, file, and network requests are limited to

--- a/internal/app/agent_control_epoch.go
+++ b/internal/app/agent_control_epoch.go
@@ -23,6 +23,7 @@ const (
 )
 
 type agentControlWire interface {
+	ReadLifecycleSnapshot(context.Context, string) (codexappserver.LifecycleSnapshot, error)
 	StartExactTurn(context.Context, string, string) (codexappserver.ControlResult, error)
 	SteerExactTurn(context.Context, string, string, string) (codexappserver.ControlResult, error)
 	InterruptExactTurn(context.Context, string, string) (codexappserver.ControlResult, error)
@@ -184,8 +185,23 @@ func (e *codexControlEpoch) Handle(ctx context.Context, request agentControlRequ
 	case agentControlOpApprovals:
 		return agentControlResponse{OK: true, Availability: e.availability(), Approvals: e.approvals()}
 	case agentControlOpStart:
-		if strings.TrimSpace(request.Text) == "" || !e.canStart() {
+		if strings.TrimSpace(request.Text) == "" {
 			return refusedControl("stale-turn", "thread is not idle; new turn write refused")
+		}
+		snapshot, err := e.wire.ReadLifecycleSnapshot(ctx, e.identity.ThreadID)
+		if err != nil || snapshot.ThreadID != e.identity.ThreadID || !validFreshStartSnapshot(snapshot) {
+			return refusedControl("turn-state-unavailable", "fresh exact turn state is unavailable; new turn write refused")
+		}
+		// The snapshot request travels through the same connection/control epoch,
+		// but the Registry binding can still be replaced while that read is in
+		// flight. Re-check the existing binding fence before accepting either its
+		// state or a provider mutation.
+		if !e.current(e.identity) {
+			return refusedControl("stale-binding", "exact Agent binding or activation generation changed")
+		}
+		e.reconcileTurn(snapshot)
+		if !e.canStart() {
+			return refusedControl("turn-in-progress", "exact thread already has a turn in progress")
 		}
 		result, err := e.wire.StartExactTurn(ctx, e.identity.ThreadID, request.Text)
 		if err != nil {
@@ -195,6 +211,8 @@ func (e *codexControlEpoch) Handle(ctx context.Context, request agentControlRequ
 			return refusedControl("protocol-error", "turn/start returned a different or incomplete identity")
 		}
 		e.turnID, e.turnState, e.threadState = result.TurnID, codexappserver.TurnStateInProgress, codexappserver.ThreadStateActive
+		e.pending = map[string]codexappserver.ApprovalEnvelope{}
+		e.ambiguous = map[string]struct{}{}
 		return agentControlResponse{OK: true, ThreadID: result.ThreadID, TurnID: result.TurnID}
 	case agentControlOpSteer:
 		if strings.TrimSpace(request.Text) == "" || !e.canMutateCurrentTurn() {
@@ -290,6 +308,32 @@ func (e *codexControlEpoch) HasActionableRequest(requestID string) bool {
 
 func (e *codexControlEpoch) canStart() bool {
 	return e.threadState == codexappserver.ThreadStateIdle && (e.turnID == "" || e.turnState == codexappserver.TurnStateCompleted || e.turnState == codexappserver.TurnStateFailed || e.turnState == codexappserver.TurnStateInterrupted)
+}
+
+func validFreshStartSnapshot(snapshot codexappserver.LifecycleSnapshot) bool {
+	turnID := strings.TrimSpace(snapshot.TurnID)
+	switch snapshot.ThreadState {
+	case codexappserver.ThreadStateActive, codexappserver.ThreadStateWaitingOnApproval, codexappserver.ThreadStateWaitingOnUserInput:
+		return turnID != "" && snapshot.TurnState == codexappserver.TurnStateInProgress
+	case codexappserver.ThreadStateIdle:
+		if turnID == "" {
+			return snapshot.TurnState == "" || snapshot.TurnState == codexappserver.TurnStateUnknown
+		}
+		return snapshot.TurnState == codexappserver.TurnStateCompleted || snapshot.TurnState == codexappserver.TurnStateFailed || snapshot.TurnState == codexappserver.TurnStateInterrupted
+	default:
+		return false
+	}
+}
+
+func (e *codexControlEpoch) reconcileTurn(snapshot codexappserver.LifecycleSnapshot) {
+	turnChanged := e.turnID != strings.TrimSpace(snapshot.TurnID)
+	e.threadState = snapshot.ThreadState
+	e.turnID = strings.TrimSpace(snapshot.TurnID)
+	e.turnState = snapshot.TurnState
+	if turnChanged || snapshot.TurnState != codexappserver.TurnStateInProgress {
+		e.pending = map[string]codexappserver.ApprovalEnvelope{}
+		e.ambiguous = map[string]struct{}{}
+	}
 }
 
 func (e *codexControlEpoch) canMutateCurrentTurn() bool {

--- a/internal/app/agent_control_epoch_test.go
+++ b/internal/app/agent_control_epoch_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -17,33 +18,50 @@ import (
 )
 
 type fakeExactControlWire struct {
-	mu        sync.Mutex
-	threadID  string
-	turnID    string
-	start     int
-	steer     int
-	interrupt int
-	responses []json.RawMessage
-	results   []any
-	err       error
+	mu          sync.Mutex
+	threadID    string
+	turnID      string
+	snapshot    codexappserver.LifecycleSnapshot
+	snapshotErr error
+	reads       int
+	start       int
+	steer       int
+	interrupt   int
+	responses   []json.RawMessage
+	results     []any
+	operations  []string
+	err         error
 }
 
-func (w *fakeExactControlWire) StartExactTurn(context.Context, string, string) (codexappserver.ControlResult, error) {
+func (w *fakeExactControlWire) ReadLifecycleSnapshot(_ context.Context, threadID string) (codexappserver.LifecycleSnapshot, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.reads++
+	w.operations = append(w.operations, "lifecycle-read:"+threadID)
+	if w.snapshot != (codexappserver.LifecycleSnapshot{}) {
+		return w.snapshot, w.snapshotErr
+	}
+	return codexappserver.LifecycleSnapshot{ThreadID: w.resultThreadID(), ThreadState: codexappserver.ThreadStateIdle}, w.snapshotErr
+}
+func (w *fakeExactControlWire) StartExactTurn(_ context.Context, threadID, _ string) (codexappserver.ControlResult, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.start++
+	w.operations = append(w.operations, "turn-start:"+threadID)
 	return codexappserver.ControlResult{ThreadID: w.resultThreadID(), TurnID: "turn-new"}, w.err
 }
-func (w *fakeExactControlWire) SteerExactTurn(context.Context, string, string, string) (codexappserver.ControlResult, error) {
+func (w *fakeExactControlWire) SteerExactTurn(_ context.Context, threadID, turnID, _ string) (codexappserver.ControlResult, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.steer++
+	w.operations = append(w.operations, "turn-steer:"+threadID+":"+turnID)
 	return codexappserver.ControlResult{ThreadID: w.resultThreadID(), TurnID: w.resultTurnID()}, w.err
 }
-func (w *fakeExactControlWire) InterruptExactTurn(context.Context, string, string) (codexappserver.ControlResult, error) {
+func (w *fakeExactControlWire) InterruptExactTurn(_ context.Context, threadID, turnID string) (codexappserver.ControlResult, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.interrupt++
+	w.operations = append(w.operations, "turn-interrupt:"+threadID+":"+turnID)
 	return codexappserver.ControlResult{ThreadID: w.resultThreadID(), TurnID: w.resultTurnID()}, w.err
 }
 func (w *fakeExactControlWire) RespondServerRequest(_ context.Context, id json.RawMessage, result any) error {
@@ -51,6 +69,7 @@ func (w *fakeExactControlWire) RespondServerRequest(_ context.Context, id json.R
 	defer w.mu.Unlock()
 	w.responses = append(w.responses, append(json.RawMessage(nil), id...))
 	w.results = append(w.results, result)
+	w.operations = append(w.operations, "approval-response")
 	return w.err
 }
 func (w *fakeExactControlWire) writes() int {
@@ -85,9 +104,10 @@ func TestExactAgentControlActionGenerationEpochAndTurnTable(t *testing.T) {
 		request    agentControlRequest
 		current    bool
 		wantOK     bool
+		wantReads  int
 		wantWrites int
 	}{
-		{name: "idle exact new turn", snapshot: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle, TurnID: "turn-old", TurnState: codexappserver.TurnStateCompleted}, request: agentControlRequest{Operation: agentControlOpStart, Text: "new"}, current: true, wantOK: true, wantWrites: 1},
+		{name: "idle exact new turn", snapshot: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle, TurnID: "turn-old", TurnState: codexappserver.TurnStateCompleted}, request: agentControlRequest{Operation: agentControlOpStart, Text: "new"}, current: true, wantOK: true, wantReads: 1, wantWrites: 1},
 		{name: "active exact steer", snapshot: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive, TurnID: "turn-1", TurnState: codexappserver.TurnStateInProgress}, request: agentControlRequest{Operation: agentControlOpSteer, Text: "steer"}, current: true, wantOK: true, wantWrites: 1},
 		{name: "idle steer refused", snapshot: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle, TurnID: "turn-1", TurnState: codexappserver.TurnStateCompleted}, request: agentControlRequest{Operation: agentControlOpSteer, Text: "steer"}, current: true},
 		{name: "old epoch", snapshot: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle}, request: agentControlRequest{Operation: agentControlOpStart, Epoch: "old", Text: "new"}, current: true},
@@ -108,8 +128,8 @@ func TestExactAgentControlActionGenerationEpochAndTurnTable(t *testing.T) {
 				request.Epoch = "epoch-1"
 			}
 			response := epoch.Handle(context.Background(), request)
-			if response.OK != test.wantOK || wire.writes() != test.wantWrites {
-				t.Fatalf("response=%+v writes=%d", response, wire.writes())
+			if response.OK != test.wantOK || wire.reads != test.wantReads || wire.writes() != test.wantWrites {
+				t.Fatalf("response=%+v reads=%d writes=%d", response, wire.reads, wire.writes())
 			}
 		})
 	}
@@ -122,6 +142,103 @@ func TestExactAgentControlActionGenerationEpochAndTurnTable(t *testing.T) {
 	}
 	if second := epoch.Handle(context.Background(), request); second.OK || wire.interrupt != 1 {
 		t.Fatalf("second interrupt = %+v writes=%d", second, wire.interrupt)
+	}
+}
+
+func TestExactAgentControlStartFreshLifecycleAdmissionTable(t *testing.T) {
+	identity := phase6Identity()
+	active := codexappserver.LifecycleSnapshot{
+		ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive,
+		TurnID: "turn-1", TurnState: codexappserver.TurnStateInProgress,
+	}
+	idle := codexappserver.LifecycleSnapshot{
+		ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle,
+		TurnID: "turn-old", TurnState: codexappserver.TurnStateCompleted,
+	}
+	for _, test := range []struct {
+		name       string
+		cached     codexappserver.LifecycleSnapshot
+		fresh      codexappserver.LifecycleSnapshot
+		freshErr   error
+		wantOK     bool
+		wantCode   string
+		wantReads  int
+		wantStarts int
+		wantOrder  []string
+	}{
+		{name: "cached active fresh same active", cached: active, fresh: active, wantCode: "turn-in-progress", wantReads: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "cached active fresh later active", cached: active, fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive, TurnID: "turn-later", TurnState: codexappserver.TurnStateInProgress}, wantCode: "turn-in-progress", wantReads: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "cached idle fresh later active", cached: idle, fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateWaitingOnApproval, TurnID: "turn-later", TurnState: codexappserver.TurnStateInProgress}, wantCode: "turn-in-progress", wantReads: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "cached idle fresh waiting on input", cached: idle, fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateWaitingOnUserInput, TurnID: "turn-later", TurnState: codexappserver.TurnStateInProgress}, wantCode: "turn-in-progress", wantReads: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "cached active fresh same terminal", cached: active, fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle, TurnID: "turn-1", TurnState: codexappserver.TurnStateCompleted}, wantOK: true, wantReads: 1, wantStarts: 1, wantOrder: []string{"lifecycle-read:thread-1", "turn-start:thread-1"}},
+		{name: "cached active fresh later terminal", cached: active, fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle, TurnID: "turn-later", TurnState: codexappserver.TurnStateInterrupted}, wantOK: true, wantReads: 1, wantStarts: 1, wantOrder: []string{"lifecycle-read:thread-1", "turn-start:thread-1"}},
+		{name: "cached idle fresh failed terminal", cached: idle, fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle, TurnID: "turn-later", TurnState: codexappserver.TurnStateFailed}, wantOK: true, wantReads: 1, wantStarts: 1, wantOrder: []string{"lifecycle-read:thread-1", "turn-start:thread-1"}},
+		{name: "cached active fresh never started", cached: active, fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle}, wantOK: true, wantReads: 1, wantStarts: 1, wantOrder: []string{"lifecycle-read:thread-1", "turn-start:thread-1"}},
+		{name: "fresh read error", cached: idle, freshErr: errors.New("private provider detail"), wantCode: "turn-state-unavailable", wantReads: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh read timeout", cached: idle, freshErr: context.DeadlineExceeded, wantCode: "turn-state-unavailable", wantReads: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh wrong thread", cached: idle, fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-other", ThreadState: codexappserver.ThreadStateIdle}, wantCode: "turn-state-unavailable", wantReads: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh active without turn", cached: idle, fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive, TurnState: codexappserver.TurnStateInProgress}, wantCode: "turn-state-unavailable", wantReads: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh idle with active turn", cached: idle, fresh: activeWithThreadState(codexappserver.ThreadStateIdle), wantCode: "turn-state-unavailable", wantReads: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh active with terminal turn", cached: idle, fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive, TurnID: "turn-1", TurnState: codexappserver.TurnStateCompleted}, wantCode: "turn-state-unavailable", wantReads: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh terminal without turn", cached: idle, fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle, TurnState: codexappserver.TurnStateCompleted}, wantCode: "turn-state-unavailable", wantReads: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh system error", cached: idle, fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateSystemError}, wantCode: "turn-state-unavailable", wantReads: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			wire := &fakeExactControlWire{snapshot: test.fresh, snapshotErr: test.freshErr}
+			epoch := newCodexControlEpoch(wire, identity, "epoch-1", test.cached, func(codexLifecycleIdentity) bool { return true })
+			response := epoch.Handle(context.Background(), agentControlRequest{Operation: agentControlOpStart, Identity: identity, Epoch: "epoch-1", Text: "private prompt"})
+			if response.OK != test.wantOK || response.Code != test.wantCode || wire.reads != test.wantReads || wire.start != test.wantStarts || !slices.Equal(wire.operations, test.wantOrder) {
+				t.Fatalf("response=%+v reads=%d starts=%d order=%q", response, wire.reads, wire.start, wire.operations)
+			}
+			if wire.steer != 0 || wire.interrupt != 0 || len(wire.responses) != 0 || strings.Contains(response.Message, "private") || strings.Contains(strings.Join(wire.operations, " "), "private") {
+				t.Fatalf("unexpected mutation or private detail: response=%+v wire=%+v", response, wire)
+			}
+		})
+	}
+}
+
+func activeWithThreadState(state codexappserver.ThreadState) codexappserver.LifecycleSnapshot {
+	return codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: state, TurnID: "turn-1", TurnState: codexappserver.TurnStateInProgress}
+}
+
+func TestExactAgentControlStartRechecksBindingAfterFreshLifecycleRead(t *testing.T) {
+	identity := phase6Identity()
+	currentCalls := 0
+	wire := &fakeExactControlWire{snapshot: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle, TurnID: "turn-old", TurnState: codexappserver.TurnStateCompleted}}
+	epoch := newCodexControlEpoch(wire, identity, "epoch-1", codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive, TurnID: "turn-old", TurnState: codexappserver.TurnStateInProgress}, func(codexLifecycleIdentity) bool {
+		currentCalls++
+		return currentCalls == 1
+	})
+	response := epoch.Handle(context.Background(), agentControlRequest{Operation: agentControlOpStart, Identity: identity, Epoch: "epoch-1", Text: "new"})
+	if response.OK || response.Code != "stale-binding" || wire.reads != 1 || wire.writes() != 0 || !slices.Equal(wire.operations, []string{"lifecycle-read:thread-1"}) {
+		t.Fatalf("response=%+v current-calls=%d reads=%d writes=%d order=%q", response, currentCalls, wire.reads, wire.writes(), wire.operations)
+	}
+}
+
+func TestExactAgentControlFreshTerminalReconcileClearsCachedApproval(t *testing.T) {
+	identity := phase6Identity()
+	wire := &fakeExactControlWire{snapshot: codexappserver.LifecycleSnapshot{
+		ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle,
+		TurnID: "turn-1", TurnState: codexappserver.TurnStateCompleted,
+	}}
+	epoch := newCodexControlEpoch(wire, identity, "epoch-1", codexappserver.LifecycleSnapshot{
+		ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateWaitingOnApproval,
+		TurnID: "turn-1", TurnState: codexappserver.TurnStateInProgress,
+	}, func(codexLifecycleIdentity) bool { return true })
+	approval := codexappserver.Notification{
+		Method: "item/commandExecution/requestApproval", RequestID: "7", RawRequestID: json.RawMessage(`7`),
+		Params: json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","itemId":"item-1","startedAtMs":1,"command":"old","cwd":"/work","availableDecisions":["accept"]}`),
+	}
+	if err := epoch.ApplyNotification(approval); err != nil || !epoch.HasActionableRequest("7") {
+		t.Fatalf("seed cached approval: actionable=%v err=%v", epoch.HasActionableRequest("7"), err)
+	}
+	start := epoch.Handle(context.Background(), agentControlRequest{Operation: agentControlOpStart, Identity: identity, Epoch: "epoch-1", Text: "new"})
+	if !start.OK || wire.reads != 1 || wire.writes() != 1 || epoch.HasActionableRequest("7") {
+		t.Fatalf("start=%+v reads=%d writes=%d cached-approval=%v", start, wire.reads, wire.writes(), epoch.HasActionableRequest("7"))
+	}
+	review := epoch.Handle(context.Background(), agentControlRequest{Operation: agentControlOpReview, Identity: identity, Epoch: "epoch-1", RequestKey: "7", Decision: "accept"})
+	if review.OK || wire.writes() != 1 {
+		t.Fatalf("stale approval survived reconcile: response=%+v writes=%d", review, wire.writes())
 	}
 }
 

--- a/internal/app/ai_ingest_codex_native_test.go
+++ b/internal/app/ai_ingest_codex_native_test.go
@@ -845,6 +845,10 @@ type fakeControllableCodexLifecycleConnection struct {
 	*fakeExactControlWire
 }
 
+func (c *fakeControllableCodexLifecycleConnection) ReadLifecycleSnapshot(ctx context.Context, threadID string) (codexappserver.LifecycleSnapshot, error) {
+	return c.fakeCodexLifecycleConnection.ReadLifecycleSnapshot(ctx, threadID)
+}
+
 func TestCodexNativeObserverReadyHandshakeSteersAndShutdownRemovesControlSocket(t *testing.T) {
 	root, err := os.MkdirTemp("/tmp", "observer-control-")
 	if err != nil {

--- a/test/e2e/codex-lifecycle.sh
+++ b/test/e2e/codex-lifecycle.sh
@@ -803,13 +803,35 @@ assert_lifecycle_sibling_semantics "sibling replacement steer"
 # Same-Agent native control is recovered directly through the exact Agent UID;
 # no focus, reopen, send-keys, or fresh-Agent lane participates. Wait until both
 # replacement snapshot barriers have closed before adding this target RPC to
-# the shared connection, then require exactly one target-qualified write.
+# the shared connection, then require exactly one target-qualified write. The
+# replacement observer's owned snapshot may still hold the broker's bounded
+# same-thread lifecycle retry fence. Fresh start admission exposes that exact
+# read refusal as turn-state-unavailable with zero mutation, so retry the same
+# request on that typed result only; the polling interval is pacing, never turn
+# state authority.
 lifecycle_target_starts_before="$(grep -Fxc 'thread-phase3|turn/start' "$lifecycle_fixture_state/provider-writes" || true)"
-if ! lifecycle_pmx_at_anchor agent turn start "uid:$lifecycle_agent_uid" -- "target replacement exact start" >"$lifecycle_root/target-e2-start.out" 2>"$lifecycle_root/target-e2-start.err"; then
-  echo "target same-Agent exact native start failed after replacement epoch" >&2
-  cat "$lifecycle_root/target-e2-start.err" >&2
-  exit 1
-fi
+lifecycle_target_start_deadline="$((SECONDS + 10))"
+lifecycle_target_start_attempts=0
+while true; do
+  lifecycle_target_start_attempts="$((lifecycle_target_start_attempts + 1))"
+  if lifecycle_pmx_at_anchor agent turn start "uid:$lifecycle_agent_uid" -- "target replacement exact start" >"$lifecycle_root/target-e2-start.out" 2>"$lifecycle_root/target-e2-start.err"; then
+    break
+  fi
+  lifecycle_target_starts_during_retry="$(grep -Fxc 'thread-phase3|turn/start' "$lifecycle_fixture_state/provider-writes" || true)"
+  if [[ "$lifecycle_target_starts_during_retry" != "$lifecycle_target_starts_before" ]] ||
+    [[ -s "$lifecycle_root/target-e2-start.out" ]] ||
+    ! grep -Fq '(turn-state-unavailable)' "$lifecycle_root/target-e2-start.err"; then
+    echo "target same-Agent exact native start failed outside bounded fresh-state retry" >&2
+    cat "$lifecycle_root/target-e2-start.err" >&2
+    exit 1
+  fi
+  if ((SECONDS >= lifecycle_target_start_deadline)); then
+    echo "target same-Agent exact native start remained turn-state-unavailable after replacement epoch" >&2
+    cat "$lifecycle_root/target-e2-start.err" >&2
+    exit 1
+  fi
+  sleep 0.025
+done
 lifecycle_target_starts_after="$(grep -Fxc 'thread-phase3|turn/start' "$lifecycle_fixture_state/provider-writes" || true)"
 if [[ "$lifecycle_target_starts_after" != "$((lifecycle_target_starts_before + 1))" ]]; then
   echo "target E2 start did not produce one target-qualified provider write: before=$lifecycle_target_starts_before after=$lifecycle_target_starts_after" >&2
@@ -824,5 +846,5 @@ fi
 
 lifecycle_cleanup
 trap smoke_cleanup_env EXIT
-echo ">> Codex native lifecycle E2E passed: socket=$lifecycle_socket path=$lifecycle_socket_path target-epochs=$epoch_one,$epoch_two sibling-epochs=$sibling_epoch_one,$sibling_epoch_two sibling-steer-writes=0,1"
+echo ">> Codex native lifecycle E2E passed: socket=$lifecycle_socket path=$lifecycle_socket_path target-epochs=$epoch_one,$epoch_two sibling-epochs=$sibling_epoch_one,$sibling_epoch_two sibling-steer-writes=0,1 target-start-attempts=$lifecycle_target_start_attempts"
 smoke_contract_pass


### PR DESCRIPTION
## Acceptance

- Fresh exact active/in-progress state returns `turn-in-progress` with zero start writes.
- Fresh exact idle/terminal state reconciles stale cached state and performs the same start request exactly once.
- Fresh lifecycle read timeout/error, wrong thread, or structurally inconsistent turn state returns `turn-state-unavailable` with zero mutation writes.
- Prompt/turn bodies remain absent from retained state, logs, and errors; no TUI/live fleet/external app-server access is introduced.

## Verification

- `go test ./internal/app -count=1`
- `make fmt`
- `make fix`
- `make test`
- Root review focused test: `go test ./internal/app -run TestExactAgentControl... -count=1`
- Pending on this exact head while CI runs: `make test-integration`, then `make test-e2e`

## Scope audit

Changed only the control epoch, direct epoch coverage, the required controllable test fake, the maintained test list, and minimal hand-maintained CLI guidance. The existing Agent/Pane/runtime/generation/thread/control-epoch and generation-consumer fences remain in force.

Explicitly excluded: Phase 1 steer success/receipt, generic lifecycle transport bounds/recovery, provider schema/generation/qualification, `backlog-overflow`, `observer-timeout`, unrelated cleanup, TUI capture, `activation.turnId` authority, time-threshold inference, and live process manipulation.

## Archive

`30.Projects/Projmux/12.Archive/2026-09-06/로드맵 진행 기록 - agent turn refuses forever on a stale-turn record.md`