### PR TITLE
fix(agent): make steer acceptance explicit

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -355,9 +355,35 @@
   Agent/Pane/runtime/generation/thread binding current across the fresh read,
   while `TestExactAgentControlFreshTerminalReconcileClearsCachedApproval`
   proves that an idle/terminal snapshot repairs stale turn and approval state
-  before the same request starts exactly one new turn. Existing steer,
+  before the same request starts exactly one new turn. Start-specific behavior,
   interrupt, approval, old-epoch, and canonical generation-consumer fences are
-  unchanged.
+  unchanged by the steer admission slice below.
+
+- `make test`: Exact Codex steer admission reuses the content-free lifecycle
+  read and accepts only the cached turn that a fresh snapshot still proves is
+  the same exact active turn. `TestExactAgentControlSteerFreshLifecycleAcceptanceTable`
+  pins the active/idle/terminal/different-turn/unavailable matrix plus exact
+  lifecycle-read-before-steer order and one-or-zero steer wire count;
+  `TestExactAgentControlSteerDifferentTurnReconcilesWithoutRetargetingCurrentRequest`
+  proves reconciliation cannot retarget the current request and only an
+  explicit retry may address the newly observed turn.
+  `TestExactAgentControlSteerPostReadFenceMismatchIsTurnStateUnavailable` and
+  `TestExactAgentControlSteerOldOrCrossEpochReadsAndWritesZero` keep the
+  Agent/Pane/runtime/generation/thread/control-epoch fences closed before the
+  provider write. `TestBodyFreeSteerSuccessIsProviderAcceptanceWithDeliveryUnconfirmed`
+  kills a body-free-success-to-delivery-confirmed mutant by requiring the
+  structured `acceptance=provider`, `delivery=unconfirmed` receipt, while
+  `TestAgentControlCLISteerExactAcceptanceRefusalOutputAndExit` fixes the exact
+  CLI receipt, refusal tokens, and exit 0/1 mapping.
+  `TestAgentControlCLISteerRejectsMissingOrConfirmedDeliveryReceipt` prevents a
+  missing or fabricated delivery acknowledgement from reaching successful CLI
+  output. `make test-e2e E2E_SCENARIO=C01` runs the maintained
+  `test/e2e/codex-lifecycle.sh` replacement-sibling steer: it boundedly retries
+  only `turn-state-unavailable` with stdout and the exact sibling steer ledger
+  held at zero, then requires one qualified provider write and the exact
+  acceptance/unconfirmed-delivery receipt. Retry time is pacing only, never
+  lifecycle authority. Start, interrupt, approval, payload privacy, TUI
+  input/resume, and upstream delivery acknowledgement remain unchanged.
 
 - `make test` / `make test-integration`: Codex public turn control live-binding
   compatibility uses one strict six-field tmux frame. Unit tests accept only

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -450,10 +450,18 @@ id and one text input. Immediately before that write it reads one bounded,
 content-free lifecycle snapshot: fresh active/in-progress returns
 `turn-in-progress`, fresh idle/terminal repairs stale cached state and starts
 once, and an unavailable or inconsistent snapshot returns
-`turn-state-unavailable` with no turn mutation. `steer` supplies the current
-expected turn id; and `interrupt` supplies that exact turn id. These commands
-never install sticky model, effort, cwd, sandbox, permission, or collaboration
-overrides.
+`turn-state-unavailable` with no turn mutation. `steer` also reads that
+content-free snapshot before any write and submits exactly once only when it
+still proves the same exact active turn. Fresh idle, terminal, or different-turn
+state returns `no-active-turn`; an unavailable or inconsistent read, including
+a fence mismatch after the read, returns `turn-state-unavailable`. Both are
+nonzero exits with zero `turn/steer` writes. A successful steer prints the exact
+machine-readable receipt `acceptance=provider delivery=unconfirmed`. Exit zero
+means the provider accepted the body-free `turn/steer` request; it does not
+confirm TUI display, model consumption, or goal continuation. `interrupt`
+supplies the cached exact turn id without adopting the steer preflight in this
+phase. These commands never install sticky model, effort, cwd, sandbox,
+permission, or collaboration overrides.
 
 Approval review shows only the safe one-shot intersection supplied by the
 exact pending request. Command, file, and network requests are limited to

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -239,7 +239,7 @@ Subcommands:
 | Route | Summary |
 | --- | --- |
 | [`projmux agent turn start`](#projmux-agent-turn-start) | Send a new turn to one exact idle Codex thread |
-| [`projmux agent turn steer`](#projmux-agent-turn-steer) | Steer one exact current Codex turn |
+| [`projmux agent turn steer`](#projmux-agent-turn-steer) | Request provider acceptance for one exact current Codex turn; delivery remains unconfirmed |
 | [`projmux agent turn interrupt`](#projmux-agent-turn-interrupt) | Interrupt one exact current Codex turn |
 
 Canonical spelling: `projmux agent turn start`, `projmux agent turn steer`, `projmux agent turn interrupt`
@@ -267,7 +267,7 @@ projmux agent turn start <agent-ref> -- <text>
 
 #### `projmux agent turn steer`
 
-Steer one exact current Codex turn
+Request provider acceptance for one exact current Codex turn; delivery remains unconfirmed
 
 Selectorless authority: `explicit-target` — the route or caller must name the exact target.
 

--- a/internal/app/agent_control.go
+++ b/internal/app/agent_control.go
@@ -382,10 +382,17 @@ func (c *agentCommand) runTurn(args []string, stdout, stderr io.Writer) error {
 		if err := response.Error(); err != nil {
 			return addOpenCodexBindingRecovery(err, binding)
 		}
+		if op == agentControlOpSteer && (response.Acceptance != agentControlAcceptanceProvider || response.Delivery != agentControlDeliveryUnconfirmed) {
+			return addOpenCodexBindingRecovery(&exactAgentControlBindingError{Reason: "turn/steer response did not carry the exact provider-acceptance receipt"}, binding)
+		}
 		if op == agentControlOpStart {
 			if err := c.recordStartedCodexTurn(binding, response); err != nil {
 				return err
 			}
+		}
+		if op == agentControlOpSteer {
+			_, err = fmt.Fprintf(stdout, "%s thread=%s turn=%s acceptance=%s delivery=%s\n", c.agentActionText(label), safeApprovalDetail(response.ThreadID), safeApprovalDetail(response.TurnID), response.Acceptance, response.Delivery)
+			return err
 		}
 		_, err = fmt.Fprintf(stdout, "%s thread=%s turn=%s\n", c.agentActionText(label), safeApprovalDetail(response.ThreadID), safeApprovalDetail(response.TurnID))
 		return err

--- a/internal/app/agent_control_cli_test.go
+++ b/internal/app/agent_control_cli_test.go
@@ -164,7 +164,11 @@ func TestAgentControlCLIExactTurnDispatchAndTextFidelity(t *testing.T) {
 					t.Fatalf("transport binding state=%q endpoint=%+v identity=%+v", stateDir, endpoint, identity)
 				}
 				calls = append(calls, request)
-				return agentControlResponse{OK: true, ThreadID: "thread-1", TurnID: "turn-1"}, nil
+				response := agentControlResponse{OK: true, ThreadID: "thread-1", TurnID: "turn-1"}
+				if request.Operation == agentControlOpSteer {
+					response.Acceptance, response.Delivery = agentControlAcceptanceProvider, agentControlDeliveryUnconfirmed
+				}
+				return response, nil
 			}
 			if _, _, err := runRoute(t, cmd, test.args...); err != nil {
 				t.Fatal(err)
@@ -209,7 +213,11 @@ func TestAgentControlCLIPublicTurnsDispatchFromBothSupportedTmuxFrames(t *testin
 						t.Fatalf("dispatch state=%q endpoint=%+v identity=%+v request=%+v", stateDir, endpoint, identity, request)
 					}
 					calls = append(calls, request)
-					return agentControlResponse{OK: true, ThreadID: "thread-1", TurnID: "turn-1"}, nil
+					response := agentControlResponse{OK: true, ThreadID: "thread-1", TurnID: "turn-1"}
+					if request.Operation == agentControlOpSteer {
+						response.Acceptance, response.Delivery = agentControlAcceptanceProvider, agentControlDeliveryUnconfirmed
+					}
+					return response, nil
 				}
 				if _, _, err := runRoute(t, cmd, turn.args...); err != nil {
 					t.Fatal(err)
@@ -219,6 +227,81 @@ func TestAgentControlCLIPublicTurnsDispatchFromBothSupportedTmuxFrames(t *testin
 				}
 			})
 		}
+	}
+}
+
+func TestAgentControlCLISteerExactAcceptanceRefusalOutputAndExit(t *testing.T) {
+	active := codexappserver.LifecycleSnapshot{
+		ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive,
+		TurnID: "turn-1", TurnState: codexappserver.TurnStateInProgress,
+	}
+	for _, test := range []struct {
+		name       string
+		fresh      codexappserver.LifecycleSnapshot
+		freshErr   error
+		wantCode   string
+		wantExit   int
+		wantSteers int
+		wantOutput string
+		wantOrder  []string
+	}{
+		{
+			name: "provider accepted but delivery unconfirmed", fresh: active, wantSteers: 1,
+			wantOutput: "Steer current turn thread=\"thread-1\" turn=\"turn-1\" acceptance=provider delivery=unconfirmed\n",
+			wantOrder:  []string{"lifecycle-read:thread-1", "turn-steer:thread-1:turn-1"},
+		},
+		{name: "fresh terminal refusal", fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle, TurnID: "turn-1", TurnState: codexappserver.TurnStateCompleted}, wantCode: "no-active-turn", wantExit: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh different turn refusal", fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive, TurnID: "turn-2", TurnState: codexappserver.TurnStateInProgress}, wantCode: "no-active-turn", wantExit: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh unavailable refusal", freshErr: errors.New("private provider detail"), wantCode: "turn-state-unavailable", wantExit: 1, wantOrder: []string{"lifecycle-read:thread-1"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd, _, _ := exactControlCLICommand(t)
+			wire := &fakeExactControlWire{snapshot: test.fresh, snapshotErr: test.freshErr}
+			epoch := newCodexControlEpoch(wire, phase6CLIIdentity(), "epoch-1", active, func(codexLifecycleIdentity) bool { return true })
+			cmd.controlCall = func(_ context.Context, _ string, _ coremetadata.CodexEndpointRef, _ codexLifecycleIdentity, request agentControlRequest) (agentControlResponse, error) {
+				return epoch.Handle(context.Background(), request), nil
+			}
+			stdout, _, err := runRoute(t, cmd, "turn", "steer", "uid:agt-alpha-codex", "--", "private steer payload")
+			exit := 0
+			if err != nil {
+				exit = 1
+				if IsUsageError(err) {
+					exit = 2
+				}
+			}
+			if exit != test.wantExit || stdout != test.wantOutput || wire.reads != 1 || wire.steer != test.wantSteers || !slices.Equal(wire.operations, test.wantOrder) {
+				t.Fatalf("exit=%d stdout=%q err=%v reads=%d steer=%d order=%q", exit, stdout, err, wire.reads, wire.steer, wire.operations)
+			}
+			if test.wantCode != "" && (err == nil || !strings.Contains(err.Error(), "("+test.wantCode+")")) {
+				t.Fatalf("refusal error=%v, want code %s", err, test.wantCode)
+			}
+			if strings.Contains(stdout, "private") || (err != nil && strings.Contains(err.Error(), "private provider")) {
+				t.Fatalf("private detail escaped stdout=%q err=%v", stdout, err)
+			}
+		})
+	}
+}
+
+func TestAgentControlCLISteerRejectsMissingOrConfirmedDeliveryReceipt(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		acceptance string
+		delivery   string
+	}{
+		{name: "missing", acceptance: "", delivery: ""},
+		{name: "fabricated confirmation", acceptance: agentControlAcceptanceProvider, delivery: "confirmed"},
+		{name: "wrong acceptance", acceptance: "tui", delivery: agentControlDeliveryUnconfirmed},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd, _, _ := exactControlCLICommand(t)
+			cmd.controlCall = func(context.Context, string, coremetadata.CodexEndpointRef, codexLifecycleIdentity, agentControlRequest) (agentControlResponse, error) {
+				return agentControlResponse{OK: true, ThreadID: "thread-1", TurnID: "turn-1", Acceptance: test.acceptance, Delivery: test.delivery}, nil
+			}
+			stdout, _, err := runRoute(t, cmd, "turn", "steer", "uid:agt-alpha-codex", "--", "steer")
+			if err == nil || IsUsageError(err) || stdout != "" || !strings.Contains(err.Error(), "provider-acceptance receipt") {
+				t.Fatalf("stdout=%q err=%v", stdout, err)
+			}
+		})
 	}
 }
 

--- a/internal/app/agent_control_epoch.go
+++ b/internal/app/agent_control_epoch.go
@@ -20,6 +20,9 @@ const (
 	agentControlOpInterrupt = "turn-interrupt"
 	agentControlOpApprovals = "approval-list"
 	agentControlOpReview    = "approval-review"
+
+	agentControlAcceptanceProvider  = "provider"
+	agentControlDeliveryUnconfirmed = "unconfirmed"
 )
 
 type agentControlWire interface {
@@ -43,6 +46,8 @@ type agentControlResponse struct {
 	OK           bool                     `json:"ok"`
 	Code         string                   `json:"code,omitempty"`
 	Message      string                   `json:"message,omitempty"`
+	Acceptance   string                   `json:"acceptance,omitempty"`
+	Delivery     string                   `json:"delivery,omitempty"`
 	Availability agentControlAvailability `json:"availability"`
 	Approvals    []agentPendingApproval   `json:"approvals,omitempty"`
 	ThreadID     string                   `json:"threadId,omitempty"`
@@ -215,17 +220,43 @@ func (e *codexControlEpoch) Handle(ctx context.Context, request agentControlRequ
 		e.ambiguous = map[string]struct{}{}
 		return agentControlResponse{OK: true, ThreadID: result.ThreadID, TurnID: result.TurnID}
 	case agentControlOpSteer:
-		if strings.TrimSpace(request.Text) == "" || !e.canMutateCurrentTurn() {
+		if strings.TrimSpace(request.Text) == "" {
 			return refusedControl("stale-turn", "no exact active turn is available to steer")
 		}
-		result, err := e.wire.SteerExactTurn(ctx, e.identity.ThreadID, e.turnID, request.Text)
+		if !e.canMutateCurrentTurn() {
+			return refusedControl("no-active-turn", "no exact active turn is available to steer")
+		}
+		expectedTurnID := e.turnID
+		snapshot, err := e.wire.ReadLifecycleSnapshot(ctx, e.identity.ThreadID)
+		if err != nil || snapshot.ThreadID != e.identity.ThreadID || !validFreshStartSnapshot(snapshot) {
+			return refusedControl("turn-state-unavailable", "fresh exact turn state is unavailable; steer write refused")
+		}
+		// The lifecycle read is content-free and travels through the same exact
+		// connection epoch. Re-check the Agent/Pane/runtime/generation/thread
+		// binding after it returns; this mutex keeps the control epoch fixed.
+		// Reconcile even a terminal or different turn, but never retarget this
+		// request from the cached exact turn to the newly observed one.
+		if !e.current(e.identity) {
+			return refusedControl("turn-state-unavailable", "fresh exact turn state is unavailable; steer write refused")
+		}
+		e.reconcileTurn(snapshot)
+		if e.turnID != expectedTurnID || !e.canMutateCurrentTurn() {
+			return refusedControl("no-active-turn", "no exact active turn is available to steer")
+		}
+		result, err := e.wire.SteerExactTurn(ctx, e.identity.ThreadID, expectedTurnID, request.Text)
 		if err != nil {
 			return controlWireFailure("stale-turn", err)
 		}
-		if result.ThreadID != e.identity.ThreadID || result.TurnID != e.turnID {
+		if result.ThreadID != e.identity.ThreadID || result.TurnID != expectedTurnID {
 			return refusedControl("protocol-error", "turn/steer returned a different identity")
 		}
-		return agentControlResponse{OK: true, ThreadID: result.ThreadID, TurnID: result.TurnID}
+		// A body-free turn/steer response proves only that the provider accepted
+		// the request. It carries no acknowledgement of TUI display, model
+		// consumption, or goal continuation.
+		return agentControlResponse{
+			OK: true, ThreadID: result.ThreadID, TurnID: result.TurnID,
+			Acceptance: agentControlAcceptanceProvider, Delivery: agentControlDeliveryUnconfirmed,
+		}
 	case agentControlOpInterrupt:
 		if !e.canMutateCurrentTurn() {
 			return refusedControl("stale-turn", "no exact active turn is available to interrupt")

--- a/internal/app/agent_control_epoch_test.go
+++ b/internal/app/agent_control_epoch_test.go
@@ -108,7 +108,7 @@ func TestExactAgentControlActionGenerationEpochAndTurnTable(t *testing.T) {
 		wantWrites int
 	}{
 		{name: "idle exact new turn", snapshot: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle, TurnID: "turn-old", TurnState: codexappserver.TurnStateCompleted}, request: agentControlRequest{Operation: agentControlOpStart, Text: "new"}, current: true, wantOK: true, wantReads: 1, wantWrites: 1},
-		{name: "active exact steer", snapshot: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive, TurnID: "turn-1", TurnState: codexappserver.TurnStateInProgress}, request: agentControlRequest{Operation: agentControlOpSteer, Text: "steer"}, current: true, wantOK: true, wantWrites: 1},
+		{name: "active exact steer", snapshot: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive, TurnID: "turn-1", TurnState: codexappserver.TurnStateInProgress}, request: agentControlRequest{Operation: agentControlOpSteer, Text: "steer"}, current: true, wantOK: true, wantReads: 1, wantWrites: 1},
 		{name: "idle steer refused", snapshot: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle, TurnID: "turn-1", TurnState: codexappserver.TurnStateCompleted}, request: agentControlRequest{Operation: agentControlOpSteer, Text: "steer"}, current: true},
 		{name: "old epoch", snapshot: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle}, request: agentControlRequest{Operation: agentControlOpStart, Epoch: "old", Text: "new"}, current: true},
 		{name: "old generation", snapshot: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle}, request: agentControlRequest{Operation: agentControlOpStart, Text: "new", Identity: codexLifecycleIdentity{AgentUID: "agent-1", PaneUID: "pane-1", RuntimeID: "%7", Generation: "old", ThreadID: "thread-1"}}, current: true},
@@ -118,7 +118,7 @@ func TestExactAgentControlActionGenerationEpochAndTurnTable(t *testing.T) {
 		{name: "binding replaced", snapshot: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle}, request: agentControlRequest{Operation: agentControlOpStart, Text: "new"}, current: false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			wire := &fakeExactControlWire{}
+			wire := &fakeExactControlWire{snapshot: test.snapshot}
 			epoch := newCodexControlEpoch(wire, identity, "epoch-1", test.snapshot, func(codexLifecycleIdentity) bool { return test.current })
 			request := test.request
 			if request.Identity == (codexLifecycleIdentity{}) {
@@ -142,6 +142,131 @@ func TestExactAgentControlActionGenerationEpochAndTurnTable(t *testing.T) {
 	}
 	if second := epoch.Handle(context.Background(), request); second.OK || wire.interrupt != 1 {
 		t.Fatalf("second interrupt = %+v writes=%d", second, wire.interrupt)
+	}
+}
+
+func TestExactAgentControlSteerFreshLifecycleAcceptanceTable(t *testing.T) {
+	identity := phase6Identity()
+	active := codexappserver.LifecycleSnapshot{
+		ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive,
+		TurnID: "turn-1", TurnState: codexappserver.TurnStateInProgress,
+	}
+	for _, test := range []struct {
+		name      string
+		fresh     codexappserver.LifecycleSnapshot
+		freshErr  error
+		wantOK    bool
+		wantCode  string
+		wantSteer int
+		wantOrder []string
+	}{
+		{name: "same exact active", fresh: active, wantOK: true, wantSteer: 1, wantOrder: []string{"lifecycle-read:thread-1", "turn-steer:thread-1:turn-1"}},
+		{name: "same exact waiting approval", fresh: activeWithThreadState(codexappserver.ThreadStateWaitingOnApproval), wantOK: true, wantSteer: 1, wantOrder: []string{"lifecycle-read:thread-1", "turn-steer:thread-1:turn-1"}},
+		{name: "same exact waiting input", fresh: activeWithThreadState(codexappserver.ThreadStateWaitingOnUserInput), wantOK: true, wantSteer: 1, wantOrder: []string{"lifecycle-read:thread-1", "turn-steer:thread-1:turn-1"}},
+		{name: "fresh same terminal", fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle, TurnID: "turn-1", TurnState: codexappserver.TurnStateCompleted}, wantCode: "no-active-turn", wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh different active turn", fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive, TurnID: "turn-2", TurnState: codexappserver.TurnStateInProgress}, wantCode: "no-active-turn", wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh different terminal turn", fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle, TurnID: "turn-2", TurnState: codexappserver.TurnStateInterrupted}, wantCode: "no-active-turn", wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh idle before any turn", fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle}, wantCode: "no-active-turn", wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh read error", freshErr: errors.New("private upstream detail"), wantCode: "turn-state-unavailable", wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh wrong thread", fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-other", ThreadState: codexappserver.ThreadStateActive, TurnID: "turn-1", TurnState: codexappserver.TurnStateInProgress}, wantCode: "turn-state-unavailable", wantOrder: []string{"lifecycle-read:thread-1"}},
+		{name: "fresh malformed state", fresh: codexappserver.LifecycleSnapshot{ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateIdle, TurnID: "turn-1", TurnState: codexappserver.TurnStateInProgress}, wantCode: "turn-state-unavailable", wantOrder: []string{"lifecycle-read:thread-1"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			wire := &fakeExactControlWire{snapshot: test.fresh, snapshotErr: test.freshErr}
+			epoch := newCodexControlEpoch(wire, identity, "epoch-1", active, func(codexLifecycleIdentity) bool { return true })
+			response := epoch.Handle(context.Background(), agentControlRequest{
+				Operation: agentControlOpSteer, Identity: identity, Epoch: "epoch-1", Text: "private steer payload",
+			})
+			if response.OK != test.wantOK || response.Code != test.wantCode || wire.reads != 1 || wire.steer != test.wantSteer || !slices.Equal(wire.operations, test.wantOrder) {
+				t.Fatalf("response=%+v reads=%d steer=%d order=%q", response, wire.reads, wire.steer, wire.operations)
+			}
+			if wire.start != 0 || wire.interrupt != 0 || len(wire.responses) != 0 || strings.Contains(response.Message, "private") || strings.Contains(strings.Join(wire.operations, " "), "private") {
+				t.Fatalf("unexpected mutation or private detail: response=%+v wire=%+v", response, wire)
+			}
+			if response.OK && (response.Acceptance != agentControlAcceptanceProvider || response.Delivery != agentControlDeliveryUnconfirmed) {
+				t.Fatalf("success receipt=%+v", response)
+			}
+			if !response.OK && (response.Acceptance != "" || response.Delivery != "") {
+				t.Fatalf("refusal fabricated receipt=%+v", response)
+			}
+		})
+	}
+}
+
+func TestExactAgentControlSteerDifferentTurnReconcilesWithoutRetargetingCurrentRequest(t *testing.T) {
+	identity := phase6Identity()
+	cached := activeWithThreadState(codexappserver.ThreadStateActive)
+	fresh := codexappserver.LifecycleSnapshot{
+		ThreadID: "thread-1", ThreadState: codexappserver.ThreadStateActive,
+		TurnID: "turn-2", TurnState: codexappserver.TurnStateInProgress,
+	}
+	wire := &fakeExactControlWire{snapshot: fresh, turnID: "turn-2"}
+	epoch := newCodexControlEpoch(wire, identity, "epoch-1", cached, func(codexLifecycleIdentity) bool { return true })
+	request := agentControlRequest{Operation: agentControlOpSteer, Identity: identity, Epoch: "epoch-1", Text: "steer"}
+	first := epoch.Handle(context.Background(), request)
+	if first.OK || first.Code != "no-active-turn" || wire.steer != 0 || !slices.Equal(wire.operations, []string{"lifecycle-read:thread-1"}) {
+		t.Fatalf("different-turn request retargeted: response=%+v operations=%q", first, wire.operations)
+	}
+	second := epoch.Handle(context.Background(), request)
+	if !second.OK || wire.steer != 1 || !slices.Equal(wire.operations, []string{"lifecycle-read:thread-1", "lifecycle-read:thread-1", "turn-steer:thread-1:turn-2"}) {
+		t.Fatalf("explicit retry did not use reconciled exact turn: response=%+v operations=%q", second, wire.operations)
+	}
+}
+
+func TestExactAgentControlSteerPostReadFenceMismatchIsTurnStateUnavailable(t *testing.T) {
+	identity := phase6Identity()
+	currentCalls := 0
+	active := activeWithThreadState(codexappserver.ThreadStateActive)
+	wire := &fakeExactControlWire{snapshot: active}
+	epoch := newCodexControlEpoch(wire, identity, "epoch-1", active, func(codexLifecycleIdentity) bool {
+		currentCalls++
+		return currentCalls == 1
+	})
+	response := epoch.Handle(context.Background(), agentControlRequest{Operation: agentControlOpSteer, Identity: identity, Epoch: "epoch-1", Text: "steer"})
+	if response.OK || response.Code != "turn-state-unavailable" || currentCalls != 2 || wire.reads != 1 || wire.writes() != 0 || !slices.Equal(wire.operations, []string{"lifecycle-read:thread-1"}) {
+		t.Fatalf("response=%+v current-calls=%d reads=%d writes=%d order=%q", response, currentCalls, wire.reads, wire.writes(), wire.operations)
+	}
+}
+
+func TestExactAgentControlSteerOldOrCrossEpochReadsAndWritesZero(t *testing.T) {
+	identity := phase6Identity()
+	active := activeWithThreadState(codexappserver.ThreadStateActive)
+	for _, test := range []struct {
+		name    string
+		request agentControlRequest
+	}{
+		{name: "old control epoch", request: agentControlRequest{Operation: agentControlOpSteer, Identity: identity, Epoch: "epoch-old", Text: "steer"}},
+		{name: "cross Agent", request: agentControlRequest{Operation: agentControlOpSteer, Identity: codexLifecycleIdentity{AgentUID: "agent-other", PaneUID: identity.PaneUID, RuntimeID: identity.RuntimeID, Generation: identity.Generation, ThreadID: identity.ThreadID}, Epoch: "epoch-1", Text: "steer"}},
+		{name: "cross Pane", request: agentControlRequest{Operation: agentControlOpSteer, Identity: codexLifecycleIdentity{AgentUID: identity.AgentUID, PaneUID: "pane-other", RuntimeID: identity.RuntimeID, Generation: identity.Generation, ThreadID: identity.ThreadID}, Epoch: "epoch-1", Text: "steer"}},
+		{name: "cross runtime", request: agentControlRequest{Operation: agentControlOpSteer, Identity: codexLifecycleIdentity{AgentUID: identity.AgentUID, PaneUID: identity.PaneUID, RuntimeID: "%8", Generation: identity.Generation, ThreadID: identity.ThreadID}, Epoch: "epoch-1", Text: "steer"}},
+		{name: "cross generation", request: agentControlRequest{Operation: agentControlOpSteer, Identity: codexLifecycleIdentity{AgentUID: identity.AgentUID, PaneUID: identity.PaneUID, RuntimeID: identity.RuntimeID, Generation: "generation-other", ThreadID: identity.ThreadID}, Epoch: "epoch-1", Text: "steer"}},
+		{name: "cross thread", request: agentControlRequest{Operation: agentControlOpSteer, Identity: codexLifecycleIdentity{AgentUID: identity.AgentUID, PaneUID: identity.PaneUID, RuntimeID: identity.RuntimeID, Generation: identity.Generation, ThreadID: "thread-other"}, Epoch: "epoch-1", Text: "steer"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			wire := &fakeExactControlWire{snapshot: active}
+			epoch := newCodexControlEpoch(wire, identity, "epoch-1", active, func(codexLifecycleIdentity) bool { return true })
+			response := epoch.Handle(context.Background(), test.request)
+			if response.OK || response.Code != "stale-epoch" || wire.reads != 0 || wire.writes() != 0 || len(wire.operations) != 0 {
+				t.Fatalf("response=%+v reads=%d writes=%d operations=%q", response, wire.reads, wire.writes(), wire.operations)
+			}
+		})
+	}
+}
+
+func TestBodyFreeSteerSuccessIsProviderAcceptanceWithDeliveryUnconfirmed(t *testing.T) {
+	identity := phase6Identity()
+	active := activeWithThreadState(codexappserver.ThreadStateActive)
+	// fakeExactControlWire returns only ControlResult identity after a nil
+	// turn/steer error, matching the provider's body-free success response.
+	wire := &fakeExactControlWire{snapshot: active}
+	epoch := newCodexControlEpoch(wire, identity, "epoch-1", active, func(codexLifecycleIdentity) bool { return true })
+	response := epoch.Handle(context.Background(), agentControlRequest{Operation: agentControlOpSteer, Identity: identity, Epoch: "epoch-1", Text: "steer"})
+	if !response.OK || response.Acceptance != "provider" || response.Delivery != "unconfirmed" || wire.steer != 1 {
+		t.Fatalf("body-free success receipt=%+v steer-writes=%d", response, wire.steer)
+	}
+	payload, err := json.Marshal(response)
+	if err != nil || !strings.Contains(string(payload), `"acceptance":"provider"`) || !strings.Contains(string(payload), `"delivery":"unconfirmed"`) || strings.Contains(string(payload), `"delivery":"confirmed"`) {
+		t.Fatalf("structured body-free receipt=%s err=%v", payload, err)
 	}
 }
 

--- a/internal/app/ai_ingest_codex_native_test.go
+++ b/internal/app/ai_ingest_codex_native_test.go
@@ -905,7 +905,7 @@ func TestCodexNativeObserverReadyHandshakeSteersAndShutdownRemovesControlSocket(
 		<-done
 		t.Skip("Unix sockets are unavailable in this sandbox")
 	}
-	if err != nil || !response.OK || wire.writes() != 1 {
+	if err != nil || !response.OK || response.Acceptance != agentControlAcceptanceProvider || response.Delivery != agentControlDeliveryUnconfirmed || wire.writes() != 1 {
 		cancel()
 		<-done
 		t.Fatalf("exact steer response=%+v err=%v writes=%d", response, err, wire.writes())

--- a/internal/cli/canonical_graph_test.go
+++ b/internal/cli/canonical_graph_test.go
@@ -15,7 +15,9 @@ import (
 // one digest, so any change to the public command contract has to be made on
 // purpose.
 //
-// The baseline moved once here, when the Project lifecycle verbs were added:
+// The baseline last moved when steer's public summary began distinguishing
+// provider acceptance from unconfirmed delivery. The prior move added the
+// Project lifecycle verbs:
 // `start|open|stop project` and the canonical `unregister project` are new
 // rows, `delete` became a source edge of the last of those instead of a
 // canonical owner, `switch` became a source of `create project` and
@@ -30,7 +32,7 @@ func TestCanonicalCommandGraphProjectionMatchesBaseline(t *testing.T) {
 			route.Spelling, route.Summary, strings.Join(route.Sources, ","),
 			outputModesString(route.Outputs), fieldProjectionsString(route.Fields))
 	}
-	const want = "07c4f3a5a49806e6a9567de1a9165a3a8137feeeb05b8304d5207a88ce078a5b"
+	const want = "5abd90fbd6dd851124fead66ec4aca92e5f442991b7963ba0f78c50e8e302b76"
 	if got := fmt.Sprintf("%x", sha256.Sum256([]byte(baseline.String()))); got != want {
 		t.Fatalf("canonical command projection digest = %s, want %s\n%s", got, want, baseline.String())
 	}

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -784,7 +784,7 @@ var routes = []Route{
 				Canonical:  []string{"agent turn start", "agent turn steer", "agent turn interrupt"},
 				Children: []Route{
 					{Effects: unchangedEffects(CardinalityExactOne), Name: "start", Invocation: InvocationExplicit, Summary: "Send a new turn to one exact idle Codex thread", Usage: []string{"projmux agent turn start <agent-ref> -- <text>"}, Canonical: []string{"agent turn start"}},
-					{Effects: unchangedEffects(CardinalityExactOne), Name: "steer", Invocation: InvocationExplicit, Summary: "Steer one exact current Codex turn", Usage: []string{"projmux agent turn steer <agent-ref> -- <text>"}, Canonical: []string{"agent turn steer"}},
+					{Effects: unchangedEffects(CardinalityExactOne), Name: "steer", Invocation: InvocationExplicit, Summary: "Request provider acceptance for one exact current Codex turn; delivery remains unconfirmed", Usage: []string{"projmux agent turn steer <agent-ref> -- <text>"}, Canonical: []string{"agent turn steer"}},
 					{Effects: unchangedEffects(CardinalityExactOne), Name: "interrupt", Invocation: InvocationExplicit, Summary: "Interrupt one exact current Codex turn", Usage: []string{"projmux agent turn interrupt <agent-ref>"}, Canonical: []string{"agent turn interrupt"}},
 				},
 			},

--- a/test/e2e/codex-lifecycle.sh
+++ b/test/e2e/codex-lifecycle.sh
@@ -788,8 +788,38 @@ if [[ "$lifecycle_sibling_writes_before" != "0" ]]; then
   echo "sibling steer ledger was not empty before its exact reconnect receipt: writes=$lifecycle_sibling_writes_before" >&2
   exit 1
 fi
-if ! lifecycle_pmx_at_anchor agent turn steer "uid:$lifecycle_sibling_agent_uid" -- "sibling replacement steer" >"$lifecycle_root/sibling-replacement-steer.out" 2>"$lifecycle_root/sibling-replacement-steer.err"; then
-  echo "healthy sibling native steer failed after its replacement barrier" >&2
+# The replacement barrier proves semantic projection and the new control epoch,
+# but the broker's bounded same-thread lifecycle read may still be completing.
+# Retry only that exact content-free read refusal. Every refused attempt must
+# keep both stdout and the exact sibling steer ledger empty; elapsed time paces
+# retries and never supplies turn authority.
+lifecycle_sibling_steer_deadline="$((SECONDS + 10))"
+lifecycle_sibling_steer_attempts=0
+while true; do
+  lifecycle_sibling_steer_attempts="$((lifecycle_sibling_steer_attempts + 1))"
+  if lifecycle_pmx_at_anchor agent turn steer "uid:$lifecycle_sibling_agent_uid" -- "sibling replacement steer" >"$lifecycle_root/sibling-replacement-steer.out" 2>"$lifecycle_root/sibling-replacement-steer.err"; then
+    break
+  fi
+  lifecycle_sibling_writes_during_retry="$(grep -Fxc 'thread-sibling|turn/steer' "$lifecycle_fixture_state/provider-writes" || true)"
+  if [[ "$lifecycle_sibling_writes_during_retry" != "$lifecycle_sibling_writes_before" ]] ||
+    [[ -s "$lifecycle_root/sibling-replacement-steer.out" ]] ||
+    ! grep -Fq '(turn-state-unavailable)' "$lifecycle_root/sibling-replacement-steer.err" ||
+    grep -Eo '\([a-z][a-z0-9-]*\)' "$lifecycle_root/sibling-replacement-steer.err" | grep -Fvx '(turn-state-unavailable)' >/dev/null; then
+    echo "healthy sibling native steer failed outside bounded fresh-state retry" >&2
+    cat "$lifecycle_root/sibling-replacement-steer.err" >&2
+    exit 1
+  fi
+  if ((SECONDS >= lifecycle_sibling_steer_deadline)); then
+    echo "healthy sibling native steer remained turn-state-unavailable after its replacement barrier" >&2
+    cat "$lifecycle_root/sibling-replacement-steer.err" >&2
+    exit 1
+  fi
+  sleep 0.025
+done
+if [[ -s "$lifecycle_root/sibling-replacement-steer.err" ]] ||
+  ! grep -Fqx 'Steer current turn thread="thread-sibling" turn="turn-sibling" acceptance=provider delivery=unconfirmed' "$lifecycle_root/sibling-replacement-steer.out"; then
+  echo "sibling replacement steer success did not expose exact provider acceptance and unconfirmed delivery" >&2
+  cat "$lifecycle_root/sibling-replacement-steer.out" >&2
   cat "$lifecycle_root/sibling-replacement-steer.err" >&2
   exit 1
 fi
@@ -846,5 +876,5 @@ fi
 
 lifecycle_cleanup
 trap smoke_cleanup_env EXIT
-echo ">> Codex native lifecycle E2E passed: socket=$lifecycle_socket path=$lifecycle_socket_path target-epochs=$epoch_one,$epoch_two sibling-epochs=$sibling_epoch_one,$sibling_epoch_two sibling-steer-writes=0,1 target-start-attempts=$lifecycle_target_start_attempts"
+echo ">> Codex native lifecycle E2E passed: socket=$lifecycle_socket path=$lifecycle_socket_path target-epochs=$epoch_one,$epoch_two sibling-epochs=$sibling_epoch_one,$sibling_epoch_two sibling-steer-writes=0,1 sibling-steer-attempts=$lifecycle_sibling_steer_attempts target-start-attempts=$lifecycle_target_start_attempts"
 smoke_contract_pass


### PR DESCRIPTION
## Summary
- preflight steer against a fresh content-free lifecycle snapshot and refuse stale, terminal, different-turn, or unavailable state without a steer write
- expose provider acceptance separately from delivery=unconfirmed in the structured control response and exact CLI output
- preserve start, interrupt, approval, and payload-privacy contracts with deterministic control/CLI regressions

## Validation
- make fmt
- make fix
- make test
- focused exact steer control/CLI/local-socket tests
- make test-integration (in progress)
- make test-e2e (pending)

## Scope
Phase 1 only. No upstream delivery acknowledgement, TUI injection/resume, start-admission redesign, generic lifecycle transport/schema/generation change, or live app-server/fleet mutation.