### PR TITLE
feat(agent): add provider-neutral message broker

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1088,6 +1088,48 @@
   `config apply --no-reload` byte-identical for both absent and present
   coordination families.
 
+### Provider-neutral message broker Phase 3 tests
+
+- `TestAgentCapabilityCatalogPinsCurrentGroupsAndDeferredVocabulary`,
+  `TestAgentCapabilitiesClaudeMessageCellsReflectMissingRegistrationLease`, and
+  `TestAgentCapabilityCatalogRoutesMatchExecutableHelpGraph` supersede the Phase
+  0 placeholder boundary: `agent message send|wait|status` and `agent wait` are
+  callable through one provider-neutral catalog, while Antigravity and Claude
+  inbox claim remain explicit unsupported cells and exact Claude availability
+  follows its current registration lease.
+- `TestAuthorityMatrixIsExhaustiveAndPeerNeverEscalates`,
+  `TestEnvelopeRetryAndReplyCorrelationRandomizedProperties`, and
+  `TestPublicReducerMatchesReferenceModelForRandomSequences` own the exhaustive
+  authority table, immutable v1 envelope, exact reversed reply route and
+  conversation, idempotent message reference, and terminal-once public reducer.
+  Peer input remains untrusted coordination and cannot become a user turn,
+  approval, configuration, tool, connector, or model-history write.
+- The `TestStore*` suite owns the private 0700/0600 store, advisory locking,
+  atomic replace, bounded payload/file/record count, terminal retention,
+  unknown-field refusal, concurrent claim, restart, timeout, and post-handoff
+  `failed` plus unknown-outcome contract. Codex claim touches only the exact
+  activation-scoped inbox and leaves unrelated Claude records unchanged.
+- `TestAgentMessageSendGatesBothStaticCellsAndRoutesBeforeStoreOrAdapter`,
+  `TestAgentMessageUnsupportedProviderStopsBeforeRouteAndStore`,
+  `TestAgentMessageSendSameReferenceRetryKeepsBrokerCorrelationAndDoesNotResend`,
+  `TestAgentMessageConcurrentSameReferenceUsesOneConversation`, and
+  `TestAgentMessageReplyReturnsOnlyToOriginalSourceConversation` pin exact
+  current-Pane source authority, exact target eligibility before effects,
+  same-envelope retry without resend, and broker-owned reply correlation.
+- `TestClaudePrivateProjectionPreservesPublicBoundaryAndAmbiguity`,
+  `TestLiveClaudeAdapterMapsTerminalResponseKindsWithoutDelivery`,
+  `TestLiveClaudeAdapterRefusesPublicValidEnvelopeThatExceedsPrivateFrame`, and
+  `TestAgentMessageBrokerHasNoCodexOrUserTurnWritePath` own the Phase 2 Claude
+  projection, transport-bound refusal, foreign receipt no-op, and zero Codex
+  app-server, user-turn, raw-terminal, or model-history write path.
+- `TestAgentMessageWaitClaimsOnlyCurrentExactActivation`,
+  `TestAgentMessageClaimDefaultOutputEscapesTerminalControlsAndKeepsEnvelope`,
+  `TestAgentMessageWaitDetectsGenerationChangeBeforeClaim`, and
+  `TestAgentWaitRegistryIdleReadyTimeoutAndStale` pin full-envelope self-claim,
+  terminal-safe output, activation fencing, and deterministic Registry-only
+  idle, timeout, and stale waits. Codex `delivered` ends at target self-claim;
+  it does not assert model processing or reply.
+
 ### Provider hook pane identity tests
 
 - `TestProviderHookCommandsCarryTheirOwnPaneIdentity` and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,7 +39,7 @@ Root parser bridges outside the route graph are censused from their parser token
 
 Every route declares one allowed-effect record over seven independent resource axes. A pipe separates conditional success outcomes; preflight refusal remains zero-effect. `domain-effect=null` means the route has no typed extension beyond this resource tuple.
 
-The machine-readable manifest contains 184 route-effect records, including hidden plumbing that the public route sections omit.
+The machine-readable manifest contains 189 route-effect records, including hidden plumbing that the public route sections omit.
 
 | Axis | Closed vocabulary |
 | --- | --- |
@@ -60,7 +60,7 @@ projmux <command> [args...]
 
 | Command | Kind | Summary |
 | --- | --- | --- |
-| [`projmux agent`](#projmux-agent) | canonical | Manage Agent state, topic, capabilities, integrations, and account usage |
+| [`projmux agent`](#projmux-agent) | canonical | Manage Agent state, messages, waits, capabilities, integrations, and account usage |
 | [`projmux attention`](#projmux-attention) | canonical | View and manage live tmux pane attention state |
 | [`projmux attach`](#projmux-attach) | canonical | Enter a Project runtime from outside tmux |
 | [`projmux config`](#projmux-config) | canonical | Edit AI split-mode settings; render or apply generated tmux configuration |
@@ -98,7 +98,7 @@ projmux <command> [args...]
 
 ## `projmux agent`
 
-Manage Agent state, topic, capabilities, integrations, and account usage
+Manage Agent state, messages, waits, capabilities, integrations, and account usage
 
 Selectorless authority: `refusal` — there is no safe selectorless action; refuse before output or mutation.
 
@@ -129,6 +129,10 @@ projmux agent app-server upgrade resume|abort --operation <ref>
 projmux agent app-server handover plan|apply --request <absolute-json>
 projmux agent app-server handover resume|abort --operation <ref>
 projmux agent capabilities [<agent-ref> | --provider <codex|claude|antigravity>] [-o json]
+projmux agent message send <agent-ref> [--message-ref <ref>] [--reply-to <ref>] [--ttl <duration>] -- <text>
+projmux agent message wait [<self-agent-ref>] [--timeout <duration>] [-o json]
+projmux agent message status <message-ref> [-o json]
+projmux agent wait <agent-ref> [--until idle] [--timeout <duration>] [-o json]
 ```
 
 Subcommands:
@@ -145,8 +149,10 @@ Subcommands:
 | [`projmux agent usage`](#projmux-agent-usage) | Read provider account usage quota snapshots |
 | [`projmux agent app-server`](#projmux-agent-app-server) | Manage explicitly requested private Codex app-server generation operations |
 | [`projmux agent capabilities`](#projmux-agent-capabilities) | Read static provider support or one exact Agent's Registry-backed runtime eligibility |
+| [`projmux agent message`](#projmux-agent-message) | Exchange bounded untrusted coordination messages through exact Agent activations |
+| [`projmux agent wait`](#projmux-agent-wait) | Wait read-only for one exact Agent's Registry-backed idle observation |
 
-Canonical spelling: `projmux agent status`, `projmux agent topic`, `projmux agent resume`, `projmux agent turn start`, `projmux agent turn steer`, `projmux agent turn interrupt`, `projmux agent approval review`, `projmux agent review`, `projmux agent integrate`, `projmux agent usage`, `projmux agent app-server upgrade plan`, `projmux agent app-server upgrade apply`, `projmux agent app-server upgrade resume`, `projmux agent app-server upgrade abort`, `projmux agent app-server handover plan`, `projmux agent app-server handover apply`, `projmux agent app-server handover resume`, `projmux agent app-server handover abort`, `projmux agent capabilities`
+Canonical spelling: `projmux agent status`, `projmux agent topic`, `projmux agent resume`, `projmux agent turn start`, `projmux agent turn steer`, `projmux agent turn interrupt`, `projmux agent approval review`, `projmux agent review`, `projmux agent integrate`, `projmux agent usage`, `projmux agent app-server upgrade plan`, `projmux agent app-server upgrade apply`, `projmux agent app-server upgrade resume`, `projmux agent app-server upgrade abort`, `projmux agent app-server handover plan`, `projmux agent app-server handover apply`, `projmux agent app-server handover resume`, `projmux agent app-server handover abort`, `projmux agent capabilities`, `projmux agent message send`, `projmux agent message wait`, `projmux agent message status`, `projmux agent wait`
 
 ### `projmux agent status`
 
@@ -701,6 +707,129 @@ Allowed effects:
 
 ```
 projmux agent capabilities [<agent-ref> | --provider <codex|claude|antigravity>] [-o json]
+```
+
+Output modes (`-o`): `json`
+
+### `projmux agent message`
+
+Exchange bounded untrusted coordination messages through exact Agent activations
+
+Selectorless authority: `refusal` — there is no safe selectorless action; refuse before output or mutation.
+
+Allowed effects:
+
+- `identity=unchanged`
+- `address=unchanged`
+- `topology=unchanged`
+- `desired-state=unchanged`
+- `runtime=unchanged`
+- `focus=unchanged`
+- `cardinality=exact-one`
+- `domain-effect=agent-delivery`
+
+```
+projmux agent message send <agent-ref> [--message-ref <ref>] [--reply-to <ref>] [--ttl <duration>] -- <text>
+projmux agent message wait [<self-agent-ref>] [--timeout <duration>] [-o json]
+projmux agent message status <message-ref> [-o json]
+```
+
+Subcommands:
+
+| Route | Summary |
+| --- | --- |
+| [`projmux agent message send`](#projmux-agent-message-send) | Submit a bounded coordination message from the current exact Agent |
+| [`projmux agent message wait`](#projmux-agent-message-wait) | Claim the oldest compatible message for the current exact Codex Agent |
+| [`projmux agent message status`](#projmux-agent-message-status) | Read a payload-free broker delivery receipt |
+
+Canonical spelling: `projmux agent message send`, `projmux agent message wait`, `projmux agent message status`
+
+#### `projmux agent message send`
+
+Submit a bounded coordination message from the current exact Agent
+
+Selectorless authority: `explicit-target` — the route or caller must name the exact target.
+
+Allowed effects:
+
+- `identity=unchanged`
+- `address=unchanged`
+- `topology=unchanged`
+- `desired-state=unchanged`
+- `runtime=unchanged`
+- `focus=unchanged`
+- `cardinality=exact-one`
+- `domain-effect=agent-delivery`
+
+```
+projmux agent message send <agent-ref> [--message-ref <ref>] [--reply-to <ref>] [--ttl <duration>] -- <text>
+```
+
+#### `projmux agent message wait`
+
+Claim the oldest compatible message for the current exact Codex Agent
+
+Selectorless authority: `natural-omitted` — omission resolves one predictable current resource or documented contextual read/scope; any selector replaces it.
+
+Allowed effects:
+
+- `identity=unchanged`
+- `address=unchanged`
+- `topology=unchanged`
+- `desired-state=unchanged`
+- `runtime=unchanged`
+- `focus=unchanged`
+- `cardinality=exact-one`
+- `domain-effect=agent-delivery`
+
+```
+projmux agent message wait [<self-agent-ref>] [--timeout <duration>] [-o json]
+```
+
+Output modes (`-o`): `json`
+
+#### `projmux agent message status`
+
+Read a payload-free broker delivery receipt
+
+Selectorless authority: `explicit-target` — the route or caller must name the exact target.
+
+Allowed effects:
+
+- `identity=unchanged`
+- `address=unchanged`
+- `topology=unchanged`
+- `desired-state=unchanged`
+- `runtime=unchanged`
+- `focus=unchanged`
+- `cardinality=unchanged`
+- `domain-effect=agent-delivery`
+
+```
+projmux agent message status <message-ref> [-o json]
+```
+
+Output modes (`-o`): `json`
+
+### `projmux agent wait`
+
+Wait read-only for one exact Agent's Registry-backed idle observation
+
+Selectorless authority: `explicit-target` — the route or caller must name the exact target.
+
+Allowed effects:
+
+- `identity=unchanged`
+- `address=unchanged`
+- `topology=unchanged`
+- `desired-state=unchanged`
+- `runtime=unchanged`
+- `focus=unchanged`
+- `cardinality=exact-one`
+- `domain-effect=null`
+
+```
+projmux agent wait <agent-ref> [--until idle] [--timeout <duration>] [-o json]
 ```
 
 Output modes (`-o`): `json`

--- a/internal/aiprovider/capabilities.go
+++ b/internal/aiprovider/capabilities.go
@@ -16,6 +16,7 @@ const (
 	SupportNativeExact     AgentSupportMode = "native-exact-control"
 	SupportProviderHook    AgentSupportMode = "provider-hook"
 	SupportReadOnlyAdapter AgentSupportMode = "read-only-adapter"
+	SupportCoordination    AgentSupportMode = "coordination-broker"
 	SupportUnsupported     AgentSupportMode = "unsupported"
 )
 
@@ -36,6 +37,10 @@ const (
 	CompletionPlanPreview       CompletionPrecision = "plan-preview"
 	CompletionLocalConfigCommit CompletionPrecision = "local-config-commit"
 	CompletionProviderSnapshot  CompletionPrecision = "provider-snapshot"
+	CompletionBrokerAccepted    CompletionPrecision = "broker-accepted"
+	CompletionTargetClaim       CompletionPrecision = "target-self-claim"
+	CompletionDeliveryReceipt   CompletionPrecision = "delivery-receipt"
+	CompletionInteractionIdle   CompletionPrecision = "interaction-idle"
 )
 
 // AgentCapabilityCell is one and only one provider cell for an action.
@@ -79,10 +84,23 @@ func codexOnly(precision CompletionPrecision) []AgentCapabilityCell {
 	return out
 }
 
+func coordination(precision CompletionPrecision, providers ...ID) []AgentCapabilityCell {
+	out := make([]AgentCapabilityCell, 0, len(providerOrder))
+	for _, provider := range AgentProviders() {
+		cell := AgentCapabilityCell{Provider: provider, Mode: SupportUnsupported, CompletionPrecision: CompletionNone}
+		if slices.Contains(providers, provider) {
+			cell.Mode = SupportCoordination
+			cell.CompletionPrecision = precision
+		}
+		out = append(out, cell)
+	}
+	return out
+}
+
 // agentActions is the authoritative action x provider matrix. The first nine
 // groups are the current public `projmux agent` groups. message and wait are
-// reserved provider-neutral vocabulary only; Phase 0 intentionally gives them
-// no route and no parser surface.
+// provider-neutral coordination actions; unsupported provider directions stay
+// explicit cells rather than falling through to another transport.
 var agentActions = []AgentAction{
 	{ID: "status.get", Group: "status", Route: "agent status", Callable: true, Cells: cells(SupportGenericRegistry, CompletionRegistryRead)},
 	{ID: "status.set", Group: "status", Route: "agent status", Callable: true, Cells: cells(SupportGenericRegistry, CompletionRegistryCommit)},
@@ -107,10 +125,10 @@ var agentActions = []AgentAction{
 	{ID: "app-server.handover.apply", Group: "app-server", Route: "agent app-server handover apply", Callable: true, Cells: codexOnly(CompletionExactOperation)},
 	{ID: "app-server.handover.resume", Group: "app-server", Route: "agent app-server handover resume", Callable: true, Cells: codexOnly(CompletionExactOperation)},
 	{ID: "app-server.handover.abort", Group: "app-server", Route: "agent app-server handover abort", Callable: true, Cells: codexOnly(CompletionExactOperation)},
-	{ID: "message.send", Group: "message", Callable: false, Cells: cells(SupportUnsupported, CompletionNone)},
-	{ID: "message.wait", Group: "message", Callable: false, Cells: cells(SupportUnsupported, CompletionNone)},
-	{ID: "message.status", Group: "message", Callable: false, Cells: cells(SupportUnsupported, CompletionNone)},
-	{ID: "wait.idle", Group: "wait", Callable: false, Cells: cells(SupportUnsupported, CompletionNone)},
+	{ID: "message.send", Group: "message", Route: "agent message send", Callable: true, Cells: coordination(CompletionBrokerAccepted, Codex, Claude)},
+	{ID: "message.wait", Group: "message", Route: "agent message wait", Callable: true, Cells: coordination(CompletionTargetClaim, Codex)},
+	{ID: "message.status", Group: "message", Route: "agent message status", Callable: true, Cells: coordination(CompletionDeliveryReceipt, Codex, Claude)},
+	{ID: "wait.idle", Group: "wait", Route: "agent wait", Callable: true, Cells: cells(SupportGenericRegistry, CompletionInteractionIdle)},
 }
 
 // IntegrationTarget is a target accepted by `agent integrate`. tmux-bell is a

--- a/internal/aiprovider/capabilities_test.go
+++ b/internal/aiprovider/capabilities_test.go
@@ -53,17 +53,22 @@ func TestAgentCapabilityCatalogIsClosedCartesianMatrix(t *testing.T) {
 func TestAgentCapabilityCatalogPinsCurrentGroupsAndDeferredVocabulary(t *testing.T) {
 	t.Parallel()
 
-	wantGroups := []string{"status", "topic", "resume", "turn", "approval", "review", "integrate", "usage", "app-server"}
+	wantGroups := []string{"status", "topic", "resume", "turn", "approval", "review", "integrate", "usage", "app-server", "message", "wait"}
 	if got := AgentGroups(); !reflect.DeepEqual(got, wantGroups) {
 		t.Fatalf("groups = %v, want %v", got, wantGroups)
 	}
 	for _, id := range []string{"message.send", "message.wait", "message.status", "wait.idle"} {
 		for _, provider := range AgentProviders() {
-			action, cell, ok := LookupAgentCapability(id, provider)
-			if !ok || action.Callable || action.Route != "" || cell.Mode != SupportUnsupported || cell.CompletionPrecision != CompletionNone {
-				t.Errorf("%s/%s = action %#v cell %#v", id, provider, action, cell)
+			action, _, ok := LookupAgentCapability(id, provider)
+			if !ok || !action.Callable || action.Route == "" {
+				t.Errorf("%s/%s = action %#v", id, provider, action)
 			}
 		}
+	}
+	_, antigravitySend, _ := LookupAgentCapability("message.send", Antigravity)
+	_, claudeWait, _ := LookupAgentCapability("message.wait", Claude)
+	if antigravitySend.Mode != SupportUnsupported || claudeWait.Mode != SupportUnsupported {
+		t.Fatalf("unsupported coordination directions changed: antigravity send=%#v claude wait=%#v", antigravitySend, claudeWait)
 	}
 }
 

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -67,6 +67,13 @@ type agentCommand struct {
 	controlPaths   agentControlPathResolver
 	controlPicker  agentControlPicker
 	controlTimeout time.Duration
+	messageStore   agentMessageStore
+	messagePaths   agentMessagePaths
+	messageNow     func() time.Time
+	messageSleep   func(context.Context, time.Duration) error
+	messageNewRef  func(string) string
+	messageClaude  agentMessageClaudeAdapter
+	messageRoute   agentMessageRouteResolver
 	focus          rawArgvCommand
 	codexUpgrade   rawArgvCommand
 	codexHandover  rawArgvCommand
@@ -78,7 +85,7 @@ type codexDrainingHandoverRequester interface {
 }
 
 func newAgentCommand() *agentCommand {
-	return &agentCommand{
+	command := &agentCommand{
 		loadRegistry:     loadResourceRegistry,
 		store:            newResourceStore(),
 		activeTarget:     defaultActiveTargetLookup(),
@@ -96,7 +103,17 @@ func newAgentCommand() *agentCommand {
 		controlPaths:   config.DefaultPathsFromEnv,
 		controlPicker:  intpicker.NativeRunner{In: os.Stdin, Out: os.Stdout},
 		controlTimeout: 10 * time.Second,
+		messageNow:     time.Now,
+		messageSleep:   waitAgentMessagePoll,
+		messageNewRef:  newCoordinationRef,
+		messageClaude:  liveAgentMessageClaudeAdapter{},
 	}
+	if paths, err := config.DefaultPathsFromEnv(); err == nil {
+		command.messagePaths = defaultAgentMessagePaths(paths)
+		command.messageStore = newAgentMessageStore(paths.StateDir)
+		command.messageRoute = liveAgentMessageRouteResolver{registryPath: command.messagePaths.registryPath}
+	}
+	return command
 }
 
 func (c *agentCommand) clock() time.Time {
@@ -146,6 +163,10 @@ func (c *agentCommand) Run(args []string, stdout, stderr io.Writer) error {
 		}
 	case "capabilities":
 		return c.runCapabilities(rest, stdout, stderr)
+	case "message":
+		return c.runMessage(rest, stdout, stderr)
+	case "wait":
+		return c.runWait(rest, stdout, stderr)
 	default:
 		return usageError(fmt.Sprintf("agent %s is not available; this release implements: %s",
 			args[0], strings.Join(agentSubcommands, ", ")))

--- a/internal/app/agent_capabilities.go
+++ b/internal/app/agent_capabilities.go
@@ -112,6 +112,14 @@ func (c *agentCommand) runCapabilities(args []string, stdout, stderr io.Writer) 
 		projection = projectExactAgentCapabilities(registry, agent, metadata.ID)
 		if metadata.ID == aiprovider.Claude {
 			projection.Runtime.Coordination = projectClaudeCoordinationEligibility(registry, agent)
+			for i := range projection.Capabilities {
+				if projection.Capabilities[i].Action != "message.send" && projection.Capabilities[i].Action != "message.status" {
+					continue
+				}
+				projection.Capabilities[i].Available = &projection.Runtime.Coordination.Eligible
+				projection.Capabilities[i].Evidence = projection.Runtime.Coordination.Evidence
+				projection.Capabilities[i].Reason = projection.Runtime.Coordination.Reason
+			}
 		}
 	}
 	return writeAgentCapabilityProjection(stdout, projection, jsonOutput)
@@ -130,7 +138,7 @@ func projectClaudeCoordinationEligibility(registry coremetadata.Registry, agent 
 		return projection
 	}
 	projection.Eligible = true
-	projection.Reason = "exact local registration lease is ready; message delivery is unavailable"
+	projection.Reason = "exact local registration lease is ready for coordination delivery"
 	return projection
 }
 
@@ -216,6 +224,14 @@ func exactAgentActionEligibility(registry coremetadata.Registry, agent coremetad
 		if reason := exactCodexReviewRegistryReason(registry, agent); reason != "" {
 			return false, reason
 		}
+	case "message.send", "message.wait", "message.status":
+		if _, reason := coremetadata.ResolveAgentRoute(registry, agent.Metadata.UID); reason != "" {
+			return false, reason
+		}
+	case "wait.idle":
+		if reason := exactAgentActivationReason(registry, agent); reason != "" {
+			return false, reason
+		}
 	default:
 		if mode == aiprovider.SupportNativeExact {
 			if reason := exactCodexControlRegistryReason(registry, agent); reason != "" {
@@ -224,6 +240,19 @@ func exactAgentActionEligibility(registry coremetadata.Registry, agent coremetad
 		}
 	}
 	return true, "eligible from current Registry evidence"
+}
+
+func exactAgentActivationReason(registry coremetadata.Registry, agent coremetadata.Agent) string {
+	if agent.Status.Phase != coremetadata.PhaseRunning || agent.Status.PaneRef == "" {
+		return "requires a Running Agent with a current managed Pane"
+	}
+	pane, ok := registry.Pane(agent.Status.PaneRef)
+	if !ok || pane.Spec.Role != coremetadata.PaneRoleAgent || pane.Metadata.OwnerRef == nil ||
+		pane.Metadata.OwnerRef.Kind != coremetadata.KindAgent || pane.Metadata.OwnerRef.UID != agent.Metadata.UID ||
+		pane.Status.Activation.AgentUID != agent.Metadata.UID || pane.Status.Activation.Generation == "" || pane.Status.Activation.RuntimeID == "" {
+		return "managed Agent activation identity is incomplete"
+	}
+	return ""
 }
 
 func slicesContainsAgentPhase(phases []coremetadata.AgentPhase, phase coremetadata.AgentPhase) bool {

--- a/internal/app/agent_capabilities_test.go
+++ b/internal/app/agent_capabilities_test.go
@@ -105,11 +105,38 @@ func TestAgentCapabilitiesExactProjectionSeparatesRuntimeEpochAndAvailability(t 
 	for _, entry := range projection.Capabilities {
 		entries[entry.Action] = entry
 	}
-	if entries["turn.start"].Available == nil || !*entries["turn.start"].Available || entries["message.send"].Available == nil || *entries["message.send"].Available {
-		t.Fatalf("native/future availability = start:%#v send:%#v", entries["turn.start"], entries["message.send"])
+	if entries["turn.start"].Available == nil || !*entries["turn.start"].Available || entries["message.send"].Available == nil || !*entries["message.send"].Available {
+		t.Fatalf("native/coordination availability = start:%#v send:%#v", entries["turn.start"], entries["message.send"])
 	}
 	if entries["turn.start"].Evidence != "registry" || entries["message.send"].Evidence != "registry" {
 		t.Fatalf("per-action evidence = start:%#v send:%#v", entries["turn.start"], entries["message.send"])
+	}
+}
+
+func TestAgentCapabilitiesClaudeMessageCellsReflectMissingRegistrationLease(t *testing.T) {
+	h := newSessionRefHarness(t, aiModeClaude)
+	active := insideTmux(h.paneUID, "")
+	cmd := &agentCommand{activeTarget: active.lookup, loadRegistry: func() (coremetadata.Registry, error) {
+		return h.registry.Clone(), nil
+	}}
+	var stdout, stderr bytes.Buffer
+	if err := cmd.Run([]string{"capabilities", "uid:" + h.agentUID, "-o", "json"}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	var projection agentCapabilityProjection
+	if err := json.Unmarshal(stdout.Bytes(), &projection); err != nil {
+		t.Fatal(err)
+	}
+	if projection.Runtime == nil || projection.Runtime.Coordination == nil || projection.Runtime.Coordination.Eligible {
+		t.Fatalf("coordination eligibility = %#v", projection.Runtime)
+	}
+	for _, entry := range projection.Capabilities {
+		if entry.Action != "message.send" && entry.Action != "message.status" {
+			continue
+		}
+		if entry.Available == nil || *entry.Available || entry.Reason != projection.Runtime.Coordination.Reason {
+			t.Fatalf("%s did not reflect lease failure: %#v coordination=%#v", entry.Action, entry, projection.Runtime.Coordination)
+		}
 	}
 }
 

--- a/internal/app/agent_message.go
+++ b/internal/app/agent_message.go
@@ -1,0 +1,643 @@
+package app
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/aiprovider"
+	"github.com/crevissepartners/projmux/internal/config"
+	"github.com/crevissepartners/projmux/internal/core/agentdelivery"
+	coremessage "github.com/crevissepartners/projmux/internal/core/agentmessage"
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	"github.com/crevissepartners/projmux/internal/core/selector"
+	messagestore "github.com/crevissepartners/projmux/internal/integrations/agents/agentmessage"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
+	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
+)
+
+const defaultAgentMessageTimeout = 30 * time.Second
+
+type agentMessageStore interface {
+	Get(string) (messagestore.Record, bool, error)
+	PutAccepted(coremessage.Envelope, string) (messagestore.Record, bool, error)
+	Apply(string, coremessage.Event) (messagestore.Record, bool, error)
+	MarkHandoff(string) (messagestore.Record, bool, error)
+	Status(string, time.Time) (messagestore.Record, bool, error)
+	Claim(coremessage.Route, time.Time) (messagestore.Record, bool, error)
+}
+
+type agentMessagePaths struct {
+	registryPath string
+	loadRegistry func() (coremetadata.Registry, error)
+}
+
+func defaultAgentMessagePaths(paths config.Paths) agentMessagePaths {
+	store := intmetadata.NewDefaultStore(paths)
+	return agentMessagePaths{registryPath: store.Path(), loadRegistry: store.LoadReadOnly}
+}
+
+func newAgentMessageStore(stateDir string) agentMessageStore { return messagestore.NewStore(stateDir) }
+
+type agentMessageRouteResolver interface {
+	Resolve(coremetadata.Registry, coremetadata.Agent) (coremetadata.AgentRouteRef, error)
+}
+
+type liveAgentMessageRouteResolver struct{ registryPath string }
+
+func (r liveAgentMessageRouteResolver) Resolve(registry coremetadata.Registry, agent coremetadata.Agent) (coremetadata.AgentRouteRef, error) {
+	route, reason := coremetadata.ResolveAgentRoute(registry, agent.Metadata.UID)
+	if reason != "" {
+		return coremetadata.AgentRouteRef{}, errors.New(reason)
+	}
+	if route.Authority().Provider() == string(aiprovider.Claude) && !probeClaudeRegistrationLease(r.registryPath, route) {
+		return coremetadata.AgentRouteRef{}, errors.New("claude registration lease is stale or unavailable")
+	}
+	return route, nil
+}
+
+type agentMessageClaudeAdapter interface {
+	Submit(context.Context, string, coremetadata.AgentRouteRef, coremessage.Envelope) (agentdelivery.Delivery, error)
+	Status(context.Context, string, coremetadata.AgentRouteRef, string) (agentdelivery.Delivery, error)
+}
+
+type liveAgentMessageClaudeAdapter struct{}
+
+func (liveAgentMessageClaudeAdapter) Submit(ctx context.Context, registryPath string, route coremetadata.AgentRouteRef, envelope coremessage.Envelope) (agentdelivery.Delivery, error) {
+	target, ok := claudeTargetForRoute(route)
+	if !ok {
+		return agentdelivery.Delivery{}, errors.New("claude target authority is unavailable")
+	}
+	private := claudeCoordinationEnvelope{Version: claudeCoordinationVersion, MessageRef: envelope.MessageRef, Target: target,
+		Source:   claudeCoordinationSource{Kind: "peer", Trust: "untrusted", Authority: "coordination-only"},
+		Deadline: envelope.Deadline, BrokerEnvelope: &envelope}
+	now := time.Now()
+	if !private.valid(now, route) {
+		return agentdelivery.Delivery{MessageRef: envelope.MessageRef, State: agentdelivery.StateRefused,
+			Reason: "claude-private-frame-unsupported"}, nil
+	}
+	deadline := now.Add(localipc.Deadline)
+	if envelope.Deadline.Before(deadline) {
+		deadline = envelope.Deadline
+	}
+	callCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	response, err := callClaudeCoordination(callCtx, registryPath, route, claudeCoordinationRequest{
+		Version: claudeCoordinationVersion, Operation: "submit", Target: target, Envelope: &private,
+	})
+	return claudeResponseDelivery(envelope.MessageRef, response), err
+}
+
+func (liveAgentMessageClaudeAdapter) Status(ctx context.Context, registryPath string, route coremetadata.AgentRouteRef, messageRef string) (agentdelivery.Delivery, error) {
+	target, ok := claudeTargetForRoute(route)
+	if !ok {
+		return agentdelivery.Delivery{}, errors.New("claude target authority is unavailable")
+	}
+	callCtx, cancel := context.WithTimeout(ctx, localipc.Deadline)
+	defer cancel()
+	response, err := callClaudeCoordination(callCtx, registryPath, route, claudeCoordinationRequest{
+		Version: claudeCoordinationVersion, Operation: "status", Target: target, MessageRef: messageRef,
+	})
+	return claudeResponseDelivery(messageRef, response), err
+}
+
+func claudeResponseDelivery(messageRef string, response claudeCoordinationResponse) agentdelivery.Delivery {
+	if response.Delivery.MessageRef != "" || response.Delivery.State != "" {
+		return response.Delivery
+	}
+	switch response.Kind {
+	case "refused":
+		return agentdelivery.Delivery{MessageRef: messageRef, State: agentdelivery.StateRefused, Reason: "provider-refused"}
+	case "stale":
+		return agentdelivery.Delivery{MessageRef: messageRef, State: agentdelivery.StateStale, Reason: "target-activation-stale"}
+	default:
+		return agentdelivery.Delivery{}
+	}
+}
+
+type agentMessageReceipt struct {
+	Version         int                  `json:"version"`
+	MessageRef      string               `json:"messageRef"`
+	ConversationRef string               `json:"conversationRef"`
+	ReplyTo         string               `json:"replyTo,omitempty"`
+	Source          coremessage.Route    `json:"source"`
+	Target          coremessage.Route    `json:"target"`
+	Delivery        coremessage.Delivery `json:"delivery"`
+	Deadline        time.Time            `json:"deadline"`
+}
+
+func receiptFor(record messagestore.Record) agentMessageReceipt {
+	return agentMessageReceipt{Version: record.Envelope.Version, MessageRef: record.Envelope.MessageRef,
+		ConversationRef: record.Envelope.ConversationRef, ReplyTo: record.Envelope.ReplyTo,
+		Source: record.Envelope.Source, Target: record.Envelope.Target, Delivery: record.Delivery,
+		Deadline: record.Envelope.Deadline}
+}
+
+func (c *agentCommand) runMessage(args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		return usageError("agent message requires send, wait, or status")
+	}
+	switch args[0] {
+	case "send":
+		return c.runMessageSend(args[1:], stdout, stderr)
+	case "wait":
+		return c.runMessageClaim(args[1:], stdout, stderr)
+	case "status":
+		return c.runMessageStatus(args[1:], stdout, stderr)
+	default:
+		return usageError("agent message requires send, wait, or status")
+	}
+}
+
+func (c *agentCommand) runMessageSend(args []string, stdout, stderr io.Writer) error {
+	const spelling = "agent message send"
+	separator := -1
+	for i, arg := range args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator < 0 || separator+2 != len(args) {
+		return usageError(spelling + " requires <target-agent-ref> -- <text>; quote text as one argument")
+	}
+	fs := flag.NewFlagSet(spelling, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var messageRef, replyTo string
+	var ttl time.Duration
+	fs.StringVar(&messageRef, "message-ref", "", "idempotency reference")
+	fs.StringVar(&replyTo, "reply-to", "", "message reference being replied to")
+	fs.DurationVar(&ttl, "ttl", 10*time.Minute, "delivery deadline")
+	positionals, err := parseWithPositionals(fs, args[:separator])
+	if err != nil {
+		return err
+	}
+	if len(positionals) != 1 || strings.TrimSpace(args[separator+1]) == "" {
+		return usageError(spelling + " requires one <target-agent-ref> and non-empty text")
+	}
+	if ttl <= 0 || ttl > coremessage.MaxTTL {
+		return usageError(fmt.Sprintf("%s: --ttl must be greater than zero and at most %s", spelling, coremessage.MaxTTL))
+	}
+	authorityAction := coremessage.ActionCoordinationSend
+	if replyTo != "" {
+		authorityAction = coremessage.ActionCoordinationReply
+	}
+	if !coremessage.Authorize(coremessage.PrincipalPeer, authorityAction) {
+		return fmt.Errorf("%s: peer authority does not permit %s", spelling, authorityAction)
+	}
+	registry, err := c.readMessageRegistry()
+	if err != nil {
+		return MapMetadataError(err)
+	}
+	source, err := c.currentMessageAgent(registry, spelling)
+	if err != nil {
+		return err
+	}
+	target, err := c.resolveMessageAgent(registry, positionals[0], spelling)
+	if err != nil {
+		return err
+	}
+	if err := requireAgentMessageCapability("message.send", source); err != nil {
+		return err
+	}
+	if err := requireAgentMessageCapability("message.send", target); err != nil {
+		return err
+	}
+	// Both static cells and both exact activation authorities are proved before
+	// the broker store or provider adapter is touched.
+	sourceRoute, err := c.resolveMessageRoute(registry, source)
+	if err != nil {
+		return fmt.Errorf("%s: source Agent is not eligible: %w", spelling, err)
+	}
+	targetRoute, err := c.resolveMessageRoute(registry, target)
+	if err != nil {
+		return fmt.Errorf("%s: target Agent is not eligible: %w", spelling, err)
+	}
+	if messageRef == "" {
+		messageRef = c.newMessageRef("message")
+	}
+	now := c.messageClock()
+	conversationRef := conversationRefFor(messageRef)
+	if replyTo != "" {
+		conversationRef = ""
+	}
+	envelope := coremessage.Envelope{Version: coremessage.Version, MessageRef: messageRef,
+		ConversationRef: conversationRef, ReplyTo: replyTo,
+		Source: publicMessageRoute(sourceRoute), Target: publicMessageRoute(targetRoute), Authority: coremessage.PeerAuthority(),
+		Payload: args[separator+1], AcceptedAt: now, Deadline: now.Add(ttl)}
+	if replyTo != "" {
+		original, found, getErr := c.messageStore.Get(replyTo)
+		if getErr != nil || !found {
+			if getErr == nil {
+				getErr = messagestore.ErrNotFound
+			}
+			return fmt.Errorf("%s: reply correlation failed: %w", spelling, getErr)
+		}
+		envelope.ConversationRef = original.Envelope.ConversationRef
+		if err := coremessage.ValidateReply(original.Envelope, envelope); err != nil {
+			return fmt.Errorf("%s: %w", spelling, err)
+		}
+	}
+	adapter := "codex-inbox"
+	if target.Spec.Provider == string(aiprovider.Claude) {
+		adapter = "claude-coordination"
+	}
+	record, created, err := c.messageStore.PutAccepted(envelope, adapter)
+	if err != nil {
+		return fmt.Errorf("%s: %w", spelling, err)
+	}
+	if created && adapter == "claude-coordination" {
+		private, submitErr := c.messageClaude.Submit(context.Background(), c.messagePaths.registryPath, targetRoute, envelope)
+		record, err = c.projectClaudeDelivery(record, private, submitErr)
+		if err != nil {
+			return fmt.Errorf("%s: persist provider projection: %w", spelling, err)
+		}
+	}
+	return writeAgentMessageReceipt(stdout, receiptFor(record), false)
+}
+
+func conversationRefFor(messageRef string) string {
+	digest := sha256.Sum256([]byte(messageRef))
+	return fmt.Sprintf("conversation-%x", digest[:18])
+}
+
+func (c *agentCommand) runMessageClaim(args []string, stdout, stderr io.Writer) error {
+	const spelling = "agent message wait"
+	fs := flag.NewFlagSet(spelling, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var timeout time.Duration
+	var output string
+	fs.DurationVar(&timeout, "timeout", defaultAgentMessageTimeout, "maximum wait duration")
+	fs.StringVar(&output, "o", "", "output mode: json")
+	refs, err := parseWithPositionals(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(refs) > 1 || (output != "" && output != "json") || timeout < 0 || timeout > coremessage.MaxTTL {
+		return usageError(spelling + " accepts [<self-agent-ref>] [--timeout <duration>] [-o json]")
+	}
+	if !coremessage.Authorize(coremessage.PrincipalPeer, coremessage.ActionCoordinationRead) {
+		return fmt.Errorf("%s: peer authority does not permit inbox reads", spelling)
+	}
+	registry, err := c.readMessageRegistry()
+	if err != nil {
+		return MapMetadataError(err)
+	}
+	self, err := c.currentMessageAgent(registry, spelling)
+	if err != nil {
+		return err
+	}
+	if len(refs) == 1 {
+		explicit, resolveErr := c.resolveMessageAgent(registry, refs[0], spelling)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		if explicit.Metadata.UID != self.Metadata.UID {
+			return fmt.Errorf("%s: explicit Agent is not the current managed Pane owner", spelling)
+		}
+	}
+	if err := requireAgentMessageCapability("message.wait", self); err != nil {
+		return err
+	}
+	route, err := c.resolveMessageRoute(registry, self)
+	if err != nil {
+		return fmt.Errorf("%s: current Agent is not eligible: %w", spelling, err)
+	}
+	deadline := c.messageClock().Add(timeout)
+	expectedRoute := publicMessageRoute(route)
+	for {
+		record, claimed, claimErr := c.messageStore.Claim(expectedRoute, c.messageClock())
+		if claimErr != nil {
+			return claimErr
+		}
+		if claimed {
+			return writeAgentMessageClaim(stdout, record, output == "json")
+		}
+		if !c.messageClock().Before(deadline) {
+			return fmt.Errorf("%s: timed out with no compatible message", spelling)
+		}
+		if err := c.sleepMessage(context.Background(), 50*time.Millisecond); err != nil {
+			return err
+		}
+		latest, loadErr := c.readMessageRegistry()
+		if loadErr != nil {
+			return MapMetadataError(loadErr)
+		}
+		current, ok := latest.Agent(self.Metadata.UID)
+		if !ok {
+			return fmt.Errorf("%s: current Agent activation is stale", spelling)
+		}
+		if err := requireAgentMessageCapability("message.wait", *current); err != nil {
+			return err
+		}
+		currentRoute, routeErr := c.resolveMessageRoute(latest, *current)
+		if routeErr != nil || publicMessageRoute(currentRoute) != expectedRoute {
+			return fmt.Errorf("%s: current Agent activation is stale", spelling)
+		}
+	}
+}
+
+func (c *agentCommand) runMessageStatus(args []string, stdout, stderr io.Writer) error {
+	const spelling = "agent message status"
+	fs := flag.NewFlagSet(spelling, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var output string
+	fs.StringVar(&output, "o", "", "output mode: json")
+	refs, err := parseWithPositionals(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(refs) != 1 || (output != "" && output != "json") {
+		return usageError(spelling + " requires <message-ref> [-o json]")
+	}
+	record, found, err := c.messageStore.Get(refs[0])
+	if err != nil || !found {
+		if err == nil {
+			err = messagestore.ErrNotFound
+		}
+		return fmt.Errorf("%s: %w", spelling, err)
+	}
+	if !record.Delivery.State.Terminal() {
+		registry, loadErr := c.readMessageRegistry()
+		if loadErr != nil {
+			return loadErr
+		}
+		target, ok := registry.Agent(record.Envelope.Target.AgentUID)
+		if !ok {
+			record, _, err = c.messageStore.Apply(record.Envelope.MessageRef, c.staleMessageEvent(record, "target-removed"))
+		} else if capabilityErr := requireAgentMessageCapability("message.status", *target); capabilityErr != nil {
+			return capabilityErr
+		} else if route, routeErr := c.resolveMessageRoute(registry, *target); routeErr != nil || publicMessageRoute(route) != record.Envelope.Target {
+			record, _, err = c.messageStore.Apply(record.Envelope.MessageRef, c.staleMessageEvent(record, "target-activation-stale"))
+		} else if record.Adapter == "claude-coordination" {
+			private, statusErr := c.messageClaude.Status(context.Background(), c.messagePaths.registryPath, route, record.Envelope.MessageRef)
+			record, err = c.projectClaudeDelivery(record, private, statusErr)
+		} else if record.Adapter == "codex-inbox" {
+			record, found, err = c.messageStore.Status(refs[0], c.messageClock())
+			if err == nil && !found {
+				err = messagestore.ErrNotFound
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("%s: persist delivery projection: %w", spelling, err)
+		}
+	}
+	return writeAgentMessageReceipt(stdout, receiptFor(record), output == "json")
+}
+
+func (c *agentCommand) runWait(args []string, stdout, stderr io.Writer) error {
+	const spelling = "agent wait"
+	fs := flag.NewFlagSet(spelling, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var timeout time.Duration
+	var until, output string
+	fs.DurationVar(&timeout, "timeout", defaultAgentMessageTimeout, "maximum wait duration")
+	fs.StringVar(&until, "until", "idle", "condition: idle")
+	fs.StringVar(&output, "o", "", "output mode: json")
+	refs, err := parseWithPositionals(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(refs) != 1 || until != "idle" || (output != "" && output != "json") || timeout < 0 || timeout > coremessage.MaxTTL {
+		return usageError(spelling + " requires <agent-ref> [--until idle] [--timeout <duration>] [-o json]")
+	}
+	registry, loadErr := c.readMessageRegistry()
+	if loadErr != nil {
+		return MapMetadataError(loadErr)
+	}
+	agent, resolveErr := c.resolveMessageAgent(registry, refs[0], spelling)
+	if resolveErr != nil {
+		return resolveErr
+	}
+	if err := requireAgentMessageCapability("wait.idle", agent); err != nil {
+		return err
+	}
+	if reason := exactAgentActivationReason(registry, agent); reason != "" {
+		return fmt.Errorf("%s: Agent activation is stale: %s", spelling, reason)
+	}
+	expectedUID, expectedPaneUID := agent.Metadata.UID, agent.Status.PaneRef
+	expectedPane, _ := registry.Pane(expectedPaneUID)
+	expectedGeneration := expectedPane.Status.Activation.Generation
+	deadline := c.messageClock().Add(timeout)
+	for {
+		current, ok := registry.Agent(expectedUID)
+		if !ok {
+			return fmt.Errorf("%s: Agent activation is stale", spelling)
+		}
+		agent = current.Clone()
+		if reason := exactAgentActivationReason(registry, agent); reason != "" {
+			return fmt.Errorf("%s: Agent activation is stale: %s", spelling, reason)
+		}
+		pane, _ := registry.Pane(agent.Status.PaneRef)
+		if agent.Status.PaneRef != expectedPaneUID || pane.Status.Activation.Generation != expectedGeneration {
+			return fmt.Errorf("%s: Agent activation is stale", spelling)
+		}
+		interaction := agent.EffectiveInteraction(c.messageClock())
+		if interaction.Kind == coremetadata.InteractionIdle {
+			result := struct {
+				AgentUID    string                        `json:"agentUID"`
+				Name        string                        `json:"name"`
+				Interaction coremetadata.AgentInteraction `json:"interaction"`
+			}{agent.Metadata.UID, agent.Metadata.Name, interaction}
+			if output == "json" {
+				return json.NewEncoder(stdout).Encode(result)
+			}
+			_, err = fmt.Fprintf(stdout, "%s\tidle\n", agent.Metadata.UID)
+			return err
+		}
+		if !c.messageClock().Before(deadline) {
+			return fmt.Errorf("%s: timed out waiting for idle", spelling)
+		}
+		if err := c.sleepMessage(context.Background(), 50*time.Millisecond); err != nil {
+			return err
+		}
+		registry, loadErr = c.readMessageRegistry()
+		if loadErr != nil {
+			return MapMetadataError(loadErr)
+		}
+	}
+}
+
+func (c *agentCommand) readMessageRegistry() (coremetadata.Registry, error) {
+	if c == nil || c.messagePaths.loadRegistry == nil {
+		return coremetadata.Registry{}, errors.New("agent message registry path is unavailable")
+	}
+	return c.messagePaths.loadRegistry()
+}
+
+func (c *agentCommand) currentMessageAgent(registry coremetadata.Registry, spelling string) (coremetadata.Agent, error) {
+	uid, resolved, detail := activeUID(c.activeTarget, coremetadata.KindAgent, registry)
+	if !resolved {
+		if detail == "" {
+			detail = "not inside a managed Agent Pane"
+		}
+		return coremetadata.Agent{}, fmt.Errorf("%s: source authority unavailable: %s", spelling, detail)
+	}
+	agent, ok := registry.Agent(uid)
+	if !ok {
+		return coremetadata.Agent{}, fmt.Errorf("%s: current Agent disappeared", spelling)
+	}
+	return agent.Clone(), nil
+}
+
+func (c *agentCommand) resolveMessageAgent(registry coremetadata.Registry, ref, spelling string) (coremetadata.Agent, error) {
+	flags := resourceQueryFlags{kind: coremetadata.KindAgent, active: c.activeTarget}
+	flags.addPositionalRef(ref)
+	resolution, err := flags.resolve(selector.VerbStatus, false, registry)
+	if err != nil {
+		return coremetadata.Agent{}, MapMetadataError(err)
+	}
+	agent, ok := registry.Agent(resolution.Matches[0].UID)
+	if !ok {
+		return coremetadata.Agent{}, fmt.Errorf("%s: resolved Agent disappeared", spelling)
+	}
+	return agent.Clone(), nil
+}
+
+func requireAgentMessageCapability(action string, agent coremetadata.Agent) error {
+	provider, ok := aiprovider.Lookup(agent.Spec.Provider)
+	if !ok {
+		return fmt.Errorf("capability %s unsupported for provider %q", action, agent.Spec.Provider)
+	}
+	_, cell, ok := aiprovider.LookupAgentCapability(action, provider.ID)
+	if !ok || cell.Mode == aiprovider.SupportUnsupported {
+		return fmt.Errorf("capability %s unsupported for provider %q", action, agent.Spec.Provider)
+	}
+	return nil
+}
+
+func (c *agentCommand) resolveMessageRoute(registry coremetadata.Registry, agent coremetadata.Agent) (coremetadata.AgentRouteRef, error) {
+	if c == nil || c.messageRoute == nil {
+		return coremetadata.AgentRouteRef{}, errors.New("agent message route resolver is unavailable")
+	}
+	return c.messageRoute.Resolve(registry, agent)
+}
+
+func publicMessageRoute(route coremetadata.AgentRouteRef) coremessage.Route {
+	provider := ""
+	if route.Authority() != nil {
+		provider = route.Authority().Provider()
+	}
+	return coremessage.Route{AgentUID: route.AgentUID, PaneUID: route.PaneUID,
+		ActivationGeneration: route.Generation, Provider: provider}
+}
+
+func (c *agentCommand) publicMessageEvent(record messagestore.Record, kind coremessage.EventKind, reason string, unknown bool) coremessage.Event {
+	return coremessage.Event{Kind: kind, MessageRef: record.Envelope.MessageRef,
+		ConversationRef: record.Envelope.ConversationRef, Target: record.Envelope.Target,
+		Reason: reason, ObservedAt: c.messageClock(), OutcomeUnknown: unknown}
+}
+
+func (c *agentCommand) projectClaudeDelivery(record messagestore.Record, private agentdelivery.Delivery, adapterErr error) (messagestore.Record, error) {
+	kind, reason, unknown := coremessage.EventKind(""), private.Reason, private.Ambiguous
+	if private.MessageRef != "" && private.MessageRef != record.Envelope.MessageRef {
+		return record, nil
+	}
+	if adapterErr != nil {
+		kind, reason, unknown = coremessage.EventFail, "provider-handoff-outcome-unknown", true
+	} else if private.MessageRef != record.Envelope.MessageRef {
+		return record, nil
+	} else {
+		switch private.State {
+		case agentdelivery.StateHeld:
+			kind = coremessage.EventHold
+		case agentdelivery.StateHandoff:
+			updated, _, err := c.messageStore.MarkHandoff(record.Envelope.MessageRef)
+			return updated, err
+		case agentdelivery.StateDelivered:
+			kind = coremessage.EventDeliver
+		case agentdelivery.StateRefused:
+			kind = coremessage.EventRefuse
+		case agentdelivery.StateExpired:
+			if record.HandoffObserved {
+				kind, reason, unknown = coremessage.EventFail, "provider-handoff-outcome-unknown", true
+			} else {
+				kind = coremessage.EventExpire
+			}
+		case agentdelivery.StateStale:
+			if record.HandoffObserved {
+				kind, reason, unknown = coremessage.EventFail, "provider-handoff-outcome-unknown", true
+			} else {
+				kind = coremessage.EventStale
+			}
+		case agentdelivery.StateFailed:
+			kind = coremessage.EventFail
+			if record.HandoffObserved {
+				reason, unknown = "provider-handoff-outcome-unknown", true
+			}
+		}
+	}
+	if kind == "" {
+		return record, nil
+	}
+	updated, _, err := c.messageStore.Apply(record.Envelope.MessageRef, c.publicMessageEvent(record, kind, reason, unknown))
+	if err != nil {
+		return record, err
+	}
+	return updated, nil
+}
+
+func (c *agentCommand) staleMessageEvent(record messagestore.Record, reason string) coremessage.Event {
+	if record.HandoffObserved {
+		return c.publicMessageEvent(record, coremessage.EventFail, "provider-handoff-outcome-unknown", true)
+	}
+	return c.publicMessageEvent(record, coremessage.EventStale, reason, false)
+}
+
+func writeAgentMessageReceipt(stdout io.Writer, receipt agentMessageReceipt, asJSON bool) error {
+	if asJSON {
+		return json.NewEncoder(stdout).Encode(receipt)
+	}
+	_, err := fmt.Fprintf(stdout, "%s\t%s\n", receipt.MessageRef, receipt.Delivery.State)
+	return err
+}
+
+func writeAgentMessageClaim(stdout io.Writer, record messagestore.Record, _ bool) error {
+	payload, err := json.Marshal(struct {
+		Envelope coremessage.Envelope `json:"envelope"`
+		Delivery coremessage.Delivery `json:"delivery"`
+	}{record.Envelope, record.Delivery})
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(payload)
+	return err
+}
+
+func (c *agentCommand) messageClock() time.Time {
+	if c == nil || c.messageNow == nil {
+		return time.Now().UTC()
+	}
+	return c.messageNow().UTC()
+}
+
+func (c *agentCommand) newMessageRef(prefix string) string {
+	if c == nil || c.messageNewRef == nil {
+		return newCoordinationRef(prefix)
+	}
+	return c.messageNewRef(prefix)
+}
+
+func (c *agentCommand) sleepMessage(ctx context.Context, duration time.Duration) error {
+	if c == nil || c.messageSleep == nil {
+		return waitAgentMessagePoll(ctx, duration)
+	}
+	return c.messageSleep(ctx, duration)
+}
+
+func waitAgentMessagePoll(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/app/agent_message_test.go
+++ b/internal/app/agent_message_test.go
@@ -1,0 +1,687 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/agentdelivery"
+	coremessage "github.com/crevissepartners/projmux/internal/core/agentmessage"
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	messagestore "github.com/crevissepartners/projmux/internal/integrations/agents/agentmessage"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
+)
+
+type traceMessageRouteResolver struct {
+	trace  *[]string
+	route  coremetadata.AgentRouteRef
+	failAt int
+	calls  int
+}
+
+func (r *traceMessageRouteResolver) Resolve(coremetadata.Registry, coremetadata.Agent) (coremetadata.AgentRouteRef, error) {
+	r.calls++
+	if r.trace != nil {
+		*r.trace = append(*r.trace, "route")
+	}
+	if r.calls == r.failAt {
+		return coremetadata.AgentRouteRef{}, errors.New("stale activation")
+	}
+	return r.route, nil
+}
+
+type traceMessageStore struct {
+	trace *[]string
+	base  *messagestore.Store
+}
+
+func (s *traceMessageStore) Get(ref string) (messagestore.Record, bool, error) {
+	*s.trace = append(*s.trace, "store-get")
+	return s.base.Get(ref)
+}
+func (s *traceMessageStore) PutAccepted(envelope coremessage.Envelope, adapter string) (messagestore.Record, bool, error) {
+	*s.trace = append(*s.trace, "store-put")
+	return s.base.PutAccepted(envelope, adapter)
+}
+func (s *traceMessageStore) Apply(ref string, event coremessage.Event) (messagestore.Record, bool, error) {
+	*s.trace = append(*s.trace, "store-apply")
+	return s.base.Apply(ref, event)
+}
+func (s *traceMessageStore) MarkHandoff(ref string) (messagestore.Record, bool, error) {
+	*s.trace = append(*s.trace, "store-handoff")
+	return s.base.MarkHandoff(ref)
+}
+func (s *traceMessageStore) Status(ref string, now time.Time) (messagestore.Record, bool, error) {
+	*s.trace = append(*s.trace, "store-status")
+	return s.base.Status(ref, now)
+}
+func (s *traceMessageStore) Claim(route coremessage.Route, now time.Time) (messagestore.Record, bool, error) {
+	*s.trace = append(*s.trace, "store-claim")
+	return s.base.Claim(route, now)
+}
+
+type traceClaudeMessageAdapter struct {
+	trace          *[]string
+	statusDelivery agentdelivery.Delivery
+}
+
+func (a *traceClaudeMessageAdapter) Submit(context.Context, string, coremetadata.AgentRouteRef, coremessage.Envelope) (agentdelivery.Delivery, error) {
+	*a.trace = append(*a.trace, "adapter")
+	return agentdelivery.Delivery{MessageRef: "message-fixed", State: agentdelivery.StateQueued}, nil
+}
+func (a *traceClaudeMessageAdapter) Status(context.Context, string, coremetadata.AgentRouteRef, string) (agentdelivery.Delivery, error) {
+	*a.trace = append(*a.trace, "adapter-status")
+	return a.statusDelivery, nil
+}
+
+func replaceClaudeServerWithResponse(t *testing.T, fixture *claudeCoordinationTestFixture, kind string) <-chan error {
+	t.Helper()
+	fixture.server.Close()
+	listener, err := localipc.Listen(claudeCoordinationSocket(fixture.registryPath, fixture.target))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	done := make(chan error, 1)
+	go func() {
+		conn, acceptErr := listener.Unix.AcceptUnix()
+		if acceptErr != nil {
+			done <- acceptErr
+			return
+		}
+		defer conn.Close()
+		var request claudeCoordinationRequest
+		if readErr := localipc.ReadJSON(conn, &request); readErr != nil {
+			done <- readErr
+			return
+		}
+		done <- localipc.WriteJSON(conn, claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: kind})
+	}()
+	return done
+}
+
+func TestAgentMessageSendGatesBothStaticCellsAndRoutesBeforeStoreOrAdapter(t *testing.T) {
+	fixture := newClaudeCoordinationTestFixture(t)
+	h := newSessionRefHarness(t, aiModeClaude)
+	active := insideTmux(h.paneUID, "")
+	clock := sessionRefObservedAt.Add(time.Minute)
+	newCommand := func(trace *[]string, failAt int) *agentCommand {
+		return &agentCommand{
+			activeTarget: active.lookup,
+			messagePaths: agentMessagePaths{registryPath: fixture.registryPath, loadRegistry: func() (coremetadata.Registry, error) {
+				return h.registry.Clone(), nil
+			}},
+			messageStore:  &traceMessageStore{trace: trace, base: messagestore.NewStore(t.TempDir())},
+			messageRoute:  &traceMessageRouteResolver{trace: trace, route: fixture.route, failAt: failAt},
+			messageClaude: &traceClaudeMessageAdapter{trace: trace},
+			messageNow:    func() time.Time { return clock },
+			messageNewRef: func(prefix string) string {
+				if prefix == "message" {
+					return "message-fixed"
+				}
+				return "conversation-fixed"
+			},
+		}
+	}
+
+	t.Run("second route refusal is mutation zero", func(t *testing.T) {
+		var trace []string
+		cmd := newCommand(&trace, 2)
+		_, _, err := runRoute(t, cmd, "message", "send", "uid:"+h.agentUID, "--", "hello")
+		if err == nil || !strings.Contains(err.Error(), "target Agent is not eligible") {
+			t.Fatalf("error = %v", err)
+		}
+		if got := strings.Join(trace, ","); got != "route,route" {
+			t.Fatalf("call order = %s", got)
+		}
+	})
+
+	t.Run("success touches provider after accepted store record", func(t *testing.T) {
+		var trace []string
+		cmd := newCommand(&trace, 0)
+		if _, _, err := runRoute(t, cmd, "message", "send", "uid:"+h.agentUID, "--", "hello"); err != nil {
+			t.Fatal(err)
+		}
+		if got := strings.Join(trace, ","); got != "route,route,store-put,adapter" {
+			t.Fatalf("call order = %s", got)
+		}
+	})
+}
+
+func TestAgentMessageUnsupportedProviderStopsBeforeRouteAndStore(t *testing.T) {
+	h := newSessionRefHarness(t, aiModeAntigravity)
+	active := insideTmux(h.paneUID, "")
+	var trace []string
+	cmd := &agentCommand{
+		activeTarget: active.lookup,
+		messagePaths: agentMessagePaths{loadRegistry: func() (coremetadata.Registry, error) { return h.registry.Clone(), nil }},
+		messageStore: &traceMessageStore{trace: &trace, base: messagestore.NewStore(t.TempDir())},
+		messageRoute: &traceMessageRouteResolver{trace: &trace},
+		messageNow:   func() time.Time { return sessionRefObservedAt },
+		messageNewRef: func(string) string {
+			return "must-not-be-called"
+		},
+	}
+	_, _, err := runRoute(t, cmd, "message", "send", "uid:"+h.agentUID, "--", "hello")
+	if err == nil || !strings.Contains(err.Error(), "capability message.send unsupported") {
+		t.Fatalf("error = %v", err)
+	}
+	if len(trace) != 0 {
+		t.Fatalf("unsupported route touched side effects: %v", trace)
+	}
+}
+
+func TestAgentMessageSendSameReferenceRetryKeepsBrokerCorrelationAndDoesNotResend(t *testing.T) {
+	cmd, store, _ := exactControlCLICommand(t)
+	active := insideTmux("pan-alpha-codex", "win-alpha-main")
+	var trace []string
+	private := &traceMessageStore{trace: &trace, base: messagestore.NewStore(t.TempDir())}
+	cmd.activeTarget = active.lookup
+	cmd.messagePaths = agentMessagePaths{loadRegistry: func() (coremetadata.Registry, error) { return store.registry.Clone(), nil }}
+	cmd.messageStore = private
+	cmd.messageRoute = &traceMessageRouteResolver{trace: &trace, route: mustMessageRoute(t, store.registry, "agt-alpha-codex")}
+	cmd.messageNow = func() time.Time { return resourceFixtureClock.Add(time.Hour) }
+	cmd.messageNewRef = func(prefix string) string {
+		t.Fatalf("explicit message ref must not mint %s", prefix)
+		return "unused"
+	}
+	args := []string{"message", "send", "uid:agt-alpha-codex", "--message-ref", "message-retry", "--ttl", "1m", "--", "same payload"}
+	first, _, err := runRoute(t, cmd, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := runRoute(t, cmd, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("retry output changed: first=%q second=%q", first, second)
+	}
+	if strings.Count(strings.Join(trace, ","), "store-put") != 2 {
+		t.Fatalf("retry trace = %v", trace)
+	}
+}
+
+func TestAgentMessageConcurrentSameReferenceUsesOneConversation(t *testing.T) {
+	_, registryStore, _ := exactControlCLICommand(t)
+	registry := registryStore.registry.Clone()
+	route := mustMessageRoute(t, registry, "agt-alpha-codex")
+	private := messagestore.NewStore(t.TempDir())
+	newCommand := func() *agentCommand {
+		return &agentCommand{
+			activeTarget: func() (activeTargetObserver, bool) {
+				return activeTargetObserver{paneID: "%7", paneUID: func() string { return "pan-alpha-codex" }}, true
+			},
+			messagePaths: agentMessagePaths{loadRegistry: func() (coremetadata.Registry, error) { return registry.Clone(), nil }},
+			messageStore: private,
+			messageRoute: &traceMessageRouteResolver{route: route},
+			messageNow:   func() time.Time { return resourceFixtureClock.Add(time.Hour) },
+			messageNewRef: func(prefix string) string {
+				t.Fatalf("explicit message ref must not mint %s", prefix)
+				return ""
+			},
+		}
+	}
+	const workers = 16
+	errs := make(chan error, workers)
+	outputs := make(chan string, workers)
+	for range workers {
+		go func() {
+			cmd := newCommand()
+			stdout, _, err := runRoute(t, cmd, "message", "send", "uid:agt-alpha-codex", "--message-ref", "message-race", "--ttl", "1m", "--", "same")
+			errs <- err
+			outputs <- stdout
+		}()
+	}
+	for range workers {
+		if err := <-errs; err != nil {
+			t.Fatal(err)
+		}
+		if output := <-outputs; output != "message-race\taccepted\n" {
+			t.Fatalf("output = %q", output)
+		}
+	}
+	record, found, err := private.Get("message-race")
+	if err != nil || !found || record.Envelope.ConversationRef != conversationRefFor("message-race") {
+		t.Fatalf("record=%#v found=%t err=%v", record, found, err)
+	}
+}
+
+func TestAgentMessageReplyReturnsOnlyToOriginalSourceConversation(t *testing.T) {
+	_, registryStore, _ := exactControlCLICommand(t)
+	registry := registryStore.registry.Clone()
+	sourceAgent, _ := registry.Agent("agt-alpha-codex")
+	sourcePane, _ := registry.Pane("pan-alpha-codex")
+	targetAgent := sourceAgent.Clone()
+	targetAgent.Metadata.UID = "agt-target-codex"
+	targetAgent.Metadata.Name = "target-codex"
+	targetAgent.Status.PaneRef = "pan-target-codex"
+	targetAgent.Status.SessionRef.Codex.ThreadID = "thread-target"
+	targetPane := sourcePane.Clone()
+	targetPane.Metadata.UID = "pan-target-codex"
+	targetPane.Metadata.Name = "target-codex-pane"
+	targetPane.Metadata.OwnerRef = &coremetadata.OwnerRef{Kind: coremetadata.KindAgent, UID: targetAgent.Metadata.UID}
+	targetPane.Status.Activation.AgentUID = targetAgent.Metadata.UID
+	targetPane.Status.Activation.Generation = "generation-target"
+	targetPane.Status.Activation.RuntimeID = "%8"
+	targetAuthority := *sourcePane.Status.Activation.Codex.Authority
+	targetPane.Status.Activation.Codex = &coremetadata.CodexActivationBinding{ThreadID: "thread-target", TurnID: "turn-target", Authority: &targetAuthority}
+	registry.Agents = append(registry.Agents, targetAgent)
+	registry.Panes = append(registry.Panes, targetPane)
+
+	private := messagestore.NewStore(t.TempDir())
+	activePane := sourcePane.Metadata.UID
+	active := func() (activeTargetObserver, bool) {
+		return activeTargetObserver{paneID: "%7", paneUID: func() string { return activePane }}, true
+	}
+	cmd := &agentCommand{
+		activeTarget: active,
+		messagePaths: agentMessagePaths{loadRegistry: func() (coremetadata.Registry, error) { return registry.Clone(), nil }},
+		messageStore: private,
+		messageRoute: liveAgentMessageRouteResolver{},
+		messageNow:   func() time.Time { return resourceFixtureClock.Add(time.Hour) },
+		messageNewRef: func(prefix string) string {
+			t.Fatalf("explicit references must not mint %s", prefix)
+			return ""
+		},
+	}
+	if _, _, err := runRoute(t, cmd, "message", "send", "uid:"+targetAgent.Metadata.UID,
+		"--message-ref", "message-original", "--", "request"); err != nil {
+		t.Fatal(err)
+	}
+	activePane = targetPane.Metadata.UID
+	if _, _, err := runRoute(t, cmd, "message", "send", "uid:"+sourceAgent.Metadata.UID,
+		"--message-ref", "message-reply", "--reply-to", "message-original", "--", "response"); err != nil {
+		t.Fatal(err)
+	}
+	original, _, _ := private.Get("message-original")
+	reply, _, _ := private.Get("message-reply")
+	if err := coremessage.ValidateReply(original.Envelope, reply.Envelope); err != nil ||
+		reply.Envelope.ConversationRef != original.Envelope.ConversationRef {
+		t.Fatalf("reply correlation original=%#v reply=%#v err=%v", original.Envelope, reply.Envelope, err)
+	}
+	if _, _, err := runRoute(t, cmd, "message", "send", "uid:"+targetAgent.Metadata.UID,
+		"--message-ref", "message-foreign-reply", "--reply-to", "message-original", "--", "misrouted"); err == nil ||
+		!strings.Contains(err.Error(), "reply route or conversation mismatch") {
+		t.Fatalf("misrouted reply error = %v", err)
+	}
+	if _, found, err := private.Get("message-foreign-reply"); err != nil || found {
+		t.Fatalf("misrouted reply stored = %t err=%v", found, err)
+	}
+}
+
+func TestAgentMessageStatusJSONNeverContainsPayload(t *testing.T) {
+	cmd, store, _ := exactControlCLICommand(t)
+	route := mustMessageRoute(t, store.registry, "agt-alpha-codex")
+	now := resourceFixtureClock.Add(time.Hour)
+	private := messagestore.NewStore(t.TempDir())
+	envelope := coremessage.Envelope{Version: coremessage.Version, MessageRef: "message-secret", ConversationRef: "conversation-secret",
+		Source: publicMessageRoute(route), Target: publicMessageRoute(route), Authority: coremessage.PeerAuthority(),
+		Payload: "do-not-expose-payload", AcceptedAt: now, Deadline: now.Add(time.Minute)}
+	if _, _, err := private.PutAccepted(envelope, "codex-inbox"); err != nil {
+		t.Fatal(err)
+	}
+	cmd.messageStore = private
+	cmd.messagePaths = agentMessagePaths{loadRegistry: func() (coremetadata.Registry, error) { return store.registry.Clone(), nil }}
+	cmd.messageRoute = liveAgentMessageRouteResolver{}
+	cmd.messageNow = func() time.Time { return now }
+	var stdout, stderr bytes.Buffer
+	if err := cmd.Run([]string{"message", "status", envelope.MessageRef, "-o", "json"}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stdout.String(), envelope.Payload) || strings.Contains(stdout.String(), `"payload"`) {
+		t.Fatalf("status leaked payload: %s", stdout.String())
+	}
+	var receipt agentMessageReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.MessageRef != envelope.MessageRef {
+		t.Fatalf("receipt=%#v err=%v", receipt, err)
+	}
+}
+
+func TestAgentMessageStatusMarksCodexGenerationChangeStale(t *testing.T) {
+	cmd, registryStore, _ := exactControlCLICommand(t)
+	registry := registryStore.registry.Clone()
+	route := mustMessageRoute(t, registry, "agt-alpha-codex")
+	now := resourceFixtureClock.Add(time.Hour)
+	private := messagestore.NewStore(t.TempDir())
+	envelope := coremessage.Envelope{Version: coremessage.Version, MessageRef: "message-codex-stale", ConversationRef: "conversation-codex-stale",
+		Source: publicMessageRoute(route), Target: publicMessageRoute(route), Authority: coremessage.PeerAuthority(),
+		Payload: "private", AcceptedAt: now.Add(-time.Minute), Deadline: now.Add(-time.Second)}
+	if _, _, err := private.PutAccepted(envelope, "codex-inbox"); err != nil {
+		t.Fatal(err)
+	}
+	pane, _ := registry.Pane("pan-alpha-codex")
+	pane.Status.Activation.Generation = "generation-restarted"
+	cmd.messagePaths = agentMessagePaths{loadRegistry: func() (coremetadata.Registry, error) { return registry.Clone(), nil }}
+	cmd.messageStore = private
+	cmd.messageRoute = liveAgentMessageRouteResolver{}
+	cmd.messageNow = func() time.Time { return now }
+	stdout, _, err := runRoute(t, cmd, "message", "status", envelope.MessageRef, "-o", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, `"state":"stale"`) || strings.Contains(stdout, envelope.Payload) {
+		t.Fatalf("stale status = %s", stdout)
+	}
+}
+
+func TestAgentMessageStatusProjectsClaudeReceiptBeforeLocalDeadline(t *testing.T) {
+	fixture := newClaudeCoordinationTestFixture(t)
+	h := newSessionRefHarness(t, aiModeClaude)
+	if h.agentUID != fixture.route.AgentUID || h.paneUID != fixture.route.PaneUID {
+		t.Fatalf("deterministic Claude fixtures diverged: harness=%s/%s route=%s/%s", h.agentUID, h.paneUID, fixture.route.AgentUID, fixture.route.PaneUID)
+	}
+	now := time.Now().UTC()
+	private := messagestore.NewStore(t.TempDir())
+	envelope := coremessage.Envelope{Version: coremessage.Version, MessageRef: "message-late-claude-receipt", ConversationRef: "conversation-late-claude-receipt",
+		Source: publicMessageRoute(fixture.route), Target: publicMessageRoute(fixture.route), Authority: coremessage.PeerAuthority(),
+		Payload: "private", AcceptedAt: now.Add(-time.Minute), Deadline: now.Add(-time.Second)}
+	if _, _, err := private.PutAccepted(envelope, "claude-coordination"); err != nil {
+		t.Fatal(err)
+	}
+	var trace []string
+	cmd := &agentCommand{
+		messagePaths: agentMessagePaths{registryPath: fixture.registryPath, loadRegistry: func() (coremetadata.Registry, error) { return h.registry.Clone(), nil }},
+		messageStore: private,
+		messageRoute: &traceMessageRouteResolver{route: fixture.route},
+		messageClaude: &traceClaudeMessageAdapter{trace: &trace, statusDelivery: agentdelivery.Delivery{
+			MessageRef: envelope.MessageRef, State: agentdelivery.StateDelivered,
+		}},
+		messageNow: func() time.Time { return now },
+	}
+	stdout, _, err := runRoute(t, cmd, "message", "status", envelope.MessageRef, "-o", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, `"state":"delivered"`) || strings.Contains(stdout, `"state":"expired"`) ||
+		strings.Join(trace, ",") != "adapter-status" {
+		t.Fatalf("late Claude receipt = %s trace=%v", stdout, trace)
+	}
+}
+
+func TestClaudePrivateProjectionPreservesPublicBoundaryAndAmbiguity(t *testing.T) {
+	now := resourceFixtureClock.Add(time.Hour)
+	store := messagestore.NewStore(t.TempDir())
+	cmd := &agentCommand{messageStore: store, messageNow: func() time.Time { return now }}
+	newRecord := func(ref string) messagestore.Record {
+		envelope := coremessage.Envelope{Version: coremessage.Version, MessageRef: ref, ConversationRef: "conversation-" + ref,
+			Source:    coremessage.Route{AgentUID: "source", PaneUID: "source-pane", ActivationGeneration: "source-generation", Provider: "codex"},
+			Target:    coremessage.Route{AgentUID: "target", PaneUID: "target-pane", ActivationGeneration: "target-generation", Provider: "claude"},
+			Authority: coremessage.PeerAuthority(), Payload: "coordination", AcceptedAt: now, Deadline: now.Add(time.Minute)}
+		record, _, err := store.PutAccepted(envelope, "claude-coordination")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return record
+	}
+
+	queued := newRecord("message-private-queued")
+	queued, err := cmd.projectClaudeDelivery(queued, agentdelivery.Delivery{MessageRef: queued.Envelope.MessageRef, State: agentdelivery.StateQueued}, nil)
+	if err != nil || queued.Delivery.State != coremessage.StateAccepted {
+		t.Fatalf("queued projection = %#v err=%v", queued, err)
+	}
+	held := newRecord("message-private-held")
+	held, err = cmd.projectClaudeDelivery(held, agentdelivery.Delivery{MessageRef: held.Envelope.MessageRef, State: agentdelivery.StateHeld}, nil)
+	if err != nil || held.Delivery.State != coremessage.StateHeld {
+		t.Fatalf("held projection = %#v err=%v", held, err)
+	}
+	handoff := newRecord("message-private-handoff")
+	handoff, err = cmd.projectClaudeDelivery(handoff, agentdelivery.Delivery{MessageRef: handoff.Envelope.MessageRef, State: agentdelivery.StateHandoff}, nil)
+	if err != nil || handoff.Delivery.State != coremessage.StateAccepted || !handoff.HandoffObserved {
+		t.Fatalf("handoff projection = %#v err=%v", handoff, err)
+	}
+	failed, err := cmd.projectClaudeDelivery(handoff, agentdelivery.Delivery{MessageRef: handoff.Envelope.MessageRef,
+		State: agentdelivery.StateFailed, Reason: "malformed-known-failure", Ambiguous: false}, nil)
+	if err != nil || failed.Delivery.State != coremessage.StateFailed || !failed.Delivery.OutcomeUnknown ||
+		failed.Delivery.Reason != "provider-handoff-outcome-unknown" {
+		t.Fatalf("ambiguous projection = %#v err=%v", failed, err)
+	}
+	postHandoffStale := newRecord("message-private-stale-after-handoff")
+	postHandoffStale, _, err = store.MarkHandoff(postHandoffStale.Envelope.MessageRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	postHandoffStale, err = cmd.projectClaudeDelivery(postHandoffStale, agentdelivery.Delivery{
+		MessageRef: postHandoffStale.Envelope.MessageRef, State: agentdelivery.StateStale, Reason: "helper-replaced",
+	}, nil)
+	if err != nil || postHandoffStale.Delivery.State != coremessage.StateFailed || !postHandoffStale.Delivery.OutcomeUnknown {
+		t.Fatalf("post-handoff stale projection = %#v err=%v", postHandoffStale, err)
+	}
+	for _, state := range []agentdelivery.State{agentdelivery.StateDelivered, agentdelivery.StateRefused} {
+		foreign := newRecord("message-private-foreign-" + string(state))
+		unchanged, projectErr := cmd.projectClaudeDelivery(foreign, agentdelivery.Delivery{
+			MessageRef: "message-other", State: state, Reason: "foreign-private-event",
+		}, nil)
+		if projectErr != nil || unchanged.Delivery.State != coremessage.StateAccepted {
+			t.Fatalf("foreign %s projection = %#v err=%v", state, unchanged, projectErr)
+		}
+		persisted, found, getErr := store.Get(foreign.Envelope.MessageRef)
+		if getErr != nil || !found || persisted.Delivery.State != coremessage.StateAccepted {
+			t.Fatalf("foreign %s mutated store: %#v found=%v err=%v", state, persisted, found, getErr)
+		}
+	}
+}
+
+func TestLiveClaudeAdapterMapsTerminalResponseKindsWithoutDelivery(t *testing.T) {
+	for _, test := range []struct {
+		kind string
+		want agentdelivery.State
+	}{
+		{kind: "refused", want: agentdelivery.StateRefused},
+		{kind: "stale", want: agentdelivery.StateStale},
+	} {
+		for _, operation := range []string{"submit", "status"} {
+			t.Run(test.kind+"/"+operation, func(t *testing.T) {
+				fixture := newClaudeCoordinationTestFixture(t)
+				done := replaceClaudeServerWithResponse(t, fixture, test.kind)
+				now := time.Now().UTC()
+				envelope := coremessage.Envelope{Version: coremessage.Version, MessageRef: "message-kind-" + test.kind + "-" + operation,
+					ConversationRef: "conversation-kind-" + test.kind + "-" + operation,
+					Source:          publicMessageRoute(fixture.route), Target: publicMessageRoute(fixture.route), Authority: coremessage.PeerAuthority(),
+					Payload: "peer text", AcceptedAt: now, Deadline: now.Add(time.Minute)}
+				adapter := liveAgentMessageClaudeAdapter{}
+				var delivery agentdelivery.Delivery
+				var err error
+				if operation == "submit" {
+					delivery, err = adapter.Submit(context.Background(), fixture.registryPath, fixture.route, envelope)
+				} else {
+					delivery, err = adapter.Status(context.Background(), fixture.registryPath, fixture.route, envelope.MessageRef)
+				}
+				if err != nil || delivery.MessageRef != envelope.MessageRef || delivery.State != test.want {
+					t.Fatalf("%s %s delivery = %#v err=%v", test.kind, operation, delivery, err)
+				}
+				if serverErr := <-done; serverErr != nil {
+					t.Fatal(serverErr)
+				}
+			})
+		}
+	}
+}
+
+func TestLiveClaudeAdapterRefusesPublicValidEnvelopeThatExceedsPrivateFrame(t *testing.T) {
+	fixture := newClaudeCoordinationTestFixture(t)
+	now := time.Now().UTC()
+	envelope := coremessage.Envelope{Version: coremessage.Version, MessageRef: "message-control-heavy", ConversationRef: "conversation-control-heavy",
+		Source: publicMessageRoute(fixture.route), Target: publicMessageRoute(fixture.route), Authority: coremessage.PeerAuthority(),
+		Payload: strings.Repeat("\x1b", coremessage.MaxPayloadBytes), AcceptedAt: now, Deadline: now.Add(time.Minute)}
+	if err := envelope.Validate(); err != nil {
+		t.Fatalf("control-heavy public envelope should remain valid: %v", err)
+	}
+	delivery, err := (liveAgentMessageClaudeAdapter{}).Submit(context.Background(), fixture.registryPath+"-missing", fixture.route, envelope)
+	if err != nil || delivery.MessageRef != envelope.MessageRef || delivery.State != agentdelivery.StateRefused ||
+		delivery.Reason != "claude-private-frame-unsupported" {
+		t.Fatalf("private-frame refusal = %#v err=%v", delivery, err)
+	}
+}
+
+func TestAgentMessageWaitClaimsOnlyCurrentExactActivation(t *testing.T) {
+	cmd, registryStore, _ := exactControlCLICommand(t)
+	registry := registryStore.registry.Clone()
+	route := mustMessageRoute(t, registry, "agt-alpha-codex")
+	now := resourceFixtureClock.Add(time.Hour)
+	private := messagestore.NewStore(t.TempDir())
+	envelope := coremessage.Envelope{Version: coremessage.Version, MessageRef: "message-claim", ConversationRef: "conversation-claim",
+		Source: publicMessageRoute(route), Target: publicMessageRoute(route), Authority: coremessage.PeerAuthority(),
+		Payload: "full envelope for target", AcceptedAt: now, Deadline: now.Add(time.Minute)}
+	if _, _, err := private.PutAccepted(envelope, "codex-inbox"); err != nil {
+		t.Fatal(err)
+	}
+	active := insideTmux("pan-alpha-codex", "win-alpha-main")
+	cmd.activeTarget = active.lookup
+	cmd.messagePaths = agentMessagePaths{loadRegistry: func() (coremetadata.Registry, error) { return registry.Clone(), nil }}
+	cmd.messageStore = private
+	cmd.messageRoute = &traceMessageRouteResolver{route: route}
+	cmd.messageNow = func() time.Time { return now }
+	stdout, _, err := runRoute(t, cmd, "message", "wait", "uid:agt-alpha-codex", "--timeout", "0", "-o", "json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, envelope.Payload) || !strings.Contains(stdout, `"state":"delivered"`) ||
+		!strings.Contains(stdout, `"reason":"target-self-claim"`) {
+		t.Fatalf("claim output = %s", stdout)
+	}
+	if !strings.Contains(stdout, `"kind":"peer"`) || !strings.Contains(stdout, `"trust":"untrusted"`) ||
+		!strings.Contains(stdout, `"permission":"coordination-only"`) {
+		t.Fatalf("claim lost peer provenance: %s", stdout)
+	}
+}
+
+func TestAgentMessageClaimDefaultOutputEscapesTerminalControlsAndKeepsEnvelope(t *testing.T) {
+	now := resourceFixtureClock.Add(time.Hour)
+	payload := "peer text\x1b]52;c;Zm9v\a\nnext line"
+	envelope := coremessage.Envelope{Version: coremessage.Version, MessageRef: "message-control", ConversationRef: "conversation-control",
+		Source:    coremessage.Route{AgentUID: "source", PaneUID: "source-pane", ActivationGeneration: "source-generation", Provider: "claude"},
+		Target:    coremessage.Route{AgentUID: "target", PaneUID: "target-pane", ActivationGeneration: "target-generation", Provider: "codex"},
+		Authority: coremessage.PeerAuthority(), Payload: payload, AcceptedAt: now, Deadline: now.Add(time.Minute)}
+	delivery, _ := coremessage.Reduce(coremessage.Delivery{}, envelope, coremessage.Event{Kind: coremessage.EventAccept,
+		MessageRef: envelope.MessageRef, ConversationRef: envelope.ConversationRef, Target: envelope.Target, ObservedAt: now})
+	delivery, _ = coremessage.Reduce(delivery, envelope, coremessage.Event{Kind: coremessage.EventDeliver,
+		MessageRef: envelope.MessageRef, ConversationRef: envelope.ConversationRef, Target: envelope.Target, ObservedAt: now})
+	var stdout bytes.Buffer
+	if err := writeAgentMessageClaim(&stdout, messagestore.Record{Envelope: envelope, Delivery: delivery, Adapter: "codex-inbox"}, false); err != nil {
+		t.Fatal(err)
+	}
+	for _, value := range stdout.Bytes() {
+		if value < 0x20 || value == 0x7f {
+			t.Fatalf("claim emitted raw terminal control byte %#x: %q", value, stdout.Bytes())
+		}
+	}
+	var got struct {
+		Envelope coremessage.Envelope `json:"envelope"`
+		Delivery coremessage.Delivery `json:"delivery"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Envelope.Payload != payload || got.Envelope.Authority != coremessage.PeerAuthority() || got.Delivery.State != coremessage.StateDelivered {
+		t.Fatalf("safe claim lost envelope: %#v", got)
+	}
+}
+
+func TestAgentMessageWaitDetectsGenerationChangeBeforeClaim(t *testing.T) {
+	cmd, registryStore, _ := exactControlCLICommand(t)
+	registry := registryStore.registry.Clone()
+	now := resourceFixtureClock.Add(time.Hour)
+	active := insideTmux("pan-alpha-codex", "win-alpha-main")
+	cmd.activeTarget = active.lookup
+	cmd.messagePaths = agentMessagePaths{loadRegistry: func() (coremetadata.Registry, error) { return registry.Clone(), nil }}
+	cmd.messageStore = messagestore.NewStore(t.TempDir())
+	cmd.messageRoute = liveAgentMessageRouteResolver{}
+	cmd.messageNow = func() time.Time { return now }
+	cmd.messageSleep = func(context.Context, time.Duration) error {
+		pane, _ := registry.Pane("pan-alpha-codex")
+		pane.Status.Activation.Generation = "generation-replaced"
+		now = now.Add(50 * time.Millisecond)
+		return nil
+	}
+	_, _, err := runRoute(t, cmd, "message", "wait", "--timeout", "1s")
+	if err == nil || !strings.Contains(err.Error(), "activation is stale") {
+		t.Fatalf("generation change error = %v", err)
+	}
+}
+
+func TestClaudeBrokerEnvelopeAtPublicPayloadBoundFitsPrivateFrame(t *testing.T) {
+	fixture := newClaudeCoordinationTestFixture(t)
+	now := time.Now().UTC()
+	publicRoute := publicMessageRoute(fixture.route)
+	envelope := coremessage.Envelope{Version: coremessage.Version, MessageRef: "message-frame-bound", ConversationRef: "conversation-frame-bound",
+		Source: publicRoute, Target: publicRoute, Authority: coremessage.PeerAuthority(),
+		Payload: strings.Repeat("x", coremessage.MaxPayloadBytes), AcceptedAt: now, Deadline: now.Add(time.Minute)}
+	private := claudeCoordinationEnvelope{Version: claudeCoordinationVersion, MessageRef: envelope.MessageRef, Target: fixture.target,
+		Source:   claudeCoordinationSource{Kind: "peer", Trust: "untrusted", Authority: "coordination-only"},
+		Deadline: envelope.Deadline, BrokerEnvelope: &envelope}
+	if !private.valid(now, fixture.route) {
+		t.Fatal("maximum public payload does not fit the Claude private frame")
+	}
+}
+
+func TestAgentMessageBrokerHasNoCodexOrUserTurnWritePath(t *testing.T) {
+	source, err := os.ReadFile("agent_message.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"turn/start", "turn/steer", "thread/inject_items", "send-keys", "sendkeys"} {
+		if bytes.Contains(source, []byte(forbidden)) {
+			t.Errorf("broker source contains forbidden write path %q", forbidden)
+		}
+	}
+}
+
+func TestAgentWaitRegistryIdleReadyTimeoutAndStale(t *testing.T) {
+	h := newSessionRefHarness(t, aiModeCodex)
+	activeTime := sessionRefObservedAt.Add(time.Minute)
+	setInteraction := func(kind coremetadata.AgentInteractionKind) {
+		agent, _ := h.registry.Agent(h.agentUID)
+		agent.Status.Interaction = coremetadata.AgentInteraction{Kind: kind, ObservedAt: activeTime, Source: string(coremetadata.InteractionSourceLifecycle)}
+	}
+	newCommand := func(now *time.Time) *agentCommand {
+		return &agentCommand{
+			messagePaths: agentMessagePaths{loadRegistry: func() (coremetadata.Registry, error) { return h.registry.Clone(), nil }},
+			messageNow:   func() time.Time { return *now },
+			messageSleep: func(_ context.Context, duration time.Duration) error { *now = now.Add(duration); return nil },
+		}
+	}
+
+	t.Run("ready", func(t *testing.T) {
+		setInteraction(coremetadata.InteractionIdle)
+		now := activeTime
+		stdout, _, err := runRoute(t, newCommand(&now), "wait", "uid:"+h.agentUID, "--timeout", "0", "-o", "json")
+		if err != nil || !strings.Contains(stdout, `"kind":"idle"`) {
+			t.Fatalf("ready stdout=%q err=%v", stdout, err)
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		setInteraction(coremetadata.InteractionInProgress)
+		now := activeTime
+		_, _, err := runRoute(t, newCommand(&now), "wait", "uid:"+h.agentUID, "--timeout", "100ms")
+		if err == nil || !strings.Contains(err.Error(), "timed out waiting for idle") {
+			t.Fatalf("timeout error=%v", err)
+		}
+	})
+
+	t.Run("stale generation", func(t *testing.T) {
+		setInteraction(coremetadata.InteractionInProgress)
+		pane, _ := h.registry.Pane(h.paneUID)
+		pane.Status.Activation.Generation = ""
+		now := activeTime
+		_, _, err := runRoute(t, newCommand(&now), "wait", "uid:"+h.agentUID, "--timeout", "1s")
+		if err == nil || !strings.Contains(err.Error(), "activation is stale") {
+			t.Fatalf("stale error=%v", err)
+		}
+	})
+}
+
+func mustMessageRoute(t *testing.T, registry coremetadata.Registry, agentUID string) coremetadata.AgentRouteRef {
+	t.Helper()
+	route, reason := coremetadata.ResolveAgentRoute(registry, agentUID)
+	if reason != "" {
+		t.Fatal(reason)
+	}
+	return route
+}

--- a/internal/app/claude_coordination.go
+++ b/internal/app/claude_coordination.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/crevissepartners/projmux/internal/core/agentdelivery"
+	coremessage "github.com/crevissepartners/projmux/internal/core/agentmessage"
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
 	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
 	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
@@ -68,18 +69,30 @@ type claudeCoordinationSource struct {
 }
 
 type claudeCoordinationEnvelope struct {
-	Version    int                      `json:"version"`
-	MessageRef string                   `json:"messageRef"`
-	Target     claudeCoordinationTarget `json:"target"`
-	Source     claudeCoordinationSource `json:"source"`
-	Payload    string                   `json:"payload"`
-	Deadline   time.Time                `json:"deadline"`
+	Version        int                      `json:"version"`
+	MessageRef     string                   `json:"messageRef"`
+	Target         claudeCoordinationTarget `json:"target"`
+	Source         claudeCoordinationSource `json:"source"`
+	Payload        string                   `json:"payload,omitempty"`
+	Deadline       time.Time                `json:"deadline"`
+	BrokerEnvelope *coremessage.Envelope    `json:"brokerEnvelope,omitempty"`
 }
 
 func (e claudeCoordinationEnvelope) valid(now time.Time, route coremetadata.AgentRouteRef) bool {
 	if e.Version != claudeCoordinationVersion || !validCoordinationRef(e.MessageRef) || !e.Target.matches(route) ||
 		e.Source.Kind != "peer" || e.Source.Trust != "untrusted" || e.Source.Authority != "coordination-only" ||
-		e.Payload == "" || e.Deadline.IsZero() {
+		e.Deadline.IsZero() {
+		return false
+	}
+	if e.BrokerEnvelope != nil {
+		broker := *e.BrokerEnvelope
+		if broker.Validate() != nil || e.Payload != "" || broker.MessageRef != e.MessageRef ||
+			!broker.Deadline.Equal(e.Deadline) || broker.Target.AgentUID != e.Target.AgentUID ||
+			broker.Target.PaneUID != e.Target.PaneUID || broker.Target.ActivationGeneration != e.Target.Generation ||
+			broker.Target.Provider != e.Target.Provider || broker.Authority != coremessage.PeerAuthority() {
+			return false
+		}
+	} else if e.Payload == "" {
 		return false
 	}
 	payload, err := json.Marshal(e)

--- a/internal/cli/agent_capabilities_parity_test.go
+++ b/internal/cli/agent_capabilities_parity_test.go
@@ -41,9 +41,9 @@ func TestAgentCapabilityCatalogRoutesMatchExecutableHelpGraph(t *testing.T) {
 			t.Errorf("provider-specific public agent namespace %q exists", provider)
 		}
 	}
-	for _, future := range []string{"message", "wait"} {
-		if slices.ContainsFunc(agent.Children, func(child Route) bool { return child.Name == future }) {
-			t.Errorf("future placeholder agent %s is callable", future)
+	for _, group := range []string{"message", "wait"} {
+		if !slices.ContainsFunc(agent.Children, func(child Route) bool { return child.Name == group }) {
+			t.Errorf("coordination agent %s is absent", group)
 		}
 	}
 }

--- a/internal/cli/canonical_graph_test.go
+++ b/internal/cli/canonical_graph_test.go
@@ -15,9 +15,9 @@ import (
 // one digest, so any change to the public command contract has to be made on
 // purpose.
 //
-// The baseline last moved when steer's public summary began distinguishing
-// provider acceptance from unconfirmed delivery. The prior move added the
-// Project lifecycle verbs:
+// The baseline last moved when provider-neutral Agent message and wait routes
+// were added on top of steer's explicit provider-acceptance summary. The prior
+// move added the Project lifecycle verbs:
 // `start|open|stop project` and the canonical `unregister project` are new
 // rows, `delete` became a source edge of the last of those instead of a
 // canonical owner, `switch` became a source of `create project` and
@@ -32,7 +32,7 @@ func TestCanonicalCommandGraphProjectionMatchesBaseline(t *testing.T) {
 			route.Spelling, route.Summary, strings.Join(route.Sources, ","),
 			outputModesString(route.Outputs), fieldProjectionsString(route.Fields))
 	}
-	const want = "5abd90fbd6dd851124fead66ec4aca92e5f442991b7963ba0f78c50e8e302b76"
+	const want = "1424e7ffdda6a28545c5a37c4297dc115789356f8e7ecaf97140f337ae670e7a"
 	if got := fmt.Sprintf("%x", sha256.Sum256([]byte(baseline.String()))); got != want {
 		t.Fatalf("canonical command projection digest = %s, want %s\n%s", got, want, baseline.String())
 	}

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -146,6 +146,12 @@ func unchangedEffects(cardinality CardinalityEffect) *AllowedEffects {
 	)
 }
 
+func agentDeliveryEffects(cardinality CardinalityEffect) *AllowedEffects {
+	effects := unchangedEffects(cardinality)
+	effects.DomainEffect = &DomainEffect{Kind: DomainEffectAgentDelivery}
+	return effects
+}
+
 func createProjectEffects() *AllowedEffects {
 	return allowedEffects(
 		[]IdentityEffect{IdentityCreated, IdentityReused},
@@ -737,7 +743,7 @@ var routes = []Route{
 		Name:           "agent",
 		Invocation:     InvocationRefusal,
 		CanonicalOrder: 17,
-		Summary:        "Manage Agent state, topic, capabilities, integrations, and account usage",
+		Summary:        "Manage Agent state, messages, waits, capabilities, integrations, and account usage",
 		Disposition:    DispositionCanonical,
 		Usage: []string{
 			"projmux agent status [get [<agent-ref>] | set <unknown|idle|in_progress|approval_required|input_required|response_complete> [<agent-ref>]] [--agent <ref>]",
@@ -755,8 +761,12 @@ var routes = []Route{
 			"projmux agent app-server handover plan|apply --request <absolute-json>",
 			"projmux agent app-server handover resume|abort --operation <ref>",
 			"projmux agent capabilities [<agent-ref> | --provider <codex|claude|antigravity>] [-o json]",
+			"projmux agent message send <agent-ref> [--message-ref <ref>] [--reply-to <ref>] [--ttl <duration>] -- <text>",
+			"projmux agent message wait [<self-agent-ref>] [--timeout <duration>] [-o json]",
+			"projmux agent message status <message-ref> [-o json]",
+			"projmux agent wait <agent-ref> [--until idle] [--timeout <duration>] [-o json]",
 		},
-		Canonical: []string{"agent status", "agent topic", "agent resume", "agent turn start", "agent turn steer", "agent turn interrupt", "agent approval review", "agent review", "agent integrate", "agent usage", "agent app-server upgrade plan", "agent app-server upgrade apply", "agent app-server upgrade resume", "agent app-server upgrade abort", "agent app-server handover plan", "agent app-server handover apply", "agent app-server handover resume", "agent app-server handover abort", "agent capabilities"},
+		Canonical: []string{"agent status", "agent topic", "agent resume", "agent turn start", "agent turn steer", "agent turn interrupt", "agent approval review", "agent review", "agent integrate", "agent usage", "agent app-server upgrade plan", "agent app-server upgrade apply", "agent app-server upgrade resume", "agent app-server upgrade abort", "agent app-server handover plan", "agent app-server handover apply", "agent app-server handover resume", "agent app-server handover abort", "agent capabilities", "agent message send", "agent message wait", "agent message status", "agent wait"},
 		Children: []Route{
 			{Effects: unchangedEffects(CardinalityExactOne), Name: "status", Invocation: InvocationNatural, Summary: "Read or set semantic Agent interaction independently of lifecycle", CanonicalSummary: "Read or set Agent status state", Usage: []string{"projmux agent status [get [<agent-ref>] | set <unknown|idle|in_progress|approval_required|input_required|response_complete> [<agent-ref>]] [--agent <ref>]"}, Canonical: []string{"agent status"}},
 			{Effects: unchangedEffects(CardinalityExactOne), Name: "topic", Invocation: InvocationNatural, Summary: "Read, set, or clear one exact Agent topic annotation", CanonicalSummary: "Read, set, or clear the Agent topic annotation", Usage: []string{"projmux agent topic get|clear [<agent-ref>] [--agent <ref>]", "projmux agent topic set <text> [<agent-ref>] [--agent <ref>]"}, Canonical: []string{"agent topic"}},
@@ -848,6 +858,22 @@ var routes = []Route{
 				Canonical:  []string{"agent capabilities"},
 				Outputs:    []OutputMode{OutputModeJSON},
 			},
+			{
+				Effects: agentDeliveryEffects(CardinalityExactOne), Name: "message", Invocation: InvocationRefusal,
+				Summary: "Exchange bounded untrusted coordination messages through exact Agent activations",
+				Usage: []string{
+					"projmux agent message send <agent-ref> [--message-ref <ref>] [--reply-to <ref>] [--ttl <duration>] -- <text>",
+					"projmux agent message wait [<self-agent-ref>] [--timeout <duration>] [-o json]",
+					"projmux agent message status <message-ref> [-o json]",
+				},
+				Canonical: []string{"agent message send", "agent message wait", "agent message status"},
+				Children: []Route{
+					{Effects: agentDeliveryEffects(CardinalityExactOne), Name: "send", Invocation: InvocationExplicit, Summary: "Submit a bounded coordination message from the current exact Agent", Usage: []string{"projmux agent message send <agent-ref> [--message-ref <ref>] [--reply-to <ref>] [--ttl <duration>] -- <text>"}, Canonical: []string{"agent message send"}},
+					{Effects: agentDeliveryEffects(CardinalityExactOne), Name: "wait", Invocation: InvocationNatural, Summary: "Claim the oldest compatible message for the current exact Codex Agent", Usage: []string{"projmux agent message wait [<self-agent-ref>] [--timeout <duration>] [-o json]"}, Canonical: []string{"agent message wait"}, Outputs: []OutputMode{OutputModeJSON}},
+					{Effects: agentDeliveryEffects(CardinalityUnchanged), Name: "status", Invocation: InvocationExplicit, Summary: "Read a payload-free broker delivery receipt", Usage: []string{"projmux agent message status <message-ref> [-o json]"}, Canonical: []string{"agent message status"}, Outputs: []OutputMode{OutputModeJSON}},
+				},
+			},
+			{Effects: unchangedEffects(CardinalityExactOne), Name: "wait", Invocation: InvocationExplicit, Summary: "Wait read-only for one exact Agent's Registry-backed idle observation", Usage: []string{"projmux agent wait <agent-ref> [--until idle] [--timeout <duration>] [-o json]"}, Canonical: []string{"agent wait"}, Outputs: []OutputMode{OutputModeJSON}},
 		},
 	},
 	{

--- a/internal/cli/testdata/root-help.golden
+++ b/internal/cli/testdata/root-help.golden
@@ -1,7 +1,7 @@
 projmux
 
 Commands:
-  agent     Manage Agent state, topic, capabilities, integrations, and account usage
+  agent     Manage Agent state, messages, waits, capabilities, integrations, and account usage
   attention View and manage live tmux pane attention state
   attach    Enter a Project runtime from outside tmux
   config    Edit AI split-mode settings; render or apply generated tmux configuration

--- a/internal/cli/testdata/route-effects-manifest-schema-v3.golden
+++ b/internal/cli/testdata/route-effects-manifest-schema-v3.golden
@@ -24,6 +24,11 @@ route=agent app-server handover apply identity=unchanged address=unchanged topol
 route=agent app-server handover resume identity=unchanged address=unchanged topology=unchanged desired-state=unchanged runtime=unchanged focus=unchanged cardinality=unchanged domain-effect=null
 route=agent app-server handover abort identity=unchanged address=unchanged topology=unchanged desired-state=unchanged runtime=unchanged focus=unchanged cardinality=unchanged domain-effect=null
 route=agent capabilities identity=unchanged address=unchanged topology=unchanged desired-state=unchanged runtime=unchanged focus=unchanged cardinality=exact-one domain-effect=null
+route=agent message identity=unchanged address=unchanged topology=unchanged desired-state=unchanged runtime=unchanged focus=unchanged cardinality=exact-one domain-effect=agent-delivery
+route=agent message send identity=unchanged address=unchanged topology=unchanged desired-state=unchanged runtime=unchanged focus=unchanged cardinality=exact-one domain-effect=agent-delivery
+route=agent message wait identity=unchanged address=unchanged topology=unchanged desired-state=unchanged runtime=unchanged focus=unchanged cardinality=exact-one domain-effect=agent-delivery
+route=agent message status identity=unchanged address=unchanged topology=unchanged desired-state=unchanged runtime=unchanged focus=unchanged cardinality=unchanged domain-effect=agent-delivery
+route=agent wait identity=unchanged address=unchanged topology=unchanged desired-state=unchanged runtime=unchanged focus=unchanged cardinality=exact-one domain-effect=null
 route=attention identity=unchanged address=unchanged topology=unchanged desired-state=unchanged runtime=unchanged focus=unchanged cardinality=unchanged domain-effect=null
 route=attention toggle identity=unchanged address=unchanged topology=unchanged desired-state=unchanged runtime=unchanged focus=unchanged cardinality=exact-one domain-effect=null
 route=attention clear identity=unchanged address=unchanged topology=unchanged desired-state=unchanged runtime=unchanged focus=unchanged cardinality=exact-one domain-effect=null

--- a/internal/core/agentmessage/authority.go
+++ b/internal/core/agentmessage/authority.go
@@ -1,0 +1,58 @@
+package agentmessage
+
+import "slices"
+
+// Principal and Action form the exhaustive peer-authority matrix. The broker
+// accepts only PrincipalPeer, but keeping the other authority domains explicit
+// prevents coordination from inheriting their permissions by omission.
+type Principal string
+type Action string
+
+const (
+	PrincipalHuman            Principal = "human"
+	PrincipalPeer             Principal = "peer-agent"
+	PrincipalProviderRuntime  Principal = "provider-runtime"
+	PrincipalApprovalReviewer Principal = "approval-reviewer"
+)
+
+const (
+	ActionCoordinationSend  Action = "coordination-send"
+	ActionCoordinationRead  Action = "coordination-read"
+	ActionCoordinationReply Action = "coordination-reply"
+	ActionTurnStart         Action = "turn-start"
+	ActionTurnSteer         Action = "turn-steer"
+	ActionTurnInterrupt     Action = "turn-interrupt"
+	ActionApprovalReview    Action = "approval-review"
+	ActionConfigWrite       Action = "config-write"
+	ActionToolOrConnector   Action = "tool-or-connector"
+	ActionModelHistoryWrite Action = "model-history-write"
+)
+
+func Principals() []Principal {
+	return []Principal{PrincipalHuman, PrincipalPeer, PrincipalProviderRuntime, PrincipalApprovalReviewer}
+}
+
+func Actions() []Action {
+	return []Action{ActionCoordinationSend, ActionCoordinationRead, ActionCoordinationReply, ActionTurnStart,
+		ActionTurnSteer, ActionTurnInterrupt, ActionApprovalReview, ActionConfigWrite, ActionToolOrConnector,
+		ActionModelHistoryWrite}
+}
+
+func Authorize(principal Principal, action Action) bool {
+	if !slices.Contains(Principals(), principal) || !slices.Contains(Actions(), action) {
+		return false
+	}
+	switch principal {
+	case PrincipalHuman:
+		return action == ActionCoordinationSend || action == ActionCoordinationRead || action == ActionCoordinationReply ||
+			action == ActionTurnStart || action == ActionTurnSteer || action == ActionTurnInterrupt || action == ActionConfigWrite
+	case PrincipalPeer:
+		return action == ActionCoordinationSend || action == ActionCoordinationRead || action == ActionCoordinationReply
+	case PrincipalProviderRuntime:
+		return action == ActionToolOrConnector || action == ActionModelHistoryWrite
+	case PrincipalApprovalReviewer:
+		return action == ActionApprovalReview
+	default:
+		return false
+	}
+}

--- a/internal/core/agentmessage/message.go
+++ b/internal/core/agentmessage/message.go
@@ -1,0 +1,247 @@
+// Package agentmessage owns the provider-neutral coordination envelope and
+// public delivery reducer. Provider adapters may project their private state
+// into this package, but provider locators, credentials, thread IDs, and
+// session secrets are deliberately not representable here.
+package agentmessage
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	Version         = 1
+	MaxRefBytes     = 160
+	MaxPayloadBytes = 4 << 10
+	MaxTTL          = 24 * time.Hour
+)
+
+var (
+	ErrInvalidEnvelope = errors.New("invalid Agent message envelope")
+	ErrRetryMismatch   = errors.New("agent message retry does not match the immutable envelope")
+)
+
+type Authority struct {
+	Kind       string `json:"kind"`
+	Trust      string `json:"trust"`
+	Permission string `json:"permission"`
+}
+
+func PeerAuthority() Authority {
+	return Authority{Kind: "peer", Trust: "untrusted", Permission: "coordination-only"}
+}
+
+// Route is the only durable address in a message. Provider authority and its
+// volatile locator are re-resolved from the Registry for every operation.
+type Route struct {
+	AgentUID             string `json:"agentUID"`
+	PaneUID              string `json:"paneUID"`
+	ActivationGeneration string `json:"activationGeneration"`
+	Provider             string `json:"provider"`
+}
+
+func (r Route) Valid() bool {
+	return validRef(r.AgentUID) && validRef(r.PaneUID) && validRef(r.ActivationGeneration) && validProvider(r.Provider)
+}
+
+func (r Route) Same(other Route) bool {
+	return r.Valid() && r == other
+}
+
+type Envelope struct {
+	Version         int       `json:"version"`
+	MessageRef      string    `json:"messageRef"`
+	ConversationRef string    `json:"conversationRef"`
+	ReplyTo         string    `json:"replyTo,omitempty"`
+	Source          Route     `json:"source"`
+	Target          Route     `json:"target"`
+	Authority       Authority `json:"authority"`
+	Payload         string    `json:"payload"`
+	AcceptedAt      time.Time `json:"acceptedAt"`
+	Deadline        time.Time `json:"deadline"`
+}
+
+func (e Envelope) Validate() error {
+	if e.Version != Version || !validRef(e.MessageRef) || !validRef(e.ConversationRef) ||
+		(e.ReplyTo != "" && !validRef(e.ReplyTo)) || !e.Source.Valid() || !e.Target.Valid() ||
+		e.Authority != PeerAuthority() || !validPayload(e.Payload) || e.AcceptedAt.IsZero() || e.Deadline.IsZero() ||
+		!e.Deadline.After(e.AcceptedAt) || e.Deadline.Sub(e.AcceptedAt) > MaxTTL {
+		return ErrInvalidEnvelope
+	}
+	return nil
+}
+
+// SameRetry compares every caller-controlled immutable field plus the original
+// TTL. acceptedAt is broker-owned, so a retry made later need not reproduce its
+// timestamp; requiring the same duration still prevents a retry from extending
+// the deadline.
+func (e Envelope) SameRetry(candidate Envelope) bool {
+	return e.Version == candidate.Version && e.MessageRef == candidate.MessageRef &&
+		e.ConversationRef == candidate.ConversationRef && e.ReplyTo == candidate.ReplyTo &&
+		e.Source.Same(candidate.Source) && e.Target.Same(candidate.Target) &&
+		e.Authority == candidate.Authority && e.Payload == candidate.Payload &&
+		e.Deadline.Sub(e.AcceptedAt) == candidate.Deadline.Sub(candidate.AcceptedAt)
+}
+
+// ValidateReply proves broker correlation rather than trusting a native reply
+// address or caller-authored source. The new message must reverse the original
+// route exactly and remain in its conversation.
+func ValidateReply(original, reply Envelope) error {
+	if err := original.Validate(); err != nil {
+		return err
+	}
+	if err := reply.Validate(); err != nil {
+		return err
+	}
+	if reply.ReplyTo != original.MessageRef || reply.ConversationRef != original.ConversationRef ||
+		reply.MessageRef == original.MessageRef || !reply.Source.Same(original.Target) || !reply.Target.Same(original.Source) {
+		return fmt.Errorf("%w: reply route or conversation mismatch", ErrInvalidEnvelope)
+	}
+	return nil
+}
+
+func validRef(value string) bool {
+	if value != strings.TrimSpace(value) || value == "" || len(value) > MaxRefBytes || !utf8.ValidString(value) {
+		return false
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func validProvider(value string) bool {
+	switch value {
+	case "codex", "claude", "antigravity":
+		return true
+	default:
+		return false
+	}
+}
+
+func validPayload(value string) bool {
+	return value != "" && len(value) <= MaxPayloadBytes && utf8.ValidString(value) && !strings.ContainsRune(value, '\x00')
+}
+
+type State string
+
+const (
+	StateAccepted  State = "accepted"
+	StateHeld      State = "held"
+	StateDelivered State = "delivered"
+	StateRefused   State = "refused"
+	StateExpired   State = "expired"
+	StateStale     State = "stale"
+	StateFailed    State = "failed"
+)
+
+func (s State) Terminal() bool {
+	switch s {
+	case StateDelivered, StateRefused, StateExpired, StateStale, StateFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+type Delivery struct {
+	MessageRef      string    `json:"messageRef"`
+	ConversationRef string    `json:"conversationRef"`
+	State           State     `json:"state"`
+	Reason          string    `json:"reason,omitempty"`
+	OutcomeUnknown  bool      `json:"outcomeUnknown,omitempty"`
+	AcceptedAt      time.Time `json:"acceptedAt"`
+	TerminalAt      time.Time `json:"terminalAt"`
+}
+
+type EventKind string
+
+const (
+	EventAccept  EventKind = "accept"
+	EventHold    EventKind = "hold"
+	EventDeliver EventKind = "deliver"
+	EventRefuse  EventKind = "refuse"
+	EventExpire  EventKind = "expire"
+	EventStale   EventKind = "stale"
+	EventFail    EventKind = "fail"
+)
+
+type Event struct {
+	Kind            EventKind
+	MessageRef      string
+	ConversationRef string
+	Target          Route
+	Reason          string
+	ObservedAt      time.Time
+	OutcomeUnknown  bool
+}
+
+// Reduce owns the public terminal-once lifecycle. Foreign message,
+// conversation, or target events and all duplicate/out-of-order events are
+// no-ops. There is no transition back to accepted, so automatic resend is not
+// representable.
+func Reduce(current Delivery, envelope Envelope, event Event) (Delivery, bool) {
+	if envelope.Validate() != nil || event.MessageRef != envelope.MessageRef || event.ConversationRef != envelope.ConversationRef ||
+		!event.Target.Same(envelope.Target) || event.ObservedAt.Before(envelope.AcceptedAt) ||
+		(current.State != "" && (current.MessageRef != envelope.MessageRef || current.ConversationRef != envelope.ConversationRef)) || current.State.Terminal() {
+		return current, false
+	}
+	if current.State == "" {
+		if event.Kind != EventAccept {
+			return current, false
+		}
+		return Delivery{MessageRef: envelope.MessageRef, ConversationRef: envelope.ConversationRef,
+			State: StateAccepted, AcceptedAt: envelope.AcceptedAt}, true
+	}
+	next := current
+	switch event.Kind {
+	case EventHold:
+		if current.State != StateAccepted {
+			return current, false
+		}
+		next.State = StateHeld
+		next.Reason = boundedReason(event.Reason)
+	case EventDeliver, EventRefuse, EventExpire, EventStale, EventFail:
+		if current.State != StateAccepted && current.State != StateHeld {
+			return current, false
+		}
+		switch event.Kind {
+		case EventDeliver:
+			next.State = StateDelivered
+		case EventRefuse:
+			next.State = StateRefused
+		case EventExpire:
+			next.State = StateExpired
+		case EventStale:
+			next.State = StateStale
+		case EventFail:
+			next.State = StateFailed
+		}
+		next.Reason = boundedReason(event.Reason)
+		next.OutcomeUnknown = event.Kind == EventFail && event.OutcomeUnknown
+		next.TerminalAt = event.ObservedAt.UTC()
+	default:
+		return current, false
+	}
+	return next, true
+}
+
+func boundedReason(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unspecified"
+	}
+	if len(value) > MaxRefBytes {
+		value = value[:MaxRefBytes]
+		for !utf8.ValidString(value) {
+			value = value[:len(value)-1]
+		}
+	}
+	return value
+}

--- a/internal/core/agentmessage/message_test.go
+++ b/internal/core/agentmessage/message_test.go
@@ -1,0 +1,301 @@
+package agentmessage
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+	"time"
+)
+
+var messageTestNow = time.Date(2026, 9, 6, 1, 2, 3, 0, time.UTC)
+
+func messageEnvelopeFixture() Envelope {
+	return Envelope{
+		Version: Version, MessageRef: "message-one", ConversationRef: "conversation-one",
+		Source:    Route{AgentUID: "agent-source", PaneUID: "pane-source", ActivationGeneration: "generation-source", Provider: "codex"},
+		Target:    Route{AgentUID: "agent-target", PaneUID: "pane-target", ActivationGeneration: "generation-target", Provider: "claude"},
+		Authority: PeerAuthority(), Payload: "untrusted coordination text", AcceptedAt: messageTestNow,
+		Deadline: messageTestNow.Add(time.Minute),
+	}
+}
+
+func eventFor(envelope Envelope, kind EventKind) Event {
+	return Event{Kind: kind, MessageRef: envelope.MessageRef, ConversationRef: envelope.ConversationRef,
+		Target: envelope.Target, Reason: string(kind), ObservedAt: messageTestNow.Add(time.Second)}
+}
+
+func TestEnvelopeBoundsAndReplyCorrelation(t *testing.T) {
+	t.Parallel()
+	original := messageEnvelopeFixture()
+	if err := original.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	reply := messageEnvelopeFixture()
+	reply.MessageRef = "message-reply"
+	reply.ReplyTo = original.MessageRef
+	reply.ConversationRef = original.ConversationRef
+	reply.Source, reply.Target = original.Target, original.Source
+	if err := ValidateReply(original, reply); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, mutate := range []func(*Envelope){
+		func(e *Envelope) { e.Version++ },
+		func(e *Envelope) { e.MessageRef = "message\x1b]52;c;Zm9v\a" },
+		func(e *Envelope) { e.ConversationRef = "conversation\u0085control" },
+		func(e *Envelope) { e.Payload = "" },
+		func(e *Envelope) { e.Payload = string(make([]byte, MaxPayloadBytes+1)) },
+		func(e *Envelope) { e.Authority.Permission = "approval" },
+		func(e *Envelope) { e.Source.Provider = "unknown" },
+		func(e *Envelope) { e.Deadline = e.AcceptedAt.Add(MaxTTL + time.Nanosecond) },
+	} {
+		candidate := original
+		mutate(&candidate)
+		if candidate.Validate() == nil {
+			t.Fatalf("invalid envelope accepted: %+v", candidate)
+		}
+	}
+	for _, mutate := range []func(*Envelope){
+		func(e *Envelope) { e.MessageRef = original.MessageRef },
+		func(e *Envelope) { e.ReplyTo = "foreign" },
+		func(e *Envelope) { e.ConversationRef = "foreign" },
+		func(e *Envelope) { e.Source = original.Source },
+		func(e *Envelope) { e.Target = original.Target },
+	} {
+		candidate := reply
+		mutate(&candidate)
+		if ValidateReply(original, candidate) == nil {
+			t.Fatalf("mis-correlated reply accepted: %+v", candidate)
+		}
+	}
+}
+
+func TestSameEnvelopeRetryCannotChangeImmutableInputOrExtendTTL(t *testing.T) {
+	t.Parallel()
+	stored := messageEnvelopeFixture()
+	retry := stored
+	retry.AcceptedAt = stored.AcceptedAt.Add(time.Hour)
+	retry.Deadline = retry.AcceptedAt.Add(stored.Deadline.Sub(stored.AcceptedAt))
+	if !stored.SameRetry(retry) {
+		t.Fatal("same caller envelope was not idempotent")
+	}
+	for _, mutate := range []func(*Envelope){
+		func(e *Envelope) { e.Payload = "changed" },
+		func(e *Envelope) { e.Source.ActivationGeneration = "" },
+		func(e *Envelope) { e.Target.ActivationGeneration = "changed" },
+		func(e *Envelope) { e.Deadline = e.Deadline.Add(time.Second) },
+		func(e *Envelope) { e.ReplyTo = "other" },
+	} {
+		candidate := retry
+		mutate(&candidate)
+		if stored.SameRetry(candidate) {
+			t.Fatalf("mismatched retry accepted: %+v", candidate)
+		}
+	}
+}
+
+func TestEnvelopeRetryAndReplyCorrelationRandomizedProperties(t *testing.T) {
+	t.Parallel()
+	for seed := range int64(512) {
+		random := rand.New(rand.NewSource(seed)) // #nosec G404 -- deterministic property exploration.
+		original := messageEnvelopeFixture()
+		original.MessageRef = fmt.Sprintf("message-%d-%d", seed, random.Uint64())
+		original.ConversationRef = fmt.Sprintf("conversation-%d-%d", seed, random.Uint64())
+		original.Payload = fmt.Sprintf("payload-%d-%d", seed, random.Uint64())
+		original.AcceptedAt = messageTestNow.Add(time.Duration(random.Intn(1000)) * time.Millisecond)
+		original.Deadline = original.AcceptedAt.Add(time.Duration(random.Intn(3600)+1) * time.Second)
+		if err := original.Validate(); err != nil {
+			t.Fatalf("seed=%d generated invalid envelope: %v", seed, err)
+		}
+
+		retry := original
+		retry.AcceptedAt = retry.AcceptedAt.Add(time.Hour)
+		retry.Deadline = retry.AcceptedAt.Add(original.Deadline.Sub(original.AcceptedAt))
+		if !original.SameRetry(retry) {
+			t.Fatalf("seed=%d exact retry rejected", seed)
+		}
+		mismatch := retry
+		switch random.Intn(7) {
+		case 0:
+			mismatch.Payload += "-foreign"
+		case 1:
+			mismatch.Source.AgentUID += "-foreign"
+		case 2:
+			mismatch.Target.PaneUID += "-foreign"
+		case 3:
+			mismatch.Target.ActivationGeneration += "-foreign"
+		case 4:
+			mismatch.ReplyTo = "foreign"
+		case 5:
+			mismatch.ConversationRef += "-foreign"
+		case 6:
+			mismatch.Deadline = mismatch.Deadline.Add(time.Nanosecond)
+		}
+		if original.SameRetry(mismatch) {
+			t.Fatalf("seed=%d mismatched retry accepted: %#v", seed, mismatch)
+		}
+
+		reply := original
+		reply.MessageRef += "-reply"
+		reply.ReplyTo = original.MessageRef
+		reply.Source, reply.Target = original.Target, original.Source
+		if err := ValidateReply(original, reply); err != nil {
+			t.Fatalf("seed=%d exact reply rejected: %v", seed, err)
+		}
+		foreign := reply
+		switch random.Intn(4) {
+		case 0:
+			foreign.ReplyTo += "-foreign"
+		case 1:
+			foreign.ConversationRef += "-foreign"
+		case 2:
+			foreign.Source.AgentUID += "-foreign"
+		case 3:
+			foreign.Target.ActivationGeneration += "-foreign"
+		}
+		if ValidateReply(original, foreign) == nil {
+			t.Fatalf("seed=%d foreign reply accepted: %#v", seed, foreign)
+		}
+	}
+}
+
+func TestAuthorityMatrixIsExhaustiveAndPeerNeverEscalates(t *testing.T) {
+	t.Parallel()
+	want := map[Principal]map[Action]bool{
+		PrincipalHuman: {
+			ActionCoordinationSend: true, ActionCoordinationRead: true, ActionCoordinationReply: true,
+			ActionTurnStart: true, ActionTurnSteer: true, ActionTurnInterrupt: true, ActionConfigWrite: true,
+		},
+		PrincipalPeer: {
+			ActionCoordinationSend: true, ActionCoordinationRead: true, ActionCoordinationReply: true,
+		},
+		PrincipalProviderRuntime:  {ActionToolOrConnector: true, ActionModelHistoryWrite: true},
+		PrincipalApprovalReviewer: {ActionApprovalReview: true},
+	}
+	seen := 0
+	for _, principal := range Principals() {
+		for _, action := range Actions() {
+			seen++
+			if got := Authorize(principal, action); got != want[principal][action] {
+				t.Errorf("Authorize(%s, %s) = %t", principal, action, got)
+			}
+		}
+	}
+	if seen != len(Principals())*len(Actions()) {
+		t.Fatalf("authority matrix cells = %d", seen)
+	}
+}
+
+func TestPublicReducerTransitionTable(t *testing.T) {
+	t.Parallel()
+	envelope := messageEnvelopeFixture()
+	accepted, changed := Reduce(Delivery{}, envelope, eventFor(envelope, EventAccept))
+	if !changed || accepted.State != StateAccepted {
+		t.Fatalf("accept = (%+v, %t)", accepted, changed)
+	}
+	held, changed := Reduce(accepted, envelope, eventFor(envelope, EventHold))
+	if !changed || held.State != StateHeld {
+		t.Fatalf("hold = (%+v, %t)", held, changed)
+	}
+	for _, test := range []struct {
+		kind EventKind
+		want State
+	}{
+		{EventDeliver, StateDelivered}, {EventRefuse, StateRefused}, {EventExpire, StateExpired},
+		{EventStale, StateStale}, {EventFail, StateFailed},
+	} {
+		for _, initial := range []Delivery{accepted, held} {
+			event := eventFor(envelope, test.kind)
+			event.OutcomeUnknown = test.kind == EventFail
+			got, changed := Reduce(initial, envelope, event)
+			if !changed || got.State != test.want || got.State.Terminal() != true || got.OutcomeUnknown != event.OutcomeUnknown {
+				t.Errorf("%s from %s = (%+v, %t)", test.kind, initial.State, got, changed)
+			}
+		}
+	}
+	for _, event := range []Event{
+		eventFor(envelope, EventDeliver),
+		{Kind: EventHold, MessageRef: "foreign", ConversationRef: envelope.ConversationRef, Target: envelope.Target, ObservedAt: messageTestNow},
+		{Kind: EventHold, MessageRef: envelope.MessageRef, ConversationRef: "foreign", Target: envelope.Target, ObservedAt: messageTestNow},
+		{Kind: EventHold, MessageRef: envelope.MessageRef, ConversationRef: envelope.ConversationRef, Target: envelope.Source, ObservedAt: messageTestNow},
+	} {
+		got, changed := Reduce(accepted, envelope, event)
+		if event.Kind == EventDeliver {
+			continue
+		}
+		if changed || !reflect.DeepEqual(got, accepted) {
+			t.Errorf("foreign event changed state: %+v", event)
+		}
+	}
+	terminal, _ := Reduce(accepted, envelope, eventFor(envelope, EventDeliver))
+	for _, kind := range []EventKind{EventAccept, EventHold, EventDeliver, EventRefuse, EventExpire, EventStale, EventFail} {
+		got, changed := Reduce(terminal, envelope, eventFor(envelope, kind))
+		if changed || !reflect.DeepEqual(got, terminal) {
+			t.Errorf("terminal changed on %s", kind)
+		}
+	}
+	foreignCurrent := accepted
+	foreignCurrent.MessageRef = "foreign"
+	if got, changed := Reduce(foreignCurrent, envelope, eventFor(envelope, EventHold)); changed || !reflect.DeepEqual(got, foreignCurrent) {
+		t.Fatalf("foreign current delivery changed: %#v", got)
+	}
+	early := eventFor(envelope, EventHold)
+	early.ObservedAt = envelope.AcceptedAt.Add(-time.Nanosecond)
+	if got, changed := Reduce(accepted, envelope, early); changed || !reflect.DeepEqual(got, accepted) {
+		t.Fatalf("early event changed state: %#v", got)
+	}
+}
+
+func TestPublicReducerMatchesReferenceModelForRandomSequences(t *testing.T) {
+	t.Parallel()
+	envelope := messageEnvelopeFixture()
+	kinds := []EventKind{EventAccept, EventHold, EventDeliver, EventRefuse, EventExpire, EventStale, EventFail}
+	for seed := range int64(512) {
+		random := rand.New(rand.NewSource(seed)) // #nosec G404 -- deterministic state exploration.
+		var got, want Delivery
+		for step := range 128 {
+			event := eventFor(envelope, kinds[random.Intn(len(kinds))])
+			if random.Intn(7) == 0 {
+				event.MessageRef = "foreign"
+			}
+			if random.Intn(7) == 0 {
+				event.Target = envelope.Source
+			}
+			event.OutcomeUnknown = random.Intn(2) == 1
+			got, _ = Reduce(got, envelope, event)
+			want = referenceReduce(want, envelope, event)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("seed=%d step=%d event=%+v got=%+v want=%+v", seed, step, event, got, want)
+			}
+		}
+	}
+}
+
+func referenceReduce(current Delivery, envelope Envelope, event Event) Delivery {
+	if event.MessageRef != envelope.MessageRef || event.ConversationRef != envelope.ConversationRef || event.Target != envelope.Target ||
+		event.ObservedAt.Before(envelope.AcceptedAt) || (current.State != "" && (current.MessageRef != envelope.MessageRef || current.ConversationRef != envelope.ConversationRef)) || current.State.Terminal() {
+		return current
+	}
+	if current.State == "" {
+		if event.Kind == EventAccept {
+			return Delivery{MessageRef: envelope.MessageRef, ConversationRef: envelope.ConversationRef, State: StateAccepted, AcceptedAt: envelope.AcceptedAt}
+		}
+		return current
+	}
+	if event.Kind == EventHold && current.State == StateAccepted {
+		current.State, current.Reason = StateHeld, string(EventHold)
+		return current
+	}
+	if current.State != StateAccepted && current.State != StateHeld {
+		return current
+	}
+	terminal := map[EventKind]State{EventDeliver: StateDelivered, EventRefuse: StateRefused, EventExpire: StateExpired, EventStale: StateStale, EventFail: StateFailed}
+	state, ok := terminal[event.Kind]
+	if !ok {
+		return current
+	}
+	current.State, current.Reason, current.TerminalAt = state, string(event.Kind), event.ObservedAt
+	current.OutcomeUnknown = event.Kind == EventFail && event.OutcomeUnknown
+	return current
+}

--- a/internal/integrations/agents/agentmessage/store.go
+++ b/internal/integrations/agents/agentmessage/store.go
@@ -1,0 +1,458 @@
+// Package agentmessage persists the local provider-neutral coordination inbox.
+// The store is private to the same-user host and contains only the public v1
+// envelope: provider locators, credentials, thread IDs, and session secrets are
+// never part of its model.
+package agentmessage
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	coremessage "github.com/crevissepartners/projmux/internal/core/agentmessage"
+	localstate "github.com/crevissepartners/projmux/internal/state"
+)
+
+const (
+	storeVersion      = 1
+	storeDirName      = "agent-messages"
+	storeFileName     = "messages.json"
+	maxRecords        = 256
+	maxStoreBytes     = 2 << 20
+	terminalRetention = 24 * time.Hour
+)
+
+var (
+	ErrCapacity       = errors.New("agent message store is at capacity")
+	ErrMalformedStore = errors.New("malformed Agent message store")
+	ErrNotFound       = errors.New("agent message not found")
+)
+
+type Record struct {
+	Envelope        coremessage.Envelope `json:"envelope"`
+	Delivery        coremessage.Delivery `json:"delivery"`
+	Adapter         string               `json:"adapter"`
+	HandoffObserved bool                 `json:"handoffObserved,omitempty"`
+}
+
+type diskState struct {
+	Version int      `json:"version"`
+	Records []Record `json:"records"`
+}
+
+type storeHooks struct {
+	beforeRename func() error
+}
+
+type Store struct {
+	path  string
+	now   func() time.Time
+	hooks storeHooks
+}
+
+func NewStore(stateDir string) *Store {
+	return NewStoreAt(filepath.Join(stateDir, storeDirName, storeFileName))
+}
+
+func NewStoreAt(path string) *Store {
+	return &Store{path: path, now: time.Now}
+}
+
+func (s *Store) Path() string {
+	if s == nil {
+		return ""
+	}
+	return s.path
+}
+
+func (s *Store) Get(messageRef string) (Record, bool, error) {
+	var record Record
+	var found bool
+	err := s.withLock(func() error {
+		state, err := s.loadLocked()
+		if err != nil {
+			return err
+		}
+		for _, candidate := range state.Records {
+			if candidate.Envelope.MessageRef == messageRef {
+				record, found = candidate, true
+				break
+			}
+		}
+		return nil
+	})
+	return record, found, err
+}
+
+// PutAccepted atomically installs the broker acceptance record. A repeated
+// message ref returns the existing record only when the caller-controlled
+// immutable envelope and original TTL match.
+func (s *Store) PutAccepted(envelope coremessage.Envelope, adapter string) (Record, bool, error) {
+	if err := envelope.Validate(); err != nil {
+		return Record{}, false, err
+	}
+	if adapter != "codex-inbox" && adapter != "claude-coordination" {
+		return Record{}, false, fmt.Errorf("invalid Agent message adapter %q", adapter)
+	}
+	if (adapter == "codex-inbox") != (envelope.Target.Provider == "codex") ||
+		(adapter == "claude-coordination") != (envelope.Target.Provider == "claude") {
+		return Record{}, false, fmt.Errorf("agent message adapter %q does not match target provider %q", adapter, envelope.Target.Provider)
+	}
+	var out Record
+	var created bool
+	err := s.withLock(func() error {
+		state, err := s.loadLocked()
+		if err != nil {
+			return err
+		}
+		for _, existing := range state.Records {
+			if existing.Envelope.MessageRef != envelope.MessageRef {
+				continue
+			}
+			if existing.Adapter != adapter || !existing.Envelope.SameRetry(envelope) {
+				return coremessage.ErrRetryMismatch
+			}
+			out = existing
+			return nil
+		}
+		now := s.clock()
+		state.Records = pruneRecords(state.Records, now)
+		if len(state.Records) >= maxRecords {
+			return ErrCapacity
+		}
+		delivery, changed := coremessage.Reduce(coremessage.Delivery{}, envelope, coremessage.Event{
+			Kind: coremessage.EventAccept, MessageRef: envelope.MessageRef, ConversationRef: envelope.ConversationRef,
+			Target: envelope.Target, ObservedAt: envelope.AcceptedAt,
+		})
+		if !changed {
+			return coremessage.ErrInvalidEnvelope
+		}
+		out = Record{Envelope: envelope, Delivery: delivery, Adapter: adapter}
+		state.Records = append(state.Records, out)
+		if err := s.writeLocked(state); err != nil {
+			return err
+		}
+		created = true
+		return nil
+	})
+	return out, created, err
+}
+
+func (s *Store) Apply(messageRef string, event coremessage.Event) (Record, bool, error) {
+	var out Record
+	var changed bool
+	err := s.withLock(func() error {
+		state, err := s.loadLocked()
+		if err != nil {
+			return err
+		}
+		for i := range state.Records {
+			if state.Records[i].Envelope.MessageRef != messageRef {
+				continue
+			}
+			next, didChange := coremessage.Reduce(state.Records[i].Delivery, state.Records[i].Envelope, event)
+			if didChange {
+				state.Records[i].Delivery = next
+				if err := s.writeLocked(state); err != nil {
+					return err
+				}
+				changed = true
+			}
+			out = state.Records[i]
+			return nil
+		}
+		return ErrNotFound
+	})
+	return out, changed, err
+}
+
+// MarkHandoff durably remembers the provider-private point after which a lost
+// receipt is ambiguous. It does not invent a public lifecycle state: the
+// public reducer remains accepted|held -> terminal.
+func (s *Store) MarkHandoff(messageRef string) (Record, bool, error) {
+	var out Record
+	var changed bool
+	err := s.withLock(func() error {
+		state, err := s.loadLocked()
+		if err != nil {
+			return err
+		}
+		for i := range state.Records {
+			record := &state.Records[i]
+			if record.Envelope.MessageRef != messageRef {
+				continue
+			}
+			if record.Adapter != "claude-coordination" {
+				return fmt.Errorf("agent message %q has no provider handoff phase", messageRef)
+			}
+			if !record.Delivery.State.Terminal() && !record.HandoffObserved {
+				record.HandoffObserved = true
+				if err := s.writeLocked(state); err != nil {
+					return err
+				}
+				changed = true
+			}
+			out = *record
+			return nil
+		}
+		return ErrNotFound
+	})
+	return out, changed, err
+}
+
+// Status expires an unclaimed pre-handoff record at its broker deadline. A
+// terminal record is returned unchanged, and payload remains available only to
+// the private caller which decides its public projection.
+func (s *Store) Status(messageRef string, now time.Time) (Record, bool, error) {
+	record, found, err := s.Get(messageRef)
+	if err != nil || !found || record.Delivery.State.Terminal() || record.Envelope.Deadline.After(now) {
+		return record, found, err
+	}
+	event := deadlineEvent(record, now)
+	record, _, err = s.Apply(messageRef, event)
+	return record, true, err
+}
+
+// Claim returns the oldest compatible full envelope and commits delivered in
+// the same file lock. It is the Codex safe boundary: target self read, not model
+// processing, reply, user input, or app-server history mutation.
+func (s *Store) Claim(target coremessage.Route, now time.Time) (Record, bool, error) {
+	if !target.Valid() {
+		return Record{}, false, coremessage.ErrInvalidEnvelope
+	}
+	var out Record
+	var claimed bool
+	err := s.withLock(func() error {
+		state, err := s.loadLocked()
+		if err != nil {
+			return err
+		}
+		changed := false
+		for i := range state.Records {
+			record := &state.Records[i]
+			if record.Adapter == "codex-inbox" && record.Envelope.Target.Same(target) &&
+				!record.Delivery.State.Terminal() && !record.Envelope.Deadline.After(now) {
+				next, didChange := coremessage.Reduce(record.Delivery, record.Envelope, deadlineEvent(*record, now))
+				if didChange {
+					record.Delivery, changed = next, true
+				}
+			}
+		}
+		order := make([]int, len(state.Records))
+		for i := range order {
+			order[i] = i
+		}
+		sort.SliceStable(order, func(i, j int) bool {
+			return state.Records[order[i]].Envelope.AcceptedAt.Before(state.Records[order[j]].Envelope.AcceptedAt)
+		})
+		for _, index := range order {
+			record := &state.Records[index]
+			if record.Adapter != "codex-inbox" || (record.Delivery.State != coremessage.StateAccepted && record.Delivery.State != coremessage.StateHeld) ||
+				!record.Envelope.Target.Same(target) {
+				continue
+			}
+			next, didChange := coremessage.Reduce(record.Delivery, record.Envelope, coremessage.Event{
+				Kind: coremessage.EventDeliver, MessageRef: record.Envelope.MessageRef,
+				ConversationRef: record.Envelope.ConversationRef, Target: record.Envelope.Target,
+				Reason: "target-self-claim", ObservedAt: now,
+			})
+			if didChange {
+				record.Delivery = next
+				out, changed, claimed = *record, true, true
+			}
+			break
+		}
+		if changed {
+			return s.writeLocked(state)
+		}
+		return nil
+	})
+	return out, claimed, err
+}
+
+func deadlineEvent(record Record, now time.Time) coremessage.Event {
+	kind, reason, unknown := coremessage.EventExpire, "deadline-expired", false
+	if record.HandoffObserved {
+		kind, reason, unknown = coremessage.EventFail, "provider-handoff-outcome-unknown", true
+	}
+	return coremessage.Event{Kind: kind, MessageRef: record.Envelope.MessageRef,
+		ConversationRef: record.Envelope.ConversationRef, Target: record.Envelope.Target,
+		Reason: reason, ObservedAt: now, OutcomeUnknown: unknown}
+}
+
+func (s *Store) clock() time.Time {
+	if s == nil || s.now == nil {
+		return time.Now().UTC()
+	}
+	return s.now().UTC()
+}
+
+func (s *Store) withLock(fn func() error) error {
+	if s == nil || s.path == "" {
+		return errors.New("agent message store path is empty")
+	}
+	dir := filepath.Dir(s.path)
+	if err := localstate.EnsurePrivateDir(dir); err != nil {
+		return err
+	}
+	lock, err := os.OpenFile(s.path+".flock", os.O_CREATE|os.O_RDWR, localstate.PrivateFileMode) // #nosec G304 -- private store sibling.
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+	if err := unix.Flock(int(lock.Fd()), unix.LOCK_EX); err != nil {
+		return err
+	}
+	defer unix.Flock(int(lock.Fd()), unix.LOCK_UN) //nolint:errcheck -- releasing an owned advisory lock.
+	return fn()
+}
+
+func (s *Store) loadLocked() (diskState, error) {
+	data, err := os.ReadFile(s.path) // #nosec G304 -- explicit private store path.
+	if errors.Is(err, os.ErrNotExist) {
+		return diskState{Version: storeVersion}, nil
+	}
+	if err != nil {
+		return diskState{}, err
+	}
+	if len(data) == 0 || len(data) > maxStoreBytes {
+		return diskState{}, ErrMalformedStore
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var state diskState
+	if decoder.Decode(&state) != nil || state.Version != storeVersion || len(state.Records) > maxRecords {
+		return diskState{}, ErrMalformedStore
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return diskState{}, ErrMalformedStore
+	}
+	seen := make(map[string]bool, len(state.Records))
+	for _, record := range state.Records {
+		if !validRecord(record) || seen[record.Envelope.MessageRef] {
+			return diskState{}, ErrMalformedStore
+		}
+		seen[record.Envelope.MessageRef] = true
+	}
+	return state, nil
+}
+
+func validRecord(record Record) bool {
+	if record.Envelope.Validate() != nil || record.Delivery.MessageRef != record.Envelope.MessageRef ||
+		record.Delivery.ConversationRef != record.Envelope.ConversationRef ||
+		!record.Delivery.AcceptedAt.Equal(record.Envelope.AcceptedAt) {
+		return false
+	}
+	if (record.Adapter == "codex-inbox") != (record.Envelope.Target.Provider == "codex") ||
+		(record.Adapter == "claude-coordination") != (record.Envelope.Target.Provider == "claude") ||
+		(record.HandoffObserved && record.Adapter != "claude-coordination") {
+		return false
+	}
+	switch record.Delivery.State {
+	case coremessage.StateAccepted, coremessage.StateHeld:
+		return record.Delivery.TerminalAt.IsZero() && !record.Delivery.OutcomeUnknown
+	case coremessage.StateDelivered, coremessage.StateRefused, coremessage.StateExpired, coremessage.StateStale:
+		return !record.Delivery.TerminalAt.IsZero() && !record.Delivery.OutcomeUnknown
+	case coremessage.StateFailed:
+		return !record.Delivery.TerminalAt.IsZero()
+	default:
+		return false
+	}
+}
+
+func (s *Store) writeLocked(state diskState) error {
+	state.Version = storeVersion
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if len(data) > maxStoreBytes || len(state.Records) > maxRecords {
+		return ErrCapacity
+	}
+	dir := filepath.Dir(s.path)
+	tmp, err := os.CreateTemp(dir, ".messages.tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		_ = tmp.Close()
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(localstate.PrivateFileMode); err != nil {
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if s.hooks.beforeRename != nil {
+		if err := s.hooks.beforeRename(); err != nil {
+			return err
+		}
+	}
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		return err
+	}
+	committed = true
+	localstate.RepairPrivateFile(s.path)
+	directory, err := os.Open(dir) // #nosec G304 -- withLock validated this exact parent as a private directory before writeLocked.
+	if err == nil {
+		if syncErr := directory.Sync(); syncErr != nil && !errors.Is(syncErr, fs.ErrInvalid) && !errors.Is(syncErr, fs.ErrPermission) {
+			_ = directory.Close()
+			return syncErr
+		}
+		_ = directory.Close()
+	}
+	return nil
+}
+
+func pruneRecords(records []Record, now time.Time) []Record {
+	cutoff := now.Add(-terminalRetention)
+	out := records[:0]
+	for _, record := range records {
+		if record.Delivery.State.Terminal() && !record.Delivery.TerminalAt.IsZero() && record.Delivery.TerminalAt.Before(cutoff) {
+			continue
+		}
+		out = append(out, record)
+	}
+	if len(out) < maxRecords {
+		return out
+	}
+	// At capacity, reclaim the oldest terminal records first. Non-terminal
+	// records are never silently evicted.
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Envelope.AcceptedAt.Before(out[j].Envelope.AcceptedAt) })
+	for len(out) >= maxRecords {
+		index := -1
+		for i := range out {
+			if out[i].Delivery.State.Terminal() {
+				index = i
+				break
+			}
+		}
+		if index < 0 {
+			break
+		}
+		out = append(out[:index], out[index+1:]...)
+	}
+	return out
+}

--- a/internal/integrations/agents/agentmessage/store_test.go
+++ b/internal/integrations/agents/agentmessage/store_test.go
@@ -1,0 +1,368 @@
+package agentmessage
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	coremessage "github.com/crevissepartners/projmux/internal/core/agentmessage"
+)
+
+var storeTestNow = time.Date(2026, 9, 6, 2, 3, 4, 0, time.UTC)
+
+func storeEnvelope(index int) coremessage.Envelope {
+	return coremessage.Envelope{
+		Version: coremessage.Version, MessageRef: fmt.Sprintf("message-%03d", index), ConversationRef: fmt.Sprintf("conversation-%03d", index),
+		Source:    coremessage.Route{AgentUID: "agent-source", PaneUID: "pane-source", ActivationGeneration: "generation-source", Provider: "claude"},
+		Target:    coremessage.Route{AgentUID: "agent-target", PaneUID: "pane-target", ActivationGeneration: "generation-target", Provider: "codex"},
+		Authority: coremessage.PeerAuthority(), Payload: fmt.Sprintf("payload-%03d", index),
+		AcceptedAt: storeTestNow.Add(time.Duration(index) * time.Nanosecond), Deadline: storeTestNow.Add(time.Hour + time.Duration(index)*time.Nanosecond),
+	}
+}
+
+func TestStoreRetryRestartAndSecretFreeWire(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "messages", "messages.json")
+	store := NewStoreAt(path)
+	envelope := storeEnvelope(1)
+	first, created, err := store.PutAccepted(envelope, "codex-inbox")
+	if err != nil || !created || first.Delivery.State != coremessage.StateAccepted {
+		t.Fatalf("PutAccepted = (%+v, %t, %v)", first, created, err)
+	}
+	retry := envelope
+	retry.AcceptedAt = retry.AcceptedAt.Add(time.Minute)
+	retry.Deadline = retry.Deadline.Add(time.Minute)
+	second, created, err := store.PutAccepted(retry, "codex-inbox")
+	if err != nil || created || second != first {
+		t.Fatalf("idempotent retry = (%+v, %t, %v)", second, created, err)
+	}
+	retry.Payload = "changed"
+	if _, _, err := store.PutAccepted(retry, "codex-inbox"); !errors.Is(err, coremessage.ErrRetryMismatch) {
+		t.Fatalf("mismatched retry error = %v", err)
+	}
+
+	restarted := NewStoreAt(path)
+	got, found, err := restarted.Get(envelope.MessageRef)
+	if err != nil || !found || got != first {
+		t.Fatalf("restart Get = (%+v, %t, %v)", got, found, err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"token", "socket", "threadId", "sessionId", "locator", "credential"} {
+		if strings.Contains(strings.ToLower(string(data)), strings.ToLower(forbidden)) {
+			t.Errorf("store wire retained forbidden field %q: %s", forbidden, data)
+		}
+	}
+	if info, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	} else if info.Mode().Perm() != 0o600 {
+		t.Fatalf("store mode = %v", info.Mode())
+	}
+	if info, err := os.Stat(filepath.Dir(path)); err != nil {
+		t.Fatal(err)
+	} else if info.Mode().Perm() != 0o700 {
+		t.Fatalf("store directory mode = %v", info.Mode())
+	}
+}
+
+func TestStoreRefusesFullNonterminalCapacityWithoutChangingDisk(t *testing.T) {
+	t.Parallel()
+	store := NewStoreAt(filepath.Join(t.TempDir(), "messages.json"))
+	records := make([]Record, maxRecords)
+	for i := range records {
+		envelope := storeEnvelope(i + 100)
+		delivery, changed := coremessage.Reduce(coremessage.Delivery{}, envelope, coremessage.Event{Kind: coremessage.EventAccept,
+			MessageRef: envelope.MessageRef, ConversationRef: envelope.ConversationRef, Target: envelope.Target, ObservedAt: envelope.AcceptedAt})
+		if !changed {
+			t.Fatalf("accept record %d", i)
+		}
+		records[i] = Record{Envelope: envelope, Delivery: delivery, Adapter: "codex-inbox"}
+	}
+	if err := store.withLock(func() error { return store.writeLocked(diskState{Version: storeVersion, Records: records}) }); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(store.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, created, err := store.PutAccepted(storeEnvelope(999), "codex-inbox"); !errors.Is(err, ErrCapacity) || created {
+		t.Fatalf("capacity put = created %t err %v", created, err)
+	}
+	after, err := os.ReadFile(store.Path())
+	if err != nil || !bytes.Equal(after, before) {
+		t.Fatalf("capacity refusal changed disk: err=%v", err)
+	}
+}
+
+func TestStoreRejectsOversizedFileOnRestart(t *testing.T) {
+	t.Parallel()
+	store := NewStoreAt(filepath.Join(t.TempDir(), "messages.json"))
+	if _, _, err := store.PutAccepted(storeEnvelope(1), "codex-inbox"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.Path(), bytes.Repeat([]byte{'x'}, maxStoreBytes+1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := NewStoreAt(store.Path()).Get("message-001"); !errors.Is(err, ErrMalformedStore) {
+		t.Fatalf("oversized restart error = %v", err)
+	}
+}
+
+func TestStoreRejectsUnknownProviderSecretFieldOnRestart(t *testing.T) {
+	t.Parallel()
+	store := NewStoreAt(filepath.Join(t.TempDir(), "messages.json"))
+	if _, _, err := store.PutAccepted(storeEnvelope(1), "codex-inbox"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(store.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = bytes.Replace(data, []byte(`"adapter":"codex-inbox"`),
+		[]byte(`"adapter":"codex-inbox","token":"must-not-enter-v1-schema"`), 1)
+	if err := os.WriteFile(store.Path(), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := NewStoreAt(store.Path()).Get("message-001"); !errors.Is(err, ErrMalformedStore) {
+		t.Fatalf("unknown provider secret field restart error = %v", err)
+	}
+}
+
+func TestStoreAtomicClaimIsOldestExactActivationAndTerminalOnce(t *testing.T) {
+	t.Parallel()
+	store := NewStoreAt(filepath.Join(t.TempDir(), "messages.json"))
+	first, second := storeEnvelope(1), storeEnvelope(2)
+	if _, _, err := store.PutAccepted(second, "codex-inbox"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.PutAccepted(first, "codex-inbox"); err != nil {
+		t.Fatal(err)
+	}
+	foreign := first.Target
+	foreign.ActivationGeneration = "replacement"
+	if _, claimed, err := store.Claim(foreign, storeTestNow.Add(time.Minute)); err != nil || claimed {
+		t.Fatalf("foreign claim = %t, %v", claimed, err)
+	}
+	claimed, ok, err := store.Claim(first.Target, storeTestNow.Add(time.Minute))
+	if err != nil || !ok || claimed.Envelope.MessageRef != first.MessageRef || claimed.Envelope.Payload != first.Payload ||
+		claimed.Delivery.State != coremessage.StateDelivered || claimed.Delivery.Reason != "target-self-claim" {
+		t.Fatalf("first claim = (%+v, %t, %v)", claimed, ok, err)
+	}
+	duplicate, ok, err := store.Claim(first.Target, storeTestNow.Add(2*time.Minute))
+	if err != nil || !ok || duplicate.Envelope.MessageRef != second.MessageRef {
+		t.Fatalf("second claim = (%+v, %t, %v)", duplicate, ok, err)
+	}
+	if _, ok, err := store.Claim(first.Target, storeTestNow.Add(3*time.Minute)); err != nil || ok {
+		t.Fatalf("duplicate terminal claim = %t, %v", ok, err)
+	}
+}
+
+func TestStoreConcurrentWritersAndClaimersSerialize(t *testing.T) {
+	t.Parallel()
+	store := NewStoreAt(filepath.Join(t.TempDir(), "messages.json"))
+	const count = 64
+	var writers sync.WaitGroup
+	errs := make(chan error, count)
+	for index := range count {
+		writers.Add(1)
+		go func(index int) {
+			defer writers.Done()
+			_, _, err := store.PutAccepted(storeEnvelope(index), "codex-inbox")
+			errs <- err
+		}(index)
+	}
+	writers.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	claimed := make(chan string, count)
+	claimErrs := make(chan error, count)
+	var readers sync.WaitGroup
+	for range count {
+		readers.Go(func() {
+			if record, ok, err := store.Claim(storeEnvelope(0).Target, storeTestNow.Add(time.Minute)); err != nil {
+				claimErrs <- err
+			} else if ok {
+				claimed <- record.Envelope.MessageRef
+			}
+		})
+	}
+	readers.Wait()
+	close(claimed)
+	close(claimErrs)
+	for err := range claimErrs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	seen := map[string]bool{}
+	for ref := range claimed {
+		if seen[ref] {
+			t.Fatalf("message %s claimed twice", ref)
+		}
+		seen[ref] = true
+	}
+	if len(seen) != count {
+		t.Fatalf("claimed %d records, want %d", len(seen), count)
+	}
+}
+
+func TestStoreAtomicReplaceFailurePreservesPriorBytes(t *testing.T) {
+	t.Parallel()
+	store := NewStoreAt(filepath.Join(t.TempDir(), "messages.json"))
+	if _, _, err := store.PutAccepted(storeEnvelope(1), "codex-inbox"); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(store.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.hooks.beforeRename = func() error { return errors.New("injected before rename") }
+	if _, _, err := store.PutAccepted(storeEnvelope(2), "codex-inbox"); err == nil {
+		t.Fatal("injected failure succeeded")
+	}
+	after, err := os.ReadFile(store.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("failed atomic replace changed prior bytes")
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(store.Path()), ".messages.tmp-*"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("staged files = %v, err=%v", matches, err)
+	}
+}
+
+func TestStoreBoundsRetentionTimeoutAndMalformedRestart(t *testing.T) {
+	t.Parallel()
+	store := NewStoreAt(filepath.Join(t.TempDir(), "messages.json"))
+	expired := storeEnvelope(1)
+	expired.Deadline = expired.AcceptedAt.Add(time.Second)
+	if _, _, err := store.PutAccepted(expired, "codex-inbox"); err != nil {
+		t.Fatal(err)
+	}
+	status, found, err := store.Status(expired.MessageRef, expired.Deadline.Add(time.Second))
+	if err != nil || !found || status.Delivery.State != coremessage.StateExpired {
+		t.Fatalf("expired status = (%+v, %t, %v)", status, found, err)
+	}
+
+	oversized := storeEnvelope(2)
+	oversized.Payload = strings.Repeat("x", coremessage.MaxPayloadBytes+1)
+	if _, _, err := store.PutAccepted(oversized, "codex-inbox"); !errors.Is(err, coremessage.ErrInvalidEnvelope) {
+		t.Fatalf("oversized payload error = %v", err)
+	}
+
+	old := make([]Record, maxRecords)
+	for i := range old {
+		envelope := storeEnvelope(i + 1000)
+		envelope.AcceptedAt = storeTestNow.Add(-terminalRetention - 2*time.Hour).Add(time.Duration(i) * time.Nanosecond)
+		envelope.Deadline = envelope.AcceptedAt.Add(time.Minute)
+		delivery, _ := coremessage.Reduce(coremessage.Delivery{}, envelope, coremessage.Event{Kind: coremessage.EventAccept,
+			MessageRef: envelope.MessageRef, ConversationRef: envelope.ConversationRef, Target: envelope.Target, ObservedAt: envelope.AcceptedAt})
+		delivery, _ = coremessage.Reduce(delivery, envelope, coremessage.Event{Kind: coremessage.EventDeliver,
+			MessageRef: envelope.MessageRef, ConversationRef: envelope.ConversationRef, Target: envelope.Target,
+			Reason: "old", ObservedAt: envelope.AcceptedAt.Add(time.Second)})
+		old[i] = Record{Envelope: envelope, Delivery: delivery, Adapter: "codex-inbox"}
+	}
+	store.hooks = storeHooks{}
+	store.now = func() time.Time { return storeTestNow }
+	if err := store.withLock(func() error { return store.writeLocked(diskState{Version: storeVersion, Records: old}) }); err != nil {
+		t.Fatal(err)
+	}
+	if _, created, err := store.PutAccepted(storeEnvelope(3), "codex-inbox"); err != nil || !created {
+		t.Fatalf("retention put = %t, %v", created, err)
+	}
+	if _, found, err := store.Get(old[0].Envelope.MessageRef); err != nil || found {
+		t.Fatalf("old terminal retained = %t, %v", found, err)
+	}
+
+	if err := os.WriteFile(store.Path(), []byte(`{"version":1,"records":[]} trailing`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := NewStoreAt(store.Path()).Get("anything"); !errors.Is(err, ErrMalformedStore) {
+		t.Fatalf("malformed restart error = %v", err)
+	}
+}
+
+func TestStorePostHandoffDeadlineIsFailedUnknownAcrossRestart(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "messages.json")
+	store := NewStoreAt(path)
+	envelope := storeEnvelope(77)
+	envelope.Target.Provider = "claude"
+	if _, _, err := store.PutAccepted(envelope, "claude-coordination"); err != nil {
+		t.Fatal(err)
+	}
+	if marked, changed, err := store.MarkHandoff(envelope.MessageRef); err != nil || !changed || !marked.HandoffObserved {
+		t.Fatalf("mark handoff = (%#v, %t, %v)", marked, changed, err)
+	}
+	restarted := NewStoreAt(path)
+	status, found, err := restarted.Status(envelope.MessageRef, envelope.Deadline.Add(time.Second))
+	if err != nil || !found || status.Delivery.State != coremessage.StateFailed || !status.Delivery.OutcomeUnknown ||
+		status.Delivery.Reason != "provider-handoff-outcome-unknown" {
+		t.Fatalf("post-handoff timeout = (%#v, %t, %v)", status, found, err)
+	}
+}
+
+func TestCodexClaimLeavesUnrelatedOverdueClaudeHandoffUnchanged(t *testing.T) {
+	t.Parallel()
+	store := NewStoreAt(filepath.Join(t.TempDir(), "messages.json"))
+	claude := storeEnvelope(81)
+	claude.Target.Provider = "claude"
+	claude.Deadline = claude.AcceptedAt.Add(time.Second)
+	if _, _, err := store.PutAccepted(claude, "claude-coordination"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.MarkHandoff(claude.MessageRef); err != nil {
+		t.Fatal(err)
+	}
+	codex := storeEnvelope(82)
+	codex.AcceptedAt = claude.Deadline.Add(time.Second)
+	codex.Deadline = codex.AcceptedAt.Add(time.Minute)
+	if _, _, err := store.PutAccepted(codex, "codex-inbox"); err != nil {
+		t.Fatal(err)
+	}
+	if _, claimed, err := store.Claim(codex.Target, codex.AcceptedAt); err != nil || !claimed {
+		t.Fatalf("Codex claim = %t, %v", claimed, err)
+	}
+	status, found, err := store.Get(claude.MessageRef)
+	if err != nil || !found || status.Delivery.State != coremessage.StateAccepted || !status.HandoffObserved {
+		t.Fatalf("Claude handoff after Codex claim = (%#v, %t, %v)", status, found, err)
+	}
+}
+
+func TestMarkHandoffRefusesCodexRecordWithoutChangingDisk(t *testing.T) {
+	t.Parallel()
+	store := NewStoreAt(filepath.Join(t.TempDir(), "messages.json"))
+	envelope := storeEnvelope(91)
+	if _, _, err := store.PutAccepted(envelope, "codex-inbox"); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(store.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, changed, err := store.MarkHandoff(envelope.MessageRef); err == nil || changed {
+		t.Fatalf("Codex handoff = changed %t err %v", changed, err)
+	}
+	after, err := os.ReadFile(store.Path())
+	if err != nil || string(after) != string(before) {
+		t.Fatalf("Codex handoff changed disk: err=%v", err)
+	}
+	if _, found, err := NewStoreAt(store.Path()).Get(envelope.MessageRef); err != nil || !found {
+		t.Fatalf("restart after refusal = found %t err %v", found, err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a provider-neutral v1 broker with exact current-Pane source authority, exact activation targets, immutable retry/reply correlation, and terminal-once delivery receipts.
- Project the Phase 2 Claude final hop while keeping Codex ingress in a private activation-scoped self-claim inbox with zero app-server/user-turn/model-history writes.
- Publish shared capability/help/docs surfaces and keep Antigravity and unsupported directions fail-closed; actual provider/model traffic and effective-tool canaries remain Phase 4 follow-ups.

## Test plan
- [x] make fmt
- [x] make fix
- [x] make test
- [x] go test -race ./internal/core/agentmessage ./internal/integrations/agents/agentmessage ./internal/app
- [x] make test-integration
- [x] make test-e2e
- [x] required CI checks and aggregate Test
- [x] make security-static
- [x] make security-go

## Globalization
- [ ] No user-facing string changes.
- [ ] User-facing strings are behind internal/i18n catalog keys with tests.
- [x] Non-translated strings are classified as command spellings, provider/protocol literals, or bounded internal diagnostics.

## Deliberately deferred
- Phase 4 actual Claude/Codex/model wake and round-trip canary.
- Effective-tool isolation proof, live settings convergence, provider history replication, cross-host relay, peer approval/interrupt, and badge integration.