### PR TITLE
fix(agent): preserve provider frame rejection reasons

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1814,6 +1814,22 @@ separate decision this measurement exists to inform.
 - `TestClaudePushSourceReplacementAfterDurableHandoffWritesZero` and
   `TestClaudeProviderPushFinalRouteCheckPrecedesSoleWrite` cover source/target
   authority loss across durable work and the final provider pre-write fence.
+- `TestClaudeProviderFrameSerializedByteBoundaryAndSafeRejection` fixes the
+  complete auth/user frame boundary at 8191/8192/8193 serialized bytes.
+  `TestClaudeProviderPostPreservesConstructionReasonBeforeAnyRouteOrWrite`
+  separates invalid auth/content from size rejection before route or write.
+  `TestClaudeProviderWriteReasonsRequireOneActualWrite` distinguishes actual
+  zero/partial writes and invalid-count/full-with-error unknown outcomes.
+  `TestClaudeProviderRejectionReasonsSurviveHubReceiptStatusAndStoreReload`
+  preserves reasons through helper and public receipts, terminal store reload,
+  sender recovery text, secret exclusion, and duplicate sends with zero retries.
+  `TestClaudeProviderRejectionResponseValidationIsClosedAndLegacyCompatible`
+  admits canonical numeric size details and legacy reasons while rejecting
+  inconsistent ambiguity and secret-bearing suffixes.
+  `TestClaudeEndpointProcessIntegration/provider-frame-rejection-receipt`
+  exercises the built binary's public send/status against the isolated provider:
+  size/action survive, credentials stay absent, and the rejected frame adds no
+  provider connection before the next expected message.
 - `TestClaudeExplicitMultipleRequestsAndHumanOverlapSelectOnlyNamedOriginal`
   requires an explicit choice of the original request; Stop text has no reply
   authority regardless of human activity or pending request count.

--- a/internal/app/agent_message.go
+++ b/internal/app/agent_message.go
@@ -123,7 +123,7 @@ func (liveAgentMessageClaudeAdapter) Submit(ctx context.Context, registryPath st
 	if err != nil {
 		if !claudeCoordinationCallPossiblyDispatched(err) {
 			return agentdelivery.Delivery{MessageRef: envelope.MessageRef, State: agentdelivery.StateFailed,
-				Reason: "provider-write-zero"}, nil
+				Reason: "provider-prewrite-refused"}, nil
 		}
 		return ambiguousClaudeDelivery(envelope.MessageRef), nil
 	}
@@ -200,11 +200,12 @@ func claudeResponseDelivery(messageRef string, response claudeCoordinationRespon
 			}
 		case delivery.Ambiguous:
 			if delivery.Reason != "provider-handoff-outcome-unknown" &&
+				delivery.Reason != "provider-write-partial" &&
 				delivery.Reason != "broker-delivery-persist-failed" &&
 				delivery.Reason != "observation-timeout" && delivery.Reason != "delivery-outcome-unknown" {
 				return agentdelivery.Delivery{}, false
 			}
-		case delivery.Reason != "provider-write-zero":
+		case !knownClaudeProviderFailureReason(delivery.Reason):
 			return agentdelivery.Delivery{}, false
 		}
 	}
@@ -701,9 +702,6 @@ func (c *agentCommand) projectClaudeDelivery(record messagestore.Record, private
 			}
 		case agentdelivery.StateFailed:
 			kind, unknown = coremessage.EventFail, private.Ambiguous
-			if private.Ambiguous {
-				reason = "provider-handoff-outcome-unknown"
-			}
 		}
 	}
 	if kind == "" {
@@ -727,8 +725,34 @@ func writeAgentMessageReceipt(stdout io.Writer, receipt agentMessageReceipt, asJ
 	if asJSON {
 		return json.NewEncoder(stdout).Encode(receipt)
 	}
+	if receipt.Delivery.State.Terminal() && receipt.Delivery.State != coremessage.StateDelivered {
+		_, err := fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\n", receipt.MessageRef, receipt.Delivery.State,
+			receipt.Delivery.Reason, agentMessageFailureAction(receipt.Delivery))
+		return err
+	}
 	_, err := fmt.Fprintf(stdout, "%s\t%s\n", receipt.MessageRef, receipt.Delivery.State)
 	return err
+}
+
+func agentMessageFailureAction(delivery coremessage.Delivery) string {
+	if delivery.OutcomeUnknown {
+		return "inspect provider outcome; do not resend while unknown; automatic resend disabled"
+	}
+	if isClaudeProviderFrameSizeReason(delivery.Reason) {
+		return "reduce payload before retrying; frame bytes include auth and serialized content"
+	}
+	switch delivery.Reason {
+	case "provider-frame-invalid-auth":
+		return "check provider auth configuration before retrying"
+	case "provider-frame-invalid-content", "provider-frame-build-failed", "provider-frame-unsupported", "claude-private-frame-unsupported":
+		return "correct message content or configuration before retrying"
+	case "provider-prewrite-refused":
+		return "check current provider route before retrying"
+	case "provider-write-zero":
+		return "check provider connection before retrying"
+	default:
+		return "check message status and target availability before retrying"
+	}
 }
 
 func writeAgentMessageClaim(stdout io.Writer, record messagestore.Record, _ bool) error {

--- a/internal/app/agent_message_test.go
+++ b/internal/app/agent_message_test.go
@@ -539,7 +539,7 @@ func TestLiveClaudeAdapterDistinguishesPreDispatchWriteZeroFromMissingHelperResp
 		AcceptedAt: now, Deadline: now.Add(time.Minute)}
 	adapter := liveAgentMessageClaudeAdapter{}
 	known, err := adapter.Submit(context.Background(), fixture.registryPath+"-missing", fixture.route, envelope)
-	if err != nil || known.State != agentdelivery.StateFailed || known.Ambiguous || known.Reason != "provider-write-zero" {
+	if err != nil || known.State != agentdelivery.StateFailed || known.Ambiguous || known.Reason != "provider-prewrite-refused" {
 		t.Fatalf("pre-dispatch result=%+v err=%v", known, err)
 	}
 

--- a/internal/app/claude_endpoint_process_test.go
+++ b/internal/app/claude_endpoint_process_test.go
@@ -40,7 +40,9 @@ inbox = socket.socket(socket.AF_UNIX)
 inbox.bind(path)
 os.chmod(path, 0o600)
 inbox.listen()
-token = secrets.token_hex(24)
+# Exercise the existing valid auth boundary; short qualification/message
+# frames still fit, while the rejection fixture can reach the full byte cap.
+token = secrets.token_hex(2048)
 os.environ['CLAUDE_CODE_MESSAGING_SOCKET'] = path
 os.environ['CLAUDE_CODE_MESSAGING_TOKEN'] = token
 capture = socket.socket(socket.AF_UNIX)
@@ -427,6 +429,65 @@ func TestClaudeEndpointProcessIntegration(t *testing.T) {
 		}
 	}
 	qualify(first, "qualify-1")
+	t.Run("provider-frame-rejection-receipt", func(t *testing.T) {
+		const ref = "process-frame-rejection"
+		now := time.Now().UTC()
+		envelope := dialogueForRoute(ref, first, now)
+		envelope.BrokerEnvelope.Source = publicMessageRoute(sourceRoute)
+		envelope.BrokerEnvelope.ConversationRef = conversationRefFor(ref)
+		var expectedReason string
+		// Select from actual serialized bytes, not payload length. Keep the
+		// content valid so this fixture observes the frame cap specifically.
+		for count := 1; count <= coremessage.MaxPayloadBytes; count++ {
+			envelope.BrokerEnvelope.Payload = strings.Repeat("<", count)
+			content, err := providerCoordinationContent(envelope, binary)
+			if err != nil || !validClaudeAssistantReply(content) {
+				continue
+			}
+			size := len(serializedClaudeTestFrame(t, private.Token, content))
+			if size > 8192 {
+				expectedReason = fmt.Sprintf("provider-frame-too-large: frameBytes=%d limitBytes=8192", size)
+				break
+			}
+		}
+		if expectedReason == "" {
+			t.Fatal("fixture could not reach full-frame size rejection with valid content")
+		}
+		callCLI := func(args ...string) []byte {
+			t.Helper()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			command := exec.CommandContext(ctx, binary, args...)
+			command.Dir = root
+			command.Env = claudeEndpointProcessEnv(root, binary)
+			output, err := command.CombinedOutput()
+			if bytes.Contains(output, []byte(private.Token)) || bytes.Contains(output, []byte(envelope.BrokerEnvelope.Payload)) {
+				t.Fatal("sender output exposed auth or payload")
+			}
+			if err != nil {
+				t.Fatalf("isolated sender command failed: %v", err)
+			}
+			return output
+		}
+		output := callCLI("agent", "message", "send", "uid:"+first.AgentUID, "--source", "uid:"+sourceRoute.AgentUID,
+			"--message-ref", ref, "--", envelope.BrokerEnvelope.Payload)
+		if !bytes.Contains(output, []byte(expectedReason)) || !bytes.Contains(output, []byte("reduce payload")) {
+			t.Fatalf("sender did not preserve frame size/action: %s", output)
+		}
+		var receipt agentMessageReceipt
+		if json.Unmarshal(callCLI("agent", "message", "status", ref, "-o", "json"), &receipt) != nil ||
+			receipt.Delivery.State != coremessage.StateFailed || receipt.Delivery.Reason != expectedReason || receipt.Delivery.OutcomeUnknown {
+			t.Fatal("status did not preserve known frame size rejection")
+		}
+		record, found, err := messageStore.Get(ref)
+		if err != nil || !found || record.Delivery != receipt.Delivery {
+			t.Fatal("public terminal receipt did not survive store reload")
+		}
+		t.Logf("provider frame rejection: state=%s reason=%s outcomeUnknown=%t",
+			receipt.Delivery.State, receipt.Delivery.Reason, receipt.Delivery.OutcomeUnknown)
+		// The provider's next receive below must still be process-message-1.
+		// An auth-only or partial rejection connection would fail that check.
+	})
 
 	send := func(route coremetadata.AgentRouteRef, ref, command string) {
 		t.Helper()

--- a/internal/app/claude_provider_push.go
+++ b/internal/app/claude_provider_push.go
@@ -3,8 +3,10 @@ package app
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,6 +22,7 @@ const claudeFrozenFrameProviderVersion = "2.1.263"
 type claudeProviderPostOutcome struct {
 	FullFrameWritten bool
 	WroteAny         bool
+	Reason           string
 }
 
 func (o claudeProviderPostOutcome) Ambiguous() bool {
@@ -48,17 +51,19 @@ type claudeProviderUserFrame struct {
 // buildClaudeProviderPushFrame owns the only permitted post-auth vendor frame.
 // Do not add a control, reply, status, or inferred frame to this boundary.
 func buildClaudeProviderPushFrame(token, content string) ([]byte, error) {
-	if token == "" || len(token) > 4096 || strings.ContainsAny(token, "\r\n\x00") ||
-		content == "" || !validClaudeAssistantReply(content) {
-		return nil, errors.New("claude provider push frame is unavailable")
+	if token == "" || len(token) > 4096 || strings.ContainsAny(token, "\r\n\x00") {
+		return nil, errors.New("provider-frame-invalid-auth")
+	}
+	if content == "" || !validClaudeAssistantReply(content) {
+		return nil, errors.New("provider-frame-invalid-content")
 	}
 	auth, err := json.Marshal(claudeProviderAuthFrame{Type: "auth", Token: token})
 	if err != nil {
-		return nil, errors.New("claude provider push frame is unavailable")
+		return nil, errors.New("provider-frame-build-failed")
 	}
 	message, err := json.Marshal(claudeProviderUserFrame{Type: "user", Message: claudeProviderUserMessage{Role: "user", Content: content}})
 	if err != nil {
-		return nil, errors.New("claude provider push frame is unavailable")
+		return nil, errors.New("provider-frame-build-failed")
 	}
 	frame := make([]byte, 0, len(auth)+len(message)+2)
 	frame = append(frame, auth...)
@@ -66,22 +71,55 @@ func buildClaudeProviderPushFrame(token, content string) ([]byte, error) {
 	frame = append(frame, message...)
 	frame = append(frame, '\n')
 	if len(frame) > claudeProviderFrameMaxBytes {
-		return nil, errors.New("claude provider push frame is unavailable")
+		return nil, errors.New(claudeProviderFrameSizeReason(len(frame)))
 	}
 	return frame, nil
+}
+
+// Reasons cross the helper/public boundary and are persisted in existing
+// receipts. Only closed tokens and canonical numeric frame sizes belong here;
+// never attach a marshal, socket, credential, content, or writer error.
+func claudeProviderFrameSizeReason(size int) string {
+	return fmt.Sprintf("provider-frame-too-large: frameBytes=%d limitBytes=%d", size, claudeProviderFrameMaxBytes)
+}
+
+func isClaudeProviderFrameSizeReason(reason string) bool {
+	value, ok := strings.CutPrefix(reason, "provider-frame-too-large: frameBytes=")
+	if !ok {
+		return false
+	}
+	sizeText, _, ok := strings.Cut(value, " ")
+	size, err := strconv.Atoi(sizeText)
+	return ok && err == nil && size > claudeProviderFrameMaxBytes && reason == claudeProviderFrameSizeReason(size)
+}
+
+func knownClaudeProviderFailureReason(reason string) bool {
+	switch reason {
+	case "provider-frame-invalid-auth", "provider-frame-invalid-content", "provider-frame-build-failed",
+		"provider-prewrite-refused", "provider-write-zero":
+		return true
+	default:
+		return isClaudeProviderFrameSizeReason(reason)
+	}
 }
 
 // writeClaudeProviderPushFrame makes exactly one write. Retrying a partial
 // provider write could duplicate a model-visible message and is forbidden.
 func writeClaudeProviderPushFrame(writer io.Writer, frame []byte) claudeProviderPostOutcome {
 	n, err := writer.Write(frame)
-	if n < 0 {
-		return claudeProviderPostOutcome{}
+	if n < 0 || n > len(frame) {
+		return claudeProviderPostOutcome{WroteAny: true, Reason: "provider-handoff-outcome-unknown"}
 	}
-	if n > len(frame) {
-		return claudeProviderPostOutcome{WroteAny: true}
+	if n == 0 {
+		return claudeProviderPostOutcome{Reason: "provider-write-zero"}
 	}
-	return claudeProviderPostOutcome{FullFrameWritten: err == nil && n == len(frame), WroteAny: n > 0}
+	if n < len(frame) {
+		return claudeProviderPostOutcome{WroteAny: true, Reason: "provider-write-partial"}
+	}
+	if err != nil {
+		return claudeProviderPostOutcome{WroteAny: true, Reason: "provider-handoff-outcome-unknown"}
+	}
+	return claudeProviderPostOutcome{FullFrameWritten: true, WroteAny: true}
 }
 
 type liveClaudeProviderPoster struct {
@@ -97,26 +135,29 @@ func (p *liveClaudeProviderPoster) Post(content string, fence func() bool) (clau
 		return p.current != nil && p.current() && (fence == nil || fence())
 	}
 	frame, err := buildClaudeProviderPushFrame(p.token, content)
-	if err != nil || !current() {
-		return claudeProviderPostOutcome{}, errors.New("claude provider push refused")
+	if err != nil {
+		return claudeProviderPostOutcome{Reason: err.Error()}, err
+	}
+	if !current() {
+		return claudeProviderPostOutcome{Reason: "provider-prewrite-refused"}, errors.New("claude provider push refused")
 	}
 	identity, err := inspectClaudeSocket(p.socket)
 	if err != nil || identity != p.socketIdentity {
-		return claudeProviderPostOutcome{}, errors.New("claude provider push refused")
+		return claudeProviderPostOutcome{Reason: "provider-prewrite-refused"}, errors.New("claude provider push refused")
 	}
 	connection, err := net.DialUnix("unix", nil, &net.UnixAddr{Name: p.socket, Net: "unix"})
 	if err != nil {
-		return claudeProviderPostOutcome{}, errors.New("claude provider push refused")
+		return claudeProviderPostOutcome{Reason: "provider-prewrite-refused"}, errors.New("claude provider push refused")
 	}
 	defer connection.Close()
 	_ = connection.SetDeadline(time.Now().Add(2 * time.Second))
 	peer, err := claudeadapter.PeerProcess(connection)
 	if err != nil || peer != p.process || !current() {
-		return claudeProviderPostOutcome{}, errors.New("claude provider push refused")
+		return claudeProviderPostOutcome{Reason: "provider-prewrite-refused"}, errors.New("claude provider push refused")
 	}
 	identity, err = inspectClaudeSocket(p.socket)
 	if err != nil || identity != p.socketIdentity || !current() {
-		return claudeProviderPostOutcome{}, errors.New("claude provider push refused")
+		return claudeProviderPostOutcome{Reason: "provider-prewrite-refused"}, errors.New("claude provider push refused")
 	}
 	outcome := writeClaudeProviderPushFrame(connection, frame)
 	if !outcome.FullFrameWritten {

--- a/internal/app/claude_provider_push_test.go
+++ b/internal/app/claude_provider_push_test.go
@@ -95,7 +95,7 @@ func TestClaudeProviderPushUsesOneWriteAndClassifiesUnknownOutcome(t *testing.T)
 		ambiguous bool
 	}{
 		{name: "zero byte known failure", n: 0, err: errors.New("closed")},
-		{name: "invalid negative count is known failure", n: -2, err: errors.New("invalid")},
+		{name: "invalid negative count is ambiguous", n: -2, err: errors.New("invalid"), wroteAny: true, ambiguous: true},
 		{name: "invalid oversized count is ambiguous", n: 6, err: errors.New("invalid"), wroteAny: true, ambiguous: true},
 		{name: "partial is ambiguous", n: 2, err: errors.New("short"), wroteAny: true, ambiguous: true},
 		{name: "full with error is ambiguous", n: -1, err: errors.New("post-write close"), wroteAny: true, ambiguous: true},

--- a/internal/app/claude_provider_rejection_test.go
+++ b/internal/app/claude_provider_rejection_test.go
@@ -1,0 +1,280 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/agentdelivery"
+	coremessage "github.com/crevissepartners/projmux/internal/core/agentmessage"
+	messagestore "github.com/crevissepartners/projmux/internal/integrations/agents/agentmessage"
+)
+
+func serializedClaudeTestFrame(t *testing.T, token, content string) []byte {
+	t.Helper()
+	auth, err := json.Marshal(map[string]string{"type": "auth", "token": token})
+	if err != nil {
+		t.Fatal("fixture auth serialization failed")
+	}
+	user, err := json.Marshal(map[string]any{"type": "user", "message": map[string]string{"role": "user", "content": content}})
+	if err != nil {
+		t.Fatal("fixture content serialization failed")
+	}
+	return append(append(append(auth, '\n'), user...), '\n')
+}
+
+func TestClaudeProviderFrameSerializedByteBoundaryAndSafeRejection(t *testing.T) {
+	if claudeProviderFrameMaxBytes != 8192 {
+		t.Fatal("frozen provider frame limit changed")
+	}
+	token := strings.Repeat("T", 4096)
+	prefix := "private-payload-한\"<\\\t"
+	baseSize := len(serializedClaudeTestFrame(t, token, prefix))
+	for _, size := range []int{8191, 8192, 8193} {
+		t.Run(fmt.Sprint(size), func(t *testing.T) {
+			content := prefix + strings.Repeat("x", size-baseSize)
+			if !validClaudeAssistantReply(content) || len(serializedClaudeTestFrame(t, token, content)) != size {
+				t.Fatal("fixture does not reach exact valid-content serialized byte boundary")
+			}
+			frame, err := buildClaudeProviderPushFrame(token, content)
+			if size <= 8192 {
+				if err != nil || len(frame) != size {
+					t.Fatalf("frame size=%d expected=%d error=%v", len(frame), size, err)
+				}
+				return
+			}
+			if err == nil || frame != nil || err.Error() != "provider-frame-too-large: frameBytes=8193 limitBytes=8192" {
+				t.Fatal("oversize rejection lost exact serialized frame bytes or fixed limit")
+			}
+			if strings.Contains(err.Error(), token) || strings.Contains(err.Error(), prefix) {
+				t.Fatal("frame rejection exposed auth or content")
+			}
+		})
+	}
+}
+
+func TestClaudeProviderPostPreservesConstructionReasonBeforeAnyRouteOrWrite(t *testing.T) {
+	for _, test := range []struct {
+		name, token, content, reason string
+	}{
+		{name: "empty auth", content: "private-payload", reason: "provider-frame-invalid-auth"},
+		{name: "invalid auth", token: "private-token\n", content: "private-payload", reason: "provider-frame-invalid-auth"},
+		{name: "auth too long", token: strings.Repeat("t", 4097), content: "private-payload", reason: "provider-frame-invalid-auth"},
+		{name: "empty content", token: "private-token", reason: "provider-frame-invalid-content"},
+		{name: "invalid content", token: "private-token", content: "private-payload\x00", reason: "provider-frame-invalid-content"},
+		{name: "invalid utf8 content", token: "private-token", content: "private-payload\xff", reason: "provider-frame-invalid-content"},
+		{name: "content too long", token: "private-token", content: strings.Repeat("x", coremessage.MaxPayloadBytes+1), reason: "provider-frame-invalid-content"},
+		{name: "serialized frame too large", token: strings.Repeat("t", 4096), content: strings.Repeat("x", 4096)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			want := test.reason
+			if want == "" {
+				want = fmt.Sprintf("provider-frame-too-large: frameBytes=%d limitBytes=8192", len(serializedClaudeTestFrame(t, test.token, test.content)))
+			}
+			checks := 0
+			poster := &liveClaudeProviderPoster{token: test.token, current: func() bool { checks++; return true }}
+			outcome, err := poster.Post(test.content, func() bool { checks++; return true })
+			if err == nil || err.Error() != want || outcome.Reason != want || outcome.WroteAny || outcome.FullFrameWritten || checks != 0 {
+				t.Fatalf("construction outcome=%+v route checks=%d", outcome, checks)
+			}
+			if strings.Contains(err.Error(), "private-token") || strings.Contains(err.Error(), "private-payload") {
+				t.Fatal("Post error exposed credential or content")
+			}
+		})
+	}
+}
+
+func TestClaudeProviderWriteReasonsRequireOneActualWrite(t *testing.T) {
+	for _, test := range []struct {
+		name, reason string
+		n            int
+		err          error
+		unknown      bool
+	}{
+		{name: "zero with error", n: 0, err: errors.New("private writer error"), reason: "provider-write-zero"},
+		{name: "zero without error", n: 0, reason: "provider-write-zero"},
+		{name: "partial with error", n: 2, err: errors.New("private writer error"), reason: "provider-write-partial", unknown: true},
+		{name: "partial without error", n: 2, reason: "provider-write-partial", unknown: true},
+		{name: "invalid negative", n: -2, reason: "provider-handoff-outcome-unknown", unknown: true},
+		{name: "invalid overflow", n: 1000, reason: "provider-handoff-outcome-unknown", unknown: true},
+		{name: "full with error", n: -1, err: errors.New("private writer error"), reason: "provider-handoff-outcome-unknown", unknown: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			writer := &singleWriteRecorder{n: test.n, err: test.err}
+			outcome := writeClaudeProviderPushFrame(writer, []byte("private frame"))
+			if outcome.Reason != test.reason || outcome.FullFrameWritten || outcome.Ambiguous() != test.unknown || writer.writes != 1 {
+				t.Fatalf("outcome=%+v calls=%d", outcome, writer.writes)
+			}
+		})
+	}
+}
+
+// Construction cases use the real Post pre-write boundary. Write cases replace
+// only the socket writer so zero and short writes can be produced deterministically.
+type rejectionFixturePoster struct {
+	poster liveClaudeProviderPoster
+	writer *singleWriteRecorder
+	calls  int
+}
+
+func (p *rejectionFixturePoster) Post(content string, fence func() bool) (claudeProviderPostOutcome, error) {
+	p.calls++
+	if p.writer == nil {
+		return p.poster.Post(content, fence)
+	}
+	frame, err := buildClaudeProviderPushFrame(p.poster.token, content)
+	if err != nil {
+		return claudeProviderPostOutcome{Reason: err.Error()}, err
+	}
+	outcome := writeClaudeProviderPushFrame(p.writer, frame)
+	return outcome, errors.New("private writer detail must not reach receipt")
+}
+
+func TestClaudeProviderRejectionReasonsSurviveHubReceiptStatusAndStoreReload(t *testing.T) {
+	for _, test := range []struct {
+		name, token, reason, action string
+		payloadBytes                int
+		writer                      *singleWriteRecorder
+		unknown                     bool
+	}{
+		{name: "invalid auth", token: "private-token\n", reason: "provider-frame-invalid-auth", action: "check provider auth"},
+		{name: "invalid content", token: "private-token", payloadBytes: 4096, reason: "provider-frame-invalid-content", action: "correct message content"},
+		{name: "serialized size", token: strings.Repeat("t", 4096), payloadBytes: -1, action: "reduce payload"},
+		{name: "prewrite refusal", token: "private-token", reason: "provider-prewrite-refused", action: "check current provider route"},
+		{name: "actual zero write", token: "private-token", writer: &singleWriteRecorder{}, reason: "provider-write-zero", action: "check provider connection"},
+		{name: "partial write", token: "private-token", writer: &singleWriteRecorder{n: 2}, reason: "provider-write-partial", unknown: true, action: "automatic resend disabled"},
+		{name: "write outcome unknown", token: "private-token", writer: &singleWriteRecorder{n: -1, err: errors.New("private-writer-secret")}, reason: "provider-handoff-outcome-unknown", unknown: true, action: "automatic resend disabled"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newClaudeCoordinationTestFixture(t)
+			now := time.Now().UTC()
+			envelope := *dialogueForRoute("message-rejection", fixture.route, now).BrokerEnvelope
+			envelope.Payload = "private-payload"
+			if test.payloadBytes > 0 {
+				envelope.Payload = strings.Repeat("x", test.payloadBytes)
+			}
+			private := dialogueForRoute(envelope.MessageRef, fixture.route, now)
+			private.BrokerEnvelope = &envelope
+			content, err := providerCoordinationContent(private)
+			if err != nil {
+				t.Fatal("fixture content unavailable")
+			}
+			if test.payloadBytes == -1 {
+				envelope.Payload += strings.Repeat("x", coremessage.MaxPayloadBytes-len(content))
+				content, err = providerCoordinationContent(private)
+				if err != nil || !validClaudeAssistantReply(content) {
+					t.Fatal("size fixture must pass content validation")
+				}
+			}
+			want := test.reason
+			if want == "" {
+				want = fmt.Sprintf("provider-frame-too-large: frameBytes=%d limitBytes=8192", len(serializedClaudeTestFrame(t, test.token, content)))
+			}
+			poster := &rejectionFixturePoster{poster: liveClaudeProviderPoster{token: test.token}, writer: test.writer}
+			fixture.server.poster = poster
+			fixture.server.broker = &failingClaudeDialogueBroker{}
+			adapter := liveAgentMessageClaudeAdapter{}
+			delivery, err := adapter.Submit(context.Background(), fixture.registryPath, fixture.route, envelope)
+			if err != nil || delivery.Reason != want || delivery.State != agentdelivery.StateFailed || delivery.Ambiguous != test.unknown {
+				t.Fatalf("delivery=%+v error=%v expected reason=%s", delivery, err, want)
+			}
+			status, err := adapter.Status(context.Background(), fixture.registryPath, fixture.route, envelope.MessageRef)
+			if err != nil || status != delivery {
+				t.Fatalf("helper status=%+v error=%v", status, err)
+			}
+			duplicate, err := adapter.Submit(context.Background(), fixture.registryPath, fixture.route, envelope)
+			if err != nil || duplicate != delivery || poster.calls != 1 || (test.writer != nil && test.writer.writes != 1) {
+				t.Fatal("terminal attempt was retried or changed")
+			}
+			stateDir := t.TempDir()
+			store := messagestore.NewStore(stateDir)
+			record, _, err := store.PutAccepted(envelope, "claude-coordination")
+			if err != nil {
+				t.Fatal(err)
+			}
+			command := &agentCommand{messageStore: store, messageNow: func() time.Time { return now }}
+			projected, err := command.projectClaudeDelivery(record, delivery, nil)
+			if err != nil || projected.Delivery.Reason != want || projected.Delivery.OutcomeUnknown != test.unknown {
+				t.Fatalf("public projection=%+v error=%v", projected.Delivery, err)
+			}
+			reloaded, found, err := messagestore.NewStore(stateDir).Status(envelope.MessageRef, now.Add(2*time.Minute))
+			if err != nil || !found || reloaded.Delivery != projected.Delivery {
+				t.Fatal("terminal reason changed across persisted store reload or deadline")
+			}
+			for _, asJSON := range []bool{false, true} {
+				var output bytes.Buffer
+				if err := writeAgentMessageReceipt(&output, receiptFor(reloaded), asJSON); err != nil {
+					t.Fatal(err)
+				}
+				if !strings.Contains(output.String(), want) || (!asJSON && !strings.Contains(output.String(), test.action)) {
+					t.Fatal("sender receipt omitted failure reason or next action")
+				}
+				for _, secret := range []string{test.token, envelope.Payload, "private-writer-secret", "private writer detail"} {
+					if secret != "" && strings.Contains(output.String(), secret) {
+						t.Fatal("public receipt exposed token, payload, or writer details")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestClaudeProviderRejectionResponseValidationIsClosedAndLegacyCompatible(t *testing.T) {
+	for _, reason := range []string{
+		"provider-frame-invalid-auth", "provider-frame-invalid-content", "provider-frame-build-failed",
+		"provider-prewrite-refused", "provider-write-zero", "provider-frame-too-large: frameBytes=8193 limitBytes=8192",
+	} {
+		t.Run(reason, func(t *testing.T) {
+			delivery := agentdelivery.Delivery{MessageRef: "message-validation", State: agentdelivery.StateFailed, WaiterRef: "push-ref", Reason: reason}
+			response := claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "failed", Delivery: delivery}
+			if actual, valid := claudeResponseDelivery(delivery.MessageRef, response); !valid || actual != delivery {
+				t.Fatal("known no-write failure rejected")
+			}
+			response.Delivery.Ambiguous = true
+			if _, valid := claudeResponseDelivery(delivery.MessageRef, response); valid {
+				t.Fatal("known no-write reason accepted as ambiguous")
+			}
+			response.Delivery = delivery
+			response.Delivery.WaiterRef = ""
+			if _, valid := claudeResponseDelivery(delivery.MessageRef, response); valid {
+				t.Fatal("post-attempt failure accepted without handoff reference")
+			}
+			response.Kind = "refused"
+			response.Delivery.State = agentdelivery.StateRefused
+			if _, valid := claudeResponseDelivery(delivery.MessageRef, response); valid {
+				t.Fatal("post-attempt reason accepted in an inconsistent state")
+			}
+		})
+	}
+	for _, reason := range []string{"provider-write-partial", "provider-handoff-outcome-unknown", "broker-delivery-persist-failed", "observation-timeout", "delivery-outcome-unknown"} {
+		delivery := agentdelivery.Delivery{MessageRef: "message-validation", State: agentdelivery.StateFailed, WaiterRef: "push-ref", Reason: reason, Ambiguous: true}
+		response := claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "failed", Delivery: delivery}
+		if actual, valid := claudeResponseDelivery(delivery.MessageRef, response); !valid || actual != delivery {
+			t.Fatalf("unknown reason rejected: %s", reason)
+		}
+		response.Delivery.Ambiguous = false
+		if _, valid := claudeResponseDelivery(delivery.MessageRef, response); valid {
+			t.Fatalf("unknown reason accepted as known: %s", reason)
+		}
+	}
+	for _, reason := range []string{
+		"provider-frame-too-large", "provider-frame-too-large: frameBytes=8192 limitBytes=8192",
+		"provider-frame-too-large: frameBytes=8193 limitBytes=8193", "provider-frame-too-large: frameBytes=08193 limitBytes=8192",
+		"provider-frame-too-large: frameBytes=+8193 limitBytes=8192", "provider-frame-too-large: frameBytes=-1 limitBytes=8192",
+		"provider-frame-too-large: frameBytes=9999999999999999999999999999999999 limitBytes=8192",
+		"provider-frame-too-large: frameBytes=8193 limitBytes=8192 private-token",
+		"provider-frame-too-large: frameBytes=8193 limitBytes=8192\nprivate-payload", "provider-write-zero: private-token",
+	} {
+		response := claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "failed", Delivery: agentdelivery.Delivery{
+			MessageRef: "message-validation", State: agentdelivery.StateFailed, WaiterRef: "push-ref", Reason: reason,
+		}}
+		if _, valid := claudeResponseDelivery("message-validation", response); valid {
+			t.Fatal("noncanonical or secret-bearing failure accepted")
+		}
+	}
+}

--- a/internal/app/claude_push_hub.go
+++ b/internal/app/claude_push_hub.go
@@ -109,13 +109,18 @@ func (h *claudeCoordinationHub) submitPush(envelope claudeCoordinationEnvelope, 
 		return envelope.Deadline.After(h.now()) && broker.Current(*envelope.BrokerEnvelope)
 	})
 	if postErr != nil || !outcome.FullFrameWritten {
-		reason := "provider-write-zero"
-		if outcome.WroteAny {
+		reason := outcome.Reason
+		if outcome.WroteAny || outcome.FullFrameWritten {
 			reason = "provider-handoff-outcome-unknown"
+			if outcome.Reason == "provider-write-partial" && !outcome.FullFrameWritten {
+				reason = outcome.Reason
+			}
+		} else if !knownClaudeProviderFailureReason(reason) {
+			reason = "provider-prewrite-refused"
 		}
 		message.delivery, _ = agentdelivery.Reduce(message.delivery, agentdelivery.Event{
 			Kind: agentdelivery.EventFail, MessageRef: envelope.MessageRef, WaiterRef: handoffRef,
-			Reason: reason, OutcomeKnown: !outcome.WroteAny,
+			Reason: reason, OutcomeKnown: !outcome.WroteAny && !outcome.FullFrameWritten,
 		})
 		return message.delivery
 	}

--- a/internal/app/claude_push_hub_test.go
+++ b/internal/app/claude_push_hub_test.go
@@ -121,7 +121,7 @@ func TestClaudePushSourceReplacementAfterDurableHandoffWritesZero(t *testing.T) 
 	poster := &qualificationPosterRecorder{outcome: claudeProviderPostOutcome{FullFrameWritten: true, WroteAny: true}}
 	envelope := dialogueEnvelope("message-source-replaced", now.Add(time.Minute))
 	delivery := hub.submitPush(envelope, broker, poster)
-	if delivery.State != agentdelivery.StateFailed || delivery.Ambiguous || delivery.Reason != "provider-write-zero" || poster.calls != 0 {
+	if delivery.State != agentdelivery.StateFailed || delivery.Ambiguous || delivery.Reason != "provider-prewrite-refused" || poster.calls != 0 {
 		t.Fatalf("source replacement delivery=%+v writes=%d", delivery, poster.calls)
 	}
 }


### PR DESCRIPTION
## Summary
A Claude message rejected during frame construction previously surfaced as `provider-write-zero`. Preserve distinct auth/content, frame-size, pre-write, actual zero-write, partial-write and unknown reasons through sender receipts and status. Size refusals include actual serialized frame bytes and the unchanged 8192-byte limit; sender text explains the safe next action. Partial and unknown outcomes remain terminal without automatic resend, and diagnostics exclude credentials and payloads.

## Test plan
- [x] Rebase onto latest main; patch equivalence and Phase 1 scope reviewed.
- [x] Head `77f3f2f8`: `make fmt` and `make test` passed. `make fix` ran and reported only the clean-main baseline pair; full file/symbol findings 335 → 335, increase 0.
- [x] Serialized 8191/8192/8193 boundary, invalid construction, zero/partial/unknown write, closed reason validation, redaction, persisted status and duplicate-send regressions.
- [x] Same-head `make test-integration` → `make test-e2e`: five integration suites and all 22 E2E contracts passed.
- [x] Same-head required five CI jobs plus aggregate `Test`: [CI run 34370558317](https://github.com/crevissepartners/projmux/actions/runs/34370558317) passed.
- [x] Post-merge isolated `make install` and installed CLI send/status provider fixture passed from merged source `c780a16c`. Installed binary SHA-256: `82edf9144cf9457056b7554aabbfaff46bebf5f27173771dabb926e7db787e27`. Private filesystem, process and network boundaries verified; live artifacts remained unchanged.

The existing baseline findings are `claudeCoordinationHub.coordinationEligible` and `writeAgentMessageClaim`.

## Globalization
- [x] Non-translated strings are classified as literal/data/debug-only: stable delivery reason tokens, numeric frame-boundary data, and CLI failure/recovery diagnostics.
