### PR TITLE
fix(agent): preserve failed reply causes and safe retry paths

### DIFF
--- a/docs/agent-message-replies.md
+++ b/docs/agent-message-replies.md
@@ -1,0 +1,49 @@
+# Explicit reply recovery
+
+An explicit Claude reply names the original request with `--reply-to`. The
+broker preserves that request's `conversationRef`, reverses its exact source
+and target routes, and retains peer, untrusted, coordination-only authority.
+Both activations and the original deadline must still be current. A reply
+cannot extend that deadline. Source metadata remains an unverified routing
+claim; an explicit reply also requires the registered provider's descendant
+caller and any existing qualification and execution guard.
+
+When a reply fails, `agent message send` exits nonzero and reports its ref,
+underlying reason, outcome uncertainty, and safe action. Inspect the durable
+attempt before deciding whether to retry:
+
+```sh
+projmux agent message status <failed-reply-ref>
+projmux agent message status <failed-reply-ref> -o json
+```
+
+Only a confirmed zero-write Claude failure permits a new manual attempt.
+Examples include rejected content or frame size, invalid auth configuration,
+pre-write refusal, and an actual zero-byte write. Correct the reported cause,
+then send a new reply ref on the same original correlation:
+
+```sh
+projmux agent message send uid:<original-source-agent> --reply-to <original-request-ref> --message-ref <fresh-reply-ref> -- '<corrected reply>'
+```
+
+Omitting `--message-ref` generates a fresh ref. In the qualified reply-only
+execution guard, use the existing bounded command without that flag:
+
+```sh
+projmux agent message send uid:<original-source-agent> --reply-to <original-request-ref> -- '<corrected reply>'
+```
+
+A same-ref call returns the original immutable receipt and never pushes again.
+Changing its payload is refused with the earlier ref and cause. A fresh ref
+allows one new attempt only when every previous attempt is known-zero. Failed
+records and the original request remain available; recovery never deletes or
+resets them. Store capacity can refuse a new attempt rather than discard its
+history.
+
+Delivered replies, partial writes, unknown outcomes, pending attempts, expired
+deadlines, and stale routes must not be resent. Inspect their status and the
+provider outcome. A false `outcomeUnknown` flag by itself is insufficient:
+the stored state and specific zero-write reason must agree. These rules also
+apply after store reload and to concurrent callers. Automatic resend is
+disabled, and replies whose delivery target is Codex do not gain a new retry
+policy here.

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1175,6 +1175,34 @@
 - `TestClaudeExplicitReplyRejectsForeignStaleAndAlteredCorrelationBeforeCommit`
   covers foreign refs, altered conversations, stale generations/incarnations,
   reversed-route mismatch, and a wrong qualification response with commit zero.
+- `TestClaudeExplicitReplyKnownZeroManualRetryPublicReceiptsAndReload` and
+  `TestStoreExplicitReplyKnownZeroManualRetrySurvivesReload` pin the documented
+  [manual reply recovery](agent-message-replies.md): a known-zero failure keeps
+  its immutable receipt, same-ref calls write zero, and a fresh corrected ref
+  delivers once with the original conversation, reversed routes, deadline and
+  peer authority. Public stderr and text/JSON status preserve cause and ref.
+- `TestClaudeExplicitReplyPartialUnknownExpiredAndStaleNeverDuplicate`,
+  `TestStoreExplicitReplyNonzeroUnknownAndExpiredNeverRetry`, and
+  `TestStoreExplicitReplyRetryKeepsDeadlineAndExactRoute` reject delivered,
+  partial/unknown, pending, expired and stale retries, including store reload,
+  false-unknown-flag and unrecognized-reason cases; Codex retry policy stays
+  unchanged. `TestStoreExplicitReplyConcurrentAttemptsAndCapacityPreserveReceipts`
+  permits only one concurrent new attempt and prevents capacity pruning from
+  reopening a live reply relationship.
+- `TestClaudeExplicitReplyGuardRetryRetainsQualificationAndRouteFences` keeps
+  known-zero recovery behind the existing exact qualification, provider caller,
+  route and bounded-command gates. `TestClaudeEndpointProcessIntegration/explicit-reply-known-zero-manual-retry`
+  runs the public CLI as the synthetic provider's real descendant: invalid
+  content fails with stderr/ref/action, a corrected manual reply reaches the
+  provider once, same/different-ref duplicates write zero, and independent
+  public status processes preserve both attempts. The provider checks for
+  unexpected queued connections before exit.
+- `TestClaudeExplicitReplyAcknowledgementRequiresFreshDispatchProof` refuses
+  legacy or malformed acknowledgements without granting a push; replay replies
+  use a distinct response kind that older callers also cannot dispatch.
+  `TestClaudeExplicitReplyStoreRefusalsKeepCauseAndUnknownReservation` preserves
+  bounded busy/capacity/missing/malformed store causes, frees only proven
+  pre-write refusals, and keeps an ambiguous persistence attempt reserved.
 - `TestClaudeExplicitMultipleRequestsAndHumanOverlapSelectOnlyNamedOriginal`
   permits an explicit reply to B then A across human activity, rejects a second
   reply to either request, and never chooses correlation by arrival order.

--- a/internal/app/agent_message.go
+++ b/internal/app/agent_message.go
@@ -156,7 +156,7 @@ func (liveAgentMessageClaudeAdapter) Status(ctx context.Context, registryPath st
 
 func claudeResponseDelivery(messageRef string, response claudeCoordinationResponse) (agentdelivery.Delivery, bool) {
 	if response.Version != claudeCoordinationVersion || response.AutoResend || response.Reason != "" ||
-		response.ReplyRef != "" || response.QualificationRef != "" ||
+		response.ReplyRef != "" || response.ReplyCreated || response.ReplyDelivery != nil || response.QualificationRef != "" ||
 		response.ProviderVersion != "" || response.Ambiguous || response.ToolResult != nil {
 		return agentdelivery.Delivery{}, false
 	}
@@ -308,13 +308,21 @@ func (c *agentCommand) runMessageSend(args []string, stdout, stderr io.Writer) e
 		return err
 	}
 	// Both static cells and both exact activation authorities are proved before
-	// the broker store or provider adapter is touched.
+	// accepting or dispatching a message. Refusals may read earlier reply receipts.
 	sourceRoute, err := c.resolveMessageRoute(registry, source)
 	if err != nil {
+		if replyTo != "" {
+			return fmt.Errorf("%s: source Agent is not eligible: %w; %w", spelling, err,
+				c.replyCorrelationRefusal(replyTo, "explicit-reply-source-route-stale"))
+		}
 		return fmt.Errorf("%s: source Agent is not eligible: %w", spelling, err)
 	}
 	targetRoute, err := c.resolveMessageTargetRoute(registry, target)
 	if err != nil {
+		if replyTo != "" {
+			return fmt.Errorf("%s: target Agent is not eligible: %w; %w", spelling, err,
+				c.replyCorrelationRefusal(replyTo, "explicit-reply-target-route-stale"))
+		}
 		return fmt.Errorf("%s: target Agent is not eligible: %w", spelling, err)
 	}
 	if messageRef == "" {
@@ -338,15 +346,29 @@ func (c *agentCommand) runMessageSend(args []string, stdout, stderr io.Writer) e
 			return fmt.Errorf("%s: reply correlation failed: %w", spelling, getErr)
 		}
 		envelope.ConversationRef = original.Envelope.ConversationRef
+		if envelope.Deadline.After(original.Envelope.Deadline) {
+			envelope.Deadline = original.Envelope.Deadline
+		}
+		// A same-ref call is a receipt replay, never a new dispatch. Keep the
+		// durable times so reducing the remaining original TTL cannot change
+		// its immutable-envelope comparison.
+		if existing, exists, err := c.messageStore.Get(messageRef); err != nil {
+			return fmt.Errorf("%s: reply receipt lookup failed: %w", spelling, err)
+		} else if exists && existing.Envelope.ReplyTo == replyTo {
+			envelope.AcceptedAt, envelope.Deadline = existing.Envelope.AcceptedAt, existing.Envelope.Deadline
+		}
+		if !original.Envelope.Deadline.After(now) {
+			return fmt.Errorf("%s: %w", spelling, c.replyCorrelationRefusal(replyTo, "explicit-reply-deadline-expired"))
+		}
 		if err := coremessage.ValidateReply(original.Envelope, envelope); err != nil {
-			return fmt.Errorf("%s: %w", spelling, err)
+			return fmt.Errorf("%s: %w; %w", spelling, err, c.replyCorrelationRefusal(replyTo, "invalid-explicit-reply-correlation"))
 		}
 	}
 	if source.Spec.Provider == string(aiprovider.Claude) && replyTo != "" {
 		if adapter, ok := c.messageClaude.(interface {
-			ExplicitReply(context.Context, string, coremetadata.AgentRouteRef, coremessage.Envelope) (string, error)
+			ExplicitReply(context.Context, string, coremetadata.AgentRouteRef, coremessage.Envelope) (string, bool, error)
 		}); ok {
-			ref, replyErr := adapter.ExplicitReply(context.Background(), c.messagePaths.registryPath, sourceRoute, envelope)
+			ref, created, replyErr := adapter.ExplicitReply(context.Background(), c.messagePaths.registryPath, sourceRoute, envelope)
 			if replyErr != nil {
 				return fmt.Errorf("%s: explicit reply refused: %w", spelling, replyErr)
 			}
@@ -357,8 +379,18 @@ func (c *agentCommand) runMessageSend(args []string, stdout, stderr io.Writer) e
 			// A reply is delivered the same way any other message is. Without
 			// this it only reached the store, and with the self-claim inbox gone
 			// nothing would ever hand it to the target.
-			record = c.pushCoordination(record, target, targetRoute, envelope)
-			return writeAgentMessageReceipt(stdout, receiptFor(record), false)
+			if created {
+				record = c.pushCoordination(record, target, targetRoute, record.Envelope)
+			}
+			if err := writeAgentMessageReceipt(stdout, receiptFor(record), false); err != nil {
+				return err
+			}
+			if record.Delivery.State.Terminal() && record.Delivery.State != coremessage.StateDelivered {
+				return fmt.Errorf("%s: explicit reply not delivered: previousRef=%s state=%s reason=%s outcomeUnknown=%t; %s",
+					spelling, ref, record.Delivery.State, record.Delivery.Reason, record.Delivery.OutcomeUnknown,
+					agentMessageReplyFailureAction(record))
+			}
+			return nil
 		}
 		return fmt.Errorf("%s: exact explicit reply adapter is unavailable", spelling)
 	}
@@ -374,6 +406,18 @@ func (c *agentCommand) runMessageSend(args []string, stdout, stderr io.Writer) e
 		record = c.pushCoordination(record, target, targetRoute, envelope)
 	}
 	return writeAgentMessageReceipt(stdout, receiptFor(record), false)
+}
+
+func (c *agentCommand) replyCorrelationRefusal(originalRef, reason string) error {
+	response := claudeCoordinationResponse{Reason: reason}
+	if lookup, ok := c.messageStore.(interface {
+		Reply(string) (messagestore.Record, bool, error)
+	}); ok {
+		if previous, found, err := lookup.Reply(originalRef); err == nil && found {
+			response.ReplyRef, response.ReplyDelivery = previous.Envelope.MessageRef, &previous.Delivery
+		}
+	}
+	return fmt.Errorf("replyTo=%s: %w", originalRef, explicitReplyRefusal(response))
 }
 
 func (c *agentCommand) resolveMessageTargetRoute(registry coremetadata.Registry, agent coremetadata.Agent) (coremetadata.AgentRouteRef, error) {
@@ -727,12 +771,31 @@ func writeAgentMessageReceipt(stdout io.Writer, receipt agentMessageReceipt, asJ
 		return json.NewEncoder(stdout).Encode(receipt)
 	}
 	if receipt.Delivery.State.Terminal() && receipt.Delivery.State != coremessage.StateDelivered {
+		action := agentMessageFailureAction(receipt.Delivery)
+		if receipt.ReplyTo != "" {
+			action = agentMessageReplyFailureAction(messagestore.Record{Envelope: coremessage.Envelope{
+				ReplyTo: receipt.ReplyTo, Deadline: receipt.Deadline}, Adapter: adapterForReplyReceipt(receipt), Delivery: receipt.Delivery})
+		}
 		_, err := fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\n", receipt.MessageRef, receipt.Delivery.State,
-			receipt.Delivery.Reason, agentMessageFailureAction(receipt.Delivery))
+			receipt.Delivery.Reason, action)
 		return err
 	}
 	_, err := fmt.Fprintf(stdout, "%s\t%s\n", receipt.MessageRef, receipt.Delivery.State)
 	return err
+}
+
+func adapterForReplyReceipt(receipt agentMessageReceipt) string {
+	if receipt.Target.Provider == "claude" {
+		return "claude-coordination"
+	}
+	return "codex-inbox"
+}
+
+func agentMessageReplyFailureAction(record messagestore.Record) string {
+	if messagestore.KnownZeroReply(record) {
+		return agentMessageFailureAction(record.Delivery) + "; retry manually with the same --reply-to and a new --message-ref (or omit --message-ref); original deadline and exact routes must remain valid"
+	}
+	return "inspect original and previous reply status and provider outcome; do not resend"
 }
 
 func agentMessageFailureAction(delivery coremessage.Delivery) string {

--- a/internal/app/agent_message_test.go
+++ b/internal/app/agent_message_test.go
@@ -674,7 +674,7 @@ func TestAgentMessageLifecycleLeavesInteractionAndBadgeAuthorityUntouched(t *tes
 			agent.Status.Interaction = coremetadata.AgentInteraction{Kind: interaction, Source: string(coremetadata.InteractionSourceProviderControl), ObservedAt: resourceFixtureClock}
 			before := h.registry.Clone()
 			store := messagestore.NewStore(t.TempDir())
-			now := resourceFixtureClock.Add(time.Minute)
+			now := time.Now().UTC()
 			original := coremessage.Envelope{Version: coremessage.Version, MessageRef: "message-badge-" + string(interaction),
 				ConversationRef: "conversation-badge-" + string(interaction),
 				Source: coremessage.Route{AgentUID: h.agentUID, PaneUID: h.paneUID, ActivationGeneration: h.envGeneration,
@@ -698,7 +698,7 @@ func TestAgentMessageLifecycleLeavesInteractionAndBadgeAuthorityUntouched(t *tes
 			}
 			replyAt := now.Add(2 * time.Second)
 			if _, _, err := store.PutReply(original.MessageRef, "reply-badge-"+string(interaction), "answer",
-				original.Target, original.Source, replyAt, replyAt.Add(time.Minute)); err != nil {
+				original.Target, original.Source, replyAt, original.Deadline); err != nil {
 				t.Fatal(err)
 			}
 			if reply, claimed, err := store.Claim(original.Source, replyAt.Add(time.Second)); err != nil || !claimed ||

--- a/internal/app/claude_coordination.go
+++ b/internal/app/claude_coordination.go
@@ -132,6 +132,8 @@ type claudeCoordinationResponse struct {
 	Kind             string                       `json:"kind"`
 	Delivery         agentdelivery.Delivery       `json:"delivery,omitzero"`
 	ReplyRef         string                       `json:"replyRef,omitempty"`
+	ReplyCreated     bool                         `json:"replyCreated,omitempty"`
+	ReplyDelivery    *coremessage.Delivery        `json:"replyDelivery,omitempty"`
 	Reason           string                       `json:"reason,omitempty"`
 	QualificationRef string                       `json:"qualificationRef,omitempty"`
 	ProviderVersion  string                       `json:"providerVersion,omitempty"`
@@ -239,7 +241,7 @@ type claudeDialogueBroker interface {
 	Current(coremessage.Envelope) bool
 	MarkHandoff(coremessage.Envelope) error
 	MarkDelivered(coremessage.Envelope, time.Time) error
-	CommitReply(coremessage.Envelope, coremessage.Envelope) error
+	CommitReply(coremessage.Envelope, coremessage.Envelope) (bool, error)
 }
 
 type liveClaudeDialogueBroker struct {

--- a/internal/app/claude_coordination_test.go
+++ b/internal/app/claude_coordination_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/crevissepartners/projmux/internal/core/agentdelivery"
 	coremessage "github.com/crevissepartners/projmux/internal/core/agentmessage"
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	messagestore "github.com/crevissepartners/projmux/internal/integrations/agents/agentmessage"
 	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
 	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
 )
@@ -46,6 +47,7 @@ type failingClaudeDialogueBroker struct {
 	handoffs     int
 	deliveries   int
 	replies      int
+	replyRefs    map[string]string
 }
 
 func (b *failingClaudeDialogueBroker) Current(coremessage.Envelope) bool {
@@ -65,9 +67,21 @@ func (b *failingClaudeDialogueBroker) MarkDelivered(coremessage.Envelope, time.T
 	return b.deliveredErr
 }
 
-func (b *failingClaudeDialogueBroker) CommitReply(_, _ coremessage.Envelope) error {
+func (b *failingClaudeDialogueBroker) CommitReply(original, reply coremessage.Envelope) (bool, error) {
+	if previous := b.replyRefs[original.MessageRef]; previous != "" {
+		if previous == reply.MessageRef {
+			return false, nil
+		}
+		return false, &messagestore.ReplyConflictError{Reason: "reply-already-committed"}
+	}
 	b.replies++
-	return b.replyErr
+	if b.replyErr == nil {
+		if b.replyRefs == nil {
+			b.replyRefs = make(map[string]string)
+		}
+		b.replyRefs[original.MessageRef] = reply.MessageRef
+	}
+	return b.replyErr == nil, b.replyErr
 }
 
 type claudeCoordinationTestFixture struct {

--- a/internal/app/claude_endpoint_process_test.go
+++ b/internal/app/claude_endpoint_process_test.go
@@ -49,16 +49,19 @@ capture = socket.socket(socket.AF_UNIX)
 capture.connect(os.environ['PMX_TEST_CAPTURE'])
 receipt = capture.makefile('w', buffering=1)
 receipt.write(json.dumps({'socket':path,'token':token,'pid':os.getpid(),'pane_env':os.environ.get('PMX_INTERNAL_ACTIVATION_PANE_UID'),'generation_env':os.environ.get('PMX_INTERNAL_ACTIVATION_GENERATION'),'registry_env':os.environ.get('PMX_INTERNAL_CLAUDE_REGISTRY_PATH')}) + '\n'); receipt.flush()
-def hook(session):
+def hook(session, guarded=True):
     # The supervisor must scrub inherited activation policy. This private
     # fixture opts its owned registration child in explicitly, after launch.
     hook_env = dict(os.environ)
-    hook_env['PMX_INTERNAL_CLAUDE_REPLY_GUARD'] = '1'
+    if guarded: hook_env['PMX_INTERNAL_CLAUDE_REPLY_GUARD'] = '1'
     result = subprocess.run([os.environ['PMX_TEST_BIN'],'internal','claude-endpoint-register'], input=json.dumps({'hook_event_name':'SessionStart','session_id':session}).encode(), env=hook_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     assert result.returncode == 0 and not result.stdout and not result.stderr
     receipt.write('hook-returned\n'); receipt.flush()
+connections = 0
 def receive(kind, session):
+    global connections
     connection, _ = inbox.accept()
+    connections += 1
     stream = connection.makefile('rb')
     auth = json.loads(stream.readline())
     frame = json.loads(stream.readline())
@@ -89,10 +92,24 @@ for line in sys.stdin:
     elif command == 'repeat': hook('synthetic-session-2')
     elif command == 'qualify-2': receive('qualification', 'synthetic-session-2')
     elif command == 'message-2': receive('message', 'synthetic-session-2')
+    elif command == 'ordinary': hook('synthetic-session-3', guarded=False)
+    elif command == 'message-3': receive('message', 'synthetic-session-3')
+    elif command == 'message-4': receive('message', 'synthetic-session-3')
+    elif command.startswith('{'):
+        request = json.loads(command)
+        child_env={k:v for k,v in os.environ.items() if k not in {'CLAUDE_CODE_MESSAGING_TOKEN','CLAUDE_CODE_MESSAGING_SOCKET'}}
+        result = subprocess.run([os.environ['PMX_TEST_BIN']] + request['argv'], env=child_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        receipt.write(json.dumps({'replyExit':result.returncode,'stdout':result.stdout.decode(),'stderr':result.stderr.decode()}) + '\n'); receipt.flush()
     elif command == 'exit': break
+inbox.settimeout(0.15)
+try:
+    extra, _ = inbox.accept()
+    extra.close()
+    raise AssertionError('unexpected duplicate provider connection')
+except socket.timeout: pass
 inbox.close()
 os.unlink(path)
-receipt.write('provider-connections=4\n'); receipt.flush()
+receipt.write('provider-connections='+str(connections)+'\n'); receipt.flush()
 `
 
 // This fixture uses the same real broker authority surface as L20. Registry
@@ -489,7 +506,7 @@ func TestClaudeEndpointProcessIntegration(t *testing.T) {
 		// An auth-only or partial rejection connection would fail that check.
 	})
 
-	send := func(route coremetadata.AgentRouteRef, ref, command string) {
+	send := func(route coremetadata.AgentRouteRef, ref, command string, sourceOverride ...coremetadata.AgentRouteRef) {
 		t.Helper()
 		target, ok := claudeTargetForRoute(route)
 		if !ok {
@@ -501,6 +518,9 @@ func TestClaudeEndpointProcessIntegration(t *testing.T) {
 			Source: publicMessageRoute(sourceRoute),
 			Target: publicMessageRoute(route), Authority: coremessage.PeerAuthority(), Payload: "HETEROGENEOUS_MARKER:" + ref,
 			AcceptedAt: now, Deadline: now.Add(time.Minute)}
+		if len(sourceOverride) == 1 {
+			public.Source = publicMessageRoute(sourceOverride[0])
+		}
 		if _, _, err := messageStore.PutAccepted(public, "claude-coordination"); err != nil {
 			t.Fatal(err)
 		}
@@ -546,8 +566,108 @@ func TestClaudeEndpointProcessIntegration(t *testing.T) {
 	qualify(second, "qualify-2")
 	send(second, "process-message-2", "message-2")
 
+	t.Run("explicit-reply-known-zero-manual-retry", func(t *testing.T) {
+		// An ordinary registration exercises the public descendant CLI. The
+		// earlier guarded qualification fixtures and their parser stay intact.
+		_, _ = writeControl.WriteString("ordinary\n")
+		waitLine(t, reader, "hook-returned\n")
+		third := getRoute()
+		const originalRef = "process-explicit-original"
+		send(third, originalRef, "message-3", third)
+		original, found, err := messageStore.Get(originalRef)
+		if err != nil || !found {
+			t.Fatal("missing delivered original")
+		}
+		callReply := func(ref, payload string) (string, string, int) {
+			t.Helper()
+			request, err := json.Marshal(map[string]any{"argv": []string{"agent", "message", "send", "uid:" + third.AgentUID,
+				"--source", "uid:" + third.AgentUID, "--reply-to", originalRef, "--message-ref", ref, "--", payload}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := writeControl.Write(append(request, '\n')); err != nil {
+				t.Fatal(err)
+			}
+			line, err := reader.ReadBytes('\n')
+			if err != nil {
+				t.Fatal("provider reply process did not return")
+			}
+			var result struct {
+				Exit   int    `json:"replyExit"`
+				Stdout string `json:"stdout"`
+				Stderr string `json:"stderr"`
+			}
+			if json.Unmarshal(line, &result) != nil {
+				t.Fatal("invalid provider reply result")
+			}
+			if strings.Contains(result.Stdout+result.Stderr, private.Token) || strings.Contains(result.Stdout+result.Stderr, payload) {
+				t.Fatal("public reply output exposed auth or payload")
+			}
+			return result.Stdout, result.Stderr, result.Exit
+		}
+		status := func(ref string) agentMessageReceipt {
+			t.Helper()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			command := exec.CommandContext(ctx, binary, "agent", "message", "status", ref, "-o", "json")
+			command.Env, command.Dir = claudeEndpointProcessEnv(root, binary), root
+			output, err := command.Output()
+			var receipt agentMessageReceipt
+			if err != nil || json.Unmarshal(output, &receipt) != nil {
+				t.Fatal("public reply status unavailable")
+			}
+			return receipt
+		}
+		const failedRef, retryRef = "process-reply-failed", "process-reply-manual"
+		payload := strings.Repeat("x", coremessage.MaxPayloadBytes)
+		out, refusal, exit := callReply(failedRef, payload)
+		failed := status(failedRef)
+		if exit == 0 || failed.Delivery.State != coremessage.StateFailed || failed.Delivery.OutcomeUnknown ||
+			failed.Delivery.Reason != "provider-frame-invalid-content" || !strings.Contains(refusal, "previousRef="+failedRef) ||
+			!strings.Contains(refusal, failed.Delivery.Reason) || !strings.Contains(out+refusal, "new --message-ref") {
+			t.Fatalf("known-zero reply did not expose cause/ref/action: exit=%d out=%s stderr=%s", exit, out, refusal)
+		}
+		statusCommand := exec.Command(binary, "agent", "message", "status", failedRef)
+		statusCommand.Env, statusCommand.Dir = claudeEndpointProcessEnv(root, binary), root
+		statusText, statusErr := statusCommand.Output()
+		if statusErr != nil || !bytes.Contains(statusText, []byte(failed.Delivery.Reason)) || !bytes.Contains(statusText, []byte("new --message-ref")) {
+			t.Fatal("public text status omitted known-zero recovery action")
+		}
+		if _, _, exit := callReply(failedRef, payload); exit == 0 {
+			t.Fatal("same failed ref did not retain failure")
+		}
+		if _, refusal, exit := callReply(failedRef, "corrected answer"); exit == 0 || !strings.Contains(refusal, failed.Delivery.Reason) {
+			t.Fatal("changed same ref lost immutable failure cause")
+		}
+		if out, refusal, exit := callReply(retryRef, "corrected answer"); exit != 0 || refusal != "" || !strings.Contains(out, "delivered") {
+			t.Fatalf("manual retry failed: %d %s %s", exit, out, refusal)
+		}
+		_, _ = writeControl.WriteString("message-4\n")
+		assertProviderReceipt(t, reader, "message", `"messageRef":"`+retryRef+`"`)
+		if _, _, exit := callReply(retryRef, "corrected answer"); exit != 0 {
+			t.Fatal("same delivered ref not idempotent")
+		}
+		delivered := status(retryRef)
+		if _, refusal, exit := callReply("process-reply-duplicate", "corrected answer"); exit == 0 ||
+			!strings.Contains(refusal, "previousRef="+retryRef) || !strings.Contains(refusal, "state=delivered") ||
+			!strings.Contains(refusal, "reason="+delivered.Delivery.Reason) || !strings.Contains(refusal, "do not resend") {
+			t.Fatalf("delivered reply refusal lost cause/ref/action: %d %s", exit, refusal)
+		}
+		if delivered.Delivery.State != coremessage.StateDelivered || delivered.ReplyTo != originalRef || delivered.ConversationRef != original.Envelope.ConversationRef ||
+			delivered.Source != original.Envelope.Target || delivered.Target != original.Envelope.Source || delivered.Deadline.After(original.Envelope.Deadline) {
+			t.Fatal("manual retry changed original correlation")
+		}
+		if status(failedRef).Delivery != failed.Delivery {
+			t.Fatal("manual retry overwrote failed receipt")
+		}
+		if got, _, _ := messageStore.Get(originalRef); got != original {
+			t.Fatal("manual retry altered delivered original")
+		}
+		t.Logf("known-zero reply reason=%s; same-ref writes=0; manual retry delivered once; duplicate refused with previousRef=%s", failed.Delivery.Reason, retryRef)
+	})
+
 	_, _ = writeControl.WriteString("exit\n")
-	waitLine(t, reader, "provider-connections=4\n")
+	waitLine(t, reader, "provider-connections=6\n")
 	select {
 	case err := <-done:
 		if err != nil {

--- a/internal/app/claude_explicit_reply.go
+++ b/internal/app/claude_explicit_reply.go
@@ -3,12 +3,14 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/crevissepartners/projmux/internal/core/agentdelivery"
 	coremessage "github.com/crevissepartners/projmux/internal/core/agentmessage"
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	messagestore "github.com/crevissepartners/projmux/internal/integrations/agents/agentmessage"
 	"github.com/crevissepartners/projmux/internal/integrations/agents/localipc"
 )
 
@@ -38,10 +40,10 @@ func claudeProviderDescendant(peer, provider coremetadata.ProcessIdentity) bool 
 
 func (a liveAgentMessageClaudeAdapter) ExplicitReply(ctx context.Context, registryPath string,
 	source coremetadata.AgentRouteRef, reply coremessage.Envelope,
-) (string, error) {
+) (string, bool, error) {
 	target, ok := claudeTargetForRoute(source)
 	if !ok {
-		return "", coremessage.ErrInvalidEnvelope
+		return "", false, coremessage.ErrInvalidEnvelope
 	}
 	ctx, cancel := context.WithTimeout(ctx, localipc.Deadline)
 	defer cancel()
@@ -49,23 +51,55 @@ func (a liveAgentMessageClaudeAdapter) ExplicitReply(ctx context.Context, regist
 		Version: claudeCoordinationVersion, Operation: "explicit-reply", Target: target,
 		SessionID: target.Authority.SessionID, ReplyEnvelope: &reply,
 	})
-	if err != nil || response.Kind != "reply-accepted" || response.ReplyRef != reply.MessageRef || response.AutoResend {
-		return "", errors.New("exact explicit reply was not acknowledged; do not resend")
+	if err != nil || response.Version != claudeCoordinationVersion || response.AutoResend {
+		return "", false, fmt.Errorf("replyRef=%s: explicit-reply-outcome-unknown; inspect message status; do not resend", reply.MessageRef)
 	}
-	return response.ReplyRef, nil
+	if response.Kind == "reply-refused" {
+		return "", false, explicitReplyRefusal(response)
+	}
+	if response.ReplyRef != reply.MessageRef || response.Reason != "" || response.ReplyDelivery != nil ||
+		(response.Kind != "reply-accepted" || !response.ReplyCreated) && (response.Kind != "reply-replayed" || response.ReplyCreated) {
+		return "", false, fmt.Errorf("replyRef=%s: invalid-explicit-reply-receipt; inspect message status; do not resend", reply.MessageRef)
+	}
+	return response.ReplyRef, response.ReplyCreated, nil
 }
 
-func (b *liveClaudeDialogueBroker) CommitReply(original, reply coremessage.Envelope) error {
+func explicitReplyRefusal(response claudeCoordinationResponse) error {
+	action := "inspect original and previous reply status; do not resend"
+	if response.ReplyDelivery != nil {
+		return fmt.Errorf("%s; previousRef=%s state=%s reason=%s outcomeUnknown=%t; %s",
+			response.Reason, response.ReplyRef, response.ReplyDelivery.State, response.ReplyDelivery.Reason,
+			response.ReplyDelivery.OutcomeUnknown, action)
+	}
+	return fmt.Errorf("%s; previousRef=%s; %s", response.Reason, response.ReplyRef, action)
+}
+
+func (b *liveClaudeDialogueBroker) ReplyStatus(originalRef string) (messagestore.Record, bool, error) {
+	return b.store.Reply(originalRef)
+}
+
+func knownZeroExplicitReply(broker claudeDialogueBroker, originalRef string) bool {
+	lookup, ok := broker.(interface {
+		ReplyStatus(string) (messagestore.Record, bool, error)
+	})
+	if !ok {
+		return false
+	}
+	record, found, err := lookup.ReplyStatus(originalRef)
+	return err == nil && found && messagestore.KnownZeroReply(record)
+}
+
+func (b *liveClaudeDialogueBroker) CommitReply(original, reply coremessage.Envelope) (bool, error) {
 	// The reply target is no longer pinned to Codex. Plain homogeneous sends
 	// already succeed through the broker, so refusing only their replies left a
 	// lane that half worked and reported no reason for the half that did not.
 	if b == nil || b.store == nil || coremessage.ValidateReply(original, reply) != nil ||
 		!original.Deadline.After(time.Now()) || !b.Current(reply) {
-		return coremessage.ErrInvalidEnvelope
+		return false, coremessage.ErrInvalidEnvelope
 	}
-	_, _, err := b.store.PutReply(original.MessageRef, reply.MessageRef, reply.Payload, reply.Source,
+	_, created, err := b.store.PutReply(original.MessageRef, reply.MessageRef, reply.Payload, reply.Source,
 		reply.Target, reply.AcceptedAt, reply.Deadline)
-	return err
+	return created, err
 }
 
 // commitExplicitReply selects the broker's original request by ref, never by
@@ -77,14 +111,33 @@ func (h *claudeCoordinationHub) commitExplicitReply(reply coremessage.Envelope,
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	refuse := func(reason string) claudeCoordinationResponse {
-		return claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "reply-refused", Reason: reason}
+		response := claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "reply-refused", Reason: reason}
+		if lookup, ok := broker.(interface {
+			ReplyStatus(string) (messagestore.Record, bool, error)
+		}); ok {
+			if previous, found, err := lookup.ReplyStatus(reply.ReplyTo); err == nil && found {
+				response.ReplyRef, response.ReplyDelivery = previous.Envelope.MessageRef, &previous.Delivery
+			}
+		}
+		if response.ReplyRef == "" {
+			if message := h.messages[reply.ReplyTo]; message != nil {
+				response.ReplyRef = message.replyRef
+			}
+		}
+		return response
 	}
 	h.expireQualificationLocked(h.now())
 	message := h.messages[reply.ReplyTo]
 	if h.closed || broker == nil || message == nil || message.envelope.BrokerEnvelope == nil ||
-		message.delivery.State != agentdelivery.StateDelivered || !message.envelope.Deadline.After(h.now()) ||
+		message.delivery.State != agentdelivery.StateDelivered ||
 		reply.Source != publicMessageRoute(source) || coremessage.ValidateReply(*message.envelope.BrokerEnvelope, reply) != nil {
 		return refuse("invalid-explicit-reply-correlation")
+	}
+	if !message.envelope.Deadline.After(h.now()) || !reply.Deadline.After(h.now()) {
+		return refuse("explicit-reply-deadline-expired")
+	}
+	if reply.Deadline.After(message.envelope.Deadline) {
+		return refuse("explicit-reply-deadline-extended")
 	}
 	// A reply is a qualification answer only when it answers the pending
 	// challenge. Ordinary replies no longer have to wait for qualification;
@@ -97,16 +150,41 @@ func (h *claudeCoordinationHub) commitExplicitReply(reply coremessage.Envelope,
 	if message.replyReserved {
 		return refuse("broker-reply-outcome-unknown")
 	}
-	if message.replyRef != "" && message.replyRef != reply.MessageRef {
-		return refuse("reply-already-committed")
-	}
 	if !broker.Current(reply) {
 		return refuse("explicit-reply-route-stale")
 	}
 	// Reserve before the durable call. A failed/ambiguous commit is never
 	// retried automatically, including by a later unrelated Stop.
 	message.replyReserved = true
-	if broker.CommitReply(*message.envelope.BrokerEnvelope, reply) != nil {
+	created, err := broker.CommitReply(*message.envelope.BrokerEnvelope, reply)
+	if err != nil {
+		var conflict *messagestore.ReplyConflictError
+		if errors.As(err, &conflict) {
+			message.replyReserved = false // A refusal made no durable change.
+			response := refuse(conflict.Reason)
+			if conflict.Previous.Envelope.MessageRef != "" {
+				response.ReplyRef, response.ReplyDelivery = conflict.Previous.Envelope.MessageRef, &conflict.Previous.Delivery
+			}
+			return response
+		}
+		// These store refusals precede any durable write. Preserve their
+		// cause without leaking a filesystem path or poisoning correlation.
+		for _, rejection := range []struct {
+			err    error
+			reason string
+		}{
+			{messagestore.ErrBusy, "broker-reply-store-busy"},
+			{messagestore.ErrCapacity, "broker-reply-store-capacity"},
+			{messagestore.ErrNotFound, "broker-reply-original-not-found"},
+			{messagestore.ErrMalformedStore, "broker-reply-store-malformed"},
+			{coremessage.ErrInvalidEnvelope, "invalid-explicit-reply-correlation"},
+		} {
+			if errors.Is(err, rejection.err) {
+				message.replyReserved = false
+				return refuse(rejection.reason)
+			}
+		}
+		message.replyRef = reply.MessageRef
 		return refuse("broker-reply-outcome-unknown")
 	}
 	message.replyReserved = false
@@ -117,7 +195,13 @@ func (h *claudeCoordinationHub) commitExplicitReply(reply coremessage.Envelope,
 		h.qualification.ambiguous = false
 		h.qualifiedVersion = claudeFrozenFrameProviderVersion
 	}
-	return claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: "reply-accepted", ReplyRef: reply.MessageRef}
+	kind := "reply-accepted"
+	if !created {
+		// Older callers only dispatch reply-accepted. A replay must not give
+		// them their old unconditional push permission either.
+		kind = "reply-replayed"
+	}
+	return claudeCoordinationResponse{Version: claudeCoordinationVersion, Kind: kind, ReplyRef: reply.MessageRef, ReplyCreated: created}
 }
 
 func (e claudeQualificationEvidence) validExplicit(now time.Time, route coremetadata.AgentRouteRef) bool {

--- a/internal/app/claude_explicit_reply_test.go
+++ b/internal/app/claude_explicit_reply_test.go
@@ -1,0 +1,294 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/agentdelivery"
+	coremessage "github.com/crevissepartners/projmux/internal/core/agentmessage"
+	messagestore "github.com/crevissepartners/projmux/internal/integrations/agents/agentmessage"
+	intmetadata "github.com/crevissepartners/projmux/internal/integrations/metadata"
+)
+
+// Keep the durable reply implementation real while replacing only the
+// fixture's provider liveness observation. This does not bypass the helper's
+// exact source route or process-descendant gate.
+type durableReplyTestBroker struct {
+	store   *messagestore.Store
+	current bool
+}
+
+func (b *durableReplyTestBroker) Current(coremessage.Envelope) bool { return b.current }
+func (b *durableReplyTestBroker) MarkHandoff(e coremessage.Envelope) error {
+	_, _, err := b.store.MarkHandoff(e.MessageRef)
+	return err
+}
+func (b *durableReplyTestBroker) MarkDelivered(e coremessage.Envelope, now time.Time) error {
+	_, _, err := b.store.Apply(e.MessageRef, coremessage.Event{Kind: coremessage.EventDeliver, MessageRef: e.MessageRef,
+		ConversationRef: e.ConversationRef, Target: e.Target, ObservedAt: now, Reason: "provider-pipe-full-frame"})
+	return err
+}
+func (b *durableReplyTestBroker) CommitReply(original, reply coremessage.Envelope) (bool, error) {
+	_, created, err := b.store.PutReply(original.MessageRef, reply.MessageRef, reply.Payload, reply.Source, reply.Target,
+		reply.AcceptedAt, reply.Deadline)
+	return created, err
+}
+func (b *durableReplyTestBroker) ReplyStatus(ref string) (messagestore.Record, bool, error) {
+	return b.store.Reply(ref)
+}
+
+type replyFrameWriter struct {
+	mode   string
+	writes int
+	frames [][]byte
+}
+
+func (w *replyFrameWriter) Write(frame []byte) (int, error) {
+	w.writes++
+	switch w.mode {
+	case "zero":
+		return 0, errors.New("private write cause")
+	case "partial":
+		return 2, errors.New("private write cause")
+	case "unknown":
+		return -1, errors.New("private write cause")
+	}
+	w.frames = append(w.frames, append([]byte(nil), frame...))
+	return len(frame), nil
+}
+
+type replyTestPoster struct{ writer *replyFrameWriter }
+
+func (p replyTestPoster) Post(content string, current func() bool) (claudeProviderPostOutcome, error) {
+	if !current() {
+		return claudeProviderPostOutcome{Reason: "provider-prewrite-refused"}, errors.New("stale")
+	}
+	frame, err := buildClaudeProviderPushFrame("private-fixture-token", content)
+	if err != nil {
+		return claudeProviderPostOutcome{Reason: err.Error()}, err
+	}
+	return writeClaudeProviderPushFrame(p.writer, frame), nil
+}
+
+func explicitReplyCommandFixture(t *testing.T) (*claudeCoordinationTestFixture, *agentCommand, *durableReplyTestBroker, *replyFrameWriter, coremessage.Envelope) {
+	t.Helper()
+	f := newClaudeCoordinationTestFixture(t)
+	store := messagestore.NewStore(t.TempDir())
+	broker := &durableReplyTestBroker{store: store, current: true}
+	writer := &replyFrameWriter{}
+	f.server.broker, f.server.poster = broker, replyTestPoster{writer}
+	original := *dialogueForRoute("original-request", f.route, time.Now().UTC()).BrokerEnvelope
+	original.Source = original.Target // A homogeneous reply exercises the provider-write boundary.
+	if _, _, err := store.PutAccepted(original, "claude-coordination"); err != nil {
+		t.Fatal(err)
+	}
+	adapter := liveAgentMessageClaudeAdapter{}
+	if got, err := adapter.Submit(context.Background(), f.registryPath, f.route, original); err != nil || got.State != agentdelivery.StateDelivered {
+		t.Fatalf("original not delivered: %+v %v", got, err)
+	}
+	command := &agentCommand{messageStore: store, messageClaude: adapter,
+		messagePaths: agentMessagePaths{registryPath: f.registryPath, loadRegistry: intmetadata.NewStore(f.registryPath).LoadReadOnly},
+		messageRoute: &traceMessageRouteResolver{route: f.route}}
+	return f, command, broker, writer, original
+}
+
+func runExplicitFixtureCommand(t *testing.T, command *agentCommand, original coremessage.Envelope, ref, payload string) (string, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	err := command.runMessageSend([]string{"uid:" + original.Source.AgentUID, "--source", "uid:" + original.Target.AgentUID,
+		"--reply-to", original.MessageRef, "--message-ref", ref, "--", payload}, &stdout, &stderr)
+	return stdout.String() + stderr.String(), err
+}
+
+func TestClaudeExplicitReplyKnownZeroManualRetryPublicReceiptsAndReload(t *testing.T) {
+	f, command, broker, writer, original := explicitReplyCommandFixture(t)
+	writer.mode = "zero"
+	output, err := runExplicitFixtureCommand(t, command, original, "reply-zero", "initial answer")
+	if err == nil || !strings.Contains(err.Error(), "previousRef=reply-zero") || !strings.Contains(err.Error(), "provider-write-zero") ||
+		!strings.Contains(output, "new --message-ref") || writer.writes != 2 {
+		t.Fatalf("zero receipt: %s %v writes=%d", output, err, writer.writes)
+	}
+	failed, _, _ := broker.store.Get("reply-zero")
+	command.messageStore = messagestore.NewStoreAt(broker.store.Path())
+	broker.store = messagestore.NewStoreAt(broker.store.Path())
+	writer.mode = "full"
+	if _, err := runExplicitFixtureCommand(t, command, original, "reply-zero", "initial answer"); err == nil || writer.writes != 2 {
+		t.Fatal("same ref resent the zero-write attempt")
+	}
+	if _, err := runExplicitFixtureCommand(t, command, original, "reply-zero", "changed answer"); err == nil || !strings.Contains(err.Error(), "provider-write-zero") || writer.writes != 2 {
+		t.Fatal("same ref changed immutable payload or lost previous cause")
+	}
+	if output, err := runExplicitFixtureCommand(t, command, original, "reply-manual", "corrected answer"); err != nil || !strings.Contains(output, "delivered") || writer.writes != 3 {
+		t.Fatalf("manual retry: %s %v writes=%d", output, err, writer.writes)
+	}
+	delivered, _, _ := broker.store.Get("reply-manual")
+	if delivered.Envelope.ReplyTo != original.MessageRef || delivered.Envelope.ConversationRef != original.ConversationRef ||
+		delivered.Envelope.Source != original.Target || delivered.Envelope.Target != original.Source || delivered.Envelope.Authority != coremessage.PeerAuthority() ||
+		delivered.Envelope.Deadline.After(original.Deadline) {
+		t.Fatal("retry changed correlation, route, deadline or authority")
+	}
+	// Forget every in-memory reply ref; the reloaded store still owns admission.
+	f.server.hub.mu.Lock()
+	f.server.hub.messages[original.MessageRef].replyRef = ""
+	f.server.hub.mu.Unlock()
+	if _, err := runExplicitFixtureCommand(t, command, original, "reply-manual", "corrected answer"); err != nil || writer.writes != 3 {
+		t.Fatal("same delivered ref dispatched after reload")
+	}
+	if _, err := runExplicitFixtureCommand(t, command, original, "reply-duplicate", "corrected answer"); err == nil ||
+		!strings.Contains(err.Error(), "previousRef=reply-manual") || !strings.Contains(err.Error(), "provider-pipe-full-frame") || !strings.Contains(err.Error(), "do not resend") || writer.writes != 3 {
+		t.Fatalf("different delivered ref refusal: %v writes=%d", err, writer.writes)
+	}
+	for _, want := range []messagestore.Record{failed, delivered} {
+		got, found, err := broker.store.Get(want.Envelope.MessageRef)
+		if err != nil || !found || got != want {
+			t.Fatal("retry replaced immutable attempt")
+		}
+		var status bytes.Buffer
+		if err := command.runMessageStatus([]string{want.Envelope.MessageRef, "-o", "json"}, &status, &bytes.Buffer{}); err != nil {
+			t.Fatal(err)
+		}
+		var receipt agentMessageReceipt
+		if json.Unmarshal(status.Bytes(), &receipt) != nil || receipt.Delivery != want.Delivery {
+			t.Fatal("public status lost durable cause")
+		}
+	}
+	if got, _, _ := broker.store.Get(original.MessageRef); got.Envelope != original {
+		t.Fatal("retry altered original")
+	}
+	if len(writer.frames) != 2 || !bytes.Contains(writer.frames[1], []byte("corrected answer")) || !bytes.Contains(writer.frames[1], []byte("coordination-only")) {
+		t.Fatal("successful retry did not preserve peer framing")
+	}
+}
+
+func TestClaudeExplicitReplyPartialUnknownExpiredAndStaleNeverDuplicate(t *testing.T) {
+	for _, mode := range []string{"partial", "unknown", "expired", "expired at CLI", "stale", "stale source resolution", "stale target resolution"} {
+		t.Run(mode, func(t *testing.T) {
+			f, command, broker, writer, original := explicitReplyCommandFixture(t)
+			writer.mode = mode
+			if mode != "partial" && mode != "unknown" {
+				writer.mode = "zero"
+			}
+			if _, err := runExplicitFixtureCommand(t, command, original, "previous", "answer"); err == nil {
+				t.Fatal("expected failed first write")
+			}
+			previous, _, _ := broker.store.Get("previous")
+			broker.store = messagestore.NewStoreAt(broker.store.Path())
+			command.messageStore = broker.store
+			if mode == "expired" {
+				f.server.hub.now = func() time.Time { return original.Deadline }
+			}
+			if mode == "expired at CLI" {
+				command.messageNow = func() time.Time { return original.Deadline }
+			}
+			if mode == "stale" {
+				broker.current = false
+			}
+			writer.mode = "full"
+			for _, ref := range []string{"previous", "manual"} {
+				if mode == "stale source resolution" {
+					command.messageRoute = &traceMessageRouteResolver{route: f.route, failAt: 1}
+				}
+				if mode == "stale target resolution" {
+					command.messageRoute = &traceMessageRouteResolver{route: f.route, failAt: 2}
+				}
+				_, err := runExplicitFixtureCommand(t, command, original, ref, "answer")
+				if err == nil || !strings.Contains(err.Error(), "previousRef=previous") || !strings.Contains(err.Error(), previous.Delivery.Reason) ||
+					!strings.Contains(err.Error(), "do not resend") || writer.writes != 2 {
+					t.Fatalf("unsafe %s retry: %v writes=%d", mode, err, writer.writes)
+				}
+			}
+		})
+	}
+}
+
+func TestClaudeExplicitReplyAcknowledgementRequiresFreshDispatchProof(t *testing.T) {
+	for _, response := range []claudeCoordinationResponse{
+		{Version: claudeCoordinationVersion, Kind: "reply-accepted", ReplyRef: "reply-test"}, // Older helper, no creation proof.
+		{Version: claudeCoordinationVersion, Kind: "reply-replayed", ReplyRef: "reply-test", ReplyCreated: true},
+		{Version: claudeCoordinationVersion, Kind: "reply-accepted", ReplyRef: "other", ReplyCreated: true},
+		{Version: claudeCoordinationVersion, Kind: "reply-accepted", ReplyRef: "reply-test", ReplyCreated: true, AutoResend: true},
+	} {
+		t.Run(response.Kind+response.ReplyRef, func(t *testing.T) {
+			fixture := newClaudeCoordinationTestFixture(t)
+			done := replaceClaudeServerWithCoordinationResponse(t, fixture, response)
+			reply := explicitTestReply(*dialogueForRoute("original", fixture.route, time.Now().UTC()).BrokerEnvelope, "answer")
+			reply.MessageRef = "reply-test"
+			if _, created, err := (liveAgentMessageClaudeAdapter{}).ExplicitReply(context.Background(), fixture.registryPath, fixture.route, reply); err == nil || created || !strings.Contains(err.Error(), "replyRef=reply-test") || !strings.Contains(err.Error(), "do not resend") {
+				t.Fatal("invalid or legacy acknowledgement granted a dispatch")
+			}
+			if err := <-done; err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestClaudeExplicitReplyStoreRefusalsKeepCauseAndUnknownReservation(t *testing.T) {
+	for _, tc := range []struct {
+		err     error
+		reason  string
+		unknown bool
+	}{
+		{messagestore.ErrBusy, "broker-reply-store-busy", false},
+		{messagestore.ErrCapacity, "broker-reply-store-capacity", false},
+		{messagestore.ErrNotFound, "broker-reply-original-not-found", false},
+		{messagestore.ErrMalformedStore, "broker-reply-store-malformed", false},
+		{errors.New("private filesystem failure"), "broker-reply-outcome-unknown", true},
+	} {
+		t.Run(tc.reason, func(t *testing.T) {
+			fixture := newClaudeCoordinationTestFixture(t)
+			now := time.Now().UTC()
+			hub := qualifiedPushHub(now)
+			broker := &failingClaudeDialogueBroker{replyErr: tc.err}
+			original := dialogueForRoute("original", fixture.route, now)
+			poster := &qualificationPosterRecorder{outcome: claudeProviderPostOutcome{FullFrameWritten: true, WroteAny: true}}
+			hub.submitPush(original, broker, poster)
+			reply := explicitTestReply(*original.BrokerEnvelope, "answer")
+			got := hub.commitExplicitReply(reply, fixture.route, broker)
+			if got.Kind != "reply-refused" || got.Reason != tc.reason || hub.messages[original.MessageRef].replyReserved != tc.unknown {
+				t.Fatalf("refusal lost no-write/unknown cause: %+v", got)
+			}
+			broker.replyErr = nil
+			retried := hub.commitExplicitReply(reply, fixture.route, broker)
+			if tc.unknown {
+				if retried.Reason != "broker-reply-outcome-unknown" || retried.ReplyRef != reply.MessageRef || broker.replies != 1 {
+					t.Fatal("ambiguous persistence retried")
+				}
+			} else if retried.Kind != "reply-accepted" || !retried.ReplyCreated {
+				t.Fatal("pre-write store refusal permanently reserved original")
+			}
+		})
+	}
+}
+
+func TestClaudeExplicitReplyGuardRetryRetainsQualificationAndRouteFences(t *testing.T) {
+	f, command, broker, writer, original := explicitReplyCommandFixture(t)
+	writer.mode = "zero"
+	_, _ = runExplicitFixtureCommand(t, command, original, "failed", "answer")
+	argv := []string{"/owned/projmux", "agent", "message", "send", "uid:" + original.Source.AgentUID, "--reply-to", original.MessageRef, "--", "corrected"}
+	hub := f.server.hub
+	if hub.permitsExplicitTool(argv, f.route, broker) {
+		t.Fatal("retry relaxed qualification")
+	}
+	hub.qualifiedVersion = claudeFrozenFrameProviderVersion
+	if !hub.permitsExplicitTool(argv, f.route, broker) {
+		t.Fatal("qualified known-zero retry permanently consumed guard")
+	}
+	broker.current = false
+	if hub.permitsExplicitTool(argv, f.route, broker) {
+		t.Fatal("retry relaxed exact route")
+	}
+	broker.current = true
+	writer.mode = "full"
+	if _, err := runExplicitFixtureCommand(t, command, original, "manual", "corrected"); err != nil {
+		t.Fatal(err)
+	}
+	if hub.permitsExplicitTool(argv, f.route, broker) {
+		t.Fatal("delivered reply reopened guarded execution")
+	}
+}

--- a/internal/app/claude_reply_tool.go
+++ b/internal/app/claude_reply_tool.go
@@ -270,7 +270,10 @@ func (h *claudeCoordinationHub) permitsExplicitTool(argv []string, route coremet
 	defer h.mu.Unlock()
 	h.expireQualificationLocked(h.now())
 	message := h.messages[argv[6]]
-	if h.closed || broker == nil || message == nil || message.envelope.BrokerEnvelope == nil || message.delivery.State != agentdelivery.StateDelivered || message.replyReserved || message.replyRef != "" || !message.envelope.Deadline.After(h.now()) {
+	if h.closed || broker == nil || message == nil || message.envelope.BrokerEnvelope == nil || message.delivery.State != agentdelivery.StateDelivered || message.replyReserved || !message.envelope.Deadline.After(h.now()) {
+		return false
+	}
+	if message.replyRef != "" && !knownZeroExplicitReply(broker, message.envelope.MessageRef) {
 		return false
 	}
 	original := message.envelope.BrokerEnvelope

--- a/internal/app/claude_reply_tool_test.go
+++ b/internal/app/claude_reply_tool_test.go
@@ -261,7 +261,7 @@ func TestClaudeExplicitReplyUnsupportedTargetCannotCorruptStore(t *testing.T) {
 		return err
 	})
 	broker := &liveClaudeDialogueBroker{store: store}
-	if broker.CommitReply(*original, explicitTestReply(*original, "reply")) == nil {
+	if _, err := broker.CommitReply(*original, explicitTestReply(*original, "reply")); err == nil {
 		t.Fatal("unsupported target accepted")
 	}
 	for path, before := range contents {

--- a/internal/integrations/agents/agentmessage/reply_retry_test.go
+++ b/internal/integrations/agents/agentmessage/reply_retry_test.go
@@ -1,0 +1,207 @@
+package agentmessage
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	coremessage "github.com/crevissepartners/projmux/internal/core/agentmessage"
+)
+
+func retryStoreFixture(t *testing.T) (*Store, coremessage.Envelope) {
+	t.Helper()
+	store := NewStoreAt(filepath.Join(t.TempDir(), "messages.json"))
+	store.now = func() time.Time { return storeTestNow }
+	original := storeEnvelope(1)
+	original.Source.Provider, original.Target.Provider = "claude", "claude"
+	if _, _, err := store.PutAccepted(original, "claude-coordination"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.Apply(original.MessageRef, coremessage.Event{Kind: coremessage.EventDeliver,
+		MessageRef: original.MessageRef, ConversationRef: original.ConversationRef, Target: original.Target,
+		ObservedAt: original.AcceptedAt}); err != nil {
+		t.Fatal(err)
+	}
+	return store, original
+}
+
+func retryStoreReply(t *testing.T, store *Store, original coremessage.Envelope, ref, payload string) Record {
+	t.Helper()
+	record, created, err := store.PutReply(original.MessageRef, ref, payload, original.Target, original.Source,
+		original.AcceptedAt, original.Deadline)
+	if err != nil || !created {
+		t.Fatalf("PutReply: created=%t err=%v", created, err)
+	}
+	return record
+}
+
+func retryStoreOutcome(t *testing.T, store *Store, record Record, kind coremessage.EventKind, reason string, unknown bool) Record {
+	t.Helper()
+	updated, changed, err := store.Apply(record.Envelope.MessageRef, coremessage.Event{Kind: kind,
+		MessageRef: record.Envelope.MessageRef, ConversationRef: record.Envelope.ConversationRef, Target: record.Envelope.Target,
+		ObservedAt: record.Envelope.AcceptedAt, Reason: reason, OutcomeUnknown: unknown})
+	if err != nil || !changed {
+		t.Fatalf("Apply: changed=%t err=%v", changed, err)
+	}
+	return updated
+}
+
+func TestStoreExplicitReplyKnownZeroManualRetrySurvivesReload(t *testing.T) {
+	store, original := retryStoreFixture(t)
+	failed := retryStoreOutcome(t, store, retryStoreReply(t, store, original, "reply-failed", "too large"),
+		coremessage.EventFail, "provider-frame-too-large: frameBytes=8193 limitBytes=8192", false)
+	store = NewStoreAt(store.Path())
+	store.now = func() time.Time { return storeTestNow }
+	replay, created, err := store.PutReply(original.MessageRef, failed.Envelope.MessageRef, failed.Envelope.Payload,
+		original.Target, original.Source, original.AcceptedAt, original.Deadline)
+	if err != nil || created || replay != failed {
+		t.Fatalf("same-ref replay changed failed attempt: created=%t err=%v", created, err)
+	}
+	for _, ref := range []string{failed.Envelope.MessageRef, original.MessageRef} {
+		if _, _, err := store.PutReply(original.MessageRef, ref, "corrected", original.Target, original.Source,
+			original.AcceptedAt, original.Deadline); !errors.Is(err, coremessage.ErrRetryMismatch) {
+			t.Fatalf("immutable/global ref collision accepted: %v", err)
+		}
+	}
+	retried := retryStoreReply(t, store, original, "reply-manual", "corrected")
+	if retried.Envelope.ReplyTo != original.MessageRef || retried.Envelope.ConversationRef != original.ConversationRef ||
+		retried.Envelope.Source != original.Target || retried.Envelope.Target != original.Source ||
+		retried.Envelope.Authority != coremessage.PeerAuthority() || retried.Envelope.Deadline != original.Deadline {
+		t.Fatal("retry changed original correlation or authority")
+	}
+	delivered := retryStoreOutcome(t, store, retried, coremessage.EventDeliver, "provider-pipe-full-frame", false)
+	store = NewStoreAt(store.Path())
+	store.now = func() time.Time { return storeTestNow }
+	if _, _, err := store.PutReply(original.MessageRef, "reply-duplicate", "corrected", original.Target, original.Source,
+		original.AcceptedAt, original.Deadline); err == nil {
+		t.Fatal("delivered reply allowed another ref after reload")
+	} else {
+		var conflict *ReplyConflictError
+		if !errors.As(err, &conflict) || conflict.Previous != delivered {
+			t.Fatal("refusal lost previous ref and delivery cause")
+		}
+	}
+	for _, want := range []Record{failed, delivered} {
+		if got, found, err := store.Get(want.Envelope.MessageRef); err != nil || !found || got != want {
+			t.Fatal("manual retry deleted or rewrote an attempt")
+		}
+	}
+	if got, _, err := store.Get(original.MessageRef); err != nil || got.Envelope != original {
+		t.Fatal("manual retry rewrote original")
+	}
+}
+
+func TestStoreExplicitReplyNonzeroUnknownAndExpiredNeverRetry(t *testing.T) {
+	for _, tc := range []struct {
+		name, reason string
+		kind         coremessage.EventKind
+		unknown      bool
+	}{
+		{"delivered", "provider-pipe-full-frame", coremessage.EventDeliver, false},
+		{"partial", "provider-write-partial", coremessage.EventFail, true},
+		{"partial without unknown flag", "provider-write-partial", coremessage.EventFail, false},
+		{"unknown", "provider-handoff-outcome-unknown", coremessage.EventFail, true},
+		{"zero with unknown flag", "provider-write-zero", coremessage.EventFail, true},
+		{"unrecognized failure", "future-failure", coremessage.EventFail, false},
+		{"invalid size evidence", "provider-frame-too-large: frameBytes=8193 limitBytes=9000", coremessage.EventFail, false},
+		{"refused without zero evidence", "provider-refused", coremessage.EventRefuse, false},
+		{"expired", "deadline-expired", coremessage.EventExpire, false},
+		{"stale", "target-activation-stale", coremessage.EventStale, false},
+		{"pending", "", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, original := retryStoreFixture(t)
+			previous := retryStoreReply(t, store, original, "previous", "payload")
+			if tc.kind != "" {
+				previous = retryStoreOutcome(t, store, previous, tc.kind, tc.reason, tc.unknown)
+			}
+			store = NewStoreAt(store.Path())
+			store.now = func() time.Time { return storeTestNow }
+			if replay, created, err := store.PutReply(original.MessageRef, "previous", "payload", original.Target, original.Source,
+				original.AcceptedAt, original.Deadline); err != nil || created || replay != previous {
+				t.Fatal("same ref must only return immutable receipt")
+			}
+			_, created, err := store.PutReply(original.MessageRef, "new-ref", "corrected", original.Target, original.Source,
+				original.AcceptedAt, original.Deadline)
+			var conflict *ReplyConflictError
+			if created || !errors.As(err, &conflict) || conflict.Previous != previous {
+				t.Fatalf("unsafe retry or missing cause: created=%t err=%v", created, err)
+			}
+		})
+	}
+}
+
+func TestStoreExplicitReplyRetryKeepsDeadlineAndExactRoute(t *testing.T) {
+	for _, mode := range []string{"original expired", "reply expired", "deadline extended", "source stale", "target stale", "codex outcome"} {
+		t.Run(mode, func(t *testing.T) {
+			store, original := retryStoreFixture(t)
+			if mode == "codex outcome" {
+				original.Source.Provider = "codex"
+				state, err := store.loadLocked()
+				if err != nil {
+					t.Fatal(err)
+				}
+				state.Records[0].Envelope = original
+				if err := store.writeLocked(state); err != nil {
+					t.Fatal(err)
+				}
+			}
+			retryStoreOutcome(t, store, retryStoreReply(t, store, original, "failed", "payload"), coremessage.EventFail, "provider-write-zero", false)
+			source, target, accepted, deadline := original.Target, original.Source, original.AcceptedAt, original.Deadline
+			switch mode {
+			case "original expired":
+				store.now = func() time.Time { return original.Deadline }
+			case "reply expired":
+				deadline = storeTestNow.Add(-time.Second)
+			case "deadline extended":
+				deadline = original.Deadline.Add(time.Second)
+			case "source stale":
+				source.Incarnation = "old"
+			case "target stale":
+				target.ActivationGeneration = "old"
+			}
+			if _, created, err := store.PutReply(original.MessageRef, "retry", "corrected", source, target, accepted, deadline); err == nil || created {
+				t.Fatalf("%s allowed retry", mode)
+			}
+		})
+	}
+}
+
+func TestStoreExplicitReplyConcurrentAttemptsAndCapacityPreserveReceipts(t *testing.T) {
+	store, original := retryStoreFixture(t)
+	retryStoreOutcome(t, store, retryStoreReply(t, store, original, "failed", "payload"), coremessage.EventFail, "provider-write-zero", false)
+	var wg sync.WaitGroup
+	created := make(chan string, 8)
+	for i := range 8 {
+		wg.Go(func() {
+			ref := fmt.Sprintf("retry-%d", i)
+			if _, fresh, _ := store.PutReply(original.MessageRef, ref, "corrected", original.Target, original.Source,
+				original.AcceptedAt, original.Deadline); fresh {
+				created <- ref
+			}
+		})
+	}
+	wg.Wait()
+	close(created)
+	if len(created) != 1 {
+		t.Fatalf("concurrent dispatch permits=%d", len(created))
+	}
+	ref := <-created
+	reply, _, _ := store.Get(ref)
+	retryStoreOutcome(t, store, reply, coremessage.EventDeliver, "provider-pipe-full-frame", false)
+	for i := 2; i <= maxRecords; i++ {
+		_, _, _ = store.PutAccepted(storeEnvelope(i), "codex-inbox")
+	}
+	for _, ref := range []string{original.MessageRef, "failed", ref} {
+		if _, found, err := store.Get(ref); err != nil || !found {
+			t.Fatal("capacity pruned active reply correlation")
+		}
+	}
+	if _, _, err := store.PutReply(original.MessageRef, "duplicate", "corrected", original.Target, original.Source,
+		original.AcceptedAt, original.Deadline); err == nil {
+		t.Fatal("capacity reopened delivered reply")
+	}
+}

--- a/internal/integrations/agents/agentmessage/store.go
+++ b/internal/integrations/agents/agentmessage/store.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -44,6 +46,42 @@ type Record struct {
 	Delivery        coremessage.Delivery `json:"delivery"`
 	Adapter         string               `json:"adapter"`
 	HandoffObserved bool                 `json:"handoffObserved,omitempty"`
+}
+
+// ReplyConflictError preserves the prior immutable attempt when a second
+// attempt cannot be authorized. The caller can report its public delivery
+// cause without exposing payload or provider-private errors.
+type ReplyConflictError struct {
+	Previous Record
+	Reason   string
+}
+
+func (e *ReplyConflictError) Error() string { return e.Reason }
+func (e *ReplyConflictError) Unwrap() error { return coremessage.ErrRetryMismatch }
+
+// KnownZeroReply is deliberately a closed list of Claude pre-write outcomes.
+// A false unknown flag alone is not evidence that delivery did not happen.
+// Codex delivery outcomes are outside this recovery contract.
+func KnownZeroReply(record Record) bool {
+	if record.Envelope.ReplyTo == "" || record.Adapter != "claude-coordination" || record.Delivery.OutcomeUnknown {
+		return false
+	}
+	if record.Delivery.State == coremessage.StateRefused {
+		return record.Delivery.Reason == "provider-frame-unsupported" || record.Delivery.Reason == "claude-private-frame-unsupported"
+	}
+	if record.Delivery.State != coremessage.StateFailed {
+		return false
+	}
+	switch record.Delivery.Reason {
+	case "provider-frame-invalid-auth", "provider-frame-invalid-content", "provider-frame-build-failed",
+		"provider-prewrite-refused", "provider-write-zero", "broker-handoff-persist-failed":
+		return true
+	}
+	value, ok := strings.CutPrefix(record.Delivery.Reason, "provider-frame-too-large: frameBytes=")
+	sizeText, _, separated := strings.Cut(value, " ")
+	size, err := strconv.Atoi(sizeText)
+	return ok && separated && err == nil && size > 8192 &&
+		record.Delivery.Reason == fmt.Sprintf("provider-frame-too-large: frameBytes=%d limitBytes=8192", size)
 }
 
 type diskState struct {
@@ -159,11 +197,6 @@ func (s *Store) PutAccepted(envelope coremessage.Envelope, adapter string) (Reco
 	return out, created, err
 }
 
-// PutReply atomically creates the single broker reply authorized by one
-// delivered Claude coordination message. The caller must present the current
-// exact reversed routes; native reply addresses and assistant wording are not
-// correlation authority. Replays return the same immutable record, while a
-// second or mismatched reply fails closed.
 // adapterForTarget keeps the stored adapter in step with the target provider.
 // A reply used to be pinned to the Codex inbox because that was the only
 // direction explicit replies could take.
@@ -174,6 +207,33 @@ func adapterForTarget(target coremessage.Route) string {
 	return "claude-coordination"
 }
 
+// Reply returns the latest durable attempt, including a failed attempt. It is
+// diagnostic evidence only; PutReply decides retry admission under one lock.
+func (s *Store) Reply(originalRef string) (Record, bool, error) {
+	if originalRef == "" {
+		return Record{}, false, coremessage.ErrInvalidEnvelope
+	}
+	var out Record
+	var found bool
+	err := s.withLock(func() error {
+		state, err := s.loadLocked()
+		if err != nil {
+			return err
+		}
+		for _, record := range state.Records {
+			if record.Envelope.ReplyTo == originalRef {
+				out, found = record, true
+			}
+		}
+		return nil
+	})
+	return out, found, err
+}
+
+// PutReply atomically authorizes one attempt on an exact reversed route. A
+// same-ref replay only returns its immutable receipt. A fresh ref can follow
+// known-zero failures while the original correlation is still live; every
+// earlier attempt remains stored and any other outcome closes this lane.
 func (s *Store) PutReply(originalRef, messageRef, payload string, source, target coremessage.Route, acceptedAt, deadline time.Time) (Record, bool, error) {
 	var out Record
 	var created bool
@@ -191,28 +251,44 @@ func (s *Store) PutReply(originalRef, messageRef, payload string, source, target
 		if originalIndex < 0 {
 			return ErrNotFound
 		}
-		candidate := replyEnvelope(state.Records[originalIndex].Envelope, messageRef, payload, source, target, acceptedAt, deadline)
+		original := state.Records[originalIndex]
+		candidate := replyEnvelope(original.Envelope, messageRef, payload, source, target, acceptedAt, deadline)
+		var previous Record
 		for i := range state.Records {
 			record := state.Records[i]
-			if record.Envelope.ReplyTo != originalRef {
+			if record.Envelope.MessageRef != messageRef {
 				continue
 			}
 			if record.Adapter != adapterForTarget(candidate.Target) || !record.Envelope.SameRetry(candidate) {
-				return coremessage.ErrRetryMismatch
+				return &ReplyConflictError{Previous: record, Reason: "reply-ref-envelope-mismatch"}
 			}
 			out = record
 			return nil
 		}
-		original := state.Records[originalIndex]
+		for _, record := range state.Records {
+			if record.Envelope.ReplyTo != originalRef {
+				continue
+			}
+			previous = record
+			if !KnownZeroReply(record) {
+				return &ReplyConflictError{Previous: record, Reason: "reply-already-committed"}
+			}
+		}
 		if original.Delivery.State != coremessage.StateDelivered ||
 			!source.Same(original.Envelope.Target) || !target.Same(original.Envelope.Source) {
-			return coremessage.ErrInvalidEnvelope
+			return &ReplyConflictError{Previous: previous, Reason: "invalid-explicit-reply-correlation"}
 		}
-		envelope := replyEnvelope(original.Envelope, messageRef, payload, source, target, acceptedAt, deadline)
+		if !original.Envelope.Deadline.After(s.clock()) || !deadline.After(s.clock()) {
+			return &ReplyConflictError{Previous: previous, Reason: "explicit-reply-deadline-expired"}
+		}
+		envelope := candidate
+		if envelope.Deadline.After(original.Envelope.Deadline) {
+			return &ReplyConflictError{Previous: previous, Reason: "explicit-reply-deadline-extended"}
+		}
 		if err := coremessage.ValidateReply(original.Envelope, envelope); err != nil {
 			return err
 		}
-		state.Records = pruneRecords(state.Records, s.clock())
+		// Recovery never removes or resets an old attempt to make room.
 		if len(state.Records) >= maxRecords {
 			return ErrCapacity
 		}
@@ -536,10 +612,24 @@ func (s *Store) writeLocked(state diskState) error {
 }
 
 func pruneRecords(records []Record, now time.Time) []Record {
+	// A live original and its attempts form one durable idempotency boundary.
+	// Evicting a delivered/unknown reply while retaining the original would
+	// make a later fresh ref look like the first attempt after store reload.
+	protected := make(map[string]bool)
+	for _, record := range records {
+		if record.Envelope.Target.Provider == "claude" && record.Envelope.Deadline.After(now) && record.Delivery.State == coremessage.StateDelivered {
+			protected[record.Envelope.MessageRef] = true
+		}
+	}
+	for _, record := range records {
+		if protected[record.Envelope.ReplyTo] {
+			protected[record.Envelope.MessageRef] = true
+		}
+	}
 	cutoff := now.Add(-terminalRetention)
 	out := records[:0]
 	for _, record := range records {
-		if record.Delivery.State.Terminal() && !record.Delivery.TerminalAt.IsZero() && record.Delivery.TerminalAt.Before(cutoff) {
+		if !protected[record.Envelope.MessageRef] && record.Delivery.State.Terminal() && !record.Delivery.TerminalAt.IsZero() && record.Delivery.TerminalAt.Before(cutoff) {
 			continue
 		}
 		out = append(out, record)
@@ -553,7 +643,7 @@ func pruneRecords(records []Record, now time.Time) []Record {
 	for len(out) >= maxRecords {
 		index := -1
 		for i := range out {
-			if out[i].Delivery.State.Terminal() {
+			if out[i].Delivery.State.Terminal() && !protected[out[i].Envelope.MessageRef] {
 				index = i
 				break
 			}


### PR DESCRIPTION
## Summary
- Preserve explicit reply refusal causes, previous reply references, and recovery guidance in CLI stderr and durable status.
- Allow a corrected manual attempt with a fresh ref only after confirmed zero-write failure, retaining the original deadline, exact reversed routes, peer authority, and all previous receipts. Atomic creation grants one dispatch; replay, delivered, partial, unknown, pending, expired, and stale attempts cannot duplicate delivery.
- Keep the existing qualification and caller guards, protect live reply history from capacity pruning, and document the manual recovery command. Legacy helper acknowledgments without creation proof fail closed.

## Test plan
Validated source head: `2ba4db5324113d868e7aaf7a65558a8848a7952c`. Full local gates and CI completed on this exact head.
- [x] `make fmt`
- [x] `make fix` ran: exit 2 matches clean main exactly (`coordinationEligible`, `writeAgentMessageClaim`); all 335 file/symbol findings match, increase 0. The unrelated Go 1.26 fix transformation also reproduced on clean main and was excluded.
- [x] `make test`
- [x] `make test-integration`
- [x] `make test-e2e` — all 22 contract scenarios passed.
- [x] Targeted store/app regressions and built CLI known-zero → manual retry fixture passed before rebase.
- [x] Required five CI jobs and aggregate `Test` on the final head; all 20 workflow jobs passed.
- [x] After merge: isolated `make install` and the installed CLI reply recovery fixture on `95ecd01537aaf2bacdf50e29a6f5989400a9d10e` (tree identical to validated candidate). Binary SHA256: `8e5317bc65bb88c67ca6ae27cf825684578e535cd67ca70bd76c2b33cf8d52f7`. Private HOME/XDG/PID/network/socket boundaries verified; live binary/config/socket/process fingerprints unchanged.

## Globalization
- [ ] No user-facing string changes.
- [ ] User-facing strings are behind `internal/i18n` catalog keys with tests.
- [x] Non-translated strings are classified as literal/data/debug-only: stable CLI diagnostic reason tokens, reply references, and associated diagnostic recovery instructions.
