### PR TITLE
fix(agent): report Codex coordination push failures to senders

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1174,6 +1174,11 @@
   steer after a successful start, no new event or delivery change from a second
   push over a terminal record, and a delivered reason that names only the
   provider turn push, never model consumption, acknowledgement, or completion.
+- The offline Claude dialogue fixtures reply to a Codex source, so they now
+  accept a terminal Codex push failure receipt from the qualification reply --
+  the four-field `ref/state/reason/action` line for a fresh reply ref, read
+  instead of the exit code -- because no Codex app-server exists in those
+  fixtures.
 
 ### Heterogeneous Agent dialogue Phase 4 tests
 

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1152,6 +1152,28 @@
   terminal-safe output, activation fencing, and deterministic Registry-only
   idle, timeout, and stale waits. Codex `delivered` ends at target self-claim;
   it does not assert model processing or reply.
+- `TestCodexCoordinationPushClassifiesNativeOutcomesForSenders` and
+  `TestCodexCoordinationPushExpiresBeforeAnyProviderCall` own the native Codex
+  push outcome table: start success and the `turn-in-progress` steer fallback
+  deliver as `provider-turn-push`, every known zero-write refusal code fails as
+  `codex-turn-push-refused`, every ambiguous or unrecognised code fails closed
+  as `codex-turn-push-outcome-unknown`, an unconfigured seam, a failed content
+  render and an unavailable binding fail with their own causes, and a
+  pre-dispatch deadline expires as `deadline-expired` with zero binding
+  resolutions and zero control calls. The refusal code is the discriminator and
+  `stale-turn` keeps its per-operation split.
+- `TestCodexCoordinationPushFailuresExitNonzeroWithCauseAndStatusParity` pins
+  the sender contract: `agent message send` to a Codex target prints
+  `ref/state/reason/action` and then exits nonzero without a usage dump when the
+  native push did not deliver, and `agent message status` reports the same state
+  and reason. A failed terminal store write keeps the original cause token on
+  the receipt, and a delivered turn whose write failed projects
+  `broker-delivery-persist-failed` with an unknown outcome; those two cases
+  cannot reach status parity, because the store write is what failed.
+- `TestCodexCoordinationPushKeepsTerminalReceiptAndSkipsExtraSteer` pins no
+  steer after a successful start, no new event or delivery change from a second
+  push over a terminal record, and a delivered reason that names only the
+  provider turn push, never model consumption, acknowledgement, or completion.
 
 ### Heterogeneous Agent dialogue Phase 4 tests
 

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/crevissepartners/projmux/internal/aiprovider"
 	"github.com/crevissepartners/projmux/internal/config"
+	coremessage "github.com/crevissepartners/projmux/internal/core/agentmessage"
 	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
 	"github.com/crevissepartners/projmux/internal/core/selector"
 	inttmux "github.com/crevissepartners/projmux/internal/integrations/tmux"
@@ -74,10 +75,14 @@ type agentCommand struct {
 	messageNewRef  func(string) string
 	messageClaude  agentMessageClaudeAdapter
 	messageRoute   agentMessageRouteResolver
-	focus          rawArgvCommand
-	codexUpgrade   rawArgvCommand
-	codexHandover  rawArgvCommand
-	handover       codexDrainingHandoverRequester
+	// messageCodexContent is the unexported render seam for the Codex
+	// coordination turn body. It exists so the content-build failure branch of
+	// the native push is reachable in tests; it is not a public surface.
+	messageCodexContent func(coremessage.Envelope) (string, error)
+	focus               rawArgvCommand
+	codexUpgrade        rawArgvCommand
+	codexHandover       rawArgvCommand
+	handover            codexDrainingHandoverRequester
 }
 
 type codexDrainingHandoverRequester interface {

--- a/internal/app/agent_message.go
+++ b/internal/app/agent_message.go
@@ -379,11 +379,15 @@ func (c *agentCommand) runMessageSend(args []string, stdout, stderr io.Writer) e
 			// A reply is delivered the same way any other message is. Without
 			// this it only reached the store, and with the self-claim inbox gone
 			// nothing would ever hand it to the target.
+			var pushErr error
 			if created {
-				record = c.pushCoordination(record, target, targetRoute, record.Envelope)
+				record, pushErr = c.pushCoordination(record, target, targetRoute, record.Envelope)
 			}
 			if err := writeAgentMessageReceipt(stdout, receiptFor(record), false); err != nil {
 				return err
+			}
+			if pushErr != nil {
+				return fmt.Errorf("%s: %w", spelling, pushErr)
 			}
 			if record.Delivery.State.Terminal() && record.Delivery.State != coremessage.StateDelivered {
 				return fmt.Errorf("%s: explicit reply not delivered: previousRef=%s state=%s reason=%s outcomeUnknown=%t; %s",
@@ -402,10 +406,19 @@ func (c *agentCommand) runMessageSend(args []string, stdout, stderr io.Writer) e
 	if err != nil {
 		return fmt.Errorf("%s: %w", spelling, err)
 	}
+	var pushErr error
 	if created {
-		record = c.pushCoordination(record, target, targetRoute, envelope)
+		record, pushErr = c.pushCoordination(record, target, targetRoute, envelope)
 	}
-	return writeAgentMessageReceipt(stdout, receiptFor(record), false)
+	// The receipt is written before the failure is returned, so the sender sees
+	// the terminal state, reason, and action on stdout and still exits nonzero.
+	if err := writeAgentMessageReceipt(stdout, receiptFor(record), false); err != nil {
+		return err
+	}
+	if pushErr != nil {
+		return fmt.Errorf("%s: %w", spelling, pushErr)
+	}
+	return nil
 }
 
 func (c *agentCommand) replyCorrelationRefusal(originalRef, reason string) error {
@@ -440,47 +453,172 @@ func (c *agentCommand) resolveMessageTargetRoute(registry coremetadata.Registry,
 // Codex takes exact native turn control.
 func (c *agentCommand) pushCoordination(record messagestore.Record, target coremetadata.Agent,
 	targetRoute coremetadata.AgentRouteRef, envelope coremessage.Envelope,
-) messagestore.Record {
+) (messagestore.Record, error) {
 	if target.Spec.Provider == string(aiprovider.Claude) {
 		private, submitErr := c.messageClaude.Submit(context.Background(), c.messagePaths.registryPath, targetRoute, envelope)
 		updated, err := c.projectClaudeDelivery(record, private, submitErr)
 		if err != nil {
-			return record
+			return record, nil
 		}
-		return updated
+		return updated, nil
 	}
 	return c.pushCodexCoordination(record, target, envelope)
 }
 
+const (
+	// codexPushRefusedReason marks a native push that provably wrote no turn.
+	codexPushRefusedReason = "codex-turn-push-refused"
+	// codexPushUnknownReason marks a native push whose provider-side outcome
+	// cannot be known. It is the fail-closed classification.
+	codexPushUnknownReason = "codex-turn-push-outcome-unknown"
+)
+
+// codexTurnPushOutcome is one native control attempt classified into the public
+// coordination vocabulary. steer is set only for the single start refusal that
+// a steer can complete.
+type codexTurnPushOutcome struct {
+	delivered bool
+	steer     bool
+	reason    string
+	unknown   bool
+	err       error
+}
+
+// classifyCodexTurnPush reads the refusal code, never the response text, and
+// classifies per operation. A Go error from callControl is split the same way:
+// the typed binding refusal is proved pre-transport, anything else may already
+// have reached the provider.
+func classifyCodexTurnPush(operation string, response agentControlResponse, callErr error) codexTurnPushOutcome {
+	if callErr != nil {
+		var bindingErr *exactAgentControlBindingError
+		if errors.As(callErr, &bindingErr) {
+			// The consumer fence revalidation refused before transport, so the
+			// request never left and no turn was written.
+			return codexTurnPushOutcome{reason: codexPushRefusedReason, err: callErr}
+		}
+		// Transport failed after the request may already have left.
+		return codexTurnPushOutcome{reason: codexPushUnknownReason, unknown: true, err: callErr}
+	}
+	if err := response.Error(); err != nil {
+		switch operation {
+		case agentControlOpStart:
+			switch response.Code {
+			case "turn-in-progress":
+				// The only start refusal a steer can complete. Nothing was
+				// written, and the thread is busy rather than unreachable.
+				return codexTurnPushOutcome{steer: true, reason: codexPushRefusedReason, err: err}
+			case "stale-epoch", "stale-binding", "unavailable", "stale-turn", "turn-state-unavailable", "invalid-operation":
+				// turn-start emits every one of these before StartExactTurn.
+				return codexTurnPushOutcome{reason: codexPushRefusedReason, err: err}
+			}
+		case agentControlOpSteer:
+			switch response.Code {
+			case "stale-epoch", "stale-binding", "unavailable", "no-active-turn", "turn-state-unavailable", "invalid-operation":
+				return codexTurnPushOutcome{reason: codexPushRefusedReason, err: err}
+			}
+			// `stale-turn` is per-operation, not one shared meaning: turn-start
+			// emits it as a pre-write refusal, while turn-steer emits it as
+			// controlWireFailure("stale-turn", err) after SteerExactTurn was
+			// already called. Do not re-flatten the collision.
+		}
+		// turn-start-failed, steer stale-turn, timeout, protocol-error, and every
+		// unrecognised code fail closed as ambiguous.
+		return codexTurnPushOutcome{reason: codexPushUnknownReason, unknown: true, err: err}
+	}
+	return codexTurnPushOutcome{delivered: true}
+}
+
 func (c *agentCommand) pushCodexCoordination(record messagestore.Record, target coremetadata.Agent,
 	envelope coremessage.Envelope,
-) messagestore.Record {
-	// The push reuses the native control seam, which is only wired on the real
-	// command. A caller without it keeps the stored-only behaviour.
-	if c.loadRegistry == nil || (c.controlBinding == nil && c.controlRoute == nil) {
-		return record
+) (messagestore.Record, error) {
+	// Pre-dispatch expiry is decided before the seam check, the render, and the
+	// binding resolution, so an expired envelope reaches no provider call at
+	// all. The token matches the store's own deadline event so `agent message
+	// status` reports the identical reason.
+	if !c.messageClock().Before(record.Envelope.Deadline) {
+		return c.terminalCoordination(record, coremessage.EventExpire, "deadline-expired", false,
+			errors.New("coordination deadline expired before the native turn push"))
 	}
-	text, err := codexCoordinationContent(envelope)
+	// The push reuses the native control seam, which is only wired on the real
+	// command. Without it nothing can be pushed, and the sender is told so.
+	if c.loadRegistry == nil || (c.controlBinding == nil && c.controlRoute == nil) {
+		return c.terminalCoordination(record, coremessage.EventFail, "codex-native-control-unconfigured", false,
+			errors.New("exact Agent native control is not configured"))
+	}
+	text, err := c.codexCoordinationText(envelope)
 	if err != nil {
-		return record
+		return c.terminalCoordination(record, coremessage.EventFail, "codex-turn-content-build-failed", false,
+			fmt.Errorf("build coordination turn content: %w", err))
 	}
 	binding, bindErr := c.resolveControlBinding("agent turn start", selector.UIDPrefix+target.Metadata.UID)
 	if bindErr != nil {
-		return record
+		return c.terminalCoordination(record, coremessage.EventFail, "codex-native-binding-unavailable", false, bindErr)
 	}
 	response, callErr := c.callControl(binding, agentControlRequest{Operation: agentControlOpStart, Text: text})
-	if callErr != nil || response.Error() != nil {
+	outcome := classifyCodexTurnPush(agentControlOpStart, response, callErr)
+	if outcome.steer {
+		// The one fallback in this path. There is no steer after a successful
+		// start and no automatic resend anywhere.
 		response, callErr = c.callControl(binding, agentControlRequest{Operation: agentControlOpSteer, Text: text})
+		outcome = classifyCodexTurnPush(agentControlOpSteer, response, callErr)
 	}
-	if callErr != nil || response.Error() != nil {
-		return record
+	if !outcome.delivered {
+		return c.terminalCoordination(record, coremessage.EventFail, outcome.reason, outcome.unknown, outcome.err)
 	}
 	updated, _, applyErr := c.messageStore.Apply(record.Envelope.MessageRef,
 		c.publicMessageEvent(record, coremessage.EventDeliver, "provider-turn-push", false))
 	if applyErr != nil {
-		return record
+		// The turn was pushed but the record could not be persisted. Resend
+		// stays discouraged, so the projection is the ambiguous persist token
+		// rather than the delivered receipt the store never accepted.
+		return c.projectTerminalDelivery(record, coremessage.StateFailed, "broker-delivery-persist-failed", true),
+			fmt.Errorf("persist delivered coordination turn: %w", applyErr)
 	}
-	return updated
+	return updated, nil
+}
+
+// terminalCoordination persists one terminal coordination outcome and always
+// returns a record the sender can act on. When the store write fails the
+// ORIGINAL cause token is kept as the receipt reason; the persistence failure
+// only widens the returned Go error.
+func (c *agentCommand) terminalCoordination(record messagestore.Record, kind coremessage.EventKind,
+	reason string, unknown bool, cause error,
+) (messagestore.Record, error) {
+	updated, _, applyErr := c.messageStore.Apply(record.Envelope.MessageRef,
+		c.publicMessageEvent(record, kind, reason, unknown))
+	if applyErr != nil {
+		state := coremessage.StateFailed
+		if kind == coremessage.EventExpire {
+			state = coremessage.StateExpired
+		}
+		return c.projectTerminalDelivery(record, state, reason, unknown),
+			fmt.Errorf("%w; persist coordination outcome: %w", cause, applyErr)
+	}
+	return updated, cause
+}
+
+// projectTerminalDelivery is the in-memory terminal view used when the store
+// could not record the outcome. The sender still sees the cause on its receipt;
+// `agent message status` may not match, because the store write is exactly what
+// failed.
+func (c *agentCommand) projectTerminalDelivery(record messagestore.Record, state coremessage.State,
+	reason string, unknown bool,
+) messagestore.Record {
+	projected := record
+	projected.Delivery.State = state
+	projected.Delivery.Reason = reason
+	projected.Delivery.OutcomeUnknown = unknown
+	projected.Delivery.TerminalAt = c.messageClock()
+	return projected
+}
+
+// codexCoordinationText renders the coordination turn body through the
+// unexported seam when one is wired, and otherwise through the real renderer.
+func (c *agentCommand) codexCoordinationText(envelope coremessage.Envelope) (string, error) {
+	if c == nil || c.messageCodexContent == nil {
+		return codexCoordinationContent(envelope)
+	}
+	return c.messageCodexContent(envelope)
 }
 
 func codexCoordinationContent(envelope coremessage.Envelope) (string, error) {
@@ -808,8 +946,13 @@ func agentMessageFailureAction(delivery coremessage.Delivery) string {
 	switch delivery.Reason {
 	case "provider-frame-invalid-auth":
 		return "check provider auth configuration before retrying"
-	case "provider-frame-invalid-content", "provider-frame-build-failed", "provider-frame-unsupported", "claude-private-frame-unsupported":
+	case "provider-frame-invalid-content", "provider-frame-build-failed", "provider-frame-unsupported",
+		"claude-private-frame-unsupported", "codex-turn-content-build-failed":
 		return "correct message content or configuration before retrying"
+	case "codex-native-control-unconfigured", "codex-native-binding-unavailable":
+		return "check exact Agent native control availability before retrying"
+	case codexPushRefusedReason:
+		return "no turn was written; retry manually once the target thread state allows it"
 	case "provider-prewrite-refused":
 		return "check current provider route before retrying"
 	case "provider-write-zero":

--- a/internal/app/agent_message_codex_push_test.go
+++ b/internal/app/agent_message_codex_push_test.go
@@ -1,0 +1,465 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	coremessage "github.com/crevissepartners/projmux/internal/core/agentmessage"
+	coremetadata "github.com/crevissepartners/projmux/internal/core/metadata"
+	messagestore "github.com/crevissepartners/projmux/internal/integrations/agents/agentmessage"
+)
+
+// countingControlBindingLookup makes binding resolutions countable, so a test
+// can prove a push stopped before the Registry/live-activation read rather than
+// inferring it from the absence of a transport call.
+type countingControlBindingLookup struct {
+	inner agentControlBindingLookup
+	err   error
+	calls int
+}
+
+func (l *countingControlBindingLookup) Live(ctx context.Context, paneUID string) (agentControlLive, bool, error) {
+	l.calls++
+	if l.err != nil {
+		return agentControlLive{}, false, l.err
+	}
+	return l.inner.Live(ctx, paneUID)
+}
+
+// applyFailingMessageStore fails only the terminal write. Every other operation
+// stays on the real store, so the sender-visible receipt can be compared with
+// what the store actually holds.
+type applyFailingMessageStore struct {
+	agentMessageStore
+	err error
+}
+
+func (s applyFailingMessageStore) Apply(string, coremessage.Event) (messagestore.Record, bool, error) {
+	return messagestore.Record{}, false, s.err
+}
+
+type codexPushFixture struct {
+	cmd      *agentCommand
+	store    *messagestore.Store
+	registry coremetadata.Registry
+	binding  *countingControlBindingLookup
+	route    coremessage.Route
+	target   coremetadata.Agent
+	clock    time.Time
+	calls    map[string]int
+}
+
+// newCodexPushFixture reuses the control-seam fixture style: a static live
+// binding, a scripted control transport, and the same Registry the exact
+// control CLI tests drive.
+func newCodexPushFixture(t *testing.T) *codexPushFixture {
+	t.Helper()
+	cmd, registryStore, live := exactControlCLICommand(t)
+	registry := registryStore.registry.Clone()
+	target, ok := registry.Agent("agt-alpha-codex")
+	if !ok {
+		t.Fatal("codex target fixture is missing")
+	}
+	fixture := &codexPushFixture{
+		cmd: cmd, store: messagestore.NewStore(t.TempDir()), registry: registry,
+		binding: &countingControlBindingLookup{inner: live}, target: target.Clone(),
+		// The store prunes terminal records against its own real clock, so the
+		// fixture clock stays close to real time.
+		clock: time.Now().UTC(), calls: map[string]int{},
+	}
+	fixture.route = publicMessageRoute(mustMessageRoute(t, registry, "agt-alpha-codex"))
+	cmd.activeTarget = insideTmux("pan-alpha-codex", "win-alpha-main").lookup
+	cmd.messagePaths = agentMessagePaths{loadRegistry: func() (coremetadata.Registry, error) { return registry.Clone(), nil }}
+	cmd.messageStore = fixture.store
+	cmd.messageRoute = &traceMessageRouteResolver{route: mustMessageRoute(t, registry, "agt-alpha-codex")}
+	cmd.messageNow = func() time.Time { return fixture.clock }
+	cmd.controlBinding = fixture.binding
+	cmd.loadRegistry = func() (coremetadata.Registry, error) { return registry.Clone(), nil }
+	fixture.script(nil, nil)
+	return fixture
+}
+
+// script answers each control operation with one scripted response or error and
+// counts the calls per operation.
+func (f *codexPushFixture) script(responses map[string]agentControlResponse, errs map[string]error) {
+	f.cmd.controlCall = func(_ context.Context, _ string, _ coremetadata.CodexEndpointRef, _ codexLifecycleIdentity,
+		request agentControlRequest,
+	) (agentControlResponse, error) {
+		f.calls[request.Operation]++
+		if err, ok := errs[request.Operation]; ok && err != nil {
+			return agentControlResponse{}, err
+		}
+		if response, ok := responses[request.Operation]; ok {
+			return response, nil
+		}
+		return agentControlResponse{OK: true, ThreadID: "thread-1", TurnID: "turn-1"}, nil
+	}
+}
+
+func (f *codexPushFixture) accept(t *testing.T, ref string) messagestore.Record {
+	t.Helper()
+	envelope := coremessage.Envelope{Version: coremessage.Version, MessageRef: ref,
+		ConversationRef: conversationRefFor(ref), Source: f.route, Target: f.route,
+		Authority: coremessage.PeerAuthority(), Payload: "peer coordination payload",
+		AcceptedAt: f.clock, Deadline: f.clock.Add(10 * time.Minute)}
+	record, created, err := f.store.PutAccepted(envelope, "codex-inbox")
+	if err != nil || !created {
+		t.Fatalf("accept %s: created=%t err=%v", ref, created, err)
+	}
+	return record
+}
+
+// staleFenceRegistry answers the first Registry read with the binding the push
+// resolves and every later read with a changed authority, so the consumer fence
+// revalidation inside callControl refuses before transport.
+func (f *codexPushFixture) staleFenceRegistry(t *testing.T) {
+	t.Helper()
+	stale := f.registry.Clone()
+	pane, ok := stale.Pane("pan-alpha-codex")
+	if !ok || pane.Status.Activation.Codex == nil || pane.Status.Activation.Codex.Authority == nil {
+		t.Fatal("codex authority fixture is missing")
+	}
+	authority := *pane.Status.Activation.Codex.Authority
+	authority.BindingEpoch++
+	pane.Status.Activation.Codex.Authority = &authority
+	reads := 0
+	f.cmd.loadRegistry = func() (coremetadata.Registry, error) {
+		reads++
+		if reads == 1 {
+			return f.registry.Clone(), nil
+		}
+		return stale.Clone(), nil
+	}
+}
+
+func refusal(code string) agentControlResponse { return refusedControl(code, "fixture refusal") }
+
+func TestCodexCoordinationPushClassifiesNativeOutcomesForSenders(t *testing.T) {
+	type pushCase struct {
+		name         string
+		prepare      func(t *testing.T, f *codexPushFixture)
+		responses    map[string]agentControlResponse
+		errs         map[string]error
+		wantState    coremessage.State
+		wantReason   string
+		wantUnknown  bool
+		wantStarts   int
+		wantSteers   int
+		wantBindings int
+	}
+	cases := []pushCase{
+		{
+			name:      "start succeeds",
+			wantState: coremessage.StateDelivered, wantReason: "provider-turn-push",
+			wantStarts: 1, wantBindings: 1,
+		},
+		{
+			name:      "turn-in-progress falls through to a steer that succeeds",
+			responses: map[string]agentControlResponse{agentControlOpStart: refusal("turn-in-progress")},
+			wantState: coremessage.StateDelivered, wantReason: "provider-turn-push",
+			wantStarts: 1, wantSteers: 1, wantBindings: 1,
+		},
+		{
+			name: "render failure never reaches the binding",
+			prepare: func(_ *testing.T, f *codexPushFixture) {
+				f.cmd.messageCodexContent = func(coremessage.Envelope) (string, error) {
+					return "", errors.New("fixture render failure")
+				}
+			},
+			wantState: coremessage.StateFailed, wantReason: "codex-turn-content-build-failed",
+		},
+		{
+			name:      "missing native control seam",
+			prepare:   func(_ *testing.T, f *codexPushFixture) { f.cmd.loadRegistry = nil },
+			wantState: coremessage.StateFailed, wantReason: "codex-native-control-unconfigured",
+		},
+		{
+			name: "binding resolution failure",
+			prepare: func(_ *testing.T, f *codexPushFixture) {
+				f.binding.err = errors.New("fixture live binding failure")
+			},
+			wantState: coremessage.StateFailed, wantReason: "codex-native-binding-unavailable",
+			wantBindings: 1,
+		},
+		{
+			name:      "consumer fence refuses before transport",
+			prepare:   func(t *testing.T, f *codexPushFixture) { f.staleFenceRegistry(t) },
+			wantState: coremessage.StateFailed, wantReason: codexPushRefusedReason,
+			wantBindings: 1,
+		},
+		{
+			name:      "transport failure is ambiguous",
+			errs:      map[string]error{agentControlOpStart: errors.New("fixture transport failure")},
+			wantState: coremessage.StateFailed, wantReason: codexPushUnknownReason, wantUnknown: true,
+			wantStarts: 1, wantBindings: 1,
+		},
+	}
+	for _, code := range []string{"stale-epoch", "stale-binding", "unavailable", "stale-turn", "turn-state-unavailable", "invalid-operation"} {
+		cases = append(cases, pushCase{
+			name:      "start known-zero " + code,
+			responses: map[string]agentControlResponse{agentControlOpStart: refusal(code)},
+			wantState: coremessage.StateFailed, wantReason: codexPushRefusedReason,
+			wantStarts: 1, wantBindings: 1,
+		})
+	}
+	for _, code := range []string{"turn-start-failed", "timeout", "protocol-error", "fixture-unrecognised-code"} {
+		cases = append(cases, pushCase{
+			name:      "start ambiguous " + code,
+			responses: map[string]agentControlResponse{agentControlOpStart: refusal(code)},
+			wantState: coremessage.StateFailed, wantReason: codexPushUnknownReason, wantUnknown: true,
+			wantStarts: 1, wantBindings: 1,
+		})
+	}
+	for _, code := range []string{"stale-epoch", "stale-binding", "unavailable", "no-active-turn", "turn-state-unavailable", "invalid-operation"} {
+		cases = append(cases, pushCase{
+			name: "steer known-zero " + code,
+			responses: map[string]agentControlResponse{
+				agentControlOpStart: refusal("turn-in-progress"), agentControlOpSteer: refusal(code),
+			},
+			wantState: coremessage.StateFailed, wantReason: codexPushRefusedReason,
+			wantStarts: 1, wantSteers: 1, wantBindings: 1,
+		})
+	}
+	// `stale-turn` is ambiguous for turn-steer and known-zero for turn-start:
+	// the steer spelling is controlWireFailure after the provider write left.
+	for _, code := range []string{"stale-turn", "timeout", "protocol-error", "fixture-unrecognised-code"} {
+		cases = append(cases, pushCase{
+			name: "steer ambiguous " + code,
+			responses: map[string]agentControlResponse{
+				agentControlOpStart: refusal("turn-in-progress"), agentControlOpSteer: refusal(code),
+			},
+			wantState: coremessage.StateFailed, wantReason: codexPushUnknownReason, wantUnknown: true,
+			wantStarts: 1, wantSteers: 1, wantBindings: 1,
+		})
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newCodexPushFixture(t)
+			fixture.script(test.responses, test.errs)
+			if test.prepare != nil {
+				test.prepare(t, fixture)
+			}
+			record := fixture.accept(t, "message-classify")
+			updated, err := fixture.cmd.pushCodexCoordination(record, fixture.target, record.Envelope)
+			if (err != nil) != (test.wantState != coremessage.StateDelivered) {
+				t.Fatalf("push error = %v, want failure = %t", err, test.wantState != coremessage.StateDelivered)
+			}
+			if updated.Delivery.State != test.wantState || updated.Delivery.Reason != test.wantReason ||
+				updated.Delivery.OutcomeUnknown != test.wantUnknown {
+				t.Fatalf("delivery = %+v, want %s/%s/unknown=%t", updated.Delivery, test.wantState, test.wantReason, test.wantUnknown)
+			}
+			if fixture.calls[agentControlOpStart] != test.wantStarts || fixture.calls[agentControlOpSteer] != test.wantSteers ||
+				fixture.binding.calls != test.wantBindings {
+				t.Fatalf("start=%d steer=%d bindings=%d, want %d/%d/%d", fixture.calls[agentControlOpStart],
+					fixture.calls[agentControlOpSteer], fixture.binding.calls, test.wantStarts, test.wantSteers, test.wantBindings)
+			}
+			stored, found, getErr := fixture.store.Get("message-classify")
+			if getErr != nil || !found || stored.Delivery != updated.Delivery {
+				t.Fatalf("stored delivery = %+v found=%t err=%v, want the receipt's %+v", stored.Delivery, found, getErr, updated.Delivery)
+			}
+		})
+	}
+}
+
+func TestCodexCoordinationPushExpiresBeforeAnyProviderCall(t *testing.T) {
+	fixture := newCodexPushFixture(t)
+	record := fixture.accept(t, "message-expired")
+	// The fake clock reaches the envelope deadline before the push runs.
+	fixture.clock = record.Envelope.Deadline
+	updated, err := fixture.cmd.pushCodexCoordination(record, fixture.target, record.Envelope)
+	if err == nil {
+		t.Fatal("expired push error = nil, want the sender-visible cause")
+	}
+	if updated.Delivery.State != coremessage.StateExpired || updated.Delivery.Reason != "deadline-expired" ||
+		updated.Delivery.OutcomeUnknown {
+		t.Fatalf("delivery = %+v, want expired/deadline-expired", updated.Delivery)
+	}
+	if len(fixture.calls) != 0 || fixture.binding.calls != 0 {
+		t.Fatalf("expired push touched the provider: calls=%v bindings=%d", fixture.calls, fixture.binding.calls)
+	}
+	// `deadline-expired` is deliberately the token the store's own deadline
+	// event uses, so status reports exactly what the sender already saw.
+	stdout, _, statusErr := runRoute(t, fixture.cmd, "message", "status", "message-expired")
+	if statusErr != nil {
+		t.Fatal(statusErr)
+	}
+	state, reason := receiptStateAndReason(t, stdout)
+	if state != string(updated.Delivery.State) || reason != updated.Delivery.Reason {
+		t.Fatalf("status = %s/%s, want the receipt's %s/%s", state, reason, updated.Delivery.State, updated.Delivery.Reason)
+	}
+}
+
+func TestCodexCoordinationPushFailuresExitNonzeroWithCauseAndStatusParity(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		prepare    func(t *testing.T, f *codexPushFixture)
+		wantState  string
+		wantReason string
+		wantAction string
+	}{
+		{
+			name:      "native control unconfigured",
+			prepare:   func(_ *testing.T, f *codexPushFixture) { f.cmd.loadRegistry = nil },
+			wantState: "failed", wantReason: "codex-native-control-unconfigured",
+			wantAction: "check exact Agent native control availability before retrying",
+		},
+		{
+			name: "native binding unavailable",
+			prepare: func(_ *testing.T, f *codexPushFixture) {
+				f.binding.err = errors.New("fixture live binding failure")
+			},
+			wantState: "failed", wantReason: "codex-native-binding-unavailable",
+			wantAction: "check exact Agent native control availability before retrying",
+		},
+		{
+			name: "content build failed",
+			prepare: func(_ *testing.T, f *codexPushFixture) {
+				f.cmd.messageCodexContent = func(coremessage.Envelope) (string, error) {
+					return "", errors.New("fixture render failure")
+				}
+			},
+			wantState: "failed", wantReason: "codex-turn-content-build-failed",
+			wantAction: "correct message content or configuration before retrying",
+		},
+		{
+			name: "known zero-write refusal",
+			prepare: func(_ *testing.T, f *codexPushFixture) {
+				f.script(map[string]agentControlResponse{agentControlOpStart: refusal("stale-epoch")}, nil)
+			},
+			wantState: "failed", wantReason: codexPushRefusedReason,
+			wantAction: "no turn was written; retry manually once the target thread state allows it",
+		},
+		{
+			name: "ambiguous outcome",
+			prepare: func(_ *testing.T, f *codexPushFixture) {
+				f.script(map[string]agentControlResponse{agentControlOpStart: refusal("timeout")}, nil)
+			},
+			wantState: "failed", wantReason: codexPushUnknownReason,
+			wantAction: "inspect provider outcome; do not resend while unknown; automatic resend disabled",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newCodexPushFixture(t)
+			test.prepare(t, fixture)
+			stdout, _, err := runRoute(t, fixture.cmd, "message", "send", "uid:agt-alpha-codex",
+				"--message-ref", "message-send-failure", "--", "peer coordination payload")
+			if err == nil {
+				t.Fatal("send error = nil, want a nonzero exit for an undelivered push")
+			}
+			if IsUsageError(err) {
+				t.Fatalf("send error = %v, want a runtime failure rather than a usage dump", err)
+			}
+			fields := receiptFields(t, stdout)
+			if fields[0] != "message-send-failure" || fields[1] != test.wantState ||
+				fields[2] != test.wantReason || fields[3] != test.wantAction {
+				t.Fatalf("receipt = %q, want ref/%s/%s/%s", stdout, test.wantState, test.wantReason, test.wantAction)
+			}
+			statusOut, _, statusErr := runRoute(t, fixture.cmd, "message", "status", "message-send-failure")
+			if statusErr != nil {
+				t.Fatal(statusErr)
+			}
+			state, reason := receiptStateAndReason(t, statusOut)
+			if state != test.wantState || reason != test.wantReason {
+				t.Fatalf("status = %s/%s, want the send receipt's %s/%s", state, reason, test.wantState, test.wantReason)
+			}
+		})
+	}
+
+	// Both persistence branches keep the sender informed even though the store
+	// write is exactly what failed, so `agent message status` cannot match the
+	// send receipt for either of them. That limit is the reason the failure
+	// cause is never overwritten by the persistence error.
+	t.Run("failure event whose persistence fails keeps the original cause", func(t *testing.T) {
+		fixture := newCodexPushFixture(t)
+		fixture.script(map[string]agentControlResponse{agentControlOpStart: refusal("stale-epoch")}, nil)
+		fixture.cmd.messageStore = applyFailingMessageStore{agentMessageStore: fixture.store, err: errors.New("fixture persist failure")}
+		stdout, _, err := runRoute(t, fixture.cmd, "message", "send", "uid:agt-alpha-codex",
+			"--message-ref", "message-persist-failure", "--", "peer coordination payload")
+		if err == nil || IsUsageError(err) {
+			t.Fatalf("send error = %v, want a nonzero non-usage exit", err)
+		}
+		if !strings.Contains(err.Error(), "persist coordination outcome") {
+			t.Fatalf("send error = %v, want the persistence failure named in the Go error", err)
+		}
+		fields := receiptFields(t, stdout)
+		if fields[1] != "failed" || fields[2] != codexPushRefusedReason {
+			t.Fatalf("receipt = %q, want the original cause token", stdout)
+		}
+		stored, found, getErr := fixture.store.Get("message-persist-failure")
+		if getErr != nil || !found || stored.Delivery.State != coremessage.StateAccepted {
+			t.Fatalf("stored = %+v found=%t err=%v, want the unpersisted accepted record", stored.Delivery, found, getErr)
+		}
+	})
+
+	t.Run("delivered turn whose persistence fails discourages resend", func(t *testing.T) {
+		fixture := newCodexPushFixture(t)
+		fixture.cmd.messageStore = applyFailingMessageStore{agentMessageStore: fixture.store, err: errors.New("fixture persist failure")}
+		stdout, _, err := runRoute(t, fixture.cmd, "message", "send", "uid:agt-alpha-codex",
+			"--message-ref", "message-delivered-persist", "--", "peer coordination payload")
+		if err == nil || IsUsageError(err) {
+			t.Fatalf("send error = %v, want a nonzero non-usage exit", err)
+		}
+		fields := receiptFields(t, stdout)
+		if fields[1] != "failed" || fields[2] != "broker-delivery-persist-failed" ||
+			fields[3] != "inspect provider outcome; do not resend while unknown; automatic resend disabled" {
+			t.Fatalf("receipt = %q, want the ambiguous persist projection", stdout)
+		}
+		if fixture.calls[agentControlOpStart] != 1 || fixture.calls[agentControlOpSteer] != 0 {
+			t.Fatalf("calls = %v, want exactly one start", fixture.calls)
+		}
+	})
+}
+
+func TestCodexCoordinationPushKeepsTerminalReceiptAndSkipsExtraSteer(t *testing.T) {
+	fixture := newCodexPushFixture(t)
+	record := fixture.accept(t, "message-terminal")
+	delivered, err := fixture.cmd.pushCodexCoordination(record, fixture.target, record.Envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fixture.calls[agentControlOpStart] != 1 || fixture.calls[agentControlOpSteer] != 0 {
+		t.Fatalf("calls = %v, want one start and no steer after a successful start", fixture.calls)
+	}
+	if delivered.Delivery.State != coremessage.StateDelivered || delivered.Delivery.Reason != "provider-turn-push" ||
+		delivered.Delivery.OutcomeUnknown {
+		t.Fatalf("delivery = %+v, want delivered/provider-turn-push", delivered.Delivery)
+	}
+	// The delivered reason names the push and nothing beyond it: a pushed turn
+	// is not evidence of model consumption, acknowledgement, or completion.
+	for _, forbidden := range []string{"consum", "acknowledg", "complete", "processed", "read", "answer"} {
+		if strings.Contains(delivered.Delivery.Reason, forbidden) {
+			t.Fatalf("delivered reason %q claims more than the push", delivered.Delivery.Reason)
+		}
+	}
+	// Reduce is terminal-once, so a second push over the terminal record adds no
+	// event and leaves the stored delivery byte-identical.
+	again, err := fixture.cmd.pushCodexCoordination(delivered, fixture.target, delivered.Envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Delivery != delivered.Delivery {
+		t.Fatalf("second push changed the terminal delivery: %+v, want %+v", again.Delivery, delivered.Delivery)
+	}
+	stored, found, getErr := fixture.store.Get("message-terminal")
+	if getErr != nil || !found || stored.Delivery != delivered.Delivery {
+		t.Fatalf("stored delivery = %+v found=%t err=%v, want %+v", stored.Delivery, found, getErr, delivered.Delivery)
+	}
+}
+
+func receiptFields(t *testing.T, stdout string) []string {
+	t.Helper()
+	fields := strings.Split(strings.TrimSuffix(stdout, "\n"), "\t")
+	if len(fields) != 4 {
+		t.Fatalf("receipt = %q, want ref\\tstate\\treason\\taction on one line", stdout)
+	}
+	return fields
+}
+
+func receiptStateAndReason(t *testing.T, stdout string) (string, string) {
+	t.Helper()
+	fields := receiptFields(t, stdout)
+	return fields[1], fields[2]
+}

--- a/internal/app/agent_message_source_test.go
+++ b/internal/app/agent_message_source_test.go
@@ -107,7 +107,11 @@ func TestAgentMessageSendSourceAnchorAndOmittedFallbackPreserveRouteAndPeerAutho
 			}
 			args = append(args, "--", "peer request")
 			_, _, err := runRoute(t, cmd, args...)
-			if (err != nil) != test.wantError {
+			// This fixture wires no native control seam, so an accepted Codex
+			// envelope now terminates as codex-native-control-unconfigured
+			// instead of silently reporting accepted. Source anchoring is what
+			// this test proves; the push classification has its own tests.
+			if err == nil || (!test.wantError && !strings.Contains(err.Error(), "exact Agent native control is not configured")) {
 				t.Fatalf("send error = %v, wantError = %t", err, test.wantError)
 			}
 			record, found, err := store.Get("message-source-anchor")

--- a/internal/app/agent_message_test.go
+++ b/internal/app/agent_message_test.go
@@ -185,6 +185,13 @@ func TestAgentMessageUnsupportedProviderStopsBeforeRouteAndStore(t *testing.T) {
 	}
 }
 
+// messageFixtureNow is deliberately close to real time. The store prunes
+// terminal records whose TerminalAt is older than its own retention window
+// against its own real clock, and a Codex coordination send now reaches a
+// terminal state, so a stale fixture clock would evict the record the next
+// store write is about to correlate against.
+func messageFixtureNow() time.Time { return time.Now().UTC() }
+
 func TestAgentMessageSendSameReferenceRetryKeepsBrokerCorrelationAndDoesNotResend(t *testing.T) {
 	cmd, store, _ := exactControlCLICommand(t)
 	active := insideTmux("pan-alpha-codex", "win-alpha-main")
@@ -194,10 +201,15 @@ func TestAgentMessageSendSameReferenceRetryKeepsBrokerCorrelationAndDoesNotResen
 	cmd.messagePaths = agentMessagePaths{loadRegistry: func() (coremetadata.Registry, error) { return store.registry.Clone(), nil }}
 	cmd.messageStore = private
 	cmd.messageRoute = &traceMessageRouteResolver{trace: &trace, route: mustMessageRoute(t, store.registry, "agt-alpha-codex")}
-	cmd.messageNow = func() time.Time { return resourceFixtureClock.Add(time.Hour) }
+	cmd.messageNow = messageFixtureNow
 	cmd.messageNewRef = func(prefix string) string {
 		t.Fatalf("explicit message ref must not mint %s", prefix)
 		return "unused"
+	}
+	// The native push is part of the first send now that its outcome is
+	// reported, so the seam is wired to accept exactly one turn.
+	cmd.controlCall = func(context.Context, string, coremetadata.CodexEndpointRef, codexLifecycleIdentity, agentControlRequest) (agentControlResponse, error) {
+		return agentControlResponse{OK: true, ThreadID: "thread-1", TurnID: "turn-1"}, nil
 	}
 	args := []string{"message", "send", "uid:agt-alpha-codex", "--message-ref", "message-retry", "--ttl", "1m", "--", "same payload"}
 	first, _, err := runRoute(t, cmd, args...)
@@ -217,7 +229,7 @@ func TestAgentMessageSendSameReferenceRetryKeepsBrokerCorrelationAndDoesNotResen
 }
 
 func TestAgentMessageConcurrentSameReferenceUsesOneConversation(t *testing.T) {
-	_, registryStore, _ := exactControlCLICommand(t)
+	base, registryStore, binding := exactControlCLICommand(t)
 	registry := registryStore.registry.Clone()
 	route := mustMessageRoute(t, registry, "agt-alpha-codex")
 	private := messagestore.NewStore(t.TempDir())
@@ -226,10 +238,19 @@ func TestAgentMessageConcurrentSameReferenceUsesOneConversation(t *testing.T) {
 			activeTarget: func() (activeTargetObserver, bool) {
 				return activeTargetObserver{paneID: "%7", paneUID: func() string { return "pan-alpha-codex" }}, true
 			},
+			// Only the one creating send pushes, so the native seam is wired to
+			// keep the losers on the stored record rather than a push failure.
+			loadRegistry:   base.loadRegistry,
+			store:          base.store,
+			controlBinding: binding,
+			controlPaths:   base.controlPaths,
+			controlCall: func(context.Context, string, coremetadata.CodexEndpointRef, codexLifecycleIdentity, agentControlRequest) (agentControlResponse, error) {
+				return agentControlResponse{OK: true, ThreadID: "thread-1", TurnID: "turn-1"}, nil
+			},
 			messagePaths: agentMessagePaths{loadRegistry: func() (coremetadata.Registry, error) { return registry.Clone(), nil }},
 			messageStore: private,
 			messageRoute: &traceMessageRouteResolver{route: route},
-			messageNow:   func() time.Time { return resourceFixtureClock.Add(time.Hour) },
+			messageNow:   messageFixtureNow,
 			messageNewRef: func(prefix string) string {
 				t.Fatalf("explicit message ref must not mint %s", prefix)
 				return ""
@@ -239,9 +260,12 @@ func TestAgentMessageConcurrentSameReferenceUsesOneConversation(t *testing.T) {
 	const workers = 16
 	errs := make(chan error, workers)
 	outputs := make(chan string, workers)
+	commands := make([]*agentCommand, 0, workers)
 	for range workers {
+		commands = append(commands, newCommand())
+	}
+	for _, cmd := range commands {
 		go func() {
-			cmd := newCommand()
 			stdout, _, err := runRoute(t, cmd, "message", "send", "uid:agt-alpha-codex", "--message-ref", "message-race", "--ttl", "1m", "--", "same")
 			errs <- err
 			outputs <- stdout
@@ -251,12 +275,15 @@ func TestAgentMessageConcurrentSameReferenceUsesOneConversation(t *testing.T) {
 		if err := <-errs; err != nil {
 			t.Fatal(err)
 		}
-		if output := <-outputs; output != "message-race\taccepted\n" {
+		// The creator reports the pushed turn; every other worker reports the
+		// stored record it found. Neither is a second dispatch.
+		if output := <-outputs; output != "message-race\taccepted\n" && output != "message-race\tdelivered\n" {
 			t.Fatalf("output = %q", output)
 		}
 	}
 	record, found, err := private.Get("message-race")
-	if err != nil || !found || record.Envelope.ConversationRef != conversationRefFor("message-race") {
+	if err != nil || !found || record.Envelope.ConversationRef != conversationRefFor("message-race") ||
+		record.Delivery.State != coremessage.StateDelivered {
 		t.Fatalf("record=%#v found=%t err=%v", record, found, err)
 	}
 }
@@ -293,19 +320,25 @@ func TestAgentMessageReplyReturnsOnlyToOriginalSourceConversation(t *testing.T) 
 		messagePaths: agentMessagePaths{loadRegistry: func() (coremetadata.Registry, error) { return registry.Clone(), nil }},
 		messageStore: private,
 		messageRoute: liveAgentMessageRouteResolver{},
-		messageNow:   func() time.Time { return resourceFixtureClock.Add(time.Hour) },
+		messageNow:   messageFixtureNow,
 		messageNewRef: func(prefix string) string {
 			t.Fatalf("explicit references must not mint %s", prefix)
 			return ""
 		},
 	}
+	// This fixture wires no native control seam, so both accepted envelopes
+	// terminate as codex-native-control-unconfigured. Correlation is what this
+	// test proves, and it is decided before the push.
+	unconfigured := func(err error) bool {
+		return err != nil && strings.Contains(err.Error(), "exact Agent native control is not configured")
+	}
 	if _, _, err := runRoute(t, cmd, "message", "send", "uid:"+targetAgent.Metadata.UID,
-		"--message-ref", "message-original", "--", "request"); err != nil {
+		"--message-ref", "message-original", "--", "request"); !unconfigured(err) {
 		t.Fatal(err)
 	}
 	activePane = targetPane.Metadata.UID
 	if _, _, err := runRoute(t, cmd, "message", "send", "uid:"+sourceAgent.Metadata.UID,
-		"--message-ref", "message-reply", "--reply-to", "message-original", "--", "response"); err != nil {
+		"--message-ref", "message-reply", "--reply-to", "message-original", "--", "response"); !unconfigured(err) {
 		t.Fatal(err)
 	}
 	original, _, _ := private.Get("message-original")

--- a/internal/app/claude_endpoint_process_test.go
+++ b/internal/app/claude_endpoint_process_test.go
@@ -33,7 +33,7 @@ import (
 // reply/control frame. Its private capture socket is test memory, not a product
 // receipt, log, or artifact.
 const claudeEndpointSyntheticProvider = `
-import json, os, secrets, shlex, socket, subprocess, sys
+import json, os, re, secrets, shlex, socket, subprocess, sys
 path = os.path.join(os.environ['PMX_TEST_ROOT'], 'provider-' + secrets.token_hex(8) + '.sock')
 os.umask(0o077)
 inbox = socket.socket(socket.AF_UNIX)
@@ -82,7 +82,25 @@ def receive(kind, session):
         decision = json.loads(prepare.stdout)['hookSpecificOutput']
         assert decision['permissionDecision'] == 'allow'
         result = subprocess.run([argv[0], 'internal', 'claude-reply-tool', 'execute', "fixture opaque carrier '"+decision['updatedInput']['command']+"'"], env=child_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        assert result.returncode == 0 and result.stdout and not result.stderr
+        # The reply's source is a Codex Agent, and a Codex coordination reply
+        # now reports its native turn push outcome. This offline fixture has no
+        # Codex app-server, so the push cannot land and the command exits
+        # nonzero after printing the terminal receipt. Read the receipt, not the
+        # exit code: a nonzero exit is accepted only when stdout is exactly one
+        # four-field receipt line for a freshly minted reply ref whose reason is
+        # a Codex native push failure. The Go error text also reaches stderr on
+        # that path, so the empty-stderr condition stays asserted for the exit-0
+        # branch only. Anything else -- no receipt, the original ref, another
+        # reason -- still fails here loudly.
+        if result.returncode == 0:
+            assert result.stdout and not result.stderr
+        else:
+            line = result.stdout.decode()
+            assert line.endswith('\n') and line.count('\n') == 1, result.stdout
+            fields = line[:-1].split('\t')
+            assert len(fields) == 4, result.stdout
+            assert re.fullmatch(r'message-[0-9a-f]{36}', fields[0]) and fields[0] != envelope['messageRef'], result.stdout
+            assert fields[1] == 'failed' and fields[2] in {'codex-native-control-unconfigured','codex-native-binding-unavailable','codex-turn-push-refused','codex-turn-push-outcome-unknown'}, result.stdout
         receipt.write('qualification-explicit-returned\n'); receipt.flush()
 hook('synthetic-session-1')
 for line in sys.stdin:

--- a/test/e2e/claudefixture/main.go
+++ b/test/e2e/claudefixture/main.go
@@ -20,6 +20,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"syscall"
 )
@@ -289,15 +290,65 @@ func runExplicitReply(ctx context.Context, binary string, environment []string, 
 		consume = exec.CommandContext(ctx, alias, carrier)
 	}
 	consume.Env, consume.Stderr = cleanEnvironment, io.Discard
+	// Output() returns the collected stdout together with the *exec.ExitError,
+	// so the receipt is available on the failure path.
 	receipt, err := consume.Output()
 	if err != nil {
-		return err
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			return err
+		}
+		// The reply's source is a Codex Agent, and a Codex coordination reply
+		// now reports its native turn push outcome. This offline fixture has no
+		// Codex app-server, so the push cannot land and the command exits
+		// nonzero after printing the terminal receipt. Read the receipt instead
+		// of the exit code; anything that is not a terminal Codex push failure
+		// for a freshly minted reply ref stays fatal here.
+		if err := checkCodexPushFailureReceipt(receipt, content.MessageRef); err != nil {
+			return err
+		}
 	}
 	if publicProfile {
 		if err := publicEvent(map[string]any{"type": "user", "message": map[string]any{"role": "user", "content": []any{map[string]any{"type": "tool_result", "tool_use_id": toolID, "content": string(receipt), "is_error": false}}}, "tool_use_result": map[string]any{"stdout": string(receipt), "stderr": "", "interrupted": false}}); err != nil {
 			return err
 		}
 		return publicEvent(map[string]any{"type": "result", "subtype": "success", "is_error": false})
+	}
+	return nil
+}
+
+// codexPushFailureReasons are the terminal reasons `agent message send` reports
+// when a Codex native turn push wrote no turn or its outcome cannot be known.
+var codexPushFailureReasons = map[string]bool{
+	"codex-native-control-unconfigured": true,
+	"codex-native-binding-unavailable":  true,
+	"codex-turn-push-refused":           true,
+	"codex-turn-push-outcome-unknown":   true,
+}
+
+// replyReceiptRef is the shape of the fresh coordination ref the broker mints
+// for an explicit reply. The fixture cannot pass --message-ref (the reply tool
+// permit pins an exact nine-token argv), so the ref is proved by shape and by
+// being distinct from the ref it replies to.
+var replyReceiptRef = regexp.MustCompile(`^message-[0-9a-f]{36}$`)
+
+// checkCodexPushFailureReceipt accepts a nonzero explicit reply only when its
+// stdout is exactly one four-field receipt line proving a terminal Codex push
+// failure. An empty receipt, a different ref, or a non-Codex reason is fatal.
+func checkCodexPushFailureReceipt(receipt []byte, originalRef string) error {
+	text := string(receipt)
+	if !strings.HasSuffix(text, "\n") || strings.Count(text, "\n") != 1 {
+		return fmt.Errorf("fixture reply receipt is not one terminated line: %q", text)
+	}
+	fields := strings.Split(strings.TrimSuffix(text, "\n"), "\t")
+	if len(fields) != 4 {
+		return fmt.Errorf("fixture reply receipt has %d fields, want 4: %q", len(fields), text)
+	}
+	if !replyReceiptRef.MatchString(fields[0]) || fields[0] == originalRef {
+		return fmt.Errorf("fixture reply receipt ref is not a fresh reply ref: %q", text)
+	}
+	if fields[1] != "failed" || !codexPushFailureReasons[fields[2]] {
+		return fmt.Errorf("fixture reply receipt is not a terminal Codex push failure: %q", text)
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

`pushCodexCoordination` returned the still-`accepted` record on five distinct
failure paths, so `projmux agent message send` to a Codex target exited 0 and
printed `accepted` even when no turn was ever written. The record then sat until
its TTL and expired, so the sender learned nothing at the one moment it could
have acted. It also fell back to `turn-steer` after *any* start failure,
including failures where the start may already have reached the provider.

## Change

`pushCodexCoordination` now classifies every outcome, persists a terminal
delivery state, and `agent message send` prints the receipt and then exits
nonzero when the push did not deliver.

| Condition | State | Reason | outcomeUnknown | Provider calls |
| --- | --- | --- | --- | ---: |
| deadline reached before dispatch (checked first) | `expired` | `deadline-expired` | false | 0 |
| native control seam not configured | `failed` | `codex-native-control-unconfigured` | false | 0 |
| turn content render failed | `failed` | `codex-turn-content-build-failed` | false | 0 |
| control binding unavailable | `failed` | `codex-native-binding-unavailable` | false | 0 |
| refusal that provably wrote no turn | `failed` | `codex-turn-push-refused` | false | 0–2 |
| failure whose provider-side outcome cannot be known | `failed` | `codex-turn-push-outcome-unknown` | **true** | 1–2 |
| start or steer accepted the turn | `delivered` | `provider-turn-push` | false | 1–2 |

The **refusal code token** is the discriminator, never the response text, and it
is read per operation: `stale-turn` is a pre-write refusal from `turn-start` but
`controlWireFailure("stale-turn", err)` from `turn-steer`, i.e. ambiguous. A Go
error from `callControl` is split the same way — the typed
`*exactAgentControlBindingError` proves the consumer-fence refusal happened
before transport, anything else may already have left. Unrecognised codes fail
closed as ambiguous.

`turn-in-progress` is the only start refusal that falls through to a steer.
There is no steer after a successful start and no automatic resend anywhere.

`delivered` continues to mean the provider accepted a turn push. It is not
evidence of model consumption, acknowledgement, or task completion, and a test
holds the reason token to that.

When the terminal store write itself fails, the sender still gets an actionable
receipt: a failure keeps its **original** cause token (the persistence error only
widens the returned error), and a delivered turn whose write failed projects
`broker-delivery-persist-failed` with `outcomeUnknown`, so resend stays
discouraged. Those two cases are the only ones where `agent message status`
cannot match the send receipt — the store write is exactly what failed — and
both are asserted with that limit stated.

## Tests

- `TestCodexCoordinationPushClassifiesNativeOutcomesForSenders` — the full
  outcome table over every early return, every known-zero and ambiguous refusal
  code per operation, the fence and transport `callErr` split, with exact
  per-operation call counts and binding-resolution counts.
- `TestCodexCoordinationPushExpiresBeforeAnyProviderCall` — fake clock at the
  deadline: `expired` / `deadline-expired`, zero control calls, zero binding
  resolutions, and status parity.
- `TestCodexCoordinationPushFailuresExitNonzeroWithCauseAndStatusParity` —
  end-to-end `agent message send`: `ref/state/reason/action` on stdout, a
  nonzero non-usage exit, and `agent message status` agreeing; plus both
  persistence-failure branches.
- `TestCodexCoordinationPushKeepsTerminalReceiptAndSkipsExtraSteer` — no extra
  steer, terminal-once idempotency, and a delivered reason that claims only the
  push.

Four pre-existing fixtures wired a Codex target with no native control seam and
relied on the silent `accepted`; they now assert the
`codex-native-control-unconfigured` failure while their route, correlation, and
authority assertions stay unchanged. Three of them also moved off a fixture
clock in the past, because the store prunes terminal records against its own
real clock and a Codex send can now reach a terminal state.

`internal/core/agentmessage` is unchanged — `Reduce` already supported every
state used here. The 8192 frame limit, exact route/epoch fences, and the
untrusted coordination-only authority are untouched.

## Validation

`make fmt` → `make fix` → `make test` → `make test-integration` → `make test-e2e`
on this exact head. `make fix` is red on clean `main` with two pre-existing
deadcode baseline findings; the raw finding set is byte-identical between clean
main and this head (335 vs 335, zero added, zero removed).

Roadmap: Coordination source is a claim rendered as attribution / Phase 3 Codex sender failure reporting
Contract: C-5 Guarantee, Failure.Detection, Scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)
