### PR TITLE
fix(usage): recover quiet Codex rate-limit connections

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1065,6 +1065,11 @@
   That token is deliberately not `binding-revoked`: the four close-cause tokens
   answer "who closed the stream" and come from the broker epoch, and here the
   stream was never closed at all.
+- `test/e2e/codex-lifecycle.sh` (C01) exercises its actual projection barrier on
+  an inert fixture pane with an already-ready or later-ready level and repeated
+  option hooks before waiting. An atomic claim shared by the level check and
+  hook emits exactly one signal; duplicate `wait-for -S` calls would otherwise
+  lose the pending wakeup. The existing barrier deadline is unchanged.
 - `test/e2e/codex-lifecycle.sh` (C01) pins the exact disconnect token at its
   disconnect projection barrier and at the reconnect-gap hook comparison. It
   waited on the literal `disconnected` before, which was the bucket published

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -321,6 +321,28 @@
 - `make test`: Codex native control plane Phase 8 capability and review coverage pins distinct localized default/advanced provider rows; default Codex launch with zero capability-session/readiness calls and zero `--model`/`model_reasoning_effort` overrides; advanced-only hidden/duplicate model removal, supported-effort and closed-modality normalization, boolean-only personality projection, catalog-localized semantic picker labels with provider model/effort/modality data unchanged, paginated `model/list`, connection/version epoch cache invalidation, stale picker refusal, live-session cleanup on pre-plan create refusal, the live picker-to-pre-create session refresh rejecting a removed option, and dynamic `model/list` -> exact launch argv. Advanced discovery failure returns its exact unavailable reason with zero create intents while a separate default launch remains usable. Review tests require one exact Running Agent -> owned Pane -> activation generation -> stored/live thread binding before `review/start`, use one bounded action context, reject incomplete or unknown initial turns, map only a valid initial response to provider-control-plane interaction state, and commit zero lifecycle writes for unavailable, timed-out, mismatched, or replaced bindings. The installed smoke is opt-in through `PROJMUX_CODEX_CAPABILITY_INSTALLED_SMOKE=1`; it closes the discovery context before refreshing the retained live connection. CI does not require a local authenticated Codex daemon or create a disposable provider thread.
 
 - `make test`: Codex native control plane Phase 5 makes `account/rateLimits/read` the authoritative Codex Usage source and consumes `account/rateLimits/updated` through one single-lease, demand-bounded read-only watcher. Bucket/malformed/sparse-event goldens pin percent, reset, label, nullable identity, unknown cadence, and row-level isolation. Manager tests require an accepted native event batch to atomically replace only Codex rows, preserve other-provider/backoff state, advance the Codex throttle timestamp, and trigger zero second collector calls in the same HUD invocation. Watcher tests pin single ownership, demand-expiry heartbeat cleanup, failure backoff, sparse-update recovery after malformed events, and a private atomic native-only sidecar that never replaces last-known-good bytes with rollout/fallback provenance. The watcher launch boundary rejects `.test` and `.test.exe` executables before starting a child; the status regression runs repeated calls from the actual Go test binary with zero child starts and all usage state confined to its isolated root. Adapter/CLI/HUD/diagnostics tests keep unavailable and unsupported accounts on the existing rollout lane, all-malformed native batches on last-known-good with a closed stale reason, source/value parity across table/JSON/HUD, and an exact request inventory containing only `account/rateLimits/read` with zero login/logout/config/token mutation.
+- `TestWatchNativeRateLimitsPeriodicReadKeepsQuietConnection`,
+  `TestWatchNativeRateLimitsNoEOFFailureIsBounded`, and
+  `TestWatchNativeRateLimitsPeriodicReadRefreshesSparseBase` use Go's virtual
+  clock to pin the initial read, fixed 30-second same-client reads, two-second
+  timeout, busy-notification independence, single pending read, native-only
+  publication, validated sparse base and malformed-result last-good retention.
+  `TestWatchNativeRateLimitsParentCancelRejectsLateProbeAndEvents` prevents a
+  canceled connection's late results or queued events from publishing.
+  `TestOwnedProxyCloseIsBoundedWhenPeerDoesNotRead` and
+  `TestOwnedProxyCloseUnblocksConcurrentWriterAndReapsChild` fill real owned
+  child pipes and require local close within one second, child reap, joined
+  reader/writers and concurrent/idempotent Close. Close never waits for a
+  WebSocket close frame or its write lock. Only the exact owned proxy is killed;
+  its upstream daemon lifecycle is unchanged.
+  `TestNativeWatcherProbeFailureUsesExistingBackoff` and
+  `TestNativeWatcherDemandExpiryCancelsPendingProbe` distinguish a failed
+  two-second probe from parent cancellation. They pin failure timestamps,
+  heartbeat removal, lease release, the existing inclusive 30-second backoff,
+  next-demand relaunch, and the 15-second demand TTL plus one-second monitor.
+  Existing cache freshness, newer-than-store, independent collector/fallback,
+  request cancellation/late-response and notification channel lifetime tests
+  remain the parity gates; heartbeat alone supplies no connection health proof.
 
 - `make test`: Codex native control plane Phase 9 makes the compact Usage identity native-first: label goldens map healthy authoritative app-server rows to exact `Codex`, fresh rollout rows and unknown non-stale provenance to `Codex [fallback]`, and retained last-known-good rows to `Codex [stale]`; en-US/ko-KR narrow statusbar fixtures pin spacing and width. Same-snapshot HUD/table/JSON tests and operations-journal tests preserve exact percent/reset values plus typed source/fallback/stale reasons, while Claude/Antigravity labels, projection order, and Usage semantics remain unchanged.
 

--- a/internal/app/usagecmd/native_watcher.go
+++ b/internal/app/usagecmd/native_watcher.go
@@ -154,6 +154,12 @@ func (c *Command) ensureNativeWatcher(stateDir string) {
 }
 
 func (c *Command) runNativeWatcher() error {
+	signalCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
+	return c.runNativeWatcherContext(signalCtx)
+}
+
+func (c *Command) runNativeWatcherContext(ctx context.Context) error {
 	stateDir, err := c.resolveStateDir()
 	if err != nil {
 		return err
@@ -175,9 +181,7 @@ func (c *Command) runNativeWatcher() error {
 		return err
 	}
 
-	signalCtx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stopSignals()
-	watchCtx, cancelWatch := context.WithCancel(signalCtx)
+	watchCtx, cancelWatch := context.WithCancel(ctx)
 	monitorDone := make(chan struct{})
 	go func() {
 		defer close(monitorDone)
@@ -205,6 +209,9 @@ func (c *Command) runNativeWatcher() error {
 	failurePath := nativeWatcherPath(stateDir, nativeWatcherFailureName)
 	published := false
 	publish := func(snapshots []usage.Snapshot) error {
+		if err := watchCtx.Err(); err != nil {
+			return err
+		}
 		if err := cache.Publish(snapshots); err != nil {
 			return err
 		}
@@ -222,9 +229,12 @@ func (c *Command) runNativeWatcher() error {
 		}
 	}
 	watchErr := watch(watchCtx, publish)
+	// Only parent lifetime cancellation is a clean stop. A probe's own
+	// deadline is a connection failure and must retain the normal backoff.
+	parentErr := watchCtx.Err()
 	cancelWatch()
 	<-monitorDone
-	if errors.Is(watchErr, context.Canceled) || errors.Is(watchErr, context.DeadlineExceeded) {
+	if parentErr != nil {
 		return nil
 	}
 	if watchErr != nil {

--- a/internal/app/usagecmd/native_watcher_recovery_test.go
+++ b/internal/app/usagecmd/native_watcher_recovery_test.go
@@ -1,0 +1,197 @@
+package usagecmd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/usage"
+	codexadapter "github.com/crevissepartners/projmux/internal/core/usage/adapters/codex"
+)
+
+func nativeWatcherRecoveryCommand(t *testing.T) (*Command, string) {
+	t.Helper()
+	stateDir := t.TempDir()
+	command := New(time.Now)
+	command.lookupEnv = func(name string) string {
+		if name == StateDirEnvVar {
+			return stateDir
+		}
+		return ""
+	}
+	command.executableFn = func() (string, error) { return "/test/projmux", nil }
+	if err := touchNativeWatcherMarker(nativeWatcherPath(stateDir, nativeWatcherDemandName), time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	return command, stateDir
+}
+
+func nativeWatcherRecoveryRows(pct float64) []usage.Snapshot {
+	return []usage.Snapshot{{Model: codexadapter.Name, Window: usage.Window5h, Pct: pct, UpdatedAt: time.Now(), Source: usage.SourceAppServer, RateLimit: &usage.RateLimitMetadata{Slot: "primary"}}}
+}
+
+func requireNativeWatcherReleased(t *testing.T, stateDir string, failed bool) {
+	t.Helper()
+	if _, err := os.Lstat(nativeWatcherPath(stateDir, nativeWatcherHeartbeatName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("heartbeat remains: %v", err)
+	}
+	_, err := os.Lstat(nativeWatcherPath(stateDir, nativeWatcherFailureName))
+	if failed && err != nil || !failed && !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failure marker failed=%v err=%v", failed, err)
+	}
+	release, acquired, err := acquireNativeWatcherLease(nativeWatcherPath(stateDir, nativeWatcherLeaseName))
+	if err != nil || !acquired {
+		t.Fatalf("lease retained: acquired=%v err=%v", acquired, err)
+	}
+	release()
+}
+
+func TestNativeWatcherProbeFailureUsesExistingBackoff(t *testing.T) {
+	for _, rawDeadline := range []bool{false, true} {
+		t.Run(map[bool]string{false: "adapter-timeout", true: "request-deadline"}[rawDeadline], func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				command, stateDir := nativeWatcherRecoveryCommand(t)
+				cache := codexadapter.NewNativeEventCache(stateDir, time.Now)
+				var oldPublish func([]usage.Snapshot) error
+				command.watchNativeRateLimitsFn = func(ctx context.Context, publish func([]usage.Snapshot) error) error {
+					oldPublish = publish
+					if err := publish(nativeWatcherRecoveryRows(11)); err != nil {
+						return err
+					}
+					time.Sleep(30 * time.Second)
+					requestCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+					defer cancel()
+					<-requestCtx.Done()
+					if rawDeadline {
+						return requestCtx.Err()
+					}
+					return &usage.StaleReasonError{Reason: usage.ReasonAppServerTimeout, Err: errors.New("watcher read failed")}
+				}
+				done := make(chan error, 1)
+				go func() { done <- command.runNativeWatcherContext(context.Background()) }()
+				synctest.Wait()
+				// Keep HUD demand alive across the first periodic read.
+				for range 3 {
+					time.Sleep(10 * time.Second)
+					if err := touchNativeWatcherMarker(nativeWatcherPath(stateDir, nativeWatcherDemandName), time.Now()); err != nil {
+						t.Fatal(err)
+					}
+					synctest.Wait()
+				}
+				time.Sleep(2 * time.Second)
+				if err := <-done; err == nil {
+					t.Fatal("probe timeout became a clean stop")
+				}
+				requireNativeWatcherReleased(t, stateDir, true)
+				failedAt := time.Now()
+				failure, err := os.Stat(nativeWatcherPath(stateDir, nativeWatcherFailureName))
+				if err != nil || !failure.ModTime().Equal(failedAt) {
+					t.Fatalf("failure timestamp=%v err=%v", failure, err)
+				}
+				batch, err := cache.Load()
+				if err != nil || len(batch.Snapshots) != 1 || batch.Snapshots[0].Pct != 11 {
+					t.Fatalf("last good=%#v err=%v", batch, err)
+				}
+				starts := 0
+				restarted := make(chan error, 1)
+				command.watchNativeRateLimitsFn = func(ctx context.Context, publish func([]usage.Snapshot) error) error {
+					if err := publish(nativeWatcherRecoveryRows(44)); err != nil {
+						return err
+					}
+					<-ctx.Done()
+					return ctx.Err()
+				}
+				command.startNativeWatcherFn = func(string) error {
+					starts++
+					go func() { restarted <- command.runNativeWatcherContext(context.Background()) }()
+					return nil
+				}
+				for _, delay := range []time.Duration{0, 29 * time.Second, time.Second} {
+					time.Sleep(delay)
+					command.ensureNativeWatcher(stateDir)
+					if starts != 0 {
+						t.Fatalf("restart during backoff at %v", time.Since(failedAt))
+					}
+				}
+				time.Sleep(time.Nanosecond)
+				if starts != 0 {
+					t.Fatal("watcher relaunched without demand")
+				}
+				command.ensureNativeWatcher(stateDir)
+				synctest.Wait()
+				if starts != 1 {
+					t.Fatalf("next-demand starts=%d", starts)
+				}
+				command.ensureNativeWatcher(stateDir)
+				if starts != 1 {
+					t.Fatal("fresh heartbeat launched duplicate watcher")
+				}
+				if err := command.runNativeWatcherContext(context.Background()); err != nil {
+					t.Fatal(err)
+				}
+				if err := oldPublish(nativeWatcherRecoveryRows(99)); !errors.Is(err, context.Canceled) {
+					t.Fatalf("retired publisher=%v", err)
+				}
+				batch, err = cache.Load()
+				if err != nil || batch.Snapshots[0].Pct != 44 || batch.Snapshots[0].Source != usage.SourceAppServer || !batch.ObservedAt.After(failedAt) {
+					t.Fatalf("replacement batch=%#v err=%v", batch, err)
+				}
+				time.Sleep(16 * time.Second)
+				if err := <-restarted; err != nil {
+					t.Fatal(err)
+				}
+				requireNativeWatcherReleased(t, stateDir, false)
+			})
+		})
+	}
+}
+
+func TestNativeWatcherDemandExpiryCancelsPendingProbe(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		command, stateDir := nativeWatcherRecoveryCommand(t)
+		started := time.Now()
+		var stopCause error
+		command.watchNativeRateLimitsFn = func(ctx context.Context, publish func([]usage.Snapshot) error) error {
+			if err := publish(nativeWatcherRecoveryRows(11)); err != nil {
+				return err
+			}
+			time.Sleep(30 * time.Second)
+			probe, cancel := context.WithTimeout(ctx, 2*time.Second)
+			defer cancel()
+			<-probe.Done()
+			stopCause = probe.Err()
+			// A late result on a canceled demand cannot touch the cache.
+			return publish(nativeWatcherRecoveryRows(99))
+		}
+		done := make(chan error, 1)
+		go func() { done <- command.runNativeWatcherContext(context.Background()) }()
+		synctest.Wait()
+		time.Sleep(15 * time.Second)
+		if err := touchNativeWatcherMarker(nativeWatcherPath(stateDir, nativeWatcherDemandName), time.Now()); err != nil {
+			t.Fatal(err)
+		}
+		synctest.Wait()
+		time.Sleep(15 * time.Second)
+		synctest.Wait()
+		select {
+		case err := <-done:
+			t.Fatalf("stopped before TTL: %v", err)
+		default:
+		}
+		time.Sleep(time.Second)
+		if err := <-done; err != nil {
+			t.Fatalf("demand expiry created failure: %v", err)
+		}
+		if !errors.Is(stopCause, context.Canceled) || time.Since(started) != 31*time.Second {
+			t.Fatalf("stop=%v elapsed=%v", stopCause, time.Since(started))
+		}
+		requireNativeWatcherReleased(t, stateDir, false)
+		batch, err := codexadapter.NewNativeEventCache(stateDir, time.Now).Load()
+		if err != nil || batch.Snapshots[0].Pct != 11 {
+			t.Fatalf("late publication=%#v err=%v", batch, err)
+		}
+	})
+}

--- a/internal/core/usage/adapters/codex/native.go
+++ b/internal/core/usage/adapters/codex/native.go
@@ -20,6 +20,7 @@ const (
 	methodRateLimitsRead    = "account/rateLimits/read"
 	methodRateLimitsUpdated = "account/rateLimits/updated"
 	nativeRequestTimeout    = 2 * time.Second
+	nativeWatchReadEvery    = 30 * time.Second
 	nativeEventSettle       = 10 * time.Millisecond
 )
 

--- a/internal/core/usage/adapters/codex/native_watch.go
+++ b/internal/core/usage/adapters/codex/native_watch.go
@@ -4,15 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"time"
 
 	"github.com/crevissepartners/projmux/internal/core/usage"
 	"github.com/crevissepartners/projmux/internal/integrations/agents/codexappserver"
 )
 
 // WatchNativeRateLimits keeps one read-only native connection open and emits a
-// complete normalized native batch after the initial read and every usable
-// sparse rate-limit update. It never invokes the rollout fallback or any
-// account/config mutation. The caller owns process lifetime through ctx.
+// complete normalized native batch after the initial and periodic reads and
+// every usable sparse rate-limit update. Notifications never postpone the
+// same-connection read that detects a silent disconnect. It never invokes the
+// rollout fallback or any account/config mutation. The caller owns process
+// lifetime through ctx.
 func (a *Adapter) WatchNativeRateLimits(ctx context.Context, publish func([]usage.Snapshot) error) error {
 	if a == nil || !a.native.enabled {
 		return errors.New("codex native rate-limit watcher is disabled")
@@ -39,31 +42,65 @@ func (a *Adapter) WatchNativeRateLimits(ctx context.Context, publish func([]usag
 	}
 	defer client.Close()
 
-	requestCtx, cancel := context.WithTimeout(ctx, nativeRequestTimeout)
-	var response json.RawMessage
-	err = client.Request(requestCtx, methodRateLimitsRead, json.RawMessage("null"), &response)
-	cancel()
-	if err != nil {
+	var base json.RawMessage
+	read := func() error {
+		requestCtx, cancel := context.WithTimeout(ctx, nativeRequestTimeout)
+		defer cancel()
+		var response json.RawMessage
+		err := client.Request(requestCtx, methodRateLimitsRead, json.RawMessage("null"), &response)
+		// Cancellation owns the outcome even if a response became ready at
+		// the same instant. Retired clients cannot publish a late batch.
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		return &usage.StaleReasonError{Reason: nativeReasonFromError(err), Err: errors.New("codex native watcher read failed")}
+		if err != nil {
+			return &usage.StaleReasonError{Reason: nativeReasonFromError(err), Err: errors.New("codex native watcher read failed")}
+		}
+		if err := requestCtx.Err(); err != nil {
+			return &usage.StaleReasonError{Reason: nativeReasonFromError(err), Err: errors.New("codex native watcher read failed")}
+		}
+		rows, valid := a.normalizeNativeWatchBatch(response)
+		if !valid {
+			return &usage.StaleReasonError{Reason: usage.ReasonAppServerProtocol, Err: errors.New("codex native watcher received no valid rate-limit rows")}
+		}
+		if err := publish(rows); err != nil {
+			return err
+		}
+		base = validNativeWatchBase(response, rows)
+		return nil
 	}
-	base := append(json.RawMessage(nil), response...)
-	initial, valid := a.normalizeNativeWatchBatch(base)
-	if !valid {
-		return errors.New("codex native watcher received no valid rate-limit rows")
-	}
-	if err := publish(initial); err != nil {
+	if err := read(); err != nil {
 		return err
 	}
 
+	ticker := time.NewTicker(nativeWatchReadEvery)
+	defer ticker.Stop()
 	events := client.Notifications()
 	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		// Prefer a due read even when the notification queue stays busy. The
+		// synchronous request also ensures at most one read is in flight.
+		select {
+		case <-ticker.C:
+			if err := read(); err != nil {
+				return err
+			}
+			continue
+		default:
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-ticker.C:
+			if err := read(); err != nil {
+				return err
+			}
 		case event, ok := <-events:
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			if !ok {
 				if ctx.Err() != nil {
 					return ctx.Err()
@@ -89,9 +126,47 @@ func (a *Adapter) WatchNativeRateLimits(ctx context.Context, publish func([]usag
 			if err := publish(next); err != nil {
 				return err
 			}
-			base = merged
+			base = validNativeWatchBase(merged, next)
 		}
 	}
+}
+
+// validNativeWatchBase retains only windows that normalized successfully, so
+// a later sparse update cannot inherit fields from a rejected row. The native
+// map remains authoritative; the compatible single bucket keeps its routing
+// identity for updates that omit limitId.
+func validNativeWatchBase(raw json.RawMessage, rows []usage.Snapshot) json.RawMessage {
+	root, _ := rawObject(raw)
+	prune := func(raw json.RawMessage, rows []usage.Snapshot) json.RawMessage {
+		bucket, _ := rawObject(raw)
+		kept := make(map[string]json.RawMessage)
+		for _, name := range []string{"limitId", "limitName"} {
+			if value, ok := bucket[name]; ok {
+				kept[name] = value
+			}
+		}
+		for _, row := range rows {
+			kept[row.RateLimit.Slot] = bucket[row.RateLimit.Slot]
+		}
+		encoded, _ := json.Marshal(kept)
+		return encoded
+	}
+	if multi, ok := rawObject(root["rateLimitsByLimitId"]); ok {
+		byBucket := make(map[string][]usage.Snapshot)
+		for _, row := range rows {
+			key := row.RateLimit.BucketKey
+			byBucket[key] = append(byBucket[key], row)
+		}
+		kept := make(map[string]json.RawMessage)
+		for key, rows := range byBucket {
+			kept[key] = prune(multi[key], rows)
+		}
+		root["rateLimitsByLimitId"], _ = json.Marshal(kept)
+		rows, _ = normalizeNativeBucket(root["rateLimits"], "", "", time.Time{})
+	}
+	root["rateLimits"] = prune(root["rateLimits"], rows)
+	encoded, _ := json.Marshal(root)
+	return encoded
 }
 
 func (a *Adapter) normalizeNativeWatchBatch(raw json.RawMessage) ([]usage.Snapshot, bool) {

--- a/internal/core/usage/adapters/codex/native_watch_recovery_test.go
+++ b/internal/core/usage/adapters/codex/native_watch_recovery_test.go
@@ -1,0 +1,276 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/crevissepartners/projmux/internal/core/usage"
+	"github.com/crevissepartners/projmux/internal/integrations/agents/codexappserver"
+)
+
+type nativeWatchProbeClient struct {
+	mu                        sync.Mutex
+	response                  func(context.Context, int) (json.RawMessage, error)
+	events                    chan codexappserver.Notification
+	reads                     []time.Time
+	budgets                   []time.Duration
+	active, maxActive, closes int
+}
+
+func (c *nativeWatchProbeClient) Request(ctx context.Context, method string, params, result any) error {
+	if method != methodRateLimitsRead || string(params.(json.RawMessage)) != "null" {
+		return errors.New("unexpected watcher request")
+	}
+	c.mu.Lock()
+	c.reads = append(c.reads, time.Now())
+	deadline, _ := ctx.Deadline()
+	c.budgets = append(c.budgets, time.Until(deadline))
+	c.active++
+	c.maxActive = max(c.maxActive, c.active)
+	call := len(c.reads)
+	c.mu.Unlock()
+	defer func() { c.mu.Lock(); c.active--; c.mu.Unlock() }()
+	raw, err := c.response(ctx, call)
+	if err == nil {
+		*result.(*json.RawMessage) = raw
+	}
+	return err
+}
+func (c *nativeWatchProbeClient) Notifications() <-chan codexappserver.Notification { return c.events }
+func (c *nativeWatchProbeClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closes++
+	return nil
+}
+
+type nativeWatchProbeStats struct {
+	reads                     []time.Time
+	budgets                   []time.Duration
+	active, maxActive, closes int
+}
+
+func (c *nativeWatchProbeClient) stats() nativeWatchProbeStats {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return nativeWatchProbeStats{reads: append([]time.Time(nil), c.reads...), budgets: append([]time.Duration(nil), c.budgets...), active: c.active, maxActive: c.maxActive, closes: c.closes}
+}
+
+type nativeWatchBatches struct {
+	mu   sync.Mutex
+	rows []usage.Snapshot
+}
+
+func (b *nativeWatchBatches) snapshots() []usage.Snapshot {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]usage.Snapshot(nil), b.rows...)
+}
+
+func nativeWatchResponse(pct int, label string) json.RawMessage {
+	return json.RawMessage(fmt.Sprintf(`{"rateLimits":{"limitId":"codex","limitName":%q,"primary":{"usedPercent":%d,"windowDurationMins":300,"resetsAt":1787380200}}}`, label, pct))
+}
+
+func startNativeClockWatch(t *testing.T, client *nativeWatchProbeClient) (context.CancelFunc, <-chan error, *nativeWatchBatches, *int) {
+	t.Helper()
+	adapter := NewWithRoot(t.TempDir())
+	adapter.native = availableNative(client)
+	opens := new(int)
+	adapter.native.open = func(context.Context) (nativeClient, error) { *opens++; return client, nil }
+	ctx, cancel := context.WithCancel(context.Background())
+	rows := &nativeWatchBatches{}
+	done := make(chan error, 1)
+	go func() {
+		done <- adapter.WatchNativeRateLimits(ctx, func(next []usage.Snapshot) error {
+			rows.mu.Lock()
+			rows.rows = append(rows.rows, next...)
+			rows.mu.Unlock()
+			return nil
+		})
+	}()
+	synctest.Wait()
+	return cancel, done, rows, opens
+}
+
+func TestWatchNativeRateLimitsPeriodicReadKeepsQuietConnection(t *testing.T) {
+	for _, busy := range []bool{false, true} {
+		t.Run(fmt.Sprintf("busy=%t", busy), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				start := time.Now()
+				client := &nativeWatchProbeClient{events: make(chan codexappserver.Notification, 64)}
+				client.response = func(context.Context, int) (json.RawMessage, error) { return nativeWatchResponse(11, "General"), nil }
+				cancel, done, rows, opens := startNativeClockWatch(t, client)
+				defer cancel()
+				for second := 1; second <= 60; second++ {
+					if busy {
+						// A permanently queued burst at each second must not reset or
+						// defer the read cadence, including exactly on the tick.
+						for range cap(client.events) {
+							client.events <- codexappserver.Notification{Method: methodRateLimitsUpdated, Params: json.RawMessage(`{"rateLimits":{"primary":{"usedPercent":12}}}`)}
+						}
+					}
+					time.Sleep(time.Second)
+					synctest.Wait()
+					if got, want := len(client.stats().reads), 1+second/30; got != want {
+						t.Fatalf("at %ds reads=%d, want %d", second, got, want)
+					}
+				}
+				cancel()
+				if err := <-done; !errors.Is(err, context.Canceled) {
+					t.Fatal(err)
+				}
+				if *opens != 1 || client.stats().closes != 1 || client.stats().maxActive != 1 {
+					t.Fatalf("opens=%d closes=%d max reads=%d", *opens, client.stats().closes, client.stats().maxActive)
+				}
+				for i, at := range client.stats().reads {
+					if at.Sub(start) != time.Duration(i)*30*time.Second || client.stats().budgets[i] != 2*time.Second {
+						t.Fatalf("read %d at=%v budget=%v", i, at.Sub(start), client.stats().budgets[i])
+					}
+				}
+				for _, row := range rows.snapshots() {
+					if row.Source != usage.SourceAppServer || row.FallbackReason != "" || row.StaleReason != "" {
+						t.Fatalf("bad provenance: %#v", row)
+					}
+				}
+			})
+		})
+	}
+}
+
+func TestWatchNativeRateLimitsNoEOFFailureIsBounded(t *testing.T) {
+	for _, lateSuccess := range []bool{false, true} {
+		t.Run(fmt.Sprintf("late-success=%t", lateSuccess), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				start := time.Now()
+				client := &nativeWatchProbeClient{events: make(chan codexappserver.Notification, 2)}
+				client.response = func(ctx context.Context, call int) (json.RawMessage, error) {
+					if call == 1 {
+						return nativeWatchResponse(11, "General"), nil
+					}
+					<-ctx.Done() // No EOF and no response until the two-second deadline.
+					if lateSuccess {
+						return nativeWatchResponse(99, "Late"), nil
+					}
+					return nil, ctx.Err()
+				}
+				cancel, done, rows, opens := startNativeClockWatch(t, client)
+				defer cancel()
+				time.Sleep(31 * time.Second)
+				synctest.Wait()
+				select {
+				case err := <-done:
+					t.Fatalf("early failure: %v", err)
+				default:
+				}
+				if len(client.stats().reads) != 2 || client.stats().active != 1 {
+					t.Fatalf("reads=%d active=%d", len(client.stats().reads), client.stats().active)
+				}
+				client.events <- codexappserver.Notification{Method: methodRateLimitsUpdated, Params: json.RawMessage(`{"rateLimits":{"primary":{"usedPercent":33}}}`)}
+				time.Sleep(time.Second)
+				err := <-done
+				var stale *usage.StaleReasonError
+				if !errors.As(err, &stale) || stale.Reason != usage.ReasonAppServerTimeout {
+					t.Fatalf("failure=%v", err)
+				}
+				if time.Since(start) != 32*time.Second || *opens != 1 || client.stats().closes != 1 || client.stats().active != 0 {
+					t.Fatalf("elapsed=%v opens=%d closes=%d active=%d", time.Since(start), *opens, client.stats().closes, client.stats().active)
+				}
+				client.events <- codexappserver.Notification{Method: methodRateLimitsUpdated, Params: json.RawMessage(`{"rateLimits":{"primary":{"usedPercent":99}}}`)}
+				time.Sleep(30 * time.Second)
+				synctest.Wait()
+				if len(rows.snapshots()) != 1 || rows.snapshots()[0].Pct != 11 {
+					t.Fatalf("last good overwritten: %#v", rows.snapshots())
+				}
+			})
+		})
+	}
+}
+
+func TestWatchNativeRateLimitsPeriodicReadRefreshesSparseBase(t *testing.T) {
+	for _, multi := range []bool{false, true} {
+		t.Run(fmt.Sprintf("multi=%t", multi), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				client := &nativeWatchProbeClient{events: make(chan codexappserver.Notification, 1)}
+				client.response = func(_ context.Context, call int) (json.RawMessage, error) {
+					var raw json.RawMessage
+					switch call {
+					case 1:
+						raw = nativeWatchResponse(11, "Old")
+					case 2:
+						raw = json.RawMessage(`{"rateLimits":{"limitId":"codex","limitName":"New","primary":{"usedPercent":22,"windowDurationMins":10080,"resetsAt":1787380999},"secondary":{"usedPercent":"bad","windowDurationMins":300}}}`)
+					default:
+						raw = json.RawMessage(`{"rateLimits":{"primary":{"usedPercent":"bad"}}}`)
+					}
+					if multi {
+						root, _ := rawObject(raw)
+						root["rateLimitsByLimitId"], _ = json.Marshal(map[string]json.RawMessage{
+							"codex":   root["rateLimits"],
+							"invalid": json.RawMessage(`{"limitId":123,"primary":{"usedPercent":99}}`),
+						})
+						raw, _ = json.Marshal(root)
+					}
+					return raw, nil
+				}
+				cancel, done, batches, _ := startNativeClockWatch(t, client)
+				defer cancel()
+				time.Sleep(30 * time.Second)
+				synctest.Wait()
+				rows := batches.snapshots()
+				if len(rows) != 2 || rows[1].Pct != 22 {
+					t.Fatalf("periodic batch=%#v", rows)
+				}
+				client.events <- codexappserver.Notification{Method: methodRateLimitsUpdated, Params: json.RawMessage(`{"rateLimits":{"primary":{"usedPercent":33},"secondary":{"usedPercent":44}}}`)}
+				synctest.Wait()
+				rows = batches.snapshots()
+				if len(rows) != 4 {
+					t.Fatalf("sparse batch=%#v", rows)
+				}
+				row := rows[2]
+				if row.Pct != 33 || row.Window != usage.WindowWeekly || *row.RateLimit.Label != "New" || row.ResetsAt.Unix() != 1787380999 || row.Source != usage.SourceAppServer || !row.UpdatedAt.Equal(rows[1].UpdatedAt) {
+					t.Fatalf("sparse row did not inherit periodic base: %#v", row)
+				}
+				if row := rows[3]; row.Pct != 44 || row.Window != usage.WindowQuota || row.RateLimit.CadenceMinutes != nil {
+					t.Fatalf("sparse row inherited cadence from a rejected row: %#v", row)
+				}
+				time.Sleep(30 * time.Second)
+				err := <-done
+				var stale *usage.StaleReasonError
+				if !errors.As(err, &stale) || stale.Reason != usage.ReasonAppServerProtocol {
+					t.Fatalf("malformed result=%v", err)
+				}
+				if len(batches.snapshots()) != 4 {
+					t.Fatalf("malformed result replaced last good: %#v", batches.snapshots())
+				}
+			})
+		})
+	}
+}
+
+func TestWatchNativeRateLimitsParentCancelRejectsLateProbeAndEvents(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		client := &nativeWatchProbeClient{events: make(chan codexappserver.Notification, 1)}
+		client.response = func(ctx context.Context, call int) (json.RawMessage, error) {
+			if call > 1 {
+				<-ctx.Done()
+			}
+			return nativeWatchResponse(call*11, "General"), nil
+		}
+		cancel, done, rows, _ := startNativeClockWatch(t, client)
+		time.Sleep(30 * time.Second)
+		synctest.Wait()
+		cancel()
+		client.events <- codexappserver.Notification{Method: methodRateLimitsUpdated, Params: json.RawMessage(`{"rateLimits":{"primary":{"usedPercent":99}}}`)}
+		if err := <-done; !errors.Is(err, context.Canceled) {
+			t.Fatalf("stop=%v", err)
+		}
+		if len(rows.snapshots()) != 1 || client.stats().active != 0 || client.stats().closes != 1 {
+			t.Fatalf("rows=%#v active=%d closes=%d", rows.snapshots(), client.stats().active, client.stats().closes)
+		}
+	})
+}

--- a/internal/core/usage/adapters/codex/native_watch_test.go
+++ b/internal/core/usage/adapters/codex/native_watch_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/crevissepartners/projmux/internal/core/usage"
@@ -12,12 +13,16 @@ import (
 )
 
 func TestWatchNativeRateLimitsPublishesInitialAndSparseEventWithoutFallback(t *testing.T) {
+	synctest.Test(t, testWatchNativeRateLimitsPublishesInitialAndSparseEventWithoutFallback)
+}
+
+func testWatchNativeRateLimitsPublishesInitialAndSparseEventWithoutFallback(t *testing.T) {
 	now := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
 	client := &fakeNativeClient{
 		response: json.RawMessage(`{
-			"rateLimits":{"limitId":"codex","limitName":"General","primary":{"usedPercent":11,"windowDurationMins":300,"resetsAt":1787380200}},
-			"rateLimitsByLimitId":{"codex":{"limitId":"codex","limitName":"General","primary":{"usedPercent":11,"windowDurationMins":300,"resetsAt":1787380200}}}
-		}`),
+		"rateLimits":{"limitId":"codex","limitName":"General","primary":{"usedPercent":11,"windowDurationMins":300,"resetsAt":1787380200}},
+		"rateLimitsByLimitId":{"codex":{"limitId":"codex","limitName":"General","primary":{"usedPercent":11,"windowDurationMins":300,"resetsAt":1787380200}}}
+	}`),
 		events: make(chan codexappserver.Notification, 1),
 	}
 	adapter := NewWithRoot(t.TempDir())
@@ -42,8 +47,8 @@ func TestWatchNativeRateLimitsPublishesInitialAndSparseEventWithoutFallback(t *t
 	client.events <- codexappserver.Notification{
 		Method: methodRateLimitsUpdated,
 		Params: json.RawMessage(`{
-			"rateLimits":{"limitName":null,"primary":{"usedPercent":73,"resetsAt":1787380999}}
-		}`),
+		"rateLimits":{"limitName":null,"primary":{"usedPercent":73,"resetsAt":1787380999}}
+	}`),
 	}
 	updated := receiveNativeWatchBatch(t, published)
 	if len(updated) != 1 || updated[0].Pct != 73 ||
@@ -72,6 +77,10 @@ func TestWatchNativeRateLimitsPublishesInitialAndSparseEventWithoutFallback(t *t
 }
 
 func TestWatchNativeRateLimitsMalformedEventRetainsPriorBatch(t *testing.T) {
+	synctest.Test(t, testWatchNativeRateLimitsMalformedEventRetainsPriorBatch)
+}
+
+func testWatchNativeRateLimitsMalformedEventRetainsPriorBatch(t *testing.T) {
 	now := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
 	client := &fakeNativeClient{
 		response: json.RawMessage(`{"rateLimits":{"limitId":"codex","primary":{"usedPercent":11,"windowDurationMins":300,"resetsAt":1787380200}}}`),

--- a/internal/integrations/agents/codexappserver/client.go
+++ b/internal/integrations/agents/codexappserver/client.go
@@ -110,6 +110,11 @@ type Client struct {
 	version string
 	once    sync.Once
 
+	closeOnce  sync.Once
+	closeErr   error
+	readerDone chan struct{}
+	writers    sync.WaitGroup
+
 	// answered is the connection-scoped response-once ledger for inbound
 	// server requests. Entries are kind-tagged so the string id "1" and the
 	// number id 1 stay distinct, and they are never released: at-most-once on
@@ -137,6 +142,8 @@ func NewClient(stream readWriteCloser) *Client {
 		events:   make(chan Notification, notificationBacklog),
 		done:     make(chan struct{}),
 		answered: make(map[string]struct{}),
+
+		readerDone: make(chan struct{}),
 	}
 	go c.readLoop()
 	return c
@@ -241,11 +248,16 @@ func (c *Client) abort() error {
 	return c.stream.Close()
 }
 
-// Close terminates the connection and unblocks all pending requests.
+// Close terminates the connection, unblocks all pending requests, and joins
+// the owned reader/writers before returning. It is safe to call concurrently.
 func (c *Client) Close() error {
-	err := c.stream.Close()
-	c.fail(ErrDisconnected)
-	return err
+	c.closeOnce.Do(func() {
+		c.fail(ErrDisconnected)
+		c.closeErr = c.stream.Close()
+		<-c.readerDone
+		c.writers.Wait()
+	})
+	return c.closeErr
 }
 
 func (c *Client) notify(ctx context.Context, method string, params any) error {
@@ -256,8 +268,19 @@ func (c *Client) writeJSONContext(ctx context.Context, message any) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	// Register under the same lock that closes admission, so Close can wait
+	// for every writer without racing a new WaitGroup.Add.
+	c.mu.Lock()
+	if c.err != nil {
+		err := c.err
+		c.mu.Unlock()
+		return err
+	}
+	c.writers.Add(1)
+	c.mu.Unlock()
 	writeDone := make(chan error, 1)
 	go func() {
+		defer c.writers.Done()
 		writeDone <- c.writeJSON(message)
 	}()
 	select {
@@ -320,6 +343,7 @@ func (c *Client) writeJSON(message any) error {
 // failing the connection here suspends every binding and forces a reconnect
 // that re-issues the same oversized read; that is a cycle, not a recovery.
 func (c *Client) readLoop() {
+	defer close(c.readerDone)
 	stream, framed := c.stream.(messageStream)
 	reader := bufio.NewReaderSize(c.stream, frameReaderBytes)
 	for {

--- a/internal/integrations/agents/codexappserver/owned_close_test.go
+++ b/internal/integrations/agents/codexappserver/owned_close_test.go
@@ -1,0 +1,181 @@
+package codexappserver
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// This child owns only its stdio pipes. It never opens an endpoint, reads
+// credentials, or starts another process, and deliberately never reads stdin.
+func TestOwnedProxyCloseHelperProcess(t *testing.T) {
+	if os.Getenv("PROJMUX_TEST_OWNED_PROXY_CLOSE") != "1" {
+		return
+	}
+	_, _ = os.Stdout.Write([]byte{1})
+	time.Sleep(time.Hour)
+	os.Exit(0)
+}
+
+func fullOwnedProxyPipe(t *testing.T) *commandStream {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestOwnedProxyCloseHelperProcess$")
+	cmd.Dir = t.TempDir()
+	cmd.Env = []string{"PROJMUX_TEST_OWNED_PROXY_CLOSE=1"}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	stream := &commandStream{stdin: stdin, stdout: stdout, cmd: cmd}
+	t.Cleanup(func() { _ = stream.Close() })
+	var ready [1]byte
+	if _, err := io.ReadFull(stdout, ready[:]); err != nil {
+		t.Fatal(err)
+	}
+	fd := int(stdin.(*os.File).Fd())
+	if err := unix.SetNonblock(fd, true); err != nil {
+		t.Fatal(err)
+	}
+	fill := make([]byte, 4096)
+	for {
+		_, err := unix.Write(fd, fill)
+		if errors.Is(err, unix.EAGAIN) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The close frame is smaller than PIPE_BUF: finish any remaining pipe
+	// capacity, then restore the descriptor's blocking mode before the test.
+	for {
+		_, err := unix.Write(fd, []byte{0})
+		if errors.Is(err, unix.EAGAIN) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := unix.SetNonblock(fd, false); err != nil {
+		t.Fatal(err)
+	}
+	return stream
+}
+
+func requireOwnedProxyClosed(t *testing.T, client *Client, stream *commandStream) {
+	t.Helper()
+	started := time.Now()
+	done := make(chan error, 2)
+	for range 2 {
+		go func() { done <- client.Close() }()
+	}
+	for range 2 {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			// Rescue only this exact fixture; do not leave the failed test's
+			// blocked Close or writer alive after reporting the regression.
+			_ = stream.Close()
+			<-done
+			t.Fatal("owned proxy Close exceeded one second")
+		}
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("Close elapsed=%v", elapsed)
+	}
+	if stream.cmd.ProcessState == nil {
+		t.Fatal("Close returned before owned child was reaped")
+	}
+	if err := stream.cmd.Process.Signal(unix.Signal(0)); !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("owned child is not reaped: %v", err)
+	}
+	select {
+	case <-client.readerDone:
+	default:
+		t.Fatal("Close left its reader running")
+	}
+	if _, ok := <-client.Notifications(); ok {
+		t.Fatal("notification channel remained open")
+	}
+	if err := client.Request(context.Background(), "after-close", nil, nil); !errors.Is(err, ErrDisconnected) {
+		t.Fatalf("closed client request=%v", err)
+	}
+	_ = client.Close()
+}
+
+func TestOwnedProxyCloseIsBoundedWhenPeerDoesNotRead(t *testing.T) {
+	stream := fullOwnedProxyPipe(t)
+	websocket := &websocketStream{raw: stream, reader: bufio.NewReader(stream)}
+	client := NewClient(websocket)
+	requireOwnedProxyClosed(t, client, stream)
+}
+
+type witnessedProxyWrite struct {
+	*commandStream
+	once     sync.Once
+	started  chan struct{}
+	finished chan struct{}
+}
+
+func (s *witnessedProxyWrite) Write(p []byte) (int, error) {
+	s.once.Do(func() { close(s.started) })
+	n, err := s.commandStream.Write(p)
+	select {
+	case s.finished <- struct{}{}:
+	default:
+	}
+	return n, err
+}
+
+func TestOwnedProxyCloseUnblocksConcurrentWriterAndReapsChild(t *testing.T) {
+	stream := fullOwnedProxyPipe(t)
+	raw := &witnessedProxyWrite{commandStream: stream, started: make(chan struct{}), finished: make(chan struct{}, 3)}
+	websocket := &websocketStream{raw: raw, reader: bufio.NewReader(raw)}
+	client := NewClient(websocket)
+	requests := make(chan error, 2)
+	go func() { requests <- client.Request(context.Background(), "blocked-first", nil, nil) }()
+	<-raw.started
+	go func() { requests <- client.Request(context.Background(), "queued-second", nil, nil) }()
+	control := make(chan error, 1)
+	go func() { control <- websocket.writeFrame(0xA, nil) }()
+	requireOwnedProxyClosed(t, client, stream)
+	for range 2 {
+		select {
+		case err := <-requests:
+			if !errors.Is(err, ErrDisconnected) {
+				t.Fatalf("writer result=%v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("request writer did not finish")
+		}
+	}
+	select {
+	case <-raw.finished:
+	default:
+		t.Fatal("Close returned before pipe writer finished")
+	}
+	select {
+	case err := <-control:
+		if !errors.Is(err, ErrDisconnected) {
+			t.Fatalf("control writer result=%v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("websocket lock waiter did not finish")
+	}
+}

--- a/internal/integrations/agents/codexappserver/probe.go
+++ b/internal/integrations/agents/codexappserver/probe.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -18,17 +19,25 @@ type commandStream struct {
 	stdin  io.WriteCloser
 	stdout io.ReadCloser
 	cmd    *exec.Cmd
+
+	closeOnce sync.Once
+	closeErr  error
 }
 
 func (s *commandStream) Read(p []byte) (int, error)  { return s.stdout.Read(p) }
 func (s *commandStream) Write(p []byte) (int, error) { return s.stdin.Write(p) }
 func (s *commandStream) Close() error {
-	_ = s.stdin.Close()
-	_ = s.stdout.Close()
-	if s.cmd.Process != nil {
-		_ = s.cmd.Process.Kill()
-	}
-	return s.cmd.Wait()
+	s.closeOnce.Do(func() {
+		// This Cmd is the proxy we started, never the shared upstream daemon.
+		// Kill first so even a stopped proxy cannot keep a pipe writer alive.
+		if s.cmd.Process != nil {
+			_ = s.cmd.Process.Kill()
+		}
+		_ = s.stdin.Close()
+		_ = s.stdout.Close()
+		s.closeErr = s.cmd.Wait()
+	})
+	return s.closeErr
 }
 
 // ProbeDefaultProxy performs an initialize-only probe against the existing

--- a/internal/integrations/agents/codexappserver/websocket.go
+++ b/internal/integrations/agents/codexappserver/websocket.go
@@ -50,6 +50,8 @@ func upgradeProxyWebSocket(ctx context.Context, raw readWriteCloser) (*websocket
 	}()
 	select {
 	case <-ctx.Done():
+		_ = raw.Close()
+		<-writeDone
 		return nil, ctx.Err()
 	case err := <-writeDone:
 		if err != nil {
@@ -70,6 +72,8 @@ func upgradeProxyWebSocket(ctx context.Context, raw readWriteCloser) (*websocket
 	var response *http.Response
 	select {
 	case <-ctx.Done():
+		_ = raw.Close()
+		<-readDone
 		return nil, ctx.Err()
 	case got := <-readDone:
 		if got.err != nil {
@@ -152,8 +156,10 @@ func (s *websocketStream) Write(p []byte) (int, error) {
 }
 
 func (s *websocketStream) Close() error {
-	_ = s.writeFrame(0x8, nil)
-	return s.raw.Close()
+	// Local teardown must not wait for the peer to read a close frame or for
+	// a data/control writer holding writeMu. Closing the owned transport also
+	// releases those writers; no asynchronous graceful cleanup is left behind.
+	return s.abort()
 }
 
 // abort bypasses the graceful close frame because a blocked data-frame write

--- a/test/e2e/codex-lifecycle.sh
+++ b/test/e2e/codex-lifecycle.sh
@@ -478,18 +478,25 @@ lifecycle_projection_barrier_pane=""
 lifecycle_projection_barrier_channel=""
 lifecycle_projection_barrier_label=""
 lifecycle_arm_projection_condition() {
-  local pane="$1" condition="$2" label="$3"
+  local pane="$1" condition="$2" label="$3" signal_shell="" signal_command=""
   lifecycle_projection_barrier_serial="$((lifecycle_projection_barrier_serial + 1))"
   lifecycle_projection_barrier_pane="$pane"
   lifecycle_projection_barrier_channel="codex-lifecycle-$lifecycle_server_pid-$lifecycle_projection_barrier_serial"
   lifecycle_projection_barrier_label="$label"
+  # wait-for -S is not idempotent: a second signal before a waiter arrives
+  # consumes the first pending wakeup. The level check and every matching hook
+  # therefore share one atomic claim, retained for this barrier's lifetime.
+  printf -v signal_shell 'if mkdir -- %q 2>/dev/null; then env -u TMUX -u TMUX_PANE %q -L %q wait-for -S %q; fi' \
+    "$lifecycle_fixture_state/projection-barrier-$lifecycle_projection_barrier_serial" \
+    "$lifecycle_real_tmux" "$lifecycle_socket" "$lifecycle_projection_barrier_channel"
+  signal_command="run-shell \"$signal_shell\""
   lifecycle_tmux set-hook -p -t "$pane" after-set-option \
-    "if-shell -F '$condition' 'wait-for -S $lifecycle_projection_barrier_channel'"
+    "if-shell -F '$condition' '$signal_command'"
   # Close the lost-wakeup window without polling: if the exact level became
   # current before the hook was installed, signal the same one-shot channel
   # synchronously. Otherwise the hook owns the future edge.
   lifecycle_tmux if-shell -F -t "$pane" "$condition" \
-    "wait-for -S $lifecycle_projection_barrier_channel"
+    "$signal_command"
 }
 
 # The attention field is part of the condition because the projection writes
@@ -617,6 +624,28 @@ dump_lifecycle_diagnostics() {
   lifecycle_queue_json >&2 || true
   tail -n 8 "$XDG_STATE_HOME/projmux/ai-ingest.log" >&2 2>/dev/null || true
 }
+
+# Exercise the actual barrier on the fixture's inert anchor, without touching
+# either Agent's projection. Both an already-ready level and a later ready edge
+# must survive one or three further matching option hooks before the wait starts
+# (the old helper emitted two or four signals and lost the pending wakeup).
+for lifecycle_barrier_initial in ready pending; do
+  for lifecycle_barrier_updates in 1 3; do
+    lifecycle_tmux set-option -p -t "$lifecycle_anchor_pane" @c01_barrier_ready "$lifecycle_barrier_initial"
+    lifecycle_arm_projection_condition "$lifecycle_anchor_pane" '#{==:#{@c01_barrier_ready},ready}' \
+      "once-signal regression $lifecycle_barrier_initial/$lifecycle_barrier_updates"
+    if [[ "$lifecycle_barrier_initial" == pending ]]; then
+      lifecycle_tmux set-option -p -t "$lifecycle_anchor_pane" @c01_barrier_ready ready
+    fi
+    for ((lifecycle_barrier_update = 0; lifecycle_barrier_update < lifecycle_barrier_updates; lifecycle_barrier_update++)); do
+      lifecycle_tmux set-option -p -t "$lifecycle_anchor_pane" @c01_barrier_noise "$lifecycle_barrier_update"
+    done
+    lifecycle_wait_projection_barrier
+  done
+done
+lifecycle_tmux set-option -pu -t "$lifecycle_anchor_pane" @c01_barrier_ready
+lifecycle_tmux set-option -pu -t "$lifecycle_anchor_pane" @c01_barrier_noise
+echo ">> C01 projection barrier retained one signal across ready/pending levels and repeated option hooks"
 
 wait_lifecycle_option @projmux_codex_authority provider-control-plane "native authority"
 wait_lifecycle_option @projmux_ai_state thinking "native active snapshot"


### PR DESCRIPTION
## Summary
- Probe the existing Codex usage connection every 30 seconds so quiet connections remain healthy and silent disconnects enter the existing timeout, backoff, and demand-driven recovery path.
- Close the owned transport without waiting for a peer close frame, then join readers/writers and reap the owned proxy. Preserve freshness, last-good data, fallback, leases, and stale-writer fences.
- Add clock/transport/watcher regressions and make the C01 projection barrier signal once across initial readiness and repeated option hooks.

## Test plan
- [x] make fmt
- [x] make deadcode and make fix
- [x] make test
- [x] Scoped race and consumer regressions (299 scoped + 21 qualification/receipt tests)
- [x] make test-integration
- [x] make test-e2e (all 22 scenarios)
- [x] Private endpoint: quiet two cycles, no-EOF stall, EOF, restart, demand expiry
- [x] Required CI jobs and aggregate Test (20 checks green on f6d666bb)

## Globalization
- [x] No user-facing string changes.

Phase 0 only. Authority changes, lifecycle diagnostics, pool/CLI removal, and shared daemon management remain outside this change.

